### PR TITLE
Feature/presentation score

### DIFF
--- a/src/main/webapp/app/course-list/course-score-calculation.service.ts
+++ b/src/main/webapp/app/course-list/course-score-calculation.service.ts
@@ -11,6 +11,7 @@ import { Moment } from 'moment';
 export const ABSOLUTE_SCORE = 'absoluteScore';
 export const RELATIVE_SCORE = 'relativeScore';
 export const MAX_SCORE = 'maxScore';
+export const PRESENTATION_SCORE = 'presentationScore';
 
 @Injectable({ providedIn: 'root' })
 export class CourseScoreCalculationService {
@@ -23,6 +24,7 @@ export class CourseScoreCalculationService {
         const scores = new Map<string, number>();
         let absoluteScore = 0.0;
         let maxScore = 0;
+        let presentationScore = 0;
         for (const exercise of courseExercises) {
             if (exercise.maxScore != null) {
                 maxScore = maxScore + exercise.maxScore;
@@ -36,6 +38,7 @@ export class CourseScoreCalculationService {
                         }
                         absoluteScore = absoluteScore + score * this.SCORE_NORMALIZATION_VALUE * exercise.maxScore;
                     }
+                    presentationScore += participation.presentationScore !== undefined ? participation.presentationScore : 0;
                 }
             }
         }
@@ -46,6 +49,7 @@ export class CourseScoreCalculationService {
             scores.set(RELATIVE_SCORE, 0);
         }
         scores.set(MAX_SCORE, maxScore);
+        scores.set(PRESENTATION_SCORE, presentationScore);
         return scores;
     }
 

--- a/src/main/webapp/app/entities/participation/participation.component.html
+++ b/src/main/webapp/app/entities/participation/participation.component.html
@@ -1,83 +1,104 @@
 <div *ngIf="participations">
     <h2>
-        <span>{{ exercise?.title }} - </span>{{ participations.length }} <span jhiTranslate="arTeMiSApp.participation.home.title">Participations</span>
+        <span>{{ exercise?.title }} - </span>{{ participations.length }} <span
+        jhiTranslate="arTeMiSApp.participation.home.title">Participations</span>
     </h2>
     <jhi-alert></jhi-alert>
     <div class="row"></div>
-    <br />
+    <br/>
     <div class="table-responsive" *ngIf="participations">
         <table class="table table-striped">
             <thead>
-                <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="callback">
-                    <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span> <fa-icon icon="sort"></fa-icon></th>
-                    <th *ngIf="exercise?.type == PROGRAMMING" jhiSortBy="repositoryUrl">
-                        <span jhiTranslate="arTeMiSApp.participation.repositoryUrl">Repository Url</span> <fa-icon icon="sort"></fa-icon>
-                    </th>
-                    <th *ngIf="exercise?.type == PROGRAMMING" jhiSortBy="buildPlanId">
-                        <span jhiTranslate="arTeMiSApp.participation.buildPlanId">Build Plan Id</span> <fa-icon icon="sort"></fa-icon>
-                    </th>
-                    <th jhiSortBy="initializationState">
-                        <span jhiTranslate="arTeMiSApp.participation.initializationState">Initialization State</span> <fa-icon icon="sort"></fa-icon>
-                    </th>
-                    <th jhiSortBy="initializationDate">
-                        <span jhiTranslate="arTeMiSApp.participation.initializationDate">Initialization Date</span> <fa-icon icon="sort"></fa-icon>
-                    </th>
-                    <th jhiSortBy="student.firstName"><span jhiTranslate="arTeMiSApp.participation.student">Student</span> <fa-icon icon="sort"></fa-icon></th>
-                    <th></th>
-                </tr>
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="callback">
+                <th jhiSortBy="id"><span jhiTranslate="global.field.id">ID</span>
+                    <fa-icon icon="sort"></fa-icon>
+                </th>
+                <th *ngIf="exercise?.type == PROGRAMMING" jhiSortBy="repositoryUrl">
+                    <span jhiTranslate="arTeMiSApp.participation.repositoryUrl">Repository Url</span>
+                    <fa-icon icon="sort"></fa-icon>
+                </th>
+                <th *ngIf="exercise?.type == PROGRAMMING" jhiSortBy="buildPlanId">
+                    <span jhiTranslate="arTeMiSApp.participation.buildPlanId">Build Plan Id</span>
+                    <fa-icon icon="sort"></fa-icon>
+                </th>
+                <th jhiSortBy="initializationState">
+                    <span jhiTranslate="arTeMiSApp.participation.initializationState">Initialization State</span>
+                    <fa-icon icon="sort"></fa-icon>
+                </th>
+                <th jhiSortBy="initializationDate">
+                    <span jhiTranslate="arTeMiSApp.participation.initializationDate">Initialization Date</span>
+                    <fa-icon icon="sort"></fa-icon>
+                </th>
+                <th jhiSortBy="student.firstName"><span jhiTranslate="arTeMiSApp.participation.student">Student</span>
+                    <fa-icon icon="sort"></fa-icon>
+                </th>
+                <th jhiSortBy="presentationScore"><span jhiTranslate="arTeMiSApp.participation.presentationScore">Presentation Score</span>
+                    <fa-icon icon="sort"></fa-icon>
+                </th>
+                <th></th>
+            </tr>
             </thead>
             <tbody>
