### PR TITLE
Bugfix/Programming-Exercise instruction preview not working for template participation

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
@@ -149,7 +149,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
         if (this.participationSubscription) {
             this.participationSubscription.unsubscribe();
         }
-        this.participationWebsocketService.addParticipation(this.participation);
+        this.participationWebsocketService.addParticipation(this.participation, this.exercise);
         this.participationSubscription = this.participationWebsocketService
             .subscribeForLatestResultOfParticipation(this.participation.id)
             .pipe(filter(participation => !!participation))


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
<!-- Describe your changes in detail -->
Broke with the participation websocket service: The programming exercise instruction preview in update & dialog was no longer working because the templateParticipation doesn't have an exercise attached to it.
The fix is to manually pass the exercise, as it is a prop of the instructions anyway.

Other areas (code-editor and programming-exercise view) were not concerned.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Open programming exercise dialog/update
2. Change to preview tab
3. Instructions should be rendered, no console error
