### PR TITLE
Bugfix/Fix editor height in modeling exercise dialogs

### DIFF
--- a/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.component.html
+++ b/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.component.html
@@ -95,13 +95,11 @@
         </div>
         <div class="form-group" name="problemStatement" id="field_problemStatement">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.problemStatement" for="field_problemStatement">Problem Statement</label>
-            <div class="question-content background-editor-color">
-                <jhi-markdown-editor [(markdown)]="modelingExercise.problemStatement"></jhi-markdown-editor>
-            </div>
+            <jhi-markdown-editor class="markdown-editor background-editor-color" [(markdown)]="modelingExercise.problemStatement"></jhi-markdown-editor>
         </div>
         <div class="form-group" name="gradingInstructions" id="field_gradingInstructions">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.gradingInstructions" for="field_gradingInstructions">Grading Instructions</label>
-            <jhi-markdown-editor [(markdown)]="modelingExercise.gradingInstructions"></jhi-markdown-editor>
+            <jhi-markdown-editor class="markdown-editor background-editor-color" [(markdown)]="modelingExercise.gradingInstructions"></jhi-markdown-editor>
         </div>
         <div class="form-group">
             <span jhiTranslate="artemisApp.modelingExercise.exampleSolution">Example Solution</span>
@@ -133,9 +131,7 @@
             <label class="form-control-label" jhiTranslate="artemisApp.modelingExercise.exampleSolutionExplanation" for="field_exampleSolutionExplanation">
                 Example Solution Explanation
             </label>
-            <div class="question-content background-editor-color">
-                <jhi-markdown-editor [(markdown)]="modelingExercise.sampleSolutionExplanation"></jhi-markdown-editor>
-            </div>
+            <jhi-markdown-editor class="markdown-editor background-editor-color" [(markdown)]="modelingExercise.sampleSolutionExplanation"></jhi-markdown-editor>
         </div>
         <div class="form-group">
             <span jhiTranslate="artemisApp.modelingExercise.exampleSubmissions">Example submissions</span>

--- a/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.component.ts
+++ b/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.component.ts
@@ -18,7 +18,7 @@ import { ExampleSubmissionService } from 'app/entities/example-submission/exampl
 @Component({
     selector: 'jhi-modeling-exercise-dialog',
     templateUrl: './modeling-exercise-dialog.component.html',
-    styles: ['.invalid-feedback { display: block }'],
+    styleUrls: ['./modeling-exercise-dialog.scss'],
 })
 export class ModelingExerciseDialogComponent implements OnInit {
     modelingExercise: ModelingExercise;

--- a/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.scss
+++ b/src/main/webapp/app/entities/modeling-exercise/modeling-exercise-dialog.scss
@@ -1,0 +1,6 @@
+.invalid-feedback {
+    display: block;
+}
+.markdown-editor {
+    height: 350px;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] ~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

Markdown-Editor in the modeling-exercise dialog hat the wrong height because of missing css stylings.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
