### PR TITLE
Deduplicate code for managing code in Exercise class

### DIFF
--- a/src/main/webapp/app/entities/exercise/exercise.model.ts
+++ b/src/main/webapp/app/entities/exercise/exercise.model.ts
@@ -1,7 +1,9 @@
-import { BaseEntity } from './../../shared';
+import { BaseEntity } from 'app/shared';
 import { Course } from '../course';
 import { Participation } from '../participation';
+import * as moment from 'moment';
 import { Moment } from 'moment';
+import { EntityArrayResponseType, EntityResponseType } from 'app/entities/exercise/exercise.service';
 
 export const enum DifficultyLevel {
     EASY = 'EASY',
@@ -50,7 +52,28 @@ export abstract class Exercise implements BaseEntity {
     public isAtLeastTutor: boolean;
     public loading: boolean;
 
-    constructor(type: ExerciseType) {
+    static convertDateFromClient<E extends Exercise>(exercise: E): E {
+        return Object.assign({}, exercise, {
+            releaseDate: exercise.releaseDate != null && moment(exercise.releaseDate).isValid() ? exercise.releaseDate.toJSON() : null,
+            dueDate: exercise.dueDate != null && moment(exercise.dueDate).isValid() ? exercise.dueDate.toJSON() : null
+        });
+    }
+
+    static convertDateFromServer<ERT extends EntityResponseType>(res: ERT): ERT {
+        res.body.releaseDate = res.body.releaseDate != null ? moment(res.body.releaseDate) : null;
+        res.body.dueDate = res.body.dueDate != null ? moment(res.body.dueDate) : null;
+        return res;
+    }
+
+    static convertDateArrayFromServer<E extends Exercise, EART extends EntityArrayResponseType>(res: EART): EART {
+        res.body.forEach((exercise: E) => {
+            exercise.releaseDate = exercise.releaseDate != null ? moment(exercise.releaseDate) : null;
+            exercise.dueDate = exercise.dueDate != null ? moment(exercise.dueDate) : null;
+        });
+        return res;
+    }
+
+    protected constructor(type: ExerciseType) {
         this.type = type;
     }
 }

--- a/src/main/webapp/app/entities/exercise/exercise.service.ts
+++ b/src/main/webapp/app/entities/exercise/exercise.service.ts
@@ -20,14 +20,14 @@ export class ExerciseService {
     constructor(private http: HttpClient, private participationService: ParticipationService) {}
 
     create(exercise: Exercise): Observable<EntityResponseType> {
-        const copy = this.convertDateFromClient(exercise);
+        const copy = Exercise.convertDateFromClient(exercise);
         return this.http
             .post<Exercise>(this.resourceUrl, copy, { observe: 'response' })
             .map((res: EntityResponseType) => this.convertDateFromServer(res));
     }
 
     update(exercise: Exercise): Observable<EntityResponseType> {
-        const copy = this.convertDateFromClient(exercise);
+        const copy = Exercise.convertDateFromClient(exercise);
         return this.http
             .put<Exercise>(this.resourceUrl, copy, { observe: 'response' })
             .map((res: EntityResponseType) => this.convertDateFromServer(res));
@@ -65,14 +65,6 @@ export class ExerciseService {
 
     exportRepos(id: number, students: string[]): Observable<HttpResponse<Blob>> {
         return this.http.get(`${this.resourceUrl}/${id}/participations/${students}`, { observe: 'response', responseType: 'blob' });
-    }
-
-    convertDateFromClient(exercise: Exercise): Exercise {
-        const copy: Exercise = Object.assign({}, exercise, {
-            releaseDate: exercise.releaseDate != null && exercise.releaseDate.isValid() ? exercise.releaseDate.toJSON() : null,
-            dueDate: exercise.dueDate != null && exercise.dueDate.isValid() ? exercise.dueDate.toJSON() : null
-        });
-        return copy;
     }
 
     convertExerciseDateFromServer(exercise: Exercise) {

--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.service.ts
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.service.ts
@@ -19,55 +19,33 @@ export class FileUploadExerciseService {
     constructor(private http: HttpClient) {}
 
     create(fileUploadExercise: FileUploadExercise): Observable<EntityResponseType> {
-        const copy = this.convertDateFromClient(fileUploadExercise);
+        const copy = Exercise.convertDateFromClient(fileUploadExercise);
         return this.http
             .post<FileUploadExercise>(this.resourceUrl, copy, { observe: 'response' })
-            .map((res: EntityResponseType) => this.convertDateFromServer(res));
+            .map((res: EntityResponseType) => Exercise.convertDateFromServer(res));
     }
 
     update(fileUploadExercise: FileUploadExercise): Observable<EntityResponseType> {
-        const copy = this.convertDateFromClient(fileUploadExercise);
+        const copy = Exercise.convertDateFromClient(fileUploadExercise);
         return this.http
             .put<FileUploadExercise>(this.resourceUrl, copy, { observe: 'response' })
-            .map((res: EntityResponseType) => this.convertDateFromServer(res));
+            .map((res: EntityResponseType) => Exercise.convertDateFromServer(res));
     }
 
     find(id: number): Observable<EntityResponseType> {
         return this.http
             .get<FileUploadExercise>(`${this.resourceUrl}/${id}`, { observe: 'response' })
-            .map((res: EntityResponseType) => this.convertDateFromServer(res));
+            .map((res: EntityResponseType) => Exercise.convertDateFromServer(res));
     }
 
     query(req?: any): Observable<EntityArrayResponseType> {
         const options = createRequestOption(req);
         return this.http
             .get<FileUploadExercise[]>(this.resourceUrl, { params: options, observe: 'response' })
-            .map((res: EntityArrayResponseType) => this.convertDateArrayFromServer(res));
+            .map((res: EntityArrayResponseType) => Exercise.convertDateArrayFromServer(res));
     }
 
     delete(id: number): Observable<HttpResponse<void>> {
         return this.http.delete<void>(`${this.resourceUrl}/${id}`, { observe: 'response' });
-    }
-
-    private convertDateFromClient(exercise: FileUploadExercise): FileUploadExercise {
-        const copy: FileUploadExercise = Object.assign({}, exercise, {
-            releaseDate: exercise.releaseDate != null && exercise.releaseDate.isValid() ? exercise.releaseDate.toJSON() : null,
-            dueDate: exercise.dueDate != null && exercise.dueDate.isValid() ? exercise.dueDate.toJSON() : null
-        });
-        return copy;
-    }
-
-    private convertDateFromServer(res: EntityResponseType): EntityResponseType {
-        res.body.releaseDate = res.body.releaseDate != null ? moment(res.body.releaseDate) : null;
-        res.body.dueDate = res.body.dueDate != null ? moment(res.body.dueDate) : null;
-        return res;
-    }
-
-    private convertDateArrayFromServer(res: EntityArrayResponseType): EntityArrayResponseType {
-        res.body.forEach((exercise: Exercise) => {
-            exercise.releaseDate = exercise.releaseDate != null ? moment(exercise.releaseDate) : null;
-            exercise.dueDate = exercise.dueDate != null ? moment(exercise.dueDate) : null;
-        });
-        return res;
     }
 }

--- a/src/main/webapp/app/entities/modeling-exercise/modeling-exercise.service.ts
+++ b/src/main/webapp/app/entities/modeling-exercise/modeling-exercise.service.ts
@@ -19,55 +19,33 @@ export class ModelingExerciseService {
     constructor(private http: HttpClient) {}
 
     create(modelingExercise: ModelingExercise): Observable<EntityResponseType> {
-        const copy = this.convertDateFromClient(modelingExercise);
+        const copy = ModelingExercise.convertDateFromClient(modelingExercise);
         return this.http
             .post<ModelingExercise>(this.resourceUrl, copy, { observe: 'response' })
-            .map((res: EntityResponseType) => this.convertDateFromServer(res));
+            .map((res: EntityResponseType) => ModelingExercise.convertDateFromServer(res));
     }
 
     update(modelingExercise: ModelingExercise): Observable<EntityResponseType> {
-        const copy = this.convertDateFromClient(modelingExercise);
+        const copy = ModelingExercise.convertDateFromClient(modelingExercise);
         return this.http
             .put<ModelingExercise>(this.resourceUrl, copy, { observe: 'response' })
-            .map((res: EntityResponseType) => this.convertDateFromServer(res));
+            .map((res: EntityResponseType) => ModelingExercise.convertDateFromServer(res));
     }
 
     find(id: number): Observable<EntityResponseType> {
         return this.http
             .get<ModelingExercise>(`${this.resourceUrl}/${id}`, { observe: 'response' })
-            .map((res: EntityResponseType) => this.convertDateFromServer(res));
+            .map((res: EntityResponseType) => ModelingExercise.convertDateFromServer(res));
     }
 
     query(req?: any): Observable<EntityArrayResponseType> {
         const options = createRequestOption(req);
         return this.http
             .get<ModelingExercise[]>(this.resourceUrl, { params: options, observe: 'response' })
-            .map((res: EntityArrayResponseType) => this.convertDateArrayFromServer(res));
+            .map((res: EntityArrayResponseType) => ModelingExercise.convertDateArrayFromServer(res));
     }
 
     delete(id: number): Observable<HttpResponse<void>> {
         return this.http.delete<void>(`${this.resourceUrl}/${id}`, { observe: 'response' });
-    }
-
-    private convertDateFromClient(exercise: ModelingExercise): ModelingExercise {
-        const copy: ModelingExercise = Object.assign({}, exercise, {
-            releaseDate: exercise.releaseDate != null && moment(exercise.releaseDate).isValid() ? exercise.releaseDate.toJSON() : null,
-            dueDate: exercise.dueDate != null && moment(exercise.dueDate).isValid() ? exercise.dueDate.toJSON() : null
-        });
-        return copy;
-    }
-
-    private convertDateFromServer(res: EntityResponseType): EntityResponseType {
-        res.body.releaseDate = res.body.releaseDate != null ? moment(res.body.releaseDate) : null;
-        res.body.dueDate = res.body.dueDate != null ? moment(res.body.dueDate) : null;
-        return res;
-    }
-
-    private convertDateArrayFromServer(res: EntityArrayResponseType): EntityArrayResponseType {
-        res.body.forEach((exercise: Exercise) => {
-            exercise.releaseDate = exercise.releaseDate != null ? moment(exercise.releaseDate) : null;
-            exercise.dueDate = exercise.dueDate != null ? moment(exercise.dueDate) : null;
-        });
-        return res;
     }
 }

--- a/src/main/webapp/app/entities/text-exercise/text-exercise.service.ts
+++ b/src/main/webapp/app/entities/text-exercise/text-exercise.service.ts
@@ -19,55 +19,33 @@ export class TextExerciseService {
     constructor(private http: HttpClient) {}
 
     create(textExercise: TextExercise): Observable<EntityResponseType> {
-        const copy = this.convertDateFromClient(textExercise);
+        const copy = Exercise.convertDateFromClient(textExercise);
         return this.http
             .post<TextExercise>(this.resourceUrl, copy, { observe: 'response' })
-            .map((res: EntityResponseType) => this.convertDateFromServer(res));
+            .map((res: EntityResponseType) => Exercise.convertDateFromServer(res));
     }
 
     update(textExercise: TextExercise): Observable<EntityResponseType> {
-        const copy = this.convertDateFromClient(textExercise);
+        const copy = Exercise.convertDateFromClient(textExercise);
         return this.http
             .put<TextExercise>(this.resourceUrl, copy, { observe: 'response' })
-            .map((res: EntityResponseType) => this.convertDateFromServer(res));
+            .map((res: EntityResponseType) => Exercise.convertDateFromServer(res));
     }
 
     find(id: number): Observable<EntityResponseType> {
         return this.http
             .get<TextExercise>(`${this.resourceUrl}/${id}`, { observe: 'response' })
-            .map((res: EntityResponseType) => this.convertDateFromServer(res));
+            .map((res: EntityResponseType) => Exercise.convertDateFromServer(res));
     }
 
     query(req?: any): Observable<EntityArrayResponseType> {
         const options = createRequestOption(req);
         return this.http
             .get<TextExercise[]>(this.resourceUrl, { params: options, observe: 'response' })
-            .map((res: EntityArrayResponseType) => this.convertDateArrayFromServer(res));
+            .map((res: EntityArrayResponseType) => Exercise.convertDateArrayFromServer(res));
     }
 
     delete(id: number): Observable<HttpResponse<void>> {
         return this.http.delete<void>(`${this.resourceUrl}/${id}`, { observe: 'response' });
-    }
-
-    private convertDateFromClient(exercise: TextExercise): TextExercise {
-        const copy: TextExercise = Object.assign({}, exercise, {
-            releaseDate: exercise.releaseDate != null && exercise.releaseDate.isValid() ? exercise.releaseDate.toJSON() : null,
-            dueDate: exercise.dueDate != null && exercise.dueDate.isValid() ? exercise.dueDate.toJSON() : null
-        });
-        return copy;
-    }
-
-    private convertDateFromServer(res: EntityResponseType): EntityResponseType {
-        res.body.releaseDate = res.body.releaseDate != null ? moment(res.body.releaseDate) : null;
-        res.body.dueDate = res.body.dueDate != null ? moment(res.body.dueDate) : null;
-        return res;
-    }
-
-    private convertDateArrayFromServer(res: EntityArrayResponseType): EntityArrayResponseType {
-        res.body.forEach((exercise: Exercise) => {
-            exercise.releaseDate = exercise.releaseDate != null ? moment(exercise.releaseDate) : null;
-            exercise.dueDate = exercise.dueDate != null ? moment(exercise.dueDate) : null;
-        });
-        return res;
     }
 }


### PR DESCRIPTION
`Exercise` class has a `releaseDate` and `dueDate` fields, which need some transformations with `moment`.

At the moment, the function for transformations is duplicate in every class which extends `Exercise`.

With this pull request, I deduplicate the code including the methods in the base `Exercise` class, and I use Typescript generics to do not lose any type checking