### PR TITLE
Make text assessment components more resilient

### DIFF
--- a/src/main/webapp/app/text-assessment/text-assessment.component.html
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.html
@@ -46,6 +46,10 @@
     </div>
 </div>
 
+<div *ngIf="notFound" class="alert alert-warning text-center mt-4" role="alert">
+    <p jhiTranslate="arTeMiSApp.textAssessment.notFound">We haven't found any new text submission without an assessment, please go back.</p>
+</div>
+
 <div class="row justify-content-end mt-4">
     <div class="col text-right">
         <span *ngIf="result && participation && showResult"><jhi-result
@@ -94,7 +98,7 @@
     <div class="col-12 resizing-bar-bottom"><span></span></div>
 </div>
 
-<div class="col-12 mt-3" *ngIf="!busy">
+<div class="col-12 mt-3" *ngIf="!busy && !notFound">
     <div *ngIf="invalidError" class="alert alert-danger" role="alert">{{ invalidError }}</div>
     <div *ngIf="!assessments || assessments.length == 0" class="alert alert-secondary text-center" role="alert">
         <p jhiTranslate="arTeMiSApp.textAssessment.assessInstruction">Please highlight the text block you want to assess

--- a/src/main/webapp/i18n/de/textAssessment.json
+++ b/src/main/webapp/i18n/de/textAssessment.json
@@ -50,7 +50,8 @@
             "complaint": "Reklamation",
             "complaintAlreadyAccepted": "Die Reklamation wurde bereits geprüft und beantwortet von",
             "complaintResponse": "Antwort der Reklamation",
-            "submitComplaintResponse": "Die Antwort der Reklamation einreichen"
+            "submitComplaintResponse": "Die Antwort der Reklamation einreichen",
+            "notFound": "Wir haben keine neue Textvorlage ohne Bewertung gefunden, bitte gehen Sie zurück."
         }
     }
 }

--- a/src/main/webapp/i18n/en/textAssessment.json
+++ b/src/main/webapp/i18n/en/textAssessment.json
@@ -50,7 +50,8 @@
             "complaint": "Complaint",
             "complaintAlreadyAccepted": "The complaint has been already reviewed and replied by",
             "complaintResponse": "Complaint's response",
-            "submitComplaintResponse": "Submit complaint's response"
+            "submitComplaintResponse": "Submit complaint's response",
+            "notFound": "We haven't found any new text submission without an assessment, please go back."
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context

If no text submission without assessment have been found, display a warning message.
For any other error, display an actual error

Fix #296 
