### PR TITLE
we dont throw the error anymore to prevent an app crash

### DIFF
--- a/src/main/webapp/app/sentry/sentry.error-handler.ts
+++ b/src/main/webapp/app/sentry/sentry.error-handler.ts
@@ -4,7 +4,7 @@ import { VERSION } from 'app/app.constants';
 import { ProfileInfo, ProfileService } from 'app/layouts';
 
 @Injectable()
-export class SentryErrorHandler implements ErrorHandler {
+export class SentryErrorHandler extends ErrorHandler {
     private static get environment(): string {
         switch (window.location.host) {
             case 'artemis.ase.in.tum.de':
@@ -33,6 +33,7 @@ export class SentryErrorHandler implements ErrorHandler {
     }
 
     constructor(private profileService: ProfileService) {
+        super(true);
         // noinspection JSIgnoredPromiseFromCall
         this.initSentry();
     }
@@ -40,10 +41,10 @@ export class SentryErrorHandler implements ErrorHandler {
     handleError(error: any): void {
         // We do not send to Sentry HttpError in the range 400-499
         if (error.name === 'HttpErrorResponse' && error.status < 500 && error.status >= 400) {
-            throw error;
+            super.handleError(error);
         }
 
         captureException(error.originalError || error);
-        throw error;
+        super.handleError(error);
     }
 }

--- a/src/main/webapp/app/sentry/sentry.error-handler.ts
+++ b/src/main/webapp/app/sentry/sentry.error-handler.ts
@@ -42,6 +42,7 @@ export class SentryErrorHandler extends ErrorHandler {
         // We do not send to Sentry HttpError in the range 400-499
         if (error.name === 'HttpErrorResponse' && error.status < 500 && error.status >= 400) {
             super.handleError(error);
+            return;
         }
 
         captureException(error.originalError || error);

--- a/src/main/webapp/app/sentry/sentry.error-handler.ts
+++ b/src/main/webapp/app/sentry/sentry.error-handler.ts
@@ -33,7 +33,7 @@ export class SentryErrorHandler extends ErrorHandler {
     }
 
     constructor(private profileService: ProfileService) {
-        super(true);
+        super();
         // noinspection JSIgnoredPromiseFromCall
         this.initSentry();
     }


### PR DESCRIPTION
### Description
The app freeze on crashed was caused by our error handling implementation. Now using the default one again. this will not freeze the whole app on an error. 

### Discussion
We can extend the error handler to add more information about the error or even inform the user. But I'm not sure if this is necessary.
We can also add a reload suggestion if we want