### PR TITLE
Bugfix/fix wrong size of drop locations

### DIFF
--- a/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.html
+++ b/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.html
@@ -218,6 +218,7 @@
                 <div class="instructions" *ngIf="!showResult">
                     <span jhiTranslate="artemisApp.dragAndDropQuestion.studentInstructions"></span>
                 </div>
+                <div *ngIf="showResult"></div>
                 <div
                     *ngIf="!showResult"
                     class="drag-items"

--- a/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.html
+++ b/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.html
@@ -60,11 +60,19 @@
                 ></jhi-quiz-scoring-infostudent-modal>
             </span>
         </div>
-        <div class="drag-and-drop-area">
-            <div class="instructions" *ngIf="showResult">
-                <span jhiTranslate="artemisApp.dragAndDropQuestion.showingSampleSolution" *ngIf="showingSampleSolution"></span>
-                <span jhiTranslate="artemisApp.dragAndDropQuestion.showingYourAnswer" *ngIf="!showingSampleSolution"></span>
+        <div class="instructions" *ngIf="showResult">
+            <span jhiTranslate="artemisApp.dragAndDropQuestion.showingSampleSolution" *ngIf="showingSampleSolution"></span>
+            <span jhiTranslate="artemisApp.dragAndDropQuestion.showingYourAnswer" *ngIf="!showingSampleSolution"></span>
+            <div *ngIf="showResult && !forceSampleSolution">
+                <div class="btn btn-outline-primary" *ngIf="!showingSampleSolution" (click)="showSampleSolution()">
+                    {{ 'artemisApp.quizQuestion.showSampleSolution' | translate }}
+                </div>
+                <div class="btn btn-outline-primary" *ngIf="showingSampleSolution" (click)="hideSampleSolution()">
+                    {{ 'artemisApp.quizQuestion.hideSampleSolution' | translate }}
+                </div>
             </div>
+        </div>
+        <div class="drag-and-drop-area">
             <div class="background-area">
                 <jhi-secured-image *ngIf="question.backgroundFilePath" [src]="question.backgroundFilePath" (endLoadingProcess)="changeLoading($event)"></jhi-secured-image>
                 <div class="click-layer">
@@ -206,11 +214,12 @@
                     </div>
                 </div>
             </div>
-            <div class="drag-and-drop-items" *ngIf="!showResult">
-                <div class="instructions">
+            <div class="drag-and-drop-items">
+                <div class="instructions" *ngIf="!showResult">
                     <span jhiTranslate="artemisApp.dragAndDropQuestion.studentInstructions"></span>
                 </div>
                 <div
+                    *ngIf="!showResult"
                     class="drag-items"
                     [ngClass]="dropAllowed ? 'drop-allowed' : ''"
                     (onDropSuccess)="onDragDrop(null, $event)"
@@ -227,14 +236,6 @@
                         [clickDisabled]="clickDisabled"
                         [minWidth]="160"
                     ></jhi-drag-item>
-                </div>
-            </div>
-            <div *ngIf="showResult && !forceSampleSolution">
-                <div class="btn btn-outline-primary" *ngIf="!showingSampleSolution" (click)="showSampleSolution()">
-                    {{ 'artemisApp.quizQuestion.showSampleSolution' | translate }}
-                </div>
-                <div class="btn btn-outline-primary" *ngIf="showingSampleSolution" (click)="hideSampleSolution()">
-                    {{ 'artemisApp.quizQuestion.hideSampleSolution' | translate }}
                 </div>
             </div>
         </div>

--- a/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.ts
+++ b/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.ts
@@ -7,7 +7,6 @@ import { DropLocation } from '../../../entities/drop-location';
 import { polyfill } from 'mobile-drag-drop';
 import { scrollBehaviourDragImageTranslateOverride } from 'mobile-drag-drop/scroll-behaviour';
 import { SecuredImageComponent } from 'app/components/util/secured-image.component';
