### PR TITLE
Schedule Event-lifecycle Tasks

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/TaskSchedulingConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/TaskSchedulingConfiguration.java
@@ -1,0 +1,22 @@
+package de.tum.in.www1.artemis.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class TaskSchedulingConfiguration {
+
+    private final Logger log = LoggerFactory.getLogger(TaskSchedulingConfiguration.class);
+
+    @Bean(name = "taskScheduler")
+    public TaskScheduler taskScheduler() {
+        log.debug("Creating Task Scheduler ");
+        return new ThreadPoolTaskScheduler();
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/domain/enumeration/ExerciseLifecycle.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/enumeration/ExerciseLifecycle.java
@@ -1,0 +1,5 @@
+package de.tum.in.www1.artemis.domain.enumeration;
+
+public enum ExerciseLifecycle {
+    RELEASE, DUE, ASSESSMENT_DUE
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseLifecycleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseLifecycleService.java
@@ -1,0 +1,49 @@
+package de.tum.in.www1.artemis.service;
+
+import java.time.ZonedDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+import de.tum.in.www1.artemis.domain.Exercise;
+import de.tum.in.www1.artemis.domain.enumeration.ExerciseLifecycle;
+
+@Service
+public class ExerciseLifecycleService {
+
+    private final Logger log = LoggerFactory.getLogger(ExerciseLifecycleService.class);
+
+    private TaskScheduler scheduler;
+
+    ExerciseLifecycleService(@Qualifier("taskScheduler") TaskScheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void scheduleTask(Exercise exercise, ExerciseLifecycle lifecycle, Runnable task) {
+        final ZonedDateTime lifecycleDate;
+
+        switch (lifecycle) {
+        case RELEASE:
+            lifecycleDate = exercise.getReleaseDate();
+            break;
+
+        case DUE:
+            lifecycleDate = exercise.getDueDate();
+            break;
+
+        case ASSESSMENT_DUE:
+            lifecycleDate = exercise.getAssessmentDueDate();
+            break;
+
+        default:
+            return;
+        }
+
+        scheduler.schedule(task, lifecycleDate.toInstant());
+        log.debug("Scheduled Task for Exercise \"" + exercise.getTitle() + "\" (#" + exercise.getId() + ") to trigger on " + lifecycle.toString() + ".");
+    }
+
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseLifecycleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseLifecycleService.java
@@ -23,6 +23,17 @@ public class ExerciseLifecycleService {
         this.scheduler = scheduler;
     }
 
+    /**
+     * Allow to schedule a {@code Runnable} task in the lifecycle of an exercise. ({@code ExerciseLifecycle}) Tasks are performed in a background thread managed by a
+     * {@code TaskScheduler}. See {@code TaskSchedulingConfiguration}. <b>Important:</b> Scheduled tasks are not persisted accross application restarts. Therefore, schedule your
+     * events from both your application logic (e.g. exercise modification) and on application startup. You can use the {@code PostConstruct} Annotation to call one service method
+     * on startup.
+     *
+     * @param exercise  Exercise
+     * @param lifecycle ExerciseLifecycle
+     * @param task      Runnable
+     * @return The {@code ScheduledFuture<?>} allows to later cancel the task or check whether it has been executed.
+     */
     public ScheduledFuture<?> scheduleTask(Exercise exercise, ExerciseLifecycle lifecycle, Runnable task) {
         final ZonedDateTime lifecycleDate;
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseLifecycleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseLifecycleService.java
@@ -17,9 +17,9 @@ public class ExerciseLifecycleService {
 
     private final Logger log = LoggerFactory.getLogger(ExerciseLifecycleService.class);
 
-    private TaskScheduler scheduler;
+    private final TaskScheduler scheduler;
 
-    ExerciseLifecycleService(@Qualifier("taskScheduler") TaskScheduler scheduler) {
+    public ExerciseLifecycleService(@Qualifier("taskScheduler") TaskScheduler scheduler) {
         this.scheduler = scheduler;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseLifecycleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseLifecycleService.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.service;
 
 import java.time.ZonedDateTime;
+import java.util.concurrent.ScheduledFuture;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,7 @@ public class ExerciseLifecycleService {
         this.scheduler = scheduler;
     }
 
-    public void scheduleTask(Exercise exercise, ExerciseLifecycle lifecycle, Runnable task) {
+    public ScheduledFuture<?> scheduleTask(Exercise exercise, ExerciseLifecycle lifecycle, Runnable task) {
         final ZonedDateTime lifecycleDate;
 
         switch (lifecycle) {
@@ -39,11 +40,12 @@ public class ExerciseLifecycleService {
             break;
 
         default:
-            return;
+            throw new IllegalStateException("Unexpected Exercise Lifecycle State: " + lifecycle);
         }
 
-        scheduler.schedule(task, lifecycleDate.toInstant());
+        final ScheduledFuture<?> future = scheduler.schedule(task, lifecycleDate.toInstant());
         log.debug("Scheduled Task for Exercise \"" + exercise.getTitle() + "\" (#" + exercise.getId() + ") to trigger on " + lifecycle.toString() + ".");
+        return future;
     }
 
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
@@ -1,0 +1,67 @@
+package de.tum.in.www1.artemis.service;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.time.ZonedDateTime;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import de.tum.in.www1.artemis.domain.Exercise;
+import de.tum.in.www1.artemis.domain.TextExercise;
+import de.tum.in.www1.artemis.domain.enumeration.ExerciseLifecycle;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase
+@ActiveProfiles("artemis")
+public class ExerciseLifecycleServiceTest {
+
+    @Autowired
+    ExerciseLifecycleService exerciseLifecycleService;
+
+    @Test
+    public void testScheduleExerciseOnReleaseTask() throws InterruptedException {
+        final ZonedDateTime now = ZonedDateTime.now();
+
+        Exercise exercise = new TextExercise().title("ExerciseLifecycleServiceTest").releaseDate(now.plusSeconds(2)).dueDate(now.plusSeconds(5))
+                .assessmentDueDate(now.plusSeconds(8));
+
+        MutableBoolean releaseTrigger = new MutableBoolean(false);
+        MutableBoolean dueTrigger = new MutableBoolean(false);
+        MutableBoolean assessmentDueTrigger = new MutableBoolean(false);
+
+        exerciseLifecycleService.scheduleTask(exercise, ExerciseLifecycle.RELEASE, releaseTrigger::setTrue);
+        exerciseLifecycleService.scheduleTask(exercise, ExerciseLifecycle.DUE, dueTrigger::setTrue);
+        exerciseLifecycleService.scheduleTask(exercise, ExerciseLifecycle.ASSESSMENT_DUE, assessmentDueTrigger::setTrue);
+
+        Thread.sleep(2500);
+        assertEqual(releaseTrigger, true);
+        assertEqual(dueTrigger, false);
+        assertEqual(assessmentDueTrigger, false);
+
+        Thread.sleep(3500);
+        assertEqual(releaseTrigger, true);
+        assertEqual(dueTrigger, true);
+        assertEqual(assessmentDueTrigger, false);
+
+        Thread.sleep(2500);
+        assertEqual(releaseTrigger, true);
+        assertEqual(dueTrigger, true);
+        assertEqual(assessmentDueTrigger, true);
+    }
+
+    private void assertEqual(MutableBoolean testBoolean, boolean expected) {
+        assertThat(testBoolean.toBoolean(), is(equalTo(expected)));
+    }
+
+}


### PR DESCRIPTION
# Checklist
- [X] ~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~
- [X] I documented my source code using the JavaDoc / JSDoc style.
- [X] I added integration test cases for the server (Spring) related to the features
- [X] ~I added integration test cases for the client (Jest) related to the features~
- [X] ~I added screenshots/screencast of my UI changes~
- [X] ~I translated all the newly inserted strings~

### Motivation and Context
For future implementation tasks, it's desired to schedule a task with the due date of a (text) exercise.
This pull request allows to schedule a `Runnable` task for a lifecycle event, being either release, due or assessment due dates.