### PR TITLE
Hotfix / Programming-Exercises: Handle Template and Solution Participation access

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -45,4 +45,8 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
     ProgrammingExercise findOneByTemplateParticipationId(Long templateParticipationId);
 
     ProgrammingExercise findOneBySolutionParticipationId(Long solutionParticipationId);
+
+    @EntityGraph(attributePaths = "course")
+    @Query("select pe from ProgrammingExercise pe left join fetch pe.templateParticipation tp left join fetch pe.solutionParticipation sp where tp.id = :#{#participationId} or sp.id = :#{#participationId}")
+    Optional<ProgrammingExercise> findOneByTemplateParticipationIdOrSolutionParticipationId(@Param("participationId") Long participationId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -396,6 +396,16 @@ public class ProgrammingExerciseService {
     }
 
     /**
+     * Find the ProgrammingExercise where the given Participation is the solution or template Participation
+     *
+     * @param participation The solution or template participation
+     * @return The ProgrammingExercise where the given Participation is the solution or template Participation
+     */
+    public Optional<ProgrammingExercise> getExerciseForSolutionOrTemplateParticipation(Participation participation) {
+        return programmingExerciseRepository.findOneByTemplateParticipationIdOrSolutionParticipationId(participation.getId());
+    }
+
+    /**
      * This methods sets the values (initialization date and initialization state) of the template and solution participation
      *
      * @param programmingExercise The programming exercise

--- a/src/main/java/de/tum/in/www1/artemis/service/RepositoryService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/RepositoryService.java
@@ -14,8 +14,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Optional;
 
-import javax.annotation.Nullable;
-
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.springframework.stereotype.Service;
@@ -37,10 +35,13 @@ public class RepositoryService {
 
     private UserService userService;
 
-    public RepositoryService(Optional<GitService> gitService, AuthorizationCheckService authCheckService, UserService userService) {
+    private ParticipationService participationService;
+
+    public RepositoryService(Optional<GitService> gitService, AuthorizationCheckService authCheckService, UserService userService, ParticipationService participationService) {
         this.gitService = gitService;
         this.authCheckService = authCheckService;
         this.userService = userService;
+        this.participationService = participationService;
     }
 
     /**
@@ -267,7 +268,7 @@ public class RepositoryService {
      * @throws InterruptedException
      */
     public Repository checkoutRepositoryByParticipation(Participation participation) throws IOException, IllegalAccessException, InterruptedException {
-        boolean hasAccess = canAccessParticipation(participation);
+        boolean hasAccess = participationService.canAccessParticipation(participation);
         if (!hasAccess) {
             throw new IllegalAccessException();
         }
@@ -275,42 +276,4 @@ public class RepositoryService {
         return gitService.get().getOrCheckoutRepository(participation);
     }
 
-    /**
-     * Check if a repository can be accessed given a participation.
-     * 
-     * @param participation
-     * @return
-     */
-    @Nullable
-    public boolean canAccessParticipation(Participation participation) {
-        if (!userHasPermissions(participation))
-            return false;
-
-        if (!Optional.ofNullable(participation).isPresent()) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Check if a user has permissions to to access a certain participation. This includes not only the owner of the participation but also the TAs and instructors of the course.
-     * 
-     * @param participation
-     * @return
-     */
-    private boolean userHasPermissions(Participation participation) {
-        if (!authCheckService.isOwnerOfParticipation(participation)) {
-            // if the user is not the owner of the participation, the user can only see it in case he is
-            // a teaching assistant or an instructor of the course, or in case he is admin
-            User user = userService.getUserWithGroupsAndAuthorities();
-            //TODO: temporary workaround for problems with the relationship between exercise and participations / templateParticipation / solutionParticipation
-            if (participation.getExercise() == null) {
-                //this can only happen if we have a template or solution participation. Then the call can only be invoked by an instructor / teaching assistant
-                return true;
-            }
-            Course course = participation.getExercise().getCourse();
-            return authCheckService.isTeachingAssistantInCourse(course, user) || authCheckService.isInstructorInCourse(course, user) || authCheckService.isAdmin();
-        }
-        return true;
-    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -392,7 +392,7 @@ public class ParticipationResource {
     public ResponseEntity<Participation> getParticipationWithLatestResult(@PathVariable Long id) {
         log.debug("REST request to get Participation : {}", id);
         Participation participation = participationService.findOneWithEagerResults(id);
-        checkAccessPermissionOwner(participation);
+        participationService.canAccessParticipation(participation);
         Result result = participation.getExercise().findLatestResultWithCompletionDate(participation);
         Set<Result> results = new HashSet<>();
         if (result != null) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryParticipationResource.java
@@ -177,8 +177,7 @@ public class RepositoryParticipationResource extends RepositoryResource {
         log.debug("REST request to get build log : {}", participationId);
 
         Participation participation = participationService.findOne(participationId);
-        boolean hasPermissions = repositoryService.canAccessParticipation(participation);
-        if (!hasPermissions)
+        if (!participationService.canAccessParticipation(participation))
             return forbidden();
 
         List<BuildLogEntry> logs = continuousIntegrationService.get().getLatestBuildLogs(participation);


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Description
<!-- Describe your changes in detail -->

Older Template and Solution Participations don't have a reference to an exercise.
This PR addresses how to handle their permissions as their exercise can't be retrieved.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
