### PR TITLE
Allow automatic selection of text blocks, if no text blocks are defined so far.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
@@ -1,0 +1,44 @@
+package de.tum.in.www1.artemis.service;
+
+import java.text.BreakIterator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import de.tum.in.www1.artemis.domain.Feedback;
+import de.tum.in.www1.artemis.domain.Result;
+import de.tum.in.www1.artemis.domain.TextSubmission;
+
+@Service
+public class TextBlockService {
+
+    public void prepopulateFeedbackBlocks(Result result) throws ClassCastException {
+        if (result.getFeedbacks().size() != 0 || !(result.getSubmission() instanceof TextSubmission)) {
+            return;
+        }
+
+        final TextSubmission textSubmission = (TextSubmission) result.getSubmission();
+        final String submissionText = textSubmission.getText();
+        final List<String> blocks = splitSubmissionIntoBlocks(submissionText);
+        final List<Feedback> feedbacks = blocks.stream().map(block -> (new Feedback()).reference(block)).collect(Collectors.toList());
+
+        result.getFeedbacks().addAll(feedbacks);
+    }
+
+    public List<String> splitSubmissionIntoBlocks(String submission) {
+        BreakIterator breakIterator = BreakIterator.getSentenceInstance();
+        breakIterator.setText(submission);
+        List<String> sentences = new ArrayList<>();
+
+        int start = breakIterator.first();
+        for (int end = breakIterator.next(); end != BreakIterator.DONE; start = end, end = breakIterator.next()) {
+            String sentence = submission.substring(start, end).trim();
+            sentences.add(sentence);
+        }
+
+        return sentences;
+    }
+
+}

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
@@ -1,41 +1,21 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import javax.annotation.Nullable;
-import org.springframework.http.ResponseEntity;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.web.rest.errors.*;
-import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
 
 public abstract class AssessmentResource {
-    protected final AuthorizationCheckService authCheckService;
-    protected final UserService userService;
 
+    protected final AuthorizationCheckService authCheckService;
+
+    protected final UserService userService;
 
     public AssessmentResource(AuthorizationCheckService authCheckService, UserService userService) {
         this.authCheckService = authCheckService;
         this.userService = userService;
     }
 
-
     abstract String getEntityName();
-
-
-    @Nullable
-    @Deprecated
-    <X> ResponseEntity<X> checkExercise(Exercise exercise) {
-        Course course = exercise.getCourse();
-        if (course == null) {
-            return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(getEntityName(), "courseNotFound", "The course belonging to this modeling exercise does not exist")).body(null);
-        }
-        User user = userService.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user)) {
-            return forbidden();
-        }
-        return null;
-    }
-
 
     /**
      * @param exercise exercise to check privileges for
@@ -50,11 +30,10 @@ public abstract class AssessmentResource {
         }
     }
 
-
-    private void validateExercise(Exercise exercise) throws BadRequestAlertException {
+    void validateExercise(Exercise exercise) throws BadRequestAlertException {
         Course course = exercise.getCourse();
         if (course == null) {
-            throw new BadRequestAlertException("The course belonging to this modeling exercise does not exist", getEntityName(), "courseNotFound");
+            throw new BadRequestAlertException("The course belonging to this exercise does not exist", getEntityName(), "courseNotFound");
         }
     }
 }

--- a/src/main/webapp/app/entities/text-assessments/text-assessments.service.ts
+++ b/src/main/webapp/app/entities/text-assessments/text-assessments.service.ts
@@ -10,7 +10,7 @@ import * as moment from 'moment';
 type EntityResponseType = HttpResponse<Result>;
 
 @Injectable({
-    providedIn: 'root'
+    providedIn: 'root',
 })
 export class TextAssessmentsService {
     private readonly resourceUrl = SERVER_API_URL + 'api/text-assessments';
@@ -27,6 +27,10 @@ export class TextAssessmentsService {
         return this.http
             .put<Result>(`${this.resourceUrl}/exercise/${exerciseId}/result/${resultId}/submit`, textAssessments, { observe: 'response' })
             .map((res: EntityResponseType) => this.convertResponse(res));
+    }
+
+    public getResultWithPredefinedTextblocks(resultId: number): Observable<EntityResponseType> {
+        return this.http.get<Result>(`${this.resourceUrl}/result/${resultId}/with-textblocks`, { observe: 'response' }).map((res: EntityResponseType) => this.convertResponse(res));
     }
 
     public getFeedbackDataForExerciseSubmission(exerciseId: number, submissionId: number): Observable<Participation> {

--- a/src/main/webapp/app/text-assessment/text-assessment.component.html
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.html
@@ -56,7 +56,7 @@
             <h3 class="card-title">
                 <fa-icon [icon]="['far', 'list-alt']"></fa-icon>
                 <span> &nbsp; Instructions &nbsp; </span>
-            </h3>
+            </h3> 
         </div>
 
         <div class="card-body">
@@ -87,7 +87,10 @@
 
 <div class="col-12 mt-3" *ngIf="!busy">
     <div *ngIf="invalidError" class="alert alert-danger" role="alert">{{invalidError}}</div>
-    <div *ngIf="!assessments || assessments.length == 0" class="alert alert-secondary" role="alert" jhiTranslate="arTeMiSApp.textAssessment.assessInstruction"></div>
+    <div *ngIf="!assessments || assessments.length == 0" class="alert alert-secondary text-center" role="alert">
+        <p jhiTranslate="arTeMiSApp.textAssessment.assessInstruction">Please highlight the text block you want to assess and click the "Assess" button.</p>
+        <a class="alert-link" jhiTranslate="arTeMiSApp.textAssessment.predefineTextBlocks" (click)="predefineTextBlocks()">Add Text Blocks automatically.</a>
+    </div>
     <div class="row">
         <div *ngFor="let assessment of assessments; let i = index" class="col-4">
             <jhi-text-assessment-detail [(assessment)]="assessments[i]" (assessmentChange)="checkScoreBoundaries()"

--- a/src/main/webapp/app/text-assessment/text-assessment.component.ts
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.ts
@@ -201,6 +201,12 @@ export class TextAssessmentComponent implements OnInit, OnDestroy, AfterViewInit
         });
     }
 
+    public predefineTextBlocks(): void {
+        this.assessmentsService.getResultWithPredefinedTextblocks(this.result.id).subscribe(response => {
+            this.assessments = response.body.feedbacks || [];
+        });
+    }
+
     private updateParticipationWithResult(): void {
         this.showResult = false;
         this.changeDetectorRef.detectChanges();

--- a/src/main/webapp/i18n/de/textAssessment.json
+++ b/src/main/webapp/i18n/de/textAssessment.json
@@ -5,7 +5,8 @@
             "submitSuccessful": "Deine Bewertung wurde erfolgreich abgesendet!",
             "resultDismissed": "Deine Bewertung wurde nicht übernommen, da ein anderer Tutor bereits bewertet hat.",
             "invalidAssessments": "Deine Bewertung ist nicht gültig!",
-            "assessInstruction": "Markiere den zu bewertenden Textausschnitt und klicke \"Assess\".",
+            "assessInstruction": "Markiere den zu bewertenden Textblock und klicke \"Bewerten\".",
+            "predefineTextBlocks": "Textblöcke automatisch anlegen",
             "lock": "Diese Einrichung kann jetzt exklusiv nur noch von Ihnen bearbeitet werden. Bitte bewerten sie diese Einreichung bevor Sie eine neue öffnen."
         }
     }

--- a/src/main/webapp/i18n/en/textAssessment.json
+++ b/src/main/webapp/i18n/en/textAssessment.json
@@ -5,7 +5,8 @@
             "submitSuccessful": "Your assessment was submitted successfully!",
             "resultDismissed": "Your assessment was dismissed because another tutor already rated this submission.",
             "invalidAssessments": "Your assessments are not valid!",
-            "assessInstruction": "Please highlight the text segment you want to assess and click the \"Assess\" button.",
+            "assessInstruction": "Please highlight the text block you want to assess and click the \"Assess\" button.",
+            "predefineTextBlocks": "Add Text Blocks automatically",
             "lock": "You do now have the lock on this submission. Only you can assess this submission. Please assess this submission before opening other submissions."
         }
     }


### PR DESCRIPTION
### Checklist
- [X] I run `yarn run webpack:build:main`: the project builds without errors.
- [X] I run `yarn lint`: the project builds without code style warnings.
- [X] I updated the documentation and models.
- [X] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] I added (end-to-end) test cases for the new functionality.

### Motivation and Context
Selecting sentences while assessing text exercises can be cumbersome.
Also, [employing an automated approach](http://ceur-ws.org/Vol-2308/isee2019paper04.pdf) cannot rely on manual text block selection.

### Description
This change adds automatic text block generation. It employs a simple approach, splitting by sentences.
TAs can use this feature in manual assessment, if no feedback has been defined so far.

### Steps for Testing
1. Log in to ArTEMiS
2. Find a text exercise with no assessment.
3. At the bottom in the grey "alert", click the "Add Text Blocks automatically" button.
4. Fill in feedback and score for all feedback items / delete unwanted feedback items.

### Screenshots
![autotextblock](https://user-images.githubusercontent.com/6382716/55647475-0af9a580-57de-11e9-9acb-5ab86c901394.gif)
