### PR TITLE
Bugfix/scoring explanation bugfix

### DIFF
--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
@@ -38,7 +38,7 @@
                 [question]="question"
                 [multipleChoiceMapping]="selectedAnswerOptions"
                 [questionIndex]="questionIndex"
-                [multipleChoiceSubmittedAnswer]="submittedAnswer"
+                [multipleChoiceSubmittedResult]="submittedResult"
             ></jhi-quiz-scoring-infostudent-modal>
         </span>
     </div>

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
@@ -38,6 +38,7 @@
                 [question]="question"
                 [multipleChoiceMapping]="selectedAnswerOptions"
                 [questionIndex]="questionIndex"
+                [multipleChoiceSubmittedAnswer]="submittedAnswer"
             ></jhi-quiz-scoring-infostudent-modal>
         </span>
     </div>

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
@@ -39,6 +39,7 @@
                 [multipleChoiceMapping]="selectedAnswerOptions"
                 [questionIndex]="questionIndex"
                 [multipleChoiceSubmittedResult]="submittedResult"
+                [submittedQuizExercise]="submittedQuizExercise"
             ></jhi-quiz-scoring-infostudent-modal>
         </span>
     </div>

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.ts
@@ -4,6 +4,7 @@ import { MultipleChoiceQuestion } from '../../../entities/multiple-choice-questi
 import { AnswerOption } from '../../../entities/answer-option';
 import { SubmittedAnswer } from 'app/entities/submitted-answer';
 import { Result } from 'app/entities/result';
