### PR TITLE
Feature/custom exercise update notifications

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/GroupNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/GroupNotificationService.java
@@ -114,12 +114,11 @@ public class GroupNotificationService {
         notifyStudentGroupAboutExerciseChange(exercise, title, notificationText);
     }
 
-    public void notifyStudentGroupAboutExerciseUpdate(Exercise exercise) {
+    public void notifyStudentGroupAboutExerciseUpdate(Exercise exercise, String notificationText) {
         if (exercise.getReleaseDate() != null && exercise.getReleaseDate().isAfter(ZonedDateTime.now())) {
             return;
         }
-        String title = "Exercise updated";
-        String notificationText = "Exercise \"" + exercise.getTitle() + "\" was updated.";
+        String title = "Exercise \"" + exercise.getTitle() + "\" updated";
         notifyStudentGroupAboutExerciseChange(exercise, title, notificationText);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -101,7 +101,8 @@ public class FileUploadExerciseResource {
      */
     @PutMapping("/file-upload-exercises")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<FileUploadExercise> updateFileUploadExercise(@RequestBody FileUploadExercise fileUploadExercise) throws URISyntaxException {
+    public ResponseEntity<FileUploadExercise> updateFileUploadExercise(@RequestBody FileUploadExercise fileUploadExercise,
+            @RequestParam(value = "notificationText", required = false) String notificationText) throws URISyntaxException {
         log.debug("REST request to update FileUploadExercise : {}", fileUploadExercise);
         if (fileUploadExercise.getId() == null) {
             return createFileUploadExercise(fileUploadExercise);
@@ -119,7 +120,9 @@ public class FileUploadExerciseResource {
             return forbidden();
         }
         FileUploadExercise result = fileUploadExerciseRepository.save(fileUploadExercise);
-        groupNotificationService.notifyStudentGroupAboutExerciseUpdate(fileUploadExercise);
+        if (notificationText != null) {
+            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(fileUploadExercise, notificationText);
+        }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, fileUploadExercise.getId().toString())).body(result);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.in.www1.artemis.domain.Course;
@@ -138,7 +139,8 @@ public class ModelingExerciseResource {
      */
     @PutMapping("/modeling-exercises")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<ModelingExercise> updateModelingExercise(@RequestBody ModelingExercise modelingExercise) throws URISyntaxException {
+    public ResponseEntity<ModelingExercise> updateModelingExercise(@RequestBody ModelingExercise modelingExercise,
+            @RequestParam(value = "notificationText", required = false) String notificationText) throws URISyntaxException {
         log.debug("REST request to update ModelingExercise : {}", modelingExercise);
         if (modelingExercise.getId() == null) {
             return createModelingExercise(modelingExercise);
@@ -155,7 +157,9 @@ public class ModelingExerciseResource {
         }
 
         ModelingExercise result = modelingExerciseRepository.save(modelingExercise);
-        groupNotificationService.notifyStudentGroupAboutExerciseUpdate(modelingExercise);
+        if (notificationText != null) {
+            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(modelingExercise, notificationText);
+        }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, modelingExercise.getId().toString())).body(result);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -284,7 +284,8 @@ public class ProgrammingExerciseResource {
      */
     @PutMapping("/programming-exercises")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<ProgrammingExercise> updateProgrammingExercise(@RequestBody ProgrammingExercise programmingExercise) throws URISyntaxException {
+    public ResponseEntity<ProgrammingExercise> updateProgrammingExercise(@RequestBody ProgrammingExercise programmingExercise,
+            @RequestParam(value = "notificationText", required = false) String notificationText) throws URISyntaxException {
         log.debug("REST request to update ProgrammingExercise : {}", programmingExercise);
         if (programmingExercise.getId() == null) {
             return createProgrammingExercise(programmingExercise);
@@ -319,7 +320,9 @@ public class ProgrammingExerciseResource {
 
         ProgrammingExercise result = programmingExerciseRepository.save(programmingExercise);
 
-        groupNotificationService.notifyStudentGroupAboutExerciseUpdate(result);
+        if (notificationText != null) {
+            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(result, notificationText);
+        }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, programmingExercise.getTitle())).body(result);
     }
 
@@ -333,7 +336,8 @@ public class ProgrammingExerciseResource {
      */
     @PatchMapping("/programming-exercises-problem")
     @PreAuthorize("hasAnyRole('TA', 'INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<ProgrammingExercise> updateProblemStatement(@RequestBody ProblemStatementUpdate problemStatementUpdate) throws URISyntaxException {
+    public ResponseEntity<ProgrammingExercise> updateProblemStatement(@RequestBody ProblemStatementUpdate problemStatementUpdate,
+            @RequestParam(value = "notificationText", required = false) String notificationText) throws URISyntaxException {
         log.debug("REST request to update ProgrammingExercise with new problem statement: {}", problemStatementUpdate);
         // fetch course from database to make sure client didn't change groups
         ProgrammingExercise programmingExercise = (ProgrammingExercise) exerciseService.findOne(problemStatementUpdate.getExerciseId());
@@ -355,7 +359,9 @@ public class ProgrammingExerciseResource {
         programmingExercise.setProblemStatement(problemStatementUpdate.getProblemStatement());
 
         ProgrammingExercise result = programmingExerciseRepository.save(programmingExercise);
-        groupNotificationService.notifyStudentGroupAboutExerciseUpdate(result);
+        if (notificationText != null) {
+            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(result, notificationText);
+        }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, programmingExercise.getTitle())).body(result);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -111,7 +111,8 @@ public class QuizExerciseResource {
      */
     @PutMapping("/quiz-exercises")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<QuizExercise> updateQuizExercise(@RequestBody QuizExercise quizExercise) throws URISyntaxException {
+    public ResponseEntity<QuizExercise> updateQuizExercise(@RequestBody QuizExercise quizExercise,
+            @RequestParam(value = "notificationText", required = false) String notificationText) throws URISyntaxException {
         log.debug("REST request to update QuizExercise : {}", quizExercise);
         if (quizExercise.getId() == null) {
             return createQuizExercise(quizExercise);
@@ -154,7 +155,9 @@ public class QuizExerciseResource {
         quizExerciseService.sendQuizExerciseToSubscribedClients(result);
 
         // NOTE: it does not make sense to notify students here!
-        // groupNotificationService.notifyStudentGroupAboutExerciseUpdate(result);
+        if (notificationText != null) {
+            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(result, notificationText);
+        }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, quizExercise.getId().toString())).body(result);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -133,7 +133,8 @@ public class TextExerciseResource {
      */
     @PutMapping("/text-exercises")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<TextExercise> updateTextExercise(@RequestBody TextExercise textExercise) throws URISyntaxException {
+    public ResponseEntity<TextExercise> updateTextExercise(@RequestBody TextExercise textExercise,
+            @RequestParam(value = "notificationText", required = false) String notificationText) throws URISyntaxException {
         log.debug("REST request to update TextExercise : {}", textExercise);
         if (textExercise.getId() == null) {
             return createTextExercise(textExercise);
@@ -157,7 +158,9 @@ public class TextExerciseResource {
             result.getExampleSubmissions().forEach(exampleSubmission -> exampleSubmission.setTutorParticipations(null));
         }
 
-        groupNotificationService.notifyStudentGroupAboutExerciseUpdate(textExercise);
+        if (notificationText != null) {
+            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(textExercise, notificationText);
+        }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, textExercise.getId().toString())).body(result);
     }
 

--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.service.ts
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.service.ts
@@ -23,9 +23,12 @@ export class FileUploadExerciseService {
             .map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 
-    update(fileUploadExercise: FileUploadExercise): Observable<EntityResponseType> {
+    update(fileUploadExercise: FileUploadExercise, req?: any): Observable<EntityResponseType> {
+        const options = createRequestOption(req);
         const copy = this.exerciseService.convertDateFromClient(fileUploadExercise);
-        return this.http.put<FileUploadExercise>(this.resourceUrl, copy, { observe: 'response' }).map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
+        return this.http
+            .put<FileUploadExercise>(this.resourceUrl, copy, { params: options, observe: 'response' })
+            .map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 
     find(id: number): Observable<EntityResponseType> {

--- a/src/main/webapp/app/entities/lecture/lecture-attachments.component.ts
+++ b/src/main/webapp/app/entities/lecture/lecture-attachments.component.ts
@@ -33,7 +33,7 @@ export class LectureAttachmentsComponent implements OnInit {
     attachmentFile: any;
     isUploadingAttachment: boolean;
     isDownloadingAttachmentLink: string | null;
-    notificationText: string;
+    notificationText: string | null;
     erroredFile: File | null;
 
     constructor(
@@ -44,6 +44,7 @@ export class LectureAttachmentsComponent implements OnInit {
     ) {}
 
     ngOnInit() {
+        this.notificationText = null;
         this.activatedRoute.data.subscribe(({ lecture }) => {
             this.lecture = lecture;
             this.attachmentService.findAllByLectureId(this.lecture.id).subscribe((attachmentsResponse: HttpResponse<Attachment[]>) => {
@@ -80,6 +81,7 @@ export class LectureAttachmentsComponent implements OnInit {
             this.attachmentService.update(this.attachmentToBeCreated!, requestOptions).subscribe((attachmentRes: HttpResponse<Attachment>) => {
                 this.attachmentToBeCreated = null;
                 this.attachmentBackup = null;
+                this.notificationText = null;
                 this.attachments = this.attachments.map(el => {
                     return el.id === attachmentRes.body!.id ? attachmentRes.body! : el;
                 });

--- a/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.component.html
+++ b/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.component.html
@@ -172,6 +172,10 @@
                 To create an example submission, you first need to finish creating the modeling exercise
             </div>
         </div>
+        <div class="form-group" *ngIf="modelingExercise.id">
+            <label class="form-control-label" jhiTranslate="artemisApp.exercise.notificationText" for="field_notification_text">Notification Text</label>
+            <input minlength="3" type="text" class="form-control" name="notificationtText" id="field_notification_text" [(ngModel)]="notificationText" />
+        </div>
     </div>
     <div class="modal-footer">
         <button id="modeling-back-cancel-button" type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">

--- a/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.component.ts
+++ b/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.component.ts
@@ -28,6 +28,7 @@ export class ModelingExerciseDialogComponent implements OnInit {
     maxScorePattern = '^[1-9]{1}[0-9]{0,4}$'; // make sure max score is a positive natural integer and not too large
     exerciseCategories: ExerciseCategory[];
     existingCategories: ExerciseCategory[];
+    notificationText: string | null;
 
     courses: Course[];
 
@@ -45,6 +46,7 @@ export class ModelingExerciseDialogComponent implements OnInit {
         this.isSaving = false;
         this.dueDateError = false;
         this.assessmentDueDateError = false;
+        this.notificationText = null;
         this.courseService.query().subscribe(
             (res: HttpResponse<Course[]>) => {
                 this.courses = res.body!;
@@ -82,7 +84,11 @@ export class ModelingExerciseDialogComponent implements OnInit {
     save() {
         this.isSaving = true;
         if (this.modelingExercise.id !== undefined) {
-            this.subscribeToSaveResponse(this.modelingExerciseService.update(this.modelingExercise));
+            const requestOptions = {} as any;
+            if (this.notificationText) {
+                requestOptions.notificationText = this.notificationText;
+            }
+            this.subscribeToSaveResponse(this.modelingExerciseService.update(this.modelingExercise, requestOptions));
         } else {
             this.subscribeToSaveResponse(this.modelingExerciseService.create(this.modelingExercise));
         }

--- a/src/main/webapp/app/entities/modeling-exercise/modeling-exercise.service.ts
+++ b/src/main/webapp/app/entities/modeling-exercise/modeling-exercise.service.ts
@@ -6,6 +6,7 @@ import { SERVER_API_URL } from '../../app.constants';
 import { ModelingExercise } from './modeling-exercise.model';
 import { ExerciseService } from 'app/entities/exercise';
 import { ModelingStatistic } from 'app/entities/modeling-statistic';
+import { createRequestOption } from 'app/shared';
 
 export type EntityResponseType = HttpResponse<ModelingExercise>;
 export type EntityArrayResponseType = HttpResponse<ModelingExercise[]>;
@@ -23,9 +24,12 @@ export class ModelingExerciseService {
         return this.http.post<ModelingExercise>(this.resourceUrl, copy, { observe: 'response' }).map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 
-    update(modelingExercise: ModelingExercise): Observable<EntityResponseType> {
+    update(modelingExercise: ModelingExercise, req?: any): Observable<EntityResponseType> {
+        const options = createRequestOption(req);
         const copy = this.exerciseService.convertDateFromClient(modelingExercise);
-        return this.http.put<ModelingExercise>(this.resourceUrl, copy, { observe: 'response' }).map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
+        return this.http
+            .put<ModelingExercise>(this.resourceUrl, copy, { params: options, observe: 'response' })
+            .map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 
     find(id: number): Observable<EntityResponseType> {

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-dialog.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-dialog.component.html
@@ -146,6 +146,10 @@
                 </label>
             </div>
         </div>
+        <div class="form-group-narrow" *ngIf="programmingExercise.id">
+            <label class="form-control-label" jhiTranslate="artemisApp.exercise.notificationText" for="field_notification_text">Notification Text</label>
+            <input minlength="3" type="text" class="form-control" name="notificationtText" id="field_notification_text" [(ngModel)]="notificationText" />
+        </div>
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-dialog.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-dialog.component.ts
@@ -31,6 +31,7 @@ export class ProgrammingExerciseDialogComponent implements OnInit {
     existingCategories: ExerciseCategory[];
     problemStatementLoaded = false;
     templateParticipationResultLoaded = true;
+    notificationText: string | null;
 
     constructor(
         public activeModal: NgbActiveModal,
@@ -45,6 +46,7 @@ export class ProgrammingExerciseDialogComponent implements OnInit {
 
     ngOnInit() {
         this.isSaving = false;
+        this.notificationText = null;
         this.courseService.query().subscribe(
             (res: HttpResponse<Course[]>) => {
                 this.courses = res.body!;
@@ -96,7 +98,11 @@ export class ProgrammingExerciseDialogComponent implements OnInit {
     save() {
         this.isSaving = true;
         if (this.programmingExercise.id !== undefined) {
-            this.subscribeToSaveResponse(this.programmingExerciseService.update(this.programmingExercise));
+            const requestOptions = {} as any;
+            if (this.notificationText) {
+                requestOptions.notificationText = this.notificationText;
+            }
+            this.subscribeToSaveResponse(this.programmingExerciseService.update(this.programmingExercise, requestOptions));
         } else {
             this.subscribeToSaveResponse(this.programmingExerciseService.create(this.programmingExercise));
         }

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
@@ -160,6 +160,10 @@
                         </label>
                     </div>
                 </div>
+                <div class="form-group-narrow" *ngIf="programmingExercise.id">
+                    <label class="form-control-label" jhiTranslate="artemisApp.exercise.notificationText" for="field_notification_text">Notification Text</label>
+                    <input minlength="3" type="text" class="form-control" name="notificationtText" id="field_notification_text" [(ngModel)]="notificationText" />
+                </div>
             </div>
             <div>
                 <button type="button" id="cancel-save" class="btn btn-secondary mr-1" (click)="previousState()">

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.ts
@@ -25,6 +25,7 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
     isSaving: boolean;
     problemStatementLoaded = false;
     templateParticipationResultLoaded = true;
+    notificationText: string | null;
 
     maxScorePattern = '^[1-9]{1}[0-9]{0,4}$'; // make sure max score is a positive natural integer and not too large
     packageNamePattern = '^[a-z][a-z0-9_]*(\\.[a-z0-9_]+)+[0-9a-z_]$'; // package name must have at least 1 dot and must not start with a number
@@ -45,6 +46,7 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
 
     ngOnInit() {
         this.isSaving = false;
+        this.notificationText = null;
         this.activatedRoute.data.subscribe(({ programmingExercise }) => {
             this.programmingExercise = programmingExercise;
         });
@@ -108,7 +110,11 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
     save() {
         this.isSaving = true;
         if (this.programmingExercise.id !== undefined) {
-            this.subscribeToSaveResponse(this.programmingExerciseService.update(this.programmingExercise));
+            const requestOptions = {} as any;
+            if (this.notificationText) {
+                requestOptions.notificationText = this.notificationText;
+            }
+            this.subscribeToSaveResponse(this.programmingExerciseService.update(this.programmingExercise, requestOptions));
         } else {
             this.subscribeToSaveResponse(this.programmingExerciseService.automaticSetup(this.programmingExercise));
         }

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.service.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.service.ts
@@ -40,16 +40,18 @@ export class ProgrammingExerciseService {
         return this.http.put(this.resourceUrl + '/' + exerciseId + '/squash-template-commits', { responseType: 'text' });
     }
 
-    update(programmingExercise: ProgrammingExercise): Observable<EntityResponseType> {
+    update(programmingExercise: ProgrammingExercise, req?: any): Observable<EntityResponseType> {
+        const options = createRequestOption(req);
         const copy = this.convertDataFromClient(programmingExercise);
         return this.http
-            .put<ProgrammingExercise>(this.resourceUrl, copy, { observe: 'response' })
+            .put<ProgrammingExercise>(this.resourceUrl, copy, { params: options, observe: 'response' })
             .map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 
-    updateProblemStatement(programmingExerciseId: number, problemStatement: string) {
+    updateProblemStatement(programmingExerciseId: number, problemStatement: string, req?: any) {
+        const options = createRequestOption(req);
         return this.http
-            .patch<ProgrammingExercise>(`${this.resourceUrl}-problem`, { exerciseId: programmingExerciseId, problemStatement }, { observe: 'response' })
+            .patch<ProgrammingExercise>(`${this.resourceUrl}-problem`, { exerciseId: programmingExerciseId, problemStatement }, { params: options, observe: 'response' })
             .map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 

--- a/src/main/webapp/app/entities/quiz-exercise/quiz-exercise-detail.component.html
+++ b/src/main/webapp/app/entities/quiz-exercise/quiz-exercise-detail.component.html
@@ -210,6 +210,19 @@
                             </option>
                         </select>
                     </div>
+                    <div class="form-group flex-fill ml-5">
+                        <div class="form-group flex-fill" *ngIf="quizExercise.id">
+                            <input
+                                minlength="3"
+                                type="text"
+                                placeholder="{{ 'artemisApp.exercise.notificationText' | translate }}"
+                                class="form-control flex-fill"
+                                name="notificationtText"
+                                id="field_notification_text"
+                                [(ngModel)]="notificationText"
+                            />
+                        </div>
+                    </div>
                     <div class="form-group">
                         <span *ngIf="!pendingChangesCache && !isSaving" jhiTranslate="artemisApp.quizExercise.edit.saved" class="badge badge-success"> </span>
                         <span *ngIf="pendingChangesCache && quizIsValid && !isSaving" jhiTranslate="artemisApp.quizExercise.edit.pendingChanges" class="badge badge-secondary">

--- a/src/main/webapp/app/entities/quiz-exercise/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/entities/quiz-exercise/quiz-exercise-detail.component.ts
@@ -59,6 +59,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
     course: Course;
     quizExercise: QuizExercise;
     courseRepository: CourseService;
+    notificationText: string | null;
 
     entity: QuizExercise;
     savedEntity: QuizExercise;
@@ -122,6 +123,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
         this.dndFilterEnabled = true;
         this.mcqFilterEnabled = true;
         this.shortAnswerFilterEnabled = true;
+        this.notificationText = null;
 
         const courseId = Number(this.route.snapshot.paramMap.get('courseId'));
         const quizId = Number(this.route.snapshot.paramMap.get('id'));
@@ -936,8 +938,13 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
         this.isSaving = true;
         this.parseAllQuestions();
         if (this.quizExercise.id !== undefined) {
-            this.quizExerciseService.update(this.quizExercise).subscribe(
+            const requestOptions = {} as any;
+            if (this.notificationText) {
+                requestOptions.notificationText = this.notificationText;
+            }
+            this.quizExerciseService.update(this.quizExercise, requestOptions).subscribe(
                 (quizExerciseResponse: HttpResponse<QuizExercise>) => {
+                    this.notificationText = null;
                     if (quizExerciseResponse.body) {
                         this.onSaveSuccess(quizExerciseResponse.body);
                     } else {

--- a/src/main/webapp/app/entities/quiz-exercise/quiz-exercise.service.ts
+++ b/src/main/webapp/app/entities/quiz-exercise/quiz-exercise.service.ts
@@ -6,6 +6,7 @@ import { SERVER_API_URL } from 'app/app.constants';
 import { QuizExercise } from './quiz-exercise.model';
 import { ExerciseService } from 'app/entities/exercise';
 import { QuizQuestion } from 'app/entities/quiz-question';
+import { createRequestOption } from 'app/shared';
 
 export type EntityResponseType = HttpResponse<QuizExercise>;
 export type EntityArrayResponseType = HttpResponse<QuizExercise[]>;
@@ -31,9 +32,12 @@ export class QuizExerciseService {
         return this.http.post<QuizExercise>(this.resourceUrl, copy, { observe: 'response' }).map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 
-    update(quizExercise: QuizExercise): Observable<EntityResponseType> {
+    update(quizExercise: QuizExercise, req?: any): Observable<EntityResponseType> {
+        const options = createRequestOption(req);
         const copy = this.exerciseService.convertDateFromClient(quizExercise);
-        return this.http.put<QuizExercise>(this.resourceUrl, copy, { observe: 'response' }).map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
+        return this.http
+            .put<QuizExercise>(this.resourceUrl, copy, { params: options, observe: 'response' })
+            .map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 
     find(id: number): Observable<EntityResponseType> {

--- a/src/main/webapp/app/entities/text-exercise/text-exercise-dialog.component.html
+++ b/src/main/webapp/app/entities/text-exercise/text-exercise-dialog.component.html
@@ -115,6 +115,10 @@
                 To create an example submission, you first need to finish creating the text exercise.
             </div>
         </div>
+        <div class="form-group" *ngIf="textExercise.id">
+            <label class="form-control-label" jhiTranslate="artemisApp.exercise.notificationText" for="field_notification_text">Notification Text</label>
+            <input minlength="3" type="text" class="form-control" name="notificationtText" id="field_notification_text" [(ngModel)]="notificationText" />
+        </div>
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">

--- a/src/main/webapp/app/entities/text-exercise/text-exercise-dialog.component.ts
+++ b/src/main/webapp/app/entities/text-exercise/text-exercise-dialog.component.ts
@@ -25,6 +25,7 @@ export class TextExerciseDialogComponent implements OnInit {
     maxScorePattern = '^[1-9]{1}[0-9]{0,4}$'; // make sure max score is a positive natural integer and not too large
     exerciseCategories: ExerciseCategory[];
     existingCategories: ExerciseCategory[];
+    notificationText: string | null;
 
     courses: Course[];
 
@@ -40,6 +41,7 @@ export class TextExerciseDialogComponent implements OnInit {
 
     ngOnInit() {
         this.isSaving = false;
+        this.notificationText = null;
         this.courseService.query().subscribe(
             (res: HttpResponse<Course[]>) => {
                 this.courses = res.body!;
@@ -67,7 +69,11 @@ export class TextExerciseDialogComponent implements OnInit {
     save() {
         this.isSaving = true;
         if (this.textExercise.id !== undefined) {
-            this.subscribeToSaveResponse(this.textExerciseService.update(this.textExercise));
+            const requestOptions = {} as any;
+            if (this.notificationText) {
+                requestOptions.notificationText = this.notificationText;
+            }
+            this.subscribeToSaveResponse(this.textExerciseService.update(this.textExercise, requestOptions));
         } else {
             this.subscribeToSaveResponse(this.textExerciseService.create(this.textExercise));
         }

--- a/src/main/webapp/app/entities/text-exercise/text-exercise.service.ts
+++ b/src/main/webapp/app/entities/text-exercise/text-exercise.service.ts
@@ -21,9 +21,12 @@ export class TextExerciseService {
         return this.http.post<TextExercise>(this.resourceUrl, copy, { observe: 'response' }).map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 
-    update(textExercise: TextExercise): Observable<EntityResponseType> {
+    update(textExercise: TextExercise, req?: any): Observable<EntityResponseType> {
+        const options = createRequestOption(req);
         const copy = this.exerciseService.convertDateFromClient(textExercise);
-        return this.http.put<TextExercise>(this.resourceUrl, copy, { observe: 'response' }).map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
+        return this.http
+            .put<TextExercise>(this.resourceUrl, copy, { params: options, observe: 'response' })
+            .map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res));
     }
 
     find(id: number): Observable<EntityResponseType> {

--- a/src/main/webapp/app/layouts/notification-container/notification-container.scss
+++ b/src/main/webapp/app/layouts/notification-container/notification-container.scss
@@ -4,6 +4,9 @@
     overflow: auto;
     .notification-item {
         cursor: pointer;
+        h5 {
+            white-space: initial;
+        }
         .notification-description {
             white-space: normal;
         }

--- a/src/main/webapp/i18n/de/exercise.json
+++ b/src/main/webapp/i18n/de/exercise.json
@@ -63,6 +63,7 @@
             "isQuiz": "Das ist eine Quizübung",
             "isText": "Das ist eine Textübung",
             "isFileUpload": "Das ist eine Datei-Upload-Übung",
+            "notificiationText": "Optional: Mitteilung über die Änderung",
             "errors": {
                 "exerciseNotFound": "Diese Übung konnte nicht gefunden werden"
             }

--- a/src/main/webapp/i18n/de/lecture.json
+++ b/src/main/webapp/i18n/de/lecture.json
@@ -39,6 +39,11 @@
                 "notificationPlaceholder": "Optional: Mitteilung über die Änderung",
                 "error": "Die Datei {{ fileName }} ist zu groß. Die maximale Dateigröße beträgt 10MB"
             }
+        },
+        "attachment": {
+            "created": "Anhang erstellt mit ID {{ param }}",
+            "updated": "Anhang aktualisiert mit ID {{ param }}",
+            "deleted": "Anhang gelöscht mit ID {{ param }}"
         }
     }
 }

--- a/src/main/webapp/i18n/en/exercise.json
+++ b/src/main/webapp/i18n/en/exercise.json
@@ -63,6 +63,7 @@
             "isQuiz": "This is a quiz exercise",
             "isText": "This is a text exercise",
             "isFileUpload": "This is a file upload exercise",
+            "notificationText": "Optional: Notification about changes",
             "errors": {
                 "exerciseNotFound": "This exercise was not found"
             }

--- a/src/main/webapp/i18n/en/lecture.json
+++ b/src/main/webapp/i18n/en/lecture.json
@@ -39,6 +39,11 @@
                 "notificationPlaceholder": "Optional: Notification about changes",
                 "error": "The file {{ fileName }} is too large. The maximum filesize is 10MB"
             }
+        },
+        "attachment": {
+            "created": "A new attachment is created with identifier {{ param }}",
+            "updated": "A attachment is updated with identifier {{ param }}",
+            "deleted": "A attachment is deleted with identifier {{ param }}"
         }
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] I added screenshots/screencast of my UI changes
- [x] I translated all the newly inserted strings

### Motivation and Context
When an instructor saves an exercise a new notification is generated. Right now it contains generic information. Students don't know what changed based on the notification.

### Description
I added an input field for optional notification texts for exercises that are edited. This text field is not visible for new exercisis.

### Steps for Testing
1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Create any type of exercise
4. Edit the same exercise
5. Provide a notification text in the input field at the bottom of the form
6. the generated notification for the student group of a course should receive a notification with the correct text.

### Screenshots
![image](https://user-images.githubusercontent.com/10998002/59770094-b081c880-92a7-11e9-8d4d-6be754406f1b.png)

