### PR TITLE
Bugfix: Add keepFileName param when importing existing dnd questions

### DIFF
--- a/src/main/webapp/app/shared/http/file-uploader.service.ts
+++ b/src/main/webapp/app/shared/http/file-uploader.service.ts
@@ -57,6 +57,6 @@ export class FileUploaderService {
         formData.append('file', file, tempFilename);
         // Upload the file to backend. This will make a new file in the backend in the temp folder
         // and will return path of the file,
-        return await this.http.post<FileUploadResponse>('/api/fileUpload', formData).toPromise();
+        return await this.http.post<FileUploadResponse>(`/api/fileUpload?keepFileName=${false}`, formData).toPromise();
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
When importing existing dnd questions, uploadFile was called without the keepFileName param.
This caused a 500 and the question could not be properly copied.

{"type":"http://www.jhipster.tech/problem/problem-with-message","title":"Bad Request","status":400,"detail":"Required Boolean parameter 'keepFileName' is not present","path":"/api/fileUpload","message":"error.http.400"}

**About keepFileName: I set it to false**, as I imagine if we copy the question, we need to make sure it has its own image file. Otherwise the deletion of the base question could cause the image to be lost for copied question, too.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Go to a course -> exercise
3. Create a quiz with a question with a dnd question
4. Create another quiz and select import existing questions
5. Try to import existing dnd question from 3
6. The question should appear after a short while
