### PR TITLE
Enhancement / disable participation repositories without repositoryUrl

### DIFF
--- a/src/main/webapp/app/code-editor/code-editor-instructor-container.component.html
+++ b/src/main/webapp/app/code-editor/code-editor-instructor-container.component.html
@@ -28,7 +28,7 @@
                 <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>{{ selectedRepository }}</button>
                 <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
                     <button
-                        [disabled]="!exercise || !exercise.templateParticipation || !exercise.templateParticipation.id"
+                        [disabled]="!exercise || !exercise.templateParticipation || !exercise.templateParticipation.id || !exercise.templateParticipation.repositoryUrl"
                         (click)="selectTemplateParticipation()"
                         ngbDropdownItem
                         [style.background-color]="selectedRepository === REPOSITORY.TEMPLATE ? '#3e8acc' : 'transparent'"
@@ -36,7 +36,7 @@
                         <span jhiTranslate="artemisApp.editor.repoSelect.templateRepo">Template Repository</span>
                     </button>
                     <button
-                        [disabled]="!exercise || !exercise.solutionParticipation || !exercise.solutionParticipation.id"
+                        [disabled]="!exercise || !exercise.solutionParticipation || !exercise.solutionParticipation.id || !exercise.solutionParticipation.repositoryUrl"
                         (click)="selectSolutionParticipation()"
                         ngbDropdownItem
                         [style.background-color]="selectedRepository === REPOSITORY.SOLUTION ? '#3e8acc' : 'transparent'"
@@ -50,7 +50,8 @@
                             loadingState === LOADING_STATE.DELETING_ASSIGNMENT_REPO ||
                             !exercise ||
                             !exercise.participations ||
-                            !exercise.participations.length
+                            !exercise.participations.length ||
+                            (exercise.participations.length && !exercise.participations[0].repositoryUrl)
                         "
                         (click)="selectAssignmentParticipation()"
                         ngbDropdownItem

