### PR TITLE
Readme: Update css contributing section

### DIFF
--- a/doc/contribute/CONTRIBUTE.md
+++ b/doc/contribute/CONTRIBUTE.md
@@ -30,19 +30,6 @@ We are using [Scss](https://sass-lang.com) to write modular, reusable css.
 
 We have a couple of global scss files in `webapp/content` but encourage [component dependent css with angular's styleUrls](https://angular.io/guide/component-styles).
 
-The [bootstrap css](https://getbootstrap.com/) is imported into Artemis, however we discourage using it in html.
-We encourage using the Scss [extend](https://sass-lang.com/documentation/at-rules/extend) mechanism if bootstrap styles are used.
-
-Discouraged html styling:
-`<div class="d-flex">some content</div>`
-
-Encouraged scss extend styling:
-```
-.my-container {
-    @extend .d-flex;
-}
-```
-
 From a methodology viewpoint we encourage the use of [BEM](http://getbem.com/introduction/).
 ```
 .my-container {
@@ -55,6 +42,12 @@ From a methodology viewpoint we encourage the use of [BEM](http://getbem.com/int
     }
 }
 ```
+
+Within the component html files, we encourage the use of [bootstrap css](https://getbootstrap.com/).
+
+Encouraged html styling:
+`<div class="d-flex ml-2">some content</div>`
+
 
 ## Testing
 


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] ~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

When we last discussed the use of bootstrap css classes, we decided to get rid of them in the html with the use of the `@extend` scss directive.
It turned out however that `@extend` comes with the drawback that it duplicates the extended styles (there is no proper inheritance in css). Also `@extend` of bootstrap classes in component css files necessitates the import of the bootstrap css files within the component css file. This further increases our css and could become an issue if we follow this path.

It would be great if we could only use component css files, but there doesn't seem a proper way to do this :thinking: 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
