### PR TITLE
🐛 Fix Bug preventing Deletion of Text Exercises with Feedback

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -556,7 +556,7 @@ public class ParticipationService {
      */
     @Transactional
     public void deleteAllByExerciseId(Long exerciseId, boolean deleteBuildPlan, boolean deleteRepository) {
-        List<Participation> participationsToDelete = participationRepository.findByExerciseId(exerciseId);
+        List<Participation> participationsToDelete = findByExerciseId(exerciseId);
 
         for (Participation participation : participationsToDelete) {
             delete(participation.getId(), deleteBuildPlan, deleteRepository);

--- a/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
@@ -86,6 +86,7 @@ public class TextAssessmentService extends AssessmentService {
         // update existing and save new
         for (Feedback feedback : textAssessment) {
             feedback.setResult(result);
+            result.addFeedback(feedback);
             feedback.setType(FeedbackType.MANUAL);
         }
         this.feedbackRepository.saveAll(textAssessment);

--- a/src/main/java/de/tum/in/www1/artemis/service/TextExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextExerciseService.java
@@ -1,17 +1,11 @@
 package de.tum.in.www1.artemis.service;
 
 import de.tum.in.www1.artemis.domain.TextExercise;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
-import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
-import de.tum.in.www1.artemis.service.connectors.GitService;
-import de.tum.in.www1.artemis.service.connectors.VersionControlService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -22,11 +16,7 @@ public class TextExerciseService {
     private final TextExerciseRepository textExerciseRepository;
     private final ParticipationService participationService;
 
-    public TextExerciseService(TextExerciseRepository textExerciseRepository,
-                               ExerciseRepository exerciseRepository,
-                               UserService userService,
-                               ParticipationService participationService,
-                               AuthorizationCheckService authCheckService) {
+    public TextExerciseService(TextExerciseRepository textExerciseRepository, ParticipationService participationService) {
 
         this.textExerciseRepository = textExerciseRepository;
         this.participationService = participationService;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -36,6 +36,7 @@ public class TextExerciseResource {
     private static final String ENTITY_NAME = "textExercise";
 
     private final TextAssessmentService textAssessmentService;
+    private final TextExerciseService textExerciseService;
     private final TextExerciseRepository textExerciseRepository;
     private final UserService userService;
     private final CourseService courseService;
@@ -44,6 +45,7 @@ public class TextExerciseResource {
     private final ResultRepository resultRepository;
 
     public TextExerciseResource(TextExerciseRepository textExerciseRepository,
+                                TextExerciseService textExerciseService,
                                 TextAssessmentService textAssessmentService,
                                 UserService userService,
                                 AuthorizationCheckService authCheckService,
@@ -51,6 +53,7 @@ public class TextExerciseResource {
                                 ParticipationService participationService,
                                 ResultRepository resultRepository) {
         this.textAssessmentService = textAssessmentService;
+        this.textExerciseService = textExerciseService;
         this.textExerciseRepository = textExerciseRepository;
         this.userService = userService;
         this.courseService = courseService;
@@ -181,7 +184,7 @@ public class TextExerciseResource {
                 !authCheckService.isAdmin()) {
                 return forbidden();
             }
-            textExerciseRepository.deleteById(id);
+            textExerciseService.delete(id);
             return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(ENTITY_NAME, id.toString())).build();
         }
         return ResponseEntity.notFound().build();


### PR DESCRIPTION
### Checklist
- [ ] I've run `yarn run webpack:build:main` from the root directory to see that the project builds without errors.
- [ ] I've removed unnecessary whitespace changes.
- [ ] I've updated the documentation and models if necessary.
- [ ] I've tested the changes and all related features on the Artemis test server

### Motivation and Context
It was not possible to delete Text Exercises, if Feedback items for said exercise exist.
The following Exception occurs:
```
Exception in de.tum.in.www1.artemis.service.TextExerciseService.delete() with cause = 'org.hibernate.HibernateException: null index column for collection: de.tum.in.www1.artemis.domain.Result.feedbacks' and exception = 'null index column for collection: de.tum.in.www1.artemis.domain.Result.feedbacks; nested exception is org.hibernate.HibernateException: null index column for collection: de.tum.in.www1.artemis.domain.Result.feedbacks'
```

### Description
- Correctly add two-way association for Feedback items with results in `TextAssessmentService`
- Call `TextExerciseService:delete` instead of `TextExerciseRepository:deleteById` from REST Endpoint.
- Removed unused imports and Dependencies in `TextExerciseService`