### PR TITLE
Prevent retry modeling submission in server

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -159,7 +159,8 @@ public class ModelingSubmissionService {
         }
         Participation participation = optionalParticipation.get();
 
-        // TODO: enable retry mechanism again
+        // For now, we do not allow students to retry their modeling exercise after they have received feedback, because this could lead to unfair situations. Some students might get the manual feedback early and can then retry the exercise within the deadline and have a second chance, others might get the manual feedback late and would not have a chance to try it out again.
+        // TODO: think about how we can enable retry again in the future in a fair way
         // make sure that no (submitted) submission exists for the given user and exercise to prevent retry submissions
         boolean submittedSubmissionExists = participation.getSubmissions().stream().anyMatch(submission -> submission.isSubmitted());
         if (submittedSubmissionExists) {


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
After disabling the retry button in the client we additionally prevent retry modeling submissions in the server now.