### PR TITLE
fix NullPointerException on empty repos

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.ZipEntry;
@@ -327,7 +328,7 @@ public class GitService {
      * @param exercise   ProgrammingExercise associated with this repo.
      */
     public void filterLateSubmissions(Repository repository, ProgrammingExercise exercise) {
-        if (exercise.getReleaseDate() == null || exercise.getDueDate() == null) {
+        if (exercise.getDueDate() == null) {
             // No dates set on exercise
             return;
         }
@@ -336,7 +337,7 @@ public class GitService {
             Git git = new Git(repository);
 
             // Get last commit before deadline
-            Date since = Date.from(exercise.getReleaseDate().toInstant());
+            Date since = Date.from(Instant.EPOCH);
             Date until = Date.from(exercise.getDueDate().toInstant());
             RevFilter between = CommitTimeRevFilter.between(since, until);
             Iterable<RevCommit> commits = git.log().setRevFilter(between).call();
@@ -344,12 +345,7 @@ public class GitService {
 
             git.close();
 
-            if (latestCommitBeforeDeadline == null) {
-                reset(repository, "origin/master");
-            }
-            else {
-                reset(repository, latestCommitBeforeDeadline.getId().getName());
-            }
+            reset(repository, latestCommitBeforeDeadline.getId().getName());
 
         }
         catch (GitAPIException ex) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -344,7 +344,12 @@ public class GitService {
 
             git.close();
 
-            reset(repository, latestCommitBeforeDeadline.getId().getName());
+            if (latestCommitBeforeDeadline == null) {
+                reset(repository, "origin/master");
+            }
+            else {
+                reset(repository, latestCommitBeforeDeadline.getId().getName());
+            }
 
         }
         catch (GitAPIException ex) {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [ ] ~I updated the documentation and models.~
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With JGit a starting date has to be set, which was set to the release date of the exercise. If no commits between the release date and due date are made, an error occurs. The starting date is now hardcoded to EPOCH (1970).


### Description
<!-- Describe your changes in detail -->
https://jirabruegge.in.tum.de/browse/ARTEMIS-376

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Re-try failed repos in download command

### Screenshots
<!-- If applicable, add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
