### PR TITLE
Ensure double-blind assessments

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
@@ -1,14 +1,5 @@
 package de.tum.in.www1.artemis.service;
 
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Optional;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import de.tum.in.www1.artemis.domain.Feedback;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.User;
@@ -16,10 +7,17 @@ import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
-import de.tum.in.www1.artemis.repository.FeedbackRepository;
 import de.tum.in.www1.artemis.repository.ModelingSubmissionRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ModelingAssessmentService extends AssessmentService {
@@ -30,14 +28,11 @@ public class ModelingAssessmentService extends AssessmentService {
 
     private final ModelingSubmissionRepository modelingSubmissionRepository;
 
-    private final FeedbackRepository feedbackRepository;
-
-    public ModelingAssessmentService(ResultRepository resultRepository, UserService userService, ModelingSubmissionRepository modelingSubmissionRepository,
-            FeedbackRepository feedbackRepository) {
+    public ModelingAssessmentService(ResultRepository resultRepository, UserService userService,
+                                     ModelingSubmissionRepository modelingSubmissionRepository) {
         super(resultRepository);
         this.userService = userService;
         this.modelingSubmissionRepository = modelingSubmissionRepository;
-        this.feedbackRepository = feedbackRepository;
     }
 
     /**
@@ -49,9 +44,9 @@ public class ModelingAssessmentService extends AssessmentService {
      * @return the ResponseEntity with result as body
      */
     @Transactional
-    public Result submitManualAssessment(Result result, ModelingExercise exercise) {
+    public Result submitManualAssessment(Result result, ModelingExercise exercise, ZonedDateTime submissionDate) {
         // TODO CZ: use AssessmentService#submitResult() function instead
-        result.setRatedIfNotExceeded(exercise.getDueDate(), result.getSubmission().getSubmissionDate());
+        result.setRatedIfNotExceeded(exercise.getDueDate(), submissionDate);
         result.setCompletionDate(ZonedDateTime.now());
         result.evaluateFeedback(exercise.getMaxScore()); // TODO CZ: move to AssessmentService class, as it's the same for
         // modeling and text exercises (i.e. total score is sum of feedback

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
@@ -104,17 +104,18 @@ public class ModelingAssessmentResource extends AssessmentResource {
         if (!courseService.userHasAtLeastStudentPermissions(exercise.getCourse()) || !authCheckService.isOwnerOfParticipation(participation)) {
             return forbidden();
         }
+        Result result = submission.getResult();
+        if (result == null) {
+            return notFound();
+        }
+
         // remove sensitive information for students
         if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise)) {
             exercise.filterSensitiveInformation();
+            result.setAssessor(null);
         }
 
-        Result result = submission.getResult();
-        if (result != null) {
-            return ResponseEntity.ok(result);
-        } else {
-            return notFound();
-        }
+        return ResponseEntity.ok(result);
     }
 
     /**
@@ -150,7 +151,6 @@ public class ModelingAssessmentResource extends AssessmentResource {
     @PutMapping("/modeling-submissions/{submissionId}/feedback")
     @PreAuthorize("hasAnyRole('TA', 'INSTRUCTOR', 'ADMIN')")
     // TODO MJ changing submitted assessment always produces Conflict
-    @Transactional
     public ResponseEntity<Object> saveModelingAssessment(@PathVariable Long submissionId, @RequestParam(value = "ignoreConflicts", defaultValue = "false") boolean ignoreConflict,
             @RequestParam(value = "submit", defaultValue = "false") boolean submit, @RequestBody List<Feedback> feedbacks) {
         ModelingSubmission modelingSubmission = modelingSubmissionService.findOneWithEagerResultAndFeedback(submissionId);
@@ -173,11 +173,15 @@ public class ModelingAssessmentResource extends AssessmentResource {
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(conflicts);
             }
             else {
-                modelingAssessmentService.submitManualAssessment(result, modelingExercise);
+                modelingAssessmentService.submitManualAssessment(result, modelingExercise, modelingSubmission.getSubmissionDate());
                 if (compassService.isSupported(modelingExercise.getDiagramType())) {
                     compassService.addAssessment(exerciseId, submissionId, feedbacks);
                 }
             }
+        }
+        // remove information about the student for tutors to ensure double-blind assessment
+        if (!authCheckService.isAtLeastInstructorForExercise(modelingExercise)) {
+            result.getParticipation().setStudent(null);
         }
         return ResponseEntity.ok(result);
     }

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -196,7 +196,7 @@ public class DatabaseUtilService {
     public Result addModelingAssessmentForSubmission(ModelingExercise exercise, ModelingSubmission submission, String path, String login) throws Exception {
         List<Feedback> assessment = loadAssessmentFomResources(path);
         Result result = modelingAssessmentService.saveManualAssessment(submission, assessment);
-        result = modelingAssessmentService.submitManualAssessment(result, exercise);
+        result = modelingAssessmentService.submitManualAssessment(result, exercise, submission.getSubmissionDate());
         return result;
     }
 


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
We want to ensure double-blind assessment for modeling exercises, i.e. the tutor does not know to whom the submission belongs that he is assessing and the student does not know the assessor of his submissions. Therefore, we have to make sure that the corresponding data about the student/assessor is removed in the appropriate situations before sending it to the client.