### PR TITLE
Bugfix/programming exercise/add fallback for test case retrieval

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
@@ -140,10 +140,10 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
                 )(testCases);
                 this.testCaseCommand.setValues(this.exerciseTestCases);
             }, 0);
-        } else if (this.exercise.solutionParticipation) {
+        } else if (this.exercise.templateParticipation) {
             // Fallback for exercises that don't have test cases yet.
             this.resultService
-                .getLatestResultWithFeedbacks(this.exercise.solutionParticipation.id)
+                .getLatestResultWithFeedbacks(this.exercise.templateParticipation.id)
                 .pipe(
                     rxMap((res: HttpResponse<Result>) => res.body),
                     rxFilter((result: Result) => !!result.feedbacks),

--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
@@ -162,8 +162,8 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
         this.testCaseSubscription = this.testCaseService
             .subscribeForTestCases(this.exercise.id)
             .pipe(
-                filter(testCases => !!testCases),
                 tap(testCases => this.exerciseTestCasesChange.emit(testCases)),
+                filter(testCases => !!testCases),
                 tap(testCases => {
                     this.exerciseTestCases = testCases && testCases.filter(({ active }) => active).map(({ testName }) => testName);
                 }),

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
@@ -39,7 +39,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
     let subscribeForTestCaseSpy: SinonSpy;
     let getLatestResultWithFeedbacksStub: SinonStub;
 
-    const exercise = { id: 30, solutionParticipation: { id: 99 } } as ProgrammingExercise;
+    const exercise = { id: 30, templateParticipation: { id: 99 } } as ProgrammingExercise;
     const participation = { id: 1, results: [{ id: 10, feedbacks: [{ id: 20 }, { id: 21 }] }] } as Participation;
     const testCases = [{ testName: 'test1', active: true }, { testName: 'test2', active: true }, { testName: 'test3', active: false }];
 
@@ -138,7 +138,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         fixture.detectChanges();
 
         expect(comp.exerciseTestCases).to.have.lengthOf(0);
-        expect(getLatestResultWithFeedbacksStub).to.have.been.calledOnceWithExactly(99);
+        expect(getLatestResultWithFeedbacksStub).to.have.been.calledOnceWithExactly(exercise.templateParticipation.id);
 
         subject.next({ body: { feedbacks: [{ text: 'testY' }, { text: 'testX' }] } } as HttpResponse<Result>);
         tick();

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
@@ -1,17 +1,19 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
+import { HttpResponse } from '@angular/common/http';
 import { MockComponent } from 'ng-mocks';
+import { of, Subject } from 'rxjs';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { DebugElement } from '@angular/core';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
-import { SinonSpy, spy } from 'sinon';
+import { SinonSpy, SinonStub, spy, stub } from 'sinon';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArTEMiSTestModule } from '../../test.module';
 import { Participation, ParticipationWebsocketService } from 'src/main/webapp/app/entities/participation';
 import { SafeHtmlPipe } from 'src/main/webapp/app/shared';
-import { ResultService } from 'src/main/webapp/app/entities/result';
+import { Result, ResultService } from 'src/main/webapp/app/entities/result';
 import { MockResultService } from '../../mocks/mock-result.service';
 import {
     ProgrammingExercise,
@@ -32,10 +34,12 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
     let fixture: ComponentFixture<ProgrammingExerciseEditableInstructionComponent>;
     let debugElement: DebugElement;
     let testCaseService: ProgrammingExerciseTestCaseService;
+    let resultService: ResultService;
 
     let subscribeForTestCaseSpy: SinonSpy;
+    let getLatestResultWithFeedbacksStub: SinonStub;
 
-    const exercise = { id: 30 } as ProgrammingExercise;
+    const exercise = { id: 30, solutionParticipation: { id: 99 } } as ProgrammingExercise;
     const participation = { id: 1, results: [{ id: 10, feedbacks: [{ id: 20 }, { id: 21 }] }] } as Participation;
     const testCases = [{ testName: 'test1', active: true }, { testName: 'test2', active: true }, { testName: 'test3', active: false }];
 
@@ -53,6 +57,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
                 { provide: ResultService, useClass: MockResultService },
                 { provide: ProgrammingExerciseTestCaseService, useClass: MockProgrammingExerciseTestCaseService },
                 { provide: ParticipationWebsocketService, useClass: MockParticipationWebsocketService },
+                { provide: ResultService, useClass: MockResultService },
             ],
         })
             .overrideModule(BrowserDynamicTestingModule, { set: { entryComponents: [FaIconComponent] } })
@@ -63,13 +68,16 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
                 debugElement = fixture.debugElement;
                 testCaseService = debugElement.injector.get(ProgrammingExerciseTestCaseService);
                 (testCaseService as MockProgrammingExerciseTestCaseService).initSubject([]);
+                resultService = debugElement.injector.get(ResultService);
                 subscribeForTestCaseSpy = spy(testCaseService, 'subscribeForTestCases');
+                getLatestResultWithFeedbacksStub = stub(resultService, 'getLatestResultWithFeedbacks');
             });
     });
 
     afterEach(() => {
         (testCaseService as MockProgrammingExerciseTestCaseService).initSubject([]);
         subscribeForTestCaseSpy.restore();
+        getLatestResultWithFeedbacksStub.restore();
     });
 
     it('should not have any test cases if the test case service emits an empty array', fakeAsync(() => {
@@ -116,5 +124,26 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         expect(comp.exerciseTestCases).to.be.empty;
 
         expect(subscribeForTestCaseSpy).to.have.been.calledOnceWithExactly(exercise.id);
+    }));
+
+    it('should try to retreive the test case values from the solution repos last build result if there are no testCases (empty result)', fakeAsync(() => {
+        comp.exercise = exercise;
+        comp.participation = participation;
+        const subject = new Subject<HttpResponse<Result>>();
+        getLatestResultWithFeedbacksStub.returns(subject);
+
+        // No test cases available, might be that the solution build never ran to create tests...
+        (testCaseService as MockProgrammingExerciseTestCaseService).next(null);
+
+        fixture.detectChanges();
+
+        expect(comp.exerciseTestCases).to.have.lengthOf(0);
+        expect(getLatestResultWithFeedbacksStub).to.have.been.calledOnceWithExactly(99);
+
+        subject.next({ body: { feedbacks: [{ text: 'testY' }, { text: 'testX' }] } } as HttpResponse<Result>);
+        tick();
+
+        expect(comp.exerciseTestCases).to.have.lengthOf(2);
+        expect(comp.exerciseTestCases).to.deep.equal(['testX', 'testY']);
     }));
 });


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] I added integration test cases for the client (Jest) related to the features
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

When a programming-exercise has not had a build run for it's solution repo since the sequential test run integration, it will not have test cases.
This way e.g. the editable instructions won't be able to use the test cases.

This is a fix for the editable instructions to try to retrieve the test cases from the template feedbacks (build result) when it has received a null result from the test case service.

Both the issue and this fix have no user impact for students.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Open a programming-exercise in edit without test cases but a template build run result
3. Test Case dropdown should show the test cases

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
