### PR TITLE
Click in Repository URL Copies URL to Clipboard. Once copied, the Text of the Copy Button Changes to provide Feedback.

### DIFF
--- a/src/main/webapp/app/courses/exercises/exercise-list.component.html
+++ b/src/main/webapp/app/courses/exercises/exercise-list.component.html
@@ -72,9 +72,9 @@
                             <i class="fa fa-folder-open fa-fw"></i>&nbsp;<span class="d-none d-md-inline">Open exercise</span></a>
                         <ng-template #popContent>
                             <p>Clone your personal repository for this exercise:</p>
-                            <pre style="max-width: 100%;">{{exercise.participations[0].repositoryUrl}}</pre>
+                            <pre style="max-width: 100%;" ngxClipboard [cbContent]="exercise.participations[0].repositoryUrl" (cbOnSuccess)="onCopySuccess()" (cbOnError)="onCopyFailure()">{{exercise.participations[0].repositoryUrl}}</pre>
                             <p *ngIf="repositoryPassword">Your password is: <code class="password">{{repositoryPassword}}</code> (hover to show)</p>
-                            <button class="btn btn-primary btn-sm mr-2" type="button" ngxClipboard [cbContent]="exercise.participations[0].repositoryUrl" (cbOnSuccess)="onCopySuccess()" (cbOnError)="onCopyFailure()" [class.btn-success]="wasCopied">Copy URL</button>
+                            <button class="btn btn-primary btn-sm mr-2" type="button" ngxClipboard [cbContent]="exercise.participations[0].repositoryUrl" (cbOnSuccess)="onCopySuccess()" (cbOnError)="onCopyFailure()" [class.btn-success]="wasCopied">{{ wasCopied ? "Copied URL" : "Copy URL"}}</button>
                             <a class="btn btn-primary btn-sm mr-2" [href]="buildSourceTreeUrl(exercise.participations[0].repositoryUrl) | safeUrl">Clone in SourceTree</a>
                             <a href="http://www.sourcetreeapp.com" target="_blank">Atlassian SourceTree</a> is the free Git client for Windows or Mac.
                         </ng-template>


### PR DESCRIPTION
### Checklist
- [X] I've run `yarn run webpack:build:main` from the root directory to see that the project builds without errors.
- [X] ~I've removed unnecessary whitespace changes.~
- [X] ~I've updated the documentation and models if necessary.~
- [ ] I've tested the changes and all related features on the Artemis test server

### Motivation and Context
A user had problems cloning the repository from manually copying the URL. By tripple clicking the url and pressing CMD + C, he also copied some extra characters.
Git responded with an Error Message like:
```
Illegal characters found in URL
```

### Description
Clicking in the URL Box will auto-copy the URL to the Clipboard.
The Copy Button will change its text, to communicate the copy-action to the user.

#### Screenshots
<img width="350" alt="screenshot 2019-01-17 at 11 33 21" src="https://user-images.githubusercontent.com/6382716/51312808-6c666f80-1a4c-11e9-90f4-cf568d3e804e.png">
