### PR TITLE
Bugfix/Fix console errors in code-editor caused by markdown rendering

### DIFF
--- a/src/main/webapp/app/code-editor/build-output/code-editor-build-output.component.ts
+++ b/src/main/webapp/app/code-editor/build-output/code-editor-build-output.component.ts
@@ -9,7 +9,7 @@ import * as $ from 'jquery';
 import { BuildLogEntryArray } from '../../entities/build-log';
 import { Feedback } from 'app/entities/feedback';
 import { Observable, Subscription } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, filter, map } from 'rxjs/operators';
 import Interactable from '@interactjs/core/Interactable';
 import interact from 'interactjs';
 
@@ -103,8 +103,10 @@ export class CodeEditorBuildOutputComponent implements AfterViewInit, OnChanges,
         if (this.resultSubscription) {
             this.resultSubscription.unsubscribe();
         }
+        this.participationWebsocketService.addParticipation(this.participation);
         this.resultSubscription = this.participationWebsocketService
             .subscribeForLatestResultOfParticipation(this.participation.id)
+            .pipe(filter(participation => !!participation))
             .subscribe((result: Result) => this.toggleBuildLogs(result));
     }
 

--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
@@ -149,10 +149,14 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
         if (this.participationSubscription) {
             this.participationSubscription.unsubscribe();
         }
-        this.participationSubscription = this.participationWebsocketService.subscribeForLatestResultOfParticipation(this.participation.id).subscribe((result: Result) => {
-            this.latestResult = result;
-            this.updateMarkdown();
-        });
+        this.participationWebsocketService.addParticipation(this.participation);
+        this.participationSubscription = this.participationWebsocketService
+            .subscribeForLatestResultOfParticipation(this.participation.id)
+            .pipe(filter(participation => !!participation))
+            .subscribe((result: Result) => {
+                this.latestResult = result;
+                this.updateMarkdown();
+            });
     }
 
     /**
@@ -178,12 +182,12 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
         this.steps = [];
         this.plantUMLs = {};
         this.renderedMarkdown = this.markdown.render(this.exercise.problemStatement);
-        // For whatever reason, we have to wait a tick here. The markdown parser should be synchronous...
+        // Wait for re-render of component
         setTimeout(() => {
             this.loadAndInsertPlantUmls();
             this.setUpClickListeners();
             this.setUpTaskIcons();
-        }, 100);
+        }, 0);
     }
 
     /**


### PR DESCRIPTION
…rs methods before component initialization

<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] ~I added (end-to-end) test cases for the new functionality.~

### Description
This fixes a couple of errors in Sentry, as the innerHtml of the instructions was sometimes not ready when the task icons, etc. weren't setup yet.
The main issue is that the initial null result of the participation websocket service was not filtered and I had a timeout of 100 ms in before rendering the markup (a tick is enough to wait for angular to render the html).
While I was at it I also corrected the initialization of the websocket participation service in the build output component.

### Steps for Testing

1. Log in to ArTEMiS
2. Open the code-editor / programming exercise view/dialog/update (all the components that contain the programming exercise instructions)
3. => No errors should show up in console
