### PR TITLE
Re-enable automatic submission service for modeling and text submissions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
@@ -1,20 +1,27 @@
 package de.tum.in.www1.artemis.repository;
 
-import de.tum.in.www1.artemis.domain.Submission;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import de.tum.in.www1.artemis.domain.Submission;
 
 /**
- * Spring Data  repository for the Submission entity.
+ * Spring Data repository for the Submission entity.
  */
 @SuppressWarnings("unused")
 @Repository
 public interface SubmissionRepository extends JpaRepository<Submission, Long> {
+
     /**
-     * @param submitted choose which submitted state you want
+     * @param submitted  choose which submitted state you want
      * @param exerciseId the id of the exercise you want the stats about
      * @return number of submission for the given exerciseId, with the submitted status expressed by the flag
      */
     long countBySubmittedAndParticipation_Exercise_Id(boolean submitted, Long exerciseId);
+
+    @Query("select submission from Submission submission where type(submission) in (ModelingSubmission, TextSubmission) and submission.submitted = false")
+    List<Submission> findAllUnsubmittedModelingAndTextSubmissions();
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
@@ -1,8 +1,7 @@
 package de.tum.in.www1.artemis.service.scheduled;
 
-import java.util.ArrayList;
+import java.text.DecimalFormat;
 import java.util.List;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,22 +51,24 @@ public class AutomaticSubmissionService {
         this.messagingTemplate = messagingTemplate;
     }
 
-    @Scheduled(cron = "0 0 1 * * *") // execute this every night at 1:00:00 am in the future
+    /**
+     * Check for every un-submitted modeling and text submissions if the corresponding exercise has finished (i.e. due date < now). - If yes, we set the submission to submitted =
+     * true (without changing the submission date) and the submissionType to TIMEOUT. We also set the initialization state of the corresponding participation to FINISHED. - If no,
+     * we ignore the submission. This is executed every night at 1:00:00 am by the cron job.
+     */
+    @Scheduled(cron = "0 0 1 * * *")
     @Transactional
     public void run() {
         // global try-catch for error logging
         try {
-            // TODO get unsubmitted text and modeling submissions from SubmissionRepository with submitted = false (probably left join participation left join exercise)
-            List<Submission> unsubmittedSubmissions = new ArrayList<>();
+            // used for calculating the elapsed time
+            long start = System.nanoTime();
 
-            // update Participations if the submission was submitted or if the exercise has ended and save them to Database (DB Write)
+            List<Submission> unsubmittedSubmissions = submissionRepository.findAllUnsubmittedModelingAndTextSubmissions();
             for (Submission unsubmittedSubmission : unsubmittedSubmissions) {
 
                 Exercise exercise = unsubmittedSubmission.getParticipation().getExercise();
 
-                // if exercise has ended, all submissions will be processed => we can remove the inner HashMap for this exercise
-                // if exercise hasn't ended, some submissions (those that are not submitted) will stay in HashMap => keep inner HashMap
-                Map<String, Submission> submissions;
                 if (exercise.isEnded()) {
                     unsubmittedSubmission.setSubmitted(true);
                     unsubmittedSubmission.setType(SubmissionType.TIMEOUT);
@@ -76,18 +77,22 @@ public class AutomaticSubmissionService {
                 updateParticipation(unsubmittedSubmission);
 
                 submissionRepository.save(unsubmittedSubmission);
-                if (unsubmittedSubmission != null) {
-                    String username = unsubmittedSubmission.getParticipation().getStudent().getLogin();
-                    if (unsubmittedSubmission instanceof ModelingSubmission) {
-                        messagingTemplate.convertAndSendToUser(username, "/topic/modelingSubmission/" + unsubmittedSubmission.getId(), unsubmittedSubmission);
-                    }
-                    if (unsubmittedSubmission instanceof TextSubmission) {
-                        messagingTemplate.convertAndSendToUser(username, "/topic/textSubmission/" + unsubmittedSubmission.getId(), unsubmittedSubmission);
-                    }
+
+                String username = unsubmittedSubmission.getParticipation().getStudent().getLogin();
+                if (unsubmittedSubmission instanceof ModelingSubmission) {
+                    messagingTemplate.convertAndSendToUser(username, "/topic/modelingSubmission/" + unsubmittedSubmission.getId(), unsubmittedSubmission);
+                }
+                if (unsubmittedSubmission instanceof TextSubmission) {
+                    messagingTemplate.convertAndSendToUser(username, "/topic/textSubmission/" + unsubmittedSubmission.getId(), unsubmittedSubmission);
                 }
             }
 
-            // TODO add some logs how long this took and how many submissions have been processed
+            // used for calculating the elapsed time
+            long end = System.nanoTime();
+            // calculate elapsed time in seconds and create log message
+            double elapsedTimeInSeconds = (double) (end - start) / 1000000000.0;
+            DecimalFormat df = new DecimalFormat("#.##");
+            log.info("Checked {} submissions in {} seconds for automatic submit.", unsubmittedSubmissions.size(), df.format(elapsedTimeInSeconds));
         }
         catch (Exception e) {
             log.error("Exception in AutomaticSubmissionService:\n{}", e.getMessage());
@@ -115,8 +120,8 @@ public class AutomaticSubmissionService {
                 modelingSubmissionService.notifyCompass(modelingSubmission, modelingExercise);
                 // check if compass could assess automatically
                 modelingSubmissionService.checkAutomaticResult(modelingSubmission, modelingExercise);
-                // set participation state to finished and persist it
             }
+            // set participation state to finished and persist it
             participation.setInitializationState(InitializationState.FINISHED);
             participationService.save(participation);
             // return modeling submission with model and optional result


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
We have an AutomaticAssessmentService that automatically submits modeling and text submissions when an exercise has expired (i.e. due date is in the past). Currently, the service is not processing any submission.

### Description
To make it work again, we query all un-submitted modeling and text submissions every night at 1 a.m. If the corresponding exercise is finished, we set the submission to submitted = true (without changing the submission date) and the submissionType to TIMEOUT. We also set the initialization state of the  corresponding participation to FINISHED.
Additionally, I added a log statement that logs the number of processed submissions and the elapsed time.