-                <tr *ngFor="let participation of (participations | sortBy: predicate:reverse); trackBy: trackId">
-                    <td>
-                        <a routerLink="/participation/{{ participation.id }}">{{ participation.id }}</a>
-                    </td>
-                    <!-- TODO get the correct URL from the server instead of hardcoding Bamboo here -->
-                    <td *ngIf="exercise?.type == PROGRAMMING">
-                        <span *ngIf="participation.repositoryUrl != null"><a href="{{ participation.repositoryUrl }}" target="_blank">Repository Link</a></span>
-                    </td>
-                    <td *ngIf="exercise?.type == PROGRAMMING">
+            <tr *ngFor="let participation of (participations | sortBy: predicate:reverse); trackBy: trackId">
+                <td>
+                    <a routerLink="/participation/{{ participation.id }}">{{ participation.id }}</a>
+                </td>
+                <!-- TODO get the correct URL from the server instead of hardcoding Bamboo here -->
+                <td *ngIf="exercise?.type == PROGRAMMING">
+                    <span *ngIf="participation.repositoryUrl != null"><a href="{{ participation.repositoryUrl }}"
+                                                                         target="_blank">Repository Link</a></span>
+                </td>
+                <td *ngIf="exercise?.type == PROGRAMMING">
                         <span *ngIf="participation.buildPlanId != null"
-                            ><a href="https://bamboobruegge.in.tum.de/browse/{{ participation.buildPlanId }}" target="_blank">{{ participation.buildPlanId }}</a></span
+                        ><a href="https://bamboobruegge.in.tum.de/browse/{{ participation.buildPlanId }}"
+                            target="_blank">{{ participation.buildPlanId }}</a></span
                         >
