### PR TITLE
Programming-Exercise / Fix latest result query failing on completionDate is null, multiple results at the same timestamp

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -32,8 +32,7 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
     List<Result> findLatestResultsForExercise(@Param("exerciseId") Long exerciseId);
 
     @EntityGraph(attributePaths = "feedbacks")
-    @Query("select distinct result from Result result where result.completionDate = (select max(result2.completionDate) from Result result2 where result2.participation.id = :#{#participationId})")
-    Optional<Result> findLatestResultWithFeedbacksForParticipation(@Param("participationId") Long participationId);
+    Optional<Result> findFirstWithFeedbacksByParticipationIdOrderByCompletionDateDesc(Long participationId);
 
     @Query("select r from Result r where r.completionDate = (select min(rr.completionDate) from Result rr where rr.participation.exercise.id = r.participation.exercise.id and rr.participation.student.id = r.participation.student.id and rr.successful = true) and r.participation.exercise.course.id = :courseId and r.successful = true order by r.completionDate asc")
     List<Result> findEarliestSuccessfulResultsForCourse(@Param("courseId") Long courseId);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
@@ -400,7 +400,7 @@ public class ResultResource {
     }
 
     /**
-     * GET /latest-result/:participationId : get the latest result with feedbacks of the given participation.
+     * GET /latest-result/:participationId : get the latest result with feedbacks of the given participation. The order of results is determined by completionDate desc.
      *
      * @param participationId the id of the participation for which to retrieve the latest result.
      * @return the ResponseEntity with status 200 (OK) and with body the result, or with status 404 (Not Found)
@@ -415,7 +415,7 @@ public class ResultResource {
             return forbidden();
         }
 
-        Optional<Result> result = resultRepository.findLatestResultWithFeedbacksForParticipation(participation.getId());
+        Optional<Result> result = resultRepository.findFirstWithFeedbacksByParticipationIdOrderByCompletionDateDesc(participation.getId());
         return result.map(ResponseEntity::ok).orElse(notFound());
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Description
<!-- Describe your changes in detail -->

Fix for a sentry error.

Edge case: If multiple results of a participation have the same completionDate or the completionDate is null (faulty data?), the latestResult call cannot get a distinct result.

The user impact of this issue is low, there were only 4 server errors in the last two days, only instructors / tas are concerned.

Instead of selecting a distinct result, I order by completion date desc and take the first result.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Go to programming-exercises > open in editor
2. Trigger a couple of results for the template participation by submitting
3. Go to programming-exercises > edt
4. Check that the latest-result call delivers the latest result of the template participation

This call is only used in the open in editor & edit programming-exercise screens.

