### PR TITLE
Fix Apollon Element Ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "@fortawesome/fontawesome-svg-core": "1.2.18",
         "@fortawesome/free-regular-svg-icons": "5.8.2",
         "@fortawesome/free-solid-svg-icons": "5.8.2",
-        "@ls1intum/apollon": "2.0.0-rc.8",
+        "@ls1intum/apollon": "2.0.0-rc.9",
         "@ng-bootstrap/ng-bootstrap": "4.1.2",
         "@nguniversal/express-engine": "7.1.1",
         "@ngx-translate/core": "11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,10 +615,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@ls1intum/apollon@2.0.0-rc.8":
-  version "2.0.0-rc.8"
-  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.0-rc.8.tgz#889cf79aa565448ae144bc819ef9586bc3961d78"
-  integrity sha512-gtJ7Eq4T6Nzd679J+FW6QJ2z/2NpmiW64o5EqAwsA91eX+U8HiQMuWS1r9QS59FdynNxy1n2ZJ0y6Wsr2Ss7ew==
+"@ls1intum/apollon@2.0.0-rc.9":
+  version "2.0.0-rc.9"
+  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.0-rc.9.tgz#4a77bcdf4432291e306dcd2e48540f8bcfcb773d"
+  integrity sha512-DvkUpVtOA1Ls7s5p/n0TTiUb6Bskrw4naQP8BbLXeZuOrCpivNGTJc6lMcmI3XKlPOzyM1J4NefSDLpqxq7yug==
   dependencies:
     pepjs "0.5.2"
     react "16.8.6"


### PR DESCRIPTION
### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context

Apparently, the z-index of elements sometimes lead to unexpected behaviour regarding the visualisation of diagrams in Apollon. This PR prevents the issue that some elements are overlapped completely by bigger elements.

### Description

To solve the issue in https://github.com/ls1intum/ArTEMiS/issues/479 we reorder elements for the visualisation regarding their size. Smaller elements are rendered now on top of bigger ones. To prevent this issue in the future, we adjusted the export of newly created diagrams to handle the z-index ordering of elements correctly, meaning Apollon now exports the same order as it was used during modeling.
