### PR TITLE
Fix reactivity in tutor leaderboard

### DIFF
--- a/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.html
+++ b/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.html
@@ -10,7 +10,7 @@
             </tr>
         </thead>
         <tbody>
-            <tr *ngFor="let tutor of tutorsData | keyvalue | orderBy:'numberOfAssessments'; let i=index;">
+            <tr *ngFor="let tutor of tutorsData | keyvalue | orderBy:'value.numberOfAssessments'; let i=index;">
                 <td>{{ i + 1 }}</td>
                 <td>{{ tutor.value.tutor.firstName }} {{ tutor.value.tutor.lastName }}</td>
                 <td>{{ tutor.value.tutor.login }}</td>

--- a/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.html
+++ b/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.html
@@ -10,7 +10,7 @@
             </tr>
         </thead>
         <tbody>
-            <tr *ngFor="let tutor of tutorsData | keyvalue | orderBy:'value.numberOfAssessments'; let i=index;">
+            <tr *ngFor="let tutor of tutorsData | keyvalue : orderByNumberOfAssessments; let i=index;">
                 <td>{{ i + 1 }}</td>
                 <td>{{ tutor.value.tutor.firstName }} {{ tutor.value.tutor.lastName }}</td>
                 <td>{{ tutor.value.tutor.login }}</td>

--- a/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.html
+++ b/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.html
@@ -10,12 +10,12 @@
             </tr>
         </thead>
         <tbody>
-            <tr *ngFor="let tutor of sortedTutorData; let i=index;">
+            <tr *ngFor="let tutor of tutorsData | keyvalue | orderBy:'numberOfAssessments'; let i=index;">
                 <td>{{ i + 1 }}</td>
-                <td>{{ tutor.tutor.firstName }} {{ tutor.tutor.lastName }}</td>
-                <td>{{ tutor.tutor.login }}</td>
-                <td>{{ tutor.numberOfAssessments }}</td>
-                <td>{{ tutor.numberOfComplaints }}</td>
+                <td>{{ tutor.value.tutor.firstName }} {{ tutor.value.tutor.lastName }}</td>
+                <td>{{ tutor.value.tutor.login }}</td>
+                <td>{{ tutor.value.numberOfAssessments }}</td>
+                <td>{{ tutor.value.numberOfComplaints }}</td>
             </tr>
         </tbody>
     </table>

--- a/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.ts
+++ b/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.ts
@@ -1,5 +1,6 @@
 import { User } from 'app/core';
 import { Component, Input } from '@angular/core';
+import { KeyValue } from '@angular/common';
 
 interface TutorLeaderboardElement {
     tutor: User;
@@ -17,4 +18,8 @@ export interface TutorLeaderboardData {
 })
 export class TutorLeaderboardComponent {
     @Input() public tutorsData: TutorLeaderboardData = {};
+
+    orderByNumberOfAssessments(firstElement: KeyValue<number, TutorLeaderboardElement>, secondElement: KeyValue<number, TutorLeaderboardElement>) {
+        return secondElement.value.numberOfAssessments - firstElement.value.numberOfAssessments;
+    }
 }

--- a/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.ts
+++ b/src/main/webapp/app/instructor-course-dashboard/tutor-leaderboard/tutor-leaderboard.component.ts
@@ -1,5 +1,5 @@
 import { User } from 'app/core';
-import { Component, Input, OnInit, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 interface TutorLeaderboardElement {
     tutor: User;
@@ -15,20 +15,6 @@ export interface TutorLeaderboardData {
     selector: 'jhi-tutor-leaderboard',
     templateUrl: './tutor-leaderboard.component.html',
 })
-export class TutorLeaderboardComponent implements OnInit, OnChanges {
+export class TutorLeaderboardComponent {
     @Input() public tutorsData: TutorLeaderboardData = {};
-    sortedTutorData: TutorLeaderboardElement[] = [];
-
-    ngOnInit() {
-        this.sortTutorData();
-    }
-
-    ngOnChanges(changes: SimpleChanges): void {
-        this.sortTutorData();
-    }
-
-    private sortTutorData() {
-        this.sortedTutorData = Object.values(this.tutorsData);
-        this.sortedTutorData = this.sortedTutorData.sort((firstElement, secondElement) => secondElement.numberOfAssessments - firstElement.numberOfAssessments);
-    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
Reactivity in Angular works in a strange way for the combo `@Input` + `async` data. See https://github.com/angular/angular/issues/5689

This means that when the data for the leaderboard is downloaded after the first render, the template will not be updated. I've rewritten the implementation to avoid such limitation
