### PR TITLE
`Quiz`: Implement quiz participation

### DIFF
--- a/.jhipster/SubmittedAnswer.json
+++ b/.jhipster/SubmittedAnswer.json
@@ -3,6 +3,12 @@
     "relationships": [
         {
             "relationshipType": "many-to-one",
+            "relationshipName": "question",
+            "otherEntityName": "question",
+            "otherEntityField": "id"
+        },
+        {
+            "relationshipType": "many-to-one",
             "relationshipName": "submission",
             "otherEntityName": "quizSubmission",
             "otherEntityField": "id"

--- a/exerciseapp.jh
+++ b/exerciseapp.jh
@@ -166,7 +166,7 @@ relationship ManyToOne {
   Participation{student(login)} to User,
   LtiOutcomeUrl{user} to User,
   LtiOutcomeUrl{exercise} to Exercise,
-
+  SubmittedAnswer{question} to Question
   DragAndDropAssignment{item} to DragItem,
   DragAndDropAssignment{location} to DropLocation
 }

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/DragAndDropSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/DragAndDropSubmittedAnswer.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.exerciseapp.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
@@ -18,6 +19,7 @@ import java.util.Set;
 @Entity
 @DiscriminatorValue(value="DD")
 //@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@JsonTypeName("drag-and-drop")
 public class DragAndDropSubmittedAnswer extends SubmittedAnswer implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/Exercise.java
@@ -35,7 +35,7 @@ public abstract class Exercise implements Serializable {
     private String title;
 
     @Column(name = "release_date")
-    private ZonedDateTime releaseDate;
+    protected ZonedDateTime releaseDate;
 
     @Column(name = "due_date")
     private ZonedDateTime dueDate;
@@ -134,6 +134,10 @@ public abstract class Exercise implements Serializable {
         this.course = course;
     }
     // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
+
+    public Boolean getIsVisibleToStudents() {
+        return releaseDate.isBefore(ZonedDateTime.now());
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/MultipleChoiceSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/MultipleChoiceSubmittedAnswer.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.exerciseapp.domain;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
@@ -13,17 +14,18 @@ import java.util.Set;
  * A MultipleChoiceSubmittedAnswer.
  */
 @Entity
-@DiscriminatorValue(value="MC")
+@DiscriminatorValue(value = "MC")
 //@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@JsonTypeName("multiple-choice")
 public class MultipleChoiceSubmittedAnswer extends SubmittedAnswer implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    @ManyToMany
+    @ManyToMany(fetch = FetchType.EAGER)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JoinTable(name = "multiple_choice_submitted_answer_selected_options",
-               joinColumns = @JoinColumn(name="multiple_choice_submitted_answers_id", referencedColumnName="id"),
-               inverseJoinColumns = @JoinColumn(name="selected_options_id", referencedColumnName="id"))
+        joinColumns = @JoinColumn(name = "multiple_choice_submitted_answers_id", referencedColumnName = "id"),
+        inverseJoinColumns = @JoinColumn(name = "selected_options_id", referencedColumnName = "id"))
     private Set<AnswerOption> selectedOptions = new HashSet<>();
 
     // jhipster-needle-entity-add-field - Jhipster will add fields here, do not remove

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizExercise.java
@@ -156,6 +156,8 @@ public class QuizExercise extends Exercise implements Serializable {
         this.duration = duration;
     }
 
+    public String getType() { return "quiz"; }
+
     public List<Question> getQuestions() {
         return questions;
     }

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizExercise.java
@@ -195,6 +195,11 @@ public class QuizExercise extends Exercise implements Serializable {
     }
 
     @Override
+    public Boolean getIsVisibleToStudents() {
+        return isVisibleBeforeStart || (isPlannedToStart && releaseDate.isBefore(ZonedDateTime.now()));
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizExercise.java
@@ -5,6 +5,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import javax.persistence.*;
 import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Objects;
 import java.util.List;
@@ -157,6 +159,15 @@ public class QuizExercise extends Exercise implements Serializable {
     }
 
     public String getType() { return "quiz"; }
+
+    @Override
+    public ZonedDateTime getDueDate() {
+        return isPlannedToStart ? getReleaseDate().plusSeconds(getDuration()) : null;
+    }
+
+    public Long getRemainingTime() {
+        return isPlannedToStart ? ChronoUnit.SECONDS.between(ZonedDateTime.now(), getDueDate()) : null;
+    }
 
     public List<Question> getQuestions() {
         return questions;

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizSubmission.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizSubmission.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
-import javax.persistence.DiscriminatorValue;
-import javax.persistence.Entity;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Objects;
@@ -22,7 +20,7 @@ public class QuizSubmission extends Submission implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    @OneToMany(mappedBy = "submission")
+    @OneToMany(mappedBy = "submission", cascade= CascadeType.ALL, fetch= FetchType.EAGER, orphanRemoval=true)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<SubmittedAnswer> submittedAnswers = new HashSet<>();
 

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizSubmission.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/QuizSubmission.java
@@ -23,7 +23,6 @@ public class QuizSubmission extends Submission implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @OneToMany(mappedBy = "submission")
-    @JsonIgnore
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<SubmittedAnswer> submittedAnswers = new HashSet<>();
 

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/Submission.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/Submission.java
@@ -5,6 +5,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import javax.persistence.*;
 import java.io.Serializable;
+import java.time.ZonedDateTime;
 import java.util.Objects;
 
 /**
@@ -12,12 +13,12 @@ import java.util.Objects;
  */
 @Entity
 @Table(name = "submission")
-@Inheritance(strategy=InheritanceType.SINGLE_TABLE)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(
-    name="discriminator",
-    discriminatorType=DiscriminatorType.STRING
+    name = "discriminator",
+    discriminatorType = DiscriminatorType.STRING
 )
-@DiscriminatorValue(value="S")
+@DiscriminatorValue(value = "S")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public abstract class Submission implements Serializable {
 
@@ -26,6 +27,20 @@ public abstract class Submission implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Transient
+    // variable name must be different from Getter name,
+    // so that Jackson ignores the @Transient annotation,
+    // but Hibernate still respects it
+    private ZonedDateTime submissionDateTransient;
+
+    public ZonedDateTime getSubmissionDate() {
+        return submissionDateTransient;
+    }
+
+    public void setSubmissionDate(ZonedDateTime submissionDate) {
+        submissionDateTransient = submissionDate;
+    }
 
     // jhipster-needle-entity-add-field - Jhipster will add fields here, do not remove
     public Long getId() {

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/SubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/SubmittedAnswer.java
@@ -28,15 +28,30 @@ public abstract class SubmittedAnswer implements Serializable {
     private Long id;
 
     @ManyToOne
+    private Question question;
+
+    @ManyToOne
     private QuizSubmission submission;
 
-    // jhipster-needle-entity-add-field - Jhipster will add fields here, do not remove
     public Long getId() {
         return id;
     }
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public Question getQuestion() {
+        return question;
+    }
+
+    public SubmittedAnswer question(Question question) {
+        this.question = question;
+        return this;
+    }
+
+    public void setQuestion(Question question) {
+        this.question = question;
     }
 
     public QuizSubmission getSubmission() {
@@ -51,7 +66,6 @@ public abstract class SubmittedAnswer implements Serializable {
     public void setSubmission(QuizSubmission quizSubmission) {
         this.submission = quizSubmission;
     }
-    // jhipster-needle-entity-add-getters-setters - Jhipster will add getters and setters here, do not remove
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/SubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/SubmittedAnswer.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.exerciseapp.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
@@ -31,6 +32,7 @@ public abstract class SubmittedAnswer implements Serializable {
     private Question question;
 
     @ManyToOne
+    @JsonIgnore
     private QuizSubmission submission;
 
     public Long getId() {

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/SubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/SubmittedAnswer.java
@@ -1,6 +1,8 @@
 package de.tum.in.www1.exerciseapp.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
@@ -20,6 +22,11 @@ import java.util.Objects;
 )
 @DiscriminatorValue(value="S")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, property="type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value=MultipleChoiceSubmittedAnswer.class, name="multiple-choice"),
+    @JsonSubTypes.Type(value=DragAndDropSubmittedAnswer.class, name="drag-and-drop")
+})
 public abstract class SubmittedAnswer implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/de/tum/in/www1/exerciseapp/domain/SubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/domain/SubmittedAnswer.java
@@ -22,6 +22,11 @@ import java.util.Objects;
 )
 @DiscriminatorValue(value="S")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+
+// add JsonTypeInfo and JsonSubTypes annotation to help Jackson decide which class the JSON should be deserialized to
+// depending on the value of the "type" property.
+// Note: The "type" property has to be added on the front-end when making a request that includes a SubmittedAnswer Object
+// However, the "type" property will be automatically added by Jackson when an object is serialized
 @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, property="type")
 @JsonSubTypes({
     @JsonSubTypes.Type(value=MultipleChoiceSubmittedAnswer.class, name="multiple-choice"),

--- a/src/main/java/de/tum/in/www1/exerciseapp/repository/ExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/repository/ExerciseRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.security.Principal;
+import java.util.List;
 
 
 /**
@@ -18,7 +19,7 @@ import java.security.Principal;
 @Repository
 public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
 
-    Page<Exercise> findByCourseId(@Param("courseId") Long courseId, Pageable pageable);
+    List<Exercise> findByCourseId(@Param("courseId") Long courseId);
 
 
     /**
@@ -30,5 +31,5 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
      *
      */
     @Query("SELECT e FROM Exercise e WHERE e.course.id =  :#{#courseId} AND ((NOT EXISTS(SELECT l from LtiOutcomeUrl l WHERE e = l.exercise)) OR EXISTS (SELECT l2 from LtiOutcomeUrl l2 WHERE e = l2.exercise AND l2.user.login = :#{#principal.name})) ")
-    Page<Exercise> findByCourseIdWhereLtiOutcomeUrlExists(@Param("courseId") Long courseId, @Param("principal") Principal principal, Pageable pageable);
+    List<Exercise> findByCourseIdWhereLtiOutcomeUrlExists(@Param("courseId") Long courseId, @Param("principal") Principal principal);
 }

--- a/src/main/java/de/tum/in/www1/exerciseapp/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/repository/ResultRepository.java
@@ -45,4 +45,6 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
 
     Optional<Result> findFirstByParticipationIdOrderByCompletionDateDesc(Long participationId);
 
+    Optional<Result> findDistinctBySubmissionId(Long submissionId);
+
 }

--- a/src/main/java/de/tum/in/www1/exerciseapp/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/service/ParticipationService.java
@@ -89,10 +89,10 @@ public class ParticipationService {
         }
         else if (exercise instanceof QuizExercise) {
             participation.setInitializationState(ParticipationState.INITIALIZED);
-            participation.setInitializationDate(ZonedDateTime.now());
-            //TODO: Valentin implement
+            if (!Optional.ofNullable(participation.getInitializationDate()).isPresent()) {
+                participation.setInitializationDate(ZonedDateTime.now());
+            }
         }
-
 
         save(participation);
         return participation;

--- a/src/main/java/de/tum/in/www1/exerciseapp/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/web/rest/ExerciseResource.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.exerciseapp.web.rest;
 import com.codahale.metrics.annotation.Timed;
 import de.tum.in.www1.exerciseapp.domain.Exercise;
 import de.tum.in.www1.exerciseapp.domain.ProgrammingExercise;
+import de.tum.in.www1.exerciseapp.domain.QuizExercise;
 import de.tum.in.www1.exerciseapp.repository.ExerciseRepository;
 import de.tum.in.www1.exerciseapp.service.ContinuousIntegrationService;
 import de.tum.in.www1.exerciseapp.service.ExerciseService;
@@ -174,7 +175,15 @@ public class ExerciseResource {
 
         //TODO: filter exercises where the user does not have access, but where he might see the course
 
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/courses/" + courseId + "exercises");
+        // filter out questions from quizExercises (so users can't see which answer options are correct)
+        for (Exercise exercise : page) {
+            if (exercise instanceof QuizExercise) {
+                QuizExercise quizExercise = (QuizExercise) exercise;
+                quizExercise.setQuestions(null);
+            }
+        }
+
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/courses/" + courseId + "/exercises");
         return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
     }
 

--- a/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizExerciseResource.java
@@ -91,7 +91,7 @@ public class QuizExerciseResource {
                         }
                     }
                 }
-                // TODO: do the same for dragItems and dropLocations (if question is drag and drop)
+                // TODO: Valentin: do the same for dragItems and dropLocations (if question is drag and drop)
             }
         }
 

--- a/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizExerciseResource.java
@@ -147,6 +147,36 @@ public class QuizExerciseResource {
     }
 
     /**
+     * GET  /quiz-exercises/:id : get the "id" quizExercise.
+     *
+     * @param id the id of the quizExercise to retrieve
+     * @return the ResponseEntity with status 200 (OK) and with body the quizExercise, or with status 404 (Not Found)
+     */
+    @GetMapping("/quiz-exercises/{id}/for-student")
+    @PreAuthorize("hasAnyRole('USER', 'TA', 'ADMIN')")
+    @Timed
+    public ResponseEntity<QuizExercise> getQuizExerciseForStudent(@PathVariable Long id) {
+        log.debug("REST request to get QuizExercise : {}", id);
+        QuizExercise quizExercise = quizExerciseRepository.findOne(id);
+
+        // filter out "explanation" field from all questions (so students can't see explanation while answering quiz)
+        for (Question question : quizExercise.getQuestions()) {
+            question.setExplanation(null);
+
+            // filter out "isCorrect" and "explanation" fields from answerOptions in all MC questions (so students can't see correct options in JSON)
+            if (question instanceof MultipleChoiceQuestion) {
+                MultipleChoiceQuestion mcQuestion = (MultipleChoiceQuestion) question;
+                for (AnswerOption answerOption : mcQuestion.getAnswerOptions()) {
+                    answerOption.setIsCorrect(null);
+                    answerOption.setExplanation(null);
+                }
+            }
+        }
+
+        return ResponseUtil.wrapOrNotFound(Optional.ofNullable(quizExercise));
+    }
+
+    /**
      * DELETE  /quiz-exercises/:id : delete the "id" quizExercise.
      *
      * @param id the id of the quizExercise to delete

--- a/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizSubmissionResource.java
@@ -68,7 +68,9 @@ public class QuizSubmissionResource {
             Result result = resultRepository.findFirstByParticipationIdOrderByCompletionDateDesc(participation.getId()).orElse(null);
             if (result == null) {
                 // no result exists yet => create a new one
-                result = new Result().participation(participation).submission(new QuizSubmission().submittedAnswers(new HashSet<>()));
+                QuizSubmission newSubmission = new QuizSubmission().submittedAnswers(new HashSet<>());
+                newSubmission = quizSubmissionRepository.save(newSubmission);
+                result = new Result().participation(participation).submission(newSubmission);
                 result = resultRepository.save(result);
             }
             QuizSubmission submission = (QuizSubmission) result.getSubmission();
@@ -116,6 +118,11 @@ public class QuizSubmissionResource {
         log.debug("REST request to update QuizSubmission : {}", quizSubmission);
 
         //TODO: check if submission belongs to user
+
+        // recreate pointers back to submission in each submitted answer
+        for (SubmittedAnswer submittedAnswer : quizSubmission.getSubmittedAnswers()) {
+            submittedAnswer.setSubmission(quizSubmission);
+        }
 
         if (quizSubmission.getId() == null) {
             return createQuizSubmission(quizSubmission);

--- a/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizSubmissionResource.java
@@ -119,7 +119,7 @@ public class QuizSubmissionResource {
     public ResponseEntity<QuizSubmission> updateQuizSubmission(@RequestBody QuizSubmission quizSubmission) throws URISyntaxException {
         log.debug("REST request to update QuizSubmission : {}", quizSubmission);
 
-        //TODO: check if submission belongs to user
+        //TODO: Valentin: check if submission belongs to user
 
         // recreate pointers back to submission in each submitted answer
         for (SubmittedAnswer submittedAnswer : quizSubmission.getSubmittedAnswers()) {
@@ -139,8 +139,7 @@ public class QuizSubmissionResource {
             if (exercise.getDueDate().isAfter(ZonedDateTime.now())) {
                 result.setCompletionDate(ZonedDateTime.now());
                 resultRepository.save(result);
-                // TODO calculate score and update result accordingly
-
+                // TODO Valentin: calculate score and update result accordingly (do this only when actual submission is made <- "Final Submission" or "Out of time")
                 quizSubmission.setSubmissionDate(result.getCompletionDate());
 
                 return ResponseEntity.ok()

--- a/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/web/rest/QuizSubmissionResource.java
@@ -1,17 +1,24 @@
 package de.tum.in.www1.exerciseapp.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
-import de.tum.in.www1.exerciseapp.domain.QuizSubmission;
+import de.tum.in.www1.exerciseapp.domain.*;
+import de.tum.in.www1.exerciseapp.repository.QuizExerciseRepository;
 import de.tum.in.www1.exerciseapp.repository.QuizSubmissionRepository;
+import de.tum.in.www1.exerciseapp.repository.ResultRepository;
+import de.tum.in.www1.exerciseapp.service.ParticipationService;
 import de.tum.in.www1.exerciseapp.web.rest.util.HeaderUtil;
 import io.github.jhipster.web.util.ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.Principal;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,8 +34,49 @@ public class QuizSubmissionResource {
     private static final String ENTITY_NAME = "quizSubmission";
 
     private final QuizSubmissionRepository quizSubmissionRepository;
-    public QuizSubmissionResource(QuizSubmissionRepository quizSubmissionRepository) {
+    private final QuizExerciseRepository quizExerciseRepository;
+    private final ResultRepository resultRepository;
+    private final ParticipationService participationService;
+
+    public QuizSubmissionResource(QuizSubmissionRepository quizSubmissionRepository, QuizExerciseRepository quizExerciseRepository, ResultRepository resultRepository, ParticipationService participationService) {
         this.quizSubmissionRepository = quizSubmissionRepository;
+        this.quizExerciseRepository = quizExerciseRepository;
+        this.resultRepository = resultRepository;
+        this.participationService = participationService;
+    }
+
+    /**
+     * GET  /courses/{courseId}/exercises/{exerciseId}/submissions/my-latest : Get the latest quizSubmission for the given course.
+     *
+     * @param courseId   only included for API consistency, not actually used
+     * @param exerciseId the id of the exercise for which to init a participation
+     * @param principal  the current user principal
+     *
+     * @return the ResponseEntity with status 200 (OK) and the quizSubmission in body, or with status 400 (Bad Request) if the exercise doesn't exist
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @GetMapping("/courses/{courseId}/exercises/{exerciseId}/submissions/my-latest")
+    @PreAuthorize("hasAnyRole('USER', 'TA', 'ADMIN')")
+    @Timed
+    public ResponseEntity<QuizSubmission> getLatestQuizSubmissionForExercise(@PathVariable Long courseId,
+                                                                       @PathVariable Long exerciseId,
+                                                                       Principal principal) throws URISyntaxException {
+        log.debug("REST request to get QuizSubmission for QuizExercise: {}", exerciseId);
+        QuizExercise quizExercise = quizExerciseRepository.findOne(exerciseId);
+        if (Optional.ofNullable(quizExercise).isPresent()) {
+            // TODO: Valentin: check if user is allowed to take part in this exercise (is this necessary?)
+            Participation participation = participationService.init(quizExercise, principal.getName());
+            Result result = resultRepository.findFirstByParticipationIdOrderByCompletionDateDesc(participation.getId()).orElse(null);
+            if (result == null) {
+                // no result exists yet => create a new one
+                result = new Result().participation(participation).submission(new QuizSubmission().submittedAnswers(new HashSet<>()));
+                result = resultRepository.save(result);
+            }
+            QuizSubmission submission = (QuizSubmission) result.getSubmission();
+            return ResponseEntity.ok(submission);
+        } else {
+            return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert("submission", "exerciseNotFound", "No exercise was found for the given ID")).body(null);
+        }
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/exerciseapp/web/rest/SubmittedAnswerResource.java
+++ b/src/main/java/de/tum/in/www1/exerciseapp/web/rest/SubmittedAnswerResource.java
@@ -83,7 +83,7 @@ public class SubmittedAnswerResource {
     public List<SubmittedAnswer> getAllSubmittedAnswers() {
         log.debug("REST request to get all SubmittedAnswers");
         return submittedAnswerRepository.findAll();
-        }
+    }
 
     /**
      * GET  /submitted-answers/:id : get the "id" submittedAnswer.

--- a/src/main/resources/config/liquibase/changelog/20171104170034_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20171104170034_changelog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="Vale (generated)" id="1509811243331-1">
+        <addColumn tableName="submitted_answer">
+            <column name="question_id" type="bigint"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="Vale (generated)" id="1509811243331-2">
+        <addForeignKeyConstraint baseColumnNames="question_id" baseTableName="submitted_answer" constraintName="FK6drbcvqf26cahd0j1u9ff0rtr" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="question"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -39,4 +39,5 @@
     <include file="classpath:config/liquibase/changelog/20171012201744_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20171013134151_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20171029012243_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20171104170034_changelog.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/main/webapp/app/courses/exercises/exercise-list.component.js
+++ b/src/main/webapp/app/courses/exercises/exercise-list.component.js
@@ -150,7 +150,6 @@
             if (exercise.type && exercise.type === "quiz") {
                 // start the quiz
                 $location.url("/quiz/" + exercise.id);
-                console.log(exercise);
                 return;
             }
 

--- a/src/main/webapp/app/courses/exercises/exercise-list.component.js
+++ b/src/main/webapp/app/courses/exercises/exercise-list.component.js
@@ -17,7 +17,7 @@
 
     ExerciseListController.$inject = ['$sce', '$window', 'AlertService', 'CourseExercises', 'Participation', 'ExerciseParticipation', '$http', '$location', 'Principal', '$rootScope'];
 
-    function ExerciseListController($sce, $window, AlertService, CourseExercises, Participation, ExerciseParticipation, $http,  $location, Principal, $rootScope) {
+    function ExerciseListController($sce, $window, AlertService, CourseExercises, Participation, ExerciseParticipation, $http, $location, Principal, $rootScope) {
         var vm = this;
 
         vm.clonePopover = {
@@ -38,7 +38,7 @@
 
         function init() {
 
-            if($location.search().welcome) {
+            if ($location.search().welcome) {
                 showWelcomeAlert();
             }
 
@@ -46,7 +46,10 @@
                 vm.repositoryPassword = password;
             });
 
-            CourseExercises.query({courseId: vm.course.id, withLtiOutcomeUrlExisting: true}).$promise.then(function (exercises) {
+            CourseExercises.query({
+                courseId: vm.course.id,
+                withLtiOutcomeUrlExisting: true
+            }).$promise.then(function (exercises) {
 
                 if (vm.filterByExerciseId) {
                     exercises = _.filter(exercises, {id: vm.filterByExerciseId})
@@ -93,18 +96,19 @@
         }
 
         function participationStatus(exercise) {
-            if(angular.equals({}, exercise.participation)) {
-                return "uninitialized";
-            } else if(exercise.participation.initializationState === "INITIALIZED") {
-                if (exercise.type && exercise.type === "quiz") {
-                    if (moment(exercise.dueDate).isBefore(moment())) {
-                        return "finished";
-                    } else {
-                        return "active"
-                    }
+            if (exercise.type && exercise.type === "quiz") {
+                if (angular.equals({}, exercise.participation)) {
+                    return "quiz-uninitialized";
+                } else if (moment(exercise.dueDate).isBefore(moment())) {
+                    return "quiz-finished";
                 } else {
-                    return "initialized";
+                    return "quiz-active"
                 }
+            }
+            if (angular.equals({}, exercise.participation)) {
+                return "uninitialized";
+            } else if (exercise.participation.initializationState === "INITIALIZED") {
+                return "initialized";
             }
             return "inactive";
         }
@@ -112,6 +116,7 @@
         function isNotOverdue(exercise) {
             return vm.showOverdueExercises || _.isEmpty(exercise.dueDate) || vm.now <= Date.parse(exercise.dueDate);
         }
+
         vm.isNotOverdue = isNotOverdue;
 
         function getRepositoryPassword() {
@@ -155,7 +160,7 @@
                 console.log(e);
                 AlertService.add({
                     type: 'danger',
-                    msg: '<strong>Uh oh! Something went wrong... Please try again in a few seconds.</strong> If this problem persists, please <a href="mailto:' + $rootScope.CONTACT_EMAIL + '?subject=Exercise%20Application%20Error%20Report&body=' + e.data.description+ '">send us an error report</a>.',
+                    msg: '<strong>Uh oh! Something went wrong... Please try again in a few seconds.</strong> If this problem persists, please <a href="mailto:' + $rootScope.CONTACT_EMAIL + '?subject=Exercise%20Application%20Error%20Report&body=' + e.data.description + '">send us an error report</a>.',
                     timeout: 30000
                 });
             }).finally(function () {
@@ -168,9 +173,9 @@
             exercise.$resume({
                 courseId: exercise.course.id,
                 exerciseId: exercise.id
-            }).catch(function(errorResponse) {
+            }).catch(function (errorResponse) {
                 alert(errorResponse.data.status + " " + errorResponse.data.detail);
-            }).finally(function() {
+            }).finally(function () {
                 vm.loading[exercise.id] = false;
             });
         }
@@ -178,6 +183,7 @@
         function toggleShowOverdueExercises() {
             vm.showOverdueExercises = true;
         }
+
         vm.toggleShowOverdueExercises = toggleShowOverdueExercises;
 
     }

--- a/src/main/webapp/app/courses/exercises/exercise-list.component.js
+++ b/src/main/webapp/app/courses/exercises/exercise-list.component.js
@@ -30,7 +30,6 @@
         vm.getClonePopoverTemplate = getClonePopoverTemplate;
         vm.goToBuildPlan = goToBuildPlan;
         vm.participationStatus = participationStatus;
-        vm.isReleased = isReleased;
         vm.start = start;
         vm.resume = resume;
         vm.now = Date.now();
@@ -56,22 +55,6 @@
                 vm.numOfOverdueExercises = _.filter(exercises, function (exercise) {
                     return !isNotOverdue(exercise);
                 }).length;
-
-
-                exercises = _.filter(exercises, function (exercise) {
-                    if(Principal.hasGroup(exercise.course.teachingAssistantGroupName)) {
-                        return true;
-                    }
-                    else if(Principal.hasGroup(exercise.course.studentGroupName)) {
-                        return vm.isReleased(exercise);
-                    }
-                    if(!Principal.hasAnyAuthority(['ROLE_ADMIN', 'ROLE_STUDENT'])) {        //== only ROLE_TA
-                        // hide exercises of other courses for TAs who are not TAs in the specific course (except Archive)
-                        return exercise.course.title === 'Archive';
-                    }
-                    return true;
-                    //TODO: test the case with LTI users from edX
-                });
 
                 angular.forEach(exercises, function (exercise) {
                     exercise['participation'] = ExerciseParticipation.get({
@@ -124,10 +107,6 @@
                 }
             }
             return "inactive";
-        }
-
-        function isReleased(exercise) {
-            return _.isEmpty(exercise.releaseDate) || vm.now >= Date.parse(exercise.releaseDate);
         }
 
         function isNotOverdue(exercise) {

--- a/src/main/webapp/app/courses/exercises/exercise-list.component.js
+++ b/src/main/webapp/app/courses/exercises/exercise-list.component.js
@@ -113,7 +113,7 @@
             if(angular.equals({}, exercise.participation)) {
                 return "uninitialized";
             } else if(exercise.participation.initializationState === "INITIALIZED") {
-                if (exercise.type === "quiz") {
+                if (exercise.type && exercise.type === "quiz") {
                     if (moment(exercise.dueDate).isBefore(moment())) {
                         return "finished";
                     } else {

--- a/src/main/webapp/app/courses/exercises/exercise-list.component.js
+++ b/src/main/webapp/app/courses/exercises/exercise-list.component.js
@@ -146,6 +146,14 @@
 
         function start(exercise) {
             vm.loading[exercise.id.toString()] = true;
+
+            if (exercise.type && exercise.type === "quiz") {
+                // start the quiz
+                $location.url("/quiz/" + exercise.id);
+                console.log(exercise);
+                return;
+            }
+
             exercise.$start({
                 courseId: exercise.course.id,
                 exerciseId: exercise.id

--- a/src/main/webapp/app/courses/exercises/exercise-list.component.js
+++ b/src/main/webapp/app/courses/exercises/exercise-list.component.js
@@ -113,7 +113,15 @@
             if(angular.equals({}, exercise.participation)) {
                 return "uninitialized";
             } else if(exercise.participation.initializationState === "INITIALIZED") {
-                return "initialized";
+                if (exercise.type === "quiz") {
+                    if (moment(exercise.dueDate).isBefore(moment())) {
+                        return "finished";
+                    } else {
+                        return "active"
+                    }
+                } else {
+                    return "initialized";
+                }
             }
             return "inactive";
         }

--- a/src/main/webapp/app/courses/exercises/exercise-list.html
+++ b/src/main/webapp/app/courses/exercises/exercise-list.html
@@ -35,8 +35,9 @@
             <span class="text-muted" ng-switch-when="uninitialized">You have not started this exercise yet.</span>
             <span ng-switch-when="initialized"><result participation="exercise.participation"></result></span>
             <span ng-switch-when="inactive"><result participation="exercise.participation"></result></span>
-            <span class="text-muted" ng-switch-when="active">You are currently participating in this exercise.</span>
-            <span ng-switch-when="finished"><result participation="exercise.participation"></result></span>
+            <span class="text-muted" ng-switch-when="quiz-uninitialized">You have not started this quiz yet.</span>
+            <span class="text-muted" ng-switch-when="quiz-active">You are currently participating in this quiz.</span>
+            <span ng-switch-when="quiz-finished"><result participation="exercise.participation"></result></span>
         </td>
         <td class="text-center">
             <button class="btn btn-primary btn-sm btn-block" id="btn-student-action"
@@ -47,10 +48,17 @@
                 <i class="fa fa-circle-o-notch fa-spin" ng-show="$ctrl.loading[exercise.id.toString()]"></i>
             </button>
             <button class="btn btn-primary btn-sm btn-block"
-                    ng-switch-when="active"
+                    ng-switch-when="quiz-uninitialized"
                     ng-click="$ctrl.start(exercise)"
                     ng-disabled="$ctrl.loading[exercise.id.toString()]">
-                <span ng-hide="$ctrl.loading[exercise.id.toString()]"><i class="fa fa-play-circle fa-fw"></i>&nbsp;Resume exercise</span>
+                <span ng-hide="$ctrl.loading[exercise.id.toString()]"><i class="fa fa-play-circle fa-fw"></i>&nbsp;Start Quiz</span>
+                <i class="fa fa-circle-o-notch fa-spin" ng-show="$ctrl.loading[exercise.id.toString()]"></i>
+            </button>
+            <button class="btn btn-primary btn-sm btn-block"
+                    ng-switch-when="quiz-active"
+                    ng-click="$ctrl.start(exercise)"
+                    ng-disabled="$ctrl.loading[exercise.id.toString()]">
+                <span ng-hide="$ctrl.loading[exercise.id.toString()]"><i class="fa fa-play-circle fa-fw"></i>&nbsp;Resume Quiz</span>
                 <i class="fa fa-circle-o-notch fa-spin" ng-show="$ctrl.loading[exercise.id.toString()]"></i>
             </button>
             <button class="btn btn-primary btn-sm btn-block"

--- a/src/main/webapp/app/courses/exercises/exercise-list.html
+++ b/src/main/webapp/app/courses/exercises/exercise-list.html
@@ -24,7 +24,7 @@
             <a class="text-primary" has-any-authority="ROLE_ADMIN, ROLE_TA"><i class="fa fa-info-circle fa-fw"
                ui-sref="instructor-dashboard({courseId: exercise.course.id, exerciseId: exercise.id})"></i></a>
 
-            <span class="label label-warning" ng-show="!$ctrl.isReleased(exercise)" uib-tooltip="Only visible to teaching assistants and instructors. Release date: {{exercise.releaseDate | date:'MMM d, y H:mm'}}"
+            <span class="label label-warning" ng-show="!exercise.isVisibleToStudents" uib-tooltip="Only visible to teaching assistants and instructors. Release date: {{exercise.releaseDate | date:'MMM d, y H:mm'}}"
                   tooltip-placement="right">Not Released</span>
         </td>
         <td>

--- a/src/main/webapp/app/courses/exercises/exercise-list.html
+++ b/src/main/webapp/app/courses/exercises/exercise-list.html
@@ -35,6 +35,8 @@
             <span class="text-muted" ng-switch-when="uninitialized">You have not started this exercise yet.</span>
             <span ng-switch-when="initialized"><result participation="exercise.participation"></result></span>
             <span ng-switch-when="inactive"><result participation="exercise.participation"></result></span>
+            <span class="text-muted" ng-switch-when="active">You are currently participating in this exercise.</span>
+            <span ng-switch-when="finished"><result participation="exercise.participation"></result></span>
         </td>
         <td class="text-center">
             <button class="btn btn-primary btn-sm btn-block" id="btn-student-action"
@@ -42,6 +44,13 @@
                     ng-click="$ctrl.start(exercise)"
                     ng-disabled="$ctrl.loading[exercise.id.toString()]">
                 <span ng-hide="$ctrl.loading[exercise.id.toString()]"><i class="fa fa-play-circle fa-fw"></i>&nbsp;Start exercise</span>
+                <i class="fa fa-circle-o-notch fa-spin" ng-show="$ctrl.loading[exercise.id.toString()]"></i>
+            </button>
+            <button class="btn btn-primary btn-sm btn-block"
+                    ng-switch-when="active"
+                    ng-click="$ctrl.start(exercise)"
+                    ng-disabled="$ctrl.loading[exercise.id.toString()]">
+                <span ng-hide="$ctrl.loading[exercise.id.toString()]"><i class="fa fa-play-circle fa-fw"></i>&nbsp;Resume exercise</span>
                 <i class="fa fa-circle-o-notch fa-spin" ng-show="$ctrl.loading[exercise.id.toString()]"></i>
             </button>
             <button class="btn btn-primary btn-sm btn-block"

--- a/src/main/webapp/app/entities/quiz-exercise/quiz-exercise.service.js
+++ b/src/main/webapp/app/entities/quiz-exercise/quiz-exercise.service.js
@@ -2,7 +2,8 @@
     'use strict';
     angular
         .module('artemisApp')
-        .factory('QuizExercise', QuizExercise);
+        .factory('QuizExercise', QuizExercise)
+        .factory('QuizExerciseForStudent', QuizExerciseForStudent);
 
     QuizExercise.$inject = ['$resource'];
 
@@ -21,6 +22,24 @@
                 }
             },
             'update': { method:'PUT' }
+        });
+    }
+
+    QuizExerciseForStudent.$inject = ['$resource'];
+
+    function QuizExerciseForStudent ($resource) {
+        var resourceUrl =  'api/quiz-exercises/:id/for-student';
+
+        return $resource(resourceUrl, {}, {
+            'get': {
+                method: 'GET',
+                transformResponse: function (data) {
+                    if (data) {
+                        data = angular.fromJson(data);
+                    }
+                    return data;
+                }
+            }
         });
     }
 })();

--- a/src/main/webapp/app/entities/quiz-submission/quiz-submission.service.js
+++ b/src/main/webapp/app/entities/quiz-submission/quiz-submission.service.js
@@ -2,7 +2,8 @@
     'use strict';
     angular
         .module('artemisApp')
-        .factory('QuizSubmission', QuizSubmission);
+        .factory('QuizSubmission', QuizSubmission)
+        .factory('QuizSubmissionForExercise', QuizSubmissionForExercise);
 
     QuizSubmission.$inject = ['$resource'];
 
@@ -21,6 +22,24 @@
                 }
             },
             'update': { method:'PUT' }
+        });
+    }
+
+    QuizSubmissionForExercise.$inject = ['$resource'];
+
+    function QuizSubmissionForExercise ($resource) {
+        var resourceUrl = 'api/courses/:courseId/exercises/:exerciseId/submissions/my-latest';
+
+        return $resource(resourceUrl, {}, {
+            'get': {
+                method: 'GET',
+                transformResponse: function (data) {
+                    if (data) {
+                        data = angular.fromJson(data);
+                    }
+                    return data;
+                }
+            }
         });
     }
 })();

--- a/src/main/webapp/app/entities/submitted-answer/submitted-answer-detail.html
+++ b/src/main/webapp/app/entities/submitted-answer/submitted-answer-detail.html
@@ -4,7 +4,11 @@
     <hr>
     <jhi-alert-error></jhi-alert-error>
     <dl class="dl-horizontal jh-entity-details">
-        <dt><span data-translate="artemisApp.submittedAnswer.submission">Submission</span></dt>
+        <dt><span data-translate="arTeMiSApp.submittedAnswer.question">Question</span></dt>
+        <dd>
+            <a ui-sref="question-detail({id:vm.submittedAnswer.question.id})">{{vm.submittedAnswer.question.id}}</a>
+        </dd>
+        <dt><span data-translate="arTeMiSApp.submittedAnswer.submission">Submission</span></dt>
         <dd>
             <a ui-sref="quiz-submission-detail({id:vm.submittedAnswer.submission.id})">{{vm.submittedAnswer.submission.id}}</a>
         </dd>

--- a/src/main/webapp/app/entities/submitted-answer/submitted-answer-detail.html
+++ b/src/main/webapp/app/entities/submitted-answer/submitted-answer-detail.html
@@ -4,11 +4,11 @@
     <hr>
     <jhi-alert-error></jhi-alert-error>
     <dl class="dl-horizontal jh-entity-details">
-        <dt><span data-translate="arTeMiSApp.submittedAnswer.question">Question</span></dt>
+        <dt><span data-translate="artemisApp.submittedAnswer.question">Question</span></dt>
         <dd>
             <a ui-sref="question-detail({id:vm.submittedAnswer.question.id})">{{vm.submittedAnswer.question.id}}</a>
         </dd>
-        <dt><span data-translate="arTeMiSApp.submittedAnswer.submission">Submission</span></dt>
+        <dt><span data-translate="artemisApp.submittedAnswer.submission">Submission</span></dt>
         <dd>
             <a ui-sref="quiz-submission-detail({id:vm.submittedAnswer.submission.id})">{{vm.submittedAnswer.submission.id}}</a>
         </dd>

--- a/src/main/webapp/app/entities/submitted-answer/submitted-answer-dialog.controller.js
+++ b/src/main/webapp/app/entities/submitted-answer/submitted-answer-dialog.controller.js
@@ -5,14 +5,15 @@
         .module('artemisApp')
         .controller('SubmittedAnswerDialogController', SubmittedAnswerDialogController);
 
-    SubmittedAnswerDialogController.$inject = ['$timeout', '$scope', '$stateParams', '$uibModalInstance', 'entity', 'SubmittedAnswer', 'QuizSubmission'];
+    SubmittedAnswerDialogController.$inject = ['$timeout', '$scope', '$stateParams', '$uibModalInstance', 'entity', 'SubmittedAnswer', 'Question', 'QuizSubmission'];
 
-    function SubmittedAnswerDialogController ($timeout, $scope, $stateParams, $uibModalInstance, entity, SubmittedAnswer, QuizSubmission) {
+    function SubmittedAnswerDialogController ($timeout, $scope, $stateParams, $uibModalInstance, entity, SubmittedAnswer, Question, QuizSubmission) {
         var vm = this;
 
         vm.submittedAnswer = entity;
         vm.clear = clear;
         vm.save = save;
+        vm.questions = Question.query();
         vm.quizsubmissions = QuizSubmission.query();
 
         $timeout(function (){

--- a/src/main/webapp/app/entities/submitted-answer/submitted-answer-dialog.html
+++ b/src/main/webapp/app/entities/submitted-answer/submitted-answer-dialog.html
@@ -15,13 +15,13 @@
         </div>
 
         <div class="form-group">
-            <label data-translate="arTeMiSApp.submittedAnswer.question" for="field_question">Question</label>
+            <label data-translate="artemisApp.submittedAnswer.question" for="field_question">Question</label>
             <select class="form-control" id="field_question" name="question" ng-model="vm.submittedAnswer.question" ng-options="question as question.id for question in vm.questions track by question.id">
                 <option value=""></option>
             </select>
         </div>
         <div class="form-group">
-            <label data-translate="arTeMiSApp.submittedAnswer.submission" for="field_submission">Submission</label>
+            <label data-translate="artemisApp.submittedAnswer.submission" for="field_submission">Submission</label>
             <select class="form-control" id="field_submission" name="submission" ng-model="vm.submittedAnswer.submission" ng-options="quizSubmission as quizSubmission.id for quizSubmission in vm.quizsubmissions track by quizSubmission.id">
                 <option value=""></option>
             </select>

--- a/src/main/webapp/app/entities/submitted-answer/submitted-answer-dialog.html
+++ b/src/main/webapp/app/entities/submitted-answer/submitted-answer-dialog.html
@@ -15,7 +15,13 @@
         </div>
 
         <div class="form-group">
-            <label data-translate="artemisApp.submittedAnswer.submission" for="field_submission">Submission</label>
+            <label data-translate="arTeMiSApp.submittedAnswer.question" for="field_question">Question</label>
+            <select class="form-control" id="field_question" name="question" ng-model="vm.submittedAnswer.question" ng-options="question as question.id for question in vm.questions track by question.id">
+                <option value=""></option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label data-translate="arTeMiSApp.submittedAnswer.submission" for="field_submission">Submission</label>
             <select class="form-control" id="field_submission" name="submission" ng-model="vm.submittedAnswer.submission" ng-options="quizSubmission as quizSubmission.id for quizSubmission in vm.quizsubmissions track by quizSubmission.id">
                 <option value=""></option>
             </select>

--- a/src/main/webapp/app/entities/submitted-answer/submitted-answers.html
+++ b/src/main/webapp/app/entities/submitted-answer/submitted-answers.html
@@ -19,13 +19,17 @@
             <thead>
                 <tr>
                     <th><span data-translate="global.field.id">ID</span></th>
-                    <th><span data-translate="artemisApp.submittedAnswer.submission">Submission</span></th>
+                    <th><span data-translate="arTeMiSApp.submittedAnswer.question">Question</span></th>
+                    <th><span data-translate="arTeMiSApp.submittedAnswer.submission">Submission</span></th>
                     <th></th>
                 </tr>
             </thead>
             <tbody>
                 <tr ng-repeat="submittedAnswer in vm.submittedAnswers track by submittedAnswer.id">
                     <td><a ui-sref="submitted-answer-detail({id:submittedAnswer.id})">{{submittedAnswer.id}}</a></td>
+                    <td>
+                        <a ui-sref="question-detail({id:submittedAnswer.question.id})">{{submittedAnswer.question.id}}</a>
+                    </td>
                     <td>
                         <a ui-sref="quiz-submission-detail({id:submittedAnswer.submission.id})">{{submittedAnswer.submission.id}}</a>
                     </td>

--- a/src/main/webapp/app/entities/submitted-answer/submitted-answers.html
+++ b/src/main/webapp/app/entities/submitted-answer/submitted-answers.html
@@ -19,8 +19,8 @@
             <thead>
                 <tr>
                     <th><span data-translate="global.field.id">ID</span></th>
-                    <th><span data-translate="arTeMiSApp.submittedAnswer.question">Question</span></th>
-                    <th><span data-translate="arTeMiSApp.submittedAnswer.submission">Submission</span></th>
+                    <th><span data-translate="artemisApp.submittedAnswer.question">Question</span></th>
+                    <th><span data-translate="artemisApp.submittedAnswer.submission">Submission</span></th>
                     <th></th>
                 </tr>
             </thead>

--- a/src/main/webapp/app/quiz/edit/multiple-choice-question/edit-multiple-choice-question.html
+++ b/src/main/webapp/app/quiz/edit/multiple-choice-question/edit-multiple-choice-question.html
@@ -51,7 +51,7 @@
     </div>
 </div>
 <div class="preview-mc-question" ng-if="vm.showPreview">
-    <multiple-choice-question question="vm.question"></multiple-choice-question>
+    <multiple-choice-question question="vm.question" selected-answer-options="[]"></multiple-choice-question>
     <hr/>
     <div class="btn btn-default" ng-click="vm.togglePreview()">
         <i class="fa fa-pencil"></i>

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.js
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.js
@@ -22,13 +22,21 @@ function MultipleChoiceQuestionController($translate, $translatePartialLoader, $
     vm.toggleSelection = toggleSelection;
 
     function toggleSelection(answerOption) {
-        if (vm.selectedAnswerOptions.indexOf(answerOption) !== -1) {
+        if (isAnswerOptionSelected(answerOption)) {
             vm.selectedAnswerOptions = vm.selectedAnswerOptions.filter(function(ao) {
-                return ao !== answerOption;
+                return ao.id !== answerOption.id;
             });
         } else {
             vm.selectedAnswerOptions.push(answerOption);
         }
+    }
+
+    vm.isAnswerOptionSelected = isAnswerOptionSelected;
+
+    function isAnswerOptionSelected(answerOption) {
+        return vm.selectedAnswerOptions.findIndex(function(selected) {
+            return selected.id === answerOption.id;
+        }) !== -1;
     }
 
     /**

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.js
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.js
@@ -23,8 +23,8 @@ function MultipleChoiceQuestionController($translate, $translatePartialLoader, $
 
     function toggleSelection(answerOption) {
         if (isAnswerOptionSelected(answerOption)) {
-            vm.selectedAnswerOptions = vm.selectedAnswerOptions.filter(function(ao) {
-                return ao.id !== answerOption.id;
+            vm.selectedAnswerOptions = vm.selectedAnswerOptions.filter(function(selectedAnswerOption) {
+                return selectedAnswerOption.id !== answerOption.id;
             });
         } else {
             vm.selectedAnswerOptions.push(answerOption);

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.js
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.js
@@ -19,7 +19,6 @@ function MultipleChoiceQuestionController($translate, $translatePartialLoader, $
         })
     };
 
-    vm.selectedAnswerOptions = [];
     vm.toggleSelection = toggleSelection;
 
     function toggleSelection(answerOption) {
@@ -59,6 +58,7 @@ angular.module('artemisApp').component('multipleChoiceQuestion', {
     controller: MultipleChoiceQuestionController,
     controllerAs: 'vm',
     bindings: {
-        question: '='
+        question: '=',
+        selectedAnswerOptions: '='
     }
 });

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.html
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.html
@@ -7,6 +7,10 @@
             <span data-translate="artemisApp.question.hint"></span>
         </span>
     </h4>
+    <div class="question-score">
+        <span data-translate="artemisApp.question.score" class="colon-suffix"></span>
+        <span>{{vm.question.score}}</span>
+    </div>
     <div class="answer-options">
         <div ng-repeat="answerOption in vm.question.answerOptions" class="answer-option" ng-click="vm.toggleSelection(answerOption)">
             <div class="selection">

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.html
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.html
@@ -14,8 +14,8 @@
     <div class="answer-options">
         <div ng-repeat="answerOption in vm.question.answerOptions" class="answer-option" ng-click="vm.toggleSelection(answerOption)">
             <div class="selection">
-                <i class="fa fa-2x fa-check-square-o" ng-if="vm.selectedAnswerOptions.indexOf(answerOption) !== -1"></i>
-                <i class="fa fa-2x fa-square-o" ng-if="vm.selectedAnswerOptions.indexOf(answerOption) === -1"></i>
+                <i class="fa fa-2x fa-check-square-o" ng-if="vm.isAnswerOptionSelected(answerOption)"></i>
+                <i class="fa fa-2x fa-square-o" ng-if="!vm.isAnswerOptionSelected(answerOption)"></i>
             </div>
             <div class="content">
                 <div class="text" ng-bind-html="vm.rendered.answerOptions[$index].text"></div>

--- a/src/main/webapp/app/quiz/participate/quiz.controller.js
+++ b/src/main/webapp/app/quiz/participate/quiz.controller.js
@@ -11,18 +11,27 @@
         var vm = this;
 
         vm.remainingTime = "?";
+        vm.remainingTimeSeconds = 0;
         $interval(function() {
-            if (vm.quizExercise && vm.quizExercise.isPlannedToStart && vm.quizExercise.releaseDate && vm.quizExercise.duration) {
-                var endDate = moment(vm.quizExercise.releaseDate).add(vm.quizExercise.duration, "seconds");
+            vm.remainingTimeSeconds = 0;
+            if (vm.quizExercise && vm.quizExercise.adjustedDueDate) {
+                var endDate = vm.quizExercise.adjustedDueDate;
                 if (endDate.isAfter(moment())) {
-                    vm.remainingTime = endDate.fromNow(true);
+                    vm.remainingTimeSeconds = endDate.diff(moment(), "seconds");
+                    if (vm.remainingTimeSeconds > 90) {
+                        vm.remainingTime = Math.ceil(vm.remainingTimeSeconds / 60) + " minutes";
+                    } else if (vm.remainingTimeSeconds > 4){
+                        vm.remainingTime = vm.remainingTimeSeconds + " seconds";
+                    } else {
+                        vm.remainingTime = "< 5 seconds";
+                    }
                 } else {
-                    vm.remainingTime = "Time over!";
+                    vm.remainingTime = "Quiz has ended!";
                 }
             } else {
                 vm.remainingTime = "?";
             }
-        }, 1000);
+        }, 100);
 
         vm.onSubmit = onSubmit;
 
@@ -35,6 +44,7 @@
                 vm.totalScore = quizExercise.questions.reduce(function (score, question) {
                     return score + question.score;
                 }, 0);
+                vm.quizExercise.adjustedDueDate = moment().add(quizExercise.remainingTime, "seconds");
             });
         }
 

--- a/src/main/webapp/app/quiz/participate/quiz.controller.js
+++ b/src/main/webapp/app/quiz/participate/quiz.controller.js
@@ -5,14 +5,16 @@
         .module('artemisApp')
         .controller('QuizController', QuizController);
 
-    QuizController.$inject = ['$scope', '$stateParams', 'QuizExerciseForStudent', '$interval'];
+    QuizController.$inject = ['$scope', '$stateParams', '$interval', 'QuizExerciseForStudent', 'QuizSubmission', 'QuizSubmissionForExercise'];
 
-    function QuizController($scope, $stateParams, QuizExerciseForStudent, $interval) {
+    function QuizController($scope, $stateParams, $interval, QuizExerciseForStudent, QuizSubmission, QuizSubmissionForExercise) {
         var vm = this;
+
+        vm.isSubmitting = false;
 
         vm.remainingTime = "?";
         vm.remainingTimeSeconds = 0;
-        $interval(function() {
+        $interval(function () {
             vm.remainingTimeSeconds = 0;
             if (vm.quizExercise && vm.quizExercise.adjustedDueDate) {
                 var endDate = vm.quizExercise.adjustedDueDate;
@@ -20,7 +22,7 @@
                     vm.remainingTimeSeconds = endDate.diff(moment(), "seconds");
                     if (vm.remainingTimeSeconds > 90) {
                         vm.remainingTime = Math.ceil(vm.remainingTimeSeconds / 60) + " minutes";
-                    } else if (vm.remainingTimeSeconds > 4){
+                    } else if (vm.remainingTimeSeconds > 4) {
                         vm.remainingTime = vm.remainingTimeSeconds + " seconds";
                     } else {
                         vm.remainingTime = "< 5 seconds";
@@ -38,33 +40,57 @@
         load();
 
         function load() {
-            QuizExerciseForStudent.get({id : $stateParams.id}).$promise.then(function (quizExercise) {
-                vm.quizExercise = quizExercise;
-                vm.totalScore = quizExercise.questions.reduce(function (score, question) {
-                    return score + question.score;
-                }, 0);
-                vm.quizExercise.adjustedDueDate = moment().add(quizExercise.remainingTime, "seconds");
+            QuizSubmissionForExercise.get({
+                courseId: 1,
+                exerciseId: $stateParams.id
+            }).$promise.then(function (quizSubmission) {
+                vm.submission = quizSubmission;
+                QuizExerciseForStudent.get({id: $stateParams.id}).$promise.then(function (quizExercise) {
+                    vm.quizExercise = quizExercise;
+                    vm.totalScore = quizExercise.questions.reduce(function (score, question) {
+                        return score + question.score;
+                    }, 0);
+                    vm.quizExercise.adjustedDueDate = moment().add(quizExercise.remainingTime, "seconds");
 
-                // prepare answers for submission
-                vm.selectedAnswerOptions = {};
-                vm.quizExercise.questions.forEach(function(question) {
-                    vm.selectedAnswerOptions[question.id] = []; // TODO: Load from existing submission, if quiz was resumed
+                    // prepare answers for submission
+                    vm.selectedAnswerOptions = {};
+                    vm.quizExercise.questions.forEach(function (question) {
+                        var submittedAnswer = vm.submission.submittedAnswers.find(function (submittedAnswer) {
+                            return submittedAnswer.question.id === question.id;
+                        });
+                        vm.selectedAnswerOptions[question.id] = submittedAnswer ? submittedAnswer.selectedOptions : [];
+                    });
                 });
             });
         }
 
         function onSubmit() {
-            var submission = {
-                submittedAnswers: Object.keys(vm.selectedAnswerOptions).map(function(questionID) {
-                    return {
-                        question: vm.quizExercise.questions.find(function(question) {
-                            return question.id === Number(questionID);
-                        }),
-                        selectedOptions: vm.selectedAnswerOptions[questionID]
-                    };
-                })
-            };
-            console.log(submission);
+            vm.submission.submittedAnswers = Object.keys(vm.selectedAnswerOptions).map(function (questionID) {
+                var question = vm.quizExercise.questions.find(function (question) {
+                    return question.id === Number(questionID);
+                });
+                if (!question) {
+                    console.error("question not found for ID: " + questionID);
+                    return null;
+                }
+                return {
+                    question: question,
+                    selectedOptions: vm.selectedAnswerOptions[questionID],
+                    type: question.type
+                };
+            });
+            vm.isSubmitting = true;
+            QuizSubmission.update(vm.submission, onSubmitSuccess, onSubmitError)
+        }
+
+        function onSubmitSuccess(result) {
+            vm.isSubmitting = false;
+            console.log("success", result);
+        }
+
+        function onSubmitError() {
+            alert("Submitting answers failed! Please try again later.");
+            vm.isSubmitting = false;
         }
     }
 })();

--- a/src/main/webapp/app/quiz/participate/quiz.controller.js
+++ b/src/main/webapp/app/quiz/participate/quiz.controller.js
@@ -1,0 +1,21 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('artemisApp')
+        .controller('QuizController', QuizController);
+
+    QuizController.$inject = ['$scope', '$stateParams', 'QuizExercise'];
+
+    function QuizController($scope, $stateParams, QuizExercise) {
+        var vm = this;
+
+        load();
+
+        function load() {
+            QuizExercise.get({id : $stateParams.id}).$promise.then(function (quizExercise) {
+                vm.quizExercise = quizExercise;
+            });
+        }
+    }
+})();

--- a/src/main/webapp/app/quiz/participate/quiz.controller.js
+++ b/src/main/webapp/app/quiz/participate/quiz.controller.js
@@ -40,17 +40,31 @@
         function load() {
             QuizExerciseForStudent.get({id : $stateParams.id}).$promise.then(function (quizExercise) {
                 vm.quizExercise = quizExercise;
-                vm.selectedAnswerOptions = []; // TODO: load existing submission
                 vm.totalScore = quizExercise.questions.reduce(function (score, question) {
                     return score + question.score;
                 }, 0);
                 vm.quizExercise.adjustedDueDate = moment().add(quizExercise.remainingTime, "seconds");
+
+                // prepare answers for submission
+                vm.selectedAnswerOptions = {};
+                vm.quizExercise.questions.forEach(function(question) {
+                    vm.selectedAnswerOptions[question.id] = []; // TODO: Load from existing submission, if quiz was resumed
+                });
             });
         }
 
         function onSubmit() {
-            // TODO
-            console.log(vm.selectedAnswerOptions);
+            var submission = {
+                submittedAnswers: Object.keys(vm.selectedAnswerOptions).map(function(questionID) {
+                    return {
+                        question: vm.quizExercise.questions.find(function(question) {
+                            return question.id === Number(questionID);
+                        }),
+                        selectedOptions: vm.selectedAnswerOptions[questionID]
+                    };
+                })
+            };
+            console.log(submission);
         }
     }
 })();

--- a/src/main/webapp/app/quiz/participate/quiz.controller.js
+++ b/src/main/webapp/app/quiz/participate/quiz.controller.js
@@ -5,17 +5,42 @@
         .module('artemisApp')
         .controller('QuizController', QuizController);
 
-    QuizController.$inject = ['$scope', '$stateParams', 'QuizExerciseForStudent'];
+    QuizController.$inject = ['$scope', '$stateParams', 'QuizExerciseForStudent', '$interval'];
 
-    function QuizController($scope, $stateParams, QuizExerciseForStudent) {
+    function QuizController($scope, $stateParams, QuizExerciseForStudent, $interval) {
         var vm = this;
+
+        vm.remainingTime = "?";
+        $interval(function() {
+            if (vm.quizExercise && vm.quizExercise.isPlannedToStart && vm.quizExercise.releaseDate && vm.quizExercise.duration) {
+                var endDate = moment(vm.quizExercise.releaseDate).add(vm.quizExercise.duration, "seconds");
+                if (endDate.isAfter(moment())) {
+                    vm.remainingTime = endDate.fromNow(true);
+                } else {
+                    vm.remainingTime = "Time over!";
+                }
+            } else {
+                vm.remainingTime = "?";
+            }
+        }, 1000);
+
+        vm.onSubmit = onSubmit;
 
         load();
 
         function load() {
             QuizExerciseForStudent.get({id : $stateParams.id}).$promise.then(function (quizExercise) {
                 vm.quizExercise = quizExercise;
+                vm.selectedAnswerOptions = []; // TODO: load existing submission
+                vm.totalScore = quizExercise.questions.reduce(function (score, question) {
+                    return score + question.score;
+                }, 0);
             });
+        }
+
+        function onSubmit() {
+            // TODO
+            console.log(vm.selectedAnswerOptions);
         }
     }
 })();

--- a/src/main/webapp/app/quiz/participate/quiz.controller.js
+++ b/src/main/webapp/app/quiz/participate/quiz.controller.js
@@ -5,15 +5,15 @@
         .module('artemisApp')
         .controller('QuizController', QuizController);
 
-    QuizController.$inject = ['$scope', '$stateParams', 'QuizExercise'];
+    QuizController.$inject = ['$scope', '$stateParams', 'QuizExerciseForStudent'];
 
-    function QuizController($scope, $stateParams, QuizExercise) {
+    function QuizController($scope, $stateParams, QuizExerciseForStudent) {
         var vm = this;
 
         load();
 
         function load() {
-            QuizExercise.get({id : $stateParams.id}).$promise.then(function (quizExercise) {
+            QuizExerciseForStudent.get({id : $stateParams.id}).$promise.then(function (quizExercise) {
                 vm.quizExercise = quizExercise;
             });
         }

--- a/src/main/webapp/app/quiz/participate/quiz.html
+++ b/src/main/webapp/app/quiz/participate/quiz.html
@@ -1,17 +1,39 @@
 <div class="quiz-header container">
-    <h3>Course: {{vm.quizExercise.course.title}}</h3>
-    <h1>Quiz: {{vm.quizExercise.title}}</h1>
-    <p>Mark the correct answers for each question and click the "Submit" button, when you're done.</p>
+    <h3>
+        <span class="colon-suffix" data-translate="artemisApp.exercise.course"></span>
+        {{vm.quizExercise.course.title}} </h3>
+    <h1>
+        <span class="colon-suffix" data-translate="artemisApp.quizExercise.quiz"></span>
+        {{vm.quizExercise.title}} </h1>
+    <p data-translate="artemisApp.quizExercise.quizInstructions"></p>
 </div>
 <div class="quiz-content container">
     <div ng-repeat="question in vm.quizExercise.questions">
-        <multiple-choice-question question="question"></multiple-choice-question>
+        <div class="question-index">
+            <span data-translate="artemisApp.question.detail.title"></span>
+            <span>{{$index+1}}:</span>
+        </div>
+        <multiple-choice-question question="question" selected-answer-options="vm.selectedAnswerOptions" total-score="vm.totalScore"></multiple-choice-question>
     </div>
 </div>
 <div class="quiz-footer">
     <div class="container">
         <div class="quiz-footer-content">
-            TODO: Footer with remaining time, submit button, socket state
+            <div>
+                <div>
+                    <span data-translate="artemisApp.quizExercise.questions" class="colon-suffix"></span>
+                    {{vm.quizExercise.questions.length}}
+                </div>
+                <div>
+                    <span data-translate="artemisApp.question.totalScore" class="colon-suffix"></span>
+                    {{vm.totalScore}}
+                </div>
+            </div>
+            <div id="remaining-time">
+                <span data-translate="artemisApp.quizExercise.remainingTime" class="colon-suffix"></span>
+                <span id="remaining-time-value">{{vm.remainingTime}}</span>
+            </div>
+            <div class="btn btn-success btn-lg" data-translate="entity.action.submit" ng-click="vm.onSubmit()"></div>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/quiz/participate/quiz.html
+++ b/src/main/webapp/app/quiz/participate/quiz.html
@@ -30,7 +30,10 @@
                     {{vm.remainingTime}}
                 </span>
             </div>
-            <div class="btn btn-success btn-lg" data-translate="entity.action.submit" ng-click="vm.onSubmit()"></div>
+            <div ng-if="!vm.isSubmitting" class="btn btn-success btn-lg" data-translate="entity.action.submit" ng-click="vm.onSubmit()"></div>
+            <div ng-if="vm.isSubmitting" class="btn btn-success btn-lg" disabled>
+                <i class="fa fa-circle-o-notch fa-spin"></i>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/quiz/participate/quiz.html
+++ b/src/main/webapp/app/quiz/participate/quiz.html
@@ -28,12 +28,16 @@
                 <div>
                     <span data-translate="artemisApp.quizExercise.remainingTime" class="colon-suffix"></span>
                     <span id="remaining-time-value" ng-class="{'time-critical': vm.remainingTimeSeconds < 60 || vm.remainingTimeSeconds < vm.quizExercise.duration / 4, 'time-warning': vm.remainingTimeSeconds < 120 || vm.remainingTimeSeconds < vm.quizExercise.duration / 2}">
-                        {{vm.remainingTime}}
+                        {{vm.remainingTimeText}}
                     </span>
                 </div>
                 <div>
                     <span ng-if="vm.isSubmitting">Submitting Answers...</span>
-                    <span ng-if="!vm.isSubmitting" uib-tooltip="{{vm.submission.adjustedSubmissionDate | date:'MMM d, y HH:mm:ss'}}" tooltip-placement="right">Last Submission: {{vm.lastSubmissionTimeText}}</span>
+                    <span ng-if="!vm.isSubmitting" uib-tooltip="{{vm.submission.adjustedSubmissionDate | date:'MMM d, y HH:mm:ss'}}" tooltip-placement="right">
+                        <span data-translate="artemisApp.quizExercise.lastSubmission" class="colon-suffix"></span>
+                        <span ng-if="vm.justSubmitted" data-translate="justNow"></span>
+                        <span ng-if="!vm.justSubmitted">{{vm.lastSubmissionTimeText}}</span>
+                    </span>
                 </div>
             </div>
             <button ng-disabled="vm.isSubmitting || vm.remainingTimeSeconds < 0" class="btn btn-success btn-lg" data-translate="entity.action.submit" ng-click="vm.onSubmit()"></button>

--- a/src/main/webapp/app/quiz/participate/quiz.html
+++ b/src/main/webapp/app/quiz/participate/quiz.html
@@ -1,0 +1,17 @@
+<div class="quiz-header container">
+    <h3>Course: {{vm.quizExercise.course.title}}</h3>
+    <h1>Quiz: {{vm.quizExercise.title}}</h1>
+    <p>Mark the correct answers for each question and click the "Submit" button, when you're done.</p>
+</div>
+<div class="quiz-content container">
+    <div ng-repeat="question in vm.quizExercise.questions">
+        <multiple-choice-question question="question"></multiple-choice-question>
+    </div>
+</div>
+<div class="quiz-footer">
+    <div class="container">
+        <div class="quiz-footer-content">
+            TODO: Footer with remaining time, submit button, socket state
+        </div>
+    </div>
+</div>

--- a/src/main/webapp/app/quiz/participate/quiz.html
+++ b/src/main/webapp/app/quiz/participate/quiz.html
@@ -8,7 +8,7 @@
             <span data-translate="artemisApp.question.detail.title"></span>
             <span>{{$index+1}}:</span>
         </div>
-        <multiple-choice-question question="question" selected-answer-options="vm.selectedAnswerOptions" total-score="vm.totalScore"></multiple-choice-question>
+        <multiple-choice-question question="question" selected-answer-options="vm.selectedAnswerOptions[question.id]" total-score="vm.totalScore"></multiple-choice-question>
     </div>
 </div>
 <div class="quiz-footer">

--- a/src/main/webapp/app/quiz/participate/quiz.html
+++ b/src/main/webapp/app/quiz/participate/quiz.html
@@ -1,10 +1,5 @@
 <div class="quiz-header container">
-    <h3>
-        <span class="colon-suffix" data-translate="artemisApp.exercise.course"></span>
-        {{vm.quizExercise.course.title}} </h3>
-    <h1>
-        <span class="colon-suffix" data-translate="artemisApp.quizExercise.quiz"></span>
-        {{vm.quizExercise.title}} </h1>
+    <h1>{{vm.quizExercise.course.title}} - {{vm.quizExercise.title}}</h1>
     <p data-translate="artemisApp.quizExercise.quizInstructions"></p>
 </div>
 <div class="quiz-content container">
@@ -31,7 +26,9 @@
             </div>
             <div id="remaining-time">
                 <span data-translate="artemisApp.quizExercise.remainingTime" class="colon-suffix"></span>
-                <span id="remaining-time-value">{{vm.remainingTime}}</span>
+                <span id="remaining-time-value" ng-class="{'time-critical': vm.remainingTimeSeconds < 60 || vm.remainingTimeSeconds < vm.quizExercise.duration / 4, 'time-warning': vm.remainingTimeSeconds < 120 || vm.remainingTimeSeconds < vm.quizExercise.duration / 2}">
+                    {{vm.remainingTime}}
+                </span>
             </div>
             <div class="btn btn-success btn-lg" data-translate="entity.action.submit" ng-click="vm.onSubmit()"></div>
         </div>

--- a/src/main/webapp/app/quiz/participate/quiz.html
+++ b/src/main/webapp/app/quiz/participate/quiz.html
@@ -25,15 +25,18 @@
                 </div>
             </div>
             <div id="remaining-time">
-                <span data-translate="artemisApp.quizExercise.remainingTime" class="colon-suffix"></span>
-                <span id="remaining-time-value" ng-class="{'time-critical': vm.remainingTimeSeconds < 60 || vm.remainingTimeSeconds < vm.quizExercise.duration / 4, 'time-warning': vm.remainingTimeSeconds < 120 || vm.remainingTimeSeconds < vm.quizExercise.duration / 2}">
-                    {{vm.remainingTime}}
-                </span>
+                <div>
+                    <span data-translate="artemisApp.quizExercise.remainingTime" class="colon-suffix"></span>
+                    <span id="remaining-time-value" ng-class="{'time-critical': vm.remainingTimeSeconds < 60 || vm.remainingTimeSeconds < vm.quizExercise.duration / 4, 'time-warning': vm.remainingTimeSeconds < 120 || vm.remainingTimeSeconds < vm.quizExercise.duration / 2}">
+                        {{vm.remainingTime}}
+                    </span>
+                </div>
+                <div>
+                    <span ng-if="vm.isSubmitting">Submitting Answers...</span>
+                    <span ng-if="!vm.isSubmitting" uib-tooltip="{{vm.submission.submissionDate | date:'MMM d, y HH:mm:ss'}}" tooltip-placement="right">Last Submission: {{vm.lastSubmissionTime}}</span>
+                </div>
             </div>
-            <div ng-if="!vm.isSubmitting" class="btn btn-success btn-lg" data-translate="entity.action.submit" ng-click="vm.onSubmit()"></div>
-            <div ng-if="vm.isSubmitting" class="btn btn-success btn-lg" disabled>
-                <i class="fa fa-circle-o-notch fa-spin"></i>
-            </div>
+            <button ng-disabled="vm.isSubmitting || vm.remainingTimeSeconds < 0" class="btn btn-success btn-lg" data-translate="entity.action.submit" ng-click="vm.onSubmit()"></button>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/quiz/participate/quiz.html
+++ b/src/main/webapp/app/quiz/participate/quiz.html
@@ -33,7 +33,7 @@
                 </div>
                 <div>
                     <span ng-if="vm.isSubmitting">Submitting Answers...</span>
-                    <span ng-if="!vm.isSubmitting" uib-tooltip="{{vm.submission.submissionDate | date:'MMM d, y HH:mm:ss'}}" tooltip-placement="right">Last Submission: {{vm.lastSubmissionTime}}</span>
+                    <span ng-if="!vm.isSubmitting" uib-tooltip="{{vm.submission.adjustedSubmissionDate | date:'MMM d, y HH:mm:ss'}}" tooltip-placement="right">Last Submission: {{vm.lastSubmissionTimeText}}</span>
                 </div>
             </div>
             <button ng-disabled="vm.isSubmitting || vm.remainingTimeSeconds < 0" class="btn btn-success btn-lg" data-translate="entity.action.submit" ng-click="vm.onSubmit()"></button>

--- a/src/main/webapp/app/quiz/participate/quiz.state.js
+++ b/src/main/webapp/app/quiz/participate/quiz.state.js
@@ -1,0 +1,35 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('artemisApp')
+        .config(stateConfig);
+
+    stateConfig.$inject = ['$stateProvider'];
+
+    function stateConfig($stateProvider) {
+        $stateProvider
+            .state('quiz-participate', {
+                parent: 'app',
+                url: '/quiz/{id}',
+                data: {
+                    authorities: []
+                },
+                views: {
+                    'content@': {
+                        templateUrl: 'app/quiz/participate/quiz.html',
+                        controller: 'QuizController',
+                        controllerAs: 'vm'
+                    }
+                },
+                resolve: {
+                    mainTranslatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate, $translatePartialLoader) {
+                        $translatePartialLoader.addPart('quizExercise');
+                        $translatePartialLoader.addPart('exercise');
+                        $translatePartialLoader.addPart('global');
+                        return $translate.refresh();
+                    }]
+                }
+            })
+    }
+})();

--- a/src/main/webapp/content/css/main.css
+++ b/src/main/webapp/content/css/main.css
@@ -8482,20 +8482,24 @@ body.editor .navbar-brand span {
     .mc-question .answer-option:hover {
       background: #fafafa; }
 
-.quiz-header h3 {
-  margin: 0; }
+.quiz-header,
+.quiz-content,
+.quiz-footer-content {
+  font-size: 16px; }
 
 .quiz-content {
-  margin-top: 20px;
+  margin-top: 6px;
   margin-bottom: 120px; }
   .quiz-content .question-index {
     padding: 2px 6px; }
 
-.quiz-footer-content #remaining-time {
-  font-size: 16px; }
-
 .quiz-footer-content #remaining-time-value {
-  font-weight: bold;
+  font-weight: bold; }
+
+.quiz-footer-content .time-warning {
+  color: orange; }
+
+.quiz-footer-content .time-critical {
   color: red; }
 
 .colon-suffix:after {

--- a/src/main/webapp/content/css/main.css
+++ b/src/main/webapp/content/css/main.css
@@ -8493,6 +8493,9 @@ body.editor .navbar-brand span {
   .quiz-content .question-index {
     padding: 2px 6px; }
 
+.quiz-footer-content #remaining-time {
+  text-align: center; }
+
 .quiz-footer-content #remaining-time-value {
   font-weight: bold; }
 

--- a/src/main/webapp/content/css/main.css
+++ b/src/main/webapp/content/css/main.css
@@ -8438,6 +8438,7 @@ body.editor .navbar-brand span {
     height: 12em; }
 
 .mc-question {
+  position: relative;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid lightgrey;
@@ -8449,6 +8450,10 @@ body.editor .navbar-brand span {
   .mc-question p {
     margin: 10px 0;
     font-size: 16px; }
+  .mc-question .question-score {
+    position: absolute;
+    top: 20px;
+    right: 20px; }
   .mc-question .label {
     cursor: pointer; }
   .mc-question .answer-options {
@@ -8479,6 +8484,19 @@ body.editor .navbar-brand span {
 
 .quiz-header h3 {
   margin: 0; }
+
+.quiz-content {
+  margin-top: 20px;
+  margin-bottom: 120px; }
+  .quiz-content .question-index {
+    padding: 2px 6px; }
+
+.quiz-footer-content #remaining-time {
+  font-size: 16px; }
+
+.quiz-footer-content #remaining-time-value {
+  font-weight: bold;
+  color: red; }
 
 .colon-suffix:after {
   content: ":"; }

--- a/src/main/webapp/content/css/main.css
+++ b/src/main/webapp/content/css/main.css
@@ -8369,7 +8369,8 @@ body.editor .navbar-brand span {
     .question-options .form-group > * {
       margin: 0 4px; }
 
-.edit-quiz-footer {
+.edit-quiz-footer,
+.quiz-footer {
   position: fixed;
   height: 100px;
   bottom: 0;
@@ -8378,22 +8379,28 @@ body.editor .navbar-brand span {
   z-index: 10;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.7);
   background: white; }
-  .edit-quiz-footer .container {
+  .edit-quiz-footer .container,
+  .quiz-footer .container {
     height: 100%; }
 
-.edit-quiz-footer-content {
+.edit-quiz-footer-content,
+.quiz-footer-content {
   height: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between; }
   .edit-quiz-footer-content .form-control,
-  .edit-quiz-footer-content .input-group-btn {
+  .edit-quiz-footer-content .input-group-btn,
+  .quiz-footer-content .form-control,
+  .quiz-footer-content .input-group-btn {
     display: inline-block;
     width: auto; }
-  .edit-quiz-footer-content .form-group {
+  .edit-quiz-footer-content .form-group,
+  .quiz-footer-content .form-group {
     display: flex;
     align-items: center; }
-    .edit-quiz-footer-content .form-group > * {
+    .edit-quiz-footer-content .form-group > *,
+    .quiz-footer-content .form-group > * {
       margin: 0 4px; }
 
 .question:first-of-type {
@@ -8469,6 +8476,9 @@ body.editor .navbar-brand span {
         font-size: 18px; }
     .mc-question .answer-option:hover {
       background: #fafafa; }
+
+.quiz-header h3 {
+  margin: 0; }
 
 .colon-suffix:after {
   content: ":"; }

--- a/src/main/webapp/content/css/main.css
+++ b/src/main/webapp/content/css/main.css
@@ -8446,7 +8446,7 @@ body.editor .navbar-brand span {
   padding: 20px;
   background: #fefefe; }
   .mc-question h2 {
-    margin: 0; }
+    margin: 0 90px 0 0; }
   .mc-question p {
     margin: 10px 0;
     font-size: 16px; }

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -116,7 +116,8 @@
             "view": "Details",
             "preview": "Vorschau",
             "cleanup": "Aufräumen",
-            "archive": "Archivieren"
+            "archive": "Archivieren",
+            "submit": "Submit"
         },
         "detail": {
             "field": "Feld",

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -117,7 +117,7 @@
             "preview": "Vorschau",
             "cleanup": "Aufräumen",
             "archive": "Archivieren",
-            "submit": "Submit"
+            "submit": "Absenden"
         },
         "detail": {
             "field": "Feld",
@@ -155,5 +155,6 @@
         "emailexists": "Email wird bereits verwendet!",
         "idexists": "Ein neuer {{entityName}} kann noch keine ID haben"
     },
-    "footer": "Dies ist Ihre Fußzeile"
+    "footer": "Dies ist Ihre Fußzeile",
+    "justNow": "gerade eben"
 }

--- a/src/main/webapp/i18n/de/question.json
+++ b/src/main/webapp/i18n/de/question.json
@@ -2,28 +2,28 @@
     "artemisApp": {
         "question" : {
             "home": {
-                "title": "Questions",
-                "createLabel": "Question erstellen",
-                "createOrEditLabel": "Question erstellen oder bearbeiten"
+                "title": "Fragen",
+                "createLabel": "Frage erstellen",
+                "createOrEditLabel": "Frage erstellen oder bearbeiten"
             },
-            "created": "Question erstellt mit ID {{ param }}",
-            "updated": "Question aktualisiert mit ID {{ param }}",
-            "deleted": "Question gelöscht mit ID {{ param }}",
+            "created": "Frage erstellt mit ID {{ param }}",
+            "updated": "Frage aktualisiert mit ID {{ param }}",
+            "deleted": "Frage gelöscht mit ID {{ param }}",
             "delete": {
-                "question": "Soll Question {{ id }} wirklich dauerhaft gelöscht werden?"
+                "question": "Soll Frage {{ id }} wirklich dauerhaft gelöscht werden?"
             },
             "detail": {
-                "title": "Question"
+                "title": "Frage"
             },
-            "title": "Title",
+            "title": "Titel",
             "text": "Text",
-            "hint": "Hint",
-            "explanation": "Explanation",
-            "score": "Points",
-            "totalScore": "Total Points",
-            "randomizeOrder": "Present Answers in Random Order",
-            "scoringType": "Scoring Type",
-            "exercise": "Exercise"
+            "hint": "Hinweis",
+            "explanation": "Erklärung",
+            "score": "Punkte",
+            "totalScore": "Gesamtpunktzahl",
+            "randomizeOrder": "Fragen in zufälliger Reihenfolge anzeigen",
+            "scoringType": "Bewertungsweise",
+            "exercise": "Übung"
         }
     }
 }

--- a/src/main/webapp/i18n/de/question.json
+++ b/src/main/webapp/i18n/de/question.json
@@ -19,7 +19,8 @@
             "text": "Text",
             "hint": "Hint",
             "explanation": "Explanation",
-            "score": "Score",
+            "score": "Points",
+            "totalScore": "Total Points",
             "randomizeOrder": "Present Answers in Random Order",
             "scoringType": "Scoring Type",
             "exercise": "Exercise"

--- a/src/main/webapp/i18n/de/quizExercise.json
+++ b/src/main/webapp/i18n/de/quizExercise.json
@@ -37,7 +37,10 @@
             "secondsShort": "s",
             "questions": "Questions",
             "status": "Status",
-            "startTime": "Start Time"
+            "startTime": "Start Time",
+            "quiz": "Quiz",
+            "remainingTime": "Remaining Time",
+            "quizInstructions": "Mark the correct answers for each question and click the \"Submit\" button, when you're done."
         }
     }
 }

--- a/src/main/webapp/i18n/de/quizExercise.json
+++ b/src/main/webapp/i18n/de/quizExercise.json
@@ -2,45 +2,46 @@
     "artemisApp": {
         "quizExercise": {
             "home": {
-                "title": "Quiz Exercises",
-                "createLabel": "Quiz Exercise erstellen",
-                "createOrEditLabel": "Quiz Exercise erstellen oder bearbeiten"
+                "title": "Quiz",
+                "createLabel": "Quiz erstellen",
+                "createOrEditLabel": "Quiz erstellen oder bearbeiten"
             },
-            "created": "Quiz Exercise erstellt mit ID {{ param }}",
-            "updated": "Quiz Exercise aktualisiert mit ID {{ param }}",
-            "deleted": "Quiz Exercise gelöscht mit ID {{ param }}",
+            "created": "Quiz erstellt mit ID {{ param }}",
+            "updated": "Quiz aktualisiert mit ID {{ param }}",
+            "deleted": "Quiz gelöscht mit ID {{ param }}",
             "delete": {
-                "question": "Soll Quiz Exercise {{ id }} wirklich dauerhaft gelöscht werden?"
+                "question": "Soll Quiz {{ id }} wirklich dauerhaft gelöscht werden?"
             },
             "edit": {
-                "title": "Edit Quiz Exercise for {{ param }}",
-                "addQuestion": "Add Question",
-                "invalidInput": "Invalid Input!",
-                "pendingChanges": "Unsaved Changes",
-                "saving": "Saving…",
-                "saved": "Saved!"
+                "title": "Quiz für {{ param }} bearbeiten",
+                "addQuestion": "Frage hinzufügen",
+                "invalidInput": "Ungültige Eingabe!",
+                "pendingChanges": "Ungespeicherte Änderungen",
+                "saving": "Speichern …",
+                "saved": "Gespeichert!"
             },
             "new": {
-                "title": "New Quiz Exercise for {{ param }}"
+                "title": "Quiz für {{ param }} erstellen"
             },
-            "description": "Description",
-            "explanation": "Explanation",
-            "randomizeQuestionOrder": "Randomize Question Order",
-            "allowedNumberOfAttempts": "Allowed Number Of Attempts",
-            "isVisibleBeforeStart": "Is Visible Before Start",
-            "isOpenForPractice": "Is Open For Practice",
-            "isPlannedToStart": "Is Planned To Start",
-            "duration": "Duration",
-            "minutes": "minutes",
-            "seconds": "seconds",
+            "description": "Beschreibung",
+            "explanation": "Erklärung",
+            "randomizeQuestionOrder": "Fragen in zufälliger Reihenfolge anzeigen",
+            "allowedNumberOfAttempts": "Erlaubte Anzahl an Versuchen",
+            "isVisibleBeforeStart": "Vor dem Start sichtbar",
+            "isOpenForPractice": "Zum Üben freigegeben",
+            "isPlannedToStart": "Geplante Startzeit",
+            "duration": "Dauer",
+            "minutes": "Minuten",
+            "seconds": "Sekunden",
             "minutesShort": "min",
             "secondsShort": "s",
-            "questions": "Questions",
+            "questions": "Fragen",
             "status": "Status",
-            "startTime": "Start Time",
+            "startTime": "Startzeit",
             "quiz": "Quiz",
-            "remainingTime": "Remaining Time",
-            "quizInstructions": "Mark the correct answers for each question and click the \"Submit\" button, when you're done."
+            "remainingTime": "Verbleibende Zeit",
+            "quizInstructions": "Wählen Sie für jede Frage die richtigen Antworten aus und klicken Sie auf \"Absenden\", um ihre Auswahl abzugeben.",
+            "lastSubmission": "Zuletzt gesendet"
         }
     }
 }

--- a/src/main/webapp/i18n/de/submittedAnswer.json
+++ b/src/main/webapp/i18n/de/submittedAnswer.json
@@ -15,6 +15,7 @@
             "detail": {
                 "title": "Submitted Answer"
             },
+            "question": "Question",
             "submission": "Submission"
         }
     }

--- a/src/main/webapp/i18n/de/submittedAnswer.json
+++ b/src/main/webapp/i18n/de/submittedAnswer.json
@@ -2,21 +2,21 @@
     "artemisApp": {
         "submittedAnswer" : {
             "home": {
-                "title": "Submitted Answers",
-                "createLabel": "Submitted Answer erstellen",
-                "createOrEditLabel": "Submitted Answer erstellen oder bearbeiten"
+                "title": "Eingereichte Lösungen",
+                "createLabel": "Eingereichte Lösung erstellen",
+                "createOrEditLabel": "Eingereichte Lösung erstellen oder bearbeiten"
             },
-            "created": "Submitted Answer erstellt mit ID {{ param }}",
-            "updated": "Submitted Answer aktualisiert mit ID {{ param }}",
-            "deleted": "Submitted Answer gelöscht mit ID {{ param }}",
+            "created": "Eingereichte Lösung erstellt mit ID {{ param }}",
+            "updated": "Eingereichte Lösung aktualisiert mit ID {{ param }}",
+            "deleted": "Eingereichte Lösung gelöscht mit ID {{ param }}",
             "delete": {
-                "question": "Soll Submitted Answer {{ id }} wirklich dauerhaft gelöscht werden?"
+                "question": "Soll Eingereichte Lösung {{ id }} wirklich dauerhaft gelöscht werden?"
             },
             "detail": {
-                "title": "Submitted Answer"
+                "title": "Eingereichte Lösung"
             },
-            "question": "Question",
-            "submission": "Submission"
+            "question": "Frage",
+            "submission": "Abgabe"
         }
     }
 }

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -157,5 +157,6 @@
         "invalid.build.plan.id": "The Build Plan ID seems to be invalid. Please make sure it exists and is accessible for ArTEMiS.",
         "invalid.repository.url": "The Repository URL seems to be invalid. Please make sure it exists and is accessible for ArTEMiS."
     },
-    "footer": "Found a bug or have some feedback? Please <a href=\"mailto:krusche@in.tum.de\">let us know</a>!"
+    "footer": "Found a bug or have some feedback? Please <a href=\"mailto:krusche@in.tum.de\">let us know</a>!",
+    "justNow": "just now"
 }

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -116,7 +116,8 @@
             "view": "View",
             "preview": "Preview",
             "cleanup": "Cleanup",
-            "archive": "Archive"
+            "archive": "Archive",
+            "submit": "Submit"
         },
         "detail": {
             "field": "Field",

--- a/src/main/webapp/i18n/en/question.json
+++ b/src/main/webapp/i18n/en/question.json
@@ -19,7 +19,8 @@
             "text": "Text",
             "hint": "Hint",
             "explanation": "Explanation",
-            "score": "Score",
+            "score": "Points",
+            "totalScore": "Total Points",
             "randomizeOrder": "Present Answers in Random Order",
             "scoringType": "Scoring Type",
             "exercise": "Exercise"

--- a/src/main/webapp/i18n/en/quizExercise.json
+++ b/src/main/webapp/i18n/en/quizExercise.json
@@ -40,7 +40,8 @@
             "startTime": "Start Time",
             "quiz": "Quiz",
             "remainingTime": "Remaining Time",
-            "quizInstructions": "Mark the correct answers for each question and click the \"Submit\" button, when you're done."
+            "quizInstructions": "Mark the correct answers for each question and click the \"Submit\" button, when you're done.",
+            "lastSubmission": "Last Submission"
         }
     }
 }

--- a/src/main/webapp/i18n/en/quizExercise.json
+++ b/src/main/webapp/i18n/en/quizExercise.json
@@ -37,7 +37,10 @@
             "secondsShort": "s",
             "questions": "Questions",
             "status": "Status",
-            "startTime": "Start Time"
+            "startTime": "Start Time",
+            "quiz": "Quiz",
+            "remainingTime": "Remaining Time",
+            "quizInstructions": "Mark the correct answers for each question and click the \"Submit\" button, when you're done."
         }
     }
 }

--- a/src/main/webapp/i18n/en/submittedAnswer.json
+++ b/src/main/webapp/i18n/en/submittedAnswer.json
@@ -15,6 +15,7 @@
             "detail": {
                 "title": "Submitted Answer"
             },
+            "question": "Question",
             "submission": "Submission"
         }
     }

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -116,6 +116,8 @@
     <script src="app/services/auth/auth.service.js"></script>
     <script src="app/services/auth/activate.service.js"></script>
     <script src="app/services/auth/account.service.js"></script>
+    <script src="app/quiz/participate/quiz.state.js"></script>
+    <script src="app/quiz/participate/quiz.controller.js"></script>
     <script src="app/quiz/participate/multiple-choice-question/multiple-choice-question.component.js"></script>
     <script src="app/quiz/edit/multiple-choice-question/edit-multiple-choice-question.component.js"></script>
     <script src="app/layouts/navbar/navbar.controller.js"></script>

--- a/src/main/webapp/scss/quiz.scss
+++ b/src/main/webapp/scss/quiz.scss
@@ -147,7 +147,7 @@
     background: #fefefe;
 
     h2 {
-        margin: 0;
+        margin: 0 90px 0 0;
     }
 
     p {

--- a/src/main/webapp/scss/quiz.scss
+++ b/src/main/webapp/scss/quiz.scss
@@ -221,6 +221,10 @@
 }
 
 .quiz-footer-content {
+    #remaining-time {
+        text-align: center;
+    }
+
     #remaining-time-value {
         font-weight: bold;
     }

--- a/src/main/webapp/scss/quiz.scss
+++ b/src/main/webapp/scss/quiz.scss
@@ -42,7 +42,8 @@
     }
 }
 
-.edit-quiz-footer {
+.edit-quiz-footer,
+.quiz-footer {
     position: fixed;
     height: 100px;
     bottom: 0;
@@ -59,7 +60,8 @@
     }
 }
 
-.edit-quiz-footer-content {
+.edit-quiz-footer-content,
+.quiz-footer-content {
     height: 100%;
     display: flex;
     align-items: center;
@@ -194,7 +196,12 @@
             background: #fafafa;
         }
     }
+}
 
+.quiz-header {
+    h3 {
+        margin: 0;
+    }
 }
 
 .colon-suffix:after {

--- a/src/main/webapp/scss/quiz.scss
+++ b/src/main/webapp/scss/quiz.scss
@@ -138,6 +138,7 @@
 }
 
 .mc-question {
+    position: relative;
     width: 100%;
     box-sizing: border-box;
     border: 1px solid lightgrey;
@@ -152,6 +153,12 @@
     p {
         margin: 10px 0;
         font-size: 16px;
+    }
+
+    .question-score {
+        position: absolute;
+        top: 20px;
+        right: 20px;
     }
 
     .label {
@@ -201,6 +208,27 @@
 .quiz-header {
     h3 {
         margin: 0;
+    }
+}
+
+.quiz-content {
+
+    margin-top: 20px;
+    margin-bottom: 120px;
+
+    .question-index {
+        padding: 2px 6px;
+    }
+}
+
+.quiz-footer-content {
+    #remaining-time {
+        font-size: 16px;
+    }
+
+    #remaining-time-value {
+        font-weight: bold;
+        color: red;
     }
 }
 

--- a/src/main/webapp/scss/quiz.scss
+++ b/src/main/webapp/scss/quiz.scss
@@ -205,15 +205,14 @@
     }
 }
 
-.quiz-header {
-    h3 {
-        margin: 0;
-    }
+.quiz-header,
+.quiz-content,
+.quiz-footer-content {
+    font-size: 16px;
 }
 
 .quiz-content {
-
-    margin-top: 20px;
+    margin-top: 6px;
     margin-bottom: 120px;
 
     .question-index {
@@ -222,12 +221,15 @@
 }
 
 .quiz-footer-content {
-    #remaining-time {
-        font-size: 16px;
-    }
-
     #remaining-time-value {
         font-weight: bold;
+    }
+
+    .time-warning {
+        color: orange;
+    }
+
+    .time-critical {
         color: red;
     }
 }

--- a/src/test/java/de/tum/in/www1/exerciseapp/web/rest/QuizSubmissionResourceIntTest.java
+++ b/src/test/java/de/tum/in/www1/exerciseapp/web/rest/QuizSubmissionResourceIntTest.java
@@ -3,7 +3,10 @@ package de.tum.in.www1.exerciseapp.web.rest;
 import de.tum.in.www1.exerciseapp.ArTEMiSApp;
 
 import de.tum.in.www1.exerciseapp.domain.QuizSubmission;
+import de.tum.in.www1.exerciseapp.repository.QuizExerciseRepository;
 import de.tum.in.www1.exerciseapp.repository.QuizSubmissionRepository;
+import de.tum.in.www1.exerciseapp.repository.ResultRepository;
+import de.tum.in.www1.exerciseapp.service.ParticipationService;
 import de.tum.in.www1.exerciseapp.web.rest.errors.ExceptionTranslator;
 
 import org.junit.Before;
@@ -41,6 +44,15 @@ public class QuizSubmissionResourceIntTest {
     private QuizSubmissionRepository quizSubmissionRepository;
 
     @Autowired
+    private QuizExerciseRepository quizExerciseRepository;
+
+    @Autowired
+    private ResultRepository resultRepository;
+
+    @Autowired
+    private ParticipationService participationService;
+
+    @Autowired
     private MappingJackson2HttpMessageConverter jacksonMessageConverter;
 
     @Autowired
@@ -59,7 +71,7 @@ public class QuizSubmissionResourceIntTest {
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        final QuizSubmissionResource quizSubmissionResource = new QuizSubmissionResource(quizSubmissionRepository);
+        final QuizSubmissionResource quizSubmissionResource = new QuizSubmissionResource(quizSubmissionRepository, quizExerciseRepository, resultRepository, participationService);
         this.restQuizSubmissionMockMvc = MockMvcBuilders.standaloneSetup(quizSubmissionResource)
             .setCustomArgumentResolvers(pageableArgumentResolver)
             .setControllerAdvice(exceptionTranslator)

--- a/src/test/javascript/karma.conf.js
+++ b/src/test/javascript/karma.conf.js
@@ -45,7 +45,10 @@ module.exports = function (config) {
             'src/main/webapp/bower_components/ace-builds/src-min-noconflict/mode-jade.js',
             'src/main/webapp/bower_components/ace-builds/src-min-noconflict/mode-swift.js',
             'src/main/webapp/bower_components/ace-builds/src-min-noconflict/ext-modelist.js',
+            'src/main/webapp/bower_components/blob-polyfill/Blob.js',
+            'src/main/webapp/bower_components/file-saver.js/FileSaver.js',
             'src/main/webapp/bower_components/remarkable/dist/remarkable.js',
+            'src/main/webapp/bower_components/showdown/dist/showdown.js',
             'src/main/webapp/bower_components/angular/angular.js',
             'src/main/webapp/bower_components/angular-aria/angular-aria.js',
             'src/main/webapp/bower_components/angular-bootstrap/ui-bootstrap-tpls.js',
@@ -67,6 +70,7 @@ module.exports = function (config) {
             'src/main/webapp/bower_components/angular-moment/angular-moment.js',
             'src/main/webapp/bower_components/bootstrap-treeview/dist/bootstrap-treeview.min.js',
             'src/main/webapp/bower_components/angular-ui-ace/ui-ace.js',
+            'src/main/webapp/bower_components/angular-file-saver/dist/angular-file-saver.bundle.js',
             'src/main/webapp/bower_components/angular-resizable/src/angular-resizable.js',
             'src/main/webapp/bower_components/angular-mocks/angular-mocks.js',
             // endbower

--- a/src/test/javascript/spec/app/entities/submitted-answer/submitted-answer-detail.controller.spec.js
+++ b/src/test/javascript/spec/app/entities/submitted-answer/submitted-answer-detail.controller.spec.js
@@ -4,7 +4,7 @@ describe('Controller Tests', function() {
 
     describe('SubmittedAnswer Management Detail Controller', function() {
         var $scope, $rootScope;
-        var MockEntity, MockPreviousState, MockSubmittedAnswer, MockQuizSubmission;
+        var MockEntity, MockPreviousState, MockSubmittedAnswer, MockQuestion, MockQuizSubmission;
         var createController;
 
         beforeEach(inject(function($injector) {
@@ -13,6 +13,7 @@ describe('Controller Tests', function() {
             MockEntity = jasmine.createSpy('MockEntity');
             MockPreviousState = jasmine.createSpy('MockPreviousState');
             MockSubmittedAnswer = jasmine.createSpy('MockSubmittedAnswer');
+            MockQuestion = jasmine.createSpy('MockQuestion');
             MockQuizSubmission = jasmine.createSpy('MockQuizSubmission');
             
 
@@ -22,6 +23,7 @@ describe('Controller Tests', function() {
                 'entity': MockEntity,
                 'previousState': MockPreviousState,
                 'SubmittedAnswer': MockSubmittedAnswer,
+                'Question': MockQuestion,
                 'QuizSubmission': MockQuizSubmission
             };
             createController = function() {


### PR DESCRIPTION
## Summary
Adds the initial student-facing quiz participation workflow. Quiz exercises in the course exercise list now open a quiz participation route where students can answer multiple-choice questions, see score, remaining time, and last-submission information, and submit answers while the quiz is still active.

## Motivation and Context
This enables students to participate in quiz exercises from the course page instead of only creating or managing quiz content. No issue is linked to this PR.

Original note from the PR: The Submit button behavior differs from what was discussed in the team call, and the socket connection is still missing.

## Description
- Adds the AngularJS quiz participation route, controller, and template under `src/main/webapp/app/quiz/participate/`, wires them in `index.html`, and updates quiz styles, labels, and English/German translations.
- Updates the course exercise list so quiz exercises navigate to `/quiz/{id}`, use quiz-specific start/resume text and status states, and rely on the backend `isVisibleToStudents` flag for release visibility.
- Extends the multiple-choice participation component so selected answer options are managed by the parent quiz controller, compared by answer option id, and displayed together with the question score.
- Adds student-safe quiz exercise retrieval via `/api/quiz-exercises/{id}/for-student`, filtering explanations and correct-answer markers from the response.
- Changes course exercise retrieval to filter by course permissions and student visibility on the backend, and removes quiz questions from exercise-list payloads.
- Adds quiz submission support with `/courses/{courseId}/exercises/{exerciseId}/submissions/my-latest` to initialize or retrieve the current participation/result/submission and `PUT /api/quiz-submissions` to save submitted answers and update the result completion date before the quiz ends.
- Extends quiz submission and submitted-answer persistence with a submitted-answer-to-question relation, JSON subtype metadata for submitted answer types, cascading eager quiz submitted answers, a transient submission date, repository helpers, Liquibase migration, and updated tests for the changed resource constructor.

## Steps for Testing
Prerequisites:
- A course with a planned quiz exercise containing multiple-choice questions.
- One instructor or teaching assistant and one student enrolled in the course.

1. Log in as the student and open the course exercise list after the quiz is visible to students.
2. Verify that the quiz row shows quiz-specific status text and Start Quiz or Resume Quiz, then start the quiz.
3. Verify that `/quiz/{exerciseId}` opens and shows the course title, quiz title, questions, question scores, total score, remaining time, and last-submission information.
4. Select and deselect multiple-choice answer options, submit the quiz, and verify that the last-submission display updates.
5. Reload or resume the quiz and verify that the previous selected answer options are loaded from the latest submission.
6. Verify that student-facing quiz responses do not expose correct-answer markers or explanations in the network payload.
7. Let the quiz time expire or use a quiz whose due date is in the past, then verify that submitting is disabled or rejected.
8. As instructor or teaching assistant, verify that the exercise list still shows unreleased exercises as not released, while students only receive exercises visible to them.

## Checklist
- [x] I have read and followed the [coding guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/)
- [x] PR title follows the Artemis naming convention.
- [x] PR description matches the actual diff.
- [ ] Manual quiz participation flow has been tested on a suitable test setup.
- [ ] Relevant automated tests have been run.