### PR TITLE
Bugfix/students do not have one week for complaining if result was submitted before assessment due date

### DIFF
--- a/src/main/webapp/app/entities/result/result.service.ts
+++ b/src/main/webapp/app/entities/result/result.service.ts
@@ -110,11 +110,11 @@ export class ResultService {
      * result. If the result was submitted after the assessment due date or the assessment due date is not set, the completion date of the result is checked. If the result was
      * submitted before the assessment due date, the assessment due date is checked, as the student can only see the result after the assessment due date.
      */
-    isResultOlderThanOneWeek(result: Result, exercise: Exercise): boolean {
+    isTimeOfComplaintValid(result: Result, exercise: Exercise): boolean {
         const resultCompletionDate = moment(result.completionDate);
         if (!exercise.assessmentDueDate || resultCompletionDate.isAfter(exercise.assessmentDueDate)) {
-            return resultCompletionDate.isBefore(moment().subtract(1, 'week'));
+            return resultCompletionDate.isAfter(moment().subtract(1, 'week'));
         }
-        return moment(exercise.assessmentDueDate).isBefore(moment().subtract(1, 'week'));
+        return moment(exercise.assessmentDueDate).isAfter(moment().subtract(1, 'week'));
     }
 }

--- a/src/main/webapp/app/entities/result/result.service.ts
+++ b/src/main/webapp/app/entities/result/result.service.ts
@@ -9,7 +9,7 @@ import { Result } from './result.model';
 import { createRequestOption } from 'app/shared';
 import { Feedback } from 'app/entities/feedback';
 import { Participation } from 'app/entities/participation';
-import { ExerciseService } from 'app/entities/exercise';
+import { Exercise, ExerciseService } from 'app/entities/exercise';
 
 export type EntityResponseType = HttpResponse<Result>;
 export type EntityArrayResponseType = HttpResponse<Result[]>;
@@ -103,5 +103,18 @@ export class ResultService {
             }
         }
         return participation;
+    }
+
+    /**
+     * This function is used to check whether the student is allowed to submit a complaint or not. Submitting a complaint is allowed within one week after the student received the
+     * result. If the result was submitted after the assessment due date or the assessment due date is not set, the completion date of the result is checked. If the result was
+     * submitted before the assessment due date, the assessment due date is checked, as the student can only see the result after the assessment due date.
+     */
+    isResultOlderThanOneWeek(result: Result, exercise: Exercise): boolean {
+        const resultCompletionDate = moment(result.completionDate);
+        if (!exercise.assessmentDueDate || resultCompletionDate.isAfter(exercise.assessmentDueDate)) {
+            return resultCompletionDate.isBefore(moment().subtract(1, 'week'));
+        }
+        return moment(exercise.assessmentDueDate).isBefore(moment().subtract(1, 'week'));
     }
 }

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.html
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.html
@@ -127,10 +127,10 @@
     <div class="row mt-2 ml-0" *ngIf="result && result.completionDate && !hasComplaint">
         <button
             class="btn btn-primary"
-            [class.not-allowed]="numberOfAllowedComplaints <= 0 || resultOlderThanOneWeek"
+            [class.not-allowed]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
             (click)="showComplaintForm = !showComplaintForm"
-            [disabled]="numberOfAllowedComplaints <= 0 || resultOlderThanOneWeek"
-            title="{{ numberOfAllowedComplaints <= 0 || resultOlderThanOneWeek ? ('arTeMiSApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
+            [disabled]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
+            title="{{ numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid ? ('arTeMiSApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
         >
             <!--TODO: use the non-temp message when the 'request more feedback' feature is implemented-->
             {{ 'arTeMiSApp.complaint.moreInfo_temp' | translate }}

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -6,7 +6,7 @@ import { Participation, ParticipationWebsocketService } from '../entities/partic
 import { ApollonDiagramService } from '../entities/apollon-diagram';
 import { DiagramType, ElementType, Selection, UMLModel, UMLRelationshipType } from '@ls1intum/apollon';
 import { JhiAlertService } from 'ng-jhipster';
-import { Result } from '../entities/result';
+import { Result, ResultService } from '../entities/result';
 import { ModelingSubmission, ModelingSubmissionService } from '../entities/modeling-submission';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ComponentCanDeactivate } from '../shared';
@@ -72,6 +72,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         private modelingSubmissionService: ModelingSubmissionService,
         private modelingAssessmentService: ModelingAssessmentService,
         private complaintService: ComplaintService,
