### PR TITLE
Add rule about whitespace in imports and make tslint mandatory in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ jobs:
         script: ./gradlew -Pprod bootWar
       - stage: test
         language: node_js
+        node_js:
+            - 10
         cache:
             yarn: true
         before_install: cd src/main/webapp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
-language: java
-jdk: openjdk8
+jobs:
+    include:
+      - stage: test
+        language: java
+        jdk: openjdk8
+        env: NODE_VERSION=10.15.0
+        cache:
+          yarn: true
+          directories:
+            - $HOME/.m2
+            - $HOME/.gradle
 
-env: NODE_VERSION=10.15.0
+        before_install: nvm install $NODE_VERSION
 
-
-cache:
-  yarn: true
-  directories:
-    - $HOME/.m2
-    - $HOME/.gradle
-
-before_install: nvm install $NODE_VERSION
-
-script: ./gradlew -Pprod bootWar
+        script: ./gradlew -Pprod bootWar
+      - stage: test
+        language: node_js
+        cache:
+            yarn: true
+        before_install: cd src/main/webapp
+        install: yarn
+        script: yarn run lint

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -1,13 +1,13 @@
-import {Component, OnInit, Input} from '@angular/core';
-import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
-import {Question, QuestionType, ScoringType} from 'app/entities/question';
-import {DragAndDropMapping} from '../../../entities/drag-and-drop-mapping';
-import {AnswerOption} from '../../../entities/answer-option';
-import {MultipleChoiceQuestion} from '../../../entities/multiple-choice-question';
-import {DragAndDropQuestion} from '../../../entities/drag-and-drop-question';
-import {ShortAnswerQuestion} from '../../../entities/short-answer-question';
-import {ShortAnswerSubmittedText} from 'app/entities/short-answer-submitted-text';
-import {TranslateService} from '@ngx-translate/core';
+import { Component, OnInit, Input } from '@angular/core';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { Question, QuestionType, ScoringType } from 'app/entities/question';
+import { DragAndDropMapping } from '../../../entities/drag-and-drop-mapping';
+import { AnswerOption } from '../../../entities/answer-option';
+import { MultipleChoiceQuestion } from '../../../entities/multiple-choice-question';
+import { DragAndDropQuestion } from '../../../entities/drag-and-drop-question';
+import { ShortAnswerQuestion } from '../../../entities/short-answer-question';
+import { ShortAnswerSubmittedText } from 'app/entities/short-answer-submitted-text';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
     selector: 'jhi-quiz-scoring-infostudent-modal',

--- a/tslint.json
+++ b/tslint.json
@@ -92,7 +92,8 @@
             "check-decl",
             "check-operator",
             "check-separator",
-            "check-type"
+            "check-type",
+            "check-module"
         ],
         "prefer-const": true,
         "arrow-parens": [true, "ban-single-arg-parens"],


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: there project builds without code style warnings.
- [x] I removed unnecessary whitespace changes in all related files.
- [x] ~I updated the documentation and models.~
- [x] ~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context

Run lint in travis, so we don't have to comment about in pull requests about code style in typescript, and we can remove the checkbox `I run yarn lint`, since travis will fail for you
Also, add the rule about whitespace inside import in tslint

