### PR TITLE
Remove unmaintained “webpack-visualizer-plugin” with deprecated dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
         "webpack-dev-server": "3.3.1",
         "webpack-merge": "4.2.1",
         "webpack-notifier": "1.7.0",
-        "webpack-visualizer-plugin": "0.1.11",
         "workbox-webpack-plugin": "4.2.0",
         "write-file-webpack-plugin": "4.5.0"
     },

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -2,12 +2,10 @@ const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
-const Visualizer = require('webpack-visualizer-plugin');
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const AngularCompilerPlugin = require('@ngtools/webpack').AngularCompilerPlugin;
-const path = require('path');
 
 const utils = require('./utils.js');
 const commonConfig = require('./webpack.common.js');
@@ -123,10 +121,6 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
                 'de'
                 // jhipster-needle-i18n-language-moment-webpack - JHipster will add/remove languages in this array
             ]
-        }),
-        new Visualizer({
-            // Webpack statistics in target folder
-            filename: '../stats.html'
         }),
         new AngularCompilerPlugin({
             mainPath: utils.root('src/main/webapp/app/app.main.ts'),


### PR DESCRIPTION
Up for discussion!

**Pros:**
Fix this Message from the build log:
```
(node:5128) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

**Cons:**
Statistics in `./build/resources/main/stats.html` are no longer available.

### Checklist
- [X] I run `yarn run webpack:build:main`: the project builds without errors.
- [X] I run `yarn lint`: the project builds without code style warnings.
- [X] ~I updated the documentation and models.~
- [X] ~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~
- [X] ~I added (end-to-end) test cases for the new functionality.~
