### PR TITLE
Fix defective modeling submission test

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
@@ -6,7 +6,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-import org.assertj.core.api.Fail;
 import org.junit.*;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -154,24 +153,18 @@ public class ModelingSubmissionIntegrationTest {
         checkDetailsHidden(returnedSubmission, true);
     }
 
-    // TODO: Fix defective test
-    @Ignore
     @Test
     @WithMockUser(value = "student2")
     public void updateModelSubmissionAfterSubmit() throws Exception {
         database.addParticipationForExercise(classExercise, "student2");
-        ModelingSubmission submission = ModelFactory.generateModelingSubmission(emptyModel, false);
+        ModelingSubmission submission = ModelFactory.generateModelingSubmission(emptyModel, true);
         ModelingSubmission returnedSubmission = performInitialModelSubmission(classExercise.getId(), submission);
         database.checkSubmissionCorrectlyStored(returnedSubmission.getId(), emptyModel);
+
         submission = ModelFactory.generateModelingSubmission(validModel, false);
-        try {
-            returnedSubmission = performUpdateOnModelSubmission(classExercise.getId(), submission);
-            database.checkSubmissionCorrectlyStored(returnedSubmission.getId(), validModel);
-            checkDetailsHidden(returnedSubmission, true);
-            Fail.fail("update on submitted ModelingSubmission worked");
-        }
-        catch (Exception e) {
-        }
+        request.putWithResponseBody("/api/exercises/" + classExercise.getId() + "/modeling-submissions", submission, ModelingSubmission.class, HttpStatus.BAD_REQUEST);
+
+        database.checkSubmissionCorrectlyStored(returnedSubmission.getId(), emptyModel);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
@@ -63,6 +63,10 @@ public class RequestUtilService {
         MvcResult res = mvc.perform(MockMvcRequestBuilders.put(new URI(path)).contentType(MediaType.APPLICATION_JSON).content(jsonBody).with(csrf()))
                 .andExpect(status().is(expectedStatus.value())).andReturn();
 
+        if (res.getResponse().getStatus() >= 299) {
+            return null;
+        }
+
         return mapper.readValue(res.getResponse().getContentAsString(), responseType);
     }
 


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
Fix and re-enable a defective modeling submission test. The test makes sure that a student cannot save a submission for a modeling exercise for which he already submitted a submission earlier.