### PR TITLE
Do not send to sentry HttpError 4xx

### DIFF
--- a/src/main/webapp/app/sentry/sentry.error-handler.ts
+++ b/src/main/webapp/app/sentry/sentry.error-handler.ts
@@ -38,6 +38,11 @@ export class SentryErrorHandler implements ErrorHandler {
     }
 
     handleError(error: any): void {
+        // We ignore HttpError in the range 400-499
+        if (error.name === 'HttpErrorResponse' && error.status < 500 && error.status >= 400) {
+            return;
+        }
+
         captureException(error.originalError || error);
         throw error;
     }

--- a/src/main/webapp/app/sentry/sentry.error-handler.ts
+++ b/src/main/webapp/app/sentry/sentry.error-handler.ts
@@ -38,9 +38,9 @@ export class SentryErrorHandler implements ErrorHandler {
     }
 
     handleError(error: any): void {
-        // We ignore HttpError in the range 400-499
+        // We do not send to Sentry HttpError in the range 400-499
         if (error.name === 'HttpErrorResponse' && error.status < 500 && error.status >= 400) {
-            return;
+            throw error;
         }
 
         captureException(error.originalError || error);


### PR DESCRIPTION
We do not need errors given by users submitting malformed bodies or students trying to access things they shouldn't access (403 and 401)