### PR TITLE
Bugfix/drag and drop statistics

### DIFF
--- a/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.ts
+++ b/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.ts
@@ -13,7 +13,8 @@ polyfill({
     dragImageTranslateOverride: scrollBehaviourDragImageTranslateOverride
 });
 
-// dragenter listener
+// Drag-enter listener for mobile devices
+// tslint:disable-next-line
 (event: any) => {
     event.preventDefault();
 };

--- a/src/main/webapp/app/statistics/drag-and-drop-question-statistic/drag-and-drop-question-statistic.component.html
+++ b/src/main/webapp/app/statistics/drag-and-drop-question-statistic/drag-and-drop-question-statistic.component.html
@@ -34,12 +34,12 @@
                             <span *ngIf="!showSolution"
                                   jhiTranslate="showStatistic.dragAndDropQuestionStatistic.showSampleSolution"></span>
                         </button>
-                        </button>
 
                         <button (click)="switchRated()" type="button" class="btn btn-primary">
                             <span class="fa fa-refresh"></span>&nbsp;
                             <span *ngIf="rated" jhiTranslate="showStatistic.switchToUnrated"></span>
-                            <span *ngIf="!rated" jhiTranslate="showStatistic.switchToRated"></span></button>
+                            <span *ngIf="!rated" jhiTranslate="showStatistic.switchToRated"></span>
+                        </button>
                     </div>
                     <p>&nbsp;</p>
                 </div>
@@ -65,7 +65,7 @@
                             <div
                                 class="drop-location"
                                 *ngFor="let dropLocation of question.dropLocations; let i = index"
-                                ng-style="{top: dropLocation.posY/2 + '%', left: dropLocation.posX/2 + '%', width: dropLocation.width/2 + '%', height: dropLocation.height/2 + '%'}"
+                                [ngStyle]="{top: dropLocation.posY/2 + '%', left: dropLocation.posX/2 + '%', width: dropLocation.width/2 + '%', height: dropLocation.height/2 + '%'}"
                             >
                                 <div class="letter-solution">
                                     <span>{{getLetter(i) + "."}}</span>
@@ -87,10 +87,9 @@
                                    [dragItem]="dragItem"
                                    [invalid]="dragItem.invalid"
                                    [clickDisabled]="true"
-                                   [minWidth]="100 + '%'"></jhi-drag-item>
-
+                                   [minWidth]="100">
+                        </jhi-drag-item>
                     </div>
-
                 </div>
                 <p>&nbsp;</p>
                 <p>&nbsp;</p>


### PR DESCRIPTION
This PR fixes two issues within the statistics component for DnD questions:
- issue where the DragItems would have no width when the sample solutions was hidden
- issue where the DragItems would all get placed in the top left corner when trying to show the sample solution