### PR TITLE
Enable source map in production

### DIFF
--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -4,7 +4,7 @@
         "target": "es2018",
         "module": "es2015",
         "moduleResolution": "node",
-        "sourceMap": false,
+        "sourceMap": true,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "removeComments": true,

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -16,7 +16,7 @@ const sass = require('sass');
 module.exports = webpackMerge(commonConfig({ env: ENV }), {
     // Enable source maps. Please note that this will slow down the build.
     // You have to enable it in UglifyJSPlugin config below and in tsconfig-aot.json as well
-    // devtool: 'source-map',
+    devtool: 'source-map',
     entry: {
         polyfills: './src/main/webapp/app/polyfills',
         global: './src/main/webapp/content/scss/global.scss',
@@ -83,7 +83,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
                 cache: true,
                 terserOptions: {
                     ie8: false,
-                    // sourceMap: true, // Enable source maps. Please note that this will slow down the build
+                    sourceMap: true, // Enable source maps. Please note that this will slow down the build
                     compress: {
                         dead_code: true,
                         warnings: false,


### PR DESCRIPTION
Enable source maps in production to have easier life debugging and better errors in Sentry