-                    </td>
-                    <td>{{ 'arTeMiSApp.InitializationState.' + participation.initializationState | translate }}</td>
-                    <td>{{ participation.initializationDate | date: 'medium' }}</td>
-                    <td>
-                        <a routerLink="/user-management/{{ participation.student?.login }}/view">{{ participation.student?.firstName }} {{ participation.student?.lastName }}</a>
-                    </td>
-                    <td class="text-right">
-                        <div class="btn-group flex-btn-group-container">
-                            <button
-                                type="submit"
-                                [routerLink]="['/', { outlets: { popup: 'participation/' + participation.id + '/delete' } }]"
-                                replaceUrl="true"
-                                queryParamsHandling="merge"
-                                class="btn btn-danger btn-sm mr-1"
-                            >
-                                <fa-icon icon="times"></fa-icon>
-                                <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
-                            </button>
-                            <button
-                                type="submit"
-                                *ngIf="exercise?.type === PROGRAMMING"
-                                [routerLink]="['/', { outlets: { popup: ['participation', participation.id, 'result', 'new'] } }]"
-                                class="btn btn-warning btn-sm mr-1"
-                            >
-                                <fa-icon icon="asterisk"></fa-icon>
-                                <span class="d-none d-md-inline" jhiTranslate="entity.action.newResult">New Result</span>
-                            </button>
-                            <button
-                                type="submit"
-                                *ngIf="exercise?.type === PROGRAMMING && participation.buildPlanId != null"
-                                [routerLink]="['/', { outlets: { popup: ['participation', participation.id, 'cleanupBuildPlan'] } }]"
-                                class="btn btn-danger btn-sm mr-1"
-                            >
-                                <fa-icon [icon]="'eraser'"></fa-icon>
-                                <span class="d-none d-md-inline" jhiTranslate="entity.action.cleanupBuildPlan">Cleanup build plan</span>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
+                </td>
+                <td>{{ 'arTeMiSApp.InitializationState.' + participation.initializationState | translate }}</td>
+                <td>{{ participation.initializationDate | date: 'medium' }}</td>
+                <td>
+                    <a routerLink="/user-management/{{ participation.student?.login }}/view">{{ participation.student?.firstName }} {{ participation.student?.lastName }}</a>
+                </td>
+                <td><span>{{ (participation.presentationScore != null) ? participation.presentationScore : 0 }}</span>
+                </td>
+                <td class="text-right">
+                    <div class="btn-group flex-btn-group-container">
+                        <button
+                            type="submit"
+                            [routerLink]="['/', { outlets: { popup: 'participation/' + participation.id + '/delete' } }]"
+                            replaceUrl="true"
+                            queryParamsHandling="merge"
+                            class="btn btn-danger btn-sm mr-1"
+                        >
+                            <fa-icon icon="times"></fa-icon>
+                            <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
+                        </button>
+                        <button
+                            type="submit"
+                            *ngIf="exercise?.type === PROGRAMMING"
+                            [routerLink]="['/', { outlets: { popup: ['participation', participation.id, 'result', 'new'] } }]"
+                            class="btn btn-warning btn-sm mr-1"
+                        >
+                            <fa-icon icon="asterisk"></fa-icon>
+                            <span class="d-none d-md-inline" jhiTranslate="entity.action.newResult">New Result</span>
+                        </button>
+                        <button
+                            type="submit"
+                            *ngIf="exercise?.type === PROGRAMMING && participation.buildPlanId != null"
+                            [routerLink]="['/', { outlets: { popup: ['participation', participation.id, 'cleanupBuildPlan'] } }]"
+                            class="btn btn-danger btn-sm mr-1"
+                        >
+                            <fa-icon [icon]="'eraser'"></fa-icon>
+                            <span class="d-none d-md-inline" jhiTranslate="entity.action.cleanupBuildPlan">Cleanup build plan</span>
+                        </button>
+                        <button (click)="addPresentation(participation)" class="btn btn-info btn-sm mr-1" [disabled]="participation.presentationScore == 1">
+                            <fa-icon icon="file-powerpoint"></fa-icon>
+                            <span class="d-none d-md-inline"
+                                  jhiTranslate="arTeMiSApp.participation.addPresentation.label">Add presentation</span>
+                        </button>
+                    </div>
+                </td>
+            </tr>
             </tbody>
         </table>
     </div>

--- a/src/main/webapp/app/entities/participation/participation.component.ts
+++ b/src/main/webapp/app/entities/participation/participation.component.ts
@@ -47,6 +47,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
             });
         });
     }
