### PR TITLE
Implement resizable markdown editor

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-dialog.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-dialog.component.html
@@ -65,7 +65,7 @@
 
             <div class="form-group-narrow" id="field_problemStatement" name="problemStatement">
                 <label class="form-control-label" for="field_problemStatement" jhiTranslate="arTeMiSApp.programmingExercise.problemStatement"></label>
-                <jhi-markdown-editor [markdown]="programmingExercise.problemStatement" (markdownChange)="updateProblemStatement($event)">
+                <jhi-markdown-editor [enableResize]="true" [markdown]="programmingExercise.problemStatement" (markdownChange)="updateProblemStatement($event)">
                     <jhi-programming-exercise-instructions
                         #preview
                         *ngIf="problemStatementLoaded"

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
@@ -120,7 +120,7 @@
 
                 <div class="form-group-narrow" id="field_problemStatement" name="problemStatement">
                     <label class="form-control-label" for="field_problemStatement" jhiTranslate="arTeMiSApp.programmingExercise.problemStatement"></label>
-                    <jhi-markdown-editor [markdown]="programmingExercise.problemStatement" (markdownChange)="updateProblemStatement($event)">
+                    <jhi-markdown-editor [enableResize]="true" [markdown]="programmingExercise.problemStatement" (markdownChange)="updateProblemStatement($event)">
                         <jhi-programming-exercise-instructions
                             *ngIf="problemStatementLoaded"
                             #preview

--- a/src/main/webapp/app/markdown-editor/markdown-editor.component.html
+++ b/src/main/webapp/app/markdown-editor/markdown-editor.component.html
@@ -41,7 +41,7 @@
                     (textChange)="markdownChange.emit($event)"
                     class="form-control markdown-editor__content"
                 ></ace-editor>
-                <div class="rg-bottom"><span></span></div>
+                <div *ngIf="enableResize" class="rg-bottom"><span></span></div>
             </div>
         </ng-template>
     </ngb-tab>

--- a/src/main/webapp/app/markdown-editor/markdown-editor.component.html
+++ b/src/main/webapp/app/markdown-editor/markdown-editor.component.html
@@ -32,15 +32,17 @@
                     </div>
                 </ng-container>
             </div>
-            <ace-editor
-                #aceEditor
-                [mode]="aceEditorOptions.mode"
-                [autoUpdateContent]="aceEditorOptions.autoUpdateContent"
-                [(text)]="markdown"
-                (textChange)="markdownChange.emit($event)"
-                style="min-height: 200px; width:100%; overflow: auto; margin-top: 5px"
-                class="form-control"
-            ></ace-editor>
+            <div class="card border-0 markdown-editor markdown-editor__small">
+                <ace-editor
+                    #aceEditor
+                    [mode]="aceEditorOptions.mode"
+                    [autoUpdateContent]="aceEditorOptions.autoUpdateContent"
+                    [(text)]="markdown"
+                    (textChange)="markdownChange.emit($event)"
+                    class="form-control markdown-editor__content"
+                ></ace-editor>
+                <div class="rg-bottom"><span></span></div>
+            </div>
         </ng-template>
     </ngb-tab>
     <!--End Editor-->

--- a/src/main/webapp/app/markdown-editor/markdown-editor.component.scss
+++ b/src/main/webapp/app/markdown-editor/markdown-editor.component.scss
@@ -1,0 +1,20 @@
+.markdown-editor {
+    touch-action: none;
+    &__small {
+        min-height: 200px;
+        .markdown-editor__content {
+            min-height: 200px;
+        }
+    }
+    &__medium {
+        min-height: 500px;
+        .markdown-editor__content {
+            min-height: 500px;
+        }
+    }
+    .markdown-editor__content {
+        width: 100%;
+        overflow: auto;
+        margin-top: 5px;
+    }
+}

