### PR TITLE
Hotfix: Extend Activity Diagrams

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "@fortawesome/fontawesome-svg-core": "1.2.19",
         "@fortawesome/free-regular-svg-icons": "5.9.0",
         "@fortawesome/free-solid-svg-icons": "5.9.0",
-        "@ls1intum/apollon": "2.0.0-rc.9",
+        "@ls1intum/apollon": "^2.0.0-rc.11",
         "@ng-bootstrap/ng-bootstrap": "4.1.3",
         "@nguniversal/express-engine": "7.1.1",
         "@ngx-translate/core": "11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -679,10 +679,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@ls1intum/apollon@2.0.0-rc.9":
-  version "2.0.0-rc.9"
-  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.0-rc.9.tgz#4a77bcdf4432291e306dcd2e48540f8bcfcb773d"
-  integrity sha512-DvkUpVtOA1Ls7s5p/n0TTiUb6Bskrw4naQP8BbLXeZuOrCpivNGTJc6lMcmI3XKlPOzyM1J4NefSDLpqxq7yug==
+"@ls1intum/apollon@^2.0.0-rc.11":
+  version "2.0.0-rc.11"
+  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.0-rc.11.tgz#07521af3adc0e3c223d6251c5f69940e6f9ffee4"
+  integrity sha512-cPlQk+5mPL5kFRHDQot3nidNgMM67gkiThqYF0OqJSaWyeq3NZmoYYjcOKpbHudohG8lPlelfm8d49C8AF+d2Q==
   dependencies:
     pepjs "0.5.2"
     react "16.8.6"


### PR DESCRIPTION
### Motivation and Context

Hotfix for Apollon to add small improvements to activity diagrams.

### Description

- Introduced a new element `Activity` which looks the same as `Actions` but can contain other elements (the package of activity diagrams)
- Updated textfields in Action, Object and Merge Nodes to automatically add line breaks if text exceeds width of the element.

### Screenshots

<img width="249" alt="Screenshot 2019-07-03 at 21 33 11" src="https://user-images.githubusercontent.com/38191490/60619960-32124400-9dda-11e9-8c28-c30d7a89da53.png">
