### PR TITLE
Make ContinuousIntegrationService optional in ResultResource to run Tests without bamboo profile.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       - stage: Build
         name: "TypeScript"
         language: node_js
-        node_js: 12.2.0
+        node_js: 12.3.1
         install: yarn install
         script: yarn build
       - stage: Test
@@ -30,7 +30,7 @@ jobs:
       - stage: Test
         name: "TypeScript"
         language: node_js
-        node_js: 12.2.0
+        node_js: 12.3.1
         install: yarn install
         script: yarn test
       - stage: Lint
@@ -42,6 +42,6 @@ jobs:
       - stage: Lint
         name: "TypeScript"
         language: node_js
-        node_js: 12.2.0
+        node_js: 12.3.1
         install: yarn install
         script: yarn prettier:check

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
@@ -62,13 +62,13 @@ public class ResultResource {
 
     private final UserService userService;
 
-    private final ContinuousIntegrationService continuousIntegrationService;
+    private final Optional<ContinuousIntegrationService> continuousIntegrationService;
 
     private final ProgrammingExerciseService programmingExerciseService;
 
     public ResultResource(UserService userService, ResultRepository resultRepository, ParticipationService participationService, ResultService resultService,
-            AuthorizationCheckService authCheckService, FeedbackService feedbackService, ExerciseService exerciseService, ContinuousIntegrationService continuousIntegrationService,
-            ProgrammingExerciseService programmingExerciseService) {
+            AuthorizationCheckService authCheckService, FeedbackService feedbackService, ExerciseService exerciseService,
+            Optional<ContinuousIntegrationService> continuousIntegrationService, ProgrammingExerciseService programmingExerciseService) {
 
         this.userService = userService;
         this.resultRepository = resultRepository;
@@ -157,7 +157,7 @@ public class ResultResource {
         }
 
         try {
-            String planKey = continuousIntegrationService.getPlanKey(requestBody);
+            String planKey = continuousIntegrationService.get().getPlanKey(requestBody);
             log.info("PlanKey for received notifyResultNew is {}", planKey);
             Optional<Participation> optionalParticipation = getParticipation(planKey);
             if (optionalParticipation.isPresent()) {

--- a/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
@@ -40,7 +40,7 @@ import de.tum.in.www1.artemis.util.RequestUtilService;
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase
-@ActiveProfiles("artemis, bamboo")
+@ActiveProfiles("artemis")
 public class AssessmentComplaintIntegrationTest {
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/CourseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/CourseIntegrationTest.java
@@ -27,7 +27,7 @@ import de.tum.in.www1.artemis.util.RequestUtilService;
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase
-@ActiveProfiles("artemis, bamboo")
+@ActiveProfiles("artemis")
 public class CourseIntegrationTest {
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/GitServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/GitServiceTest.java
@@ -28,7 +28,7 @@ import de.tum.in.www1.artemis.util.GitUtilService;
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase
-@ActiveProfiles("artemis, bamboo")
+@ActiveProfiles("artemis")
 public class GitServiceTest {
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingAssessmentIntegrationTest.java
@@ -32,7 +32,6 @@ import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.ModelingSubmissionService;
 import de.tum.in.www1.artemis.service.ParticipationService;
-import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.util.RequestUtilService;
@@ -41,7 +40,7 @@ import de.tum.in.www1.artemis.util.RequestUtilService;
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase
-@ActiveProfiles("artemis, bamboo")
+@ActiveProfiles("artemis")
 public class ModelingAssessmentIntegrationTest {
 
     @Autowired
@@ -73,9 +72,6 @@ public class ModelingAssessmentIntegrationTest {
 
     @Autowired
     ParticipationService participationService;
-
-    @Autowired
-    ContinuousIntegrationService continuousIntegrationService;
 
     private ModelingExercise classExercise;
 

--- a/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
@@ -29,7 +29,7 @@ import de.tum.in.www1.artemis.util.*;
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase
-@ActiveProfiles("artemis, bamboo")
+@ActiveProfiles("artemis")
 public class ModelingSubmissionIntegrationTest {
 
     @Autowired

--- a/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
@@ -29,7 +29,7 @@ import de.tum.in.www1.artemis.util.RequestUtilService;
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureTestDatabase
-@ActiveProfiles("artemis, bamboo")
+@ActiveProfiles("artemis")
 public class ParticipationIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
### Checklist
- [X] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [X] ~I documented my source code using the JavaDoc / JSDoc style.~
- [X] I added integration test cases for the server (Spring) related to the features
- [X] ~I added integration test cases for the client (Jest) related to the features~
- [X] ~I added screenshots/screencast of my UI changes~
- [X] ~I translated all the newly inserted strings~

### Motivation and Context
It was not possible to run test without the "bamboo" profile, as the `ResultResource` required a non-optional implementation of the `ContinuousIntegrationService` interface.

### Description
This changes the Dependency of the `ResultResource` to `Optional<ContinuousIntegrationService>` (identical to other usages) and removed the dependency to the bamboo profile from all integration tests.

### Steps for Testing
Run Unit Tests.