### PR TITLE
Fix creation of example text submission

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -1,5 +1,14 @@
 package de.tum.in.www1.artemis.service;
 
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
@@ -7,29 +16,21 @@ import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
 import de.tum.in.www1.artemis.service.scheduled.AutomaticSubmissionService;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @Transactional
 public class TextSubmissionService {
 
     private final TextSubmissionRepository textSubmissionRepository;
+
     private final ParticipationRepository participationRepository;
+
     private final ParticipationService participationService;
+
     private final ResultRepository resultRepository;
 
-    public TextSubmissionService(TextSubmissionRepository textSubmissionRepository,
-                                 ParticipationRepository participationRepository,
-                                 ParticipationService participationService,
-                                 ResultRepository resultRepository) {
+    public TextSubmissionService(TextSubmissionRepository textSubmissionRepository, ParticipationRepository participationRepository, ParticipationService participationService,
+            ResultRepository resultRepository) {
         this.textSubmissionRepository = textSubmissionRepository;
         this.participationRepository = participationRepository;
         this.participationService = participationService;
@@ -37,11 +38,8 @@ public class TextSubmissionService {
     }
 
     /**
-     * Saves the given submission. Furthermore, the submission is added to the AutomaticSubmissionService,
-     * if not submitted yet.
-     * Is used for creating and updating text submissions.
-     * If it is used for a submit action, Compass is notified about the new model.
-     * Rolls back if inserting fails - occurs for concurrent createTextSubmission() calls.
+     * Saves the given submission. Furthermore, the submission is added to the AutomaticSubmissionService, if not submitted yet. Is used for creating and updating text submissions.
+     * If it is used for a submit action, Compass is notified about the new model. Rolls back if inserting fails - occurs for concurrent createTextSubmission() calls.
      *
      * @param textSubmission the submission to notifyCompass
      * @param textExercise   the exercise to notifyCompass in
@@ -53,33 +51,25 @@ public class TextSubmissionService {
         // update submission properties
         textSubmission.setSubmissionDate(ZonedDateTime.now());
         textSubmission.setType(SubmissionType.MANUAL);
-
-        boolean isExampleSubmission = textSubmission.isExampleSubmission() == Boolean.TRUE;
-
-        // Example submissions do not have a participation
-        if (!isExampleSubmission) {
-            textSubmission.setParticipation(participation);
-        }
+        textSubmission.setParticipation(participation);
         textSubmission = textSubmissionRepository.save(textSubmission);
 
-        // All the following are useful only for real submissions
-        if (!isExampleSubmission) {
-            participation.addSubmissions(textSubmission);
+        participation.addSubmissions(textSubmission);
 
-            User user = participation.getStudent();
+        User user = participation.getStudent();
 
-            if (textSubmission.isSubmitted()) {
-                participation.setInitializationState(InitializationState.FINISHED);
-            } else if (textExercise.getDueDate() != null && !textExercise.isEnded()) {
-                // save submission to HashMap if exercise not ended yet
-                AutomaticSubmissionService.updateSubmission(textExercise.getId(), user.getLogin(), textSubmission);
-            }
-            Participation savedParticipation = participationRepository.save(participation);
-            if (textSubmission.getId() == null) {
-                Optional<TextSubmission> optionalTextSubmission = savedParticipation.findLatestTextSubmission();
-                if (optionalTextSubmission.isPresent()) {
-                    textSubmission = optionalTextSubmission.get();
-                }
+        if (textSubmission.isSubmitted()) {
+            participation.setInitializationState(InitializationState.FINISHED);
+        }
+        else if (textExercise.getDueDate() != null && !textExercise.isEnded()) {
+            // save submission to HashMap if exercise not ended yet
+            AutomaticSubmissionService.updateSubmission(textExercise.getId(), user.getLogin(), textSubmission);
+        }
+        Participation savedParticipation = participationRepository.save(participation);
+        if (textSubmission.getId() == null) {
+            Optional<TextSubmission> optionalTextSubmission = savedParticipation.findLatestTextSubmission();
+            if (optionalTextSubmission.isPresent()) {
+                textSubmission = optionalTextSubmission.get();
             }
         }
 
@@ -87,34 +77,42 @@ public class TextSubmissionService {
     }
 
     /**
-     * Given an exercise id, find a random text submission for that exercise which still doesn't have any result.
+     * The same as `save()`, but without participation, is used by example submission, which aren't linked to any participation
      *
-     * We relay for the randomness to `findAny()`, which return any element of the stream. While it is not
-     * mathematically random, it is not deterministic
-     * https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#findAny--
+     * @param textSubmission the submission to notifyCompass
+     * @return the textSubmission entity
+     */
+    @Transactional(rollbackFor = Exception.class)
+    public TextSubmission save(TextSubmission textSubmission) {
+        textSubmission.setSubmissionDate(ZonedDateTime.now());
+        textSubmission.setType(SubmissionType.MANUAL);
+
+        textSubmission = textSubmissionRepository.save(textSubmission);
+
+        return textSubmission;
+    }
+
+    /**
+     * Given an exercise id, find a random text submission for that exercise which still doesn't have any result. We relay for the randomness to `findAny()`, which return any
+     * element of the stream. While it is not mathematically random, it is not deterministic https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#findAny--
      *
      * @param exerciseId the exercise we want to retrieve
      * @return a textSubmission without any result, if any
      */
     @Transactional(readOnly = true)
     public Optional<TextSubmission> textSubmissionWithoutResult(long exerciseId) {
-        return this.participationService.findByExerciseIdWithEagerSubmissions(exerciseId)
-            .stream()
-            .peek(participation -> participation.getExercise().setParticipations(null))
+        return this.participationService.findByExerciseIdWithEagerSubmissions(exerciseId).stream().peek(participation -> participation.getExercise().setParticipations(null))
 
-            // Map to Latest Submission
-            .map(Participation::findLatestTextSubmission)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            // It needs to be submitted to be ready for assessment
-            .filter(Submission::isSubmitted)
-            .filter(textSubmission -> {
-                Result result = resultRepository.findDistinctBySubmissionId(textSubmission.getId()).orElse(null);
-                return result == null;
+                // Map to Latest Submission
+                .map(Participation::findLatestTextSubmission).filter(Optional::isPresent).map(Optional::get)
+                // It needs to be submitted to be ready for assessment
+                .filter(Submission::isSubmitted).filter(textSubmission -> {
+                    Result result = resultRepository.findDistinctBySubmissionId(textSubmission.getId()).orElse(null);
+                    return result == null;
 
-            })
+                })
 
-            .findAny();
+                .findAny();
     }
 
     /**
@@ -129,24 +127,23 @@ public class TextSubmissionService {
         // We take all the results in this exercise associated to the tutor, and from there we retrieve the submissions
         List<Result> results = this.resultRepository.findAllByParticipationExerciseIdAndAssessorId(exerciseId, tutorId);
 
-        return results.stream()
-            .map(result -> {
-                Submission submission = result.getSubmission();
-                TextSubmission textSubmission = new TextSubmission();
+        return results.stream().map(result -> {
+            Submission submission = result.getSubmission();
+            TextSubmission textSubmission = new TextSubmission();
 
-                result.setSubmission(null);
-                textSubmission.setResult(result);
-                textSubmission.setParticipation(submission.getParticipation());
-                textSubmission.setId(submission.getId());
-                textSubmission.setSubmissionDate(submission.getSubmissionDate());
+            result.setSubmission(null);
+            textSubmission.setResult(result);
+            textSubmission.setParticipation(submission.getParticipation());
+            textSubmission.setId(submission.getId());
+            textSubmission.setSubmissionDate(submission.getSubmissionDate());
 
-                return textSubmission;
-            })
-            .collect(Collectors.toList());
+            return textSubmission;
+        }).collect(Collectors.toList());
     }
 
     /**
      * Given a courseId, return the number of submissions for that course
+     * 
      * @param courseId - the course we are interested in
      * @return a number of submissions for the course
      */
@@ -155,10 +152,9 @@ public class TextSubmissionService {
     }
 
     /**
-     * Given an exerciseId, returns all the submissions for that exercise, including their results.
-     * Submissions can be filtered to include only already submitted submissions
+     * Given an exerciseId, returns all the submissions for that exercise, including their results. Submissions can be filtered to include only already submitted submissions
      *
-     * @param exerciseId - the id of the exercise we are interested into
+     * @param exerciseId    - the id of the exercise we are interested into
      * @param submittedOnly - if true, it returns only submission with submitted flag set to true
      * @return a list of text submissions for the given exercise id
      */

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -1,13 +1,11 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.repository.ResultRepository;
-import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
-import de.tum.in.www1.artemis.service.*;
-import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
-import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
-import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
-import io.github.jhipster.web.util.ResponseUtil;
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,11 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.security.Principal;
-import java.util.List;
-import java.util.Optional;
-
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
+import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.repository.ResultRepository;
+import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
+import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
+import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
+import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
+import io.github.jhipster.web.util.ResponseUtil;
 
 /**
  * REST controller for managing TextSubmission.
@@ -33,26 +34,30 @@ import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
 public class TextSubmissionResource {
 
     private static final String ENTITY_NAME = "textSubmission";
+
     private final Logger log = LoggerFactory.getLogger(TextSubmissionResource.class);
+
     private final TextSubmissionRepository textSubmissionRepository;
+
     private final ResultRepository resultRepository;
+
     private final ExerciseService exerciseService;
+
     private final TextExerciseService textExerciseService;
+
     private final CourseService courseService;
+
     private final ParticipationService participationService;
+
     private final TextSubmissionService textSubmissionService;
+
     private final UserService userService;
+
     private final AuthorizationCheckService authCheckService;
 
-    public TextSubmissionResource(TextSubmissionRepository textSubmissionRepository,
-                                  ExerciseService exerciseService,
-                                  TextExerciseService textExerciseService,
-                                  CourseService courseService,
-                                  ParticipationService participationService,
-                                  TextSubmissionService textSubmissionService,
-                                  UserService userService,
-                                  ResultRepository resultRepository,
-                                  AuthorizationCheckService authCheckService) {
+    public TextSubmissionResource(TextSubmissionRepository textSubmissionRepository, ExerciseService exerciseService, TextExerciseService textExerciseService,
+            CourseService courseService, ParticipationService participationService, TextSubmissionService textSubmissionService, UserService userService,
+            ResultRepository resultRepository, AuthorizationCheckService authCheckService) {
         this.textSubmissionRepository = textSubmissionRepository;
         this.exerciseService = exerciseService;
         this.textExerciseService = textExerciseService;
@@ -65,8 +70,7 @@ public class TextSubmissionResource {
     }
 
     /**
-     * POST  /exercises/{exerciseId}/text-submissions : Create a new textSubmission.
-     * This is called when a student saves his/her answer
+     * POST /exercises/{exerciseId}/text-submissions : Create a new textSubmission. This is called when a student saves his/her answer
      *
      * @param exerciseId     the id of the exercise for which to init a participation
      * @param principal      the current user principal
@@ -86,16 +90,14 @@ public class TextSubmissionResource {
     }
 
     /**
-     * PUT  /exercises/{exerciseId}/text-submissions : Updates an existing textSubmission.
-     * This function is called by the text editor for saving and submitting text submissions.
-     * The submit specific handling occurs in the TextSubmissionService.save() function.
+     * PUT /exercises/{exerciseId}/text-submissions : Updates an existing textSubmission. This function is called by the text editor for saving and submitting text submissions. The
+     * submit specific handling occurs in the TextSubmissionService.save() function.
      *
      * @param exerciseId     the id of the exercise for which to init a participation
      * @param principal      the current user principal
      * @param textSubmission the textSubmission to update
-     * @return the ResponseEntity with status 200 (OK) and with body the updated textSubmission,
-     * or with status 400 (Bad Request) if the textSubmission is not valid,
-     * or with status 500 (Internal Server Error) if the textSubmission couldn't be updated
+     * @return the ResponseEntity with status 200 (OK) and with body the updated textSubmission, or with status 400 (Bad Request) if the textSubmission is not valid, or with status
+     *         500 (Internal Server Error) if the textSubmission couldn't be updated
      */
     @PutMapping("/exercises/{exerciseId}/text-submissions")
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
@@ -113,38 +115,42 @@ public class TextSubmissionResource {
     private ResponseEntity<TextSubmission> handleTextSubmission(@PathVariable Long exerciseId, Principal principal, @RequestBody TextSubmission textSubmission) {
         TextExercise textExercise = textExerciseService.findOne(exerciseId);
         ResponseEntity<TextSubmission> responseFailure = this.checkExerciseValidity(textExercise);
-        if (responseFailure != null) return responseFailure;
+        if (responseFailure != null)
+            return responseFailure;
 
-        Optional<Participation> optionalParticipation = participationService.findOneByExerciseIdAndStudentLoginAnyState(exerciseId, principal.getName());
-        if (!optionalParticipation.isPresent()) {
-            throw new ResponseStatusException(HttpStatus.FAILED_DEPENDENCY, "No participation found for " + principal.getName() + " in exercise " + exerciseId);
+        if (textSubmission.isExampleSubmission()) {
+            textSubmission = textSubmissionService.save(textSubmission);
         }
-        Participation participation = optionalParticipation.get();
+        else {
+            Optional<Participation> optionalParticipation = participationService.findOneByExerciseIdAndStudentLoginAnyState(exerciseId, principal.getName());
+            if (!optionalParticipation.isPresent()) {
+                throw new ResponseStatusException(HttpStatus.FAILED_DEPENDENCY, "No participation found for " + principal.getName() + " in exercise " + exerciseId);
+            }
+            Participation participation = optionalParticipation.get();
+            textSubmission = textSubmissionService.save(textSubmission, textExercise, participation);
+        }
 
-        // update and save submission
-        textSubmission = textSubmissionService.save(textSubmission, textExercise, participation);
         hideDetails(textSubmission);
         return ResponseEntity.ok(textSubmission);
     }
 
-    //TODO: move this code to textSubmission which invokes the general part with super.hideDetails()
+    // TODO: move this code to textSubmission which invokes the general part with super.hideDetails()
     private void hideDetails(@RequestBody TextSubmission textSubmission) {
-        //do not send old submissions or old results to the client
+        // do not send old submissions or old results to the client
         if (textSubmission.getParticipation() != null) {
             textSubmission.getParticipation().setSubmissions(null);
             textSubmission.getParticipation().setResults(null);
 
             if (textSubmission.getParticipation().getExercise() != null && textSubmission.getParticipation().getExercise() instanceof TextExercise) {
-                //make sure the solution is not sent to the client
+                // make sure the solution is not sent to the client
                 TextExercise textExerciseForClient = (TextExercise) textSubmission.getParticipation().getExercise();
                 textExerciseForClient.setSampleSolution(null);
             }
         }
     }
 
-
     /**
-     * GET  /text-submissions/:id : get the "id" textSubmission.
+     * GET /text-submissions/:id : get the "id" textSubmission.
      *
      * @param id the id of the textSubmission to retrieve
      * @return the ResponseEntity with status 200 (OK) and with body the textSubmission, or with status 404 (Not Found)
@@ -164,7 +170,8 @@ public class TextSubmissionResource {
         // fetch course from database to make sure client didn't change groups
         Course course = courseService.findOne(textExercise.getCourse().getId());
         if (course == null) {
-            return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "courseNotFound", "The course belonging to this text exercise does not exist")).body(null);
+            return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "courseNotFound", "The course belonging to this text exercise does not exist"))
+                    .body(null);
         }
         if (!courseService.userHasAtLeastStudentPermissions(course)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
@@ -174,17 +181,16 @@ public class TextSubmissionResource {
     }
 
     /**
-     * GET  /text-submissions : get all the textSubmissions for an exercise. It is possible to filter, to receive only
-     * the one that have been already submitted, or only the one assessed by the tutor who is doing the call
+     * GET /text-submissions : get all the textSubmissions for an exercise. It is possible to filter, to receive only the one that have been already submitted, or only the one
+     * assessed by the tutor who is doing the call
      *
      * @return the ResponseEntity with status 200 (OK) and the list of textSubmissions in body
      */
     @GetMapping(value = "/exercises/{exerciseId}/text-submissions")
     @PreAuthorize("hasAnyRole('TA', 'INSTRUCTOR', 'ADMIN')")
     @Transactional(readOnly = true)
-    public ResponseEntity<List<TextSubmission>> getAllTextSubmissions(@PathVariable Long exerciseId,
-                                                                      @RequestParam(defaultValue = "false") boolean submittedOnly,
-                                                                      @RequestParam(defaultValue = "false") boolean assessedByTutor) {
+    public ResponseEntity<List<TextSubmission>> getAllTextSubmissions(@PathVariable Long exerciseId, @RequestParam(defaultValue = "false") boolean submittedOnly,
+            @RequestParam(defaultValue = "false") boolean assessedByTutor) {
         log.debug("REST request to get all TextSubmissions");
         Exercise exercise = exerciseService.findOne(exerciseId);
 
@@ -195,9 +201,7 @@ public class TextSubmissionResource {
         if (assessedByTutor) {
             User user = userService.getUserWithGroupsAndAuthorities();
 
-            return ResponseEntity.ok().body(
-                textSubmissionService.getAllTextSubmissionsByTutorForExercise(exerciseId, user.getId())
-            );
+            return ResponseEntity.ok().body(textSubmissionService.getAllTextSubmissionsByTutorForExercise(exerciseId, user.getId()));
         }
 
         List<TextSubmission> textSubmissions = textSubmissionService.getTextSubmissionsByExerciseId(exerciseId, submittedOnly);
@@ -206,7 +210,7 @@ public class TextSubmissionResource {
     }
 
     /**
-     * GET  /text-submission-without-assessment : get one textSubmission without assessment.
+     * GET /text-submission-without-assessment : get one textSubmission without assessment.
      *
      * @return the ResponseEntity with status 200 (OK) and the list of textSubmissions in body
      */
@@ -217,7 +221,8 @@ public class TextSubmissionResource {
         log.debug("REST request to get a text submission without assessment");
         Exercise exercise = exerciseService.findOneLoadParticipations(exerciseId);
 
-        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise)) return forbidden();
+        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise))
+            return forbidden();
 
         Optional<TextSubmission> textSubmissionWithoutAssessment = this.textSubmissionService.textSubmissionWithoutResult(exerciseId);
 


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context

The example submission doesn't have a participation, so a change that was made to be sure that every text submission has a participation broke the creation and update of text submission.

I splitt the `save()` method in two methods so it is a bit clearer

