### PR TITLE
Bugfix/code editor instructions can't be scrolled

### DIFF
--- a/src/main/webapp/app/code-editor/instructions/code-editor-instructions.component.html
+++ b/src/main/webapp/app/code-editor/instructions/code-editor-instructions.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!noInstructionsAvailable" id="cardInstructions" class="card resizable-instructions" [ngStyle]="{ 'width.vw': 40 }">
+<div *ngIf="!noInstructionsAvailable" id="cardInstructions" class="card-body card resizable-instructions p-0 border-0" [ngStyle]="{ 'width.vw': 40, overflow: 'inherit' }">
     <div class="card-header text-white bg-primary" (click)="toggleEditorCollapse($event, false)">
         <span class="float-right "><fa-icon icon="chevron-right"></fa-icon></span>
         <h3 class="card-title">
@@ -6,7 +6,13 @@
             <span jhiTranslate="arTeMiSApp.editor.instructions"> &nbsp; Instructions &nbsp; </span>
         </h3>
     </div>
-    <jhi-programming-exercise-instructions (onNoInstructionsAvailable)="onNoInstructionsAvailable()" [exercise]="participation?.exercise" [participation]="participation">
+    <jhi-programming-exercise-instructions
+        (onNoInstructionsAvailable)="onNoInstructionsAvailable()"
+        [exercise]="participation?.exercise"
+        [participation]="participation"
+        [ngClass]="['card', 'card-body', 'p-0', 'border-0']"
+        [ngStyle]="{ overflow: 'inherit' }"
+    >
     </jhi-programming-exercise-instructions>
     <!-- Required for resizing; don't remove empty span -->
     <div class="rg-left"><span></span></div>

