### PR TITLE
Add first simple workaround for missing bamboo->artemis notifications.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -46,10 +46,7 @@ import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
-import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
-import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationUpdateService;
-import de.tum.in.www1.artemis.service.connectors.GitService;
-import de.tum.in.www1.artemis.service.connectors.VersionControlService;
+import de.tum.in.www1.artemis.service.connectors.*;
 import de.tum.in.www1.artemis.service.util.structureoraclegenerator.OracleGeneratorClient;
 
 @Service
@@ -80,13 +77,15 @@ public class ProgrammingExerciseService {
 
     private final ResourceLoader resourceLoader;
 
+    private final BambooScheduleService bambooScheduleService;
+
     @Value("${server.url}")
     private String ARTEMIS_BASE_URL;
 
     public ProgrammingExerciseService(ProgrammingExerciseRepository programmingExerciseRepository, FileService fileService, GitService gitService,
             Optional<VersionControlService> versionControlService, Optional<ContinuousIntegrationService> continuousIntegrationService,
             Optional<ContinuousIntegrationUpdateService> continuousIntegrationUpdateService, ResourceLoader resourceLoader, SubmissionRepository submissionRepository,
-            ParticipationRepository participationRepository, UserService userService, AuthorizationCheckService authCheckService) {
+            ParticipationRepository participationRepository, UserService userService, AuthorizationCheckService authCheckService, BambooScheduleService bambooScheduleService) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.fileService = fileService;
         this.gitService = gitService;
@@ -98,6 +97,7 @@ public class ProgrammingExerciseService {
         this.submissionRepository = submissionRepository;
         this.userService = userService;
         this.authCheckService = authCheckService;
+        this.bambooScheduleService = bambooScheduleService;
     }
 
     /**
@@ -126,6 +126,8 @@ public class ProgrammingExerciseService {
             participationRepository.save(participation);
 
             continuousIntegrationUpdateService.get().triggerUpdate(participation.getBuildPlanId(), false);
+
+            bambooScheduleService.startResultScheduler(participation);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -127,7 +127,7 @@ public class ProgrammingExerciseService {
 
             continuousIntegrationUpdateService.get().triggerUpdate(participation.getBuildPlanId(), false);
 
-            bambooScheduleService.startResultScheduler(participation);
+            bambooScheduleService.startResultScheduler(submission);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -87,7 +87,7 @@ public class ProgrammingSubmissionService {
 
         programmingSubmissionRepository.save(programmingSubmission);
 
-        bambooScheduleService.startResultScheduler(participation);
+        bambooScheduleService.startResultScheduler(programmingSubmission);
 
         // notify user via websocket
         messagingTemplate.convertAndSend("/topic/participation/" + participation.getId() + "/newSubmission", programmingSubmission);

--- a/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.repository.ResultRepository;
+import de.tum.in.www1.artemis.service.connectors.BambooScheduleService;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.LtiService;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
@@ -39,6 +40,8 @@ public class ResultService {
 
     private final LtiService ltiService;
 
+    private final BambooScheduleService bambooScheduleService;
+
     private final SimpMessageSendingOperations messagingTemplate;
 
     private final ObjectMapper objectMapper;
@@ -47,7 +50,7 @@ public class ResultService {
 
     public ResultService(UserService userService, ParticipationService participationService, ResultRepository resultRepository,
             Optional<ContinuousIntegrationService> continuousIntegrationService, LtiService ltiService, SimpMessageSendingOperations messagingTemplate, ObjectMapper objectMapper,
-            ProgrammingExerciseTestCaseService testCaseService) {
+            ProgrammingExerciseTestCaseService testCaseService, BambooScheduleService bambooScheduleService) {
         this.userService = userService;
         this.participationService = participationService;
         this.resultRepository = resultRepository;
@@ -56,6 +59,7 @@ public class ResultService {
         this.messagingTemplate = messagingTemplate;
         this.objectMapper = objectMapper;
         this.testCaseService = testCaseService;
+        this.bambooScheduleService = bambooScheduleService;
     }
 
     public Result findOne(long id) {
@@ -122,6 +126,8 @@ public class ResultService {
             // This needs to be done as some test cases might not have been executed.
             result = testCaseService.updateResultFromTestCases(result, programmingExercise);
         }
+
+        bambooScheduleService.cancelResultScheduler(participation);
 
         notifyUser(participation, result);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooScheduleService.java
@@ -20,7 +20,7 @@ public class BambooScheduleService {
 
     private final Logger log = LoggerFactory.getLogger(BambooScheduleService.class);
 
-    private final BambooService bambooService;
+    private final ContinuousIntegrationService continuousIntegrationService;
 
     private final ResultService resultService;
 
@@ -33,8 +33,8 @@ public class BambooScheduleService {
         threadPoolTaskScheduler.initialize();
     }
 
-    public BambooScheduleService(BambooService bambooService, @Lazy ResultService resultService) { // TODO: check if @Lazy is fine
-        this.bambooService = bambooService;
+    public BambooScheduleService(ContinuousIntegrationService continuousIntegrationService, @Lazy ResultService resultService) { // TODO: check if @Lazy is fine
+        this.continuousIntegrationService = continuousIntegrationService;
         this.resultService = resultService;
     }
 
@@ -55,7 +55,7 @@ public class BambooScheduleService {
     private void checkResult(ProgrammingSubmission submission) {
         Participation participation = submission.getParticipation();
         log.info("Checking result for participation " + participation.getId());
-        ContinuousIntegrationService.BuildStatus buildStatus = bambooService.getBuildStatus(participation);
+        ContinuousIntegrationService.BuildStatus buildStatus = continuousIntegrationService.getBuildStatus(participation);
         if (buildStatus.equals(ContinuousIntegrationService.BuildStatus.INACTIVE)) {
             log.info("Inactive build state with missing result");
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooScheduleService.java
@@ -1,0 +1,77 @@
+package de.tum.in.www1.artemis.service.connectors;
+
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Service;
+
+import de.tum.in.www1.artemis.domain.Participation;
+import de.tum.in.www1.artemis.service.ResultService;
+
+@Service
+public class BambooScheduleService {
+
+    private final Logger log = LoggerFactory.getLogger(BambooScheduleService.class);
+
+    private final BambooService bambooService;
+
+    private final ResultService resultService;
+
+    private Map<Long, ScheduledFuture> scheduledFutures = new HashMap<>(); // Participation_id -> ScheduledFuture
+
+    private static ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+    static {
+        threadPoolTaskScheduler.setThreadNamePrefix("BambooScheduler");
+        threadPoolTaskScheduler.setPoolSize(3);
+        threadPoolTaskScheduler.initialize();
+    }
+
+    public BambooScheduleService(BambooService bambooService, @Lazy ResultService resultService) { // TODO: check if @Lazy is fine
+        this.bambooService = bambooService;
+        this.resultService = resultService;
+    }
+
+    public void startResultScheduler(Participation participation) {
+        log.debug("Scheduling checkResult() for Participation " + participation.getId());
+
+        cancelResultScheduler(participation); // Cancel running schedulers
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, 30);
+
+        ScheduledFuture scheduledFuture = threadPoolTaskScheduler.scheduleWithFixedDelay(() -> checkResult(participation), calendar.getTime(), 30000);
+
+        scheduledFutures.put(participation.getId(), scheduledFuture);
+    }
+
+    private void checkResult(Participation participation) {
+        log.info("Checking result for participation " + participation.getId());
+        ContinuousIntegrationService.BuildStatus buildStatus = bambooService.getBuildStatus(participation);
+        if (buildStatus.equals(ContinuousIntegrationService.BuildStatus.INACTIVE)) {
+            log.info("Inactive build state with missing result");
+
+            // We did not get notified by Bamboo -> We fetch the result manually
+            resultService.onResultNotifiedOld(participation);
+            cancelResultScheduler(participation);
+            return;
+        }
+
+        log.info("Retrying checkResult as build status is not inactive for Participation " + participation.getId());
+
+        // If the build status is not inactive, we will not cancel the schedule and check for the result again
+    }
+
+    public void cancelResultScheduler(Participation participation) {
+        ScheduledFuture scheduledFuture = scheduledFutures.get(participation.getId());
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+            scheduledFutures.remove(participation.getId());
+        }
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooScheduleService.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.artemis.service.connectors;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ScheduledFuture;
 
 import org.slf4j.Logger;
@@ -20,7 +21,7 @@ public class BambooScheduleService {
 
     private final Logger log = LoggerFactory.getLogger(BambooScheduleService.class);
 
-    private final ContinuousIntegrationService continuousIntegrationService;
+    private final Optional<ContinuousIntegrationService> continuousIntegrationService;
 
     private final ResultService resultService;
 
@@ -33,7 +34,7 @@ public class BambooScheduleService {
         threadPoolTaskScheduler.initialize();
     }
 
-    public BambooScheduleService(ContinuousIntegrationService continuousIntegrationService, @Lazy ResultService resultService) { // TODO: check if @Lazy is fine
+    public BambooScheduleService(Optional<ContinuousIntegrationService> continuousIntegrationService, @Lazy ResultService resultService) { // TODO: check if @Lazy is fine
         this.continuousIntegrationService = continuousIntegrationService;
         this.resultService = resultService;
     }
@@ -55,7 +56,7 @@ public class BambooScheduleService {
     private void checkResult(ProgrammingSubmission submission) {
         Participation participation = submission.getParticipation();
         log.info("Checking result for participation " + participation.getId());
-        ContinuousIntegrationService.BuildStatus buildStatus = continuousIntegrationService.getBuildStatus(participation);
+        ContinuousIntegrationService.BuildStatus buildStatus = continuousIntegrationService.get().getBuildStatus(participation);
         if (buildStatus.equals(ContinuousIntegrationService.BuildStatus.INACTIVE)) {
             log.info("Inactive build state with missing result");
 


### PR DESCRIPTION
This adds a first implementation for the workaround for missing bamboo->artemis notifications.

We should check in detail if it is okay that we use the BambooScheduleService directly, without adding an interface.

Also we should check if @Lazy is okay in the BambooScheduleService (needed to break dependency cycle).

<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] I documented my source code using the JavaDoc / JSDoc style.
- [ ] I added integration test cases for the server (Spring) related to the features
- [ ] I added integration test cases for the client (Jest) related to the features
- [ ] I added screenshots/screencast of my UI changes
- [ ] I translated all the newly inserted strings

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