+        private resultService: ResultService,
         private jhiAlertService: JhiAlertService,
         private route: ActivatedRoute,
         private modalService: NgbModal,
@@ -118,7 +119,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                             this.result = this.submission.result;
                         }
                         if (this.submission.submitted && this.result && this.result.completionDate) {
-                            this.resultOlderThanOneWeek = this.isResultOlderThanOneWeek(this.result);
+                            this.resultOlderThanOneWeek = this.resultService.isResultOlderThanOneWeek(this.result, this.modelingExercise);
                             this.modelingAssessmentService.getAssessment(this.submission.id).subscribe((assessmentResult: Result) => {
                                 this.assessmentResult = assessmentResult;
                                 this.prepareAssessmentData();
@@ -199,23 +200,10 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                 this.assessmentResult = newResult;
                 this.assessmentResult = this.modelingAssessmentService.convertResult(newResult);
                 this.prepareAssessmentData();
-                this.resultOlderThanOneWeek = this.isResultOlderThanOneWeek(this.assessmentResult);
+                this.resultOlderThanOneWeek = this.resultService.isResultOlderThanOneWeek(this.assessmentResult, this.modelingExercise);
                 this.jhiAlertService.info('arTeMiSApp.modelingEditor.newAssessment');
             }
         });
-    }
-
-    /**
-     * This function is used to check whether the student is allowed to submit a complaint or not. Submitting a complaint is allowed within one week after the student received the
-     * result. If the result was submitted after the assessment due date or the assessment due date is not set, the completion date of the result is checked. If the result was
-     * submitted before the assessment due date, the assessment due date is checked, as the student can only see the result after the assessment due date.
-     */
-    private isResultOlderThanOneWeek(result: Result): boolean {
-        const resultCompletionDate = moment(result.completionDate);
-        if (!this.modelingExercise.assessmentDueDate || resultCompletionDate.isAfter(this.modelingExercise.assessmentDueDate)) {
-            return resultCompletionDate.isBefore(moment().subtract(1, 'week'));
-        }
-        return moment(this.modelingExercise.assessmentDueDate).isBefore(moment().subtract(1, 'week'));
     }
 
     /**

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -61,7 +61,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
     // the number of complaints that the student is still allowed to submit in the course. this is used for disabling the complain button.
     numberOfAllowedComplaints: number;
     // indicates if the result is older than one week. if it is, the complain button is disabled.
-    resultOlderThanOneWeek: boolean;
+    isTimeOfComplaintValid: boolean;
     // indicates if the assessment due date is in the past. the assessment will not be loaded and displayed to the student if it is not.
     isAfterAssessmentDueDate: boolean;
     isLoading: boolean;
@@ -119,7 +119,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                             this.result = this.submission.result;
                         }
                         if (this.submission.submitted && this.result && this.result.completionDate) {
-                            this.resultOlderThanOneWeek = this.resultService.isResultOlderThanOneWeek(this.result, this.modelingExercise);
+                            this.isTimeOfComplaintValid = this.resultService.isTimeOfComplaintValid(this.result, this.modelingExercise);
                             this.modelingAssessmentService.getAssessment(this.submission.id).subscribe((assessmentResult: Result) => {
                                 this.assessmentResult = assessmentResult;
                                 this.prepareAssessmentData();
@@ -200,7 +200,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                 this.assessmentResult = newResult;
                 this.assessmentResult = this.modelingAssessmentService.convertResult(newResult);
                 this.prepareAssessmentData();
-                this.resultOlderThanOneWeek = this.resultService.isResultOlderThanOneWeek(this.assessmentResult, this.modelingExercise);
+                this.isTimeOfComplaintValid = this.resultService.isTimeOfComplaintValid(this.assessmentResult, this.modelingExercise);
                 this.jhiAlertService.info('arTeMiSApp.modelingEditor.newAssessment');
             }
         });

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -118,7 +118,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                             this.result = this.submission.result;
                         }
                         if (this.submission.submitted && this.result && this.result.completionDate) {
-                            this.resultOlderThanOneWeek = moment(this.result.completionDate).isBefore(moment().subtract(1, 'week'));
+                            this.resultOlderThanOneWeek = this.isResultOlderThanOneWeek(this.result);
                             this.modelingAssessmentService.getAssessment(this.submission.id).subscribe((assessmentResult: Result) => {
                                 this.assessmentResult = assessmentResult;
                                 this.prepareAssessmentData();
@@ -199,17 +199,30 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
                 this.assessmentResult = newResult;
                 this.assessmentResult = this.modelingAssessmentService.convertResult(newResult);
                 this.prepareAssessmentData();
-                this.resultOlderThanOneWeek = moment(this.assessmentResult.completionDate).isBefore(moment().subtract(1, 'week'));
+                this.resultOlderThanOneWeek = this.isResultOlderThanOneWeek(this.assessmentResult);
                 this.jhiAlertService.info('arTeMiSApp.modelingEditor.newAssessment');
             }
         });
     }
 
     /**
+     * This function is used to check whether the student is allowed to submit a complaint or not. Submitting a complaint is allowed within one week after the student received the
+     * result. If the result was submitted after the assessment due date or the assessment due date is not set, the completion date of the result is checked. If the result was
+     * submitted before the assessment due date, the assessment due date is checked, as the student can only see the result after the assessment due date.
+     */
+    private isResultOlderThanOneWeek(result: Result): boolean {
+        const resultCompletionDate = moment(result.completionDate);
+        if (!this.modelingExercise.assessmentDueDate || resultCompletionDate.isAfter(this.modelingExercise.assessmentDueDate)) {
+            return resultCompletionDate.isBefore(moment().subtract(1, 'week'));
+        }
+        return moment(this.modelingExercise.assessmentDueDate).isBefore(moment().subtract(1, 'week'));
+    }
+
+    /**
      * This function sets and starts an auto-save timer that automatically saves changes
      * to the model after at most 60 seconds.
      */
