### PR TITLE
Exercise creation UI improvements

### DIFF
--- a/src/main/webapp/app/entities/exercise/exercise.component.ts
+++ b/src/main/webapp/app/entities/exercise/exercise.component.ts
@@ -16,7 +16,7 @@ export abstract class ExerciseComponent implements OnInit, OnDestroy {
     predicate: string;
     reverse: boolean;
 
-    protected constructor(private courseService: CourseService, private translateService : TranslateService,
+    protected constructor(private courseService: CourseService, private translateService: TranslateService,
                           private route: ActivatedRoute, private eventManager: JhiEventManager) {
         this.predicate = 'id';
         this.reverse = true;

--- a/src/main/webapp/app/entities/exercise/exercise.component.ts
+++ b/src/main/webapp/app/entities/exercise/exercise.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 import { JhiEventManager } from 'ng-jhipster';
 import { Course, CourseService } from 'app/entities/course';
+import { TranslateService } from '@ngx-translate/core';
 
 export abstract class ExerciseComponent implements OnInit, OnDestroy {
     private eventSubscriber: Subscription;
@@ -15,7 +16,8 @@ export abstract class ExerciseComponent implements OnInit, OnDestroy {
     predicate: string;
     reverse: boolean;
 
-    protected constructor(private courseService: CourseService, private route: ActivatedRoute, private eventManager: JhiEventManager) {
+    protected constructor(private courseService: CourseService, private translateService : TranslateService,
+                          private route: ActivatedRoute, private eventManager: JhiEventManager) {
         this.predicate = 'id';
         this.reverse = true;
     }
@@ -46,6 +48,14 @@ export abstract class ExerciseComponent implements OnInit, OnDestroy {
             this.course = courseResponse.body;
             this.loadExercises();
         });
+    }
+
+    protected getAmountOfExercisesString<T>(exercises: Array<T> ): string {
+        if (exercises.length === 0) {
+            return this.translateService.instant('arTeMiSApp.createExercise.noExercises');
+        } else {
+            return exercises.length.toString();
+        }
     }
 
     protected abstract loadExercises(): void;

--- a/src/main/webapp/app/entities/exercise/exercise.component.ts
+++ b/src/main/webapp/app/entities/exercise/exercise.component.ts
@@ -50,7 +50,7 @@ export abstract class ExerciseComponent implements OnInit, OnDestroy {
         });
     }
 
-    protected getAmountOfExercisesString<T>(exercises: Array<T> ): string {
+    public getAmountOfExercisesString<T>(exercises: Array<T>): string {
         if (exercises.length === 0) {
             return this.translateService.instant('arTeMiSApp.createExercise.noExercises');
         } else {

--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.html
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.html
@@ -1,6 +1,6 @@
 <div>
     <h4>
-        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="fileUploadExercises && showHeading">{{fileUploadExercises.length}} </span>
+        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="fileUploadExercises && showHeading">{{getAmountOfExercisesString(fileUploadExercises)}} </span>
         <span jhiTranslate="arTeMiSApp.fileUploadExercise.home.title">File Upload Exercises</span>
         <button *ngIf="course" class="btn btn-primary float-right jh-create-entity create-file-upload-exercise" [routerLink]="['/', { outlets: { popup: ['course', course.id, 'file-upload-exercise-new'] } }]">
             <fa-icon icon="plus"></fa-icon>
@@ -13,7 +13,7 @@
     <div class="row">
     </div>
     <br>
-    <div class="table-responsive" *ngIf="fileUploadExercises">
+    <div class="table-responsive" *ngIf="fileUploadExercises && fileUploadExercises.length > 0">
         <table class="table table-striped">
             <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="callback">

--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.ts
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.ts
@@ -7,6 +7,8 @@ import { FileUploadExerciseService } from './file-upload-exercise.service';
 import { CourseExerciseService, CourseService } from '../course';
 import { ActivatedRoute } from '@angular/router';
 import { ExerciseComponent } from 'app/entities/exercise/exercise.component';
+import { TranslateService } from '@ngx-translate/core';
+
 @Component({
     selector: 'jhi-file-upload-exercise',
     templateUrl: './file-upload-exercise.component.html'
@@ -18,11 +20,12 @@ export class FileUploadExerciseComponent extends ExerciseComponent {
         private fileUploadExerciseService: FileUploadExerciseService,
         private courseExerciseService: CourseExerciseService,
         courseService: CourseService,
+        translateService: TranslateService,
         private jhiAlertService: JhiAlertService,
         eventManager: JhiEventManager,
         route: ActivatedRoute
     ) {
-        super(courseService, route, eventManager);
+        super(courseService, translateService, route, eventManager);
         this.fileUploadExercises = [];
     }
 

--- a/src/main/webapp/app/entities/modeling-exercise/modeling-exercise.component.html
+++ b/src/main/webapp/app/entities/modeling-exercise/modeling-exercise.component.html
@@ -1,6 +1,6 @@
 <div>
     <h4>
-        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="modelingExercises && showHeading">{{modelingExercises.length}} </span>
+        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="modelingExercises && showHeading">{{getAmountOfExercisesString(modelingExercises)}} </span>
         <span jhiTranslate="arTeMiSApp.modelingExercise.home.title">Modeling Exercises</span>
         <button *ngIf="course" class="btn btn-primary float-right jh-create-entity create-modeling-exercise" [routerLink]="['/', { outlets: { popup: ['course', course.id, 'modeling-exercise-new'] } }]">
             <fa-icon icon="plus"></fa-icon>
@@ -13,7 +13,7 @@
     <div class="row">
     </div>
     <br>
-    <div class="table-responsive" *ngIf="modelingExercises">
+    <div class="table-responsive" *ngIf="modelingExercises && modelingExercises.length > 0">
         <table class="table table-striped">
             <thead>
                 <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="callback">

--- a/src/main/webapp/app/entities/modeling-exercise/modeling-exercise.component.ts
+++ b/src/main/webapp/app/entities/modeling-exercise/modeling-exercise.component.ts
@@ -9,6 +9,7 @@ import { CourseExerciseService } from '../course/course.service';
 import { ActivatedRoute } from '@angular/router';
 import { CourseService } from '../course';
 import { ExerciseComponent } from 'app/entities/exercise/exercise.component';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
     selector: 'jhi-modeling-exercise',
@@ -21,12 +22,13 @@ export class ModelingExerciseComponent extends ExerciseComponent {
         private modelingExerciseService: ModelingExerciseService,
         private courseExerciseService: CourseExerciseService,
         courseService: CourseService,
+        translateService: TranslateService,
         private jhiAlertService: JhiAlertService,
         eventManager: JhiEventManager,
         private accountService: AccountService,
         route: ActivatedRoute
     ) {
-        super(courseService, route, eventManager);
+        super(courseService, translateService, route, eventManager);
         this.modelingExercises = [];
     }
 

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.html
@@ -1,6 +1,6 @@
 <div>
     <h4>
-        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="programmingExercises && showHeading">{{programmingExercises.length}} </span>
+        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="programmingExercises && showHeading">{{getAmountOfExercisesString(programmingExercises)}} </span>
         <span jhiTranslate="arTeMiSApp.programmingExercise.home.title">Programming Exercises</span>
         <button *ngIf="course" id="jh-link-entity" class="btn btn-primary float-right jh-link-entity link-programming-exercise mr-1" [routerLink]="['/', { outlets: { popup: ['course', course.id, 'programming-exercise-new'] } }]">
             <fa-icon [icon]="'plus'"></fa-icon>
@@ -19,7 +19,7 @@
     <div class="row">
     </div>
     <br>
-    <div class="table-responsive" *ngIf="programmingExercises">
+    <div class="table-responsive" *ngIf="programmingExercises && programmingExercises.length > 0">
         <table class="table table-striped">
             <thead>
                 <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="callback">

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.ts
@@ -7,6 +7,8 @@ import { ProgrammingExerciseService } from './programming-exercise.service';
 import { CourseExerciseService, CourseService } from '../course';
 import { ActivatedRoute } from '@angular/router';
 import { ExerciseComponent } from 'app/entities/exercise/exercise.component';
+import { TranslateService } from '@ngx-translate/core';
+
 @Component({
     selector: 'jhi-programming-exercise',
     templateUrl: './programming-exercise.component.html'
@@ -18,11 +20,12 @@ export class ProgrammingExerciseComponent extends ExerciseComponent implements O
         private programmingExerciseService: ProgrammingExerciseService,
         private courseExerciseService: CourseExerciseService,
         courseService: CourseService,
+        translateService: TranslateService,
         private jhiAlertService: JhiAlertService,
         eventManager: JhiEventManager,
         route: ActivatedRoute
     ) {
-        super(courseService, route, eventManager);
+        super(courseService, translateService, route, eventManager);
         this.programmingExercises = [];
     }
 

--- a/src/main/webapp/app/entities/quiz-exercise/quiz-exercise.component.html
+++ b/src/main/webapp/app/entities/quiz-exercise/quiz-exercise.component.html
@@ -1,6 +1,6 @@
 <div>
     <h4>
-        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="quizExercises && showHeading">{{quizExercises.length}} </span>
+        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="quizExercises && showHeading">{{getAmountOfExercisesString(quizExercises)}} </span>
         <span jhiTranslate="arTeMiSApp.quizExercise.home.title">Quiz Exercises</span>
         <button class="btn mr-2 btn-primary float-right jh-create-entity create-quiz-exercise" [routerLink]="['/course', courseId, 'quiz-exercise', 'new']">
             <fa-icon icon="plus"></fa-icon>
@@ -25,7 +25,7 @@
     <div class="row">
     </div>
     <br>
-    <div class="table-responsive" *ngIf="quizExercises">
+    <div class="table-responsive" *ngIf="quizExercises && quizExercises.length > 0">
         <table class="table table-striped">
             <thead>
                 <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="callback">

--- a/src/main/webapp/app/entities/quiz-exercise/quiz-exercise.component.ts
+++ b/src/main/webapp/app/entities/quiz-exercise/quiz-exercise.component.ts
@@ -9,6 +9,7 @@ import { ActivatedRoute } from '@angular/router';
 import * as moment from 'moment';
 import { CourseService } from '../course';
 import { ExerciseComponent } from 'app/entities/exercise/exercise.component';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
     selector: 'jhi-quiz-exercise',
@@ -28,13 +29,14 @@ export class QuizExerciseComponent extends ExerciseComponent {
 
     constructor(
         courseService: CourseService,
+        translateService: TranslateService,
         private quizExerciseService: QuizExerciseService,
         private jhiAlertService: JhiAlertService,
         eventManager: JhiEventManager,
         private accountService: AccountService,
         route: ActivatedRoute
     ) {
-        super(courseService, route, eventManager);
+        super(courseService, translateService, route, eventManager);
 
     }
 

--- a/src/main/webapp/app/entities/text-exercise/text-exercise.component.html
+++ b/src/main/webapp/app/entities/text-exercise/text-exercise.component.html
@@ -1,6 +1,6 @@
 <div>
     <h4>
-        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="textExercises && showHeading">{{textExercises.length}} </span>
+        <span *ngIf="course && !showHeading">{{course.title}} - </span><span *ngIf="textExercises && showHeading">{{getAmountOfExercisesString(textExercises)}} </span>
         <span jhiTranslate="arTeMiSApp.textExercise.home.title">Text Exercises</span>
         <button *ngIf="course" class="btn btn-primary float-right jh-create-entity create-text-exercise" [routerLink]="['/', { outlets: { popup: ['course', course.id, 'text-exercise-new'] } }]">
             <fa-icon icon="plus"></fa-icon>
@@ -13,7 +13,7 @@
     <div class="row">
     </div>
     <br>
-    <div class="table-responsive" *ngIf="textExercises">
+    <div class="table-responsive" *ngIf="textExercises && textExercises.length > 0">
         <table class="table table-striped">
             <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="callback">

--- a/src/main/webapp/app/entities/text-exercise/text-exercise.component.ts
+++ b/src/main/webapp/app/entities/text-exercise/text-exercise.component.ts
@@ -7,6 +7,7 @@ import { TextExerciseService } from './text-exercise.service';
 import { CourseExerciseService, CourseService } from '../course';
 import { ActivatedRoute } from '@angular/router';
 import { ExerciseComponent } from 'app/entities/exercise/exercise.component';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
     selector: 'jhi-text-exercise',
@@ -19,11 +20,12 @@ export class TextExerciseComponent extends ExerciseComponent {
         private textExerciseService: TextExerciseService,
         private courseExerciseService: CourseExerciseService,
         courseService: CourseService,
+        translateService: TranslateService,
         private jhiAlertService: JhiAlertService,
         eventManager: JhiEventManager,
         route: ActivatedRoute
     ) {
-        super(courseService, route, eventManager);
+        super(courseService, translateService, route, eventManager);
         this.textExercises = [];
     }
 

--- a/src/main/webapp/i18n/de/createExercise.json
+++ b/src/main/webapp/i18n/de/createExercise.json
@@ -1,0 +1,7 @@
+{
+    "arTeMiSApp": {
+        "createExercise": {
+            "noExercises": "Keine"
+        }
+    }
+}

--- a/src/main/webapp/i18n/en/createExercise.json
+++ b/src/main/webapp/i18n/en/createExercise.json
@@ -1,0 +1,7 @@
+{
+    "arTeMiSApp": {
+        "createExercise": {
+            "noExercises": "No"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: there project builds without code style warnings.
- [x] I removed unnecessary whitespace changes in all related files.
- [x] ~~I updated the documentation and models.~~ (nothing to change) 
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~~I added (end-to-end) test cases for the new functionality.~~ (nothing to unit test)

### Note
I did not know on how to deploy to the test server and would be happy if you tell me if it is necessary. :) Nevertheless, I have tested at my local machine at least.

### Motivation and Context
More intuitive for the user, as displaying empty tables wastes space. Furthermore, displaying 'No' instead of '0' in case of no exercises looks better.

### Description
1. If there are no exercises in this course, no table will be displayed. When a exercise is created or at least one exists, the table with the exercises is shown.
2. If there are no exercises, 'No' is displayed instead of '0'.

### Steps for Testing

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Click on 'Exercises' on an arbitrary course
4. Add or delete exercises

### Screenshots

Before:
![before](https://user-images.githubusercontent.com/10549770/54496895-9c1ee000-48f4-11e9-827d-635c0fabc81c.png)
Improved:
![improved](https://user-images.githubusercontent.com/10549770/54496899-9d500d00-48f4-11e9-8197-83e7b9722f53.png)