### PR TITLE
Proper store original result when creating a complaint

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
@@ -9,8 +9,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import de.tum.in.www1.artemis.domain.Feedback;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.User;
@@ -37,8 +35,8 @@ public class ModelingAssessmentService extends AssessmentService {
 
     public ModelingAssessmentService(UserService userService, ComplaintResponseService complaintResponseService, CompassService compassService,
             ModelingSubmissionRepository modelingSubmissionRepository, ComplaintRepository complaintRepository, ResultRepository resultRepository,
-            ParticipationRepository participationRepository, ObjectMapper objectMapper) {
-        super(complaintResponseService, complaintRepository, resultRepository, participationRepository, objectMapper);
+            ParticipationRepository participationRepository, ResultService resultService) {
+        super(complaintResponseService, complaintRepository, resultRepository, participationRepository, resultService);
         this.userService = userService;
         this.compassService = compassService;
         this.modelingSubmissionRepository = modelingSubmissionRepository;

--- a/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
@@ -6,8 +6,6 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import de.tum.in.www1.artemis.domain.Feedback;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.TextExercise;
@@ -32,8 +30,8 @@ public class TextAssessmentService extends AssessmentService {
 
     public TextAssessmentService(UserService userService, ComplaintResponseService complaintResponseService, FeedbackRepository feedbackRepository,
             ComplaintRepository complaintRepository, ResultRepository resultRepository, TextSubmissionRepository textSubmissionRepository,
-            ParticipationRepository participationRepository, ObjectMapper objectMapper) {
-        super(complaintResponseService, complaintRepository, resultRepository, participationRepository, objectMapper);
+            ParticipationRepository participationRepository, ResultService resultService) {
+        super(complaintResponseService, complaintRepository, resultRepository, participationRepository, resultService);
         this.feedbackRepository = feedbackRepository;
         this.textSubmissionRepository = textSubmissionRepository;
         this.userService = userService;


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
We didn't save the original result as json when creating a complaint