### PR TITLE
Add an manual Authentication Handler for the test cases endpoint.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
@@ -4,6 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.config.Constants;
@@ -12,6 +16,8 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.service.ExerciseService;
 import de.tum.in.www1.artemis.service.ProgrammingExerciseService;
 import de.tum.in.www1.artemis.service.ProgrammingSubmissionService;
+
+import java.util.Collection;
 
 /**
  * REST controller for managing ProgrammingSubmission.
@@ -62,7 +68,45 @@ public class ProgrammingSubmissionResource {
     @PostMapping(Constants.TEST_CASE_CHANGED_PATH + "{exerciseId}")
     public ResponseEntity<Void> testCaseChanged(@PathVariable Long exerciseId, @RequestBody Object requestBody) {
         log.info("REST request to inform about changed test cases of ProgrammingExercise : {}", exerciseId);
-        // TODO: the following leads to an exception: org.springframework.dao.InvalidDataAccessApiUsageException: Authentication object cannot be null
+        // This fixes an issue with the Spring Security Context Holder: https://jira.spring.io/browse/DATAJPA-1357
+        SecurityContext context = SecurityContextHolder.getContext();
+        Authentication authentication = new Authentication() {
+            @Override
+            public Collection<? extends GrantedAuthority> getAuthorities() {
+                return null;
+            }
+
+            @Override
+            public Object getCredentials() {
+                return null;
+            }
+
+            @Override
+            public Object getDetails() {
+                return null;
+            }
+
+            @Override
+            public Object getPrincipal() {
+                return null;
+            }
+
+            @Override
+            public boolean isAuthenticated() {
+                return true;
+            }
+
+            @Override
+            public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+            }
+
+            @Override
+            public String getName() {
+                return null;
+            }
+        };
+        context.setAuthentication(authentication);
         Exercise exercise = exerciseService.findOneLoadParticipations(exerciseId);
 
         if (!(exercise instanceof ProgrammingExercise)) {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] I updated the documentation and models.
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
When receiving the web hook about changed test cases, the method ExerciseRepository#findByIdWithEagerParticipations is executed. This method uses a Query to select a specific exercise. The Spring Security Handler fails to allow this query for unauthorized users and creates an ```org.springframework.dao.InvalidDataAccessApiUsageException Authentication object cannot be null```.
This issue is already tracked in Spring Data JPA: https://jira.spring.io/browse/DATAJPA-1357, but no fix is yet developed.

### Description
This uses a workaround described in the Spring Data JPA ticket to manually set an authorization object that allows the use of the query.

### Steps for Testing
1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Create a programming exercise
4. Change the testcases of that exercise
5. No internal server error should now be thrown