-import { DecimalPipe } from '@angular/common';
 
 // options are optional ;)
 polyfill({
@@ -78,8 +77,6 @@ export class DragAndDropQuestionComponent implements OnChanges {
 
     loadingState = 'loading';
 
-    decimalPipe = new DecimalPipe('en');
-
     constructor(private artemisMarkdown: ArtemisMarkdown, private dragAndDropQuestionUtil: DragAndDropQuestionUtil) {}
 
     @HostListener('window:resize') onResize() {
@@ -144,7 +141,6 @@ export class DragAndDropQuestionComponent implements OnChanges {
         const dragItem = dragEvent.dragData;
 
         if (dropLocation) {
-            this.resizeDropLocation();
             // check if this mapping is new
             if (this.dragAndDropQuestionUtil.isMappedTogether(this.mappings, dragItem, dropLocation)) {
                 // Do nothing
@@ -238,7 +234,6 @@ export class DragAndDropQuestionComponent implements OnChanges {
      * @return {boolean} true, if the drop location is correct, otherwise false
      */
     isLocationCorrect(dropLocation: DropLocation): boolean {
-        this.resizeDropLocation();
         if (!this.question.correctMappings) {
             return false;
         }
@@ -266,7 +261,6 @@ export class DragAndDropQuestionComponent implements OnChanges {
     showSampleSolution() {
         this.sampleSolutionMappings = this.dragAndDropQuestionUtil.solve(this.question, this.mappings);
         this.showingSampleSolution = true;
-        this.resizeDropLocation();
     }
 
     /**
@@ -308,18 +302,5 @@ export class DragAndDropQuestionComponent implements OnChanges {
             clickLayer.style.width = image.width + 'px';
             clickLayer.style.height = image.height + 'px';
         }, 300);
-    }
-
-    resizeDropLocation() {
-        setTimeout(() => {
-            const backgroundImage = document.querySelector('.background-area jhi-secured-image img') as HTMLImageElement;
-            Array.from(document.querySelectorAll('.click-layer .drop-location')).forEach(dropLocation => {
-                const dragItemPicture = dropLocation.querySelector('jhi-secured-image img') as HTMLImageElement;
-                if (dragItemPicture) {
-                    const adjustedWidth = this.decimalPipe.transform((dragItemPicture.width / backgroundImage.width) * 101) + '%';
-                    (<HTMLElement>dropLocation).style.width = adjustedWidth;
-                }
-            });
-        }, 200);
     }
 }

--- a/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.ts
+++ b/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-and-drop-question.component.ts
@@ -7,6 +7,7 @@ import { DropLocation } from '../../../entities/drop-location';
 import { polyfill } from 'mobile-drag-drop';
 import { scrollBehaviourDragImageTranslateOverride } from 'mobile-drag-drop/scroll-behaviour';
 import { SecuredImageComponent } from 'app/components/util/secured-image.component';
+import { DecimalPipe } from '@angular/common';
 
 // options are optional ;)
 polyfill({
@@ -77,6 +78,8 @@ export class DragAndDropQuestionComponent implements OnChanges {
 
     loadingState = 'loading';
 
+    decimalPipe = new DecimalPipe('en');
+
     constructor(private artemisMarkdown: ArtemisMarkdown, private dragAndDropQuestionUtil: DragAndDropQuestionUtil) {}
 
     @HostListener('window:resize') onResize() {
@@ -139,7 +142,9 @@ export class DragAndDropQuestionComponent implements OnChanges {
     onDragDrop(dropLocation: DropLocation | null, dragEvent: any) {
         this.drop();
         const dragItem = dragEvent.dragData;
+
         if (dropLocation) {
+            this.resizeDropLocation();
             // check if this mapping is new
             if (this.dragAndDropQuestionUtil.isMappedTogether(this.mappings, dragItem, dropLocation)) {
                 // Do nothing
@@ -233,6 +238,7 @@ export class DragAndDropQuestionComponent implements OnChanges {
      * @return {boolean} true, if the drop location is correct, otherwise false
      */
     isLocationCorrect(dropLocation: DropLocation): boolean {
+        this.resizeDropLocation();
         if (!this.question.correctMappings) {
             return false;
         }
@@ -260,6 +266,7 @@ export class DragAndDropQuestionComponent implements OnChanges {
     showSampleSolution() {
         this.sampleSolutionMappings = this.dragAndDropQuestionUtil.solve(this.question, this.mappings);
         this.showingSampleSolution = true;
+        this.resizeDropLocation();
     }
 
     /**
@@ -300,6 +307,19 @@ export class DragAndDropQuestionComponent implements OnChanges {
             const clickLayer = document.getElementsByClassName('click-layer').item(0) as HTMLElement;
             clickLayer.style.width = image.width + 'px';
             clickLayer.style.height = image.height + 'px';
-        }, 500);
+        }, 300);
+    }
+
+    resizeDropLocation() {
+        setTimeout(() => {
+            const backgroundImage = document.querySelector('.background-area jhi-secured-image img') as HTMLImageElement;
+            Array.from(document.querySelectorAll('.click-layer .drop-location')).forEach(dropLocation => {
+                const dragItemPicture = dropLocation.querySelector('jhi-secured-image img') as HTMLImageElement;
+                if (dragItemPicture) {
+                    const adjustedWidth = this.decimalPipe.transform((dragItemPicture.width / backgroundImage.width) * 101) + '%';
+                    (<HTMLElement>dropLocation).style.width = adjustedWidth;
+                }
+            });
+        }, 200);
     }
 }

--- a/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-item.component.html
+++ b/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-item.component.html
@@ -3,7 +3,7 @@
         <jhi-secured-image *ngIf="dragItem.pictureFilePath" [src]="dragItem.pictureFilePath" [mobileDragAndDrop]="isMobile"></jhi-secured-image>
     </div>
     <div class="drag-item-text" *ngIf="dragItem && !dragItem.pictureFilePath">
-        <div fittext [activateOnResize]="true" [maxFontSize]="17" [minFontSize]="12">
+        <div fittext [activateOnResize]="true" [maxFontSize]="17" [minFontSize]="7">
             <span dnd-draggable [dragEnabled]="!clickDisabled" [dragData]="dragItem">{{ dragItem.text }}</span>
         </div>
     </div>

--- a/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-item.component.html
+++ b/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-item.component.html
@@ -3,7 +3,7 @@
         <jhi-secured-image *ngIf="dragItem.pictureFilePath" [src]="dragItem.pictureFilePath" [mobileDragAndDrop]="isMobile"></jhi-secured-image>
     </div>
     <div class="drag-item-text" *ngIf="dragItem && !dragItem.pictureFilePath">
-        <div fittext [activateOnResize]="true" [maxFontSize]="17" [minFontSize]="7">
+        <div fittext [activateOnResize]="true" [maxFontSize]="17" [minFontSize]="5">
             <span dnd-draggable [dragEnabled]="!clickDisabled" [dragData]="dragItem">{{ dragItem.text }}</span>
         </div>
     </div>

--- a/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-item.component.html
+++ b/src/main/webapp/app/quiz/participate/drag-and-drop-question/drag-item.component.html
@@ -3,7 +3,7 @@
         <jhi-secured-image *ngIf="dragItem.pictureFilePath" [src]="dragItem.pictureFilePath" [mobileDragAndDrop]="isMobile"></jhi-secured-image>
     </div>
     <div class="drag-item-text" *ngIf="dragItem && !dragItem.pictureFilePath">
-        <div fittext [activateOnResize]="true" [maxFontSize]="17" [minFontSize]="5">
+        <div fittext [activateOnResize]="true" [maxFontSize]="17" [minFontSize]="5" [delay]="150">
             <span dnd-draggable [dragEnabled]="!clickDisabled" [dragData]="dragItem">{{ dragItem.text }}</span>
         </div>
     </div>

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -372,6 +372,13 @@
         right: 20px;
         max-width: 30%;
 
+        @media (max-width: 900px) {
+            position: relative;
+            top: 0;
+            right: 0;
+            max-width: 100%;
+        }
+
         &.result {
             font-weight: bold;
             color: green;

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -524,11 +524,30 @@
             .click-layer {
                 .drop-location {
                     .drag-item {
+                        background: transparent;
+                        border: none;
+                        position: relative;
+                        min-width: 160px;
+                        max-width: 360px;
+
                         .drag-item-text {
                             @media (max-width: 812px) {
                                 padding: 0;
                             }
                         }
+
+                        img {
+                            max-height: 100%;
+                            max-width: 100%;
+                            height: auto;
+                            width: auto !important;
+                            margin: auto;
+                            position: absolute;
+                            transform: translate(-50%, -50%);
+                            top: 50%;
+                            left: 50%;
+                        }
+
                         div {
                             @media (max-width: 812px) {
                                 padding: 0 !important;
@@ -548,8 +567,6 @@
         .drag-and-drop-items {
             @media (orientation: landscape) and (min-width: 900px) {
                 margin: -5px 0 0 20px;
-                max-width: 200px;
-                width: 20%;
             }
 
             .instructions {
@@ -558,20 +575,40 @@
                 }
             }
 
+            > div {
+                width: 100%;
+
+                @media (orientation: landscape) and (min-width: 900px) {
+                    width: 200px;
+                }
+            }
+
             .drag-items {
                 width: 100%;
 
                 @media (orientation: landscape) and (min-width: 900px) {
                     margin: 0;
+                    width: 200px;
                 }
+            }
+        }
+    }
+}
 
-                .drag-item {
-                    height: auto;
-
-                    .drag-item-picture {
-                        height: 160px;
-                    }
-                }
+.edit-dnd-question {
+    .drag-items {
+        .drag-item {
+            height: 160px;
+            img {
+                max-height: 100%;
+                max-width: 100%;
+                height: auto;
+                width: auto !important;
+                margin: auto;
+                position: absolute;
+                transform: translate(-50%, -50%);
+                top: 50%;
+                left: 50%;
             }
         }
     }
@@ -830,8 +867,6 @@
 
                 .drag-item {
                     div {
-                        padding: 6px;
-
                         span {
                             border: none;
                             padding: 0;
@@ -921,21 +956,16 @@
     background: transparent;
     border: none;
     position: relative;
-    height: 160px;
     min-width: 160px;
     max-width: 360px;
     margin: 10px 4px;
 
     img {
-        max-height: 100%;
-        max-width: 100%;
-        height: auto;
-        width: auto !important;
-        margin: auto;
-        position: absolute;
-        transform: translate(-50%, -50%);
-        top: 50%;
-        left: 50%;
+        max-width: 160px;
+
+        @media (orientation: landscape) and (min-width: 900px) {
+            width: 100%;
+        }
     }
 
     &.no-click {
@@ -950,8 +980,6 @@
 
     .drag-item-picture {
         cursor: move;
-        width: 0;
-        height: 0;
         padding: 0;
         margin: 0;
     }

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -550,12 +550,6 @@
                             @media (max-width: 812px) {
                                 padding: 0 !important;
                             }
-
-                            span {
-                                @media (max-width: 480px) {
-                                    font-size: 12px;
-                                }
-                            }
                         }
                     }
                 }
@@ -865,8 +859,6 @@
 
                 .drag-item {
                     div {
-                        line-height: 0;
-
                         span {
                             border: none;
                             padding: 0;

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -859,6 +859,8 @@
 
                 .drag-item {
                     div {
+                        line-height: 1;
+
                         span {
                             border: none;
                             padding: 0;

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -473,7 +473,6 @@
         }
 
         img {
-            max-width: fit-content;
             width: 100%;
         }
     }

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -479,6 +479,8 @@
     }
 
     .instructions {
+        display: flex;
+        justify-content: space-between;
         margin: 10px 0;
         font-weight: 500;
     }

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -470,8 +470,6 @@
 
             .drop-location {
                 position: absolute;
-                z-index: 1;
-
                 display: flex;
                 flex-direction: row;
                 align-items: flex-start;
@@ -1300,8 +1298,6 @@ table.answer-options-result {
 
         .drop-location {
             position: absolute;
-            z-index: 1;
-
             display: flex;
             flex-direction: row;
             align-items: flex-start;

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -867,10 +867,14 @@
 
                 .drag-item {
                     div {
+                        line-height: 0;
+
                         span {
                             border: none;
                             padding: 0;
                             vertical-align: middle;
+                            display: inline-block;
+                            white-space: nowrap;
                         }
                     }
                 }
@@ -962,10 +966,7 @@
 
     img {
         max-width: 160px;
-
-        @media (orientation: landscape) and (min-width: 900px) {
-            width: 100%;
-        }
+        max-height: 160px;
     }
 
     &.no-click {


### PR DESCRIPTION
### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~~I documented my source code using the JavaDoc / JSDoc style.~~
- [x] ~~I added integration test cases for the server (Spring) related to the features~~
- [x] ~~I added integration test cases for the client (Jest) related to the features~~
- [x] I added screenshots/screencast of my UI changes
- [x] ~~I translated all the newly inserted strings~~

### Motivation and Context
The drop images when dragging them onto a drop location were not displayed correctly within a drop location. The image should be horizontally and vertically centered in the drop location and displayed in its max width/height with the original aspect ratio.

### Description
I changed the css for the drop location image and also re-aligned the items in the sample solution page. 

### Steps for Testing
1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Go to Drag-And-Drop Exercise Preview and drag/drop the images

### Screenshots
![image](https://user-images.githubusercontent.com/33764166/60124882-e7198080-978a-11e9-93a1-eaefb9d4c8e6.png)
![image](https://user-images.githubusercontent.com/33764166/60124892-ea147100-978a-11e9-8276-08b6489aa9f2.png)
![image](https://user-images.githubusercontent.com/33764166/60124899-f00a5200-978a-11e9-9384-609219a4c417.png)