--- a/src/main/webapp/app/code-editor/instructions/code-editor-instructions.component.ts
+++ b/src/main/webapp/app/code-editor/instructions/code-editor-instructions.component.ts
@@ -20,8 +20,9 @@ export class CodeEditorInstructionsComponent implements AfterViewInit {
     haveDetailsBeenLoaded = false;
 
     /** Resizable constants **/
+    resizableMinWidth = 100;
+    resizableMaxWidth = 800;
     initialInstructionsWidth: number;
-    minInstructionsWidth: number;
     interactResizable: interact.Interactable;
     noInstructionsAvailable = false;
 
@@ -37,16 +38,15 @@ export class CodeEditorInstructionsComponent implements AfterViewInit {
      *       The 'resizemove' callback function processes the event values and sets new width and height values for the element.
      */
     ngAfterViewInit(): void {
-        this.initialInstructionsWidth = this.$window.nativeWindow.screen.width - 300 / 2;
-        this.minInstructionsWidth = this.$window.nativeWindow.screen.width / 4 - 50;
+        this.resizableMinWidth = this.$window.nativeWindow.screen.width / 6;
         this.interactResizable = interact('.resizable-instructions')
             .resizable({
                 // Enable resize from left edge; triggered by class rg-left
                 edges: { left: '.rg-left', right: false, bottom: false, top: false },
                 // Set maximum width
                 restrictSize: {
-                    min: { width: this.minInstructionsWidth },
-                    max: { width: this.initialInstructionsWidth },
+                    min: { width: this.resizableMinWidth },
+                    max: { width: this.resizableMaxWidth },
                 },
                 inertia: true,
             })
@@ -70,7 +70,7 @@ export class CodeEditorInstructionsComponent implements AfterViewInit {
      * @param {boolean} horizontal
      */
     toggleEditorCollapse($event: any, horizontal: boolean) {
-        this.parent.toggleCollapse($event, horizontal, this.interactResizable, this.minInstructionsWidth);
+        this.parent.toggleCollapse($event, horizontal, this.interactResizable, this.resizableMinWidth);
     }
 
     onNoInstructionsAvailable() {

--- a/src/main/webapp/app/code-editor/instructions/code-editor-instructions.component.ts
+++ b/src/main/webapp/app/code-editor/instructions/code-editor-instructions.component.ts
@@ -20,9 +20,8 @@ export class CodeEditorInstructionsComponent implements AfterViewInit {
     haveDetailsBeenLoaded = false;
 
     /** Resizable constants **/
-    resizableMinWidth = 100;
-    resizableMaxWidth = 800;
     initialInstructionsWidth: number;
+    minInstructionsWidth: number;
     interactResizable: interact.Interactable;
     noInstructionsAvailable = false;
 
@@ -38,15 +37,16 @@ export class CodeEditorInstructionsComponent implements AfterViewInit {
      *       The 'resizemove' callback function processes the event values and sets new width and height values for the element.
      */
     ngAfterViewInit(): void {
-        this.resizableMinWidth = this.$window.nativeWindow.screen.width / 6;
+        this.initialInstructionsWidth = this.$window.nativeWindow.screen.width - 300 / 2;
+        this.minInstructionsWidth = this.$window.nativeWindow.screen.width / 4 - 50;
         this.interactResizable = interact('.resizable-instructions')
             .resizable({
                 // Enable resize from left edge; triggered by class rg-left
                 edges: { left: '.rg-left', right: false, bottom: false, top: false },
                 // Set maximum width
                 restrictSize: {
-                    min: { width: this.resizableMinWidth },
-                    max: { width: this.resizableMaxWidth },
+                    min: { width: this.minInstructionsWidth },
+                    max: { width: this.initialInstructionsWidth },
                 },
                 inertia: true,
             })
@@ -70,7 +70,7 @@ export class CodeEditorInstructionsComponent implements AfterViewInit {
      * @param {boolean} horizontal
      */
     toggleEditorCollapse($event: any, horizontal: boolean) {
-        this.parent.toggleCollapse($event, horizontal, this.interactResizable, this.resizableMinWidth);
+        this.parent.toggleCollapse($event, horizontal, this.interactResizable, this.minInstructionsWidth);
     }
 
     onNoInstructionsAvailable() {

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.html
@@ -1,4 +1,4 @@
-<div class="border" *ngIf="!isLoading; else loadingInstructions">
+<div class="card" *ngIf="!isLoading; else loadingInstructions">
     <div class="card-second-header" [hidden]="steps.length === 0">
         <div class="stepwizard">
             <div class="stepwizard-row">

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
@@ -160,6 +160,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
      */
     updateMarkdown() {
         this.steps = [];
+        this.plantUMLs = {};
         this.renderedMarkdown = this.markdown.render(this.exercise.problemStatement);
         // For whatever reason, we have to wait a tick here. The markdown parser should be synchronous...
         setTimeout(() => {

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-instruction.component.ts
@@ -59,6 +59,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
     public isLoading: boolean;
     public latestResult: Result | null;
     public steps: Array<Step> = [];
+    public plantUMLs: { [id: string]: string } = {};
     public renderedMarkdown: string;
     // Can be used to remove the click listeners for result details
     private listenerRemoveFunctions: Function[] = [];
@@ -162,6 +163,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
         this.renderedMarkdown = this.markdown.render(this.exercise.problemStatement);
         // For whatever reason, we have to wait a tick here. The markdown parser should be synchronous...
         setTimeout(() => {
+            this.loadAndInsertPlantUmls();
             this.setUpClickListeners();
             this.setUpTaskIcons();
         }, 100);
@@ -273,6 +275,26 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
             iconContainer.innerHTML = '';
             iconContainer.append(domElem);
         });
+    }
+
+    /**
+     * PlantUMLs are rendered on the server, we provide their structure as a string.
+     * When parsing the file for plantUMLs we store their ids (= position in HTML) and structure in a dictionary, so that we can load them after the initial render.
+     */
+    public loadAndInsertPlantUmls() {
+        Object.entries(this.plantUMLs).forEach(([id, plantUml]) =>
+            this.editorService.getPlantUmlImage(plantUml).subscribe(
+                plantUmlSrcAttribute => {
+                    // Assign plantUmlSrcAttribute as src attribute to our img element if exists.
+                    if (document.getElementById('plantUml' + id)) {
+                        document.getElementById('plantUml' + id).setAttribute('src', 'data:image/jpeg;base64,' + plantUmlSrcAttribute);
+                    }
+                },
+                err => {
+                    console.log('Error getting plantUmlImage', err);
+                },
+            ),
+        );
     }
 
     /**
@@ -474,21 +496,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
             return done ? 'green' : 'red';
         });
 
-        /**
-         * Explanation: This call fetches the plantUml png as base64 string; the function returns and inserts an empty img tag with a placeholder
-         * When the promise is fulfilled, the src-attribute of the img element is being set with the returned value
-         */
-        this.editorService.getPlantUmlImage(plantUml).subscribe(
-            plantUmlSrcAttribute => {
-                // Assign plantUmlSrcAttribute as src attribute to our img element if exists.
-                if (document.getElementById('plantUml' + id)) {
-                    document.getElementById('plantUml' + id).setAttribute('src', 'data:image/jpeg;base64,' + plantUmlSrcAttribute);
-                }
-            },
-            err => {
-                console.log('Error getting plantUmlImage', err);
-            },
-        );
+        this.plantUMLs[id] = plantUml;
 
         return "<img id='plantUml" + id + "' alt='plantUml'" + id + " '/>";
     }

--- a/src/main/webapp/content/scss/editor.scss
+++ b/src/main/webapp/content/scss/editor.scss
@@ -70,9 +70,8 @@ body {
 }
 
 .editor-wrapper > .editor-main > .editor-sidebar-right .card-body {
+    height: inherit;
     overflow-y: scroll;
-    height: 60vh;
-    padding-bottom: 100px;
 }
 
 .editor-wrapper > .editor-main > .editor-sidebar-left .card-body {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [X] ~I updated the documentation and models.~
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [X] ~I added (end-to-end) test cases for the new functionality.~

### Description
2 Bugfixes:
- Load plantUMLs in Instructions after the instructions are rendered (planUMLs are fetched asynchronously from server), otherwise the plantUML result subscription can't find the dom element to attach the image to
- Make scrolling to the end of the instructions possible

Shows scrollbar, if width is too large:
![image](https://user-images.githubusercontent.com/28230611/56674416-4dfeb880-66ba-11e9-876c-0cd14a4269d0.png)

No scrollbar if expanded enough:
![image](https://user-images.githubusercontent.com/28230611/56681922-b3f33c00-66ca-11e9-85cb-1b3fe2627b3d.png)
