### PR TITLE
Prevent "Cannot read property 'getCurrentModel' of undefined" error

### DIFF
--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.ts
@@ -420,9 +420,11 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         }
     }
 
-    // function to check whether there are pending changes
+    /**
+     * Checks whether there are pending changes in the current model. Returns true if there are NO unsaved changes, false otherwise.
+     */
     canDeactivate(): Observable<boolean> | boolean {
-        if (this.submission && this.submission.submitted) {
+        if (!this.modelingEditor || (this.submission && this.submission.submitted)) {
             return true;
         }
         const model: UMLModel = this.modelingEditor.getCurrentModel();


### PR DESCRIPTION
Check if modelingEditor is there to prevent "Cannot read property 'getCurrentModel' of undefined" error.

Related Sentry issues:
- https://sentry.io/organizations/ls1intum/issues/1083802372/?project=1440029
- https://sentry.io/organizations/ls1intum/issues/1089365523/?project=1440029
- https://sentry.io/organizations/ls1intum/issues/1111026545/?project=1440029