### PR TITLE
[In Review] Fix for domain command name exercisePart

### DIFF
--- a/src/main/resources/templates/readme
+++ b/src/main/resources/templates/readme
@@ -8,10 +8,10 @@ First, we need to implement two sorting algorithms, in this case `MergeSort` and
 
 **You have the following tasks:**
 
-1. &#x2705;[Implement Bubble Sort](testBubbleSort)
+1. [exercisePart][Implement Bubble Sort](testBubbleSort)
 Implement the method `performSort(List<Date>)` in the class `BubbleSort`. Make sure to follow the Bubble Sort algorithm exactly.
 
-2. &#x2705;[Implement Merge Sort](testMergeSort)
+2. [exercisePart][Implement Merge Sort](testMergeSort)
 Implement the method `performSort(List<Date>)` in the class `MergeSort`. Make sure to follow the Merge Sort algorithm exactly.
 
 ### Part 2: Strategy Pattern
@@ -21,19 +21,19 @@ Use the strategy pattern to select the right sorting algorithm at runtime.
 
 **You have the following tasks:**
 
-1. &#x2705;[SortStrategy Interface](testClass[SortStrategy],testMethods[SortStrategy])
+1. [exercisePart][SortStrategy Interface](testClass[SortStrategy],testMethods[SortStrategy])
 Create a `SortStrategy` interface and adjust the sorting algorithms so that they implement this interface.
 
-2. &#x2705;[Context Class](testClass[Context],testAttributes[Context],testMethods[Context])
+2. [exercisePart][Context Class](testClass[Context],testAttributes[Context],testMethods[Context])
 Create and implement a `Context` class following the below class diagram
 
-3. &#x2705;[Context Policy](testClass[Policy],testConstructors[Policy],testAttributes[Policy],testMethods[Policy]) 
+3. [exercisePart][Context Policy](testClass[Policy],testConstructors[Policy],testAttributes[Policy],testMethods[Policy]) 
 Create and implement a `Policy` class following the below class diagram with a simple configuration mechanism:
 
-    1. &#x2705;[Select MergeSort](testClass[MergeSort],testUseMergeSortForBigList)
+    1. [exercisePart][Select MergeSort](testClass[MergeSort],testUseMergeSortForBigList)
     Select `MergeSort` when the List has more than 10 dates.
 
-    2. &#x2705;[Select BubbleSort](testClass[BubbleSort],testUseBubbleSortForSmallList)
+    2. [exercisePart][Select BubbleSort](testClass[BubbleSort],testUseBubbleSortForSmallList)
     Select `BubbleSort` when the List has less or equal 10 dates.
 
 4. Complete the `Client` class which demonstrates switching between two strategies at runtime.

--- a/src/main/resources/templates/readme
+++ b/src/main/resources/templates/readme
@@ -8,10 +8,10 @@ First, we need to implement two sorting algorithms, in this case `MergeSort` and
 
 **You have the following tasks:**
 
-1. [exercisePart][Implement Bubble Sort](testBubbleSort)
+1. [task][Implement Bubble Sort](testBubbleSort)
 Implement the method `performSort(List<Date>)` in the class `BubbleSort`. Make sure to follow the Bubble Sort algorithm exactly.
 
-2. [exercisePart][Implement Merge Sort](testMergeSort)
+2. [task][Implement Merge Sort](testMergeSort)
 Implement the method `performSort(List<Date>)` in the class `MergeSort`. Make sure to follow the Merge Sort algorithm exactly.
 
 ### Part 2: Strategy Pattern
@@ -21,19 +21,19 @@ Use the strategy pattern to select the right sorting algorithm at runtime.
 
 **You have the following tasks:**
 
-1. [exercisePart][SortStrategy Interface](testClass[SortStrategy],testMethods[SortStrategy])
+1. [task][SortStrategy Interface](testClass[SortStrategy],testMethods[SortStrategy])
 Create a `SortStrategy` interface and adjust the sorting algorithms so that they implement this interface.
 
