### PR TITLE
Cover 2 edge cases during repo download

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -17,6 +17,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.HiddenFileFilter;
 import org.eclipse.jgit.api.*;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.JGitInternalException;
 import org.eclipse.jgit.errors.IllegalTodoFileModification;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.RebaseTodoLine;
@@ -318,6 +319,12 @@ public class GitService {
             // Get last commit hash from template repo
             ObjectId latestHash = getLatestHash(exercise.getTemplateRepositoryUrlAsUrl());
 
+            if (latestHash == null) {
+                // Template Repository is somehow empty. Should never happen
+                log.info("Cannot find a commit in the template repo for:" + repository.getLocalPath());
+                return;
+            }
+
             // flush cache of files
             repository.setFiles(null);
 
@@ -354,7 +361,7 @@ public class GitService {
             repository.close();
 
         }
-        catch (GitAPIException ex) {
+        catch (GitAPIException | JGitInternalException ex) {
             log.error("Cannot rebase the repo " + repository.getLocalPath() + " due to the following exception: " + ex);
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [ ] ~I run `yarn lint`: the project builds without code style warnings.~
- [ ] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context & Description
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Context: Tutors download student repositories:
Cover edgecase when a template is changed *after* a student already started an exercise.
Also cover edgecase when a template repository doesn't have a commit at all.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Navigate to: https://artemistest.ase.in.tum.de/#/course/1/exercise/16/dashboard and download repo

