### PR TITLE
Tutors cannot start assessing submissions before the exercise due date

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -196,7 +196,7 @@ public class ModelingSubmissionResource {
         }
 
         // Tutors cannot start assessing submissions if the exercise due date hasn't been reached yet
-        if (exercise.getDueDate().isAfter(ZonedDateTime.now())) {
+        if (exercise.getDueDate() != null && exercise.getDueDate().isAfter(ZonedDateTime.now())) {
             return notFound();
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -6,6 +6,7 @@ import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.notFound;
 
 import java.net.URISyntaxException;
 import java.security.Principal;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -192,6 +193,11 @@ public class ModelingSubmissionResource {
         }
         if (!(exercise instanceof ModelingExercise)) {
             return badRequest();
+        }
+
+        // Tutors cannot start assessing submissions if the exercise due date hasn't been reached yet
+        if (exercise.getDueDate().isAfter(ZonedDateTime.now())) {
+            return notFound();
         }
 
         ModelingSubmission modelingSubmission;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -1,9 +1,7 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.badRequest;
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
-
 import java.security.Principal;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,6 +23,8 @@ import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 import io.github.jhipster.web.util.ResponseUtil;
+
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
 
 /**
  * REST controller for managing TextSubmission.
@@ -211,6 +211,12 @@ public class TextSubmissionResource {
         if (!(exercise instanceof TextExercise)) {
             return badRequest();
         }
+
+        // Tutors cannot start assessing submissions if the exercise due date hasn't been reached yet
+        if (exercise.getDueDate().isAfter(ZonedDateTime.now())) {
+            return notFound();
+        }
+
         Optional<TextSubmission> textSubmissionWithoutAssessment = this.textSubmissionService.getTextSubmissionWithoutResult((TextExercise) exercise);
 
         return ResponseUtil.wrapOrNotFound(textSubmissionWithoutAssessment);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -213,7 +213,7 @@ public class TextSubmissionResource {
         }
 
         // Tutors cannot start assessing submissions if the exercise due date hasn't been reached yet
-        if (exercise.getDueDate().isAfter(ZonedDateTime.now())) {
+        if (exercise.getDueDate() != null && exercise.getDueDate().isAfter(ZonedDateTime.now())) {
             return notFound();
         }
 

--- a/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.ts
+++ b/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.ts
@@ -135,7 +135,11 @@ export class TutorExerciseDashboardComponent implements OnInit {
                 }
 
                 this.getSubmissions();
-                this.getSubmissionWithoutAssessment();
+
+                // We don't want to assess submissions before the exercise due date
+                if (this.exercise.dueDate.isBefore(Date.now())) {
+                    this.getSubmissionWithoutAssessment();
+                }
             },
             (response: string) => this.onError(response),
         );

--- a/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.ts
+++ b/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.ts
@@ -137,7 +137,7 @@ export class TutorExerciseDashboardComponent implements OnInit {
                 this.getSubmissions();
 
                 // We don't want to assess submissions before the exercise due date
-                if (this.exercise.dueDate.isBefore(Date.now())) {
+                if (!this.exercise.dueDate || this.exercise.dueDate.isBefore(Date.now())) {
                     this.getSubmissionWithoutAssessment();
                 }
             },


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
Tutors shouldn't be able to start assessing submissions before the exercise due date isn't due

