### PR TITLE
enable submit button upon saving a new modeling submission

### DIFF
--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.html
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.html
@@ -23,7 +23,7 @@
             <button
                 class="btn btn-success"
                 (click)="submit()"
-                [disabled]="!submission || !umlModel || !umlModel.elements || umlModel.elements.length === 0"
+                [disabled]="!submission || !hasElements"
                 [hidden]="submission?.submitted || !isActive"
                 jhiTranslate="entity.action.submit"
             >
@@ -32,7 +32,7 @@
             <button
                 class="btn btn-warning"
                 (click)="submit()"
-                [disabled]="!submission || !umlModel || !umlModel.elements || umlModel.elements.length === 0"
+                [disabled]="!submission || !hasElements"
                 [hidden]="submission?.submitted || isActive"
                 jhiTranslate="entity.action.submitDeadlineMissed"
             >

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -188,7 +188,6 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                     this.submission = response.body;
                     this.result = this.submission.result;
                     this.isSaving = false;
-                    console.log('model has elements: ' + this.hasElements);
                     this.jhiAlertService.success('arTeMiSApp.modelingEditor.saveSuccessful');
                 },
                 error => {
@@ -202,7 +201,6 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                     this.submission = submission.body;
                     this.result = this.submission.result;
                     this.isSaving = false;
-                    console.log('model has elements: ' + this.hasElements);
                     this.jhiAlertService.success('arTeMiSApp.modelingEditor.saveSuccessful');
                     this.isActive = this.modelingExercise.dueDate == null || new Date() <= moment(this.modelingExercise.dueDate).toDate();
                     this.subscribeToWebsocket();

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -188,6 +188,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                     this.submission = response.body;
                     this.result = this.submission.result;
                     this.isSaving = false;
+                    console.log('model has elements: ' + this.hasElements);
                     this.jhiAlertService.success('arTeMiSApp.modelingEditor.saveSuccessful');
                 },
                 error => {
@@ -201,6 +202,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                     this.submission = submission.body;
                     this.result = this.submission.result;
                     this.isSaving = false;
+                    console.log('model has elements: ' + this.hasElements);
                     this.jhiAlertService.success('arTeMiSApp.modelingEditor.saveSuccessful');
                     this.isActive = this.modelingExercise.dueDate == null || new Date() <= moment(this.modelingExercise.dueDate).toDate();
                     this.subscribeToWebsocket();


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
After preventing the Apollon popups from closing in [PR#311](https://github.com/ls1intum/ArTEMiS/pull/311) by not updating the input UML model for Apollon upon saving a submission, the submit button was disabled for new submissions also after saving the submission. In order to submit it, you had to save the submission, navigate back to the course/exercise overview and open the previously saved submission again.

### Description
We enable the submit button upon saving again by actually checking the current model from Apollon instead of the outdated initial input model (which is and stays undefined when starting a new submission). 

### Steps for Testing
1. Log in to ArTEMiS as a student
2. Navigate to Course Overview
3. Initialize a new modeling submission 
4. Open the modeling editor
5. Add at least one element to the model
6. Save the model
7. Submit the model