### PR TITLE
Small improvements of modeling exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
@@ -29,6 +29,9 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     Optional<Participation> findByExerciseIdAndStudentLogin(Long exerciseId, String username);
 
+    @Query("select distinct participation from Participation participation left join fetch participation.submissions where participation.exercise.id = :#{#exerciseId} and participation.student.login = :#{#username}")
+    Optional<Participation> findByExerciseIdAndStudentLoginWithEagerSubmissions(@Param("exerciseId") Long exerciseId, @Param("username") String username);
+
     Participation findOneByExerciseIdAndStudentLoginAndInitializationState(Long exerciseId, String username, InitializationState state);
 
     List<Participation> findByBuildPlanIdAndInitializationState(String buildPlanId, InitializationState state);

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -153,7 +153,8 @@ public class ModelingSubmissionService {
     @Transactional(rollbackFor = Exception.class)
     public ModelingSubmission save(ModelingSubmission modelingSubmission, ModelingExercise modelingExercise, String username) {
 
-        Optional<Participation> optionalParticipation = participationService.findOneByExerciseIdAndStudentLoginAnyState(modelingExercise.getId(), username);
+        Optional<Participation> optionalParticipation =
+            participationService.findOneByExerciseIdAndStudentLoginWithEagerSubmissionsAnyState(modelingExercise.getId(), username);
         if (!optionalParticipation.isPresent()) {
             throw new EntityNotFoundException("No participation found for " + username + " in exercise with id " + modelingExercise.getId());
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -436,6 +436,19 @@ public class ParticipationService {
     }
 
     /**
+     * Get one participation (in any state) by its student and exercise with eager submissions.
+     *
+     * @param exerciseId the project key of the exercise
+     * @param username   the username of the student
+     * @return the entity
+     */
+    @Transactional(readOnly = true)
+    public Optional<Participation> findOneByExerciseIdAndStudentLoginWithEagerSubmissionsAnyState(Long exerciseId, String username) {
+        log.debug("Request to get Participation for User {} for Exercise with id: {}", username, exerciseId);
+        return participationRepository.findByExerciseIdAndStudentLoginWithEagerSubmissions(exerciseId, username);
+    }
+
+    /**
      * Get all participations for the given student including all results
      *
      * @param username the username of the student

--- a/src/main/webapp/app/example-modeling-submission/example-modeling-submission.component.html
+++ b/src/main/webapp/app/example-modeling-submission/example-modeling-submission.component.html
@@ -4,10 +4,13 @@
         <button class="btn btn-secondary" (click)="back()">&larr;</button>
     </div>
 
-    <div class="col-12 col-lg-7">
+    <div class="col-12 col-lg-7 d-flex flex-column justify-content-between">
         <h2 jhiTranslate="arTeMiSApp.modelingExercise.exampleSubmissionForModelingExercise" [translateValues]="{ exerciseTitle: exercise?.title }">
             Example Modeling Submission for Exercise {{exercise?.title}}
         </h2>
+        <p *ngIf="assessmentMode" jhiTranslate="arTeMiSApp.exampleSubmission.assessmentInstruction">
+            Double-click on a model element to view and edit the element's assessment.
+        </p>
     </div>
 
     <div class="col-12 col-lg-4 text-right" *ngIf="isAtLeastInstructor && !readOnly && !toComplete">

--- a/src/main/webapp/app/example-modeling-submission/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/example-modeling-submission/example-modeling-submission.component.ts
@@ -290,6 +290,8 @@ export class ExampleModelingSubmissionComponent implements OnInit {
     }
 
     checkAssessment() {
+        // scroll to top that the user definitely recognizes the response message (success OR score too low/high)
+        window.scroll(0, 0);
         this.checkScoreBoundaries();
         if (!this.assessmentsAreValid) {
             this.jhiAlertService.error('arTeMiSApp.modelingAssessment.invalidAssessments');

--- a/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.html
+++ b/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.html
@@ -8,7 +8,10 @@
         </div>
         <jhi-alert></jhi-alert>
         <div class="control-container row-container">
-            <span *ngIf="!isAuthorized" class="text-danger ml-3" style="font-size: 65%">Submission locked by another user!</span>
+            <span *ngIf="!isAuthorized" class="text-danger ml-3" style="font-size: 65%"
+                  jhiTranslate="modelingAssessmentEditor.assessmentLocked" [translateValues]="{ otherUser: result?.assessor?.firstName + ' ' + result?.assessor?.lastName }">
+                Assessment locked by another user!
+            </span>
             <button class="btn btn-primary" (click)="onSaveAssessment()" [disabled]="!assessmentsAreValid || !isAuthorized" [hidden]="result && result.rated">
                 <fa-icon icon="save"></fa-icon>
                 <span jhiTranslate="entity.action.save">Save</span>

--- a/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.html
+++ b/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.html
@@ -9,7 +9,7 @@
         <jhi-alert></jhi-alert>
         <div class="control-container row-container">
             <span *ngIf="!isAuthorized" class="text-danger ml-3" style="font-size: 65%"
-                  jhiTranslate="modelingAssessmentEditor.assessmentLocked" [translateValues]="{ otherUser: result?.assessor?.firstName + ' ' + result?.assessor?.lastName }">
+                  jhiTranslate="modelingAssessmentEditor.assessmentLocked" [translateValues]="{ otherUser: result?.assessor?.firstName }">
                 Assessment locked by another user!
             </span>
             <button class="btn btn-primary" (click)="onSaveAssessment()" [disabled]="!assessmentsAreValid || !isAuthorized" [hidden]="result && result.rated">

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -307,7 +307,21 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
      */
     onSelectionChanged(selection: Selection) {
         this.selectedEntities = selection.elements;
+        for (const selectedEntity of this.selectedEntities) {
+            this.selectedEntities.push(...this.getSelectedChildren(selectedEntity));
+        }
         this.selectedRelationships = selection.relationships;
+    }
+
+    /**
+     * Returns the elementIds of all the children of the element with the given elementId
+     * or an empty list, if no children exist for this element.
+     */
+    private getSelectedChildren(elementId: string): string[] {
+        if (!this.umlModel || !this.umlModel.elements) {
+            return [];
+        }
+        return this.umlModel.elements.filter(element => element.owner === elementId).map(element => element.id);
     }
 
     /**

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -145,9 +145,8 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
     }
 
     /**
-     * This function initialized the Apollon editor depending on the submission status.
-     * If it was already submitted, the Apollon editor is loaded in Assessment read-only mode.
-     * Otherwise, it is loaded in the modeling mode and an auto save timer is started.
+     * This function sets and starts an auto-save timer that automatically saves changes
+     * to the model after at most 60 seconds.
      */
     setAutoSaveTimer(): void {
         if (this.submission.submitted) {
@@ -216,7 +215,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
             return;
         }
         this.updateSubmissionModel();
-        if (!this.umlModel || this.umlModel.elements.length === 0) {
+        if (this.isModelEmpty(this.submission.model)) {
             this.jhiAlertService.warning('arTeMiSApp.modelingEditor.empty');
             return;
         }
@@ -263,6 +262,11 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         }
     }
 
+    private isModelEmpty(model: string): boolean {
+        const umlModel: UMLModel = JSON.parse(model);
+        return !umlModel || !umlModel.elements || umlModel.elements.length === 0;
+    }
+
     ngOnDestroy(): void {
         this.subscription.unsubscribe();
         clearInterval(this.autoSaveInterval);
@@ -275,8 +279,8 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
      * Updates the model of the submission with the current Apollon model state
      */
     updateSubmissionModel(): void {
-        this.umlModel = this.modelingEditor.getCurrentModel();
-        const diagramJson = JSON.stringify(this.umlModel);
+        const umlModel = this.modelingEditor.getCurrentModel();
+        const diagramJson = JSON.stringify(umlModel);
         if (this.submission && diagramJson != null) {
             this.submission.model = diagramJson;
         }

--- a/src/main/webapp/i18n/de/exampleSubmission.json
+++ b/src/main/webapp/i18n/de/exampleSubmission.json
@@ -26,7 +26,8 @@
             "score": "Punktzahl",
             "submitAssessment": "Bewertung einreichen",
             "readAndUnderstood": "Ich habe das Beispiel gelesen und verstanden.",
-            "exampleSubmission": "Beispielabgabe"
+            "exampleSubmission": "Beispielabgabe",
+            "assessmentInstruction": "Doppelklicken Sie auf ein Element im Modell, um dessen Bewertung zu öffnen und zu bearbeiten."
         }
     }
 }

--- a/src/main/webapp/i18n/de/modelingAssessmentEditor.json
+++ b/src/main/webapp/i18n/de/modelingAssessmentEditor.json
@@ -1,6 +1,7 @@
 {
     "modelingAssessmentEditor": {
         "assessment": "Bewertung",
+        "assessmentLocked": "Bewertung blockiert durch: {{otherUser}}",
         "button": {
             "overrideAssessment": "Bewertung überschreiben",
             "nextSubmission": "Nächste Abgabe bewerten"

--- a/src/main/webapp/i18n/de/modelingAssessmentEditor.json
+++ b/src/main/webapp/i18n/de/modelingAssessmentEditor.json
@@ -1,7 +1,7 @@
 {
     "modelingAssessmentEditor": {
         "assessment": "Bewertung",
-        "assessmentLocked": "Bewertung blockiert durch: {{otherUser}}",
+        "assessmentLocked": "Bewertung gesperrt von: {{otherUser}}",
         "button": {
             "overrideAssessment": "Bewertung überschreiben",
             "nextSubmission": "Nächste Abgabe bewerten"

--- a/src/main/webapp/i18n/en/exampleSubmission.json
+++ b/src/main/webapp/i18n/en/exampleSubmission.json
@@ -26,7 +26,8 @@
             "score": "Score",
             "submitAssessment": "Submit Assessment",
             "readAndUnderstood": "I have read and understood the example",
-            "exampleSubmission": "Example Submission"
+            "exampleSubmission": "Example Submission",
+            "assessmentInstruction": "Double-click on a model element to view and edit the element's assessment."
         }
     }
 }

--- a/src/main/webapp/i18n/en/modelingAssessmentEditor.json
+++ b/src/main/webapp/i18n/en/modelingAssessmentEditor.json
@@ -1,6 +1,7 @@
 {
     "modelingAssessmentEditor": {
         "assessment": "Assessment",
+        "assessmentLocked": "Assessment locked by: {{otherUser}}",
         "button": {
             "overrideAssessment": "Override Assessment",
             "nextSubmission": "Assess Next Submission"


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
Improvements contained in this PR:
- prevent additional database queries with eager loading
- show the name of the user that currently has the lock for an assessment in the assessment editor (for instructors)
- scroll to top after an example assessment has been submitted by a tutor to make response message more obvious
- do not set input model of Apollon upon saving to prevent popups from closing on auto-save
- also display children of selected elements in assessment result view 
- add hint to example assessment view