### PR TITLE
In the tutor exercise dashboard consider all the submissions, not only text

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
@@ -15,4 +15,11 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * return the number of submissions for the given courseId
      */
     long countByParticipation_Exercise_Course_IdAndSubmitted(Long courseId, Boolean submitted);
+
+    /**
+     * @param submitted choose which submitted state you want
+     * @param exerciseId the id of the exercise you want the stats about
+     * @return number of submission for the given exerciseId, with the submitted status expressed by the flag
+     */
+    long countBySubmittedAndParticipation_Exercise_Id(boolean submitted, Long exerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -11,8 +11,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.tum.in.www1.artemis.domain.enumeration.TutorParticipationStatus;
-import de.tum.in.www1.artemis.repository.ComplaintRepository;
-import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
+import de.tum.in.www1.artemis.repository.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.InputStreamResource;
@@ -25,8 +24,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
@@ -71,11 +68,11 @@ public class ExerciseResource {
 
     private final ComplaintRepository complaintRepository;
 
-    private final TextSubmissionRepository submissionRepository;
+    private final SubmissionRepository submissionRepository;
 
     public ExerciseResource(ExerciseRepository exerciseRepository, ExerciseService exerciseService, ParticipationService participationService, UserService userService,
                             CourseService courseService, AuthorizationCheckService authCheckService, Optional<ContinuousIntegrationService> continuousIntegrationService,
-                            Optional<VersionControlService> versionControlService, TutorParticipationService tutorParticipationService, ExampleSubmissionRepository exampleSubmissionRepository, ObjectMapper objectMapper, TextSubmissionService textSubmissionService, TextAssessmentService textAssessmentService, ComplaintRepository complaintRepository, TextSubmissionRepository submissionRepository) {
+                            Optional<VersionControlService> versionControlService, TutorParticipationService tutorParticipationService, ExampleSubmissionRepository exampleSubmissionRepository, ObjectMapper objectMapper, TextAssessmentService textAssessmentService, ComplaintRepository complaintRepository, SubmissionRepository submissionRepository) {
         this.exerciseRepository = exerciseRepository;
         this.exerciseService = exerciseService;
         this.participationService = participationService;


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
The exercise resource, also due a bad naming in the class property, was using the wrong submission repository, Switching to the right one gives the right stats also for tutor dashboard of modeling exercise

