### PR TITLE
Duplicate modeling and text submission creation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ParticipationRepository.java
@@ -35,8 +35,8 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 
     Optional<Participation> findByInitializationStateAndExerciseIdAndStudentLogin(InitializationState initializationState, Long exerciseId, String username);
 
-    @Query("select distinct participation from Participation participation left join fetch participation.submissions where participation.exercise.id = :#{#exerciseId} and participation.student.login = :#{#username}")
-    Optional<Participation> findByExerciseIdAndStudentLoginWithEagerSubmissions(@Param("exerciseId") Long exerciseId, @Param("username") String username);
+    @EntityGraph(attributePaths = "submissions")
+    Optional<Participation> findWithEagerSubmissionsByExerciseIdAndStudentLogin(Long exerciseId, String username);
 
     Participation findOneByExerciseIdAndStudentLoginAndInitializationState(Long exerciseId, String username, InitializationState state);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
@@ -36,4 +36,12 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      */
     @Query("SELECT COUNT (DISTINCT submission) FROM Submission submission WHERE submission.result.assessor.id = :#{#userId} AND submission.result.completionDate is null AND submission.participation.exercise.course.id = :#{#courseId}")
     long countLockedSubmissionsByUserIdAndCourseId(@Param("userId") Long userId, @Param("courseId") Long courseId);
