### PR TITLE
Bugfix/Check filename in repository file endpoints 

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/RepositoryResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/RepositoryResource.java
@@ -141,6 +141,9 @@ public class RepositoryResource {
     @PostMapping(value = "/repository/{participationId}/file", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> createFile(@PathVariable Long participationId, @RequestParam("file") String filename, HttpServletRequest request) throws IOException, InterruptedException {
         log.debug("REST request to create file {} for Participation : {}", filename, participationId);
+        if (filename.contains("../")) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
 
         Participation participation = participationService.findOne(participationId);
         ResponseEntity<Void> failureResponse = checkParticipation(participation);
@@ -168,7 +171,7 @@ public class RepositoryResource {
      * POST /repository/{participationId}/folder: Create new folder
      *
      * @param participationId Participation ID
-     * @param filename
+     * @param folderName
      * @param request
      * @return
      * @throws IOException
@@ -176,6 +179,9 @@ public class RepositoryResource {
     @PostMapping(value = "/repository/{participationId}/folder", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> createFolder(@PathVariable Long participationId, @RequestParam("folder") String folderName, HttpServletRequest request) throws IOException, InterruptedException {
         log.debug("REST request to create file {} for Participation : {}", folderName, participationId);
+        if (folderName.contains("../")) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
 
         Participation participation = participationService.findOne(participationId);
         ResponseEntity<Void> failureResponse = checkParticipation(participation);
@@ -202,6 +208,10 @@ public class RepositoryResource {
      */
     @PostMapping(value = "/repository/{participationId}/rename-file", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> renameFolder(@PathVariable Long participationId, @RequestBody FileMove fileMove) throws IOException, InterruptedException {
+        if (fileMove.getNewFilename().contains("../")) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
         Participation participation = participationService.findOne(participationId);
         ResponseEntity<Void> failureResponse = checkParticipation(participation);
         if (failureResponse != null) return failureResponse;


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [ ] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
In the repository file endpoints we should check the filename for unsupported characters. 

### Description
Added a check that returns a bad request.
