### PR TITLE
Fix problem statement overlapping with modeling editor

### DIFF
--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.html
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.html
@@ -1,4 +1,4 @@
-<div [ngClass]="{ 'submission-container': !submission?.submitted, 'assessment-result-container': submission?.submitted }">
+<div class="submission-container d-flex flex-column">
     <jhi-alert></jhi-alert>
     <div class="row" [ngClass]="{ 'align-items-center': submission?.submitted }">
         <div class="col-12 col-lg-8">
@@ -62,7 +62,7 @@
         </div>
     </div>
 
-    <div class="row editor-container">
+    <div class="row flex-grow-1">
         <div *ngIf="submission?.submitted" class="col-9">
             <jhi-modeling-assessment
                 [model]="umlModel"

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.scss
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.scss
@@ -1,29 +1,13 @@
 .submission-container {
-    display: flex;
-    min-height: 100vh;
-    flex-flow: column nowrap;
+    min-height: calc(100vh - 173px);
 }
 
-.assessment-result-container {
-    display: flex;
-    height: calc(100vh - 173px); // TODO CZ: set dynamic height here to prevent scrolling in Apollon editor -> but min-height doesnt work
-    flex-flow: column nowrap;
-}
-
-.editor-container {
-    display: flex;
-    justify-content: center;
+jhi-modeling-editor {
     width: 100%;
-    height: 100%;
-    overflow: auto;
+}
 
-    jhi-modeling-editor {
-        width: 100%;
-    }
-
-    jhi-modeling-assessment {
-        width: 100%;
-    }
+jhi-modeling-assessment {
+    width: 100%;
 }
 
 .editor-large {


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
Fix for https://github.com/ls1intum/ArTEMiS/issues/428. 
For me the problem statement was not overlapping but a large problem statement resulted in a very small scrollable modeling editor. The reason was that the `height` of the container was fixed. I changed it to a fixed `min-height` and cleaned up the CSS a bit. 

### Steps for Testing
1. Log in to ArTEMiS as a student
2. Participate in a modeling exercises with a very large problem statement
3. Check that modeling and assessment result view looks fine for student
4. Repeat the same for an exercise with a very short problem statement to verify that it still looks good