### PR TITLE
Rename #userHasInstructorPermissions, #userHasTAPermissions and #userHasStudentPermissions to show taxonomy.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -66,7 +66,7 @@ public class CourseService {
      * @param course the course to check permissions for
      * @return true, if the user has the required permissions, false otherwise
      */
-    public boolean userHasStudentPermissions(Course course) {
+    public boolean userHasAtLeastStudentPermissions(Course course) {
         User user = userService.getUserWithGroupsAndAuthorities();
         return authCheckService.isStudentInCourse(course, user) ||
             authCheckService.isTeachingAssistantInCourse(course, user) ||
@@ -80,7 +80,7 @@ public class CourseService {
      * @param course the course to check permissions for
      * @return true, if the user has the required permissions, false otherwise
      */
-    public boolean userHasTAPermissions(Course course) {
+    public boolean userHasAtLeastTAPermissions(Course course) {
         User user = userService.getUserWithGroupsAndAuthorities();
         return authCheckService.isTeachingAssistantInCourse(course, user) ||
             authCheckService.isInstructorInCourse(course, user) ||
@@ -93,7 +93,7 @@ public class CourseService {
      * @param course the course to check permissions for
      * @return true, if the user has the required permissions, false otherwise
      */
-    public boolean userHasInstructorPermissions(Course course) {
+    public boolean userHasAtLeastInstructorPermissions(Course course) {
         User user = userService.getUserWithGroupsAndAuthorities();
         return authCheckService.isInstructorInCourse(course, user) ||
             authCheckService.isAdmin();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
@@ -133,7 +133,7 @@ public class ModelingAssessmentResource {
     public ResponseEntity<String> getAssessmentBySubmissionId(@PathVariable Long participationId, @PathVariable Long submissionId) {
         Participation participation = participationRepository.findOne(participationId);
 
-        if (!courseService.userHasStudentPermissions(participation.getExercise().getCourse())) {
+        if (!courseService.userHasAtLeastStudentPermissions(participation.getExercise().getCourse())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -247,7 +247,7 @@ public class ModelingExerciseResource {
         }
         ModelingExercise modelingExercise = (ModelingExercise) participation.getExercise();
 
-        if (!courseService.userHasStudentPermissions(modelingExercise.getCourse())) {
+        if (!courseService.userHasAtLeastStudentPermissions(modelingExercise.getCourse())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -99,7 +99,7 @@ public class ModelingSubmissionResource {
         if (course == null) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "courseNotFound", "The course belonging to this modeling exercise does not exist")).body(null);
         }
-        if (!courseService.userHasStudentPermissions(course)) {
+        if (!courseService.userHasAtLeastStudentPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -148,7 +148,7 @@ public class ModelingSubmissionResource {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "courseNotFound", "The course belonging to this modeling exercise does not exist")).body(null);
         }
         User user = userService.getUserWithGroupsAndAuthorities();
-        if (!courseService.userHasStudentPermissions(course)) {
+        if (!courseService.userHasAtLeastStudentPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -71,7 +71,7 @@ public class ParticipationResource {
     public ResponseEntity<Participation> createParticipation(@RequestBody Participation participation) throws URISyntaxException {
         log.debug("REST request to save Participation : {}", participation);
         Course course = participation.getExercise().getCourse();
-        if (!courseService.userHasTAPermissions(course)) {
+        if (!courseService.userHasAtLeastTAPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         if (participation.getId() != null) {
@@ -98,7 +98,7 @@ public class ParticipationResource {
         log.debug("REST request to init Exercise : {}", exerciseId);
         Exercise exercise = exerciseService.findOne(exerciseId);
         Course course = exercise.getCourse();
-        if (!courseService.userHasStudentPermissions(course)) {
+        if (!courseService.userHasAtLeastStudentPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         if (Optional.ofNullable(exercise).isPresent()) {
@@ -131,7 +131,7 @@ public class ParticipationResource {
         Participation participation = participationService.findOneByExerciseIdAndStudentLogin(exerciseId, principal.getName());
         Course course = participation.getExercise().getCourse();
         if (!authCheckService.isOwnerOfParticipation(participation)) {
-            if(!courseService.userHasTAPermissions(course)) {
+            if(!courseService.userHasAtLeastTAPermissions(course)) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }
         }
@@ -159,7 +159,7 @@ public class ParticipationResource {
     public ResponseEntity<Participation> updateParticipation(@RequestBody Participation participation) throws URISyntaxException {
         log.debug("REST request to update Participation : {}", participation);
         Course course = participation.getExercise().getCourse();
-        if (!courseService.userHasTAPermissions(course)) {
+        if (!courseService.userHasAtLeastTAPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         if (participation.getId() == null) {
@@ -198,7 +198,7 @@ public class ParticipationResource {
         log.debug("REST request to get all Participations for Exercise {}", exerciseId);
         Exercise exercise = exerciseService.findOne(exerciseId);
         Course course = exercise.getCourse();
-        if (!courseService.userHasTAPermissions(course)) {
+        if (!courseService.userHasAtLeastTAPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         List<Participation> participations = participationService.findByExerciseId(exerciseId);
@@ -217,7 +217,7 @@ public class ParticipationResource {
     public ResponseEntity<List<Participation>> getAllParticipationsForCourse(@PathVariable Long courseId) {
         log.debug("REST request to get all Participations for Course {}", courseId);
         Course course = courseService.findOne(courseId);
-        if (!courseService.userHasTAPermissions(course)) {
+        if (!courseService.userHasAtLeastTAPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         List<Participation> participations = participationService.findByCourseId(courseId);
@@ -238,7 +238,7 @@ public class ParticipationResource {
         Participation participation = participationService.findOne(id);
         Course course = participation.getExercise().getCourse();
         if (!authCheckService.isOwnerOfParticipation(participation)) {
-             if(!courseService.userHasTAPermissions(course)) {
+             if(!courseService.userHasAtLeastTAPermissions(course)) {
                  return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
              }
         }
@@ -257,7 +257,7 @@ public class ParticipationResource {
         Participation participation = participationService.findOne(id);
         Course course = participation.getExercise().getCourse();
         if (!authCheckService.isOwnerOfParticipation(participation)) {
-             if(!courseService.userHasTAPermissions(course)) {
+             if(!courseService.userHasAtLeastTAPermissions(course)) {
                  return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
              }
         }
@@ -280,7 +280,7 @@ public class ParticipationResource {
         }
         Course course = participation.getExercise().getCourse();
         if (!authCheckService.isOwnerOfParticipation(participation)) {
-            if(!courseService.userHasTAPermissions(course)) {
+            if(!courseService.userHasAtLeastTAPermissions(course)) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }
         }
@@ -302,7 +302,7 @@ public class ParticipationResource {
         Participation participation = participationService.findOne(id);
         Course course = participation.getExercise().getCourse();
         if (!authCheckService.isOwnerOfParticipation(participation)) {
-            if(!courseService.userHasTAPermissions(course)) {
+            if(!courseService.userHasAtLeastTAPermissions(course)) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
             }
         }
@@ -329,7 +329,7 @@ public class ParticipationResource {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
         Course course = exercise.getCourse();
-        if (!courseService.userHasStudentPermissions(course)) {
+        if (!courseService.userHasAtLeastStudentPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         MappingJacksonValue result;
@@ -426,7 +426,7 @@ public class ParticipationResource {
         log.debug("REST request to delete Participation : {}, deleteBuildPlan: {}, deleteRepository: {}", id, deleteBuildPlan, deleteRepository);
         Participation participation = participationService.findOne(id);
         Course course = participation.getExercise().getCourse();
-        if (!courseService.userHasTAPermissions(course)) {
+        if (!courseService.userHasAtLeastTAPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
         participationService.delete(id, deleteBuildPlan, deleteRepository);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -69,7 +69,7 @@ public class QuizExerciseResource {
         if (course == null) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "courseNotFound", "The course belonging to this quiz exercise does not exist")).body(null);
         }
-        if (!courseService.userHasTAPermissions(course)) {
+        if (!courseService.userHasAtLeastTAPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -110,7 +110,7 @@ public class QuizExerciseResource {
         if (course == null) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "courseNotFound", "The course belonging to this quiz exercise does not exist")).body(null);
         }
-        if (!courseService.userHasTAPermissions(course)) {
+        if (!courseService.userHasAtLeastTAPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -278,7 +278,7 @@ public class QuizExerciseResource {
 
         // check permissions
         Course course = quizExercise.getCourse();
-        if (!courseService.userHasTAPermissions(course)) {
+        if (!courseService.userHasAtLeastTAPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -369,7 +369,7 @@ public class QuizExerciseResource {
         }
 
         Course course = quizExercise.getCourse();
-        if (!courseService.userHasTAPermissions(course)) {
+        if (!courseService.userHasAtLeastTAPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -415,7 +415,7 @@ public class QuizExerciseResource {
         if (course == null) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "courseNotFound", "The course belonging to this quiz exercise does not exist")).body(null);
         }
-        if (!courseService.userHasInstructorPermissions(course)) {
+        if (!courseService.userHasAtLeastInstructorPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 


### PR DESCRIPTION
This changes some methods names when checking permissions to clearify the inheritance existing within the roles.