### PR TITLE
Bugfix/no connection notification on logout->login

### DIFF
--- a/src/main/webapp/app/layouts/connection-notification/connection-notification.component.ts
+++ b/src/main/webapp/app/layouts/connection-notification/connection-notification.component.ts
@@ -20,6 +20,11 @@ export class ConnectionNotificationComponent implements OnInit, OnDestroy {
                 this.jhiWebsocketService.enableReconnect();
                 this.jhiWebsocketService.bind('connect', this.onConnect);
                 this.jhiWebsocketService.bind('disconnect', this.onDisconnect);
+            } else {
+                // On logout, reset component
+                this.connected = null;
+                this.alert = null;
+                this.notification.type = null;
             }
         });
     }

--- a/src/main/webapp/app/layouts/connection-notification/connection-notification.component.ts
+++ b/src/main/webapp/app/layouts/connection-notification/connection-notification.component.ts
@@ -25,6 +25,9 @@ export class ConnectionNotificationComponent implements OnInit, OnDestroy {
                 this.connected = null;
                 this.alert = null;
                 this.notification.type = null;
+                this.jhiWebsocketService.disableReconnect();
+                this.jhiWebsocketService.unbind('connect', this.onConnect);
+                this.jhiWebsocketService.unbind('disconnect', this.onDisconnect);
             }
         });
     }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] ~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
After (login,) logout, login the connection notification showed up because it wasn't reset after logout.
 
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Load Artemis while being logged in
2. Logout
3. Login -> connection notification should not show up anymore

When losing internet access the notification should still show up.
