### PR TITLE
Keep only text exercise and modelling exercise in the tutor dashboard

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -273,10 +273,14 @@ public class CourseResource {
 
         User user = userService.getUserWithGroupsAndAuthorities();
         List<Exercise> exercises = exerciseService.findAllForCourse(course, false, principal, user);
+
+        exercises = exercises.stream()
+            .filter(exercise -> exercise instanceof TextExercise || exercise instanceof ModelingExercise)
+            .collect(Collectors.toList());
+
         List<TutorParticipation> tutorParticipations = tutorParticipationService.findAllByCourseAndTutor(course, user);
 
         for (Exercise exercise : exercises) {
-//            TutorParticipation tutorParticipation = tutorParticipationService.findByExerciseAndTutor(exercise, user);
             TutorParticipation tutorParticipation = tutorParticipations.stream()
                 .filter(participation -> participation.getAssessedExercise().getId().equals(exercise.getId()))
                 .findFirst().orElseGet(() -> {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: there project builds without code style warnings.
- [x] I removed unnecessary whitespace changes in all related files.
- [ ] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
The tutor dashboard is about manual assessments, so this PR removes all the type of exercises which do not have any kind of manual assessment 


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Navigate to Instructor dashboard
4. Only Text exercises and modelling exercises are visible