+
+    /**
+     * Checks if a submission for the given participation exists.
+     *
+     * @param participationId the id of the participation to check
+     * @return true if a submission for the given participation exists, false otherwise
+     */
+    boolean existsByParticipationId(long participationId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -179,14 +179,13 @@ public class ModelingSubmissionService extends SubmissionService {
     }
 
     /**
-     * Saves the given submission and the corresponding model and creates the result if necessary. Furthermore, the submission is added to the AutomaticSubmissionService if not
-     * submitted yet. Is used for creating and updating modeling submissions. If it is used for a submit action, Compass is notified about the new model. Rolls back if inserting
-     * fails - occurs for concurrent createModelingSubmission() calls.
+     * Saves the given submission and the corresponding model and creates the result if necessary. This method used for creating and updating modeling submissions. If it is used
+     * for a submit action, Compass is notified about the new model. Rolls back if inserting fails - occurs for concurrent createModelingSubmission() calls.
      *
-     * @param modelingSubmission the submission to notifyCompass
-     * @param modelingExercise   the exercise to notifyCompass in
+     * @param modelingSubmission the submission that should be saved
+     * @param modelingExercise   the exercise the submission belongs to
      * @param username           the name of the corresponding user
-     * @return the modelingSubmission entity
+     * @return the saved modelingSubmission entity
      */
     @Transactional(rollbackFor = Exception.class)
     public ModelingSubmission save(ModelingSubmission modelingSubmission, ModelingExercise modelingExercise, String username) {
@@ -202,7 +201,7 @@ public class ModelingSubmissionService extends SubmissionService {
         // a chance to try it out again.
         // TODO: think about how we can enable retry again in the future in a fair way
         // make sure that no (submitted) submission exists for the given user and exercise to prevent retry submissions
-        boolean submittedSubmissionExists = participation.getSubmissions().stream().anyMatch(submission -> submission.isSubmitted());
+        boolean submittedSubmissionExists = participation.getSubmissions().stream().anyMatch(Submission::isSubmitted);
         if (submittedSubmissionExists) {
             throw new BadRequestAlertException("User " + username + " already participated in exercise with id " + modelingExercise.getId(), "modelingSubmission",
                     "participationExists");

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -167,7 +167,7 @@ public class ParticipationService {
             participation.setInitializationState(INITIALIZED);
             participation.setInitializationDate(ZonedDateTime.now());
         }
-        else if (exercise instanceof QuizExercise || exercise instanceof ModelingExercise || exercise instanceof TextExercise) {
+        else if (exercise instanceof QuizExercise || exercise instanceof ModelingExercise || exercise instanceof TextExercise || exercise instanceof FileUploadExercise) {
             if (participation.getInitializationState() == null || participation.getInitializationState() == FINISHED) {
                 // in case the participation was finished before, we set it to initialized again so that the user sees the correct button "Open modeling editor" on the client side
                 participation.setInitializationState(INITIALIZED);
@@ -178,7 +178,7 @@ public class ParticipationService {
             }
 
             if (participation.getId() == null || !submissionRepository.existsByParticipationId(participation.getId())) {
-                // initialize a modeling or text submission (depending on the exercise type), it will not do anything in the case of a quiz exercise
+                // initialize a modeling, text or file upload submission (depending on the exercise type), it will not do anything in the case of a quiz exercise
                 initializeSubmission(participation, exercise);
             }
         }
@@ -193,10 +193,11 @@ public class ParticipationService {
     }
 
     /**
-     * Initializes a new text or modeling submission (depending on the type of the given exercise), connects it with the given participation and stores it in the database.
+     * Initializes a new text, modeling or file upload submission (depending on the type of the given exercise), connects it with the given participation and stores it in the
+     * database.
      *
      * @param participation the participation for which the submission should be initialized
-     * @param exercise      the corresponding exercise, should be either a text or modeling exercise, otherwise it will instantly return and not do anything
+     * @param exercise      the corresponding exercise, should be either a text, modeling or file upload exercise, otherwise it will instantly return and not do anything
      */
     private void initializeSubmission(Participation participation, Exercise exercise) {
         if (exercise instanceof ProgrammingExercise || exercise instanceof QuizExercise) {
@@ -207,8 +208,11 @@ public class ParticipationService {
         if (exercise instanceof ModelingExercise) {
             submission = new ModelingSubmission();
         }
-        else {
+        else if (exercise instanceof TextExercise) {
             submission = new TextSubmission();
+        }
+        else {
+            submission = new FileUploadSubmission();
         }
 
         submission.setParticipation(participation);
@@ -384,7 +388,7 @@ public class ParticipationService {
     /**
      * Get all the participations.
      *
-     * @return the list of entities
+     * @return the list of participations
      */
     @Transactional(readOnly = true)
     public List<Participation> findAll() {
@@ -396,7 +400,7 @@ public class ParticipationService {
      * Get all the participations.
      *
      * @param pageable the pagination information
-     * @return the list of entities
+     * @return the list of participations
      */
     @Transactional(readOnly = true)
     public Page<Participation> findAll(Pageable pageable) {
@@ -407,15 +411,15 @@ public class ParticipationService {
     /**
      * Get one participation by id.
      *
-     * @param id the id of the entity
-     * @return the entity
+     * @param participationId the id of the participation
+     * @return the participation
      */
     @Transactional(readOnly = true)
-    public Participation findOne(Long id) {
-        log.debug("Request to get Participation : {}", id);
-        Optional<Participation> participation = participationRepository.findById(id);
+    public Participation findOne(Long participationId) {
+        log.debug("Request to get Participation : {}", participationId);
+        Optional<Participation> participation = participationRepository.findById(participationId);
         if (!participation.isPresent()) {
-            throw new EntityNotFoundException("Participation with " + id + " was not found!");
+            throw new EntityNotFoundException("Participation with " + participationId + " was not found!");
         }
         return participation.get();
     }
@@ -423,15 +427,15 @@ public class ParticipationService {
     /**
      * Get one participation by id including all results.
      *
-     * @param id the id of the participation
+     * @param participationId the id of the participation
      * @return the participation with all its results
      */
     @Transactional(readOnly = true)
-    public Participation findOneWithEagerResults(Long id) {
-        log.debug("Request to get Participation : {}", id);
-        Optional<Participation> participation = participationRepository.findByIdWithEagerResults(id);
+    public Participation findOneWithEagerResults(Long participationId) {
+        log.debug("Request to get Participation : {}", participationId);
+        Optional<Participation> participation = participationRepository.findByIdWithEagerResults(participationId);
         if (!participation.isPresent()) {
-            throw new EntityNotFoundException("Participation with " + id + " was not found!");
+            throw new EntityNotFoundException("Participation with " + participationId + " was not found!");
         }
         return participation.get();
     }
@@ -439,15 +443,15 @@ public class ParticipationService {
     /**
      * Get one participation by id including all submissions and results. Throws an EntityNotFoundException if the participation with the given id could not be found.
      *
-     * @param id the id of the entity
+     * @param participationId the id of the entity
      * @return the participation with all its submissions and results
      */
     @Transactional(readOnly = true)
-    public Participation findOneWithEagerSubmissionsAndResults(Long id) {
-        log.debug("Request to get Participation : {}", id);
-        Optional<Participation> participation = participationRepository.findWithEagerSubmissionsAndResultsById(id);
+    public Participation findOneWithEagerSubmissionsAndResults(Long participationId) {
+        log.debug("Request to get Participation : {}", participationId);
+        Optional<Participation> participation = participationRepository.findWithEagerSubmissionsAndResultsById(participationId);
         if (!participation.isPresent()) {
-            throw new EntityNotFoundException("Participation with " + id + " was not found!");
+            throw new EntityNotFoundException("Participation with " + participationId + " was not found!");
         }
         return participation.get();
     }
@@ -455,15 +459,15 @@ public class ParticipationService {
     /**
      * Get one participation by id including all results and submissions.
      *
-     * @param id the id of the participation
+     * @param participationId the id of the participation
      * @return the participation with all its results
      */
     @Transactional(readOnly = true)
-    public Participation findOneWithEagerResultsAndSubmissionsAndAssessor(Long id) {
-        log.debug("Request to get Participation : {}", id);
-        Optional<Participation> participation = participationRepository.findByIdWithEagerSubmissionsAndEagerResultsAndEagerAssessors(id);
+    public Participation findOneWithEagerResultsAndSubmissionsAndAssessor(Long participationId) {
+        log.debug("Request to get Participation : {}", participationId);
+        Optional<Participation> participation = participationRepository.findByIdWithEagerSubmissionsAndEagerResultsAndEagerAssessors(participationId);
         if (!participation.isPresent()) {
-            throw new EntityNotFoundException("Participation with " + id + " was not found!");
+            throw new EntityNotFoundException("Participation with " + participationId + " was not found!");
         }
         return participation.get();
     }
@@ -473,7 +477,7 @@ public class ParticipationService {
      *
      * @param exerciseId the project key of the exercise
      * @param username   the username of the student
-     * @return the entity
+     * @return the participation of the given student and exercise in state initialized or inactive
      */
     @Transactional(readOnly = true)
     public Participation findOneByExerciseIdAndStudentLogin(Long exerciseId, String username) {
@@ -491,7 +495,7 @@ public class ParticipationService {
      *
      * @param exerciseId the project key of the exercise
      * @param username   the username of the student
-     * @return the entity
+     * @return the participation of the given student and exercise in any state
      */
     @Transactional(readOnly = true)
     public Optional<Participation> findOneByExerciseIdAndStudentLoginAnyState(Long exerciseId, String username) {
@@ -504,7 +508,7 @@ public class ParticipationService {
      *
      * @param exerciseId the project key of the exercise
      * @param username   the username of the student
-     * @return the entity
+     * @return the participation of the given student and exercise in state finished
      */
     @Transactional(readOnly = true)
     public Optional<Participation> findOneByExerciseIdAndStudentLoginAndFinished(Long exerciseId, String username) {
@@ -517,7 +521,7 @@ public class ParticipationService {
      *
      * @param exerciseId the project key of the exercise
      * @param username   the username of the student
-     * @return the entity
+     * @return the participation of the given student and exercise with eager submissions in any state
      */
     @Transactional(readOnly = true)
     public Optional<Participation> findOneByExerciseIdAndStudentLoginWithEagerSubmissionsAnyState(Long exerciseId, String username) {
@@ -529,7 +533,7 @@ public class ParticipationService {
      * Get all participations for the given student including all results
      *
      * @param username the username of the student
-     * @return the list of entities
+     * @return the list of participations of the given student including all results
      */
     @Transactional(readOnly = true)
     public List<Participation> findWithResultsByStudentUsername(String username) {

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -520,7 +520,7 @@ public class ParticipationService {
     @Transactional(readOnly = true)
     public Optional<Participation> findOneByExerciseIdAndStudentLoginWithEagerSubmissionsAnyState(Long exerciseId, String username) {
         log.debug("Request to get Participation for User {} for Exercise with id: {}", username, exerciseId);
-        return participationRepository.findByExerciseIdAndStudentLoginWithEagerSubmissions(exerciseId, username);
+        return participationRepository.findWithEagerSubmissionsByExerciseIdAndStudentLogin(exerciseId, username);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -177,8 +177,10 @@ public class ParticipationService {
                 participation.setInitializationDate(ZonedDateTime.now());
             }
 
-            // initialize a modeling or text submission (depending on the exercise type), it will not do anything in the case of a quiz exercise
-            initializeSubmission(participation, exercise);
+            if (participation.getId() == null || !submissionRepository.existsByParticipationId(participation.getId())) {
+                // initialize a modeling or text submission (depending on the exercise type), it will not do anything in the case of a quiz exercise
+                initializeSubmission(participation, exercise);
+            }
         }
 
         participation = save(participation);

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -428,7 +428,7 @@ public class ParticipationService {
      * @return the participation with all its results
      */
     @Transactional(readOnly = true)
-    public Participation findOneWithEagerResultsAndSubmissions(Long id) {
+    public Participation findOneWithEagerResultsAndSubmissionsAndAssessor(Long id) {
         log.debug("Request to get Participation : {}", id);
         Optional<Participation> participation = participationRepository.findByIdWithEagerSubmissionsAndEagerResultsAndEagerAssessors(id);
         if (!participation.isPresent()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
@@ -7,6 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -249,9 +250,9 @@ public class ModelingAssessmentResource extends AssessmentResource {
             compassService.addAssessment(exerciseId, submissionId, result.getFeedbacks());
         }
 
-        // remove circular dependencies
-        if (result.getParticipation() != null && result.getParticipation().getResults() != null) {
-            result.getParticipation().getResults().stream().forEach(participationResult -> participationResult.setParticipation(null));
+        // remove circular dependencies if the results of the participation are there
+        if (result.getParticipation() != null && Hibernate.isInitialized(result.getParticipation().getResults()) && result.getParticipation().getResults() != null) {
+            result.getParticipation().getResults().forEach(participationResult -> participationResult.setParticipation(null));
         }
 
         return ResponseEntity.ok(result);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -280,8 +280,7 @@ public class ModelingSubmissionResource {
     }
 
     /**
-     * Returns the submission with data needed for the modeling editor, which includes the participation, the model and the result (if the assessment was already submitted). If
-     * there is no submission yet (initial call), a new one will be created and saved to the database before sending it to the client.
+     * Returns the submission with data needed for the modeling editor, which includes the participation, the model and the result (if the assessment was already submitted).
      *
      * @param participationId the participationId for which to find the submission and data for the modeling editor
      * @return the ResponseEntity with the submission as body

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -320,8 +320,9 @@ public class ModelingSubmissionResource {
         Optional<ModelingSubmission> optionalModelingSubmission = participation.findLatestModelingSubmission();
         ModelingSubmission modelingSubmission;
         if (!optionalModelingSubmission.isPresent()) {
+            // this should never happen as the submission is initialized along with the participation when the exercise is started
             modelingSubmission = new ModelingSubmission();
-            modelingSubmissionService.save(modelingSubmission, modelingExercise, participation.getStudent().getLogin());
+            modelingSubmission.setParticipation(participation);
         }
         else {
             // only try to get and set the model if the modelingSubmission existed before

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -280,14 +280,14 @@ public class ModelingSubmissionResource {
     }
 
     /**
-     * Returns the submission with data needed for the modeling editor, which includes the participation, the model and the result (if the assessment was already submitted).
+     * Returns the submission with data needed for the modeling editor, which includes the participation, the model and the result (if the assessment was already submitted). If
+     * there is no submission yet (initial call), a new one will be created and saved to the database before sending it to the client.
      *
-     * @param participationId the participationId for which to find the data for the modeling editor
-     * @return the ResponseEntity with json as body
+     * @param participationId the participationId for which to find the submission and data for the modeling editor
+     * @return the ResponseEntity with the submission as body
      */
     @GetMapping("/modeling-editor/{participationId}")
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
-    @Transactional(readOnly = true)
     public ResponseEntity<ModelingSubmission> getSubmissionForModelingEditor(@PathVariable Long participationId) {
         Participation participation = participationService.findOneWithEagerSubmissionsAndResults(participationId);
         if (participation == null) {
@@ -320,8 +320,8 @@ public class ModelingSubmissionResource {
         Optional<ModelingSubmission> optionalModelingSubmission = participation.findLatestModelingSubmission();
         ModelingSubmission modelingSubmission;
         if (!optionalModelingSubmission.isPresent()) {
-            modelingSubmission = new ModelingSubmission(); // NOTE: this object is not yet persisted
-            modelingSubmission.setParticipation(participation);
+            modelingSubmission = new ModelingSubmission();
+            modelingSubmissionService.save(modelingSubmission, modelingExercise, participation.getStudent().getLogin());
         }
         else {
             // only try to get and set the model if the modelingSubmission existed before

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
@@ -173,7 +173,7 @@ public class TextAssessmentResource extends AssessmentResource {
         }
 
         Participation participation = textSubmission.get().getParticipation();
-        participation = participationService.findOneWithEagerResultsAndSubmissions(participation.getId());
+        participation = participationService.findOneWithEagerResultsAndSubmissionsAndAssessor(participation.getId());
 
         if (!participation.getResults().isEmpty()) {
             User user = userService.getUser();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -282,9 +282,8 @@ public class TextExerciseResource {
 
         participation.getExercise().filterSensitiveInformation();
 
-        TextSubmission textSubmission;
         if (optionalTextSubmission.isPresent()) {
-            textSubmission = optionalTextSubmission.get();
+            TextSubmission textSubmission = optionalTextSubmission.get();
 
             // set reference to participation to null, since we are already inside a participation
             textSubmission.setParticipation(null);
@@ -296,10 +295,6 @@ public class TextExerciseResource {
             }
 
             participation.addSubmissions(textSubmission);
-        }
-        else {
-            textSubmission = new TextSubmission();
-            textSubmissionService.save(textSubmission, participation);
         }
 
         return ResponseEntity.ok(participation);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -38,8 +38,6 @@ public class TextExerciseResource {
     @Value("${jhipster.clientApp.name}")
     private String applicationName;
 
-    private final TextSubmissionService textSubmissionService;
-
     private final TextAssessmentService textAssessmentService;
 
     private final TextExerciseService textExerciseService;
@@ -60,11 +58,9 @@ public class TextExerciseResource {
 
     private final GroupNotificationService groupNotificationService;
 
-    public TextExerciseResource(TextSubmissionService textSubmissionService, TextExerciseRepository textExerciseRepository, TextExerciseService textExerciseService,
-            TextAssessmentService textAssessmentService, UserService userService, AuthorizationCheckService authCheckService, CourseService courseService,
-            ParticipationService participationService, ResultRepository resultRepository, GroupNotificationService groupNotificationService,
-            ExampleSubmissionRepository exampleSubmissionRepository) {
-        this.textSubmissionService = textSubmissionService;
+    public TextExerciseResource(TextExerciseRepository textExerciseRepository, TextExerciseService textExerciseService, TextAssessmentService textAssessmentService,
+            UserService userService, AuthorizationCheckService authCheckService, CourseService courseService, ParticipationService participationService,
+            ResultRepository resultRepository, GroupNotificationService groupNotificationService, ExampleSubmissionRepository exampleSubmissionRepository) {
         this.textAssessmentService = textAssessmentService;
         this.textExerciseService = textExerciseService;
         this.textExerciseRepository = textExerciseRepository;
@@ -236,7 +232,7 @@ public class TextExerciseResource {
 
     /**
      * Returns the data needed for the text editor, which includes the participation, textSubmission with answer if existing and the assessments if the submission was already
-     * submitted. If there is no submission yet (initial call), a new one will be created and saved to the database before sending it to the client along with the participation.
+     * submitted.
      *
      * @param participationId the participationId for which to find the data for the text editor
      * @return the ResponseEntity with the participation as body

--- a/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.*;
 import org.junit.runner.RunWith;
@@ -19,6 +20,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
+import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.repository.*;
@@ -244,7 +246,7 @@ public class ModelingSubmissionIntegrationTest {
 
     @Test
     @WithMockUser(value = "tutor1", roles = "TA")
-    public void getModelSubmission_lockLimitNotReached_success() throws Exception {
+    public void getModelSubmission_lockLimitReached_success() throws Exception {
         User user = database.getUserByLogin("tutor1");
         createNineLockedSubmissionsForDifferentExercisesAndUsers("tutor1");
         ModelingSubmission submission = ModelFactory.generateModelingSubmission(validModel, true);
@@ -378,6 +380,21 @@ public class ModelingSubmissionIntegrationTest {
         database.addModelingSubmission(useCaseExercise, submission, "student2");
 
         request.getList("/api/exercises/" + classExercise.getId() + "/optimal-model-submissions", HttpStatus.BAD_REQUEST, Long.class);
+    }
+
+    @Test
+    @WithMockUser(value = "student1")
+    public void getSubmissionForModelingEditor_submissionCreated() throws Exception {
+        Participation partcipation = database.addParticipationForExercise(classExercise, "student1");
+
+        ModelingSubmission returnedSubmission = request.get("/api/modeling-editor/" + partcipation.getId(), HttpStatus.OK, ModelingSubmission.class);
+
+        assertThat(returnedSubmission.getId()).as("created submission has an id").isNotNull();
+        Optional<ModelingSubmission> storedSubmission = modelingSubmissionRepo.findById(returnedSubmission.getId());
+        assertThat(storedSubmission).as("submission got saved to the database").isPresent();
+        assertThat(storedSubmission.get().getParticipation()).as("participation is correctly set").isEqualToIgnoringGivenFields(partcipation, "results", "submissions");
+        assertThat(storedSubmission.get().getType()).as("submission type is manual").isEqualTo(SubmissionType.MANUAL);
+        assertThat(storedSubmission.get().getSubmissionDate()).as("submission date is set").isNotNull();
     }
 
     private void checkDetailsHidden(ModelingSubmission submission, boolean isStudent) {

--- a/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.*;
 import org.junit.runner.RunWith;
@@ -20,7 +19,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
-import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.repository.*;
@@ -380,21 +378,6 @@ public class ModelingSubmissionIntegrationTest {
         database.addModelingSubmission(useCaseExercise, submission, "student2");
 
         request.getList("/api/exercises/" + classExercise.getId() + "/optimal-model-submissions", HttpStatus.BAD_REQUEST, Long.class);
-    }
-
-    @Test
-    @WithMockUser(value = "student1")
-    public void getSubmissionForModelingEditor_submissionCreated() throws Exception {
-        Participation partcipation = database.addParticipationForExercise(classExercise, "student1");
-
-        ModelingSubmission returnedSubmission = request.get("/api/modeling-editor/" + partcipation.getId(), HttpStatus.OK, ModelingSubmission.class);
-
-        assertThat(returnedSubmission.getId()).as("created submission has an id").isNotNull();
-        Optional<ModelingSubmission> storedSubmission = modelingSubmissionRepo.findById(returnedSubmission.getId());
-        assertThat(storedSubmission).as("submission got saved to the database").isPresent();
-        assertThat(storedSubmission.get().getParticipation()).as("participation is correctly set").isEqualToIgnoringGivenFields(partcipation, "results", "submissions");
-        assertThat(storedSubmission.get().getType()).as("submission type is manual").isEqualTo(SubmissionType.MANUAL);
-        assertThat(storedSubmission.get().getSubmissionDate()).as("submission date is set").isNotNull();
     }
 
     private void checkDetailsHidden(ModelingSubmission submission, boolean isStudent) {

--- a/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
@@ -17,10 +17,14 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import de.tum.in.www1.artemis.domain.Course;
-import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Participation;
+import de.tum.in.www1.artemis.domain.TextExercise;
+import de.tum.in.www1.artemis.domain.TextSubmission;
+import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
+import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
+import de.tum.in.www1.artemis.repository.ParticipationRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
@@ -39,6 +43,9 @@ public class ParticipationIntegrationTest {
     ExerciseRepository exerciseRepo;
 
     @Autowired
+    ParticipationRepository participationRepo;
+
+    @Autowired
     UserRepository userRepo;
 
     @Autowired
@@ -47,23 +54,47 @@ public class ParticipationIntegrationTest {
     @Autowired
     DatabaseUtilService database;
 
+    private Course course;
+
+    private ModelingExercise modelingExercise;
+
+    private TextExercise textExercise;
+
     @Before
     public void initTestCase() {
         database.resetDatabase();
         database.addUsers(2, 0, 0);
-        database.addCourseWithDifferentModelingExercises();
+        database.addCourseWithModelingAndTextExercise();
+        course = courseRepo.findAll().get(0);
+        modelingExercise = (ModelingExercise) exerciseRepo.findAll().get(0);
+        textExercise = (TextExercise) exerciseRepo.findAll().get(1);
     }
 
     @Test
-    @WithMockUser(username = "student1", roles = "USER")
-    public void participateInExercise() throws Exception {
-        Course course = courseRepo.findAll().get(0);
-        Exercise exercise = exerciseRepo.findAll().get(0);
-        URI location = request.post("/api/courses/" + course.getId() + "/exercises/" + exercise.getId() + "/participations", null, HttpStatus.CREATED);
+    @WithMockUser(username = "student1")
+    public void participateInModelingExercise() throws Exception {
+        URI location = request.post("/api/courses/" + course.getId() + "/exercises/" + modelingExercise.getId() + "/participations", null, HttpStatus.CREATED);
+
         Participation participation = request.get(location.getPath(), HttpStatus.OK, Participation.class);
-        assertThat(participation.getExercise()).as("participated in correct exercise").isEqualTo(exercise);
-        assertThat(participation.getSubmissions()).as("no submissions on initialization").isEmpty();
+        assertThat(participation.getExercise()).as("participated in correct exercise").isEqualTo(modelingExercise);
         assertThat(participation.getStudent()).as("Student got set").isNotNull();
         assertThat(participation.getStudent().getLogin()).as("Correct student got set").isEqualTo("student1");
+        Participation storedParticipation = participationRepo.findWithEagerSubmissionsByExerciseIdAndStudentLogin(modelingExercise.getId(), "student1").get();
+        assertThat(storedParticipation.getSubmissions().size()).as("submission was initialized").isEqualTo(1);
+        assertThat(storedParticipation.getSubmissions().iterator().next().getClass()).as("submission is of type modeling submission").isEqualTo(ModelingSubmission.class);
+    }
+
+    @Test
+    @WithMockUser(username = "student2")
+    public void participateInTextExercise() throws Exception {
+        URI location = request.post("/api/courses/" + course.getId() + "/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.CREATED);
+
+        Participation participation = request.get(location.getPath(), HttpStatus.OK, Participation.class);
+        assertThat(participation.getExercise()).as("participated in correct exercise").isEqualTo(textExercise);
+        assertThat(participation.getStudent()).as("Student got set").isNotNull();
+        assertThat(participation.getStudent().getLogin()).as("Correct student got set").isEqualTo("student2");
+        Participation storedParticipation = participationRepo.findWithEagerSubmissionsByExerciseIdAndStudentLogin(textExercise.getId(), "student2").get();
+        assertThat(storedParticipation.getSubmissions().size()).as("submission was initialized").isEqualTo(1);
+        assertThat(storedParticipation.getSubmissions().iterator().next().getClass()).as("submission is of type text submission").isEqualTo(TextSubmission.class);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
@@ -97,4 +97,18 @@ public class ParticipationIntegrationTest {
         assertThat(storedParticipation.getSubmissions().size()).as("submission was initialized").isEqualTo(1);
         assertThat(storedParticipation.getSubmissions().iterator().next().getClass()).as("submission is of type text submission").isEqualTo(TextSubmission.class);
     }
+
+    @Test
+    @WithMockUser(username = "student1")
+    public void participateTwiceInModelingExercise_badRequest() throws Exception {
+        request.post("/api/courses/" + course.getId() + "/exercises/" + modelingExercise.getId() + "/participations", null, HttpStatus.CREATED);
+        request.post("/api/courses/" + course.getId() + "/exercises/" + modelingExercise.getId() + "/participations", null, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = "student1")
+    public void participateTwiceInTextExercise_badRequest() throws Exception {
+        request.post("/api/courses/" + course.getId() + "/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.CREATED);
+        request.post("/api/courses/" + course.getId() + "/exercises/" + textExercise.getId() + "/participations", null, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -51,6 +51,9 @@ public class DatabaseUtilService {
     ModelingSubmissionRepository modelingSubmissionRepo;
 
     @Autowired
+    TextSubmissionRepository textSubmissionRepo;
+
+    @Autowired
     ModelAssessmentConflictRepository conflictRepo;
 
     @Autowired
@@ -86,6 +89,7 @@ public class DatabaseUtilService {
         feedbackRepo.deleteAll();
         exampleSubmissionRepo.deleteAll();
         modelingSubmissionRepo.deleteAll();
+        textSubmissionRepo.deleteAll();
         participationRepo.deleteAll();
         exerciseRepo.deleteAll();
         courseRepo.deleteAll();

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -174,6 +174,22 @@ public class DatabaseUtilService {
         assertThat(courseRepoContent.get(0).getExercises()).as("Contains all exercises").containsExactlyInAnyOrder(exerciseRepoContent.toArray(new Exercise[] {}));
     }
 
+    public void addCourseWithModelingAndTextExercise() {
+        Course course = ModelFactory.generateCourse(null, pastTimestamp, futureFutureTimestamp, new HashSet<>(), "tumuser", "tutor", "tutor");
+        ModelingExercise modelingExercise = ModelFactory.generateModelingExercise(pastTimestamp, futureTimestamp, futureFutureTimestamp, DiagramType.ClassDiagram, course);
+        course.addExercises(modelingExercise);
+        TextExercise textExercise = ModelFactory.generateTextExercise(pastTimestamp, futureTimestamp, futureFutureTimestamp, course);
+        course.addExercises(textExercise);
+        courseRepo.save(course);
+        exerciseRepo.save(modelingExercise);
+        exerciseRepo.save(textExercise);
+        List<Course> courseRepoContent = courseRepo.findAllActiveWithEagerExercises();
+        List<Exercise> exerciseRepoContent = exerciseRepo.findAll();
+        assertThat(exerciseRepoContent.size()).as("two exercises got stored").isEqualTo(2);
+        assertThat(courseRepoContent.size()).as("a course got stored").isEqualTo(1);
+        assertThat(courseRepoContent.get(0).getExercises()).as("course contains the exercises").containsExactlyInAnyOrder(exerciseRepoContent.toArray(new Exercise[] {}));
+    }
+
     /**
      * Stores for the given model a submission of the user and initiates the corresponding Result
      *


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] I added integration test cases for the server (Spring) related to the features
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Occasionally we have the situation that a modeling or text submission is created twice in the database, which then requires a manual cleanup of the duplicated submissions.

### Description
<!-- Describe your changes in detail -->
We assume that it is caused by asynchronous behavior when the user (accidentally) clicks the save button twice or when the user clicks on save exactly in the moment the auto save happens. To prevent this we now initialize and save the submissions automatically when the user opens the modeling/text editor for the first time.