### PR TITLE
Bugfix/reject complaints

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/AssessmentUpdate.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/AssessmentUpdate.java
@@ -25,11 +25,21 @@ public class AssessmentUpdate {
         this.feedbacks = feedbacks;
     }
 
+    public AssessmentUpdate feedbacks(List<Feedback> feedbacks) {
+        this.feedbacks = feedbacks;
+        return this;
+    }
+
     public ComplaintResponse getComplaintResponse() {
         return complaintResponse;
     }
 
     public void setComplaintResponse(ComplaintResponse complaintResponse) {
         this.complaintResponse = complaintResponse;
+    }
+
+    public AssessmentUpdate complaintResponse(ComplaintResponse complaintResponse) {
+        this.complaintResponse = complaintResponse;
+        return this;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -51,6 +51,9 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
     @Query("select r from Result r left join fetch r.feedbacks where r.id = :resultId")
     Optional<Result> findByIdWithEagerFeedbacks(@Param("resultId") Long id);
 
+    @Query("select r from Result r left join fetch r.feedbacks left join fetch r.assessor where r.id = :resultId")
+    Optional<Result> findByIdWithEagerFeedbacksAndAssessor(@Param("resultId") Long id);
+
     @Query("select r from Result r left join fetch r.submission left join fetch r.feedbacks left join fetch r.assessor where r.id = :resultId")
     Optional<Result> findByIdWithEagerSubmissionAndFeedbacksAndAssessor(@Param("resultId") Long id);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ComplaintResponseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ComplaintResponseService.java
@@ -49,7 +49,6 @@ public class ComplaintResponseService {
      * @return the saved complaint response
      */
     public ComplaintResponse createComplaintResponse(ComplaintResponse complaintResponse) {
-        log.debug("REST request to save ComplaintResponse: {}", complaintResponse);
         if (complaintResponse.getId() != null) {
             throw new BadRequestAlertException("A new complaint response cannot already have an id", ENTITY_NAME, "idexists");
         }
@@ -71,7 +70,7 @@ public class ComplaintResponseService {
         if (complaintResponseRepository.findByComplaint_Id(originalComplaint.getId()).isPresent()) {
             throw new BadRequestAlertException("The complaint you are referring to does already have a response", ENTITY_NAME, "complaintresponseexists");
         }
-        // Only tutors who are not part the original assessors can reply to a complaint
+        // Only tutors who are not the original assessor of the submission can reply to a complaint
         if (!authorizationCheckService.isAtLeastTeachingAssistantForExercise(originalComplaint.getResult().getParticipation().getExercise())
                 || originalComplaint.getResult().getAssessor().equals(reviewer)) {
             throw new AccessForbiddenException("Insufficient permission for creating a complaint response");

--- a/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
@@ -49,7 +49,7 @@ public class ComplaintService {
      */
     @Transactional
     public Complaint createComplaint(Complaint complaint, Principal principal) {
-        Result originalResult = resultRepository.findById(complaint.getResult().getId())
+        Result originalResult = resultRepository.findByIdWithEagerFeedbacksAndAssessor(complaint.getResult().getId())
                 .orElseThrow(() -> new BadRequestAlertException("The result you are referring to does not exist", ENTITY_NAME, "resultnotfound"));
         User originalSubmissor = originalResult.getParticipation().getStudent();
         Long courseId = originalResult.getParticipation().getExercise().getCourse().getId();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
@@ -78,7 +78,7 @@ public class ComplaintResource {
             throw new BadRequestAlertException("A complaint can be only associated to a result", ENTITY_NAME, "noresultid");
         }
 
-        if (complaintService.getById(complaint.getResult().getId()).isPresent()) {
+        if (complaintService.getByResultId(complaint.getResult().getId()).isPresent()) {
             throw new BadRequestAlertException("A complaint for this result already exists", ENTITY_NAME, "complaintexists");
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
@@ -229,6 +229,7 @@ public class ModelingAssessmentResource extends AssessmentResource {
     @PostMapping("/modeling-submissions/{submissionId}/assessment-after-complaint")
     @PreAuthorize("hasAnyRole('TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<Result> updateModelingAssessmentAfterComplaint(@PathVariable Long submissionId, @RequestBody AssessmentUpdate assessmentUpdate) {
+        log.debug("REST request to update the assessment of submission {} after complaint.", submissionId);
         ModelingSubmission modelingSubmission = modelingSubmissionService.findOneWithEagerResultAndFeedback(submissionId);
         long exerciseId = modelingSubmission.getParticipation().getExercise().getId();
         ModelingExercise modelingExercise = modelingExerciseService.findOne(exerciseId);

--- a/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
@@ -1,0 +1,191 @@
+package de.tum.in.www1.artemis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.tum.in.www1.artemis.domain.AssessmentUpdate;
+import de.tum.in.www1.artemis.domain.Complaint;
+import de.tum.in.www1.artemis.domain.ComplaintResponse;
+import de.tum.in.www1.artemis.domain.Feedback;
+import de.tum.in.www1.artemis.domain.Result;
+import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
+import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
+import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
+import de.tum.in.www1.artemis.repository.ComplaintRepository;
+import de.tum.in.www1.artemis.repository.ExerciseRepository;
+import de.tum.in.www1.artemis.repository.ResultRepository;
+import de.tum.in.www1.artemis.util.DatabaseUtilService;
+import de.tum.in.www1.artemis.util.ModelFactory;
+import de.tum.in.www1.artemis.util.RequestUtilService;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase
+@ActiveProfiles("artemis, bamboo")
+public class AssessmentComplaintIntegrationTest {
+
+    @Autowired
+    ExerciseRepository exerciseRepo;
+
+    @Autowired
+    RequestUtilService request;
+
+    @Autowired
+    DatabaseUtilService database;
+
+    @Autowired
+    ResultRepository resultRepo;
+
+    @Autowired
+    ComplaintRepository complaintRepo;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    private ModelingExercise modelingExercise;
+
+    private ModelingSubmission modelingSubmission;
+
+    private Result modelingAssessment;
+
+    private Complaint complaint;
+
+    @Before
+    public void initTestCase() throws Exception {
+        database.resetDatabase();
+        database.addUsers(1, 2);
+        database.addCourseWithOneModelingExercise();
+        modelingExercise = (ModelingExercise) exerciseRepo.findAll().get(0);
+        saveModelingSubmissionAndAssessment();
+        complaint = new Complaint().result(modelingAssessment).complaintText("This is not fair");
+    }
+
+    @Test
+    @WithMockUser(username = "student1")
+    public void submitComplaintAboutModelingAssessment() throws Exception {
+        request.post("/api/complaints", complaint, HttpStatus.CREATED);
+
+        Optional<Complaint> storedComplaint = complaintRepo.findByResult_Id(modelingAssessment.getId());
+        assertThat(storedComplaint).as("complaint is saved").isPresent();
+        assertThat(storedComplaint.get().getComplaintText()).as("complaint text got correctly saved").isEqualTo(complaint.getComplaintText());
+        assertThat(storedComplaint.get().isAccepted()).as("accepted flag of complaint is not set").isNull();
+        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).get();
+        assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is true").isTrue();
+        Result resultBeforeComplaint = mapper.readValue(storedComplaint.get().getResultBeforeComplaint(), Result.class);
+        // set date to UTC for comparison as the date saved in resultBeforeComplaint string is in UTC
+        storedResult.setCompletionDate(ZonedDateTime.ofInstant(storedResult.getCompletionDate().toInstant(), ZoneId.of("UTC")));
+        assertThat(resultBeforeComplaint).as("result before complaint is correctly stored").isEqualToIgnoringGivenFields(storedResult, "participation", "submission");
+    }
+
+    @Test
+    @WithMockUser(username = "student1")
+    public void submitComplaintAboutModelingAssessment_complaintLimitReached() throws Exception {
+        database.addComplaints("student1", modelingAssessment.getParticipation(), 3);
+
+        request.post("/api/complaints", complaint, HttpStatus.BAD_REQUEST);
+
+        assertThat(complaintRepo.findByResult_Id(modelingAssessment.getId())).as("complaint is not saved").isNotPresent();
+        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).get();
+        assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is false").isFalse();
+
+    }
+
+    @Test
+    @WithMockUser(username = "student1")
+    public void submitComplaintAboutModelingAssessment_assessmentTooOld() throws Exception {
+        database.updateAssessmentDueDate(modelingExercise.getId(), ZonedDateTime.now().minusDays(8));
+        database.updateResultCompletionDate(modelingAssessment.getId(), ZonedDateTime.now().minusDays(8));
+
+        request.post("/api/complaints", complaint, HttpStatus.BAD_REQUEST);
+
+        assertThat(complaintRepo.findByResult_Id(modelingAssessment.getId())).as("complaint is not saved").isNotPresent();
+        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).get();
+        assertThat(storedResult.hasComplaint()).as("hasComplaint flag of result is false").isFalse();
+    }
+
+    @Test
+    @WithMockUser(username = "tutor2", roles = "TA")
+    public void submitComplaintResponse_rejectComplaint() throws Exception {
+        complaintRepo.save(complaint);
+
+        ComplaintResponse complaintResponse = new ComplaintResponse().complaint(complaint.accepted(false)).responseText("rejected");
+        request.post("/api/complaint-responses", complaintResponse, HttpStatus.CREATED);
+
+        Complaint storedComplaint = complaintRepo.findByResult_Id(modelingAssessment.getId()).get();
+        assertThat(storedComplaint.isAccepted()).as("complaint is not accepted").isFalse();
+        Result storedResult = resultRepo.findByIdWithEagerFeedbacks(modelingAssessment.getId()).get();
+        checkFeedbackCorrectlyStored(modelingAssessment.getFeedbacks(), storedResult.getFeedbacks());
+    }
+
+    @Test
+    @WithMockUser(username = "tutor2", roles = "TA")
+    public void submitComplaintResponse_updateAssessment() throws Exception {
+        complaint = complaintRepo.save(complaint);
+
+        List<Feedback> feedback = database.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
+        ComplaintResponse complaintResponse = new ComplaintResponse().complaint(complaint.accepted(true)).responseText("accepted");
+        AssessmentUpdate assessmentUpdate = new AssessmentUpdate().feedbacks(feedback).complaintResponse(complaintResponse);
+        request.postWithResponseBody("/api/modeling-submissions/" + modelingSubmission.getId() + "/assessment-after-complaint", assessmentUpdate, Result.class, HttpStatus.OK);
+
+        Complaint storedComplaint = complaintRepo.findByResult_Id(modelingAssessment.getId()).get();
+        assertThat(storedComplaint.isAccepted()).as("complaint is accepted").isTrue();
+        Result resultBeforeComplaint = mapper.readValue(storedComplaint.getResultBeforeComplaint(), Result.class);
+        // set completion date to UTC for comparison as the date saved in resultBeforeComplaint string is in UTC
+        modelingAssessment.setCompletionDate(ZonedDateTime.ofInstant(modelingAssessment.getCompletionDate().toInstant(), ZoneId.of("UTC")));
+        assertThat(resultBeforeComplaint).as("result before complaint is correctly stored").isEqualToIgnoringGivenFields(modelingAssessment, "participation", "submission");
+        Result storedResult = resultRepo.findByIdWithEagerFeedbacksAndAssessor(modelingAssessment.getId()).get();
+        checkFeedbackCorrectlyStored(feedback, storedResult.getFeedbacks());
+        assertThat(storedResult.getAssessor()).as("assessor is still the original one").isEqualTo(modelingAssessment.getAssessor());
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void submitComplaintResponse_asAssessor_forbidden() throws Exception {
+        complaintRepo.save(complaint);
+
+        ComplaintResponse complaintResponse = new ComplaintResponse().complaint(complaint.accepted(false)).responseText("rejected");
+        request.post("/api/complaint-responses", complaintResponse, HttpStatus.FORBIDDEN);
+
+        Complaint storedComplaint = complaintRepo.findByResult_Id(modelingAssessment.getId()).get();
+        assertThat(storedComplaint.isAccepted()).as("accepted flag of complaint is not set").isNull();
+    }
+
+    private void checkFeedbackCorrectlyStored(List<Feedback> sentFeedback, List<Feedback> storedFeedback) {
+        assertThat(sentFeedback.size()).as("contains the same amount of feedback").isEqualTo(storedFeedback.size());
+        Result storedFeedbackResult = new Result();
+        Result sentFeedbackResult = new Result();
+        storedFeedbackResult.setFeedbacks(storedFeedback);
+        sentFeedbackResult.setFeedbacks(sentFeedback);
+        storedFeedbackResult.evaluateFeedback(20);
+        sentFeedbackResult.evaluateFeedback(20);
+        assertThat(storedFeedbackResult.getScore()).as("stored feedback evaluates to the same score as sent feedback").isEqualTo(sentFeedbackResult.getScore());
+        storedFeedback.forEach(feedback -> {
+            assertThat(feedback.getType()).as("type has been set to MANUAL").isEqualTo(FeedbackType.MANUAL);
+        });
+    }
+
+    private void saveModelingSubmissionAndAssessment() throws Exception {
+        modelingSubmission = ModelFactory.generateModelingSubmission(database.loadFileFromResources("test-data/model-submission/model.54727.json"), true);
+        modelingSubmission = database.addModelingSubmission(modelingExercise, modelingSubmission, "student1");
+        modelingAssessment = database.addModelingAssessmentForSubmission(modelingExercise, modelingSubmission, "test-data/model-assessment/assessment.54727.v2.json", "tutor1");
+    }
+}

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -60,6 +60,12 @@ public class DatabaseUtilService {
     FeedbackRepository feedbackRepo;
 
     @Autowired
+    ComplaintRepository complaintRepo;
+
+    @Autowired
+    ComplaintResponseRepository complaintResponseRepo;
+
+    @Autowired
     ModelingSubmissionService modelSubmissionService;
 
     @Autowired
@@ -71,6 +77,8 @@ public class DatabaseUtilService {
     public void resetDatabase() {
         conflictRepo.deleteAll();
         conflictingResultRepo.deleteAll();
+        complaintResponseRepo.deleteAll();
+        complaintRepo.deleteAll();
         resultRepo.deleteAll();
         feedbackRepo.deleteAll();
         modelingSubmissionRepo.deleteAll();
@@ -124,6 +132,19 @@ public class DatabaseUtilService {
         return participationRepo.findByIdWithEagerSubmissionsAndEagerResultsAndEagerAssessors(storedParticipation.get().getId()).get();
     }
 
+    public void addCourseWithOneModelingExercise() {
+        Course course = ModelFactory.generateCourse(null, pastTimestamp, futureFutureTimestamp, new HashSet<>(), "tumuser", "tutor", "tutor");
+        ModelingExercise modelingExercise = ModelFactory.generateModelingExercise(pastTimestamp, futureTimestamp, futureFutureTimestamp, DiagramType.ClassDiagram, course);
+        course.addExercises(modelingExercise);
+        courseRepo.save(course);
+        exerciseRepo.save(modelingExercise);
+        List<Course> courseRepoContent = courseRepo.findAllActiveWithEagerExercises();
+        List<Exercise> exerciseRepoContent = exerciseRepo.findAll();
+        assertThat(exerciseRepoContent.size()).as("one exercise got stored").isEqualTo(1);
+        assertThat(courseRepoContent.size()).as("a course got stored").isEqualTo(1);
+        assertThat(courseRepoContent.get(0).getExercises()).as("course contains the exercise").containsExactlyInAnyOrder(exerciseRepoContent.toArray(new Exercise[] {}));
+    }
+
     public void addCourseWithDifferentModelingExercises() {
         Course course = ModelFactory.generateCourse(null, pastTimestamp, futureFutureTimestamp, new HashSet<>(), "tumuser", "tutor", "tutor");
         ModelingExercise classExercise = ModelFactory.generateModelingExercise(pastTimestamp, futureTimestamp, futureFutureTimestamp, DiagramType.ClassDiagram, course);
@@ -141,7 +162,7 @@ public class DatabaseUtilService {
         exerciseRepo.save(useCaseExercise);
         List<Course> courseRepoContent = courseRepo.findAllActiveWithEagerExercises();
         List<Exercise> exerciseRepoContent = exerciseRepo.findAll();
-        assertThat(exerciseRepoContent.size()).as("a exercise got stored").isEqualTo(4);
+        assertThat(exerciseRepoContent.size()).as("four exercises got stored").isEqualTo(4);
         assertThat(courseRepoContent.size()).as("a course got stored").isEqualTo(1);
         assertThat(courseRepoContent.get(0).getExercises().size()).as("Course contains exercise").isEqualTo(4);
         assertThat(courseRepoContent.get(0).getExercises()).as("Contains all exercises").containsExactlyInAnyOrder(exerciseRepoContent.toArray(new Exercise[] {}));
@@ -213,6 +234,8 @@ public class DatabaseUtilService {
     public Result addModelingAssessmentForSubmission(ModelingExercise exercise, ModelingSubmission submission, String path, String login) throws Exception {
         List<Feedback> assessment = loadAssessmentFomResources(path);
         Result result = modelingAssessmentService.saveManualAssessment(submission, assessment, exercise);
+        result.setParticipation(submission.getParticipation());
+        result.setAssessor(getUserByLogin(login));
         result = modelingAssessmentService.submitManualAssessment(result, exercise, submission.getSubmissionDate());
         return result;
     }
@@ -244,5 +267,26 @@ public class DatabaseUtilService {
         Exercise exercise = exerciseRepo.findById(exerciseId).orElseThrow(() -> new IllegalArgumentException("Exercise with given ID could not be found"));
         exercise.setDueDate(newDueDate);
         exerciseRepo.save(exercise);
+    }
+
+    public void updateAssessmentDueDate(long exerciseId, ZonedDateTime newDueDate) {
+        Exercise exercise = exerciseRepo.findById(exerciseId).orElseThrow(() -> new IllegalArgumentException("Exercise with given ID could not be found"));
+        exercise.setAssessmentDueDate(newDueDate);
+        exerciseRepo.save(exercise);
+    }
+
+    public void updateResultCompletionDate(long resultId, ZonedDateTime newCompletionDate) {
+        Result result = resultRepo.findById(resultId).orElseThrow(() -> new IllegalArgumentException("Result with given ID could not be found"));
+        result.setCompletionDate(newCompletionDate);
+        resultRepo.save(result);
+    }
+
+    public void addComplaints(String studentLogin, Participation participation, int numberOfComplaints) {
+        for (int i = 0; i < numberOfComplaints; i++) {
+            Result dummyResult = new Result().participation(participation);
+            dummyResult = resultRepo.save(dummyResult);
+            Complaint complaint = new Complaint().student(getUserByLogin(studentLogin)).result(dummyResult);
+            complaintRepo.save(complaint);
+        }
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
@@ -12,14 +12,24 @@ public class ModelFactory {
 
     public static ModelingExercise generateModelingExercise(ZonedDateTime releaseDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, DiagramType diagramType,
             Course course) {
-        ModelingExercise exercise = new ModelingExercise();
+        ModelingExercise modelingExercise = new ModelingExercise();
+        modelingExercise = (ModelingExercise) populateExercise(modelingExercise, releaseDate, dueDate, assessmentDueDate, course);
+        modelingExercise.setDiagramType(diagramType);
+        return modelingExercise;
+    }
+
+    public static TextExercise generateTextExercise(ZonedDateTime releaseDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, Course course) {
+        TextExercise textExercise = new TextExercise();
+        return (TextExercise) populateExercise(textExercise, releaseDate, dueDate, assessmentDueDate, course);
+    }
+
+    public static Exercise populateExercise(Exercise exercise, ZonedDateTime releaseDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, Course course) {
         exercise.setTitle(UUID.randomUUID().toString());
         exercise.setShortName("t" + UUID.randomUUID().toString().substring(0, 3));
         exercise.setMaxScore(5.0);
         exercise.setReleaseDate(releaseDate);
         exercise.setDueDate(dueDate);
         exercise.assessmentDueDate(assessmentDueDate);
-        exercise.setDiagramType(diagramType);
         exercise.setCourse(course);
         exercise.setParticipations(new HashSet<>());
         exercise.setExampleSubmissions(new HashSet<>());


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] I added integration test cases for the server (Spring) related to the features
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Description
<!-- Describe your changes in detail -->
Currently it is not possible to reject a complaint as the complaint is not properly loaded from the database when creating the reject complaint response. This is fixed in this PR. Additionally, I added several integration tests for testing the complaints and complaint responses. While writing the tests I discovered additional issues with the complaints workflow.

Resolved issues in this PR:
- Properly load complaint from database when creating reject complaint response which allows to reject complaints again
- Use the correct service method for checking if a complaint for the corresponding result already exists
- Load result with eager feedback and assessor when creating a complaint to ensure the result is properly stored in the _resultBeforeComplaint_ string
- Removed duplicated code

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS as a student
2. Submit a complaint for a text or modeling assessment
3. Log in to ArTEMiS as a tutor
4. Reject the created complaint