### PR TITLE
Bugfix/ fix doubled preview for programming exercises problem statement editor

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.html
@@ -7,6 +7,7 @@
         (markdownChange)="updateProblemStatement($event)"
     >
         <jhi-programming-exercise-instructions
+            #preview
             class="editable-instruction-container__instructions"
             [participation]="participation"
             [exercise]="exercise"


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] ~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

This is a regression from the sequential test runs: The problem statement is shown twice in the preview mode of the editable instructions. (see screenshot below).

Only user impact for tas / instructors.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/28230611/60975980-23bdae00-a32d-11e9-9e45-c3a3fd6b7868.png)
