### PR TITLE
[WIP] Feature/programming exercises show build errors in editor

### DIFF
--- a/src/main/webapp/app/editor/ace/editor-ace.component.html
+++ b/src/main/webapp/app/editor/ace/editor-ace.component.html
@@ -16,7 +16,7 @@
                     [durationBeforeCallback]="editorDurationBeforeCallback"
                     (textChanged)="onFileTextChanged($event)"
                     class="panel panel-default"
-                    style="display: block; width:100%; min-height: 500px; overflow: auto;"
+                    style="display: block; width:100%; min-height: 500px; overflow: auto; line-height: 14px;"
                     [hidden]="!fileName">
         </ace-editor>
 

--- a/src/main/webapp/app/editor/ace/editor-ace.component.html
+++ b/src/main/webapp/app/editor/ace/editor-ace.component.html
@@ -3,24 +3,24 @@
     <div class="card-header bg-primary text-white">
         <h3 class="card-title">
             <fa-icon [icon]="['far', 'file-alt']"></fa-icon>
-            <span> &nbsp;{{fileName}}</span>
+            <span> &nbsp;{{selectedFile}}</span>
         </h3>
     </div>
 
     <div class="card-body">
         <ace-editor #editor
-                    [(text)]="editorText"
+                    [text]="editorFileSessions[selectedFile] ? editorFileSessions[selectedFile].code : ''"
                     [mode]="editorMode"
                     [readOnly]=false
-                    [autoUpdateContent]="editorAutoUpdate"
-                    [durationBeforeCallback]="editorDurationBeforeCallback"
+                    [autoUpdateContent]="true"
+                    [durationBeforeCallback]="800"
                     (textChanged)="onFileTextChanged($event)"
                     class="panel panel-default"
                     style="display: block; width:100%; min-height: 500px; overflow: auto; line-height: 14px;"
-                    [hidden]="!fileName">
+                    [hidden]="!selectedFile">
         </ace-editor>
 
-        <p class="text-center lead text-muted" [hidden]="fileName" style="padding-top: 50px">
+        <p class="text-center lead text-muted" [hidden]="selectedFile" style="padding-top: 50px">
             Select a file to get started!
         </p>
     </div>

