### PR TITLE
Check if group name is set before granting permission.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -404,9 +404,15 @@ public class BitbucketService implements VersionControlService {
         try {
             restTemplate.exchange(BITBUCKET_SERVER_URL + "/rest/api/1.0/projects", HttpMethod.POST, entity, Map.class);
             grantGroupPermissionToProject(projectKey, ADMIN_GROUP_NAME, "PROJECT_ADMIN"); // admins get administrative permissions
-            grantGroupPermissionToProject(projectKey, programmingExercise.getCourse().getInstructorGroupName(), "PROJECT_ADMIN"); // instructors get administrative permissions
-            grantGroupPermissionToProject(projectKey, programmingExercise.getCourse().getTeachingAssistantGroupName(), "PROJECT_WRITE"); // teachingAssistants get write-permissions
 
+            if (programmingExercise.getCourse().getInstructorGroupName() != null && !programmingExercise.getCourse().getInstructorGroupName().isEmpty()) {
+                grantGroupPermissionToProject(projectKey, programmingExercise.getCourse().getInstructorGroupName(), "PROJECT_ADMIN"); // instructors get administrative permissions
+            }
+
+            if (programmingExercise.getCourse().getTeachingAssistantGroupName() != null && !programmingExercise.getCourse().getTeachingAssistantGroupName().isEmpty()) {
+                grantGroupPermissionToProject(projectKey, programmingExercise.getCourse().getTeachingAssistantGroupName(), "PROJECT_WRITE"); // teachingAssistants get
+                                                                                                                                             // write-permissions
+            }
         }
         catch (HttpClientErrorException e) {
             log.error("Could not create Bitbucket project {} with key {}", projectName, projectKey, e);


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I added (end-to-end) test cases for the new functionality.

### Motivation and Context
Check if instructor/teaching assistant group name is set before granting permission.

This fixes an issue with programming exercises that can't be created due to not set teaching-assistants group.

### Steps for Testing
1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Create/Edit a course to not have a teaching-assistant group set
4. Try to create a programming exercise in that course-
