### PR TITLE
Fix german translation for editor.testStatusLabels entries.

### DIFF
--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -55,9 +55,9 @@
                 "fileOperationFailed": "Datei Operation konnte nicht durchgeführt werden. Bitte versuche es später noch einmal."
             },
             "testStatusLabels": {
-                "testStatusNoResult": "Keine Ergebnisse",
-                "testStatusTestPassing": "Test bestanden",
-                "testStatusTestFailing": "Test fehlgeschlagen",
+                "noResult": "Keine Ergebnisse",
+                "testPassing": "Test bestanden",
+                "testFailing": "Test fehlgeschlagen",
                 "totalTestsPassing": "{{totalTests}} Tests bestanden",
                 "totalTestsFailing": "{{failedTests}} von {{totalTests}} Tests fehlgeschlagen"
             }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] ~I updated the documentation and models.~
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I added (end-to-end) test cases for the new functionality.~

### Motivation and Context
The german translation for some entries located under 'arTeMiSApp.editor.testStatusLabels.' was missing as the key was wrong.

### Description
The string 'testLabels' was twice part of the key which caused a missing translation.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. ...
