### PR TITLE
 🐛 Do not show Results without a Student

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -459,6 +459,12 @@ public class ParticipationService {
         List<Participation> participations = participationRepository.findByCourseIdWithEagerResults(courseId);
         //filter all irrelevant results, i.e. rated = false or before exercise due date
         for (Participation participation : participations) {
+            // Filter out participations without Students
+            // These participations are used e.g. to store template and solution build plans in programming exercises
+            if (participation.getStudent() == null) {
+                continue;
+            }
+
             List<Result> relevantResults = new ArrayList<Result>();
 
             //search for the relevant result by filtering out irrelevant results using the continue keyword

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static de.tum.in.www1.artemis.config.Constants.PROGRAMMING_SUBMISSION_RESOURCE_API_PATH;
 import static de.tum.in.www1.artemis.domain.enumeration.InitializationState.FINISHED;
@@ -456,63 +457,60 @@ public class ParticipationService {
 
     @Transactional(readOnly = true)
     public List<Participation> findByCourseIdWithRelevantResults(Long courseId) {
-        List<Participation> participations = participationRepository.findByCourseIdWithEagerResults(courseId);
-        //filter all irrelevant results, i.e. rated = false or before exercise due date
-        for (Participation participation : participations) {
+        return participationRepository.findByCourseIdWithEagerResults(courseId).stream()
+
             // Filter out participations without Students
             // These participations are used e.g. to store template and solution build plans in programming exercises
-            if (participation.getStudent() == null) {
-                continue;
-            }
+            .filter(participation -> participation.getStudent() != null)
 
-            List<Result> relevantResults = new ArrayList<Result>();
+            //filter all irrelevant results, i.e. rated = false or before exercise due date
+            .peek(participation -> {
+                List<Result> relevantResults = new ArrayList<Result>();
 
-            //search for the relevant result by filtering out irrelevant results using the continue keyword
-            //this for loop is optimized for performance and thus not very easy to understand ;)
-            for (Result result : participation.getResults()) {
-                if (result.isRated() == Boolean.FALSE) {
-                    // we are only interested in results with rated == null (for compatibility) and rated == Boolean.TRUE
-                    //TODO: for compatibility reasons, we include rated == null, in the future we can remove this
-                    continue;
-                }
-                if (result.getCompletionDate() == null || result.getScore() == null) {
-                    // we are only interested in results with completion date and with score
-                    continue;
-                }
-                if (participation.getExercise() instanceof QuizExercise) {
-                    //in quizzes we take all rated results, because we only have one! (independent of later checks)
-                }
-                else if (participation.getExercise().getDueDate() != null) {
-                    if (participation.getExercise() instanceof ModelingExercise || participation.getExercise() instanceof TextExercise) {
-                        if (result.getSubmission() != null && result.getSubmission().getSubmissionDate() != null
-                            && result.getSubmission().getSubmissionDate().isAfter(participation.getExercise().getDueDate())) {
-                            //Filter out late results using the submission date, because in this exercise types, the
-                            //difference between submissionDate and result.completionDate can be significant due to manual assessment
-                            continue;
+                //search for the relevant result by filtering out irrelevant results using the continue keyword
+                //this for loop is optimized for performance and thus not very easy to understand ;)
+                for (Result result : participation.getResults()) {
+                    if (result.isRated() == Boolean.FALSE) {
+                        // we are only interested in results with rated == null (for compatibility) and rated == Boolean.TRUE
+                        //TODO: for compatibility reasons, we include rated == null, in the future we can remove this
+                        continue;
+                    }
+                    if (result.getCompletionDate() == null || result.getScore() == null) {
+                        // we are only interested in results with completion date and with score
+                        continue;
+                    }
+                    if (participation.getExercise() instanceof QuizExercise) {
+                        //in quizzes we take all rated results, because we only have one! (independent of later checks)
+                    } else if (participation.getExercise().getDueDate() != null) {
+                        if (participation.getExercise() instanceof ModelingExercise || participation.getExercise() instanceof TextExercise) {
+                            if (result.getSubmission() != null && result.getSubmission().getSubmissionDate() != null
+                                && result.getSubmission().getSubmissionDate().isAfter(participation.getExercise().getDueDate())) {
+                                //Filter out late results using the submission date, because in this exercise types, the
+                                //difference between submissionDate and result.completionDate can be significant due to manual assessment
+                                continue;
+                            }
+                        } else {
+                            //For all other exercises the result completion date is the same as the submission date
+                            if (result.getCompletionDate().isAfter(participation.getExercise().getDueDate())) {
+                                //and we continue (i.e. dismiss the result) if the result completion date is after the exercise due date
+                                continue;
+                            }
                         }
                     }
-                    else {
-                        //For all other exercises the result completion date is the same as the submission date
-                        if (result.getCompletionDate().isAfter(participation.getExercise().getDueDate())) {
-                            //and we continue (i.e. dismiss the result) if the result completion date is after the exercise due date
-                            continue;
-                        }
-                    }
+                    relevantResults.add(result);
                 }
-                relevantResults.add(result);
-            }
-            if (!relevantResults.isEmpty()) {
-                //make sure to take the latest result
-                relevantResults.sort((r1, r2) -> r2.getCompletionDate().compareTo(r1.getCompletionDate()));
-                Result correctResult = relevantResults.get(0);
-                relevantResults.clear();
-                relevantResults.add(correctResult);
-            }
-            participation.setResults(new HashSet<>(relevantResults));
-            //remove unnecessary elements
-            participation.getExercise().setCourse(null);
-        }
-        return participations;
+                if (!relevantResults.isEmpty()) {
+                    //make sure to take the latest result
+                    relevantResults.sort((r1, r2) -> r2.getCompletionDate().compareTo(r1.getCompletionDate()));
+                    Result correctResult = relevantResults.get(0);
+                    relevantResults.clear();
+                    relevantResults.add(correctResult);
+                }
+                participation.setResults(new HashSet<>(relevantResults));
+                //remove unnecessary elements
+                participation.getExercise().setCourse(null);
+            })
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * REST controller for managing Participation.
@@ -193,6 +194,7 @@ public class ParticipationResource {
         } else {
             participations = participationService.findByExerciseId(exerciseId);
         }
+        participations = participations.stream().filter(participation -> participation.getStudent() != null).collect(Collectors.toList());
 
         return ResponseEntity.ok(participations);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
@@ -303,7 +303,8 @@ public class ResultResource {
         List<Participation> participations = participationService.findByExerciseIdWithEagerResults(exerciseId);
 
         for (Participation participation : participations) {
-
+            // Filter out participations without Students
+            // These participations are used e.g. to store template and solution build plans in programming exercises
             if (participation.getStudent() == null) {
                 continue;
             }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
@@ -304,6 +304,10 @@ public class ResultResource {
 
         for (Participation participation : participations) {
 
+            if (participation.getStudent() == null) {
+                continue;
+            }
+
             Result relevantResult;
             if (ratedOnly == true) {
                 relevantResult = exercise.findLatestRatedResultWithCompletionDate(participation);


### PR DESCRIPTION
These Results are used to store URLs to Base and Solution Build Plan

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [X] I run `yarn lint`: there project builds without code style warnings.
- [x] I removed unnecessary whitespace changes in all related files.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
This problem occurred:
<img width="2215" alt="Screenshot 2019-03-11 at 07 34 09" src="https://user-images.githubusercontent.com/6382716/54106991-2a1c3780-43d8-11e9-9004-43f61872248b.png">

### Description
We recently moved template and solution repository urls into the participations table.
This PR filters several API Endpoint results to not return these participations, which so not have a link to a user object (student).