--- a/src/main/webapp/app/editor/ace/editor-ace.component.ts
+++ b/src/main/webapp/app/editor/ace/editor-ace.component.ts
@@ -210,6 +210,7 @@ export class EditorAceComponent implements OnInit, AfterViewInit, OnChanges {
         if (this.editorFileSessions[this.selectedFile] && this.editorFileSessions[this.selectedFile].code !== code) {
             // Assign received code to our session
             this.editorFileSessions = {
+                ...this.editorFileSessions,
                 [this.selectedFile]: {
                     ...this.editorFileSessions[this.selectedFile],
                     code,

--- a/src/main/webapp/app/editor/ace/editor-ace.component.ts
+++ b/src/main/webapp/app/editor/ace/editor-ace.component.ts
@@ -14,6 +14,7 @@ import 'brace/mode/java';
 import 'brace/mode/python';
 import 'brace/mode/javascript';
 import 'brace/mode/markdown';
+import { AceAnnotation } from '../../entities/ace-editor';
 // TODO: consider adding any modes we might need
 
 @Component({
@@ -43,6 +44,8 @@ export class EditorAceComponent implements OnInit, AfterViewInit, OnChanges {
     participation: Participation;
     @Input()
     fileName: string;
+    @Input()
+    buildLogErrors: AceAnnotation;
     @Output()
     saveStatusChange = new EventEmitter<object>();
 
@@ -89,6 +92,7 @@ export class EditorAceComponent implements OnInit, AfterViewInit, OnChanges {
             // Current file has changed
             this.loadFile(this.fileName);
         }
+        this.editor.getEditor().getSession().setAnnotations(this.buildLogErrors);
     }
 
     onSaveStatusChange(statusChange: object) {
@@ -216,6 +220,8 @@ export class EditorAceComponent implements OnInit, AfterViewInit, OnChanges {
             // Trigger file save
             this.saveFile(this.fileName);
             this.updateSaveStatusLabel();
+        } else {
+            this.editor.getEditor().getSession().setAnnotations(this.buildLogErrors);
         }
     }
 }

--- a/src/main/webapp/app/editor/build-output/editor-build-output.component.ts
+++ b/src/main/webapp/app/editor/build-output/editor-build-output.component.ts
@@ -1,6 +1,6 @@
 import { Participation } from '../../entities/participation';
 import { JhiAlertService } from 'ng-jhipster';
-import { AfterViewInit, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { AfterViewInit, EventEmitter, Component, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { WindowRef } from '../../core/websocket/window.service';
 import { RepositoryService } from '../../entities/repository/repository.service';
 import { EditorComponent } from '../editor.component';
@@ -28,6 +28,8 @@ export class EditorBuildOutputComponent implements AfterViewInit, OnChanges {
     participation: Participation;
     @Input()
     isBuilding: boolean;
+    @Output()
+    buildLogChange = new EventEmitter<BuildLogEntry[]>();
 
     constructor(
         private parent: EditorComponent,
@@ -56,7 +58,7 @@ export class EditorBuildOutputComponent implements AfterViewInit, OnChanges {
                 },
                 inertia: true
             })
-            .on('resizemove', function(event) {
+            .on('resizemove', function(event: any) {
                 const target = event.target;
                 // Update element height
                 target.style.height = event.rect.height + 'px';
@@ -105,6 +107,7 @@ export class EditorBuildOutputComponent implements AfterViewInit, OnChanges {
         this.repositoryService.buildlogs(this.participation.id).subscribe(buildLogs => {
             this.buildLogs = buildLogs;
             $('.buildoutput').scrollTop($('.buildoutput')[0].scrollHeight);
+            this.buildLogChange.emit(buildLogs);
         });
     }
 
@@ -116,6 +119,7 @@ export class EditorBuildOutputComponent implements AfterViewInit, OnChanges {
                     this.getBuildLogs();
                 } else {
                     this.buildLogs = [];
+                    this.buildLogChange.emit([]);
                 }
             });
         }

--- a/src/main/webapp/app/editor/editor.component.html
+++ b/src/main/webapp/app/editor/editor.component.html
@@ -24,7 +24,7 @@
     <div class="editor-main">
         <div class="editor-sidebar-left">
             <jhi-editor-file-browser [participation]="participation"
-                                     [fileName]="file"
+                                     [fileName]="selectedFile"
                                      [repositoryFiles]="repositoryFiles"
                                      (selectedFile)="updateSelectedFile($event)"
                                      (createdFile)="updateRepositoryCommitStatus($event)"
@@ -34,8 +34,8 @@
 
         <div class="editor-center">
             <jhi-editor-ace [participation]="participation"
-                            [fileName]="file"
-                            [buildLogErrors]="buildLogErrors ? buildLogErrors[file] : []"
+                            [selectedFile]="selectedFile"
+                            [buildLogErrors]="buildLogErrors ? buildLogErrors[selectedFile] : []"
                             (saveStatusChange)="updateSaveStatusLabel($event)">
             </jhi-editor-ace>
         </div>

--- a/src/main/webapp/app/editor/editor.component.html
+++ b/src/main/webapp/app/editor/editor.component.html
@@ -35,6 +35,7 @@
         <div class="editor-center">
             <jhi-editor-ace [participation]="participation"
                             [fileName]="file"
+                            [buildLogErrors]="buildLogErrors ? buildLogErrors[file] : []"
                             (saveStatusChange)="updateSaveStatusLabel($event)">
             </jhi-editor-ace>
         </div>
@@ -50,7 +51,8 @@
     <div class="editor-bottom">
         <jhi-editor-build-output
             [participation]="participation"
-            [isBuilding]="isBuilding">
+            [isBuilding]="isBuilding"
+            (buildLogChange)="updateLatestBuildLogs($event)">
         </jhi-editor-build-output>
     </div>
 

--- a/src/main/webapp/app/editor/editor.component.ts
+++ b/src/main/webapp/app/editor/editor.component.ts
@@ -13,6 +13,7 @@ import * as $ from 'jquery';
 import { Interactable } from 'interactjs';
 import { AceAnnotation, SaveStatusChange } from '../entities/ace-editor';
 import { BuildLogEntry } from 'app/entities/build-log';
+import { safeUnescape } from 'app/shared';
 
 @Component({
     selector: 'jhi-editor',
@@ -159,7 +160,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
                 fileName,
                 row: Math.max(parseInt(row, 10) - 1, 0),
                 column: Math.max(parseInt(column, 10) - 1, 0),
-                text
+                text: safeUnescape(text)
             }))
             .reduce((acc, { fileName, ...rest }) => ({ ...acc, [fileName]: [...(acc[fileName] || []), rest] }), {});
     }

--- a/src/main/webapp/app/editor/editor.component.ts
+++ b/src/main/webapp/app/editor/editor.component.ts
@@ -11,7 +11,7 @@ import { Result } from '../entities/result';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import * as $ from 'jquery';
 import { Interactable } from 'interactjs';
-import { AceAnnotation } from '../entities/ace-editor';
+import { AceAnnotation, SaveStatusChange } from '../entities/ace-editor';
 import { BuildLogEntry } from 'app/entities/build-log';
 
 @Component({
@@ -25,7 +25,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
 
     participation: Participation;
     repository: RepositoryService;
-    file: string;
+    selectedFile: string;
     paramSub: Subscription;
     repositoryFiles: string[];
     latestResult: Result;
@@ -131,7 +131,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
      * @desc Callback function for a save status changes of files
      * @param $event Event object which contains information regarding the save status of files
      */
-    updateSaveStatusLabel($event: any) {
+    updateSaveStatusLabel($event: SaveStatusChange) {
         this.isSaved = $event.isSaved;
         if (!this.isSaved) {
             this.isCommitted = false;
@@ -170,7 +170,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
      * @param $event Event object which contains the new file name
      */
     updateSelectedFile($event: any) {
-        this.file = $event.fileName;
+        this.selectedFile = $event.fileName;
     }
 
     /**
@@ -187,7 +187,7 @@ export class EditorComponent implements OnInit, OnChanges, OnDestroy {
                 this.repositoryFiles = files.filter(value => value !== 'README.md');
                 // Select newly created file
                 if ($event.mode === 'create') {
-                    this.file = $event.file;
+                    this.selectedFile = $event.file;
                 }
             },
             (error: HttpErrorResponse) => {

--- a/src/main/webapp/app/entities/ace-editor/annotation.model.ts
+++ b/src/main/webapp/app/entities/ace-editor/annotation.model.ts
@@ -1,0 +1,1 @@
+export type AceAnnotation = { row: string; column: string; text: string; type: string };

--- a/src/main/webapp/app/entities/ace-editor/index.ts
+++ b/src/main/webapp/app/entities/ace-editor/index.ts
@@ -1,1 +1,2 @@
 export * from './annotation.model';
+export * from './save-status-change.model';

--- a/src/main/webapp/app/entities/ace-editor/index.ts
+++ b/src/main/webapp/app/entities/ace-editor/index.ts
@@ -1,0 +1,1 @@
+export * from './annotation.model';

--- a/src/main/webapp/app/entities/ace-editor/save-status-change.model.ts
+++ b/src/main/webapp/app/entities/ace-editor/save-status-change.model.ts
@@ -1,0 +1,5 @@
+export type SaveStatusChange = {
+    isSaved: boolean;
+    saveStatusIcon: { spin: boolean; icon: string; class: string };
+    saveStatusLabel: string;
+};

--- a/src/main/webapp/app/shared/index.ts
+++ b/src/main/webapp/app/shared/index.ts
@@ -6,6 +6,7 @@ export * from './auth/has-any-authority.directive';
 export * from './language/find-language-from-key.pipe';
 export * from './login/login.component';
 export * from './util/request-util';
+export * from './util/security-util';
 export * from './model/base-entity';
 export * from './pipes/safe-html.pipe';
 export * from './pipes/safe-url.pipe';

--- a/src/main/webapp/app/shared/util/security-util.ts
+++ b/src/main/webapp/app/shared/util/security-util.ts
@@ -1,0 +1,4 @@
+export const safeUnescape = (s: string, mode = 'text/html') => {
+    const parser = new DOMParser();
+    return parser.parseFromString(s, 'text/html').body.textContent;
+};


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: there project builds without code style warnings.
- [x] I removed unnecessary whitespace changes in all related files.
- [x] I updated the documentation and models.
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] I added (end-to-end) test cases for the new functionality.

### Motivation and Context
Better visibility of build log errors (e.g. publi instead of public)

### Description
Three commits:
- Added build log errors as annotations to the ace-editor
- Some refactoring for better readability of the ace-editor code
- Bugfixes

**There are a couple of caveats/topics tbd:**

- If the user edits the text while the error annotation is active, it will move accordingly. However if the user edits the line of the error, it will disappear (might be as intended).
If the user edits the text, e.g. by entering line breaks and then switches between files, the errors will be in the wrong line. Unfortunately we can't export the updated position of the annotation from ace when leaving a file, so I see three ways to handle this: 
1) Leave the errors in the wrong line if necessary. 
2) Always remove errors if the file was saved after build (might be bad if the file has multiple errors). 
3) Build a more complex solution that updates the annotation position when the file is saved (might be lots of effort)
**EDIT: I found an approach to update the annotations, currently working on it.**

- Annotations can only be shown at the concerned line, not mark a word/expression. This could be solved by a more sophisticated solution using markers and anchors  (https://codepen.io/oatssss/pen/oYxJQV?editors=0010)

- At the load of a file, the error flashes for a moment and reappears again. As far as I see, this happens because of the the way the angular bindings work and can't be improved further.

### Steps for Testing

1. Log in to ArTEMiS
2. Navigate to Courses
3. Open a programming exercise in the online editor
4. Make a terrible mistake in the editor (e.g. publi vs public or cls vs class)
5. Commit & Run
6. See the errors :)

### Screenshots
![error-editor](https://user-images.githubusercontent.com/28230611/54188375-d3822c80-44af-11e9-93c5-f55bc85fabbd.jpg)

