### PR TITLE
Adjust the selected text range after inserting domain commands into the new markdown editor

### DIFF
--- a/src/main/webapp/app/components/util/markdown.service.ts
+++ b/src/main/webapp/app/components/util/markdown.service.ts
@@ -22,11 +22,12 @@ export class ArtemisMarkdown {
         aceEditorContainer.getEditor().moveCursorTo(aceEditorContainer.getEditor().getCursorPosition().row, Number.POSITIVE_INFINITY);
         aceEditorContainer.getEditor().insert(text);
         const range = aceEditorContainer.getEditor().selection.getRange();
-        const identifier = text.split(']');
-        const offset = identifier[0].length + 1;
-        range.setStart(range.start.row, offset);
+        const commandIdentifier = text.split(']');
+        const offsetRange = commandIdentifier[0].length + 1;
+        range.setStart(range.start.row, offsetRange);
         aceEditorContainer.getEditor().selection.setRange(range);
     }
+
 
     constructor(private sanitizer: DomSanitizer) {}
 

--- a/src/main/webapp/app/components/util/markdown.service.ts
+++ b/src/main/webapp/app/components/util/markdown.service.ts
@@ -27,8 +27,7 @@ export class ArtemisMarkdown {
         range.setStart(range.start.row, offsetRange);
         aceEditorContainer.getEditor().selection.setRange(range);
     }
-
-
+    
     constructor(private sanitizer: DomSanitizer) {}
 
     /**

--- a/src/main/webapp/app/components/util/markdown.service.ts
+++ b/src/main/webapp/app/components/util/markdown.service.ts
@@ -22,7 +22,9 @@ export class ArtemisMarkdown {
         aceEditorContainer.getEditor().moveCursorTo(aceEditorContainer.getEditor().getCursorPosition().row, Number.POSITIVE_INFINITY);
         aceEditorContainer.getEditor().insert(text);
         const range = aceEditorContainer.getEditor().selection.getRange();
-        range.setStart(range.start.row, 6);
+        const identifier = text.split(']');
+        const offset = identifier[0].length + 1;
+        range.setStart(range.start.row, offset);
         aceEditorContainer.getEditor().selection.setRange(range);
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: there project builds without code style warnings.
- [x] I removed unnecessary whitespace changes in all related files.
- [x] ~~I updated the documentation and models.~~
- [x] ~~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~~
- [x] ~~I added (end-to-end) test cases for the new functionality.~~

### Motivation and Context
BugFix - when adding a new domainCommand the range should contain only the content of the command not the identifier

### Description
1. Split the text to find the identifier 
2. Add the whitespace after the to the offsetRange 
3. Call the offset in the in the range.setStart

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- If applicable, add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->