### PR TITLE
Support automatic assessment of UML packages

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/compass/assessment/Assessment.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/assessment/Assessment.java
@@ -35,6 +35,10 @@ public class Assessment {
      * @return List of Scores added for the given context. Returns empty List when no scores are available for context
      */
     public List<Feedback> getFeedbacks(Context context) {
+        if (context == null) {
+            return new ArrayList<>();
+        }
+
         return contextFeedbackList.getOrDefault(context, new ArrayList<>());
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/controller/AutomaticAssessmentController.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/controller/AutomaticAssessmentController.java
@@ -102,6 +102,7 @@ public class AutomaticAssessmentController {
 
         Map<UMLElement, Score> scoreHashMap = new ConcurrentHashMap<>();
 
+        // TODO CZ: combine iterating over relations and packages
         for (UMLClassRelationship relation : model.getAssociationList()) {
             Optional<Assessment> assessmentOptional = assessmentIndex.getAssessment(relation.getSimilarityID());
             totalCount++;
@@ -116,6 +117,25 @@ public class AutomaticAssessmentController {
                 }
                 else {
                     scoreHashMap.put(relation, score);
+                }
+            }
+        }
+
+        // TODO CZ: combine iterating over relations and packages
+        for (UMLPackage umlPackage : model.getPackageList()) {
+            Optional<Assessment> assessmentOptional = assessmentIndex.getAssessment(umlPackage.getSimilarityID());
+            totalCount++;
+
+            if (!assessmentOptional.isPresent()) {
+                missingCount++;
+            }
+            else {
+                Score score = assessmentOptional.get().getScore(umlPackage.getContext());
+                if (score == null) {
+                    log.debug("Unable to find score for package " + umlPackage.getJSONElementID() + " in model " + model.getModelSubmissionId() + " with the specific context");
+                }
+                else {
+                    scoreHashMap.put(umlPackage, score);
                 }
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/controller/SimilarityDetector.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/controller/SimilarityDetector.java
@@ -9,6 +9,7 @@ import de.tum.in.www1.artemis.service.compass.umlmodel.classdiagram.UMLClass;
 import de.tum.in.www1.artemis.service.compass.umlmodel.classdiagram.UMLClassDiagram;
 import de.tum.in.www1.artemis.service.compass.umlmodel.classdiagram.UMLClassRelationship;
 import de.tum.in.www1.artemis.service.compass.umlmodel.classdiagram.UMLMethod;
+import de.tum.in.www1.artemis.service.compass.umlmodel.classdiagram.UMLPackage;
 
 public class SimilarityDetector {
 
@@ -36,6 +37,10 @@ public class SimilarityDetector {
             relation.setSimilarityID(index.getSimilarityId(relation));
         }
 
+        for (UMLPackage umlPackage : model.getPackageList()) {
+            umlPackage.setSimilarityID(index.getSimilarityId(umlPackage));
+        }
+
         setContext(model);
     }
 
@@ -49,8 +54,13 @@ public class SimilarityDetector {
                 method.setContext(generateContextForElement(model, method));
             }
         }
+
         for (UMLClassRelationship relation : model.getAssociationList()) {
             relation.setContext(generateContextForElement(model, relation));
+        }
+
+        for (UMLPackage umlPackage : model.getPackageList()) {
+            umlPackage.setContext(generateContextForElement(model, umlPackage));
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/strategy/NameSimilarity.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/strategy/NameSimilarity.java
@@ -7,9 +7,13 @@ import de.tum.in.www1.artemis.service.compass.utils.CompassConfiguration;
 public class NameSimilarity {
 
     /**
-     * @return 1 if both strings have any word in common (splitting on uppercase), 0 otherwise
+     * Analyzes the similarity between two given strings by calculating a Levenshtein simple ratio.
+     *
+     * @param string1 the first of the two strings that should be compared
+     * @param string2 the second of the two strings that should be compared
+     * @return the Levenshtein simple ratio between the two input strings
      */
-    public static double nameContainsSimilarity(String string1, String string2) {
+    public static double levenshteinSimilarity(String string1, String string2) {
         // TODO longterm: think about an even more sophisticated approach that takes e.g. thesaurus and specific uml conventions into account
         return FuzzySearch.ratio(string1, string2) / 100.0;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/activitydiagram/UMLActivity.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/activitydiagram/UMLActivity.java
@@ -25,7 +25,7 @@ public class UMLActivity extends UMLElement {
     public double similarity(UMLElement element) {
         double similarity = 0;
         if (element.getClass() == UMLActivity.class) {
-            similarity += NameSimilarity.nameContainsSimilarity(name, element.getName());
+            similarity += NameSimilarity.levenshteinSimilarity(name, element.getName());
         }
         return similarity;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLClass.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLClass.java
@@ -57,7 +57,7 @@ public class UMLClass extends UMLElement {
         }
         UMLClass otherClass = (UMLClass) other;
 
-        similarity += NameSimilarity.nameContainsSimilarity(name, otherClass.name) * CompassConfiguration.CLASS_NAME_WEIGHT;
+        similarity += NameSimilarity.levenshteinSimilarity(name, otherClass.name) * CompassConfiguration.CLASS_NAME_WEIGHT;
         // TODO: we could distinguish that abstract class and interface is more similar than e.g. class and enumeration
         if (this.type == otherClass.type) {
             similarity += CompassConfiguration.CLASS_TYPE_WEIGHT;

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLPackage.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLPackage.java
@@ -22,9 +22,12 @@ public class UMLPackage extends UMLElement {
     @Override
     public double similarity(UMLElement element) {
         double similarity = 0;
+
         if (element.getClass() == UMLPackage.class) {
-            similarity += NameSimilarity.nameContainsSimilarity(name, element.getName());
+            UMLPackage otherPackage = (UMLPackage) element;
+            similarity += NameSimilarity.levenshteinSimilarity(name, otherPackage.name);
         }
+
         return similarity;
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Description
<!-- Describe your changes in detail -->
In this PR we extended Compass to support automatic assessments of UML packages. In particular the following changes were made:
- set similarity of packages
- set (empty) context of packages
- rename and add documentation for levenshtein similarity calculation
- add null check when retrieving the feedback list in the Assessment to prevent NPEs