### PR TITLE
Participation websocket service - follow up

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -127,7 +127,8 @@ public class ParticipationService {
         // common for all exercises
         // Check if participation already exists
         Participation participation = findOneByExerciseIdAndStudentLogin(exercise.getId(), username);
-        if (participation == null || (exercise instanceof ProgrammingExercise && participation.getInitializationState() == InitializationState.FINISHED)) {
+        boolean isNewParticipation = participation == null;
+        if (isNewParticipation || (exercise instanceof ProgrammingExercise && participation.getInitializationState() == InitializationState.FINISHED)) {
             // create a new participation only if it was finished before (only for programming exercises)
             participation = new Participation();
             participation.setExercise(exercise);
@@ -137,7 +138,6 @@ public class ParticipationService {
                 participation.setStudent(user.get());
             }
             participation = save(participation);
-            messagingTemplate.convertAndSendToUser(username, "/topic/exercise/" + exercise.getId() + "/participation", participation);
         }
         else {
             // make sure participation and exercise are connected
@@ -171,6 +171,11 @@ public class ParticipationService {
         }
 
         participation = save(participation);
+
+        if (isNewParticipation) {
+            messagingTemplate.convertAndSendToUser(username, "/topic/exercise/" + exercise.getId() + "/participation", participation);
+        }
+
         return participation;
     }
 

--- a/src/main/webapp/app/entities/exercise/exercise.service.ts
+++ b/src/main/webapp/app/entities/exercise/exercise.service.ts
@@ -62,8 +62,11 @@ export class ExerciseService {
         });
     }
 