-2. [exercisePart][Context Class](testClass[Context],testAttributes[Context],testMethods[Context])
+2. [task][Context Class](testClass[Context],testAttributes[Context],testMethods[Context])
 Create and implement a `Context` class following the below class diagram
 
-3. [exercisePart][Context Policy](testClass[Policy],testConstructors[Policy],testAttributes[Policy],testMethods[Policy]) 
+3. [task][Context Policy](testClass[Policy],testConstructors[Policy],testAttributes[Policy],testMethods[Policy])
 Create and implement a `Policy` class following the below class diagram with a simple configuration mechanism:
 
-    1. [exercisePart][Select MergeSort](testClass[MergeSort],testUseMergeSortForBigList)
+    1. [task][Select MergeSort](testClass[MergeSort],testUseMergeSortForBigList)
     Select `MergeSort` when the List has more than 10 dates.
 
-    2. [exercisePart][Select BubbleSort](testClass[BubbleSort],testUseBubbleSortForSmallList)
+    2. [task][Select BubbleSort](testClass[BubbleSort],testUseBubbleSortForSmallList)
     Select `BubbleSort` when the List has less or equal 10 dates.
 
 4. Complete the `Client` class which demonstrates switching between two strategies at runtime.

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
@@ -151,7 +151,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
                 this.repositoryFileService.get(participationId, 'README.md').subscribe(
                     fileObj => {
                         // Old readme files contain unescaped unicode, convert it to make it persistable by the database
-                        this.exercise.problemStatement = fileObj.fileContent.replace(new RegExp(/✅/, 'g'), '&#x2705;');
+                        this.exercise.problemStatement = fileObj.fileContent.replace(new RegExp(/✅/, 'g'), '[exercisePart]');
                         resolve();
                     },
                     err => {
@@ -233,10 +233,10 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
      * @param silent
      */
     private remarkableTestsStatusParser(state: any, silent: boolean) {
-        const regex = /^&#x2705;\[([^\]]*)\]\s*\(([^)]+)\)/;
+        const regex = /^\[exercisePart\]\[([^\]]*)\]\s*\(([^)]+)\)/;
 
         // It is surely not our rule, so we can stop early
-        if (state.src[state.pos] !== '&') {
+        if (state.src[state.pos] !== '[') {
             return false;
         }
 

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
@@ -151,7 +151,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
                 this.repositoryFileService.get(participationId, 'README.md').subscribe(
                     fileObj => {
                         // Old readme files contain unescaped unicode, convert it to make it persistable by the database
-                        this.exercise.problemStatement = fileObj.fileContent.replace(new RegExp(/✅/, 'g'), '[exercisePart]');
+                        this.exercise.problemStatement = fileObj.fileContent.replace(new RegExp(/✅/, 'g'), '[task]');
                         resolve();
                     },
                     err => {
@@ -233,7 +233,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
      * @param silent
      */
     private remarkableTestsStatusParser(state: any, silent: boolean) {
-        const regex = /^\[exercisePart\]\[([^\]]*)\]\s*\(([^)]+)\)/;
+        const regex = /^\[task\]\[([^\]]*)\]\s*\(([^)]+)\)/;
 
         // It is surely not our rule, so we can stop early
         if (state.src[state.pos] !== '[') {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [ ] I updated the documentation and models.
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] I added (end-to-end) test cases for the new functionality.

### Motivation and Context
In the last PR for integrating the markdown-editor into the programming-exercises I replaced the checkmark in the problem statement with its unicode counterpart (it wasn't stored properly in my database).
However this change doesn't make sense thinking about it, we should directly exchange it with a domainCommand (even though we don't have a button for it yet).

### Description
- Adjusted the problem statement template with the new domainCommand [exercisePart]
- Changed the text parser to use this domain command

**One note**: The problem statements of programming exercises that were created since the merge of the integration PR for the markdown-editor will not show the exercise part information, as I don't think it is feasible to do an additional check for checkmarks and replace them with the domainCommands.
It should be fine if nobody has created a real problem statement yet.

### Steps for Testing
1. Login to ArTEMiS
2. Create a new programming exercise
3. Use the preview of the markdown-editor for the problem-statement: It should show the correct number of exerciseParts
