### PR TITLE
Fix for multiple websocket subscribers in result component

### DIFF
--- a/src/main/webapp/app/code-editor/build-output/code-editor-build-output.component.ts
+++ b/src/main/webapp/app/code-editor/build-output/code-editor-build-output.component.ts
@@ -1,11 +1,13 @@
 import { Participation } from '../../entities/participation';
 import { JhiAlertService } from 'ng-jhipster';
-import { AfterViewInit, EventEmitter, Component, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { AfterViewInit, EventEmitter, Component, Input, OnChanges, OnDestroy, Output, SimpleChanges } from '@angular/core';
+import { maxBy as _maxBy } from 'lodash';
 import { WindowRef } from '../../core/websocket/window.service';
 import { RepositoryService } from '../../entities/repository/repository.service';
 import { CodeEditorComponent } from '../code-editor.component';
-import { JhiWebsocketService } from '../../core';
+import { JhiWebsocketService, AccountService } from '../../core';
 import { Result, ResultService } from '../../entities/result';
+import * as moment from 'moment';
 import * as $ from 'jquery';
 import * as interact from 'interactjs';
 import { Interactable } from 'interactjs';
@@ -16,7 +18,7 @@ import { BuildLogEntryArray } from '../../entities/build-log';
     templateUrl: './code-editor-build-output.component.html',
     providers: [JhiAlertService, WindowRef, RepositoryService, ResultService],
 })
