### PR TITLE
Fix automatic submission service

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
@@ -22,6 +22,6 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      */
     long countBySubmittedAndParticipation_Exercise_Id(boolean submitted, Long exerciseId);
 
-    @Query("select submission from Submission submission where type(submission) in (ModelingSubmission, TextSubmission) and submission.submitted = false")
+    @Query("select submission from Submission submission where type(submission) in (ModelingSubmission, TextSubmission) and submission.submitted = false and not submission.participation is null")
     List<Submission> findAllUnsubmittedModelingAndTextSubmissions();
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
@@ -56,7 +56,7 @@ public class AutomaticSubmissionService {
      * due date. - If yes, we set the submission to submitted = true (without changing the submission date) and the submissionType to TIMEOUT. We also set the initialization state
      * of the corresponding participation to FINISHED. - If no, we ignore the submission. This is executed every night at 1:00:00 am by the cron job.
      */
-    @Scheduled(cron = "*/20 * * * * *")
+    @Scheduled(cron = "0 0 1 * * *")
     @Transactional
     public void run() {
         // global try-catch for error logging

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
@@ -56,7 +56,7 @@ public class AutomaticSubmissionService {
      * true (without changing the submission date) and the submissionType to TIMEOUT. We also set the initialization state of the corresponding participation to FINISHED. - If no,
      * we ignore the submission. This is executed every night at 1:00:00 am by the cron job.
      */
-    @Scheduled(cron = "0 0 1 * * *")
+    @Scheduled(cron = "0 * * * * *")
     @Transactional
     public void run() {
         // global try-catch for error logging

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
@@ -100,7 +100,8 @@ public class AutomaticSubmissionService {
     }
 
     /**
-     * Updates the participation for a given submission. The participation is set to FINISHED. Currently only handles modeling submissions.
+     * Updates the participation for a given submission. The participation is set to FINISHED. In the case of a modeling exercise Compass is additionally notified about the new
+     * submission.
      *
      * @param submission the submission for which the participation should be updated for
      * @return submission if updating participation successful, otherwise null

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
@@ -56,7 +56,7 @@ public class AutomaticSubmissionService {
      * true (without changing the submission date) and the submissionType to TIMEOUT. We also set the initialization state of the corresponding participation to FINISHED. - If no,
      * we ignore the submission. This is executed every night at 1:00:00 am by the cron job.
      */
-    @Scheduled(cron = "0 0 1 * * *")
+    @Scheduled(cron = "*/20 * * * * *")
     @Transactional
     public void run() {
         // global try-catch for error logging

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
@@ -56,7 +56,7 @@ public class AutomaticSubmissionService {
      * true (without changing the submission date) and the submissionType to TIMEOUT. We also set the initialization state of the corresponding participation to FINISHED. - If no,
      * we ignore the submission. This is executed every night at 1:00:00 am by the cron job.
      */
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "0 0 1 * * *")
     @Transactional
     public void run() {
         // global try-catch for error logging

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticSubmissionService.java
@@ -52,9 +52,9 @@ public class AutomaticSubmissionService {
     }
 
     /**
-     * Check for every un-submitted modeling and text submissions if the corresponding exercise has finished (i.e. due date < now). - If yes, we set the submission to submitted =
-     * true (without changing the submission date) and the submissionType to TIMEOUT. We also set the initialization state of the corresponding participation to FINISHED. - If no,
-     * we ignore the submission. This is executed every night at 1:00:00 am by the cron job.
+     * Check for every un-submitted modeling and text submission if the corresponding exercise has finished (i.e. due date < now) and the submission was saved before the exercise
+     * due date. - If yes, we set the submission to submitted = true (without changing the submission date) and the submissionType to TIMEOUT. We also set the initialization state
+     * of the corresponding participation to FINISHED. - If no, we ignore the submission. This is executed every night at 1:00:00 am by the cron job.
      */
     @Scheduled(cron = "*/20 * * * * *")
     @Transactional
@@ -69,10 +69,12 @@ public class AutomaticSubmissionService {
 
                 Exercise exercise = unsubmittedSubmission.getParticipation().getExercise();
 
-                if (exercise.isEnded()) {
-                    unsubmittedSubmission.setSubmitted(true);
-                    unsubmittedSubmission.setType(SubmissionType.TIMEOUT);
+                if (!exercise.isEnded() || unsubmittedSubmission.getSubmissionDate() == null || unsubmittedSubmission.getSubmissionDate().isAfter(exercise.getDueDate())) {
+                    continue;
                 }
+
+                unsubmittedSubmission.setSubmitted(true);
+                unsubmittedSubmission.setType(SubmissionType.TIMEOUT);
 
                 updateParticipation(unsubmittedSubmission);
 

--- a/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.html
+++ b/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.html
@@ -19,7 +19,7 @@
             <span *ngIf="isAuthorized" class="text-danger ml-3" style="font-size: 65%" jhiTranslate="modelingAssessmentEditor.assessmentLockedCurrentUser">
                 You have the lock for this assessment
             </span>
-            <div *ngIf="!result?.rated">
+            <div *ngIf="!result?.completionDate">
                 <button class="btn btn-primary" (click)="onSaveAssessment()" [disabled]="!assessmentsAreValid || !isAuthorized">
                     <fa-icon icon="save"></fa-icon>
                     <span jhiTranslate="entity.action.save">Save</span>
@@ -37,13 +37,13 @@
             </div>
             <button
                 class="btn btn-danger"
-                *ngIf="result?.rated && (isAtLeastInstructor || isAuthorized)"
+                *ngIf="result?.completionDate && (isAtLeastInstructor || isAuthorized)"
                 (click)="onSubmitAssessment()"
                 [disabled]="!assessmentsAreValid || !isAtLeastInstructor"
             >
                 <span jhiTranslate="modelingAssessmentEditor.button.overrideAssessment">Override Assessment</span>
             </button>
-            <button class="btn btn-success" *ngIf="result?.rated && isAuthorized" [disabled]="busy" (click)="assessNextOptimal()">
+            <button class="btn btn-success" *ngIf="result?.completionDate && isAuthorized" [disabled]="busy" (click)="assessNextOptimal()">
                 <fa-icon *ngIf="busy" icon="spinner" [spin]="true">&nbsp;</fa-icon>
                 <span jhiTranslate="modelingAssessmentEditor.button.nextSubmission"> Next Submission</span>
             </button>

--- a/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -144,7 +144,7 @@ export class ModelingAssessmentEditorComponent implements OnInit, OnDestroy {
             this.jhiAlertService.clear();
             this.jhiAlertService.error('modelingAssessmentEditor.messages.noModel');
         }
-        if ((this.result.assessor == null || this.result.assessor.id === this.userId) && !this.result.rated) {
+        if ((this.result.assessor == null || this.result.assessor.id === this.userId) && !this.result.completionDate) {
             this.jhiAlertService.clear();
             this.jhiAlertService.info('modelingAssessmentEditor.messages.lock');
         }

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -154,7 +154,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                     this.umlModel = JSON.parse(this.submission.model);
                     this.hasElements = this.umlModel.elements && this.umlModel.elements.length !== 0;
                 }
-                if (this.submission.result && this.submission.result.rated) {
+                if (this.submission.result && this.submission.result.completionDate) {
                     this.modelingAssessmentService.getAssessment(this.submission.id).subscribe((assessmentResult: Result) => {
                         this.assessmentResult = assessmentResult;
                         this.prepareAssessmentData();

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -148,6 +148,8 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         this.websocketChannel = '/user/topic/modelingSubmission/' + this.submission.id;
         this.jhiWebsocketService.subscribe(this.websocketChannel);
         this.jhiWebsocketService.receive(this.websocketChannel).subscribe(submission => {
+            console.log('automatically submitted');
+            console.log(submission);
             if (submission.submitted) {
                 this.submission = submission;
                 if (this.submission.model) {

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -148,8 +148,6 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         this.websocketChannel = '/user/topic/modelingSubmission/' + this.submission.id;
         this.jhiWebsocketService.subscribe(this.websocketChannel);
         this.jhiWebsocketService.receive(this.websocketChannel).subscribe(submission => {
-            console.log('automatically submitted');
-            console.log(submission);
             if (submission.submitted) {
                 this.submission = submission;
                 if (this.submission.model) {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The automatic submission service that was re-enabled in https://github.com/ls1intum/ArTEMiS/pull/393 did not work properly.

### Description
<!-- Describe your changes in detail -->
The problem was that the service also loaded example submissions that do not have an associated participation. The missing participation then caused a NullPointerException. I fixed it by excluding submissions that do not have a participation associated when loading the submissions from the database.