### PR TITLE
Fix modeling assessment layout issue on small window

### DIFF
--- a/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.html
+++ b/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.html
@@ -52,7 +52,7 @@
     <div class="alert alert-info" *ngIf="hasComplaint" jhiTranslate="arTeMiSApp.complaint.hint">
         You find the complaint at the end of the page
     </div>
-    <div class="editor-container">
+    <div class="editor-container flex-grow-1">
         <jhi-modeling-assessment
             *ngIf="submission"
             [diagramType]="modelingExercise.diagramType"

--- a/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.scss
+++ b/src/main/webapp/app/modeling-assessment-editor/modeling-assessment-editor.component.scss
@@ -22,7 +22,7 @@ $titlebar-height: 65px;
 
 .assessment-container {
     display: flex;
-    height: calc(100vh - 173px);
+    min-height: calc(100vh - 173px);
     flex-flow: column nowrap;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
<!-- Describe your changes in detail -->
On small browser windows the submission and instructions panel are not properly visible in the modeling assessment view as the height was fixed to the window height minus footer/header. I changed the fixed height to a minimum height resulting in a scrollable page on small windows.

### Screenshots
<!-- If applicable, add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Modeling Assessment Layout Issue
![Modeling Assessment Layout Issue](https://user-images.githubusercontent.com/5919138/58087089-2c60f600-7bc0-11e9-8314-0d906a957034.JPG)

Fixed Layout
![Modeling Assessment Layout Issue - Fix 01](https://user-images.githubusercontent.com/5919138/58087135-3f73c600-7bc0-11e9-9fd7-ae4a04b3692a.JPG)
![Modeling Assessment Layout Issue - Fix 02](https://user-images.githubusercontent.com/5919138/58087136-3f73c600-7bc0-11e9-8e50-f382eaadc810.JPG)

