### PR TITLE
Result: Also assign null result if component is reused

### DIFF
--- a/src/main/webapp/app/entities/result/updating-result.component.ts
+++ b/src/main/webapp/app/entities/result/updating-result.component.ts
@@ -24,7 +24,7 @@ export class UpdatingResultComponent implements OnChanges, OnDestroy {
     @Input() participation: Participation;
     @Input() isBuilding: boolean;
     @Input() short = false;
-    @Input() result: Result;
+    @Input() result: Result | null;
     @Input() showUngradedResults: boolean;
     @Input() showGradedBadge: boolean;
 
@@ -40,10 +40,8 @@ export class UpdatingResultComponent implements OnChanges, OnDestroy {
             }
             // The latest result is the first rated result in the sorted array (=newest) or any result if the option is active to show ungraded results.
             const latestResult = this.participation.results && this.participation.results.find(({ rated }) => this.showUngradedResults || rated === true);
-            if (latestResult) {
-                // Make sure that the participation result is connected to the newest result.
-                this.result = { ...latestResult, participation: this.participation };
-            }
+            // Make sure that the participation result is connected to the newest result.
+            this.result = latestResult ? { ...latestResult, participation: this.participation } : null;
 
             this.subscribeForNewResults();
         }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

When reusing the `updating-result` component, the result will not be replaced when the newResult is undefined or null.
The only place where this issue could have appeared, was the code editor admin area.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Go to course administration > programming exercises > create
3. Open newly created programming exercise with "edit in editor"
4. Create a new assignment participation
5. Switch to the assignment participation => result should be "no graded result" (before it would still show the template participations result)
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
