### PR TITLE
Bugfix/autofill login

### DIFF
--- a/src/main/webapp/app/home/home.component.html
+++ b/src/main/webapp/app/home/home.component.html
@@ -32,7 +32,7 @@
             </div>
             <div class="row">
                 <div class="col-12 d-flex justify-content-center">
-                    <form name="loginForm" class="form" role="form" (ngSubmit)="login()">
+                    <form name="loginForm" class="form" role="form" (change)="inputChange($event)" (ngSubmit)="login()">
                         <div class="form-group">
                             <label for="username" jhiTranslate="global.form.username">Login</label>
                             <input

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -125,5 +125,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
         if ($event.target && $event.target.name === 'username') {
             this.username = $event.target.value;
         }
+        if ($event.target && $event.target.name === 'password') {
+            this.password = $event.target.value;
+        }
     }
 }

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -121,4 +121,9 @@ export class HomeComponent implements OnInit, AfterViewInit {
     requestResetPassword() {
         this.router.navigate(['/reset', 'request']);
     }
+    inputChange($event: any) {
+        if ($event.target && $event.target.name === 'username') {
+            this.username = $event.target.value;
+        }
+    }
 }


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~~I updated the documentation and models.~~
- [x] ~~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~~ (not working at the moment. but tested locally on iOS)
- [x] ~~I added (end-to-end) test cases for the new functionality.~~

### Motivation and Context
the auto fill from password managers like lastpass did not work. also the input from chrome on iOS did not work correctly.

### Description
I added a change method that detects the change event and adds the properties manually. So users on iOS with chrome can actually log in and users who auto fill their passwords can also click on login.
