### PR TITLE
#520: proper count of number of submissions for statistics purposes

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ModelingSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ModelingSubmissionRepository.java
@@ -38,15 +38,17 @@ public interface ModelingSubmissionRepository extends JpaRepository<ModelingSubm
 
     /**
      * @param courseId the course id we are interested in
-     * @return the number of submissions belonging to the course id, which have the submitted flag set to true and the submission date before the exercise due date
+     * @return the number of submissions belonging to the course id, which have the submitted flag set to true and the submission date before the exercise due date, or no exercise
+     *         due date at all
      */
-    @Query("SELECT COUNT (DISTINCT submission) FROM ModelingSubmission submission WHERE submission.participation.exercise.course.id = :#{#courseId} AND submission.submitted = TRUE AND submission.submissionDate < submission.participation.exercise.dueDate")
+    @Query("SELECT COUNT (DISTINCT submission) FROM ModelingSubmission submission WHERE submission.participation.exercise.course.id = :#{#courseId} AND submission.submitted = TRUE AND (submission.submissionDate < submission.participation.exercise.dueDate OR submission.participation.exercise.dueDate IS NULL)")
     long countByCourseIdSubmittedBeforeDueDate(@Param("courseId") Long courseId);
 
     /**
      * @param exerciseId the exercise id we are interested in
-     * @return the number of submissions belonging to the exercise id, which have the submitted flag set to true and the submission date before the exercise due date
+     * @return the number of submissions belonging to the exercise id, which have the submitted flag set to true and the submission date before the exercise due date, or no
+     *         exercise due date at all
      */
