### PR TITLE
New layout for example submissions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/TutorParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TutorParticipationService.java
@@ -1,11 +1,9 @@
 package de.tum.in.www1.artemis.service;
 
-import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.enumeration.TutorParticipationStatus;
-import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
-import de.tum.in.www1.artemis.repository.TutorParticipationRepository;
-import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
-import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,9 +11,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.enumeration.TutorParticipationStatus;
+import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
+import de.tum.in.www1.artemis.repository.TutorParticipationRepository;
+import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 /**
  * Service Implementation for managing TutorParticipation.
@@ -25,6 +26,7 @@ import java.util.Optional;
 public class TutorParticipationService {
 
     private final Logger log = LoggerFactory.getLogger(TutorParticipationService.class);
+
     private final ExampleSubmissionRepository exampleSubmissionRepository;
 
     private final static String ENTITY_NAME = "TutorParticipation";
@@ -33,15 +35,15 @@ public class TutorParticipationService {
     private String ARTEMIS_BASE_URL;
 
     private final TutorParticipationRepository tutorParticipationRepository;
+
     private final UserService userService;
+
     private final ExampleSubmissionService exampleSubmissionService;
 
     private static final float scoreRangePercentage = 10;
 
-    public TutorParticipationService(TutorParticipationRepository tutorParticipationRepository,
-                                     ExampleSubmissionRepository exampleSubmissionRepository,
-                                     UserService userService,
-                                     ExampleSubmissionService exampleSubmissionService) {
+    public TutorParticipationService(TutorParticipationRepository tutorParticipationRepository, ExampleSubmissionRepository exampleSubmissionRepository, UserService userService,
+            ExampleSubmissionService exampleSubmissionService) {
         this.tutorParticipationRepository = tutorParticipationRepository;
         this.exampleSubmissionRepository = exampleSubmissionRepository;
         this.userService = userService;
@@ -76,8 +78,8 @@ public class TutorParticipationService {
     }
 
     /**
-     * Given an exercise and a tutor, it retrieves the participation of the tutor for that exercise. If there isn't
-     * any participation in the database, it returns a participation with status NOT_PARTICIPATED
+     * Given an exercise and a tutor, it retrieves the participation of the tutor for that exercise. If there isn't any participation in the database, it returns a participation
+     * with status NOT_PARTICIPATED
      *
      * @param exercise the exercise we want to retrieve the tutor participation
      * @param tutor    the tutor of who we want to retrieve the participation
@@ -90,7 +92,8 @@ public class TutorParticipationService {
         if (participation == null) {
             participation = new TutorParticipation();
             participation.setStatus(TutorParticipationStatus.NOT_PARTICIPATED);
-        } else {
+        }
+        else {
             participation.getTrainedExampleSubmissions().size();    // Load trained example submissions
         }
 
@@ -98,14 +101,10 @@ public class TutorParticipationService {
     }
 
     /**
-     * Given an exercise and a tutor it creates the participation of the tutor to that exercise
-     *
-     * The tutor starts a participation when she reads the grading instruction. If no grading instructions are
-     * available, then she starts her participation clicking on "Start participation".
-     * Usually, the first step is `REVIEWED_INSTRUCTIONS`: after that, she has to train reviewing some example
-     * submissions, and assessing others.
-     * If no example submissions are available, because the instructor hasn't created any, then she goes directly
-     * to the next step, that allows her to assess students' participations
+     * Given an exercise and a tutor it creates the participation of the tutor to that exercise The tutor starts a participation when she reads the grading instruction. If no
+     * grading instructions are available, then she starts her participation clicking on "Start participation". Usually, the first step is `REVIEWED_INSTRUCTIONS`: after that, she
+     * has to train reviewing some example submissions, and assessing others. If no example submissions are available, because the instructor hasn't created any, then she goes
+     * directly to the next step, that allows her to assess students' participations
      *
      * @param exercise the exercise the tutor is going to participate to
      * @param tutor    the tutor who is going to participate to the exercise
@@ -118,7 +117,8 @@ public class TutorParticipationService {
 
         if (exampleSubmissions.size() == 0) {
             tutorParticipation.setStatus(TutorParticipationStatus.TRAINED);
-        } else {
+        }
+        else {
             tutorParticipation.setStatus(TutorParticipationStatus.REVIEWED_INSTRUCTIONS);
         }
 
@@ -129,10 +129,10 @@ public class TutorParticipationService {
     }
 
     /**
-     * Given a course and a tutor, it finds all the participation of that tutor in the course, with related assessed
-     * exercise and trained example submissions
+     * Given a course and a tutor, it finds all the participation of that tutor in the course, with related assessed exercise and trained example submissions
+     * 
      * @param course - the course we are interested in
-     * @param user - the tutor who is querying the service
+     * @param user   - the tutor who is querying the service
      * @return a list of tutor participation for the course
      */
     @Transactional(readOnly = true)