-export class CodeEditorBuildOutputComponent implements AfterViewInit, OnChanges {
+export class CodeEditorBuildOutputComponent implements AfterViewInit, OnChanges, OnDestroy {
     buildLogs = new BuildLogEntryArray();
 
     /** Resizable constants **/
@@ -30,6 +32,10 @@ export class CodeEditorBuildOutputComponent implements AfterViewInit, OnChanges 
     isBuilding: boolean;
     @Output()
     buildLogChange = new EventEmitter<BuildLogEntryArray>();
+    @Input()
+    isInitial = true;
+
+    private websocketChannelResults: string;
 
     constructor(
         private parent: CodeEditorComponent,
@@ -37,6 +43,7 @@ export class CodeEditorBuildOutputComponent implements AfterViewInit, OnChanges 
         private jhiWebsocketService: JhiWebsocketService,
         private repositoryService: RepositoryService,
         private resultService: ResultService,
+        private accountService: AccountService,
     ) {}
 
     /**
@@ -78,7 +85,15 @@ export class CodeEditorBuildOutputComponent implements AfterViewInit, OnChanges 
      *
      */
     ngOnChanges(changes: SimpleChanges): void {
+        // If the participation changes, set component to initial as everything needs to be reloaded now
+        if (this.participation && changes.participation && changes.participation.currentValue && this.participation.id !== changes.participation.currentValue.id) {
+            this.isInitial = true;
+        }
         if ((changes.participation && this.participation) || (changes.isBuilding && changes.isBuilding.currentValue === false && this.participation)) {
+            if (this.isInitial) {
+                this.setupResultWebsocket();
+                this.isInitial = false;
+            }
             if (!this.participation.results) {
                 this.resultService
                     .findResultsForParticipation(this.participation.exercise.course.id, this.participation.exercise.id, this.participation.id, {
@@ -86,12 +101,34 @@ export class CodeEditorBuildOutputComponent implements AfterViewInit, OnChanges 
                         ratedOnly: this.participation.exercise.type === 'quiz',
                     })
                     .subscribe(results => {
-                        this.toggleBuildLogs(results.body);
+                        this.toggleBuildLogs(_maxBy(results.body, 'id'));
                     });
-            } else {
-                this.toggleBuildLogs(this.participation.results);
+            } else if (this.participation.results && this.participation.results.length) {
+                const latestResultPrev =
+                    changes.participation && changes.participation.previousValue ? _maxBy((changes.participation.previousValue as Participation).results, 'id') : undefined;
+                const latestResultNew = _maxBy(this.participation.results, 'id');
+                if ((!latestResultPrev && latestResultNew) || (latestResultPrev && latestResultNew && latestResultNew.id !== latestResultPrev.id)) {
+                    this.toggleBuildLogs(latestResultNew);
+                }
             }
         }
+    }
+
+    /**
+     * Setup result websocket so that the instructions can use the latest result.
+     * When a new result is received, the result details will be loaded and then the instructions will be rerendered.
+     */
+    setupResultWebsocket() {
+        this.accountService.identity().then(() => {
+            this.websocketChannelResults = `/topic/participation/${this.participation.id}/newResults`;
+            this.jhiWebsocketService.subscribe(this.websocketChannelResults);
+            this.jhiWebsocketService.receive(this.websocketChannelResults).subscribe((newResult: Result) => {
+                // convert json string to moment
+                console.log('Received new result ' + newResult.id + ': ' + newResult.resultString);
+                newResult.completionDate = newResult.completionDate != null ? moment(newResult.completionDate) : null;
+                this.toggleBuildLogs(newResult);
+            });
+        });
     }
 
     /**
@@ -106,19 +143,17 @@ export class CodeEditorBuildOutputComponent implements AfterViewInit, OnChanges 
         });
     }
 
-    toggleBuildLogs(results: Result[]) {
+    toggleBuildLogs(result: Result) {
         // TODO: can we use the result in code-editor-instructions.component.ts?
-        if (results && results[0]) {
-            this.resultService.getFeedbackDetailsForResult(results[0].id).subscribe(details => {
-                if (details.body.length === 0) {
-                    this.getBuildLogs();
-                } else {
-                    this.buildLogs = new BuildLogEntryArray();
-                    // If there are no compile errors, send recent timestamp
-                    this.buildLogChange.emit(new BuildLogEntryArray({ time: new Date(Date.now()), log: '' }));
-                }
-            });
-        }
+        this.resultService.getFeedbackDetailsForResult(result.id).subscribe(details => {
+            if (details.body.length === 0) {
+                this.getBuildLogs();
+            } else {
+                this.buildLogs = new BuildLogEntryArray();
+                // If there are no compile errors, send recent timestamp
+                this.buildLogChange.emit(new BuildLogEntryArray({ time: new Date(Date.now()), log: '' }));
+            }
+        });
     }
 
     /**
@@ -129,5 +164,11 @@ export class CodeEditorBuildOutputComponent implements AfterViewInit, OnChanges 
      */
     toggleEditorCollapse($event: any, horizontal: boolean) {
         this.parent.toggleCollapse($event, horizontal, this.interactResizable, undefined, this.resizableMinHeight);
+    }
+
+    ngOnDestroy() {
+        if (this.websocketChannelResults) {
+            this.jhiWebsocketService.unsubscribe(this.websocketChannelResults);
+        }
     }
 }

--- a/src/main/webapp/app/code-editor/code-editor.component.html
+++ b/src/main/webapp/app/code-editor/code-editor.component.html
@@ -50,7 +50,7 @@
         </div>
 
         <div class="editor-sidebar-right">
-            <jhi-code-editor-instructions [participation]="participation" [latestResult]="latestResult"> </jhi-code-editor-instructions>
+            <jhi-code-editor-instructions [participation]="participation"> </jhi-code-editor-instructions>
         </div>
     </div>
 

--- a/src/main/webapp/app/code-editor/code-editor.component.ts
+++ b/src/main/webapp/app/code-editor/code-editor.component.ts
@@ -2,7 +2,6 @@ import * as $ from 'jquery';
 import { ActivatedRoute } from '@angular/router';
 import { Component, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
-import { Interactable } from 'interactjs';
 import { JhiAlertService } from 'ng-jhipster';
 import { LocalStorageService } from 'ngx-webstorage';
 import { Subscription } from 'rxjs/Subscription';
@@ -77,12 +76,10 @@ export class CodeEditorComponent implements OnInit, OnChanges, OnDestroy {
             if (this.participationDataProvider.participationStorage && this.participationDataProvider.participationStorage.id === Number(params['participationId'])) {
                 // We found a matching participation in the data provider, so we can avoid doing a REST call
                 this.participation = this.participationDataProvider.participationStorage;
-                this.obtainLatestResult();
             } else {
                 /** Query the participationService for the participationId given by the params */
                 this.participationService.findWithLatestResult(params['participationId']).subscribe((response: HttpResponse<Participation>) => {
                     this.participation = response.body;
-                    this.obtainLatestResult();
                 });
             }
             /** Query the repositoryFileService for files in the repository */
@@ -105,12 +102,6 @@ export class CodeEditorComponent implements OnInit, OnChanges, OnDestroy {
 
         /** Assign repository */
         this.repository = this.repositoryService;
-    }
-
-    obtainLatestResult() {
-        if (this.participation.results && this.participation.results.length > 0) {
-            this.latestResult = this.participation.results[0];
-        }
     }
 
     /**
@@ -153,8 +144,6 @@ export class CodeEditorComponent implements OnInit, OnChanges, OnDestroy {
      */
     updateLatestResult($event: any) {
         this.isBuilding = false;
-        this.latestResult = $event.newResult;
-        this.participation = { ...this.participation, results: [this.latestResult, ...this.participation.results] };
     }
 
     /**

--- a/src/main/webapp/app/code-editor/code-editor.component.ts
+++ b/src/main/webapp/app/code-editor/code-editor.component.ts
@@ -18,6 +18,7 @@ import { SaveStatusChange, Session, AnnotationArray } from '../entities/ace-edit
 import { WindowRef } from '../core/websocket/window.service';
 
 import { textFileExtensions } from './text-files.json';
+import { Interactable } from 'interactjs';
 
 @Component({
     selector: 'jhi-editor',

--- a/src/main/webapp/app/code-editor/instructions/code-editor-instructions.component.ts
+++ b/src/main/webapp/app/code-editor/instructions/code-editor-instructions.component.ts
@@ -27,8 +27,6 @@ export class CodeEditorInstructionsComponent implements AfterViewInit {
 
     @Input()
     participation: Participation;
-    @Input()
-    latestResult: Result;
 
     constructor(private parent: CodeEditorComponent, private $window: WindowRef, public artemisMarkdown: ArtemisMarkdown) {}
 

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
@@ -107,9 +107,6 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
      */
     setupResultWebsocket() {
         this.accountService.identity().then(() => {
-            if (this.websocketChannelResults) {
-                this.jhiWebsocketService.unsubscribe(this.websocketChannelResults);
-            }
             this.websocketChannelResults = `/topic/participation/${this.participation.id}/newResults`;
             this.jhiWebsocketService.subscribe(this.websocketChannelResults);
             this.jhiWebsocketService.receive(this.websocketChannelResults).subscribe((newResult: Result) => {

--- a/src/main/webapp/app/entities/result/result.component.ts
+++ b/src/main/webapp/app/entities/result/result.component.ts
@@ -99,11 +99,7 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
                 (this.participation.student && user.id === this.participation.student.id && (exercise.dueDate == null || exercise.dueDate.isAfter(moment()))) ||
                 (this.participation.student == null && this.accountService.isAtLeastInstructorInCourse(exercise.course))
             ) {
-                // unsubscribe old results if a subscription exists
                 // subscribe for new results (e.g. when a programming exercise was automatically tested)
-                if (this.websocketChannelResults) {
-                    this.jhiWebsocketService.unsubscribe(this.websocketChannelResults);
-                }
                 this.websocketChannelResults = `/topic/participation/${this.participation.id}/newResults`;
                 this.jhiWebsocketService.subscribe(this.websocketChannelResults);
                 this.jhiWebsocketService.receive(this.websocketChannelResults).subscribe((newResult: Result) => {
@@ -113,11 +109,7 @@ export class ResultComponent implements OnInit, OnChanges, OnDestroy {
                     this.handleNewResult(newResult);
                 });
 
-                // unsubscribe old submissions if a subscription exists
                 // subscribe for new submissions (e.g. when code was pushed and is currently built)
-                if (this.websocketChannelSubmissions) {
-                    this.jhiWebsocketService.unsubscribe(this.websocketChannelSubmissions);
-                }
                 this.websocketChannelSubmissions = `/topic/participation/${this.participation.id}/newSubmission`;
                 this.jhiWebsocketService.subscribe(this.websocketChannelSubmissions);
                 this.jhiWebsocketService.receive(this.websocketChannelSubmissions).subscribe((newProgrammingSubmission: ProgrammingSubmission) => {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [ ] I updated the documentation and models.
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] I added (end-to-end) test cases for the new functionality.

### Description
After https://github.com/ls1intum/ArTEMiS/pull/268 I noticed that it is still possible to create multiple listeners if the user goes from exercise-list into a programming-exercise.
Then ngOnChanges is called before ngOnInit and therefore two listeners are created.

### Steps for Testing

1. Log in to ArTEMiS
2. Go to the exercise-list
3. Open a programming exercise
4. Commit
5. Check in the console that each submission / result is only received once