-    @Query("SELECT COUNT (DISTINCT submission) FROM ModelingSubmission submission WHERE submission.participation.exercise.id = :#{#exerciseId} AND submission.submitted = TRUE AND submission.submissionDate < submission.participation.exercise.dueDate")
+    @Query("SELECT COUNT (DISTINCT submission) FROM ModelingSubmission submission WHERE submission.participation.exercise.id = :#{#exerciseId} AND submission.submitted = TRUE AND (submission.submissionDate < submission.participation.exercise.dueDate OR submission.participation.exercise.dueDate IS NULL)")
     long countByExerciseIdSubmittedBeforeDueDate(@Param("exerciseId") Long exerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ModelingSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ModelingSubmissionRepository.java
@@ -35,4 +35,18 @@ public interface ModelingSubmissionRepository extends JpaRepository<ModelingSubm
      * @return number of submissions belonging to courseId with submitted status
      */
     long countByParticipation_Exercise_Course_IdAndSubmitted(Long courseId, boolean submitted);
+
+    /**
+     * @param courseId the course id we are interested in
+     * @return the number of submissions belonging to the course id, which have the submitted flag set to true and the submission date before the exercise due date
+     */
+    @Query("SELECT COUNT (DISTINCT submission) FROM ModelingSubmission submission WHERE submission.participation.exercise.course.id = :#{#courseId} AND submission.submitted = TRUE AND submission.submissionDate < submission.participation.exercise.dueDate")
+    long countByCourseIdSubmittedBeforeDueDate(@Param("courseId") Long courseId);
+
+    /**
+     * @param exerciseId the exercise id we are interested in
+     * @return the number of submissions belonging to the exercise id, which have the submitted flag set to true and the submission date before the exercise due date
+     */
+    @Query("SELECT COUNT (DISTINCT submission) FROM ModelingSubmission submission WHERE submission.participation.exercise.id = :#{#exerciseId} AND submission.submitted = TRUE AND submission.submissionDate < submission.participation.exercise.dueDate")
+    long countByExerciseIdSubmittedBeforeDueDate(@Param("exerciseId") Long exerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
@@ -19,15 +19,20 @@ public interface TextSubmissionRepository extends JpaRepository<TextSubmission, 
 
     List<TextSubmission> findByIdIn(List<Long> textSubmissionsId);
 
-    long countBySubmittedAndParticipation_Exercise_Id(boolean submitted, long exerciseId);
-
-    /**
-     * @param courseId  the course we are interested in
-     * @param submitted boolean to check if an exercise has been submitted or not
-     * @return number of submissions belonging to courseId with submitted status
-     */
-    long countByParticipation_Exercise_Course_IdAndSubmitted(Long courseId, boolean submitted);
-
     @Query("select distinct submission from TextSubmission submission left join fetch submission.result r left join fetch r.assessor where submission.id = :#{#submissionId}")
     Optional<TextSubmission> findByIdWithEagerResultAndAssessor(@Param("submissionId") Long submissionId);
+
+    /**
+     * @param courseId the course id we are interested in
+     * @return the number of submissions belonging to the course id, which have the submitted flag set to true and the submission date before the exercise due date
+     */
+    @Query("SELECT COUNT (DISTINCT textSubmission) FROM TextSubmission textSubmission WHERE textSubmission.participation.exercise.course.id = :#{#courseId} AND textSubmission.submitted = TRUE AND textSubmission.submissionDate < textSubmission.participation.exercise.dueDate")
+    long countByCourseIdSubmittedBeforeDueDate(@Param("courseId") Long courseId);
+
+    /**
+     * @param exerciseId the exercise id we are interested in
+     * @return the number of submissions belonging to the exercise id, which have the submitted flag set to true and the submission date before the exercise due date
+     */
+    @Query("SELECT COUNT (DISTINCT textSubmission) FROM TextSubmission textSubmission WHERE textSubmission.participation.exercise.id = :#{#exerciseId} AND textSubmission.submitted = TRUE AND textSubmission.submissionDate < textSubmission.participation.exercise.dueDate")
+    long countByExerciseIdSubmittedBeforeDueDate(@Param("exerciseId") Long exerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
@@ -24,15 +24,17 @@ public interface TextSubmissionRepository extends JpaRepository<TextSubmission, 
 
     /**
      * @param courseId the course id we are interested in
-     * @return the number of submissions belonging to the course id, which have the submitted flag set to true and the submission date before the exercise due date
+     * @return the number of submissions belonging to the course id, which have the submitted flag set to true and the submission date before the exercise due date or no exercise
+     *         due date at all
      */
-    @Query("SELECT COUNT (DISTINCT textSubmission) FROM TextSubmission textSubmission WHERE textSubmission.participation.exercise.course.id = :#{#courseId} AND textSubmission.submitted = TRUE AND textSubmission.submissionDate < textSubmission.participation.exercise.dueDate")
+    @Query("SELECT COUNT (DISTINCT textSubmission) FROM TextSubmission textSubmission WHERE textSubmission.participation.exercise.course.id = :#{#courseId} AND textSubmission.submitted = TRUE AND (textSubmission.submissionDate < textSubmission.participation.exercise.dueDate OR textSubmission.participation.exercise.dueDate IS NULL)")
     long countByCourseIdSubmittedBeforeDueDate(@Param("courseId") Long courseId);
 
     /**
      * @param exerciseId the exercise id we are interested in
-     * @return the number of submissions belonging to the exercise id, which have the submitted flag set to true and the submission date before the exercise due date
+     * @return the number of submissions belonging to the exercise id, which have the submitted flag set to true and the submission date before the exercise due date or no exercise
+     *         due date at all
      */
-    @Query("SELECT COUNT (DISTINCT textSubmission) FROM TextSubmission textSubmission WHERE textSubmission.participation.exercise.id = :#{#exerciseId} AND textSubmission.submitted = TRUE AND textSubmission.submissionDate < textSubmission.participation.exercise.dueDate")
+    @Query("SELECT COUNT (DISTINCT textSubmission) FROM TextSubmission textSubmission WHERE textSubmission.participation.exercise.id = :#{#exerciseId} AND textSubmission.submitted = TRUE AND (textSubmission.submissionDate < textSubmission.participation.exercise.dueDate OR textSubmission.participation.exercise.dueDate IS NULL)")
     long countByExerciseIdSubmittedBeforeDueDate(@Param("exerciseId") Long exerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -289,4 +289,22 @@ public class ModelingSubmissionService {
             modelingSubmissionRepository.save(modelingSubmission);
         }
     }
+
+    /**
+     * @param courseId the course we are interested in
+     * @return the number of text submissions which should be assessed, so we ignore the ones after the exercise due date
+     */
+    @Transactional(readOnly = true)
+    public long countSubmissionsToAssessByCourseId(Long courseId) {
+        return modelingSubmissionRepository.countByCourseIdSubmittedBeforeDueDate(courseId);
+    }
+
+    /**
+     * @param exerciseId the exercise we are interested in
+     * @return the number of text submissions which should be assessed, so we ignore the ones after the exercise due date
+     */
+    @Transactional(readOnly = true)
+    public long countSubmissionsToAssessByExerciseId(Long exerciseId) {
+        return modelingSubmissionRepository.countByExerciseIdSubmittedBeforeDueDate(exerciseId);
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -35,8 +36,6 @@ public class ResultService {
 
     private final ResultRepository resultRepository;
 
-    private final FeedbackService feedbackService;
-
     private final Optional<ContinuousIntegrationService> continuousIntegrationService;
 
     private final LtiService ltiService;
@@ -45,11 +44,10 @@ public class ResultService {
 
     private final ObjectMapper objectMapper;
 
-    public ResultService(UserService userService, ParticipationService participationService, FeedbackService feedbackService, ResultRepository resultRepository,
+    public ResultService(UserService userService, ParticipationService participationService, ResultRepository resultRepository,
             Optional<ContinuousIntegrationService> continuousIntegrationService, LtiService ltiService, SimpMessageSendingOperations messagingTemplate, ObjectMapper objectMapper) {
         this.userService = userService;
         this.participationService = participationService;
-        this.feedbackService = feedbackService;
         this.resultRepository = resultRepository;
         this.continuousIntegrationService = continuousIntegrationService;
         this.ltiService = ltiService;
@@ -168,6 +166,51 @@ public class ResultService {
 
     public List<Result> findByCourseId(Long courseId) {
         return resultRepository.findAllByParticipation_Exercise_CourseId(courseId);
+    }
+
+    /**
+     * Given a courseId, return the number of assessments for that course that have been completed (e.g. no draft!)
+     *
+     * @param courseId - the course we are interested in
+     * @return a number of assessments for the course
+     */
+    public long countNumberOfAssessments(Long courseId) {
+        return resultRepository.countByAssessorIsNotNullAndParticipation_Exercise_CourseIdAndRatedAndCompletionDateIsNotNull(courseId, true);
+    }
+
+    /**
+     * Given a courseId and a tutorId, return the number of assessments for that course written by that tutor that have been completed (e.g. no draft!)
+     *
+     * @param courseId - the course we are interested in
+     * @param tutorId  - the tutor we are interested in
+     * @return a number of assessments for the course
+     */
+    @Transactional(readOnly = true)
+    public long countNumberOfAssessmentsForTutor(Long courseId, Long tutorId) {
+        return resultRepository.countByAssessor_IdAndParticipation_Exercise_CourseIdAndRatedAndCompletionDateIsNotNull(tutorId, courseId, true);
+    }
+
+    /**
+     * Given an exerciseId, return the number of assessments for that exerciseId that have been completed (e.g. no draft!)
+     *
+     * @param exerciseId - the exercise we are interested in
+     * @return a number of assessments for the exercise
+     */
+    @Transactional(readOnly = true)
+    public long countNumberOfAssessmentsForExercise(Long exerciseId) {
+        return resultRepository.countByAssessorIsNotNullAndParticipation_ExerciseIdAndRatedAndCompletionDateIsNotNull(exerciseId, true);
+    }
+
+    /**
+     * Given a exerciseId and a tutorId, return the number of assessments for that exercise written by that tutor that have been completed (e.g. no draft!)
+     *
+     * @param exerciseId - the exercise we are interested in
+     * @param tutorId    - the tutor we are interested in
+     * @return a number of assessments for the exercise
+     */
+    @Transactional(readOnly = true)
+    public long countNumberOfAssessmentsForTutorInExercise(Long exerciseId, Long tutorId) {
+        return resultRepository.countByAssessor_IdAndParticipation_ExerciseIdAndRatedAndCompletionDateIsNotNull(tutorId, exerciseId, true);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
@@ -115,46 +115,4 @@ public class TextAssessmentService extends AssessmentService {
     private Double calculateTotalScore(List<Feedback> assessments) {
         return assessments.stream().mapToDouble(Feedback::getCredits).sum();
     }
-
-    /**
-     * Given a courseId, return the number of assessments for that course that have been completed (e.g. no draft!)
-     *
-     * @param courseId - the course we are interested in
-     * @return a number of assessments for the course
-     */
-    public long countNumberOfAssessments(Long courseId) {
-        return resultRepository.countByAssessorIsNotNullAndParticipation_Exercise_CourseIdAndRatedAndCompletionDateIsNotNull(courseId, true);
-    }
-
-    /**
-     * Given a courseId and a tutorId, return the number of assessments for that course written by that tutor that have been completed (e.g. no draft!)
-     *
-     * @param courseId - the course we are interested in
-     * @param tutorId  - the tutor we are interested in
-     * @return a number of assessments for the course
-     */
-    public long countNumberOfAssessmentsForTutor(Long courseId, Long tutorId) {
-        return resultRepository.countByAssessor_IdAndParticipation_Exercise_CourseIdAndRatedAndCompletionDateIsNotNull(tutorId, courseId, true);
-    }
-
-    /**
-     * Given an exerciseId, return the number of assessments for that exerciseId that have been completed (e.g. no draft!)
-     *
-     * @param exerciseId - the exercise we are interested in
-     * @return a number of assessments for the exercise
-     */
-    public long countNumberOfAssessmentsForExercise(Long exerciseId) {
-        return resultRepository.countByAssessorIsNotNullAndParticipation_ExerciseIdAndRatedAndCompletionDateIsNotNull(exerciseId, true);
-    }
-
-    /**
-     * Given a exerciseId and a tutorId, return the number of assessments for that exercise written by that tutor that have been completed (e.g. no draft!)
-     *
-     * @param exerciseId - the exercise we are interested in
-     * @param tutorId    - the tutor we are interested in
-     * @return a number of assessments for the exercise
-     */
-    public long countNumberOfAssessmentsForTutorInExercise(Long exerciseId, Long tutorId) {
-        return resultRepository.countByAssessor_IdAndParticipation_ExerciseIdAndRatedAndCompletionDateIsNotNull(tutorId, exerciseId, true);
-    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -214,10 +214,20 @@ public class TextSubmissionService {
     }
 
     /**
-     * @param id the exercise we are interested in
-     * @return the number of submitted submissions for the exercise passed as argument
+     * @param courseId the course we are interested in
+     * @return the number of text submissions which should be assessed, so we ignore the ones after the exercise due date
      */
-    public long countSubmittedSubmissionsForExerciseId(Long id) {
-        return textSubmissionRepository.countBySubmittedAndParticipation_Exercise_Id(true, id);
+    @Transactional(readOnly = true)
+    public long countSubmissionsToAssessByCourseId(Long courseId) {
+        return textSubmissionRepository.countByCourseIdSubmittedBeforeDueDate(courseId);
+    }
+
+    /**
+     * @param exerciseId the exercise we are interested in
+     * @return the number of text submissions which should be assessed, so we ignore the ones after the exercise due date
+     */
+    @Transactional(readOnly = true)
+    public long countSubmissionsToAssessByExerciseId(Long exerciseId) {
+        return textSubmissionRepository.countByExerciseIdSubmittedBeforeDueDate(exerciseId);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -82,16 +82,18 @@ public class CourseResource {
 
     private final NotificationService notificationService;
 
-    private final TextSubmissionRepository textSubmissionRepository;
+    private final TextSubmissionService textSubmissionService;
 
-    private final ModelingSubmissionRepository modelingSubmissionRepository;
+    private final ModelingSubmissionService modelingSubmissionService;
+
+    private final ResultService resultService;
 
     public CourseResource(Environment env, UserService userService, CourseService courseService, ParticipationService participationService, CourseRepository courseRepository,
             ExerciseService exerciseService, AuthorizationCheckService authCheckService, TutorParticipationService tutorParticipationService,
             MappingJackson2HttpMessageConverter springMvcJacksonConverter, Optional<ArtemisAuthenticationProvider> artemisAuthenticationProvider,
-            TextAssessmentService textAssessmentService, SubmissionRepository submissionRepository, ComplaintRepository complaintRepository,
-            ComplaintResponseRepository complaintResponseRepository, LectureService lectureService, NotificationService notificationService,
-            TextSubmissionRepository textSubmissionRepository, ModelingSubmissionRepository modelingSubmissionRepository) {
+            TextAssessmentService textAssessmentService, ComplaintRepository complaintRepository, ComplaintResponseRepository complaintResponseRepository,
+            LectureService lectureService, NotificationService notificationService, TextSubmissionService textSubmissionService,
+            ModelingSubmissionService modelingSubmissionService, ResultService resultService) {
         this.env = env;
         this.userService = userService;
         this.courseService = courseService;
@@ -107,8 +109,9 @@ public class CourseResource {
         this.complaintResponseRepository = complaintResponseRepository;
         this.lectureService = lectureService;
         this.notificationService = notificationService;
-        this.textSubmissionRepository = textSubmissionRepository;
-        this.modelingSubmissionRepository = modelingSubmissionRepository;
+        this.textSubmissionService = textSubmissionService;
+        this.modelingSubmissionService = modelingSubmissionService;
+        this.resultService = resultService;
     }
 
     /**
@@ -365,14 +368,14 @@ public class CourseResource {
             return forbidden();
         User user = userService.getUserWithGroupsAndAuthorities();
 
-        long numberOfSubmissions = textSubmissionRepository.countByParticipation_Exercise_Course_IdAndSubmitted(courseId, true);
-        numberOfSubmissions += modelingSubmissionRepository.countByParticipation_Exercise_Course_IdAndSubmitted(courseId, true);
+        long numberOfSubmissions = textSubmissionService.countSubmissionsToAssessByCourseId(courseId);
+        numberOfSubmissions += modelingSubmissionService.countSubmissionsToAssessByCourseId(courseId);
         data.set("numberOfSubmissions", objectMapper.valueToTree(numberOfSubmissions));
 
-        long numberOfAssessments = textAssessmentService.countNumberOfAssessments(courseId);
+        long numberOfAssessments = resultService.countNumberOfAssessments(courseId);
         data.set("numberOfAssessments", objectMapper.valueToTree(numberOfAssessments));
 
-        long numberOfTutorAssessments = textAssessmentService.countNumberOfAssessmentsForTutor(courseId, user.getId());
+        long numberOfTutorAssessments = resultService.countNumberOfAssessmentsForTutor(courseId, user.getId());
         data.set("numberOfTutorAssessments", objectMapper.valueToTree(numberOfTutorAssessments));
 
         long numberOfComplaints = complaintRepository.countByResult_Participation_Exercise_Course_IdAndResult_Assessor_Id(courseId, user.getId());
@@ -489,11 +492,11 @@ public class CourseResource {
         stats.numberOfComplaints = numberOfComplaints;
         stats.numberOfOpenComplaints = numberOfComplaints - numberOfComplaintResponses;
 
-        long numberOfSubmissions = textSubmissionRepository.countByParticipation_Exercise_Course_IdAndSubmitted(courseId, true);
-        numberOfSubmissions += modelingSubmissionRepository.countByParticipation_Exercise_Course_IdAndSubmitted(courseId, true);
+        long numberOfSubmissions = textSubmissionService.countSubmissionsToAssessByCourseId(courseId);
+        numberOfSubmissions += modelingSubmissionService.countSubmissionsToAssessByCourseId(courseId);
 
         stats.numberOfSubmissions = numberOfSubmissions;
-        stats.numberOfAssessments = textAssessmentService.countNumberOfAssessments(courseId);
+        stats.numberOfAssessments = resultService.countNumberOfAssessments(courseId);
 
         stats.tutorLeaderboard = textAssessmentService.calculateTutorLeaderboardForCourse(courseId);
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -43,8 +43,6 @@ public class ExerciseResource {
 
     private static final String ENTITY_NAME = "exercise";
 
-    private final ExerciseRepository exerciseRepository;
-
     private final ExerciseService exerciseService;
 
     private final UserService userService;
@@ -69,13 +67,17 @@ public class ExerciseResource {
 
     private final ComplaintRepository complaintRepository;
 
-    private final SubmissionRepository submissionRepository;
+    private final TextSubmissionService textSubmissionService;
 
-    public ExerciseResource(ExerciseRepository exerciseRepository, ExerciseService exerciseService, ParticipationService participationService, UserService userService,
-            CourseService courseService, AuthorizationCheckService authCheckService, Optional<ContinuousIntegrationService> continuousIntegrationService,
-            Optional<VersionControlService> versionControlService, TutorParticipationService tutorParticipationService, ExampleSubmissionRepository exampleSubmissionRepository,
-            ObjectMapper objectMapper, TextAssessmentService textAssessmentService, ComplaintRepository complaintRepository, SubmissionRepository submissionRepository) {
-        this.exerciseRepository = exerciseRepository;
+    private final ModelingSubmissionService modelingSubmissionService;
+
+    private final ResultService resultService;
+
+    public ExerciseResource(ExerciseService exerciseService, ParticipationService participationService, UserService userService, CourseService courseService,
+            AuthorizationCheckService authCheckService, Optional<ContinuousIntegrationService> continuousIntegrationService, Optional<VersionControlService> versionControlService,
+            TutorParticipationService tutorParticipationService, ExampleSubmissionRepository exampleSubmissionRepository, ObjectMapper objectMapper,
+            TextAssessmentService textAssessmentService, ComplaintRepository complaintRepository, TextSubmissionService textSubmissionService,
+            ModelingSubmissionService modelingSubmissionService, ResultService resultService) {
         this.exerciseService = exerciseService;
         this.participationService = participationService;
         this.userService = userService;
@@ -88,7 +90,9 @@ public class ExerciseResource {
         this.objectMapper = objectMapper;
         this.textAssessmentService = textAssessmentService;
         this.complaintRepository = complaintRepository;
-        this.submissionRepository = submissionRepository;
+        this.textSubmissionService = textSubmissionService;
+        this.modelingSubmissionService = modelingSubmissionService;
+        this.resultService = resultService;
     }
 
     /**
@@ -192,24 +196,37 @@ public class ExerciseResource {
             return forbidden();
         }
 
-        ObjectNode data = objectMapper.createObjectNode();
-
-        long numberOfSubmissions = submissionRepository.countBySubmittedAndParticipation_Exercise_Id(true, id);
-        data.set("numberOfSubmissions", objectMapper.valueToTree(numberOfSubmissions));
-
-        long numberOfAssessments = textAssessmentService.countNumberOfAssessmentsForExercise(id);
-        data.set("numberOfAssessments", objectMapper.valueToTree(numberOfAssessments));
-
-        long numberOfTutorAssessments = textAssessmentService.countNumberOfAssessmentsForTutorInExercise(id, user.getId());
+        ObjectNode data = populateCommonStatistics(id);
+        long numberOfTutorAssessments = resultService.countNumberOfAssessmentsForTutorInExercise(id, user.getId());
         data.set("numberOfTutorAssessments", objectMapper.valueToTree(numberOfTutorAssessments));
-
-        long numberOfComplaints = complaintRepository.countByResult_Participation_Exercise_Id(id);
-        data.set("numberOfComplaints", objectMapper.valueToTree(numberOfComplaints));
 
         long numberOfTutorComplaints = complaintRepository.countByResult_Participation_Exercise_IdAndResult_Assessor_Id(id, user.getId());
         data.set("numberOfTutorComplaints", objectMapper.valueToTree(numberOfTutorComplaints));
 
         return ResponseEntity.ok(data);
+    }
+
+    /**
+     * Given an exercise id, it creates an object node with numberOfSubmissions, numberOfAssessments and numberOfComplaints, that are used by both stats for tutor dashboard and for
+     * instructor dashboard
+     *
+     * @param exerciseId - the exercise we are interested in
+     * @return a object node with the stats
+     */
+    private ObjectNode populateCommonStatistics(@PathVariable Long exerciseId) {
+        ObjectNode data = objectMapper.createObjectNode();
+
+        long numberOfSubmissions = textSubmissionService.countSubmissionsToAssessByExerciseId(exerciseId);
+        numberOfSubmissions += modelingSubmissionService.countSubmissionsToAssessByExerciseId(exerciseId);
+        data.set("numberOfSubmissions", objectMapper.valueToTree(numberOfSubmissions));
+
+        long numberOfAssessments = resultService.countNumberOfAssessmentsForExercise(exerciseId);
+        data.set("numberOfAssessments", objectMapper.valueToTree(numberOfAssessments));
+
+        long numberOfComplaints = complaintRepository.countByResult_Participation_Exercise_Id(exerciseId);
+        data.set("numberOfComplaints", objectMapper.valueToTree(numberOfComplaints));
+
+        return data;
     }
 
     /**
@@ -228,17 +245,7 @@ public class ExerciseResource {
             return forbidden();
         }
 
-        ObjectNode data = objectMapper.createObjectNode();
-
-        long numberOfSubmissions = submissionRepository.countBySubmittedAndParticipation_Exercise_Id(true, id);
-        data.set("numberOfSubmissions", objectMapper.valueToTree(numberOfSubmissions));
-
-        long numberOfAssessments = textAssessmentService.countNumberOfAssessmentsForExercise(id);
-        data.set("numberOfAssessments", objectMapper.valueToTree(numberOfAssessments));
-
-        long numberOfComplaints = complaintRepository.countByResult_Participation_Exercise_Id(id);
-        data.set("numberOfComplaints", objectMapper.valueToTree(numberOfComplaints));
-
+        ObjectNode data = populateCommonStatistics(id);
         long numberOfOpenComplaints = complaintRepository.countByResult_Participation_Exercise_Id(id);
         data.set("numberOfOpenComplaints", objectMapper.valueToTree(numberOfOpenComplaints));
 


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~ 
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
Fix #520, improving the query we use to count the number of submissions which require assessments by tutors. I have also refactored a bit the code, trying to remove direct dependency from resources to repository, but always passing through the services.

Also, I moved some methods from the text submission service, since they are about the results, and it was confusing to have them under the text submissions
