### PR TITLE
Set authentication object when resuming exercise because of new commit.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/security/SecurityUtils.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/SecurityUtils.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.security;
 
+import java.util.Collection;
 import java.util.Optional;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -68,5 +71,53 @@ public final class SecurityUtils {
         SecurityContext securityContext = SecurityContextHolder.getContext();
         return Optional.ofNullable(securityContext.getAuthentication())
                 .map(authentication -> authentication.getAuthorities().stream().anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals(authority))).orElse(false);
+    }
+
+    /**
+     * This methods manually sets a dummy Authentication object that is always authenticated. When a request using a JpaRepository is made and the query associated with the method
+     * is not automatically generated but manually specified, the Spring Data JPA expects the user performing the request to be authenticated. If the request to the JpaRepository
+     * is made because of a REST-call from a server that is not authenticated within Spring, an InvalidDataAccessApiUsageException is raised. This method is a workaround for this
+     * behaviour. See https://jira.spring.io/browse/DATAJPA-1357 for more details.
+     */
+    public static void setAuthorizationObject() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        Authentication authentication = new Authentication() {
+
+            @Override
+            public Collection<? extends GrantedAuthority> getAuthorities() {
+                return null;
+            }
+
+            @Override
+            public Object getCredentials() {
+                return null;
+            }
+
+            @Override
+            public Object getDetails() {
+                return null;
+            }
+
+            @Override
+            public Object getPrincipal() {
+                return null;
+            }
+
+            @Override
+            public boolean isAuthenticated() {
+                return true;
+            }
+
+            @Override
+            public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+            }
+
+            @Override
+            public String getName() {
+                return null;
+            }
+        };
+        context.setAuthentication(authentication);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -35,6 +35,7 @@ import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
@@ -253,6 +254,10 @@ public class ParticipationService {
      * @return resumed participation
      */
     public Participation resumeExercise(Exercise exercise, Participation participation) {
+        // This is needed as a request using a custom query is made using the ProgrammingExerciseRepository, but the user is not authenticated
+        // as the VCS-server performs the request
+        SecurityUtils.setAuthorizationObject();
+
         // Reload programming exercise from database so that the template participation is available
         Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findById(exercise.getId());
         if (!programmingExercise.isPresent()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
@@ -1,20 +1,15 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import java.util.Collection;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ExerciseService;
 import de.tum.in.www1.artemis.service.ProgrammingExerciseService;
 import de.tum.in.www1.artemis.service.ProgrammingSubmissionService;
@@ -68,46 +63,10 @@ public class ProgrammingSubmissionResource {
     @PostMapping(Constants.TEST_CASE_CHANGED_PATH + "{exerciseId}")
     public ResponseEntity<Void> testCaseChanged(@PathVariable Long exerciseId, @RequestBody Object requestBody) {
         log.info("REST request to inform about changed test cases of ProgrammingExercise : {}", exerciseId);
-        // This fixes an issue with the Spring Security Context Holder: https://jira.spring.io/browse/DATAJPA-1357
-        SecurityContext context = SecurityContextHolder.getContext();
-        Authentication authentication = new Authentication() {
+        // This is needed as a request using a custom query is made using the ExerciseRepository, but the user is not authenticated
+        // as the VCS-server performs the request
+        SecurityUtils.setAuthorizationObject();
 
-            @Override
-            public Collection<? extends GrantedAuthority> getAuthorities() {
-                return null;
-            }
-
-            @Override
-            public Object getCredentials() {
-                return null;
-            }
-
-            @Override
-            public Object getDetails() {
-                return null;
-            }
-
-            @Override
-            public Object getPrincipal() {
-                return null;
-            }
-
-            @Override
-            public boolean isAuthenticated() {
-                return true;
-            }
-
-            @Override
-            public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
-
-            }
-
-            @Override
-            public String getName() {
-                return null;
-            }
-        };
-        context.setAuthentication(authentication);
         Exercise exercise = exerciseService.findOneLoadParticipations(exerciseId);
 
         if (!(exercise instanceof ProgrammingExercise)) {


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] I updated the documentation and models.
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
This sets an authentication object when an exercise is resumed automatically because a new commit was received. The logic for setting the authentication object is now handled in a separate method, as it is required more than once.

### Description
When a request using a JpaRepository with a custom query is made, Spring checks if the users that triggered the request is authenticated. If this request is triggered by a REST call to the server from an external server (e.g. Bitbucket or Bamboo), no user is authenticated.
This PR manually sets an authorization object when a programming exercise is resumed because of a new received commit.
This is the upstream ticket: https://jira.spring.io/browse/DATAJPA-1357
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Clean the build plan of a student
4. Let the student make a commit & push, the exercise should be resumed automatically
