### PR TITLE
Redirecting only if user is authenticated

### DIFF
--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -38,7 +38,9 @@ export class HomeComponent implements OnInit {
 
     currentUserCallback(account: User) {
         this.account = account;
-        this.router.navigate(['courses']);
+        if (account) {
+            this.router.navigate(['courses']);
+        }
     }
 
     isAuthenticated() {


### PR DESCRIPTION
User are redirected to the `courses` page even if they are not logged in. As a result they are always end up on the `accessdenied` page. This check fixes this behavior