### PR TITLE
Make Spotless work on Windows

### DIFF
--- a/linting.sh
+++ b/linting.sh
@@ -7,4 +7,10 @@ join_by () {
 
 FILES=$(join_by "," "$@")
 
+if [[ "$OSTYPE" == "msys" ]]; then
+  # replace backslashes with double backslashes in Windows file paths when
+  # using MinGW (msys = lightweight shell and GNU utilities compiled for Windows (part of MinGW)
+  FILES=$(echo $FILES | sed 's/\\/\\\\/g')
+fi
+
 ./gradlew spotlessApply -PspotlessFiles="${FILES}"

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
                 "git add"
             ],
             "*.java": [
-                "./linting.sh",
+                "bash ./linting.sh",
                 "git add"
             ]
         }


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
With the current approach approach the pre-commit hook failed on Windows. We make it work on Windows as well by
 * starting the `linting.sh` script with the `bash` command
 * and changing single backslashes to double backslashes in Windows file paths.

### Steps for Testing
1. Change formatting of .java file(s)
2. Commit changes
3. See if `linting.sh` was running and the formatting got fixed upon committing 