### PR TITLE
📈 Add Analytics using Angulartics and TUM Matomo

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "angular-fittext": "2.1.1",
         "angular-translate-interpolation-messageformat": "2.18.1",
         "angular2-moment": "1.9.0",
-        "angulartics2": "^7.4.1",
+        "angulartics2": "7.4.1",
         "bootstrap": "4.2.1",
         "core-js": "2.6.4",
         "interactjs": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "angular-fittext": "2.1.1",
         "angular-translate-interpolation-messageformat": "2.18.1",
         "angular2-moment": "1.9.0",
+        "angulartics2": "^7.4.1",
         "bootstrap": "4.2.1",
         "core-js": "2.6.4",
         "interactjs": "1.3.4",

--- a/src/main/webapp/app/app.module.ts
+++ b/src/main/webapp/app/app.module.ts
@@ -7,6 +7,7 @@ import { NgbDatepickerConfig } from '@ng-bootstrap/ng-bootstrap';
 import { NgxWebstorageModule } from 'ngx-webstorage';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgJhipsterModule } from 'ng-jhipster';
+import { Angulartics2Module } from 'angulartics2';
 
 import { AuthInterceptor } from './blocks/interceptor/auth.interceptor';
 import { AuthExpiredInterceptor } from './blocks/interceptor/auth-expired.interceptor';
@@ -65,6 +66,10 @@ import { ParticipationDataProvider } from './courses/exercises/participation-dat
             i18nEnabled: true,
             defaultI18nLang: 'en'
         }),
+        /**
+         * @external Angulartics offers Vendor-agnostic analytics and integration with Matomo
+         */
+        Angulartics2Module.forRoot(),
         ArTEMiSSharedModule.forRoot(),
         ArTEMiSCoreModule,
         ArTEMiSHomeModule,

--- a/src/main/webapp/app/layouts/main/main.component.ts
+++ b/src/main/webapp/app/layouts/main/main.component.ts
@@ -1,16 +1,36 @@
 import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRouteSnapshot, NavigationEnd, NavigationError } from '@angular/router';
+import { Angulartics2 } from 'angulartics2';
 import { Angulartics2Piwik } from 'angulartics2/piwik';
 
 import { JhiLanguageHelper } from 'app/core';
+import { ProfileService } from '../profiles/profile.service';
 
 @Component({
     selector: 'jhi-main',
     templateUrl: './main.component.html'
 })
 export class JhiMainComponent implements OnInit {
-    constructor(private jhiLanguageHelper: JhiLanguageHelper, private router: Router, private angulartics2Piwik: Angulartics2Piwik) {
-        angulartics2Piwik.startTracking();
+    constructor(
+        private jhiLanguageHelper: JhiLanguageHelper,
+        private router: Router,
+        private profileService: ProfileService,
+        private angulartics: Angulartics2,
+        private angularticsPiwik: Angulartics2Piwik
+    ) {
+        this.setupAnalytics().then(null);
+    }
+
+    private async setupAnalytics() {
+        const profileInfo = await this.profileService.getProfileInfo();
+
+        if (profileInfo.inProduction && window.location.host === 'artemis.ase.in.tum.de') {
+            // only Track in Production Environment
+            this.angularticsPiwik.startTracking();
+        } else {
+            // Enable Developer Mode in all other environments
+            this.angulartics.settings.developerMode = true;
+        }
     }
 
     private getPageTitle(routeSnapshot: ActivatedRouteSnapshot) {

--- a/src/main/webapp/app/layouts/main/main.component.ts
+++ b/src/main/webapp/app/layouts/main/main.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRouteSnapshot, NavigationEnd, NavigationError } from '@angular/router';
+import { Angulartics2Piwik } from 'angulartics2/piwik';
 
 import { JhiLanguageHelper } from 'app/core';
 
@@ -8,7 +9,9 @@ import { JhiLanguageHelper } from 'app/core';
     templateUrl: './main.component.html'
 })
 export class JhiMainComponent implements OnInit {
-    constructor(private jhiLanguageHelper: JhiLanguageHelper, private router: Router) {}
+    constructor(private jhiLanguageHelper: JhiLanguageHelper, private router: Router, private angulartics2Piwik: Angulartics2Piwik) {
+        angulartics2Piwik.startTracking();
+    }
 
     private getPageTitle(routeSnapshot: ActivatedRouteSnapshot) {
         let title: string = routeSnapshot.data && routeSnapshot.data['pageTitle'] ? routeSnapshot.data['pageTitle'] : 'arTeMiSApp';

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -86,14 +86,21 @@
             }
         </script>
     -->
-    <!-- Google Analytics: uncomment and change UA-XXXXX-X to be your site's ID.
-    <script>
-        (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
-        function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;
-        e=o.createElement(i);r=o.getElementsByTagName(i)[0];
-        e.src='//www.google-analytics.com/analytics.js';
-        r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
-        ga('create','UA-XXXXX-X');ga('send','pageview');
-    </script>-->
+
+    <!-- Matomo -->
+    <script type="text/javascript">
+        var _paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(["setDoNotTrack", true]);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+            var u="https://www.piwik.tum.de/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '125']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        })();
+    </script>
+    <!-- End Matomo Code -->
 </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,6 +744,13 @@ angular2-template-loader@0.6.2:
   resolved "https://registry.yarnpkg.com/angular/-/angular-1.7.7.tgz#26bd87693deadcbd5944610a7a0463fc79a18803"
   integrity sha512-MH3JEGd8y/EkNCKJ8EV6Ch0j9X0rZTta/QVIDpBWaIdfh85/e5KO8+ZKgvWIb02MQuiS20pDFmMFlv4ZaLcLWg==
 
+angulartics2@^7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/angulartics2/-/angulartics2-7.4.1.tgz#94455160b4e0440acf6004f2be4c21389a3a54e0"
+  integrity sha512-b+H7KrC6flwRKbQhP6Fa1M85MYNfRamUlaNnpDnCgXXJHB45J8iFHQ9P1MPd7zfIDq3XMMOw94D0kUcP42Zs+A==
+  dependencies:
+    tslib "^1.9.0"
+
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"


### PR DESCRIPTION
Closes #21

**Testing this on the Testserver is limited due to server-side settings in Matomo.**
(Matomo should only listen to request on the production domain.)

### Checklist
- [X] I've run `yarn run webpack:build:main` from the root directory to see that the project builds without errors.
- [X] ~I've removed unnecessary whitespace changes.~
- [X] ~I've updated the documentation and models if necessary.~
- [X] I've tested the changes and all related features on the Artemis test server

### Motivation and Context
See #21

### Description
We use the TUM hosted Matomo service.
[angulartics](https://github.com/angulartics/angulartics2) is a Vendor-agnostic analytics library for angular. It offers integration with Matomo, but also lots of other vendors.
