### PR TITLE
Hotfix/hints and explanations not showing up after saving

### DIFF
--- a/src/main/webapp/app/components/util/markdown.service.ts
+++ b/src/main/webapp/app/components/util/markdown.service.ts
@@ -75,9 +75,9 @@ export class ArtemisMarkdown {
      * @return {string}
      */
     generateTextHintExplanation(sourceObject: MarkDownElement) {
-        return sourceObject.text
-            ? sourceObject.text
-            : '' +
+        return !sourceObject.text
+            ? ''
+            : sourceObject.text +
                   (sourceObject.hint ? '\n\t' + HintCommand.identifier + ' ' + sourceObject.hint : '') +
                   (sourceObject.explanation ? '\n\t' + ExplanationCommand.identifier + ' ' + sourceObject.explanation : '');
     }

--- a/src/main/webapp/app/quiz/edit/multiple-choice-question/edit-multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/edit/multiple-choice-question/edit-multiple-choice-question.component.ts
@@ -131,13 +131,13 @@ export class EditMultipleChoiceQuestionComponent implements OnInit, EditQuizQues
                 currentAnswerOption.text = text;
                 this.question.answerOptions.push(currentAnswerOption);
             } else if (command instanceof ExplanationCommand) {
-                if (currentAnswerOption != null) {
+                if (currentAnswerOption.isCorrect !== undefined) {
                     currentAnswerOption.explanation = text;
                 } else {
                     this.question.explanation = text;
                 }
             } else if (command instanceof HintCommand) {
-                if (currentAnswerOption != null) {
+                if (currentAnswerOption.isCorrect !== undefined) {
                     currentAnswerOption.hint = text;
                 } else {
                     this.question.hint = text;

--- a/src/main/webapp/app/quiz/edit/multiple-choice-question/edit-multiple-choice-question.component.ts
+++ b/src/main/webapp/app/quiz/edit/multiple-choice-question/edit-multiple-choice-question.component.ts
@@ -115,7 +115,7 @@ export class EditMultipleChoiceQuestionComponent implements OnInit, EditQuizQues
      */
     domainCommandsFound(domainCommands: [string, DomainCommand][]): void {
         this.cleanupQuestion();
-        let currentAnswerOption = new AnswerOption();
+        let currentAnswerOption;
 
         for (const [text, command] of domainCommands) {
             if (command === null && text.length > 0) {
@@ -131,13 +131,13 @@ export class EditMultipleChoiceQuestionComponent implements OnInit, EditQuizQues
                 currentAnswerOption.text = text;
                 this.question.answerOptions.push(currentAnswerOption);
             } else if (command instanceof ExplanationCommand) {
-                if (currentAnswerOption.isCorrect !== undefined) {
+                if (currentAnswerOption) {
                     currentAnswerOption.explanation = text;
                 } else {
                     this.question.explanation = text;
                 }
             } else if (command instanceof HintCommand) {
-                if (currentAnswerOption.isCorrect !== undefined) {
+                if (currentAnswerOption) {
                     currentAnswerOption.hint = text;
                 } else {
                     this.question.hint = text;


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [ ] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] ~I added (end-to-end) test cases for the new functionality.~

### Description
After saving a multiple choice question, hints/explanation would disappear from editor.
D&D and short answer questions are also concerned.

There are two issues that are fixed in this PR:
- Hint/Exp for question: It was not possible until now to create a hint/exp for the complete question (even though this seems to have been supposed to be a feature)
- Hint/Exp for answerOption: Hints/Exps were only generated for answerOptions without a text

Note:
Hint/Exp for questions need to be added before the answerOptions, redundant hints/exps will be removed. See screenshot for a correct setup.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Create a new quiz, create a multiple choice question inside
3. Add a hint and/or explanation
4. Save and make sure the hint and/or explanation are still visible in editor

### Screenshots
![image](https://user-images.githubusercontent.com/28230611/57805541-6e6fdf00-775d-11e9-8413-aae513ccb2b6.png)
