### PR TITLE
Add resume button for programming exercises.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -190,10 +189,9 @@ public class ParticipationResource {
      * @param participation
      */
     private void addLatestResultToParticipation(Participation participation) {
-        // unproxy results if necessary
-        if (!Hibernate.isInitialized(participation.getResults())) {
-            participation.setResults((Set<Result>) Hibernate.unproxy(participation.getResults()));
-        }
+        // Load results of participation as they are not contained in the current object
+        participation = participationService.findOneWithEagerResults(participation.getId());
+
         Result result = participation.findLatestResult();
         participation.setResults(Sets.newHashSet(result));
     }

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -180,7 +180,7 @@
             [buttonLoading]="exercise.loading"
             [smallButton]="smallButtons"
             [hideLabelMobile]="false"
-            *ngIf="isOnlineEditorAllowed() && exercise.participations && exercise.participations.length > 0"
+            *ngIf="isOnlineEditorAllowed() && participationStatus() == INITIALIZED && exercise.participations && exercise.participations.length > 0"
             routerLink="/code-editor/{{ exercise.participations[0].id }}"
         ></button>
         <button
@@ -192,9 +192,19 @@
             [hideLabelMobile]="false"
             placement="right"
             container="body"
-            *ngIf="exercise.participations && exercise.participations.length > 0"
+            *ngIf="exercise.participations && participationStatus() == INITIALIZED && exercise.participations.length > 0"
             [ngbPopover]="popContent"
             [autoClose]="'outside'"
+        ></button>
+        <button
+            jhi-exercise-action-button
+            buttonIcon="play-circle"
+            [buttonLabel]="'arTeMiSApp.exerciseActions.resumeExercise' | translate"
+            [buttonLoading]="exercise.loading"
+            [smallButton]="smallButtons"
+            [hideLabelMobile]="false"
+            *ngIf="participationStatus() === INACTIVE"
+            (click)="resumeExercise()"
         ></button>
         <ng-template #popContent>
             <p>{{ 'arTeMiSApp.exerciseActions.clonePersonalRepository' | translate }}</p>

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -174,7 +174,12 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit {
             .resumeExercise(this.courseId, this.exercise.id)
             .finally(() => (this.exercise.loading = false))
             .subscribe(
-                () => true,
+                participation => {
+                    if (participation) {
+                        this.exercise.participations = [participation];
+                        this.exercise.participationStatus = this.participationStatus();
+                    }
+                },
                 error => {
                     console.log('Error: ' + error.status + ' ' + error.message);
                 },


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
This adds the button the resume a programming exercise manually and fixes a bug where the results of a participation were not loaded, causing an exception.

### Description
The resume button was missing for programming exercises in the client. This PR adds it and fixes a bug on the server where the results of the participation that should be resumed were not loaded by Hibernate, causing an exception.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Clean up the build plan of a student
4. Resume the exercise manually by clicking on "Resume exercise" in the course menu
5. The buildplan should be recreated and "Clone repository" should be shown again
