### PR TITLE
Highlight neutral feedback for elements with an exclamation mark.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@fortawesome/fontawesome-svg-core": "1.2.17",
         "@fortawesome/free-regular-svg-icons": "5.8.1",
         "@fortawesome/free-solid-svg-icons": "5.8.1",
-        "@ls1intum/apollon": "2.0.0-rc.5",
+        "@ls1intum/apollon": "2.0.0-rc.6",
         "@ng-bootstrap/ng-bootstrap": "4.1.2",
         "@nguniversal/express-engine": "7.1.1",
         "@ngx-translate/core": "11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -658,10 +658,10 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
-"@ls1intum/apollon@2.0.0-rc.5":
-  version "2.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.0-rc.5.tgz#b360ffb6512b7b4338577ef7669b81f0bd5b091e"
-  integrity sha512-b2HKS00BxwF4TMmTsdLe9lFInbbDxE0KOUwg7gBDw3bBrocIbzwh4+NHoiqS1sVtBI8yMpUfWR3n3gp80NDowQ==
+"@ls1intum/apollon@2.0.0-rc.6":
+  version "2.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.0-rc.6.tgz#d4fb70bd63ae8e2d8c067f1a51e111d6da68a6bd"
+  integrity sha512-GhG88c/uMyoxLpuGd6Pw7haUS4blaTNKoERUyEFoz3lmejgZS/LSy+kwkYHoP2oizySqjBD9lPEWWE7tzb4E9Q==
   dependencies:
     pepjs "0.5.2"
     react "16.8.6"


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context

When the tutors give feedback for a modeling submission and neither deduct nor add a point for that element, there is no indicator that there is feedback for this element. We add a visual indicator in form of a blue exclamation mark for neutral elements in Apollon.

### Description

See https://github.com/ls1intum/Apollon/pull/30 for details.
