### PR TITLE
fix that next assement button is not displayed when in complaint view

### DIFF
--- a/src/main/webapp/app/text-assessment/text-assessment.component.html
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.html
@@ -55,7 +55,7 @@
                 class="btn btn-success ml-3"
                 (click)="assessNextOptimal()"
                 [disabled]="!assessmentsAreValid"
-                *ngIf="result?.completionDate && (isAuthorized || isAtLeastInstructor)"
+                *ngIf="result?.completionDate && (isAuthorized || isAtLeastInstructor) && !hasComplaint"
                 jhiTranslate="artemisApp.tutorExerciseDashboard.nextAssessment"
             ></button>
         </div>


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- ~[x] I documented my source code using the JavaDoc / JSDoc style.~
- ~[x] I added integration test cases for the server (Spring) related to the features~
- ~[x] I added integration test cases for the client (Jest) related to the features~
- [x] I added screenshots/screencast of my UI changes
- ~[x] I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixed that you can see the next assessment button in the complaint view

### Description
<!-- Describe your changes in detail -->

Next assessment button is not visible in the complaint view any more (we added an additional condition that checks it it is a complaint or not)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
-

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/41108487/60802087-773acb00-a178-11e9-83fe-43906ae8b240.png)
