### PR TITLE
Bugfix: Handle errors on dnd model quiz generation gracefully

### DIFF
--- a/src/main/webapp/app/apollon-diagrams/apollon-diagram-detail.component.ts
+++ b/src/main/webapp/app/apollon-diagrams/apollon-diagram-detail.component.ts
@@ -54,7 +54,7 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
                     const model: UMLModel = diagram.jsonRepresentation && JSON.parse(diagram.jsonRepresentation);
                     this.initializeApollonEditor(model);
                 },
-                response => {
+                () => {
                     this.jhiAlertService.error('arTeMiSApp.apollonDiagram.detail.error.loading');
                 },
             );
@@ -88,7 +88,6 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
 
     saveDiagram() {
         if (this.apollonDiagram === null) {
-            // Should never happen, but let's be defensive anyway
             return;
         }
 
@@ -100,13 +99,18 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
 
         this.apollonDiagramService.update(updatedDiagram).subscribe(
             () => {},
-            response => {
+            () => {
                 this.jhiAlertService.error('arTeMiSApp.apollonDiagram.update.error');
             },
         );
     }
 
-    generateExercise() {
+    /**
+     * Opens a modal to select a course and finally generate the Drag and Drop Model Quiz.
+     *
+     * @async
+     */
+    async generateExercise() {
         if (!this.hasInteractive) {
             return;
         }
@@ -115,6 +119,16 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
         const modalComponentInstance = modalRef.componentInstance as ApollonQuizExerciseGenerationComponent;
         modalComponentInstance.apollonEditor = this.apollonEditor;
         modalComponentInstance.diagramTitle = this.apollonDiagram.title;
+
+        try {
+            const result = await modalRef.result;
+            if (result) {
+                this.jhiAlertService.success('arTeMiSApp.apollonDiagram.create.success', { title: result.title });
+            }
+        } catch (error) {
+            this.jhiAlertService.error('arTeMiSApp.apollonDiagram.create.error');
+            throw error;
+        }
     }
 
     /**

--- a/src/main/webapp/app/apollon-diagrams/exercise-generation/apollon-quiz-exercise-generation.component.html
+++ b/src/main/webapp/app/apollon-diagrams/exercise-generation/apollon-quiz-exercise-generation.component.html
@@ -1,21 +1,21 @@
-<form name="form" role="form" (ngSubmit)="save()" novalidate>
+<form name="generate-quiz-exercise" role="form" (ngSubmit)="save()" novalidate>
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="arTeMiSApp.apollonDiagram.detail.createLabel">Generate a Quiz Exercise</h4>
     </div>
 
     <div class="modal-body">
-        <label for="GenerateQuizExercise_Course" class="form-control-label" jhiTranslate="arTeMiSApp.exercise.course">Course</label>
-        <select id="GenerateQuizExercise_Course" class="form-control" name="selectedCourse" [(ngModel)]="selectedCourse">
+        <label for="generate-quiz-exercise-course" class="form-control-label" jhiTranslate="arTeMiSApp.exercise.course">Course</label>
+        <select id="generate-quiz-exercise-course" class="form-control" name="selectedCourse" [(ngModel)]="selectedCourse">
             <option *ngFor="let course of courses" [ngValue]="course">{{ course.title }}</option>
         </select>
     </div>
 
     <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" (click)="dismiss()">
+        <button id="generate-quiz-exercise-cancel" type="button" class="btn btn-secondary" (click)="dismiss()">
             <fa-icon icon="ban"></fa-icon>
             <span jhiTranslate="entity.action.cancel">Cancel</span>
         </button>
-        <button type="submit" class="btn btn-success">
+        <button id="generate-quiz-exercise-save" type="submit" class="btn btn-success">
             <fa-icon icon="save"></fa-icon>
             <span jhiTranslate="arTeMiSApp.apollonDiagram.detail.generate">Generate</span>
         </button>

--- a/src/main/webapp/app/apollon-diagrams/exercise-generation/apollon-quiz-exercise-generation.component.ts
+++ b/src/main/webapp/app/apollon-diagrams/exercise-generation/apollon-quiz-exercise-generation.component.ts
@@ -25,13 +25,10 @@ export class ApollonQuizExerciseGenerationComponent implements OnInit {
     ) {}
 
     ngOnInit() {
-        this.courseService.query().subscribe(
-            response => {
-                this.courses = response.body;
-                this.selectedCourse = this.courses[0];
-            },
-            () => {},
-        );
+        this.courseService.query().subscribe(response => {
+            this.courses = response.body;
+            this.selectedCourse = this.courses[0];
+        });
     }
 
     async save() {
@@ -41,12 +38,15 @@ export class ApollonQuizExerciseGenerationComponent implements OnInit {
 
         const model = this.apollonEditor.model;
 
-        await generateDragAndDropQuizExercise(this.selectedCourse, this.diagramTitle, model, this.fileUploaderService, this.quizExerciseService);
-
-        this.activeModal.close();
+        try {
+            const quizExercise = await generateDragAndDropQuizExercise(this.selectedCourse, this.diagramTitle, model, this.fileUploaderService, this.quizExerciseService);
+            this.activeModal.close(quizExercise);
+        } catch (error) {
+            this.activeModal.dismiss(error);
+        }
     }
 
     dismiss() {
-        this.activeModal.dismiss('cancel');
+        this.activeModal.close();
     }
 }

--- a/src/main/webapp/app/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
+++ b/src/main/webapp/app/apollon-diagrams/exercise-generation/quiz-exercise-generator.ts
@@ -29,7 +29,7 @@ export async function generateDragAndDropQuizExercise(
     model: UMLModel,
     fileUploaderService: FileUploaderService,
     quizExerciseService: QuizExerciseService,
-) {
+): Promise<QuizExercise> {
     const interactiveElements = [...model.interactive.elements, ...model.interactive.relationships];
     const elements = [...model.elements, ...model.relationships];
 
@@ -64,6 +64,8 @@ export async function generateDragAndDropQuizExercise(
 
     // Save the quiz exercise
     await quizExerciseService.create(quizExercise).toPromise();
+
+    return quizExercise;
 }
 
 /**

--- a/src/main/webapp/app/shared/http/file-uploader.service.ts
+++ b/src/main/webapp/app/shared/http/file-uploader.service.ts
@@ -33,7 +33,8 @@ export class FileUploaderService {
 
         const formData = new FormData();
         formData.append('file', file, fileName);
-        const url = options.keepFileName ? '/api/fileUpload?keepFileName=true' : '/api/fileUpload';
+        const keepFileName: boolean = !!options && options.keepFileName;
+        const url = `/api/fileUpload?keepFileName=${keepFileName}`;
         return this.http.post<FileUploadResponse>(url, formData).toPromise();
     }
 

--- a/src/main/webapp/i18n/de/apollonDiagram.json
+++ b/src/main/webapp/i18n/de/apollonDiagram.json
@@ -13,6 +13,7 @@
             "updated": "Apollon Diagram aktualisiert mit ID {{ param }}",
             "deleted": "Apollon Diagram gelöscht mit ID {{ param }}",
             "create": {
+                "success": "Apollon Diagram mit Titel {{ title }} wurde erfolgreich generiert",
                 "error": "Fehler beim Erstellen des Apollon Diagramms"
             },
             "update": {

--- a/src/main/webapp/i18n/en/apollonDiagram.json
+++ b/src/main/webapp/i18n/en/apollonDiagram.json
@@ -13,6 +13,7 @@
             "updated": "Apollon Diagram updated with ID {{ param }}",
             "deleted": "Apollon Diagram deleted with ID {{ param }}",
             "create": {
+                "success": "Apollon diagram with title {{ title }} was created successfully",
                 "error": "Error while creating Apollon diagram"
             },
             "update": {
@@ -20,7 +21,7 @@
             },
             "delete": {
                 "question": "Are you sure you want to delete Apollon Diagram {{ id }}?",
-                "success": "Apollon diagram with title {{ title }} was deleted successfully'",
+                "success": "Apollon diagram with title {{ title }} was deleted successfully",
                 "error": "Error while deleting the apollon diagrams with title {{ title }}"
             },
             "detail": {


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] I updated the documentation and models.
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context

Previous changes to the `FileUpload` service made generation of Drag and Drop Model Quizzes fail.

### Description

Fixed the issue with the `FileUpload` service and implemented mechanism to handle errors thrown on the generation modal gracefully in the Apollon diagram details component.
