### PR TITLE
Fix bug where editor preview was not updated on edited problemStatement

### DIFF
--- a/src/main/webapp/app/entities/exercise/exercise-utils.ts
+++ b/src/main/webapp/app/entities/exercise/exercise-utils.ts
@@ -7,3 +7,11 @@ export const hasExerciseChanged = (changes: SimpleChanges) => {
         (!changes.participation.previousValue || changes.participation.previousValue.id !== changes.participation.currentValue.id)
     );
 };
+export const problemStatementHasChanged = (changes: SimpleChanges) => {
+    return (
+        changes.exercise &&
+        changes.exercise.previousValue &&
+        changes.exercise.currentValue &&
+        changes.exercise.previousValue.problemStatement !== changes.exercise.currentValue.problemStatement
+    );
+};

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
@@ -28,7 +28,7 @@ import { RepositoryFileService } from '../repository';
 import { Participation, hasParticipationChanged } from '../participation';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { Observable, Subscription } from 'rxjs';
-import { hasExerciseChanged } from '../exercise';
+import { hasExerciseChanged, problemStatementHasChanged } from '../exercise';
 
 type Step = {
     title: string;
@@ -119,6 +119,10 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
                     }),
                 )
                 .subscribe();
+        } else if (problemStatementHasChanged(changes)) {
+            // If the exercise's problemStatement is updated from the parent component, re-render the markdown.
+            // This is e.g. the case if the parent component uses an editor to update the problemStatement.
+            this.updateMarkdown();
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- ~[ ] I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- ~[ ] I added (end-to-end) test cases for the new functionality.~

### Description
Bugfix for problemStatement update in markdown editor.
There was no onChange cycle for updating the markdown of the editor if the exercises problemStatement changed.
I added this onChange check to make sure the most recent markdown is shown in preview.

### Steps for Testing
1. Programming-Exercise-Detail / -Dialog
2. Edit the edit area of the markdown editor
3. Go to preview and check if the most recent changes are displayed