-    findResultsForExercise(id: number): Observable<Exercise> {
-        return this.http.get<Exercise>(`${this.resourceUrl}/${id}/results`);
+    findResultsForExercise(id: number): Observable<EntityResponseType> {
+        return this.http
+            .get<Exercise>(`${this.resourceUrl}/${id}/results`, { observe: 'response' })
+            .map((res: EntityResponseType) => this.convertDateFromServer(res))
+            .map((res: EntityResponseType) => this.checkPermission(res));
     }
 
     getNextExerciseForDays(exercises: Exercise[], delayInDays = 7): Exercise {

--- a/src/main/webapp/app/entities/participation/participation-websocket.service.ts
+++ b/src/main/webapp/app/entities/participation/participation-websocket.service.ts
@@ -7,12 +7,15 @@ import { Result } from 'app/entities/result';
 import { Exercise } from 'app/entities/exercise';
 
 const RESULTS_WEBSOCKET = 'results_';
-const EXERCISE_WEBSOCKET = 'exercise_';
+const PARTICIPATION_WEBSOCKET = 'participation_';
 
 @Injectable({ providedIn: 'root' })
 export class ParticipationWebsocketService {
     cachedParticipations: Map<number /* ID of participation */, Participation> = new Map<number, Participation>();
-    openWebsocketConnections: Map<string /* results_{id of participation} */, string /* url of websocket connection */> = new Map<string, string>();
+    openWebsocketConnections: Map<string /* results_{id of participation} OR participation_{id of exercise} */, string /* url of websocket connection */> = new Map<
+        string,
+        string
+    >();
     resultObservables: Map<number /* ID of participation */, BehaviorSubject<Result>> = new Map<number, BehaviorSubject<Result>>();
     participationObservable: BehaviorSubject<Participation>;
 
@@ -87,9 +90,9 @@ export class ParticipationWebsocketService {
         this.openWebsocketConnections.delete(`${RESULTS_WEBSOCKET}${id}`);
         // removing exercise observable
         if (exerciseId) {
-            const participationTopic = this.openWebsocketConnections.get(`${EXERCISE_WEBSOCKET}${exerciseId}`);
+            const participationTopic = this.openWebsocketConnections.get(`${PARTICIPATION_WEBSOCKET}${exerciseId}`);
             this.jhiWebsocketService.unsubscribe(participationTopic);
-            this.openWebsocketConnections.delete(`${EXERCISE_WEBSOCKET}${exerciseId}`);
+            this.openWebsocketConnections.delete(`${PARTICIPATION_WEBSOCKET}${exerciseId}`);
         }
     }
 
@@ -132,16 +135,15 @@ export class ParticipationWebsocketService {
      * @private
      */
     private checkWebsocketConnectionForNewParticipations(exerciseId: number) {
-        if (!this.openWebsocketConnections.get(`${EXERCISE_WEBSOCKET}${exerciseId}`)) {
-            const participationResultTopic = `/user/topic/exercise/${exerciseId}/participation`;
-            this.jhiWebsocketService.subscribe(participationResultTopic);
-            const participationObservable = this.jhiWebsocketService.receive(participationResultTopic);
+        if (!this.openWebsocketConnections.get(`${PARTICIPATION_WEBSOCKET}${exerciseId}`)) {
+            const participationTopic = `/user/topic/exercise/${exerciseId}/participation`;
+            this.jhiWebsocketService.subscribe(participationTopic);
+            const participationObservable = this.jhiWebsocketService.receive(participationTopic);
             participationObservable.subscribe((participationMessage: Participation) => {
-                this.cachedParticipations.set(participationMessage.id, participationMessage);
                 this.addParticipation(participationMessage);
                 this.participationObservable.next(participationMessage);
             });
-            this.openWebsocketConnections.set(`${EXERCISE_WEBSOCKET}${exerciseId}`, participationResultTopic);
+            this.openWebsocketConnections.set(`${PARTICIPATION_WEBSOCKET}${exerciseId}`, participationTopic);
         }
     }
 

--- a/src/main/webapp/app/entities/participation/participation-websocket.service.ts
+++ b/src/main/webapp/app/entities/participation/participation-websocket.service.ts
@@ -24,6 +24,13 @@ export class ParticipationWebsocketService {
         });
     }
 
+    resetLocalCache() {
+        const participations = this.getAllParticipations();
+        participations.forEach(participation => {
+            this.removeParticipation(participation.id, participation.exercise.id);
+        });
+    }
+
     updateParticipation(participation: Participation, exercise?: Exercise) {
         this.addParticipationToList(participation, exercise);
     }

--- a/src/main/webapp/app/entities/participation/participation-websocket.service.ts
+++ b/src/main/webapp/app/entities/participation/participation-websocket.service.ts
@@ -12,10 +12,7 @@ const PARTICIPATION_WEBSOCKET = 'participation_';
 @Injectable({ providedIn: 'root' })
 export class ParticipationWebsocketService {
     cachedParticipations: Map<number /* ID of participation */, Participation> = new Map<number, Participation>();
-    openWebsocketConnections: Map<string /* results_{id of participation} OR participation_{id of exercise} */, string /* url of websocket connection */> = new Map<
-        string,
-        string
-    >();
+    openWebsocketConnections: Map<string /* results_{participationId} OR participation_{exerciseId} */, string /* url of websocket connection */> = new Map<string, string>();
     resultObservables: Map<number /* ID of participation */, BehaviorSubject<Result>> = new Map<number, BehaviorSubject<Result>>();
     participationObservable: BehaviorSubject<Participation>;
 

--- a/src/main/webapp/app/entities/result/result.component.html
+++ b/src/main/webapp/app/entities/result/result.component.html
@@ -24,7 +24,7 @@
             &nbsp; <fa-icon icon="file"></fa-icon> <span jhiTranslate="arTeMiSApp.editor.downloadBuildResult">Download Build Result</span></a
         >
     </span>
-    <span *ngIf="showBadge" class="badge" [ngClass]="{ 'badge-info': !result.rated, 'badge-success': result.rated }">
+    <span *ngIf="showGradedBadge" class="badge" [ngClass]="{ 'badge-info': !result.rated, 'badge-success': result.rated }">
         {{ (result.rated ? 'arTeMiSApp.result.graded' : 'arTeMiSApp.result.notGraded') | translate | uppercase }}
     </span>
 </ng-container>

--- a/src/main/webapp/app/entities/result/result.component.ts
+++ b/src/main/webapp/app/entities/result/result.component.ts
@@ -30,7 +30,7 @@ export class ResultComponent implements OnInit, OnChanges {
     @Input() short = false;
     @Input() result: Result;
     @Input() showUngradedResults: boolean;
-    @Input() showBadge = false;
+    @Input() showGradedBadge = false;
 
     textColorClass: string;
     hasFeedback: boolean;

--- a/src/main/webapp/app/entities/result/updating-result.component.ts
+++ b/src/main/webapp/app/entities/result/updating-result.component.ts
@@ -90,7 +90,7 @@ export class UpdatingResultComponent implements OnInit, OnChanges, OnDestroy {
             // only subscribe for the currently logged in user or if the participation is a template/solution participation and the student is at least instructor
             const isInstructorInCourse = this.participation.student == null && this.accountService.isAtLeastInstructorInCourse(exercise.course);
             const isSameUser = this.participation.student && user.id === this.participation.student.id;
-            const exerciseNotOver = exercise.dueDate == null || exercise.dueDate.isAfter(moment());
+            const exerciseNotOver = exercise.dueDate == null || moment(exercise.dueDate).isAfter(moment());
 
             if ((isSameUser && exerciseNotOver) || isInstructorInCourse) {
                 this.participationWebsocketService.addParticipation(this.participation);

--- a/src/main/webapp/app/entities/result/updating-result.component.ts
+++ b/src/main/webapp/app/entities/result/updating-result.component.ts
@@ -36,7 +36,6 @@ export class UpdatingResultComponent implements OnInit, OnChanges, OnDestroy {
     @Output() newResultReceived = new EventEmitter<boolean>();
 
     private resultUpdateListener: Subscription;
-    websocketChannelSubmissions: string;
 
     constructor(
         private jhiWebsocketService: JhiWebsocketService,
@@ -50,12 +49,16 @@ export class UpdatingResultComponent implements OnInit, OnChanges, OnDestroy {
     ) {}
 
     ngOnInit(): void {
+        if (!this.participation || !this.participation.id) {
+            return;
+        }
+
         if (this.result) {
             const exercise = this.participation.exercise;
             if (exercise && exercise.type === ExerciseType.PROGRAMMING) {
                 this.subscribeForNewResults(exercise as ProgrammingExercise);
             }
-        } else if (this.participation && this.participation.id) {
+        } else {
             const exercise = this.participation.exercise;
 
             if (this.participation.results && this.participation.results.length > 0) {
@@ -121,9 +124,6 @@ export class UpdatingResultComponent implements OnInit, OnChanges, OnDestroy {
     ngOnDestroy() {
         if (this.resultUpdateListener) {
             this.resultUpdateListener.unsubscribe();
-        }
-        if (this.websocketChannelSubmissions) {
-            this.jhiWebsocketService.unsubscribe(this.websocketChannelSubmissions);
         }
     }
 }

--- a/src/main/webapp/app/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.ts
@@ -9,6 +9,7 @@ import { AccountService, JhiLanguageHelper, LoginService, User } from '../../cor
 
 import { VERSION } from '../../app.constants';
 import * as moment from 'moment';
+import { ParticipationWebsocketService } from 'app/entities/participation';
 
 @Component({
     selector: 'jhi-navbar',
@@ -30,6 +31,7 @@ export class NavbarComponent implements OnInit {
         private sessionStorage: SessionStorageService,
         private accountService: AccountService,
         private profileService: ProfileService,
+        private participationWebsocketService: ParticipationWebsocketService,
         private router: Router,
     ) {
         this.version = VERSION ? VERSION : '';
@@ -76,6 +78,7 @@ export class NavbarComponent implements OnInit {
     }
 
     logout() {
+        this.participationWebsocketService.resetLocalCache();
         this.currAccount = null;
         this.collapseNavbar();
         this.loginService.logout();

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -69,16 +69,14 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
         if (cachedParticipations && cachedParticipations.length > 0) {
             this.exerciseService.find(this.exerciseId).subscribe((exerciseResponse: HttpResponse<Exercise>) => {
                 this.exercise = exerciseResponse.body;
-                this.exercise.isAtLeastTutor = this.accountService.isAtLeastTutorInCourse(this.exercise.course);
                 this.exercise.participations = cachedParticipations.filter((participation: Participation) => participation.student.id === this.currentUser.id);
                 this.mergeResultsAndSubmissionsForParticipations();
                 this.exerciseCategories = this.exerciseService.convertExerciseCategoriesFromServer(this.exercise);
                 this.subscribeForNewResults();
             });
         } else {
-            this.exerciseService.findResultsForExercise(this.exerciseId).subscribe((exercise: Exercise) => {
-                this.exercise = exercise;
-                this.exercise.isAtLeastTutor = this.accountService.isAtLeastTutorInCourse(this.exercise.course);
+            this.exerciseService.findResultsForExercise(this.exerciseId).subscribe((exerciseResponse: HttpResponse<Exercise>) => {
+                this.exercise = exerciseResponse.body;
                 this.mergeResultsAndSubmissionsForParticipations();
                 this.exerciseCategories = this.exerciseService.convertExerciseCategoriesFromServer(this.exercise);
                 this.subscribeForNewResults();

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -7,7 +7,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 import { Result } from 'app/entities/result';
 import * as moment from 'moment';
-import { AccountService, JhiWebsocketService } from 'app/core';
+import { AccountService, JhiWebsocketService, User } from 'app/core';
 import { Participation, ParticipationService, ParticipationWebsocketService } from 'app/entities/participation';
 
 const MAX_RESULT_HISTORY_LENGTH = 5;
@@ -23,6 +23,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
     readonly MODELING = ExerciseType.MODELING;
     readonly TEXT = ExerciseType.TEXT;
     readonly FILE_UPLOAD = ExerciseType.FILE_UPLOAD;
+    private currentUser: User;
     private exerciseId: number;
     public courseId: number;
     private subscription: Subscription;
@@ -53,6 +54,9 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
             const didCourseChange = this.courseId !== parseInt(params['courseId'], 10);
             this.exerciseId = parseInt(params['exerciseId'], 10);
             this.courseId = parseInt(params['courseId'], 10);
+            this.accountService.identity().then((user: User) => {
+                this.currentUser = user;
+            });
             if (didExerciseChange || didCourseChange) {
                 this.loadExercise();
             }
@@ -66,7 +70,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
             this.exerciseService.find(this.exerciseId).subscribe((exerciseResponse: HttpResponse<Exercise>) => {
                 this.exercise = exerciseResponse.body;
                 this.exercise.isAtLeastTutor = this.accountService.isAtLeastTutorInCourse(this.exercise.course);
-                this.exercise.participations = cachedParticipations;
+                this.exercise.participations = cachedParticipations.filter((participation: Participation) => participation.student.id === this.currentUser.id);
                 this.mergeResultsAndSubmissionsForParticipations();
                 this.exerciseCategories = this.exerciseService.convertExerciseCategoriesFromServer(this.exercise);
                 this.subscribeForNewResults();

--- a/src/main/webapp/app/quiz/participate/quiz.component.ts
+++ b/src/main/webapp/app/quiz/participate/quiz.component.ts
@@ -307,7 +307,7 @@ export class QuizComponent implements OnInit, OnDestroy {
         if (!this.participationChannel) {
             this.participationWebsocketService.addExerciseForNewParticipation(this.quizId);
             this.participationChannel = this.participationWebsocketService.subscribeForParticipationChanges().subscribe((changedParticipation: Participation) => {
-                if (changedParticipation) {
+                if (changedParticipation && this.quizExercise && changedParticipation.exercise.id === this.quizExercise.id) {
                     if (this.waitingForQuizStart) {
                         // only apply completely if quiz hasn't started to prevent jumping ui during participation
                         this.applyParticipationFull(changedParticipation);

--- a/src/main/webapp/i18n/de/modelingEditor.json
+++ b/src/main/webapp/i18n/de/modelingEditor.json
@@ -10,6 +10,7 @@
             "submitDeadlineMissed": "Dein Diagramm wurde erfolgreich abgesendet! Du kannst dein Diagramm nun nicht mehr bearbeiten. Bitte warte auf dein Feedback. Da du die Deadline verpasst hast wird deine Bewertung nicht gezählt.",
             "empty": "Ein leeres Diagramm kann nicht abgegeben werden.",
             "autoSubmit": "Die Übung ist zu Ende. Du kannst dein Diagramm nun nicht mehr bearbeiten.",
+            "newAssessment": "Eine neue Bewertung für deine Abgabe wurde eingereicht.",
             "error": "Ein Fehler ist aufgetreten. Bitte versuche es später noch einmal.",
             "assessment": {
                 "title": "Bewertung",

--- a/src/main/webapp/i18n/en/modelingEditor.json
+++ b/src/main/webapp/i18n/en/modelingEditor.json
@@ -10,6 +10,7 @@
             "submitDeadlineMissed": "Your diagram was submitted successfully! Now you can't edit your diagram anymore. Please wait for your feedback. As you missed the deadline the score will not be counted.",
             "empty": "Unable to submit an empty diagram.",
             "autoSubmit": "The exercise has ended. Now you can't edit your diagram anymore.",
+            "newAssessment": "A new assessment for your submission was submitted.",
             "error": "An error occurred. Please try again later.",
             "assessment": {
                 "title": "Assessment",


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
<!-- Describe your changes in detail -->
In this PR we resolve issues regarding the participation websocket service implemented in https://github.com/ls1intum/ArTEMiS/pull/281.

Part of this PR:
 * Prevent the 'Resume' button from appearing for modeling and text exercises that resulted in an error.
 * Clear participation websockets when logging out 
 * Load results for mdoeling submissions using the participation websocket service
 * Fix missing instructor action buttons
 * Check if exercise ids match upon receiving a new participation in quiz component
 * Minor changes: cleanup, renaming, documentation, null checks