### PR TITLE
Temporarily disable retry button for modeling submissions

### DIFF
--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.html
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.html
@@ -38,9 +38,10 @@
             >
                 Submit (deadline missed)
             </button>
-            <button class="btn btn-info" (click)="retry()" *ngIf="isActive && submission?.submitted && result?.rated && !retryStarted">
-                <fa-icon icon="sync"></fa-icon>&nbsp;<span jhiTranslate="entity.action.retry">Retry</span>
-            </button>
+            <!--TODO: enable retry button again-->
+            <!--<button class="btn btn-info" (click)="retry()" *ngIf="isActive && submission?.submitted && result?.rated && !retryStarted">-->
+                <!--<fa-icon icon="sync"></fa-icon>&nbsp;<span jhiTranslate="entity.action.retry">Retry</span>-->
+            <!--</button>-->
         </div>
     </div>
     <br />


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
We temporarily disable the retry button to limit the workload for tutors.

### Steps for Testing
1. Log in to ArTEMiS as a student
2. Navigate to an already assessed submission
3. Check that there is no retry button anymore