### PR TITLE
fix drag and drop model quiz creation

### DIFF
--- a/src/main/webapp/app/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
+++ b/src/main/webapp/app/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
@@ -9,7 +9,7 @@ import { DragAndDropMapping } from '../../entities/drag-and-drop-mapping';
 import { DragItem } from '../../entities/drag-item';
 import { ScoringType } from '../../entities/quiz-question';
 import * as moment from 'moment';
-import { ApollonEditor, Element, UMLModel, SVG } from '@ls1intum/apollon';
+import { ApollonEditor, Element, UMLModel, SVG, ElementType, UMLRelationshipType, UMLElementType } from '@ls1intum/apollon';
 
 // Drop locations in quiz exercises are relatively positioned and sized
 // using integers in the interval [0,200]
@@ -40,7 +40,7 @@ export async function generateDragAndDropQuizExercise(
     const dropLocations: DropLocation[] = [];
     const correctMappings: DragAndDropMapping[] = [];
 
-    const elements = { ...model.elements, ...model.relationships };
+    const elements = [ ...model.elements, ...model.relationships ];
     // Create Drag Items, Drop Locations and their mappings for each interactive element
     for (const elementId of [...model.interactive.elements, ...model.interactive.relationships]) {
         const element = elements.find(elem => elem.id === elementId);
@@ -111,7 +111,7 @@ async function generateDragAndDropItem(
     clip: { x: number; y: number; width: number; height: number },
     fileUploaderService: FileUploaderService
 ): Promise<{ dragItem: DragItem; dropLocation: DropLocation; correctMapping: DragAndDropMapping }> {
-    const isRelationship = model.relationships.find(relationship => relationship.id === element.id) !== undefined;
+    const isRelationship = element.type in UMLRelationshipType;
 
     const margin = isRelationship ? 30 : 0;
 


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: there project builds without code style warnings.
- [x] I removed unnecessary whitespace changes in all related files.
- [x] ~I updated the documentation and models.~
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
After adapting ArTEMiS to the new Apollon version generating drag-and-drop modeling exercises resulted in an error. This is fixed in the PR.

### Steps for Testing
1. Log in to ArTEMiS as an instructor
2. Navigate to Course Administration -> Exercises -> Create Drag and Drop Model Quiz -> Create a new Apollon Diagram
3. Create a model with interactive elements
4. Click on "Generate a Quiz Exercise..."