### PR TITLE
Element Download from Drag and Drop Model Quiz Creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@fortawesome/fontawesome-svg-core": "1.2.17",
         "@fortawesome/free-regular-svg-icons": "5.8.1",
         "@fortawesome/free-solid-svg-icons": "5.8.1",
-        "@ls1intum/apollon": "2.0.0-rc.2",
+        "@ls1intum/apollon": "2.0.0-rc.3",
         "@ng-bootstrap/ng-bootstrap": "4.1.1",
         "@nguniversal/express-engine": "7.1.1",
         "@ngx-translate/core": "11.0.1",

--- a/src/main/webapp/app/apollon-diagrams/apollon-diagram-detail.component.html
+++ b/src/main/webapp/app/apollon-diagrams/apollon-diagram-detail.component.html
@@ -6,6 +6,14 @@
             <a href="#/apollon-diagrams">&larr; {{ 'entity.action.back' | translate }}</a>
         </div>
         <div class="col text-right">
+            <label class="mr-1">
+                <input type="checkbox" name="keepOriginalSize" [(ngModel)]="crop" />&nbsp;<span jhiTranslate="arTeMiSApp.apollonDiagram.detail.crop">Crop</span>
+            </label>
+            <fa-icon class="mr-1" [icon]="'question-circle'" ngbTooltip="{{ 'arTeMiSApp.apollonDiagram.detail.help' | translate }}"></fa-icon>
+            <button class="btn btn-info mr-1" (click)="downloadSelection()" [hidden]="!apollonDiagram">
+                <fa-icon [icon]="'download'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.download">Download</span>
+            </button>
+            <span class="border-right border-secondary mr-2"></span>
             <button class="btn btn-info mr-1" (click)="generateExercise()" [hidden]="!apollonDiagram">
                 {{ 'arTeMiSApp.apollonDiagram.detail.createLabel' | translate }} &hellip;
             </button>

--- a/src/main/webapp/app/apollon-diagrams/apollon-diagram-detail.component.ts
+++ b/src/main/webapp/app/apollon-diagrams/apollon-diagram-detail.component.ts
@@ -41,7 +41,7 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
 
                     this.apollonDiagram = diagram;
 
