### PR TITLE
Bugfix/participation-websocket-service modifies passed participation object

### DIFF
--- a/src/main/webapp/app/entities/participation/participation-websocket.service.ts
+++ b/src/main/webapp/app/entities/participation/participation-websocket.service.ts
@@ -46,11 +46,13 @@ export class ParticipationWebsocketService {
      * This adds a participation to the cached data maps. The exercise information is required to find the correct
      * participations for a given exercise.
      *
-     * @param participation The new participation for the cached data maps
+     * @param newParticipation The new participation for the cached data maps
      * @param exercise (optional) The exercise that the participation belongs to. Only needed if exercise is missing in participation.
      * @private
      */
-    private addParticipationToList(participation: Participation, exercise?: Exercise) {
+    private addParticipationToList(newParticipation: Participation, exercise?: Exercise) {
+        // The participation needs to be cloned so that the original object is not modified
+        const participation = { ...newParticipation };
         if (!participation.exercise && !exercise) {
             throw new Error('a link from the participation to the exercise is required. Please attach it manually or add exercise as function input');
         }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
<!-- Describe your changes in detail -->

The participation websocket service mutates the given participation by adding the exercise to it if provided.
Due to this in the programming exercise update component encounters a circular structure error when trying to save the exercise.

I have created a hotfix for this issue: https://github.com/ls1intum/ArTEMiS/pull/554

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Create a programming exercise
=> Exercise creation should be successful

### Screenshots
<!-- If applicable, add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
