### PR TITLE
Make sure text submissions are editable also after a result has been created

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -87,9 +87,8 @@ public class TextSubmissionService {
         textSubmission.setSubmissionDate(ZonedDateTime.now());
         textSubmission.setType(SubmissionType.MANUAL);
 
-        // Rebuild lost connection between result and submission: the client delete the submission object inside
-        // result, but Hibernate needs it
-        if (textSubmission.getResult() != null) {
+        // Rebuild connection between result and submission, if it has been lost, because hibernate needs it
+        if (textSubmission.getResult() != null && textSubmission.getResult().getSubmission() == null) {
             textSubmission.getResult().setSubmission(textSubmission);
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -87,6 +87,12 @@ public class TextSubmissionService {
         textSubmission.setSubmissionDate(ZonedDateTime.now());
         textSubmission.setType(SubmissionType.MANUAL);
 
+        // Rebuild lost connection between result and submission: the client delete the submission object inside
+        // result, but Hibernate needs it
+        if (textSubmission.getResult() != null) {
+            textSubmission.getResult().setSubmission(textSubmission);
+        }
+
         textSubmission = textSubmissionRepository.save(textSubmission);
 
         return textSubmission;


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context

At the moment text submission cannot be saved again after a result has been linked to them due a bug. It is not common to save again a submission after it has been assessed, but it can happen, e.g. for example submissions.

### Description
On the client side, we cut JSON objects to do not have infinite loops, so a `Submission` has a `Result`, but then we drop the link inside `Result` to the `Submission`. Hibernate actually needs this kind of link, because every `Result` needs a `Submission`. This patch check if this linking is missing (and if it is required) and add it if it is the case

### Steps for Testing

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Edit a text exercise
4. Edit an example submission with already an assessment linked
.5 You are now able to edit it

