### PR TITLE
Hibernate lazy initialization error

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
@@ -252,7 +252,7 @@ public class ModelingAssessmentResource extends AssessmentResource {
 
         // remove circular dependencies if the results of the participation are there
         if (result.getParticipation() != null && Hibernate.isInitialized(result.getParticipation().getResults()) && result.getParticipation().getResults() != null) {
-            result.getParticipation().getResults().forEach(participationResult -> participationResult.setParticipation(null));
+            result.getParticipation().setResults(null);
         }
 
         return ResponseEntity.ok(result);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
@@ -7,6 +7,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -249,9 +250,9 @@ public class ModelingAssessmentResource extends AssessmentResource {
             compassService.addAssessment(exerciseId, submissionId, result.getFeedbacks());
         }
 
-        // remove circular dependencies
-        if (result.getParticipation() != null && result.getParticipation().getResults() != null) {
-            result.getParticipation().getResults().stream().forEach(participationResult -> participationResult.setParticipation(null));
+        // remove circular dependencies if the results of the participation are there
+        if (result.getParticipation() != null && Hibernate.isInitialized(result.getParticipation().getResults()) && result.getParticipation().getResults() != null) {
+            result.getParticipation().getResults().forEach(participationResult -> participationResult.setParticipation(null));
         }
 
         return ResponseEntity.ok(result);


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
Updating a modeling assessment after a complaint might result in a lazy initialization error from Hibernate. The reason for this is that we remove circular references of the result entity before sending it to the client. However, the corresponding collection that we update there might be a Hibernate proxy which can not be loaded from the database anymore. I added a check for the Hibernate proxy, i.e. if the collection is a Hibernate proxy, it will not be updated.