### PR TITLE
Indent line if tab key is pressed in text editor

### DIFF
--- a/src/main/webapp/app/text-editor/text-editor.component.html
+++ b/src/main/webapp/app/text-editor/text-editor.component.html
@@ -45,7 +45,14 @@
 
     <div class="row">
         <div class="col-12 col-lg-10 col-xl-8" *ngIf="!result; else hasFeedback">
-            <textarea [(ngModel)]="answer" style="width: 100%; height: 50vh;" [readonly]="submission?.submitted" [disabled]="submission?.submitted"></textarea>
+            <textarea
+                #textEditor
+                [(ngModel)]="answer"
+                style="width: 100%; height: 50vh;"
+                [readonly]="submission?.submitted"
+                [disabled]="submission?.submitted"
+                (keydown.tab)="onTextEditorTab(textEditor, $event)"
+            ></textarea>
         </div>
 
         <ng-template #hasFeedback>

--- a/src/main/webapp/app/text-editor/text-editor.component.ts
+++ b/src/main/webapp/app/text-editor/text-editor.component.ts
@@ -167,6 +167,16 @@ export class TextEditorComponent implements OnInit {
         }
     }
 
+    onTextEditorTab(editor: HTMLTextAreaElement, event: KeyboardEvent) {
+        event.preventDefault();
+        const value = editor.value;
+        const start = editor.selectionStart;
+        const end = editor.selectionEnd;
+
+        editor.value = value.substring(0, start) + '\t' + value.substring(end);
+        editor.selectionStart = editor.selectionEnd = start + 1;
+    }
+
     private onError(error: HttpErrorResponse) {
         this.jhiAlertService.error(error.message, null, null);
     }


### PR DESCRIPTION
Prevent default behaviour of jumping out of the textarea
Add tab char to current line and move cursor to new position

<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] ~~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~~
- [x] I run `yarn run webpack:build:main`: the project builds without errors.
- [x] I run `yarn lint`: the project builds without code style warnings.
- [x] I added screenshots/screencast of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This should fix the problem described in #467. Pressing the tab key in the text editor resulted in losing focus of the textarea and jumping to the next field.

### Description
<!-- Describe your changes in detail -->
Pressing the tab key now results in adding a tab character to the current line in the text editor. The default handling of the event is prevented and the new functionality added instead.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to any course with a text exercise
3. Open the exercise and start writing some text in the editor.
4. Press the tab key, the expected result is a new indentation instead of losing focus of the editor window.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![tab_text_edit](https://user-images.githubusercontent.com/27979674/59465891-40e58680-8e2c-11e9-961d-e47adcdb93cd.gif)
