### PR TITLE
added more padding for dropdown

### DIFF
--- a/src/main/webapp/app/entities/course/course.component.html
+++ b/src/main/webapp/app/entities/course/course.component.html
@@ -12,7 +12,7 @@
     <div class="row">
     </div>
     <br/>
-    <div class="table-responsive" *ngIf="courses">
+    <div class="table-responsive course-table" *ngIf="courses">
         <table class="table table-striped">
             <thead>
             <tr>

--- a/src/main/webapp/app/entities/course/course.component.ts
+++ b/src/main/webapp/app/entities/course/course.component.ts
@@ -9,7 +9,8 @@ import { Principal } from '../../shared';
 
 @Component({
     selector: 'jhi-course',
-    templateUrl: './course.component.html'
+    templateUrl: './course.component.html',
+    styles: ['.course-table {padding-bottom: 5rem}']
 })
 export class CourseComponent implements OnInit, OnDestroy {
     courses: Course[];


### PR DESCRIPTION
Problem of disappearing dropdown:

The overlying div with class _table-responsive_ implies a overflow-x of auto. The result is by W3C spec http://www.w3.org/TR/css3-box/#overflow-x the overflow of y is automatically set to auto as well.

This results in the y axis also to be scrollable because of missing space.

Quick fix -> giving Table enough padding to be displayed.