--- a/src/main/webapp/app/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/markdown-editor/markdown-editor.component.ts
@@ -35,7 +35,7 @@ export enum MarkdownEditorHeight {
     selector: 'jhi-markdown-editor',
     providers: [ArtemisMarkdown],
     templateUrl: './markdown-editor.component.html',
-    styleUrls: ['/markdown-editor.component.scss'],
+    styleUrls: ['./markdown-editor.component.scss'],
 })
 export class MarkdownEditorComponent implements AfterViewInit {
     public MarkdownEditorHeight = MarkdownEditorHeight;

--- a/src/main/webapp/app/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/markdown-editor/markdown-editor.component.ts
@@ -1,7 +1,10 @@
 import { AfterViewInit, Component, ContentChild, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { AceEditorComponent } from 'ng2-ace-editor';
+import { WindowRef } from 'app/core/websocket/window.service';
 import 'brace/theme/chrome';
 import 'brace/mode/markdown';
+import Interactable from '@interactjs/core/Interactable';
+import interact from 'interactjs';
 import {
     Command,
     BoldCommand,
@@ -22,12 +25,20 @@ import { ArtemisMarkdown } from 'app/components/util/markdown.service';
 import { DomainCommand } from 'app/markdown-editor/domainCommands';
 import { ColorSelectorComponent } from 'app/components/color-selector/color-selector.component';
 
+export enum MarkdownEditorHeight {
+    SMALL = 200,
+    MEDIUM = 500,
+    LARGE = 1000,
+}
+
 @Component({
     selector: 'jhi-markdown-editor',
     providers: [ArtemisMarkdown],
     templateUrl: './markdown-editor.component.html',
+    styleUrls: ['/markdown-editor.component.scss'],
 })
 export class MarkdownEditorComponent implements AfterViewInit {
+    public MarkdownEditorHeight = MarkdownEditorHeight;
     @ViewChild('aceEditor')
     aceEditorContainer: AceEditorComponent;
     aceEditorOptions = {
@@ -86,7 +97,15 @@ export class MarkdownEditorComponent implements AfterViewInit {
      * -> parent component has to implement ng-content and set the showPreviewButton on true through an input */
     @ContentChild('preview') previewChild: ElementRef;
 
-    constructor(private artemisMarkdown: ArtemisMarkdown) {}
+    /** Resizable constants **/
+    @Input()
+    enableResize = false;
+    @Input()
+    resizableMaxHeight = MarkdownEditorHeight.LARGE;
+    resizableMinHeight = MarkdownEditorHeight.SMALL;
+    interactResizable: Interactable;
+
+    constructor(private artemisMarkdown: ArtemisMarkdown, private $window: WindowRef) {}
 
     /** {boolean} true when the plane html view is needed, false when the preview content is needed from the parent */
     get showDefaultPreview(): boolean {
@@ -133,6 +152,10 @@ export class MarkdownEditorComponent implements AfterViewInit {
             });
         }
         this.setupMarkdownEditor();
+
+        if (this.enableResize) {
+            this.setupResizable();
+        }
     }
 
     /**
@@ -147,6 +170,38 @@ export class MarkdownEditorComponent implements AfterViewInit {
         this.aceEditorContainer.getEditor().setHighlightActiveLine(false);
         this.aceEditorContainer.getEditor().setShowPrintMargin(false);
         this.aceEditorContainer.getEditor().clearSelection();
+        this.aceEditorContainer.getEditor().setAutoScrollEditorIntoView(true);
+    }
+
+    /**
+     * @function setupResizable
+     * @desc Sets up resizable to enable resizing for the user
+     */
+    setupResizable(): void {
+        this.resizableMinHeight = this.$window.nativeWindow.screen.height / 7;
+        this.interactResizable = interact('.markdown-editor')
+            .resizable({
+                // Enable resize from top edge; triggered by class rg-top
+                edges: { left: false, right: false, bottom: '.rg-bottom', top: false },
+                // Set min and max height
+                restrictSize: {
+                    min: { height: this.resizableMinHeight },
+                    max: { height: this.resizableMaxHeight },
+                },
+                inertia: true,
+            })
+            .on('resizestart', function(event: any) {
+                event.target.classList.add('card-resizable');
+            })
+            .on('resizeend', (event: any) => {
+                event.target.classList.remove('card-resizable');
+                this.aceEditorContainer.getEditor().resize();
+            })
+            .on('resizemove', function(event: any) {
+                const target = event.target;
+                // Update element height
+                target.style.height = event.rect.height + 'px';
+            });
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
It can be hard to use the markdown editor if there is a lot of content in its textarea.
It would be great to have the option to resize the editor from within the ui.

### Description
I added a new input to the markdown editor to make it resizable.
Current default is false.

When resizing is enabled, an interactable is created for resizing the card.
To make this work I also had to write some css.

### Steps for Testing

1. Log in to ArTEMiS
2. Navigate to Course > Exercises
3. Create Programming Exercise / Link Programming Exercise -> problem statement should be resizable

Also other areas with the markdown editor should not be affected by this change.

### Screenshots
![image](https://user-images.githubusercontent.com/28230611/56891079-954ec580-6a7b-11e9-93db-2c67a1fe9d71.png)
