### PR TITLE
Text: Only Show “General Feedback” if it has a `detailText`.

### DIFF
--- a/src/main/webapp/app/text-editor/text-editor.component.ts
+++ b/src/main/webapp/app/text-editor/text-editor.component.ts
@@ -99,9 +99,17 @@ export class TextEditorComponent implements OnInit {
         );
     }
 
+    /**
+     * Find "General Feedback" item for Result, if it exists.
+     * General Feedback is stored in the same Array as  the other Feedback, but does not have a reference.
+     * @return General Feedback item, if it exists and if it has a Feedback Text.
+     */
     get generalFeedback(): Feedback | null {
         if (this.result && this.result.feedbacks && Array.isArray(this.result.feedbacks)) {
-            return this.result.feedbacks.find(f => f.reference == null) || null;
+            const feedbackWithoutReference = this.result.feedbacks.find(f => f.reference == null) || null;
+            if (feedbackWithoutReference != null && feedbackWithoutReference.detailText != null && feedbackWithoutReference.detailText.length > 0) {
+                return feedbackWithoutReference;
+            }
         }
 
         return null;


### PR DESCRIPTION
### Checklist
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [X] I documented my source code using the JavaDoc / JSDoc style.
- [ ] I added integration test cases for the server (Spring) related to the features
- [ ] I added integration test cases for the client (Jest) related to the features
- [ ] I added screenshots/screencast of my UI changes
- [X] ~I translated all the newly inserted strings~

### Motivation and Context
The general feedback box is visible, also if there is no General Feedback.

### Description
Only show general feedback if it the comment is actually set.

### Steps for Testing

1. Submit Text
2. Asses Text blocks but do *not* provide general feedback 

Was:
General Feedback box was shown, but empty.

Now is:
General Feedback box is not shown if no comment text.
 