### PR TITLE
Reduce Builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
-os: linux
-language: node_js
-node_js:
-  - 10.12.0
-  - lts/*
-  - node
-jdk:
-  - oraclejdk8
-  - openjdk8
-  - openjdk10
+language: java
+jdk: openjdk8
+
+env: NODE_VERSION=10.14.2
+
 
 cache:
   yarn: true
   directories:
     - $HOME/.m2
     - $HOME/.gradle
+
+before_install: nvm install $NODE_VERSION
 
 script: ./gradlew -Pprod bootWar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk: openjdk8
 
-env: NODE_VERSION=10.14.2
+env: NODE_VERSION=10.15.0
 
 
 cache:


### PR DESCRIPTION
Update `.travis.yml` to only do one builds instead of three (to speed up build time)
Now, we will run one builds with Open JDK 8 and Node 10.14.2 to match results from Bamboo.