### PR TITLE
Fix fa-icons in programming-exercise-instructions & issue with multiple subscriptions in results component

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
@@ -88,9 +88,10 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
                 })
                 .then(() => {
                     if (this.participation.results) {
-                        this.latestResult = this.participation.results[0];
-                        // Only load results if the exercise already is in our database, otherwise their can be no build result anyway
+                        // Get the result with the highest id (most recent result)
+                        this.latestResult = this.participation.results.reduce((acc, v) => (v.id > acc.id ? v : acc));
                     } else if (this.exercise.id) {
+                        // Only load results if the exercise already is in our database, otherwise their can be no build result anyway
                         return this.loadLatestResult();
                     }
                 })

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.module.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.module.ts
@@ -24,6 +24,7 @@ import { FormDateTimePickerModule } from 'app/shared/date-time-picker/date-time-
 import { ArTEMiSCategorySelectorModule } from 'app/components/category-selector/category-selector.module';
 import { ArTEMiSDifficultyPickerModule } from 'app/components/exercise/difficulty-picker/difficulty-picker.module';
 import { ArTEMiSResultModule } from 'app/entities/result';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
 const ENTITY_STATES = [...programmingExerciseRoute, ...programmingExercisePopupRoute];
 
@@ -55,6 +56,7 @@ const ENTITY_STATES = [...programmingExerciseRoute, ...programmingExercisePopupR
         ProgrammingExercisePopupComponent,
         ProgrammingExerciseDeleteDialogComponent,
         ProgrammingExerciseDeletePopupComponent,
+        FaIconComponent,
     ],
     exports: [ProgrammingExerciseComponent, ProgrammingExerciseInstructionComponent],
     providers: [ProgrammingExerciseService, ProgrammingExercisePopupService, ProgrammingExerciseInstructionComponent],

--- a/src/main/webapp/app/entities/result/result.component.ts
+++ b/src/main/webapp/app/entities/result/result.component.ts
@@ -60,9 +60,8 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
             if (exercise && exercise.type === ExerciseType.PROGRAMMING) {
                 this.subscribeForProgramingExercise(exercise as ProgrammingExercise);
             }
-            return this.init();
-        }
-        if (this.participation && this.participation.id) {
+            this.init();
+        } else if (this.participation && this.participation.id) {
             const exercise = this.participation.exercise;
 
             if (this.participation.results && this.participation.results.length > 0) {
@@ -100,7 +99,11 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
                 (this.participation.student && user.id === this.participation.student.id && (exercise.dueDate == null || exercise.dueDate.isAfter(moment()))) ||
                 (this.participation.student == null && this.accountService.isAtLeastInstructorInCourse(exercise.course))
             ) {
+                // unsubscribe old results if a subscription exists
                 // subscribe for new results (e.g. when a programming exercise was automatically tested)
+                if (this.websocketChannelResults) {
+                    this.jhiWebsocketService.unsubscribe(this.websocketChannelResults);
+                }
                 this.websocketChannelResults = `/topic/participation/${this.participation.id}/newResults`;
                 this.jhiWebsocketService.subscribe(this.websocketChannelResults);
                 this.jhiWebsocketService.receive(this.websocketChannelResults).subscribe((newResult: Result) => {
@@ -110,7 +113,11 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
                     this.handleNewResult(newResult);
                 });
 
+                // unsubscribe old submissions if a subscription exists
                 // subscribe for new submissions (e.g. when code was pushed and is currently built)
+                if (this.websocketChannelSubmissions) {
+                    this.jhiWebsocketService.unsubscribe(this.websocketChannelSubmissions);
+                }
                 this.websocketChannelSubmissions = `/topic/participation/${this.participation.id}/newSubmission`;
                 this.jhiWebsocketService.subscribe(this.websocketChannelSubmissions);
                 this.jhiWebsocketService.receive(this.websocketChannelSubmissions).subscribe((newProgrammingSubmission: ProgrammingSubmission) => {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
~~- [ ] I updated the documentation and models.~~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
~~- [ ] I added (end-to-end) test cases for the new functionality.~~

### Description
Three bugfixes:
1. In programming-exercise-instructions fixed adding fa-icons from plain html to ComponentResolverFactory.
2. Fixed multiple subscriptions to websocket in result component, this caused a lot of unneccessary change cycles and api calls.
3. In programming-exercise-instruction component get the most recent instead of the first result (order of result array may vary)

### Steps for Testing
For Bug 1:
1. Log in to ArTEMiS
2. Open programming-exercise in editor with results
3. Check that tasks in the instruction component show icons according to their state (success / fail)

For Bug 2:
1. Log in to ArTEMiS
2. Open programming-exercise in editor with results
3. Do a couple of commits, there should only be one submission received in results 

For Bug 3:
1. Log in to ArTEMiS
2. Open programming-exercise in editor with results
3. Do a commit
4. Go to overview -> course detail and check that the result from the commit is the same that is displayed in the instruction component
