### PR TITLE
added color to course

### DIFF
--- a/src/main/webapp/app/app.constants.ts
+++ b/src/main/webapp/app/app.constants.ts
@@ -11,3 +11,5 @@ export const MIN_POINTS_GREEN = 80;
 export const MIN_POINTS_ORANGE = 40;
 
 export const TUM_REGEX = /^([a-z]{2}\d{2}[a-z]{3})$/;
+
+export const ARTEMIS_DEFAULT_COLOR = '#3E8ACC';

--- a/src/main/webapp/app/components/color-selector/color-selector.component.ts
+++ b/src/main/webapp/app/components/color-selector/color-selector.component.ts
@@ -1,11 +1,12 @@
 import { Component, Output, EventEmitter, Input, OnInit } from '@angular/core';
+import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 
 export interface Coordinates {
     left: number;
     top: number;
 }
 
-const DEFAULT_COLORS = ['#6ae8ac', '#9dca53', '#94a11c', '#691b0b', '#ad5658', '#1b97ca', '#0d3cc2', '#0ab84f'];
+const DEFAULT_COLORS = [ARTEMIS_DEFAULT_COLOR, '#9dca53', '#94a11c', '#691b0b', '#ad5658', '#1b97ca', '#0d3cc2', '#0ab84f'];
 
 @Component({
     selector: 'jhi-color-selector',

--- a/src/main/webapp/app/entities/course/course-update.component.html
+++ b/src/main/webapp/app/entities/course/course-update.component.html
@@ -10,9 +10,22 @@
                     <label for="id" jhiTranslate="global.field.id">ID</label>
                     <input type="text" class="form-control" id="id" name="id" formControlName="id" readonly />
                 </div>
-                <div class="form-group">
-                    <label class="form-control-label" jhiTranslate="arTeMiSApp.course.title" for="field_title">Title</label>
-                    <input type="text" class="form-control" name="title" id="field_title" formControlName="title" required/>
+                <div class="row">
+                    <div class="col">
+                        <div class="form-group">
+                            <label class="form-control-label" jhiTranslate="arTeMiSApp.course.title" for="field_title">Title</label>
+                            <input type="text" class="form-control" name="title" id="field_title" formControlName="title" required/>
+                        </div>
+                    </div>
+                    <div class="col-2">
+                        <div class="form-group">
+                            <label class="form-control-label" jhiTranslate="arTeMiSApp.course.color" for="field_title">Color</label>
+                            <div class="color-preview form-control" [ngStyle]="{backgroundColor: courseForm.get('color').value || ARTEMIS_DEFAULT_COLOR}" (click)="openColorSelector($event)">
+
+                            </div>
+                            <jhi-color-selector (selectedColor)="onSelectedColor($event)"></jhi-color-selector>
+                        </div>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="arTeMiSApp.course.shortName" for="field_shortName">Short Name</label>

--- a/src/main/webapp/app/entities/course/course-update.component.ts
+++ b/src/main/webapp/app/entities/course/course-update.component.ts
@@ -14,7 +14,8 @@ import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-course-update',
-    templateUrl: './course-update.component.html'
+    templateUrl: './course-update.component.html',
+    styles: ['.color-preview { cursor: pointer; }']
 })
 export class CourseUpdateComponent implements OnInit {
     @ViewChild(ColorSelectorComponent) colorSelector: ColorSelectorComponent;

--- a/src/main/webapp/app/entities/course/course-update.component.ts
+++ b/src/main/webapp/app/entities/course/course-update.component.ts
@@ -10,7 +10,6 @@ import { regexValidator } from 'app/shared/form/shortname-validator.directive';
 import { Course } from './course.model';
 import { CourseService } from './course.service';
 import { ColorSelectorComponent } from 'app/components/color-selector/color-selector.component';
-import { ExerciseCategory } from 'app/entities/exercise';
 import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 
 @Component({
@@ -65,7 +64,7 @@ export class CourseUpdateComponent implements OnInit {
         }
     }
 
-    openColorSelector(event: MouseEvent, tagItem: ExerciseCategory) {
+    openColorSelector(event: MouseEvent) {
         this.colorSelector.openColorSelector(event);
     }
 

--- a/src/main/webapp/app/entities/course/course-update.component.ts
+++ b/src/main/webapp/app/entities/course/course-update.component.ts
@@ -1,5 +1,5 @@
 import { ActivatedRoute } from '@angular/router';
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { JhiAlertService } from 'ng-jhipster';
@@ -9,12 +9,17 @@ import { regexValidator } from 'app/shared/form/shortname-validator.directive';
 
 import { Course } from './course.model';
 import { CourseService } from './course.service';
+import { ColorSelectorComponent } from 'app/components/color-selector/color-selector.component';
+import { ExerciseCategory } from 'app/entities/exercise';
+import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-course-update',
     templateUrl: './course-update.component.html'
 })
 export class CourseUpdateComponent implements OnInit {
+    @ViewChild(ColorSelectorComponent) colorSelector: ColorSelectorComponent;
+    readonly ARTEMIS_DEFAULT_COLOR = ARTEMIS_DEFAULT_COLOR;
     courseForm: FormGroup;
     course: Course;
     isSaving: boolean;
@@ -42,7 +47,8 @@ export class CourseUpdateComponent implements OnInit {
             startDate: new FormControl(this.course.startDate),
             endDate: new FormControl(this.course.endDate),
             onlineCourse: new FormControl(this.course.onlineCourse),
-            registrationEnabled: new FormControl(this.course.registrationEnabled)
+            registrationEnabled: new FormControl(this.course.registrationEnabled),
+            color: new FormControl(this.course.color)
         });
     }
 
