### PR TITLE
Disable HSTS in Sprint Web Security Configuration to prevent duplicate Header.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/SecurityConfiguration.java
@@ -45,16 +45,14 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     private final CorsFilter corsFilter;
     private final SecurityProblemSupport problemSupport;
     private final Optional<AuthenticationProvider> remoteUserAuthenticationProvider;
-    private final JHipsterProperties jHipsterProperties;
 
-    public SecurityConfiguration(AuthenticationManagerBuilder authenticationManagerBuilder, UserDetailsService userDetailsService, TokenProvider tokenProvider, CorsFilter corsFilter, SecurityProblemSupport problemSupport, Optional<AuthenticationProvider> remoteUserAuthenticationProvider, JHipsterProperties jHipsterProperties) {
+    public SecurityConfiguration(AuthenticationManagerBuilder authenticationManagerBuilder, UserDetailsService userDetailsService, TokenProvider tokenProvider, CorsFilter corsFilter, SecurityProblemSupport problemSupport, Optional<AuthenticationProvider> remoteUserAuthenticationProvider) {
         this.authenticationManagerBuilder = authenticationManagerBuilder;
         this.userDetailsService = userDetailsService;
         this.tokenProvider = tokenProvider;
         this.corsFilter = corsFilter;
         this.problemSupport = problemSupport;
         this.remoteUserAuthenticationProvider = remoteUserAuthenticationProvider;
-        this.jHipsterProperties = jHipsterProperties;
     }
 
     @PostConstruct
@@ -63,9 +61,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             authenticationManagerBuilder
                 .userDetailsService(userDetailsService)
                 .passwordEncoder(passwordEncoder());
-            if(remoteUserAuthenticationProvider.isPresent()) {
-                authenticationManagerBuilder.authenticationProvider(remoteUserAuthenticationProvider.get());
-            }
+            remoteUserAuthenticationProvider.ifPresent(authenticationManagerBuilder::authenticationProvider);
         } catch (Exception e) {
             throw new BeanInitializationException("Security configuration failed", e);
         }
@@ -125,6 +121,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         .and()
             .headers()
             .frameOptions()
+            .disable()
+        .and()
+            .headers()
+            .httpStrictTransportSecurity()
             .disable()
         .and()
             .sessionManagement()


### PR DESCRIPTION
### Checklist
- [X] I run `yarn run webpack:build:main`: the project builds without errors.
- [X] I run `yarn lint`: the project builds without code style warnings.
- [X] ~I updated the documentation and models.~
- [X] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [X] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
HSTS Header was set twice with conflicting settings.

### Description
Disable HSTS in Sprint Web Security Configuration.
HSTS is configured in Nginx only.

### Steps for Testing
https://www.ssllabs.com/ssltest/analyze.html?d=artemistest.ase.in.tum.de&hideResults=on

### Screenshots
<img width="1103" alt="image" src="https://user-images.githubusercontent.com/6382716/55403702-b42e6a80-5556-11e9-9dd5-744e58940cb8.png">
