### PR TITLE
saving the user agent during login in the database, fixed little bug that prevented a local registration

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/audit/AuditEventConverter.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/audit/AuditEventConverter.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.config.audit;
 
 import de.tum.in.www1.artemis.domain.PersistentAuditEvent;
+import javafx.util.Pair;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.stereotype.Component;
@@ -77,6 +78,9 @@ public class AuditEventConverter {
                     WebAuthenticationDetails authenticationDetails = (WebAuthenticationDetails) object;
                     results.put("remoteAddress", authenticationDetails.getRemoteAddress());
                     results.put("sessionId", authenticationDetails.getSessionId());
+                } else if (object instanceof Pair) {
+                    Pair authenticationPair = (Pair) object;
+                    results.put(authenticationPair.getKey().toString(), authenticationPair.getValue().toString());
                 } else if (object != null) {
                     results.put(entry.getKey(), object.toString());
                 } else {

--- a/src/main/java/de/tum/in/www1/artemis/service/UserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/UserService.java
@@ -130,7 +130,7 @@ public class UserService {
             }
         });
         User newUser = new User();
-        String encryptedPassword = passwordEncoder.encode(password);
+        String encryptedPassword = passwordEncoder().encode(password);
         newUser.setLogin(userDTO.getLogin().toLowerCase());
         // new user gets initially a generated password
         newUser.setPassword(encryptedPassword);

--- a/src/main/java/de/tum/in/www1/artemis/service/UserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/UserService.java
@@ -97,7 +97,7 @@ public class UserService {
         return userRepository.findOneByResetKey(key)
             .filter(user -> user.getResetDate().isAfter(Instant.now().minusSeconds(86400)))
             .map(user -> {
-                user.setPassword(passwordEncoder.encode(newPassword));
+                user.setPassword(passwordEncoder().encode(newPassword));
                 user.setResetKey(null);
                 user.setResetDate(null);
                 this.clearUserCaches(user);
@@ -287,10 +287,10 @@ public class UserService {
             .flatMap(userRepository::findOneByLogin)
             .ifPresent(user -> {
                 String currentEncryptedPassword = user.getPassword();
-                if (!passwordEncoder.matches(currentClearTextPassword, currentEncryptedPassword)) {
+                if (!passwordEncoder().matches(currentClearTextPassword, currentEncryptedPassword)) {
                     throw new InvalidPasswordException();
                 }
-                String encryptedPassword = passwordEncoder.encode(newPassword);
+                String encryptedPassword = passwordEncoder().encode(newPassword);
                 user.setPassword(encryptedPassword);
                 this.clearUserCaches(user);
                 log.debug("Changed password for User: {}", user);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/UserJWTController.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/UserJWTController.java
@@ -6,6 +6,7 @@ import de.tum.in.www1.artemis.security.jwt.JWTFilter;
 import de.tum.in.www1.artemis.security.jwt.TokenProvider;
 import de.tum.in.www1.artemis.web.rest.errors.CaptchaRequiredException;
 import de.tum.in.www1.artemis.web.rest.vm.LoginVM;
+import javafx.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import javax.validation.Valid;
 
@@ -42,11 +44,12 @@ public class UserJWTController {
 
     @PostMapping("/authenticate")
     @Timed
-    public ResponseEntity<JWTToken> authorize(@Valid @RequestBody LoginVM loginVM) {
+    public ResponseEntity<JWTToken> authorize(@Valid @RequestBody LoginVM loginVM, @RequestHeader("User-Agent") String userAgent) {
 
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginVM.getUsername(), loginVM.getPassword());
 
         try {
+            authenticationToken.setDetails(new Pair<>("userAgent", userAgent));
             Authentication authentication = this.authenticationManager.authenticate(authenticationToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
             boolean rememberMe = (loginVM.isRememberMe() == null) ? false : loginVM.isRememberMe();


### PR DESCRIPTION
For analytics reasons the user agent of each login is now saved to the database.

With this I fixed a small bug that prevented the registration of a new user on ArTEMiS.