@@ -57,6 +63,14 @@ export class CourseUpdateComponent implements OnInit {
         } else {
             this.subscribeToSaveResponse(this.courseService.create(this.courseForm.value));
         }
+    }
+
+    openColorSelector(event: MouseEvent, tagItem: ExerciseCategory) {
+        this.colorSelector.openColorSelector(event);
+    }
+
+    onSelectedColor(selectedColor: string) {
+        this.courseForm.patchValue({'color': selectedColor});
     }
 
     private subscribeToSaveResponse(result: Observable<HttpResponse<Course>>) {

--- a/src/main/webapp/app/entities/course/course.model.ts
+++ b/src/main/webapp/app/entities/course/course.model.ts
@@ -14,6 +14,7 @@ export class Course implements BaseEntity {
     public instructorGroupName: string;
     public startDate: Moment;
     public endDate: Moment;
+    public color: string;
     public onlineCourse = false; // default value
     public registrationEnabled = false; // default value
     public maxComplaints: number;

--- a/src/main/webapp/app/entities/course/course.module.ts
+++ b/src/main/webapp/app/entities/course/course.module.ts
@@ -24,6 +24,7 @@ import {
 } from './';
 import { CourseExerciseCardComponent } from 'app/entities/course/course-exercise-card.component';
 import { FormDateTimePickerModule } from '../../shared/date-time-picker/date-time-picker.module';
+import { ArTEMiSColorSelectorModule } from 'app/components/color-selector/color-selector.module';
 
 const ENTITY_STATES = [...courseRoute, ...coursePopupRoute];
 
@@ -37,7 +38,8 @@ const ENTITY_STATES = [...courseRoute, ...coursePopupRoute];
         ArTEMiSModelingExerciseModule,
         RouterModule.forChild(ENTITY_STATES),
         FormDateTimePickerModule,
-        ReactiveFormsModule
+        ReactiveFormsModule,
+        ArTEMiSColorSelectorModule
     ],
     declarations: [
         CourseComponent,

--- a/src/main/webapp/app/overview/overview-course-card.component.html
+++ b/src/main/webapp/app/overview/overview-course-card.component.html
@@ -1,5 +1,5 @@
 <div class="card">
-    <div class="card-header bg-{{randomColor}} text-white" routerLink="/overview/{{course.id}}">
+    <div class="card-header text-white" routerLink="/overview/{{course.id}}" [ngStyle]="{backgroundColor: course.color || ARTEMIS_DEFAULT_COLOR}">
         <h5 class="card-title text-center">
             {{course.title}}
         </h5>

--- a/src/main/webapp/app/overview/overview-course-card.component.ts
+++ b/src/main/webapp/app/overview/overview-course-card.component.ts
@@ -24,13 +24,6 @@ export class OverviewCourseCardComponent implements OnInit {
     ngOnInit() {
     }
 
-    // TODO: remove again!
-    get randomColor(): string {
-        const colors = ['danger', 'info', 'success', 'warning'];
-        const randomIndex = (this.course.id % colors.length) - 1;
-        return colors[randomIndex];
-    }
-
     displayTotalRelativeScore(): number {
         if (this.course.exercises.length > 0) {
             return this.courseScoreCalculationService.calculateTotalScores(this.course.exercises).get('relativeScore');

--- a/src/main/webapp/app/overview/overview-course-card.component.ts
+++ b/src/main/webapp/app/overview/overview-course-card.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { Course, CourseScoreCalculationService } from 'app/entities/course';
 import { Exercise, ExerciseService } from 'app/entities/exercise';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-overview-course-card',
@@ -9,6 +10,7 @@ import { ActivatedRoute, Router } from '@angular/router';
     styleUrls: ['overview-course-card.scss']
 })
 export class OverviewCourseCardComponent implements OnInit {
+    readonly ARTEMIS_DEFAULT_COLOR = ARTEMIS_DEFAULT_COLOR;
     @Input() course: Course;
 
     constructor(

--- a/src/main/webapp/i18n/de/course.json
+++ b/src/main/webapp/i18n/de/course.json
@@ -18,6 +18,7 @@
             },
             "totalScore": "Gesamtergebnis:",
             "title": "Titel",
+            "color": "Farbe",
             "shortName": "Kurzname",
             "studentGroupName": "Studenten Gruppe",
             "teachingAssistantGroupName": "Tutor Gruppe",

--- a/src/main/webapp/i18n/en/course.json
+++ b/src/main/webapp/i18n/en/course.json
@@ -18,6 +18,7 @@
             },
             "totalScore": "Total Score:",
             "title": "Title",
+            "color": "Color",
             "shortName": "Short Name",
             "studentGroupName": "Student Group",
             "teachingAssistantGroupName": "Tutor Group",


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: there project builds without code style warnings.
- [x] I removed unnecessary whitespace changes in all related files.
- [x] I updated the documentation and models.
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~~I added (end-to-end) test cases for the new functionality.~~

### Motivation and Context
Color for course dashboard was missing.

### Description
added color selector to the course

### Steps for Testing
1. Log in to ArTEMiS
2. Navigate to Course Administration
3. edit a course
4. select a color
5. save the course
6. go to the course dashboard
7. the header of the course card should reflect the selected color
8. remaining course should have a default blue color

### Screenshots
![image](https://user-images.githubusercontent.com/10998002/54700454-57cd5300-4b33-11e9-95da-ccd0882d244f.png)