-    setAutoSaveTimer(): void {
+    private setAutoSaveTimer(): void {
         if (this.submission.submitted) {
             return;
         }

--- a/src/main/webapp/app/text-editor/text-editor.component.html
+++ b/src/main/webapp/app/text-editor/text-editor.component.html
@@ -66,10 +66,10 @@
     <div class="row mt-4" *ngIf="result && result.completionDate && !hasComplaint">
         <button
             class="btn btn-primary"
-            [class.not-allowed]="numberOfAllowedComplaints <= 0 || resultOlderThanOneWeek"
+            [class.not-allowed]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
             (click)="showComplaintForm = !showComplaintForm"
-            [disabled]="numberOfAllowedComplaints <= 0 || resultOlderThanOneWeek"
-            title="{{ numberOfAllowedComplaints <= 0 || resultOlderThanOneWeek ? ('arTeMiSApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
+            [disabled]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
+            title="{{ numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid ? ('arTeMiSApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
         >
             <!--TODO: use the non-temp message when the 'request more feedback' feature is implemented-->
             {{ 'arTeMiSApp.complaint.moreInfo_temp' | translate }}

--- a/src/main/webapp/app/text-editor/text-editor.component.ts
+++ b/src/main/webapp/app/text-editor/text-editor.component.ts
@@ -6,7 +6,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { JhiAlertService } from 'ng-jhipster';
 import { TextSubmission, TextSubmissionService } from 'app/entities/text-submission';
 import { TextExercise, TextExerciseService } from 'app/entities/text-exercise';
-import { Result } from 'app/entities/result';
+import { Result, ResultService } from 'app/entities/result';
 import { Participation, ParticipationService } from 'app/entities/participation';
 import { TextEditorService } from 'app/text-editor/text-editor.service';
 import * as moment from 'moment';
@@ -48,6 +48,7 @@ export class TextEditorComponent implements OnInit {
         private textSubmissionService: TextSubmissionService,
         private textService: TextEditorService,
         private complaintService: ComplaintService,
+        private resultService: ResultService,
         private jhiAlertService: JhiAlertService,
         private artemisMarkdown: ArtemisMarkdown,
         private location: Location,
@@ -85,7 +86,7 @@ export class TextEditorComponent implements OnInit {
                         this.answer = this.submission.text;
                     }
                     if (this.result && this.result.completionDate) {
-                        this.resultOlderThanOneWeek = this.isResultOlderThanOneWeek(this.result);
+                        this.resultOlderThanOneWeek = this.resultService.isResultOlderThanOneWeek(this.result, this.textExercise);
                         this.complaintService.findByResultId(this.result.id).subscribe(res => {
                             this.hasComplaint = !!res.body;
                         });
@@ -168,19 +169,6 @@ export class TextEditorComponent implements OnInit {
 
     private onError(error: HttpErrorResponse) {
         this.jhiAlertService.error(error.message, null, null);
-    }
-
-    /**
-     * This function is used to check whether the student is allowed to submit a complaint or not. Submitting a complaint is allowed within one week after the student received the
-     * result. If the result was submitted after the assessment due date or the assessment due date is not set, the completion date of the result is checked. If the result was
-     * submitted before the assessment due date, the assessment due date is checked, as the student can only see the result after the assessment due date.
-     */
-    private isResultOlderThanOneWeek(result: Result): boolean {
-        const resultCompletionDate = moment(result.completionDate);
-        if (!this.textExercise.assessmentDueDate || resultCompletionDate.isAfter(this.textExercise.assessmentDueDate)) {
-            return resultCompletionDate.isBefore(moment().subtract(1, 'week'));
-        }
-        return moment(this.textExercise.assessmentDueDate).isBefore(moment().subtract(1, 'week'));
     }
 
     previous() {

--- a/src/main/webapp/app/text-editor/text-editor.component.ts
+++ b/src/main/webapp/app/text-editor/text-editor.component.ts
@@ -85,7 +85,7 @@ export class TextEditorComponent implements OnInit {
                         this.answer = this.submission.text;
                     }
                     if (this.result && this.result.completionDate) {
-                        this.resultOlderThanOneWeek = moment(this.result.completionDate).isBefore(moment().subtract(1, 'week'));
+                        this.resultOlderThanOneWeek = this.isResultOlderThanOneWeek(this.result);
                         this.complaintService.findByResultId(this.result.id).subscribe(res => {
                             this.hasComplaint = !!res.body;
                         });
@@ -168,6 +168,19 @@ export class TextEditorComponent implements OnInit {
 
     private onError(error: HttpErrorResponse) {
         this.jhiAlertService.error(error.message, null, null);
+    }
+
+    /**
+     * This function is used to check whether the student is allowed to submit a complaint or not. Submitting a complaint is allowed within one week after the student received the
+     * result. If the result was submitted after the assessment due date or the assessment due date is not set, the completion date of the result is checked. If the result was
+     * submitted before the assessment due date, the assessment due date is checked, as the student can only see the result after the assessment due date.
+     */
+    private isResultOlderThanOneWeek(result: Result): boolean {
+        const resultCompletionDate = moment(result.completionDate);
+        if (!this.textExercise.assessmentDueDate || resultCompletionDate.isAfter(this.textExercise.assessmentDueDate)) {
+            return resultCompletionDate.isBefore(moment().subtract(1, 'week'));
+        }
+        return moment(this.textExercise.assessmentDueDate).isBefore(moment().subtract(1, 'week'));
     }
 
     previous() {

--- a/src/main/webapp/app/text-editor/text-editor.component.ts
+++ b/src/main/webapp/app/text-editor/text-editor.component.ts
@@ -34,7 +34,7 @@ export class TextEditorComponent implements OnInit {
     // the number of complaints that the student is still allowed to submit in the course. this is used for disabling the complain button.
     numberOfAllowedComplaints: number;
     // indicates if the result is older than one week. if it is, the complain button is disabled
-    resultOlderThanOneWeek: boolean;
+    isTimeOfComplaintValid: boolean;
     // indicates if the assessment due date is in the past. the assessment will not be loaded and displayed to the student if it is not.
     isAfterAssessmentDueDate: boolean;
 
@@ -86,7 +86,7 @@ export class TextEditorComponent implements OnInit {
                         this.answer = this.submission.text;
                     }
                     if (this.result && this.result.completionDate) {
-                        this.resultOlderThanOneWeek = this.resultService.isResultOlderThanOneWeek(this.result, this.textExercise);
+                        this.isTimeOfComplaintValid = this.resultService.isTimeOfComplaintValid(this.result, this.textExercise);
                         this.complaintService.findByResultId(this.result.id).subscribe(res => {
                             this.hasComplaint = !!res.body;
                         });


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Description
<!-- Describe your changes in detail -->
If the assessment of a modeling or text submission was submitted before the assessment due date of the corresponding exercise, the student has less than a week for submitting a complaint. E.g. a tutor submits an assessment 4 days before the assessment due date. Since the student only sees the result after the assessment due date has passed, he has only 3 days left to submit a complaint after he received the assessment.

In this PR we change the validation in the following way:
- if the assessment was submitted before the assessment due date, the student is allowed to submit a complaint within one week after the assessment due date 
- if the assessment was submitted after the assessment due date or the assessment due date is not set, the student is allowed to submit a complaint within one week after the assessment was submitted