### PR TITLE
Fix popup display overflow

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
@@ -154,8 +154,8 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
                         )(feedbacks),
                     ),
                 )
-                .subscribe((testCases: string[]) => {
-                    this.exerciseTestCases = testCases;
+                .subscribe((_testCases: string[]) => {
+                    this.exerciseTestCases = _testCases;
                     this.testCaseCommand.setValues(this.exerciseTestCases);
                 });
         }

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
@@ -57,7 +57,7 @@
                     <ng-template #renderedAnswerOptionsHint>
                         <div [innerHTML]="rendered!.answerOptions![i].hint"></div>
                     </ng-template>
-                    <span class="label label-info" [ngbPopover]="renderedAnswerOptionsHint" placement="top" triggers="mouseenter:mouseleave" *ngIf="answerOption.hint">
+                    <span class="label label-info" [ngbPopover]="renderedAnswerOptionsHint" placement="left" triggers="mouseenter:mouseleave" *ngIf="answerOption.hint">
                         <fa-icon [icon]="['far', 'question-circle']"></fa-icon>
                         <span jhiTranslate="artemisApp.quizQuestion.hint"></span>
                     </span>

--- a/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
+++ b/src/main/webapp/app/quiz/participate/multiple-choice-question/multiple-choice-question.component.html
@@ -57,7 +57,7 @@
                     <ng-template #renderedAnswerOptionsHint>
                         <div [innerHTML]="rendered!.answerOptions![i].hint"></div>
                     </ng-template>
-                    <span class="label label-info" [ngbPopover]="renderedAnswerOptionsHint" placement="left" triggers="mouseenter:mouseleave" *ngIf="answerOption.hint">
+                    <span class="label label-info" [ngbPopover]="renderedAnswerOptionsHint" placement="top" triggers="mouseenter:mouseleave" *ngIf="answerOption.hint">
                         <fa-icon [icon]="['far', 'question-circle']"></fa-icon>
                         <span jhiTranslate="artemisApp.quizQuestion.hint"></span>
                     </span>

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -396,6 +396,10 @@
         margin: 2px 0;
     }
 
+    .label + ngb-popover-window {
+        max-width: 500px;
+    }
+
     .answer-options {
         margin-top: 20px;
     }
@@ -429,6 +433,10 @@
                 flex-direction: column;
                 align-items: flex-end;
                 font-size: 18px;
+
+                ngb-popover-window {
+                    max-width: 500px;
+                }
             }
         }
 
@@ -1403,12 +1411,6 @@ table.answer-options-result {
     border-color: #ccc;
 }
 
-@include media-breakpoint-down(xs) {
-    .btn + .btn {
-        margin-top: 15px;
-    }
-}
-
 /* CSS tooltip to overcome hybrid setup problems */
 
 /* Tooltip container */
@@ -1573,5 +1575,19 @@ ngb-tooltip-window > div {
     }
     .orange {
         color: #d86b1f;
+    }
+}
+
+@include media-breakpoint-down(xs) {
+    .btn + .btn {
+        margin-top: 15px;
+    }
+}
+
+@include media-breakpoint-down(sm) {
+    .hint {
+        ngb-popover-window {
+            max-width: 300px !important;
+        }
     }
 }

--- a/src/main/webapp/content/scss/quiz.scss
+++ b/src/main/webapp/content/scss/quiz.scss
@@ -1578,16 +1578,21 @@ ngb-tooltip-window > div {
     }
 }
 
-@include media-breakpoint-down(xs) {
-    .btn + .btn {
-        margin-top: 15px;
-    }
-}
-
 @include media-breakpoint-down(sm) {
     .hint {
         ngb-popover-window {
             max-width: 300px !important;
+        }
+    }
+}
+
+@include media-breakpoint-down(xs) {
+    .btn + .btn {
+        margin-top: 15px;
+    }
+    .hint {
+        ngb-popover-window {
+            max-width: 200px !important;
         }
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~~I documented my source code using the JavaDoc / JSDoc style.~~
- [x] ~~I added integration test cases for the server (Spring) related to the features~~
- [x] ~~I added integration test cases for the client (Jest) related to the features~~
- [x] I added screenshots/screencast of my UI changes
- [x] ~~I translated all the newly inserted strings~~

### Motivation and Context
The hint pop-up is not completely visible if the text is too long.
![image](https://user-images.githubusercontent.com/33764166/60925215-591db980-a2a3-11e9-995f-9cd1cf302712.png)

### Description
I set the max-width to 500px and changed the pop-up placement for question hints to "left" instead of "top"

### Steps for Testing
1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Visit quiz preview which has quiz hints

Test page: https://artemistest.ase.in.tum.de/#/quiz/630/preview

### Screenshots
![image](https://user-images.githubusercontent.com/33764166/60927317-c7fe1100-a2a9-11e9-9abf-d39d6ad43b74.png)
![image](https://user-images.githubusercontent.com/33764166/60927341-dea46800-a2a9-11e9-8206-c679d600e939.png)