+
     ngOnInit() {
         this.loadAll();
         this.registerChangeInParticipations();
@@ -59,8 +60,19 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     trackId(index: number, item: Participation) {
         return item.id;
     }
+
     registerChangeInParticipations() {
         this.eventSubscriber = this.eventManager.subscribe('participationListModification', () => this.loadAll());
+    }
+
+    addPresentation(participation: Participation) {
+        participation.presentationScore = 1;
+        this.participationService.update(participation).subscribe(
+            () => {},
+            () => {
+                this.jhiAlertService.error('arTeMiSApp.participation.addPresentation.error');
+            },
+        );
     }
 
     private onError(error: HttpErrorResponse) {

--- a/src/main/webapp/app/overview/course-statistics/course-statistics.component.html
+++ b/src/main/webapp/app/overview/course-statistics/course-statistics.component.html
@@ -42,6 +42,7 @@
                     <h4>{{ 'arTeMiSApp.courseOverview.statistics.absoluteScore' | translate: { number: exerciseGroup.absoluteScore } }}</h4>
                     <h4>{{ 'arTeMiSApp.courseOverview.statistics.maxScore' | translate: { number: exerciseGroup.totalMaxScore } }}</h4>
                     <h4>{{ 'arTeMiSApp.courseOverview.statistics.relativeScore' | translate: { number: exerciseGroup.relativeScore } }}</h4>
+                    <h4>{{ 'arTeMiSApp.courseOverview.statistics.presentationScore' | translate: { number: exerciseGroup.presentationScore } }}</h4>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/app/overview/course-statistics/course-statistics.component.html
+++ b/src/main/webapp/app/overview/course-statistics/course-statistics.component.html
@@ -2,7 +2,7 @@
     <div class="row" *ngIf="course.exercises && course.exercises.length > 0">
         <div class="co-12 col-md-4 statistic-summary">
             <h2 class="text-center">{{ 'arTeMiSApp.courseOverview.statistics.totalScore' | translate }}</h2>
-            <div class="chart-container">
+            <div class="chart-container" style="margin-bottom: 20px">
                 <div class="chart-text">
                     <h2 class="text-center">{{ totalRelativeScore }} %</h2>
                     <h4 class="text-center">{{ totalScore }} Pts</h4>
@@ -18,6 +18,9 @@
                     [labels]="doughnutChartLabels"
                     [chartType]="doughnutChartType"
                 ></canvas>
+            </div>
+            <div>
+                <h2 class="text-center">{{ 'arTeMiSApp.courseOverview.statistics.totalPresentationScore' | translate: { number: this.totalPresentationScore } }}</h2>
             </div>
         </div>
         <div class="col-12 col-md-8">

--- a/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
+++ b/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
@@ -4,7 +4,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { HttpResponse } from '@angular/common/http';
 import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
 
-import { ABSOLUTE_SCORE, MAX_SCORE, RELATIVE_SCORE, Course, CourseService, CourseScoreCalculationService } from 'app/entities/course';
+import { ABSOLUTE_SCORE, MAX_SCORE, RELATIVE_SCORE, PRESENTATION_SCORE, Course, CourseService, CourseScoreCalculationService } from 'app/entities/course';
 import { Exercise, ExerciseType } from 'app/entities/exercise';
 
 import { Result } from 'app/entities/result';
@@ -43,6 +43,10 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy {
     // max score
     totalMaxScore = 0;
     totalMaxScores = {};
+
+    // presentation score
+    totalPresentationScore = 0;
+    presentationScores = {};
 
     groupedExercises: Exercise[][] = [];
     doughnutChartColors = [QUIZ_EXERCISE_COLOR, PROGRAMMING_EXERCISE_COLOR, MODELING_EXERCISE_COLOR, TEXT_EXERCISE_COLOR, FILE_UPLOAD_EXERCISE_COLOR, 'rgba(0, 0, 0, 0.5)'];
@@ -168,6 +172,7 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy {
                 this.calculateMaxScores();
                 this.calculateAbsoluteScores();
                 this.calculateRelativeScores();
+                this.calculatePresentationScores();
                 this.groupExercisesByType();
             });
         } else {
@@ -175,6 +180,7 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy {
             this.calculateMaxScores();
             this.calculateAbsoluteScores();
             this.calculateRelativeScores();
+            this.calculatePresentationScores();
             this.groupExercisesByType();
         }
 
@@ -225,6 +231,7 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy {
                     relativeScore: 0,
                     totalMaxScore: 0,
                     absoluteScore: 0,
+                    presentationScore: 0,
                     names: [],
                     scores: { data: [], label: 'Score', tooltips: [] },
                     missedScores: { data: [], label: 'Missed score', tooltips: [] },
@@ -249,6 +256,7 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy {
             groupedExercises[index].relativeScore = this.relativeScores[exercise.type];
             groupedExercises[index].totalMaxScore = this.totalMaxScores[exercise.type];
             groupedExercises[index].absoluteScore = this.absoluteScores[exercise.type];
+            groupedExercises[index].presentationScore = this.presentationScores[exercise.type];
             groupedExercises[index].values = [groupedExercises[index].scores, groupedExercises[index].missedScores];
         });
         this.groupedExercises = groupedExercises;
@@ -325,6 +333,22 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy {
         relativeScores[ExerciseType.FILE_UPLOAD] = fileUploadExerciseRelativeScore;
         this.relativeScores = relativeScores;
         this.totalRelativeScore = this.calculateTotalScoreForTheCourse(RELATIVE_SCORE);
+    }
+
+    calculatePresentationScores(): void {
+        const quizzesPresentationScore = this.calculateScoreTypeForExerciseType(ExerciseType.QUIZ, PRESENTATION_SCORE);
+        const programmingExercisePresentationScore = this.calculateScoreTypeForExerciseType(ExerciseType.PROGRAMMING, PRESENTATION_SCORE);
+        const modelingExercisePresentationScore = this.calculateScoreTypeForExerciseType(ExerciseType.MODELING, PRESENTATION_SCORE);
+        const textExercisePresentationScore = this.calculateScoreTypeForExerciseType(ExerciseType.TEXT, PRESENTATION_SCORE);
+        const fileUploadExercisePresentationScore = this.calculateScoreTypeForExerciseType(ExerciseType.FILE_UPLOAD, PRESENTATION_SCORE);
+        const presentationScores = {};
+        presentationScores[ExerciseType.QUIZ] = quizzesPresentationScore;
+        presentationScores[ExerciseType.PROGRAMMING] = programmingExercisePresentationScore;
+        presentationScores[ExerciseType.MODELING] = modelingExercisePresentationScore;
+        presentationScores[ExerciseType.TEXT] = textExercisePresentationScore;
+        presentationScores[ExerciseType.FILE_UPLOAD] = fileUploadExercisePresentationScore;
+        this.presentationScores = presentationScores;
+        this.totalPresentationScore = this.calculateTotalScoreForTheCourse(PRESENTATION_SCORE);
     }
 
     calculateScores(filterFunction: (courseExercise: Exercise) => boolean) {

--- a/src/main/webapp/app/vendor.ts
+++ b/src/main/webapp/app/vendor.ts
@@ -37,6 +37,7 @@ import {
     faKeyboard,
     faProjectDiagram,
     faFileUpload,
+    faFilePowerpoint,
     faThLarge,
     faAngleUp,
     faSortAmountUp,
@@ -167,6 +168,7 @@ library.add(faCheckDouble);
 library.add(faKeyboard);
 library.add(faProjectDiagram);
 library.add(faFileUpload);
+library.add(faFilePowerpoint);
 library.add(faFont);
 library.add(faThLarge);
 library.add(faAngleUp);

--- a/src/main/webapp/i18n/de/participation.json
+++ b/src/main/webapp/i18n/de/participation.json
@@ -15,6 +15,10 @@
             "cleanupBuildPlan": {
                 "question": "Soll der Build Plan der Teilnahme von {{ student }} wirklich gelöscht werden?"
             },
+            "addPresentation": {
+                "label": "Füge Präsentation hinzu",
+                "error": "Die Präsentation konnte nicht hinzugefügt werden. Bitte versuche es nochmal."
+            },
             "detail": {
                 "title": "Teilnahme"
             },

--- a/src/main/webapp/i18n/de/student-dashboard.json
+++ b/src/main/webapp/i18n/de/student-dashboard.json
@@ -65,6 +65,7 @@
             },
             "statistics": {
                 "totalScore": "Gesamtpunktzahl",
+                "totalPresentationScore": "Deine gesamtes Präsentationsergebnisw: {{ number }}",
                 "exerciseCount": "Teilgenommen an {{ number }} Übungen",
                 "absoluteScore": "Absolute Punktzahl: {{ number }} Pts",
                 "maxScore": "Maximale Punktzahl: {{ number }} Pts",

--- a/src/main/webapp/i18n/de/student-dashboard.json
+++ b/src/main/webapp/i18n/de/student-dashboard.json
@@ -69,6 +69,7 @@
                 "absoluteScore": "Absolute Punktzahl: {{ number }} Pts",
                 "maxScore": "Maximale Punktzahl: {{ number }} Pts",
                 "relativeScore": "Relative Punktzahl: {{ number }}%",
+                "presentationScore": "Präsentationsergebnis: {{ number }} ",
                 "noStatistics": "Es sind keine Statistiken für diesen Kurs vorhanden."
             },
             "lectureList": {

--- a/src/main/webapp/i18n/en/participation.json
+++ b/src/main/webapp/i18n/en/participation.json
@@ -15,6 +15,10 @@
             "cleanupBuildPlan": {
                 "question": "Are you sure you want to delete the build plan of the participation of {{ student }}?"
             },
+            "addPresentation": {
+                "label": "Add presentation",
+                "error": "Could not add presentation. Please try again."
+            },
             "detail": {
                 "title": "Participation"
             },

--- a/src/main/webapp/i18n/en/student-dashboard.json
+++ b/src/main/webapp/i18n/en/student-dashboard.json
@@ -69,6 +69,7 @@
                 "absoluteScore": "Absolute score: {{ number }} Pts",
                 "maxScore": "Total max score: {{ number }} Pts",
                 "relativeScore": "Relative score: {{ number }}%",
+                "presentationScore": "Presentation score: {{ number }}",
                 "noStatistics": "No statistics available for the course."
             },
             "lectureList": {

--- a/src/main/webapp/i18n/en/student-dashboard.json
+++ b/src/main/webapp/i18n/en/student-dashboard.json
@@ -65,6 +65,7 @@
             },
             "statistics": {
                 "totalScore": "Your total score",
+                "totalPresentationScore": "Your total presentation score: {{ number }}",
                 "exerciseCount": "Participated in {{ number }} {{type}}",
                 "absoluteScore": "Absolute score: {{ number }} Pts",
                 "maxScore": "Total max score: {{ number }} Pts",


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~~I updated the documentation and models.~~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~~I added (end-to-end) test cases for the new functionality.~~

### Motivation and Context
The tutors want to document and update the student's presentation score whenever he/she did a presentation in the tutorial. 

### Description
It is now possible for a tutor to add a presentation score for every student who is participating in a course. This action can be performed by navigating to "Course Administration" > "Exercise" > "Participants". The students can view their total presentation score and their presentation score grouped by exercise on the student dashboard statistics page.

### Steps for Testing
1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Go to the Exercise page of a listed course
4. Click on Participants
5. Click on "Add presentation"
6. The "Add presentation" button is now disabled and the score is set to 1.

### Screenshots
![image](https://user-images.githubusercontent.com/33764166/57040880-0a2f2480-6c61-11e9-8566-306d22a08cd1.png)
![image](https://user-images.githubusercontent.com/33764166/57040964-45315800-6c61-11e9-9f35-8c2c6713ebdb.png)
