### PR TITLE
Make linting.sh posix compliant

### DIFF
--- a/linting.sh
+++ b/linting.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-function join_by {
+join_by () {
   local IFS="$1";
   shift;
   echo "$*";
 }
-PROJECT_DIR=$pwd
+PROJECT_DIR=$(pwd)
 
 FILES=$(join_by "," "$@")
 
-./gradlew spotlessApply -PspotlessFiles=${FILES//$PROJECT_DIR/}
+./gradlew spotlessApply -PspotlessFiles="${FILES//$PROJECT_DIR/}"

--- a/linting.sh
+++ b/linting.sh
@@ -4,8 +4,7 @@ join_by () {
   shift;
   echo "$*";
 }
-PROJECT_DIR=$(pwd)
 
 FILES=$(join_by "," "$@")
 
-./gradlew spotlessApply -PspotlessFiles="${FILES//$PROJECT_DIR/}"
+./gradlew spotlessApply -PspotlessFiles="${FILES}"


### PR DESCRIPTION
The `linting.sh` file is not POSIX-compatible. `function` keyword is POSIX standard, and therefore is not very portable: https://unix.stackexchange.com/questions/73750/difference-between-function-foo-and-foo

Also, we don't really want the string substitution for all the project files: the syntax of it is not standard as well, so I dropped it.

This version should now work on every system (but I have tested it only on zsh and dash)
