### PR TITLE
Fix Tutorparticipation relationships

### DIFF
--- a/artemis.jh
+++ b/artemis.jh
@@ -374,8 +374,6 @@ relationship OneToOne {
     ComplaintResponse{complaint} to Complaint,
     Complaint{student} to User,
     ComplaintResponse{reviewer} to User,
-    TutorParticipation{assessedExercise} to Exercise,
-    TutorParticipation{tutor} to User,
     ExampleSubmission{submission} to Submission
 }
 
@@ -387,7 +385,9 @@ relationship ManyToOne {
     DragAndDropMapping{dragItem} to DragItem,
     DragAndDropMapping{dropLocation} to DropLocation,
     ShortAnswerMapping{solution} to ShortAnswerSolution,
-    ShortAnswerMapping{spot} to ShortAnswerSpot
+    ShortAnswerMapping{spot} to ShortAnswerSpot,
+    TutorParticipation{tutor} to User,
+    TutorParticipation{assessedExercise} to Exercise
 }
 
 relationship ManyToMany {

--- a/src/main/java/de/tum/in/www1/artemis/domain/TutorParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TutorParticipation.java
@@ -32,12 +32,10 @@ public class TutorParticipation implements Serializable {
     @Column(name = "points")
     private Integer points;
 
-    @OneToOne
-    @JoinColumn(unique = true)
+    @ManyToOne
     private Exercise assessedExercise;
 
-    @OneToOne
-    @JoinColumn(unique = true)
+    @ManyToOne
     private User tutor;
 
     @OneToMany(mappedBy = "tutorParticipation")


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `yarn run webpack:build:main` from the root directory to see that the project builds without errors.
- [x] I've removed unnecessary whitespace changes.
- [x] I've updated the documentation and models if necessary.
- [ ] I've tested the changes and all related features on the Artemis test server

### Motivation and Context
TutorParticipation doesn't need an unique key with tutor, since every tutor will have multiple participations, and it doesn't need an unique key with exercise, since different tutors will participate to the same exercise