@@ -148,11 +148,10 @@ public class TutorParticipationService {
     }
 
     /**
-     * Given an exercise, it adds to the tutor participation of that exercise the example submission passed as
-     * argument, if it is valid (e.g: if it is an example submission used for review, we check the result is close
-     * enough to the one of the instructor)
+     * Given an exercise, it adds to the tutor participation of that exercise the example submission passed as argument, if it is valid (e.g: if it is an example submission used
+     * for review, we check the result is close enough to the one of the instructor)
      *
-     * @param exercise - the exercise we are referring to
+     * @param exercise          - the exercise we are referring to
      * @param exampleSubmission - the example submission to add
      * @return the updated tutor participation
      */
@@ -169,7 +168,8 @@ public class TutorParticipationService {
 
         ExampleSubmission originalExampleSubmission = exampleSubmissionFromDatabase.get();
 
-        if (existingTutorParticipation.getStatus() != TutorParticipationStatus.REVIEWED_INSTRUCTIONS) {
+        // Cannot start an example submission if the tutor hasn't participated to the exercise yet
+        if (existingTutorParticipation.getStatus() == TutorParticipationStatus.NOT_PARTICIPATED) {
             throw new BadRequestAlertException("The tutor needs review the instructions before assessing example submissions", ENTITY_NAME, "wrongStatus");
         }
 
@@ -200,16 +200,16 @@ public class TutorParticipationService {
 
         List<ExampleSubmission> alreadyAssessedSubmissions = new ArrayList<>(existingTutorParticipation.getTrainedExampleSubmissions());
 
-        // If the example submission was already assessed, we do not assess it again
+        // If the example submission was already assessed, we do not assess it again, we just return the current participation
         if (alreadyAssessedSubmissions.contains(exampleSubmission)) {
-            throw new BadRequestAlertException("The tutor has already assessed this example submission", ENTITY_NAME, "tooHigh");
+            return existingTutorParticipation;
         }
 
         int numberOfExampleSubmissions = this.exampleSubmissionRepository.findAllByExerciseId(exercise.getId()).size();
         int numberOfAlreadyAssessedSubmissions = alreadyAssessedSubmissions.size() + 1;  // +1 because we haven't added yet the one we just did
 
         /*
-          When the tutor has read and assessed all the exercises, the tutor status goes to the next step.
+         * When the tutor has read and assessed all the exercises, the tutor status goes to the next step.
          */
         if (numberOfAlreadyAssessedSubmissions >= numberOfExampleSubmissions) {
             existingTutorParticipation.setStatus(TutorParticipationStatus.TRAINED);

--- a/src/main/webapp/app/example-text-submission/example-text-submission.component.html
+++ b/src/main/webapp/app/example-text-submission/example-text-submission.component.html
@@ -1,116 +1,147 @@
-<jhi-alert></jhi-alert>
-<div class="p-4" *ngIf="exercise">
-    <div class="row">
-        <div class="col-lg-2">
-            <button class="btn btn-secondary" (click)="back()">&larr;</button>
-        </div>
-
-        <div class="col-12 col-lg-6">
+<div class="course-info-bar">
+    <div class="row justify-content-between">
+        <div class="col-8">
             <h2>
+                <fa-icon [icon]="'arrow-left'" (click)="back()" class="back-button mr-2"></fa-icon>
                 <span *ngIf="isNewSubmission">{{ 'arTeMiSApp.exampleSubmission.createNew' | translate }} </span>{{ 'arTeMiSApp.exampleSubmission.pageHeader' | translate }}
                 {{ exercise?.title }}
             </h2>
         </div>
 
-        <div class="col-12 col-lg-4 text-right" *ngIf="isAtLeastInstructor && !readOnly && !toComplete">
-            <div class="row">
-                <div class="form-check col-6 align-baseline">
-                    <input type="checkbox" name="usedForTutorial" id="field_usedForTutorial" [(ngModel)]="exampleSubmission.usedForTutorial" />
-                    <label class="form-check-label" for="field_usedForTutorial">{{ 'arTeMiSApp.exampleSubmission.usedForTutorial' | translate }}</label>
-                </div>
-
-                <button (click)="upsertExampleTextSubmission()" class="btn btn-primary col-6">
-                    <fa-icon icon="save"></fa-icon>
-                    <span *ngIf="isNewSubmission">{{ 'arTeMiSApp.exampleSubmission.createNewSubmission' | translate }}</span>
-                    <span *ngIf="!isNewSubmission">{{ 'arTeMiSApp.exampleSubmission.updateTextSubmission' | translate }}</span>
-                </button>
+        <div class="col-4 text-right" *ngIf="isAtLeastInstructor && !readOnly && !toComplete && exercise">
+            <div class="form-check col-12 align-baseline">
+                <input type="checkbox" name="usedForTutorial" id="field_usedForTutorial" [(ngModel)]="exampleSubmission.usedForTutorial" />
+                <label class="form-check-label" for="field_usedForTutorial">{{ 'arTeMiSApp.exampleSubmission.usedForTutorial' | translate }}</label>
             </div>
-        </div>
 
-        <div class="col-12">
-            <p class="mb-3">
-                <strong>{{ 'arTeMiSApp.exampleSubmission.problemStatement' | translate }}:</strong> <span [innerHTML]="formattedProblemStatement"></span><br />
-                <ng-container *ngIf="formattedSampleSolution">
-                    <strong>{{ 'arTeMiSApp.exampleSubmission.sampleSolution' | translate }}:</strong> <span [innerHTML]="formattedSampleSolution"></span>
-                </ng-container>
-            </p>
-        </div>
-
-        <div class="col-12" *ngIf="isAtLeastInstructor && !readOnly && !toComplete">
-            <textarea
-                [readOnly]="toComplete || readOnly || !isAtLeastInstructor"
-                [disabled]="toComplete || readOnly || !isAtLeastInstructor"
-                [(ngModel)]="textSubmission.text"
-                style="width: 100%; height: 50vh;"
-            ></textarea>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-8">
-            <h2>{{ 'arTeMiSApp.exampleSubmission.exampleAssessment' | translate }}</h2>
-        </div>
-
-        <div class="col-4 text-right">
-            <button
-                class="btn btn-primary col-6"
-                (click)="saveAssessments()"
-                [disabled]="!assessments || !assessmentsAreValid"
-                *ngIf="!isNewSubmission && isAtLeastInstructor && !readOnly && !toComplete"
-            >
+            <button (click)="upsertExampleTextSubmission()" class="btn btn-primary col-6">
                 <fa-icon icon="save"></fa-icon>
-                <span *ngIf="areNewAssessments">{{ 'arTeMiSApp.exampleSubmission.createNewAssessments' | translate }}</span>
-                <span *ngIf="!areNewAssessments">{{ 'arTeMiSApp.exampleSubmission.updateAssessments' | translate }}</span>
+                <span *ngIf="isNewSubmission">{{ 'arTeMiSApp.exampleSubmission.createNewSubmission' | translate }}</span>
+                <span *ngIf="!isNewSubmission">{{ 'arTeMiSApp.exampleSubmission.updateTextSubmission' | translate }}</span>
             </button>
         </div>
     </div>
+</div>
 
-    <div class="alert alert-info" *ngIf="isNewSubmission">
-        {{ 'arTeMiSApp.exampleSubmission.youNeedToCreate' | translate }}
+<jhi-alert></jhi-alert>
+
+<!-- This div is shown only to instructors when they can create / update an example submission -->
+<div class="row mt-4" *ngIf="exercise && isAtLeastInstructor && !readOnly && !toComplete">
+    <div class="row col-12 flex-nowrap">
+        <div class="card flex-grow-1 resizable-submission mr-4">
+            <div class="card-header text-white bg-primary" jhiTranslate="arTeMiSApp.exampleSubmission.exampleSubmission">Example submission</div>
+            <div class="card-body">
+                <textarea [(ngModel)]="textSubmission.text" style="width: 100%; height: 50vh;"></textarea>
+            </div>
+        </div>
+
+        <jhi-resizable-instructions
+            class="resizable-submission card" id="instructions"
+            [ngStyle]="{ 'min-width.px': 400 }"
+            [formattedProblemStatement]="formattedProblemStatement"
+            [formattedGradingInstructions]="formattedGradingInstructions"
+            [formattedSampleSolution]="formattedSampleSolution"
+            [toggleCollapse]="toggleCollapse.bind(this)"
+            toggleCollapseId="submission"
+        >
+            <div resizingbar class="resizing-bar"><span></span></div>
+        </jhi-resizable-instructions>
     </div>
+</div>
 
-    <div class="row" *ngIf="!isNewSubmission">
-        <div class="col text-right">
-            <h5>
-                <strong>{{ 'arTeMiSApp.exampleSubmission.score' | translate }}:</strong> {{ totalScore | number: '1.0-2' }} / {{ exercise.maxScore }}
-            </h5>
+<!--
+    This div contains the example assessment, and it is always shown, with different configurations based on the role
+    of the user.
+
+    If it is an instructor that is creating the example assessment, problem statement is not shown since it is already
+    visible in the previous div
+-->
+<div class="row mt-4 resizable-horizontal" *ngIf="exercise && !isNewSubmission" [ngStyle]="{ 'min-height.px': 500 }">
+    <div class="col-12 mr-4 mb-3">
+        <div class="row justify-content-end">
+            <div class="col-8 align-text-bottom text-right">
+                <h5>
+                    <strong>{{ 'arTeMiSApp.exampleSubmission.score' | translate }}:</strong> {{ totalScore | number: '1.0-2' }} / {{ exercise.maxScore }}
+                </h5>
+            </div>
+
+            <div class="col-2" *ngIf="!isNewSubmission && isAtLeastInstructor && !readOnly && !toComplete"
+            >
+                <button
+                    class="btn btn-primary col-12"
+                    (click)="saveAssessments()"
+                    [disabled]="!assessments || !assessmentsAreValid"
+                >
+                    <fa-icon icon="save"></fa-icon>
+                    <span *ngIf="areNewAssessments">{{ 'arTeMiSApp.exampleSubmission.createNewAssessments' | translate }}</span>
+                    <span *ngIf="!areNewAssessments">{{ 'arTeMiSApp.exampleSubmission.updateAssessments' | translate }}</span>
+                </button>
+            </div>
         </div>
     </div>
 
-    <div class="row" *ngIf="!isNewSubmission">
-        <div class="col-sm-12 col-md-7 col-xl-8 mb-sm-3">
-            <jhi-text-assessment-editor
-                [submissionText]="textSubmission?.text"
-                [assessments]="assessments"
-                (assessedText)="addAssessment($event)"
-                [disabled]="readOnly || (!isAtLeastInstructor && !toComplete)"
-            ></jhi-text-assessment-editor>
-        </div>
-        <div class="col-sm-12 col-md-5 col-xl-4">
-            <div *ngIf="invalidError" class="alert alert-danger" role="alert">{{ invalidError }}</div>
-            <div *ngIf="!assessments || assessments.length == 0" class="alert alert-secondary" role="alert" jhiTranslate="arTeMiSApp.textAssessment.assessInstruction"></div>
-            <ng-container *ngFor="let assessment of assessments; let i = index">
-                <jhi-text-assessment-detail
-                    [(assessment)]="assessments[i]"
-                    (assessmentChange)="checkScoreBoundaries()"
-                    [highlightColor]="getColorForIndex(i)"
-                    [disabled]="readOnly || (!isAtLeastInstructor && !toComplete)"
-                    (deleteAssessment)="deleteAssessment($event)"
-                ></jhi-text-assessment-detail>
-            </ng-container>
+    <div class="col-12">
+        <div class="row flex-nowrap ml-2">
+            <div class="card flex-grow-1 resizable-assessment mr-4">
+                <div class="card-header text-white bg-primary" jhiTranslate="arTeMiSApp.exampleSubmission.exampleAssessment">Example assessment</div>
+                <div class="card-body">
+                    <jhi-text-assessment-editor
+                        [submissionText]="textSubmission?.text"
+                        [assessments]="assessments"
+                        (assessedText)="addAssessment($event)"
+                        [disabled]="readOnly || (!isAtLeastInstructor && !toComplete)"
+                    ></jhi-text-assessment-editor>
+                </div>
+            </div>
+
+            <jhi-resizable-instructions
+                class="resizable-assessment card mr-4" id="assessment-instructions"
+                [ngStyle]="{ 'min-width.px': 400 }"
+                *ngIf="!isAtLeastInstructor||readOnly||toComplete"
+                [formattedProblemStatement]="formattedProblemStatement"
+                [formattedGradingInstructions]="formattedGradingInstructions"
+                [formattedSampleSolution]="formattedSampleSolution"
+                [toggleCollapse]="toggleCollapse.bind(this)"
+                toggleCollapseId="assessment"
+            >
+                <div resizingbar class="resizing-bar-assessment"><span></span></div>
+
+            </jhi-resizable-instructions>
         </div>
     </div>
 
-    <div class="col-12 text-right" *ngIf="toComplete">
-        <button class="btn btn-primary col-3" (click)="checkAssessment()" [disabled]="!assessments || !assessmentsAreValid">
-            {{ 'arTeMiSApp.exampleSubmission.submitAssessment' | translate }}
-        </button>
-    </div>
+    <!-- Required for resizing; don't remove empty span -->
+    <div class="col-12 resizing-bar-bottom"><span></span></div>
+</div>
 
-    <div class="col-12 text-rigth" *ngIf="readOnly">
-        <button (click)="readAndUnderstood()" class="btn btn-success col-3">
-            <fa-icon icon="save"></fa-icon>
-            {{ 'arTeMiSApp.exampleSubmission.readAndUnderstood' | translate }}
-        </button>
+<div class="alert alert-info mt-3" *ngIf="isNewSubmission">
+    {{ 'arTeMiSApp.exampleSubmission.youNeedToCreate' | translate }}
+</div>
+
+<div class="col-12 mt-3" *ngIf="exercise && !isNewSubmission">
+    <div *ngIf="invalidError" class="alert alert-danger" role="alert">{{ invalidError }}</div>
+    <div *ngIf="!assessments || assessments.length == 0" class="alert alert-secondary" role="alert" jhiTranslate="arTeMiSApp.textAssessment.assessInstruction"></div>
+    <div class="row">
+        <div *ngFor="let assessment of assessments; let i = index" class="col-4">
+            <jhi-text-assessment-detail
+                [(assessment)]="assessments[i]"
+                (assessmentChange)="checkScoreBoundaries()"
+                [highlightColor]="getColorForIndex(i)"
+                (deleteAssessment)="deleteAssessment($event)"
+            ></jhi-text-assessment-detail>
+        </div>
     </div>
+</div>
+
+<div class="col-12 text-right" *ngIf="toComplete">
+    <button class="btn btn-primary col-3" (click)="checkAssessment()" [disabled]="!assessments || !assessmentsAreValid">
+        {{ 'arTeMiSApp.exampleSubmission.submitAssessment' | translate }}
+    </button>
+</div>
+
+<div class="col-12 text-right" *ngIf="readOnly">
+    <button (click)="readAndUnderstood()" class="btn btn-success col-3">
+        <fa-icon icon="save"></fa-icon>
+        {{ 'arTeMiSApp.exampleSubmission.readAndUnderstood' | translate }}
+    </button>
 </div>

--- a/src/main/webapp/app/example-text-submission/example-text-submission.component.html
+++ b/src/main/webapp/app/example-text-submission/example-text-submission.component.html
@@ -122,7 +122,7 @@
     <div *ngIf="invalidError" class="alert alert-danger" role="alert">{{ invalidError }}</div>
     <div *ngIf="!assessments || assessments.length == 0" class="alert alert-secondary" role="alert" jhiTranslate="arTeMiSApp.textAssessment.assessInstruction"></div>
     <div class="row">
-        <div *ngFor="let assessment of assessments; let i = index" class="col-4">
+        <div *ngFor="let assessment of assessments; let i = index" class="col-12 col-md-4">
             <jhi-text-assessment-detail
                 [(assessment)]="assessments[i]"
                 (assessmentChange)="checkScoreBoundaries()"

--- a/src/main/webapp/app/example-text-submission/example-text-submission.component.scss
+++ b/src/main/webapp/app/example-text-submission/example-text-submission.component.scss
@@ -1,0 +1,67 @@
+.resizing-bar,
+.resizing-bar-assessment,
+.resizing-bar-bottom {
+    line-height: 14px;
+    z-index: 1;
+    -moz-user-select: -moz-none;
+    -ms-user-select: none;
+    -webkit-user-select: none;
+    user-select: none;
+    background: 0 0;
+}
+
+.resizing-bar,
+.resizing-bar-assessment {
+    position: absolute;
+    cursor: col-resize;
+    height: 100%;
+    left: 0;
+    top: 0;
+    margin-left: -20px;
+}
+
+.resizing-bar-bottom {
+    cursor: row-resize;
+    width: 100%;
+    bottom: 0;
+    left: 0;
+    margin-bottom: -14px;
+}
+
+.resizing-bar span,
+.resizing-bar-assessment span {
+    position: absolute;
+    box-sizing: border-box;
+    display: block;
+    border-style: solid;
+    border-color: #ccc;
+    top: 50%;
+    margin: -10px 0 0 3.5px;
+    height: 20px;
+    width: 7px;
+    border-width: 0 1px;
+}
+
+.resizing-bar-bottom span {
+    position: absolute;
+    box-sizing: border-box;
+    display: block;
+    border-style: solid;
+    border-color: #ccc;
+    border-width: 1px 0;
+    left: 50%;
+    margin: 3.5px 0 0 -10px;
+    width: 20px;
+    height: 7px;
+}
+
+.card.collapsed .card-body,
+.card.collapsed .card-second-header,
+.card.collapsed .card-header .float-right,
+.card.collapsed .card-header h3 span {
+    display: none;
+}
+
+.submission-area {
+    word-wrap: break-word;
+}

--- a/src/main/webapp/app/example-text-submission/example-text-submission.module.ts
+++ b/src/main/webapp/app/example-text-submission/example-text-submission.module.ts
@@ -15,12 +15,13 @@ import { ClipboardModule } from 'ngx-clipboard';
 import { exampleTextSubmissionRoute } from 'app/example-text-submission/example-text-submission.route';
 import { ExampleTextSubmissionComponent } from 'app/example-text-submission/example-text-submission.component';
 import { ArTEMiSTextAssessmentModule } from 'app/text-assessment';
+import { ResizableInstructionsComponent } from 'app/example-text-submission/resizable-instructions/resizable-instructions.component';
 
 const ENTITY_STATES = [...exampleTextSubmissionRoute];
 
 @NgModule({
     imports: [BrowserModule, ArTEMiSSharedModule, ArTEMiSResultModule, MomentModule, ClipboardModule, RouterModule.forChild(ENTITY_STATES), ArTEMiSTextAssessmentModule],
-    declarations: [ExampleTextSubmissionComponent],
+    declarations: [ExampleTextSubmissionComponent, ResizableInstructionsComponent],
     exports: [],
     entryComponents: [HomeComponent, CourseComponent, JhiMainComponent],
     providers: [CourseService, JhiAlertService, { provide: JhiLanguageService, useClass: JhiLanguageService }],

--- a/src/main/webapp/app/example-text-submission/resizable-instructions/resizable-instructions.component.html
+++ b/src/main/webapp/app/example-text-submission/resizable-instructions/resizable-instructions.component.html
@@ -1,0 +1,33 @@
+<div>
+    <!-- Required for resizing; don't remove empty span -->
+    <ng-content select="[resizingbar]"></ng-content>
+
+    <div class="card-header text-white bg-primary" (click)="toggleCollapse($event, toggleCollapseId)">
+        <span class="float-right "><fa-icon icon="chevron-right"></fa-icon></span>
+        <h3 class="card-title">
+            <fa-icon [icon]="['far', 'list-alt']"></fa-icon>
+            <span jhiTranslate="arTeMiSApp.textAssessment.instructions"> &nbsp; Instructions &nbsp; </span>
+        </h3>
+    </div>
+
+    <div class="card-body">
+        <div *ngIf="formattedProblemStatement">
+            <h4 jhiTranslate="arTeMiSApp.exercise.problemStatement">Problem statement</h4>
+            <p [innerHTML]="formattedProblemStatement"></p>
+
+            <hr />
+        </div>
+
+        <div *ngIf="formattedSampleSolution">
+            <h4 jhiTranslate="arTeMiSApp.exercise.sampleSolution">Sample solution</h4>
+            <p [innerHTML]="formattedSampleSolution"></p>
+
+            <hr />
+        </div>
+
+        <div *ngIf="formattedGradingInstructions">
+            <h4 jhiTranslate="arTeMiSApp.exercise.gradingInstructions">Grading instructions</h4>
+            <p [innerHTML]="formattedGradingInstructions"></p>
+        </div>
+    </div>
+</div>

--- a/src/main/webapp/app/example-text-submission/resizable-instructions/resizable-instructions.component.scss
+++ b/src/main/webapp/app/example-text-submission/resizable-instructions/resizable-instructions.component.scss
@@ -1,0 +1,6 @@
+.card.collapsed .card-body,
+.card.collapsed .card-second-header,
+.card.collapsed .card-header .float-right,
+.card.collapsed .card-header h3 span {
+    display: none;
+}

--- a/src/main/webapp/app/example-text-submission/resizable-instructions/resizable-instructions.component.ts
+++ b/src/main/webapp/app/example-text-submission/resizable-instructions/resizable-instructions.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+    selector: 'jhi-resizable-instructions',
+    templateUrl: './resizable-instructions.component.html',
+    styleUrls: ['./resizable-instructions.component.scss'],
+})
+export class ResizableInstructionsComponent {
+    @Input() public formattedProblemStatement: string;
+    @Input() public formattedSampleSolution: string;
+    @Input() public formattedGradingInstructions: string;
+    @Input() public toggleCollapse: ($event: any, type: string) => void;
+    @Input() public toggleCollapseId: string;
+
+    constructor() {}
+}

--- a/src/main/webapp/app/text-assessment/text-assessment-editor/text-assessment-editor.component.scss
+++ b/src/main/webapp/app/text-assessment/text-assessment-editor/text-assessment-editor.component.scss
@@ -13,7 +13,7 @@ div.container {
     z-index: 2;
 
     &__cta {
-        top: -20px;
+        top: 20px;
         left: 50%;
         position: absolute;
         color: #ffffff;

--- a/src/main/webapp/app/text-assessment/text-assessment.component.html
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.html
@@ -114,7 +114,7 @@
         <a class="alert-link" jhiTranslate="arTeMiSApp.textAssessment.predefineTextBlocks" (click)="predefineTextBlocks()" *ngIf="result">Add Text Blocks automatically.</a>
     </div>
     <div class="row">
-        <div *ngFor="let assessment of assessments; let i = index" class="col-4">
+        <div *ngFor="let assessment of assessments; let i = index" class="col-12 col-md-4">
             <jhi-text-assessment-detail
                 [(assessment)]="assessments[i]"
                 (assessmentChange)="checkScoreBoundaries()"

--- a/src/main/webapp/app/text-assessment/text-assessment.component.html
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.html
@@ -60,7 +60,7 @@
 </h2>
 
 <div class="row mt-4 resizable-horizontal" *ngIf="!busy && exercise" [ngStyle]="{ 'min-height.px': 500 }">
-    <div class="row flex-nowrap">
+    <div class="row flex-nowrap col-12">
         <div class="card flex-grow-1 resizable-submission mr-4">
             <div class="card-header text-white bg-primary" jhiTranslate="arTeMiSApp.textAssessment.studentSubmission">Student submission</div>
             <div class="card-body">

--- a/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.html
+++ b/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.html
@@ -20,43 +20,23 @@
         </div>
     </div>
 
-    <div class="col-12 text-center" style="margin-bottom: 15px" *ngIf="exercise.gradingInstructions && exercise.gradingInstructions.length > 0; else noGradingInstruction">
-        <div *ngIf="tutorParticipationStatus === NOT_PARTICIPATED" class="alert alert-warning" role="alert">
-            {{ 'arTeMiSApp.tutorExerciseDashboard.needToReadGradingInstructions' | translate }}
-        </div>
+    <div class="col-12 text-center" *ngIf="exercise.gradingInstructions && exercise.gradingInstructions.length > 0">
+        <h4>{{ 'arTeMiSApp.tutorExerciseDashboard.gradingInstructions' | translate }}</h4>
 
-        <button class="btn btn-primary" (click)="open(gradingInstructions)">
-            {{ 'arTeMiSApp.tutorExerciseDashboard.readGradingInstructions' | translate }}
-        </button>
+        <p [innerHTML]="formattedGradingInstructions"></p>
     </div>
 
-    <ng-template #noGradingInstruction>
-        <div class="col-12 text-center" *ngIf="tutorParticipationStatus === NOT_PARTICIPATED">
-            <button class="btn btn-primary" (click)="readInstruction()">
-                {{ 'arTeMiSApp.tutorExerciseDashboard.startYourParticipation' | translate }}
-            </button>
-        </div>
-    </ng-template>
-
-    <ng-template #gradingInstructions let-c="close" let-d="dismiss">
-        <div class="modal-header">
-            <h4 class="modal-title">
-                {{ 'arTeMiSApp.tutorExerciseDashboard.gradingInstructions' | translate }}
-            </h4>
-            <button type="button" class="close" aria-label="Close" (click)="d()"><span aria-hidden="true">&times;</span></button>
-        </div>
-        <div class="modal-body">
-            <span [innerHTML]="formattedGradingInstructions"></span>
-        </div>
-        <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" (click)="c()">
-                {{ 'arTeMiSApp.tutorExerciseDashboard.close' | translate }}
-            </button>
-            <button type="button" class="btn btn-primary" *ngIf="tutorParticipationStatus === NOT_PARTICIPATED" (click)="readInstruction(c)">
+    <div class="col-12 text-center" *ngIf="tutorParticipationStatus === NOT_PARTICIPATED">
+        <button class="btn btn-primary" (click)="readInstruction()">
+            <span *ngIf="exercise.gradingInstructions && exercise.gradingInstructions.length > 0">
                 {{ 'arTeMiSApp.tutorExerciseDashboard.readAndUnderstood' | translate }}
-            </button>
-        </div>
-    </ng-template>
+            </span>
+
+            <span *ngIf="!exercise.gradingInstructions || exercise.gradingInstructions.length == 0">
+                {{ 'arTeMiSApp.tutorExerciseDashboard.startYourParticipation' | translate }}
+            </span>
+        </button>
+    </div>
 
     <div *ngIf="tutorParticipationStatus === REVIEWED_INSTRUCTIONS" class="alert alert-warning row" role="alert">
         <span

--- a/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.ts
+++ b/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.ts
@@ -7,7 +7,6 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { Exercise, ExerciseService } from 'app/entities/exercise';
 import { TutorParticipation, TutorParticipationStatus } from 'app/entities/tutor-participation';
 import { TutorParticipationService } from 'app/tutor-exercise-dashboard/tutor-participation.service';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { TextSubmission, TextSubmissionService } from 'app/entities/text-submission';
 import { ExampleSubmission } from 'app/entities/example-submission';
 import { ArtemisMarkdown } from 'app/components/util/markdown.service';
@@ -58,7 +57,6 @@ export class TutorExerciseDashboardComponent implements OnInit {
         private route: ActivatedRoute,
         private tutorParticipationService: TutorParticipationService,
         private textSubmissionService: TextSubmissionService,
-        private modalService: NgbModal,
         private artemisMarkdown: ArtemisMarkdown,
     ) {}
 
@@ -139,24 +137,12 @@ export class TutorExerciseDashboardComponent implements OnInit {
         );
     }
 
-    open(content: any) {
-        this.modalService.open(content, { size: 'lg' });
-    }
-
-    readInstruction(onComplete?: () => void) {
-        this.tutorParticipationService.create(this.tutorParticipation, this.exerciseId).subscribe(
-            (res: HttpResponse<TutorParticipation>) => {
-                this.tutorParticipation = res.body;
-                this.tutorParticipationStatus = this.tutorParticipation.status;
-                this.jhiAlertService.success('arTeMiSApp.tutorExerciseDashboard.participation.instructionsReviewed');
-            },
-            this.onError,
-            () => {
-                if (onComplete) {
-                    onComplete();
-                }
-            },
-        );
+    readInstruction() {
+        this.tutorParticipationService.create(this.tutorParticipation, this.exerciseId).subscribe((res: HttpResponse<TutorParticipation>) => {
+            this.tutorParticipation = res.body;
+            this.tutorParticipationStatus = this.tutorParticipation.status;
+            this.jhiAlertService.success('arTeMiSApp.tutorExerciseDashboard.participation.instructionsReviewed');
+        }, this.onError);
     }
 
     hasBeenCompletedByTutor(id: number) {
@@ -168,7 +154,7 @@ export class TutorExerciseDashboardComponent implements OnInit {
     }
 
     calculateStatus(submission: TextSubmission) {
-        if (submission.result.completionDate) {
+        if (submission.result && submission.result.completionDate) {
             return 'DONE';
         }
 

--- a/src/main/webapp/content/scss/text.scss
+++ b/src/main/webapp/content/scss/text.scss
@@ -81,4 +81,5 @@
     width: 100%;
     min-height: 25rem;
     border: darkgrey 2px solid;
+    word-break: break-word;
 }

--- a/src/main/webapp/i18n/de/exampleSubmission.json
+++ b/src/main/webapp/i18n/de/exampleSubmission.json
@@ -25,7 +25,8 @@
             "youNeedToCreate": "Sie müssen die Beispiel-Einreichungen erstellen, bevor Sie die Beispiel-Bewertung erstellen können.",
             "score": "Punktzahl",
             "submitAssessment": "Bewertung einreichen",
-            "readAndUnderstood": "Ich habe das Beispiel gelesen und verstanden."
+            "readAndUnderstood": "Ich habe das Beispiel gelesen und verstanden.",
+            "exampleSubmission": "Beispiel-Einreichung"
         }
     }
 }

--- a/src/main/webapp/i18n/en/exampleSubmission.json
+++ b/src/main/webapp/i18n/en/exampleSubmission.json
@@ -25,7 +25,8 @@
             "youNeedToCreate": "You need to create the example text submission before creating the example assessment",
             "score": "Score",
             "submitAssessment": "Submit Assessment",
-            "readAndUnderstood": "I have read and understood the example"
+            "readAndUnderstood": "I have read and understood the example",
+            "exampleSubmission": "Example Submission"
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
Add the new layout for the example submission page, both for instructors and tutors.
It also fixes some minor issues with resizing elements

### Description
This is how it appears now the example submission page for an instructor who wants to create a new example submission:

![screenshot-artemistest ase in tum de-2019 04 09-15-44-45](https://user-images.githubusercontent.com/1713343/55806081-e81e0880-5adf-11e9-89f9-b5e041a2304b.png)

After that, they can create an example assessment:

![screenshot-artemistest ase in tum de-2019 04 09-15-47-28](https://user-images.githubusercontent.com/1713343/55806107-f409ca80-5adf-11e9-8aee-d6035070fadd.png)

This is what tutor sees:

![screenshot-artemistest ase in tum de-2019 04 09-15-50-08](https://user-images.githubusercontent.com/1713343/55806143-05eb6d80-5ae0-11e9-9a7b-ee99834f48d3.png)


Also now when the screen is small the assessments go one below the other
![screenshot-artemistest ase in tum de-2019 04 09-16-02-39](https://user-images.githubusercontent.com/1713343/55806659-fe789400-5ae0-11e9-8b6a-1f5aedd5b4ce.png)