--- a/src/main/webapp/app/code-editor/code-editor-instructor-container.component.ts
+++ b/src/main/webapp/app/code-editor/code-editor-instructor-container.component.ts
@@ -108,8 +108,22 @@ export class CodeEditorInstructorContainerComponent extends CodeEditorContainer 
                         if (this.router.url.endsWith('/test')) {
                             this.domainService.setDomain([DomainType.TEST_REPOSITORY, this.exercise]);
                         } else {
-                            // Template participation is default when no participationId is provided
-                            this.selectParticipationDomainById(participationId || this.exercise.templateParticipation.id);
+                            // Template participation is default when no participationId is provided.
+                            // We also have to filter out participations that don't have a repository url (faulty data).
+                            const availableParticipations = [
+                                this.exercise.templateParticipation,
+                                this.exercise.solutionParticipation,
+                                this.exercise.participations && this.exercise.participations.length ? this.exercise.participations[0] : undefined,
+                            ].filter(Boolean);
+                            const selectedParticipation = availableParticipations.find(({ id }: Participation) => id === participationId);
+                            const nextAvailableParticipation = [selectedParticipation, ...availableParticipations]
+                                .filter(Boolean)
+                                .find(({ repositoryUrl }: Participation) => !!repositoryUrl);
+                            if (nextAvailableParticipation) {
+                                this.selectParticipationDomainById(nextAvailableParticipation.id);
+                            } else {
+                                throwError('participationNotFound');
+                            }
                         }
                     }),
                     tap(() => {

--- a/src/main/webapp/app/code-editor/code-editor-instructor-container.component.ts
+++ b/src/main/webapp/app/code-editor/code-editor-instructor-container.component.ts
@@ -108,17 +108,7 @@ export class CodeEditorInstructorContainerComponent extends CodeEditorContainer 
                         if (this.router.url.endsWith('/test')) {
                             this.domainService.setDomain([DomainType.TEST_REPOSITORY, this.exercise]);
                         } else {
-                            // Template participation is default when no participationId is provided.
-                            // We also have to filter out participations that don't have a repository url (faulty data).
-                            const availableParticipations = [
-                                this.exercise.templateParticipation,
-                                this.exercise.solutionParticipation,
-                                this.exercise.participations && this.exercise.participations.length ? this.exercise.participations[0] : undefined,
-                            ].filter(Boolean);
-                            const selectedParticipation = availableParticipations.find(({ id }: Participation) => id === participationId);
-                            const nextAvailableParticipation = [selectedParticipation, ...availableParticipations]
-                                .filter(Boolean)
-                                .find(({ repositoryUrl }: Participation) => !!repositoryUrl);
+                            const nextAvailableParticipation = this.getNextAvailableParticipation(participationId);
                             if (nextAvailableParticipation) {
                                 this.selectParticipationDomainById(nextAvailableParticipation.id);
                             } else {
@@ -149,6 +139,23 @@ export class CodeEditorInstructorContainerComponent extends CodeEditorContainer 
         if (this.paramSub) {
             this.paramSub.unsubscribe();
         }
+    }
+
+    /**
+     * Get the next available participation, highest priority has the participation given to the method.
+     * Removes participations without a repositoryUrl (could be invalid).
+     * Returns undefined if no valid participation can be found.
+     *
+     * @param preferredParticipationId
+     */
+    private getNextAvailableParticipation(preferredParticipationId: number): Participation | undefined {
+        const availableParticipations = [
+            this.exercise.templateParticipation,
+            this.exercise.solutionParticipation,
+            this.exercise.participations && this.exercise.participations.length ? this.exercise.participations[0] : undefined,
+        ].filter(Boolean);
+        const selectedParticipation = availableParticipations.find(({ id }: Participation) => id === preferredParticipationId);
+        return [selectedParticipation, ...availableParticipations].filter(Boolean).find(({ repositoryUrl }: Participation) => !!repositoryUrl);
     }
 
     /**

--- a/src/test/javascript/spec/integration/code-editor/code-editor-instructor.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-instructor.spec.ts
@@ -197,9 +197,9 @@ describe('CodeEditorInstructorIntegration', () => {
         const exercise = {
             id: 1,
             problemStatement,
-            participations: [{ id: 2 }],
-            templateParticipation: { id: 3 },
-            solutionParticipation: { id: 4 },
+            participations: [{ id: 2, repositoryUrl: 'test' }],
+            templateParticipation: { id: 3, repositoryUrl: 'test2' },
+            solutionParticipation: { id: 4, repositoryUrl: 'test3' },
         } as ProgrammingExercise;
         exercise.participations = exercise.participations.map(p => ({ ...p, exercise }));
         exercise.templateParticipation = { ...exercise.templateParticipation, exercise };
@@ -317,9 +317,9 @@ describe('CodeEditorInstructorIntegration', () => {
         const exercise = {
             id: 1,
             problemStatement,
-            participations: [{ id: 2 }],
-            templateParticipation: { id: 3 },
-            solutionParticipation: { id: 4 },
+            participations: [{ id: 2, repositoryUrl: 'test' }],
+            templateParticipation: { id: 3, repositoryUrl: 'test2' },
+            solutionParticipation: { id: 4, repositoryUrl: 'test3' },
         } as ProgrammingExercise;
 
         const setDomainSpy = spy(domainService, 'setDomain');
@@ -366,5 +366,39 @@ describe('CodeEditorInstructorIntegration', () => {
         expect(setDomainSpy).to.have.been.calledTwice;
         expect(setDomainSpy).to.have.been.calledWith([DomainType.PARTICIPATION, exercise.participations[0]]);
         expect(setDomainSpy).to.have.been.calledWith([DomainType.PARTICIPATION, exercise.solutionParticipation]);
+    });
+
+    it('should not be able to select a repository without repositoryUrl', () => {
+        const exercise = {
+            id: 1,
+            problemStatement,
+            participations: [{ id: 2, repositoryUrl: 'test' }],
+            templateParticipation: { id: 3 },
+            solutionParticipation: { id: 4, repositoryUrl: 'test3' },
+        } as ProgrammingExercise;
+
+        const setDomainSpy = spy(domainService, 'setDomain');
+
+        // Start with assignment repository
+        // @ts-ignore
+        (container.router as MockRouter).setUrl('code-editor-instructor/1/3');
+        container.ngOnInit();
+        routeSubject.next({ exerciseId: 1, participationId: 3 });
+        findWithParticipationsSubject.next({ body: exercise });
+
+        containerFixture.detectChanges();
+
+        expect(setDomainSpy).to.have.been.calledOnce;
+        expect(setDomainSpy).to.have.been.calledOnceWithExactly([DomainType.PARTICIPATION, exercise.solutionParticipation]);
+        expect(container.selectedRepository).to.equal(container.REPOSITORY.SOLUTION);
+        expect(container.selectedParticipation).to.deep.equal({ ...exercise.solutionParticipation, exercise });
+        expect(container.grid).to.exist;
+        expect(container.fileBrowser).to.exist;
+        expect(container.actions).to.exist;
+        expect(container.instructions).to.exist;
+        expect(container.resultComp).to.exist;
+        expect(container.buildOutput).to.exist;
+        expect(container.buildOutput.participation).to.deep.equal({ ...exercise.solutionParticipation, exercise });
+        expect(container.instructions.participation).to.deep.equal({ ...exercise.solutionParticipation, exercise });
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] I added integration test cases for the client (Jest) related to the features
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Some older exercises don't have a repository url in their participations (faulty data).

### Description
<!-- Describe your changes in detail -->

Disable participation repositories (template, solution, assignment) if there is no repository_url.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Open Code-Editor for programming-exercise with the explained issue
3. Participation repositories without repository_url should be disabled in dropdown

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/28230611/60106788-12d63f80-9766-11e9-8734-bcd200cb3e96.png)