+import { QuizExercise } from 'app/entities/quiz-exercise';
 
 @Component({
     selector: 'jhi-multiple-choice-question',
@@ -37,6 +38,8 @@ export class MultipleChoiceQuestionComponent implements OnChanges {
     fnOnSelection: any;
     @Input()
     submittedResult: Result;
+    @Input()
+    submittedQuizExercise: QuizExercise;
 
     @Output()
     selectedAnswerOptionsChange = new EventEmitter();

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.ts
@@ -36,7 +36,7 @@ export class MultipleChoiceQuestionComponent implements OnChanges {
     @Input()
     fnOnSelection: any;
     @Input()
-    submittedAnswer: Result;
+    submittedResult: Result;
 
     @Output()
     selectedAnswerOptionsChange = new EventEmitter();

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from
 import { ArtemisMarkdown } from '../../../components/util/markdown.service';
 import { MultipleChoiceQuestion } from '../../../entities/multiple-choice-question';
 import { AnswerOption } from '../../../entities/answer-option';
+import { SubmittedAnswer } from 'app/entities/submitted-answer';
 
 @Component({
     selector: 'jhi-multiple-choice-question',
@@ -33,6 +34,8 @@ export class MultipleChoiceQuestionComponent implements OnChanges {
     forceSampleSolution: boolean;
     @Input()
     fnOnSelection: any;
+    @Input()
+    submittedAnswer: SubmittedAnswer[];
 
     @Output()
     selectedAnswerOptionsChange = new EventEmitter();

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.ts
@@ -3,6 +3,7 @@ import { ArtemisMarkdown } from '../../../components/util/markdown.service';
 import { MultipleChoiceQuestion } from '../../../entities/multiple-choice-question';
 import { AnswerOption } from '../../../entities/answer-option';
 import { SubmittedAnswer } from 'app/entities/submitted-answer';
+import { Result } from 'app/entities/result';
 
 @Component({
     selector: 'jhi-multiple-choice-question',
@@ -35,7 +36,7 @@ export class MultipleChoiceQuestionComponent implements OnChanges {
     @Input()
     fnOnSelection: any;
     @Input()
-    submittedAnswer: SubmittedAnswer[];
+    submittedAnswer: Result;
 
     @Output()
     selectedAnswerOptionsChange = new EventEmitter();

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -47,6 +47,7 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
     differenceMultipleChoice: number; // Difference between inTotalSelectedRightOptions and differenceMultipleChoice
     checkForCorrectAnswers = new Array<AnswerOption>();
     checkForWrongAnswers = new Array<AnswerOption>();
+    @Input() submittedQuizExercise: QuizExercise;
 
     /* Drag and Drop Counting Variables*/
     dragAndDropZones: number; // Amount of drag and drop Zones
@@ -98,6 +99,7 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
      */
     private submittedAnswerCorrectValues() {
         console.log(this.multipleChoiceSubmittedResult);
+        console.log(this.submittedQuizExercise);
 
         if (this.multipleChoiceSubmittedResult.participation.exercise.type === 'quiz') {
             const quizExercise = this.multipleChoiceSubmittedResult.participation.exercise as QuizExercise;

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -145,15 +145,6 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
         this.inTotalSelectedWrongOptions = this.multipleChoiceWrongAnswerChosen + this.forgottenMultipleChoiceRightAnswers;
         this.differenceMultipleChoice = this.inTotalSelectedRightOptions - this.inTotalSelectedWrongOptions;
 
-        console.log(this.multipleChoiceAnswerOptions);
-        console.log(this.correctMultipleChoiceAnswers);
-        console.log(this.multipleChoiceCorrectAnswerCorrectlyChosen);
-        console.log(this.multipleChoiceWrongAnswerChosen);
-        console.log(this.forgottenMultipleChoiceRightAnswers);
-        console.log(this.inTotalSelectedRightOptions);
-        console.log(this.inTotalSelectedWrongOptions);
-        console.log(this.differenceMultipleChoice);
-
         if (this.inTotalSelectedRightOptions === 1) {
             this.rightOption = this.translateService.instant(translationBasePath + 'option');
         } else {

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -9,6 +9,8 @@ import { ShortAnswerQuestion } from '../../../entities/short-answer-question';
 import { ShortAnswerSubmittedText } from 'app/entities/short-answer-submitted-text';
 import { TranslateService } from '@ngx-translate/core';
 import { SubmittedAnswer } from 'app/entities/submitted-answer';
+import { Result } from 'app/entities/result';
+import { QuizExercise, QuizExerciseComponent } from 'app/entities/quiz-exercise';
 
 @Component({
     selector: 'jhi-quiz-scoring-infostudent-modal',
@@ -30,7 +32,7 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
     @Input() multipleChoiceMapping = new Array<AnswerOption>();
     @Input() shortAnswerText = new Array<ShortAnswerSubmittedText>();
     @Input() correctlyMappedDragAndDropItems: number; // Amount of correctly mapped drag and drop items
-    @Input() multipleChoiceSubmittedAnswer: SubmittedAnswer[];
+    @Input() multipleChoiceSubmittedAnswer: Result;
 
     /* Multiple Choice Counting Variables*/
     multipleChoiceCorrectAnswerCorrectlyChosen: number; // Amount of right options chosen by the student
@@ -92,12 +94,19 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
      * checks for the correct answeroptions based on the submittedAnswer
      */
     private submittedAnswerCorrectValues() {
-        for (let type of this.multipleChoiceSubmittedAnswer) {
-            if (type.quizQuestion.id === this.question.id) {
-                if (type.quizQuestion.type === QuizQuestionType.MULTIPLE_CHOICE) {
-                    this.mcmQuestionSubmitted = type.quizQuestion as MultipleChoiceQuestion;
+        console.log(this.multipleChoiceSubmittedAnswer);
+        console.log(this.multipleChoiceSubmittedAnswer.participation.exercise);
+
+        if (this.multipleChoiceSubmittedAnswer.participation.exercise.type === 'quiz') {
+            const question = this.multipleChoiceSubmittedAnswer.participation.exercise as QuizExercise;
+
+            for (let element of question.quizQuestions) {
+                if (element.id === question.id) {
+                    const value = element as MultipleChoiceQuestion;
+                    this.correctMultipleChoiceAnswers = value.answerOptions.filter(option => option.isCorrect).length;
                 }
             }
+            console.log(true);
         }
     }
 
@@ -109,7 +118,7 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
         const translationBasePath = 'arTeMiSApp.quizExercise.explanationText.';
         const mcmQuestion = this.question as MultipleChoiceQuestion;
         this.multipleChoiceAnswerOptions = mcmQuestion.answerOptions.length;
-        this.correctMultipleChoiceAnswers = this.mcmQuestionSubmitted.answerOptions.filter(option => option.isCorrect).length;
+        //this.correctMultipleChoiceAnswers = this.mcmQuestionSubmitted.answerOptions.filter(option => option.isCorrect).length;
         this.multipleChoiceCorrectAnswerCorrectlyChosen = this.multipleChoiceMapping.filter(option => option.isCorrect).length;
         this.multipleChoiceWrongAnswerChosen = this.multipleChoiceMapping.filter(option => !option.isCorrect).length;
         this.forgottenMultipleChoiceRightAnswers = this.correctMultipleChoiceAnswers - this.multipleChoiceCorrectAnswerCorrectlyChosen;
@@ -117,9 +126,6 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
             this.multipleChoiceCorrectAnswerCorrectlyChosen + (this.multipleChoiceAnswerOptions - this.correctMultipleChoiceAnswers - this.multipleChoiceWrongAnswerChosen);
         this.inTotalSelectedWrongOptions = this.multipleChoiceWrongAnswerChosen + this.forgottenMultipleChoiceRightAnswers;
         this.differenceMultipleChoice = this.inTotalSelectedRightOptions - this.inTotalSelectedWrongOptions;
-
-        console.log(this.multipleChoiceMapping);
-        console.log(this.multipleChoiceSubmittedAnswer);
 
         console.log(this.multipleChoiceAnswerOptions);
         console.log(this.correctMultipleChoiceAnswers);

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, AfterViewInit } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { QuizQuestion, QuizQuestionType, ScoringType } from 'app/entities/quiz-question';
 import { DragAndDropMapping } from '../../../entities/drag-and-drop-mapping';
@@ -12,13 +12,14 @@ import { Result } from 'app/entities/result';
 import { QuizExercise } from 'app/entities/quiz-exercise';
 import { QuizSubmission } from 'app/entities/quiz-submission';
 import { MultipleChoiceSubmittedAnswer } from 'app/entities/multiple-choice-submitted-answer';
+import { QuizComponent } from 'app/quiz/participate';
 
 @Component({
     selector: 'jhi-quiz-scoring-infostudent-modal',
     templateUrl: './quiz-scoring-info-student-modal.component.html',
     styles: [],
 })
-export class QuizScoringInfoStudentModalComponent implements OnInit {
+export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
     readonly DRAG_AND_DROP = QuizQuestionType.DRAG_AND_DROP;
     readonly MULTIPLE_CHOICE = QuizQuestionType.MULTIPLE_CHOICE;
     readonly SHORT_ANSWER = QuizQuestionType.SHORT_ANSWER;
@@ -70,7 +71,7 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
 
     constructor(private modalService: NgbModal, private translateService: TranslateService) {}
 
-    ngOnInit() {
+    ngAfterViewInit() {
         this.checkForSingleOrPluralPoints();
         switch (this.question.type) {
             case QuizQuestionType.MULTIPLE_CHOICE:
@@ -96,6 +97,8 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
      * checks for the correct answerOptions based on the submittedAnswer
      */
     private submittedAnswerCorrectValues() {
+        console.log(this.multipleChoiceSubmittedResult);
+
         if (this.multipleChoiceSubmittedResult.participation.exercise.type === 'quiz') {
             const quizExercise = this.multipleChoiceSubmittedResult.participation.exercise as QuizExercise;
 

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -118,6 +118,15 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
         this.inTotalSelectedWrongOptions = this.multipleChoiceWrongAnswerChosen + this.forgottenMultipleChoiceRightAnswers;
         this.differenceMultipleChoice = this.inTotalSelectedRightOptions - this.inTotalSelectedWrongOptions;
 
+        console.log(this.multipleChoiceAnswerOptions);
+        console.log(this.correctMultipleChoiceAnswers);
+        console.log(this.multipleChoiceCorrectAnswerCorrectlyChosen);
+        console.log(this.multipleChoiceWrongAnswerChosen);
+        console.log(this.forgottenMultipleChoiceRightAnswers);
+        console.log(this.inTotalSelectedRightOptions);
+        console.log(this.inTotalSelectedWrongOptions);
+        console.log(this.differenceMultipleChoice);
+
         if (this.inTotalSelectedRightOptions === 1) {
             this.rightOption = this.translateService.instant(translationBasePath + 'option');
         } else {

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -118,6 +118,9 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
         this.inTotalSelectedWrongOptions = this.multipleChoiceWrongAnswerChosen + this.forgottenMultipleChoiceRightAnswers;
         this.differenceMultipleChoice = this.inTotalSelectedRightOptions - this.inTotalSelectedWrongOptions;
 
+        console.log(this.multipleChoiceMapping);
+        console.log(this.multipleChoiceSubmittedAnswer);
+
         console.log(this.multipleChoiceAnswerOptions);
         console.log(this.correctMultipleChoiceAnswers);
         console.log(this.multipleChoiceCorrectAnswerCorrectlyChosen);

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -12,7 +12,6 @@ import { Result } from 'app/entities/result';
 import { QuizExercise } from 'app/entities/quiz-exercise';
 import { QuizSubmission } from 'app/entities/quiz-submission';
 import { MultipleChoiceSubmittedAnswer } from 'app/entities/multiple-choice-submitted-answer';
-import { QuizComponent } from 'app/quiz/participate';
 
 @Component({
     selector: 'jhi-quiz-scoring-infostudent-modal',
@@ -35,6 +34,7 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
     @Input() shortAnswerText = new Array<ShortAnswerSubmittedText>();
     @Input() correctlyMappedDragAndDropItems: number; // Amount of correctly mapped drag and drop items
     @Input() multipleChoiceSubmittedResult: Result;
+    @Input() submittedQuizExercise: QuizExercise;
 
     /* Multiple Choice Counting Variables*/
     multipleChoiceCorrectAnswerCorrectlyChosen: number; // Amount of right options chosen by the student
@@ -47,7 +47,6 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
     differenceMultipleChoice: number; // Difference between inTotalSelectedRightOptions and differenceMultipleChoice
     checkForCorrectAnswers = new Array<AnswerOption>();
     checkForWrongAnswers = new Array<AnswerOption>();
-    @Input() submittedQuizExercise: QuizExercise;
 
     /* Drag and Drop Counting Variables*/
     dragAndDropZones: number; // Amount of drag and drop Zones
@@ -98,11 +97,7 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
      * checks for the correct answerOptions based on the submittedAnswer
      */
     private submittedAnswerCorrectValues() {
-        console.log(this.multipleChoiceSubmittedResult);
-        console.log(this.submittedQuizExercise.quizQuestions);
-
         let answerOptionsOfQuestion = new Array<AnswerOption>();
-
         for (const question of this.submittedQuizExercise.quizQuestions) {
             const mcQuizQuestion = question as MultipleChoiceQuestion;
             if (mcQuizQuestion.id === this.question.id) {
@@ -110,19 +105,6 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
                 this.correctMultipleChoiceAnswers = mcQuizQuestion.answerOptions.filter(option => option.isCorrect).length;
             }
         }
-
-        /** if (this.multipleChoiceSubmittedResult.participation.exercise.type === 'quiz') {
-            const quizExercise = this.multipleChoiceSubmittedResult.participation.exercise as QuizExercise;
-
-            let answerOptionsOfQuestion = new Array<AnswerOption>();
-
-            for (const quizQuestion of quizExercise.quizQuestions) {
-                if (quizQuestion.id === this.question.id) {
-                    const mcQuizQuestion = quizQuestion as MultipleChoiceQuestion;
-                    answerOptionsOfQuestion = mcQuizQuestion.answerOptions;
-                    this.correctMultipleChoiceAnswers = mcQuizQuestion.answerOptions.filter(option => option.isCorrect).length;
-                }
-            } **/
 
         const submittedQuizSubmission = this.multipleChoiceSubmittedResult.submission as QuizSubmission;
         const submittedAnswerLength = submittedQuizSubmission.submittedAnswers.length;

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -93,7 +93,7 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
     }
 
     /**
-     * checks for the correct answeroptions based on the submittedAnswer
+     * checks for the correct answerOptions based on the submittedAnswer
      */
     private submittedAnswerCorrectValues() {
         if (this.multipleChoiceSubmittedResult.participation.exercise.type === 'quiz') {

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -11,6 +11,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { SubmittedAnswer } from 'app/entities/submitted-answer';
 import { Result } from 'app/entities/result';
 import { QuizExercise, QuizExerciseComponent } from 'app/entities/quiz-exercise';
+import { QuizSubmission } from 'app/entities/quiz-submission';
 
 @Component({
     selector: 'jhi-quiz-scoring-infostudent-modal',
@@ -94,19 +95,23 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
      * checks for the correct answeroptions based on the submittedAnswer
      */
     private submittedAnswerCorrectValues() {
-        console.log(this.multipleChoiceSubmittedAnswer);
-        console.log(this.multipleChoiceSubmittedAnswer.participation.exercise);
-
         if (this.multipleChoiceSubmittedAnswer.participation.exercise.type === 'quiz') {
             const question = this.multipleChoiceSubmittedAnswer.participation.exercise as QuizExercise;
 
-            for (let element of question.quizQuestions) {
+            for (const element of question.quizQuestions) {
                 if (element.id === question.id) {
                     const value = element as MultipleChoiceQuestion;
                     this.correctMultipleChoiceAnswers = value.answerOptions.filter(option => option.isCorrect).length;
                 }
             }
-            console.log(true);
+
+            const submitted = this.multipleChoiceSubmittedAnswer.submission as QuizSubmission;
+            const number = submitted.submittedAnswers.length;
+            for (let i = 0; i < number; i++) {
+                if (submitted.submittedAnswers[i].quizQuestion.id === question.id) {
+                    console.log(submitted.submittedAnswers[i]);
+                }
+            }
         }
     }
 

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -8,6 +8,7 @@ import { DragAndDropQuestion } from '../../../entities/drag-and-drop-question';
 import { ShortAnswerQuestion } from '../../../entities/short-answer-question';
 import { ShortAnswerSubmittedText } from 'app/entities/short-answer-submitted-text';
 import { TranslateService } from '@ngx-translate/core';
+import { SubmittedAnswer } from 'app/entities/submitted-answer';
 
 @Component({
     selector: 'jhi-quiz-scoring-infostudent-modal',
@@ -29,6 +30,7 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
     @Input() multipleChoiceMapping = new Array<AnswerOption>();
     @Input() shortAnswerText = new Array<ShortAnswerSubmittedText>();
     @Input() correctlyMappedDragAndDropItems: number; // Amount of correctly mapped drag and drop items
+    @Input() multipleChoiceSubmittedAnswer: SubmittedAnswer[];
 
     /* Multiple Choice Counting Variables*/
     multipleChoiceCorrectAnswerCorrectlyChosen: number; // Amount of right options chosen by the student
@@ -39,6 +41,7 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
     inTotalSelectedRightOptions: number; // Amount of correct and wrong options assigned correctly
     inTotalSelectedWrongOptions: number; // Amount of correct and wrong options assigned wrongly
     differenceMultipleChoice: number; // Difference between inTotalSelectedRightOptions and differenceMultipleChoice
+    mcmQuestionSubmitted: MultipleChoiceQuestion;
 
     /* Drag and Drop Counting Variables*/
     dragAndDropZones: number; // Amount of drag and drop Zones
@@ -64,6 +67,7 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
     constructor(private modalService: NgbModal, private translateService: TranslateService) {}
 
     ngOnInit() {
+        this.submittedAnswerCorrectValues();
         this.checkForSingleOrPluralPoints();
         switch (this.question.type) {
             case QuizQuestionType.MULTIPLE_CHOICE:
@@ -86,13 +90,26 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
     }
 
     /**
+     * checks for the correct answeroptions based on the submittedAnswer
+     */
+    private submittedAnswerCorrectValues() {
+        for (let type of this.multipleChoiceSubmittedAnswer) {
+            if (type.quizQuestion.id === this.question.id) {
+                if (type.quizQuestion.type === QuizQuestionType.MULTIPLE_CHOICE) {
+                    this.mcmQuestionSubmitted = type.quizQuestion as MultipleChoiceQuestion;
+                }
+            }
+        }
+    }
+
+    /**
      * counts the variables for Multiple Choice Questions
      */
     private countMultipleChoice() {
         const translationBasePath = 'arTeMiSApp.quizExercise.explanationText.';
         const mcmQuestion = this.question as MultipleChoiceQuestion;
         this.multipleChoiceAnswerOptions = mcmQuestion.answerOptions.length;
-        this.correctMultipleChoiceAnswers = mcmQuestion.answerOptions.filter(option => option.isCorrect).length;
+        this.correctMultipleChoiceAnswers = this.mcmQuestionSubmitted.answerOptions.filter(option => option.isCorrect).length;
         this.multipleChoiceCorrectAnswerCorrectlyChosen = this.multipleChoiceMapping.filter(option => option.isCorrect).length;
         this.multipleChoiceWrongAnswerChosen = this.multipleChoiceMapping.filter(option => !option.isCorrect).length;
         this.forgottenMultipleChoiceRightAnswers = this.correctMultipleChoiceAnswers - this.multipleChoiceCorrectAnswerCorrectlyChosen;

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -99,9 +99,19 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
      */
     private submittedAnswerCorrectValues() {
         console.log(this.multipleChoiceSubmittedResult);
-        console.log(this.submittedQuizExercise);
+        console.log(this.submittedQuizExercise.quizQuestions);
 
-        if (this.multipleChoiceSubmittedResult.participation.exercise.type === 'quiz') {
+        let answerOptionsOfQuestion = new Array<AnswerOption>();
+
+        for (const question of this.submittedQuizExercise.quizQuestions) {
+            const mcQuizQuestion = question as MultipleChoiceQuestion;
+            if (mcQuizQuestion.id === this.question.id) {
+                answerOptionsOfQuestion = mcQuizQuestion.answerOptions;
+                this.correctMultipleChoiceAnswers = mcQuizQuestion.answerOptions.filter(option => option.isCorrect).length;
+            }
+        }
+
+        /** if (this.multipleChoiceSubmittedResult.participation.exercise.type === 'quiz') {
             const quizExercise = this.multipleChoiceSubmittedResult.participation.exercise as QuizExercise;
 
             let answerOptionsOfQuestion = new Array<AnswerOption>();
@@ -112,24 +122,23 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
                     answerOptionsOfQuestion = mcQuizQuestion.answerOptions;
                     this.correctMultipleChoiceAnswers = mcQuizQuestion.answerOptions.filter(option => option.isCorrect).length;
                 }
-            }
+            } **/
 
-            const submittedQuizSubmission = this.multipleChoiceSubmittedResult.submission as QuizSubmission;
-            const submittedAnswerLength = submittedQuizSubmission.submittedAnswers.length;
-            for (let i = 0; i < submittedAnswerLength; i++) {
-                if (submittedQuizSubmission.submittedAnswers[i].quizQuestion.id === this.question.id) {
-                    const multipleChoiceSubmittedAnswers = submittedQuizSubmission.submittedAnswers[i] as MultipleChoiceSubmittedAnswer;
-                    if (multipleChoiceSubmittedAnswers.selectedOptions === undefined) {
-                        this.checkForCorrectAnswers = [];
-                        this.checkForWrongAnswers = [];
-                    } else {
-                        for (const selectedOption of multipleChoiceSubmittedAnswers.selectedOptions) {
-                            for (const answerOptionElement of answerOptionsOfQuestion) {
-                                if (selectedOption.id === answerOptionElement.id && answerOptionElement.isCorrect) {
-                                    this.checkForCorrectAnswers.push(selectedOption);
-                                } else if (selectedOption.id === answerOptionElement.id && !answerOptionElement.isCorrect) {
-                                    this.checkForWrongAnswers.push(selectedOption);
-                                }
+        const submittedQuizSubmission = this.multipleChoiceSubmittedResult.submission as QuizSubmission;
+        const submittedAnswerLength = submittedQuizSubmission.submittedAnswers.length;
+        for (let i = 0; i < submittedAnswerLength; i++) {
+            if (submittedQuizSubmission.submittedAnswers[i].quizQuestion.id === this.question.id) {
+                const multipleChoiceSubmittedAnswers = submittedQuizSubmission.submittedAnswers[i] as MultipleChoiceSubmittedAnswer;
+                if (multipleChoiceSubmittedAnswers.selectedOptions === undefined) {
+                    this.checkForCorrectAnswers = [];
+                    this.checkForWrongAnswers = [];
+                } else {
+                    for (const selectedOption of multipleChoiceSubmittedAnswers.selectedOptions) {
+                        for (const answerOptionElement of answerOptionsOfQuestion) {
+                            if (selectedOption.id === answerOptionElement.id && answerOptionElement.isCorrect) {
+                                this.checkForCorrectAnswers.push(selectedOption);
+                            } else if (selectedOption.id === answerOptionElement.id && !answerOptionElement.isCorrect) {
+                                this.checkForWrongAnswers.push(selectedOption);
                             }
                         }
                     }

--- a/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -67,7 +67,6 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
     constructor(private modalService: NgbModal, private translateService: TranslateService) {}
 
     ngOnInit() {
-        this.submittedAnswerCorrectValues();
         this.checkForSingleOrPluralPoints();
         switch (this.question.type) {
             case QuizQuestionType.MULTIPLE_CHOICE:
@@ -106,6 +105,7 @@ export class QuizScoringInfoStudentModalComponent implements OnInit {
      * counts the variables for Multiple Choice Questions
      */
     private countMultipleChoice() {
+        this.submittedAnswerCorrectValues();
         const translationBasePath = 'arTeMiSApp.quizExercise.explanationText.';
         const mcmQuestion = this.question as MultipleChoiceQuestion;
         this.multipleChoiceAnswerOptions = mcmQuestion.answerOptions.length;

--- a/src/main/webapp/app/quiz/participate/quiz.component.html
+++ b/src/main/webapp/app/quiz/participate/quiz.component.html
@@ -23,6 +23,7 @@
             [fnOnSelection]="onSelectionChanged.bind(this)"
             [clickDisabled]="submission.submitted || remainingTimeSeconds < 0"
             [showResult]="showingResult"
+            [submittedAnswer]="submission.submittedAnswers"
             [forceSampleSolution]="mode === 'solution'"
             [questionIndex]="i + 1"
             [score]="questionScores[question.id]"

--- a/src/main/webapp/app/quiz/participate/quiz.component.html
+++ b/src/main/webapp/app/quiz/participate/quiz.component.html
@@ -23,7 +23,7 @@
             [fnOnSelection]="onSelectionChanged.bind(this)"
             [clickDisabled]="submission.submitted || remainingTimeSeconds < 0"
             [showResult]="showingResult"
-            [submittedAnswer]="submission.submittedAnswers"
+            [submittedAnswer]="result"
             [forceSampleSolution]="mode === 'solution'"
             [questionIndex]="i + 1"
             [score]="questionScores[question.id]"

--- a/src/main/webapp/app/quiz/participate/quiz.component.html
+++ b/src/main/webapp/app/quiz/participate/quiz.component.html
@@ -24,6 +24,7 @@
             [clickDisabled]="submission.submitted || remainingTimeSeconds < 0"
             [showResult]="showingResult"
             [submittedResult]="result"
+            [submittedQuizExercise]="quizExercise"
             [forceSampleSolution]="mode === 'solution'"
             [questionIndex]="i + 1"
             [score]="questionScores[question.id]"

--- a/src/main/webapp/app/quiz/participate/quiz.component.html
+++ b/src/main/webapp/app/quiz/participate/quiz.component.html
@@ -23,7 +23,7 @@
             [fnOnSelection]="onSelectionChanged.bind(this)"
             [clickDisabled]="submission.submitted || remainingTimeSeconds < 0"
             [showResult]="showingResult"
-            [submittedAnswer]="result"
+            [submittedResult]="result"
             [forceSampleSolution]="mode === 'solution'"
             [questionIndex]="i + 1"
             [score]="questionScores[question.id]"


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [X] ~~I updated the documentation and models.~~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [X] ~~I added (end-to-end) test cases for the new functionality.~~

### Motivation and Context
bugfix - scoring type change 

Problem: isCorrect Flag can not be read anymore for the participate/practice mode

### Description
Solution: Count the MC correct answers based on the result of the quizQuestion

### Screenshots
<!-- If applicable, add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Preview: 
<img width="1275" alt="Screenshot 2019-05-09 at 17 44 53" src="https://user-images.githubusercontent.com/44781621/57467552-0a43ab80-7283-11e9-85a0-80254e311e4f.png">
<img width="1275" alt="Screenshot 2019-05-09 at 17 45 18" src="https://user-images.githubusercontent.com/44781621/57467555-0a43ab80-7283-11e9-910f-deb5b7e310d8.png">
<img width="1275" alt="Screenshot 2019-05-09 at 17 44 45" src="https://user-images.githubusercontent.com/44781621/57467816-8ccc6b00-7283-11e9-9374-2ed50e04dd35.png">


Practice:
<img width="1275" alt="Screenshot 2019-05-09 at 17 46 38" src="https://user-images.githubusercontent.com/44781621/57467557-0a43ab80-7283-11e9-8e81-051a69947dee.png">
<img width="1275" alt="Screenshot 2019-05-09 at 17 46 50" src="https://user-images.githubusercontent.com/44781621/57467558-0a43ab80-7283-11e9-8e3b-fd4cf08e86a2.png">
<img width="1275" alt="Screenshot 2019-05-09 at 17 47 40" src="https://user-images.githubusercontent.com/44781621/57467559-0adc4200-7283-11e9-8f30-54032fd3de21.png">

Participate:
<img width="1275" alt="Screenshot 2019-05-09 at 17 49 14" src="https://user-images.githubusercontent.com/44781621/57467560-0adc4200-7283-11e9-9277-50dea4216b80.png">
<img width="1275" alt="Screenshot 2019-05-09 at 17 49 31" src="https://user-images.githubusercontent.com/44781621/57467561-0adc4200-7283-11e9-9e84-2a8fd14164e5.png">
<img width="1275" alt="Screenshot 2019-05-09 at 17 49 41" src="https://user-images.githubusercontent.com/44781621/57467564-0b74d880-7283-11e9-8289-e43c56b4ba35.png">