-                    const model = JSON.parse(diagram.jsonRepresentation || '{}');
+                    const model: UMLModel = diagram.jsonRepresentation && JSON.parse(diagram.jsonRepresentation);
                     this.initializeApollonEditor(model);
                 },
                 response => {

--- a/src/main/webapp/app/apollon-diagrams/apollon-diagram-detail.component.ts
+++ b/src/main/webapp/app/apollon-diagrams/apollon-diagram-detail.component.ts
@@ -6,6 +6,7 @@ import { JhiLanguageHelper } from 'app/core';
 import { JhiAlertService, JhiLanguageService } from 'ng-jhipster';
 import { ApollonDiagram, ApollonDiagramService } from '../entities/apollon-diagram';
 import { ApollonQuizExerciseGenerationComponent } from './exercise-generation/apollon-quiz-exercise-generation.component';
+import { convertRenderedSVGToPNG } from './exercise-generation/svg-renderer';
 
 @Component({
     selector: 'jhi-apollon-diagram-detail',
@@ -17,6 +18,9 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
 
     apollonDiagram: ApollonDiagram | null = null;
     apollonEditor: ApollonEditor | null = null;
+
+    /** Wether to crop the downloaded image to the selection. */
+    crop = true;
 
     constructor(
         private apollonDiagramService: ApollonDiagramService,
@@ -97,5 +101,40 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
         const modalComponentInstance = modalRef.componentInstance as ApollonQuizExerciseGenerationComponent;
         modalComponentInstance.apollonEditor = this.apollonEditor;
         modalComponentInstance.diagramTitle = this.apollonDiagram.title;
+    }
+
+    /**
+     * Download the current selection of the diagram as a PNG image.
+     *
+     * @async
+     */
+    async downloadSelection() {
+        const { selection } = this.apollonEditor;
+        const svg = this.apollonEditor.exportAsSVG({
+            keepOriginalSize: !this.crop,
+            include: [...selection.elements, ...selection.relationships],
+        });
+        const png = await convertRenderedSVGToPNG(svg);
+        this.download(png);
+    }
+
+    /**
+     * Automatically trigger the download of a file.
+     *
+     * @param {Blob | File} file A `Blob` or `File` object which should be downloaded.
+     */
+    private download(file: Blob | File) {
+        const anchor = document.createElement('a');
+        document.body.appendChild(anchor);
+        const url = window.URL.createObjectURL(file);
+        anchor.href = url;
+        anchor.download = `${this.apollonDiagram.title}.png`;
+        anchor.click();
+
+        // Async revoke of ObjectURL to prevent failure on larger files.
+        setTimeout(() => {
+            window.URL.revokeObjectURL(url);
+            document.body.removeChild(anchor);
+        }, 0);
     }
 }

--- a/src/main/webapp/i18n/de/apollonDiagram.json
+++ b/src/main/webapp/i18n/de/apollonDiagram.json
@@ -25,6 +25,8 @@
             },
             "detail": {
                 "title": "Apollon-Diagramm",
+                "crop": "Bild auf Auswahl zuschneiden",
+                "help": "Laden Sie Ihre aktuelle Auswahl als PNG-Bild herunter.",
                 "createLabel": "Erstelle eine Quizaufgabe",
                 "generate": "Erstellen",
                 "error": {

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -155,6 +155,7 @@
             "back": "Zurück",
             "cancel": "Abbrechen",
             "delete": "Löschen",
+            "download": "Herunterladen",
             "dashboard": "Dashboard",
             "edit": "Bearbeiten",
             "editLink": "Link bearbeiten",

--- a/src/main/webapp/i18n/en/apollonDiagram.json
+++ b/src/main/webapp/i18n/en/apollonDiagram.json
@@ -25,6 +25,8 @@
             },
             "detail": {
                 "title": "Apollon Diagram",
+                "crop": "Crop image to selection",
+                "help": "Download your current selection as a PNG image.",
                 "createLabel": "Generate a Quiz Exercise",
                 "generate": "Generate",
                 "error": {

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -157,6 +157,7 @@
             "dashboard": "Dashboard",
             "exportRepos": "Download Repositories",
             "delete": "Delete",
+            "download": "Download",
             "edit": "Edit",
             "editLink": "Edit Link",
             "open": "Open",

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,17 +293,16 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.17"
 
-"@ls1intum/apollon@2.0.0-rc.2":
-  version "2.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.0-rc.2.tgz#3f932e2b51d32b70b2c4f3b629c8b8cab2b262c9"
-  integrity sha512-IVsOw+prEXCYs5kO8yOXtsZgtP9pmuzpc8Wh196TIW6mrqBIjuSlNKLRMtBq/236ZE/DYUS4oqKFRr5DZtjeeg==
+"@ls1intum/apollon@2.0.0-rc.3":
+  version "2.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.0-rc.3.tgz#62c3f8d62a0ace6e37986ef8cdb555b007cd519c"
+  integrity sha512-gcDGv6Zdi+NpjrT86EU2O4t6DPmenop8xl5hLBYcxhM2h+mtJ3txb/AjN3GHFpAF2shxUJSZWf8EE92Oh8M3mA==
   dependencies:
     react "16.8.6"
     react-dom "16.8.6"
     react-redux "6.0.1"
     redux "4.0.1"
     redux-saga "1.0.2"
-    reselect "4.0.0"
     styled-components "4.2.0"
     tslib "1.9.3"
     uuid "3.3.2"
@@ -9432,11 +9431,6 @@ requires-port@1.x.x, requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
-
-reselect@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 reserved-words@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] I updated the documentation and models.
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context

When creating drag and drop model quiz with Apollon, the process of creating fake/ dummy `DragItems` which have the same look as the automatically created correct `DragItems` is difficult. Therefore the instructor should be able to download any element manually on demand.

### Description

On the Apollon diagrams view, a new button was added to download all elements which are currently selected in the Apollon editor. Most often, the instructor only wants to download single elements, therefore a checkbox, indicating to crop the resulting image, is selected by default. If the instructor unselects this checkbox, the resulting image has the same size as the complete diagram but only the selected elements are shown - useful for background images.

### Steps for Testing

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Click the button 'Exercise' in any Course or first, create a new Course if necessary
4. Click the button 'Create Drag and Drop Model Quiz'
5. Click the button 'Create a new Apollon Diagram' or open an existing one
6. Add some elements to the diagram
7. Select one or multiple elements (by holding `shift`) and hit the download button
8. An automatic download should be triggered which downloads the selected elements as a PNG image
9. Click anywhere on the editor grid to focus the canvas and hit `Ctrl+A` to select all elements
10. `shift`-click any elements to deselect them
11. Uncheck the checkbox 'Crop image to selection' and click the button 'Download'
12. An automatic download should be triggered which downloads the entire diagram as a PNG image (with its full size) but without the non-selected elements.
