### PR TITLE
Fix "Cannot read property 'name' of undefined" error

### DIFF
--- a/src/main/webapp/app/entities/modeling-assessment/modeling-assessment.service.ts
+++ b/src/main/webapp/app/entities/modeling-assessment/modeling-assessment.service.ts
@@ -112,7 +112,13 @@ export class ModelingAssessmentService {
             const referencedModelType = feedback.referenceType!;
             const referencedModelId = feedback.referenceId!;
             if (referencedModelType in UMLElementType) {
-                const element = model.elements.find(elem => elem.id === referencedModelId)!;
+                const element = model.elements.find(elem => elem.id === referencedModelId);
+                if (!element) {
+                    // prevent errors when element could not be found, should never happen
+                    assessmentsNames[referencedModelId] = { name: '', type: '' };
+                    continue;
+                }
+
                 const name = element.name;
                 let type: string;
                 switch (element.type) {


### PR DESCRIPTION
Check if element is there to prevent "Cannot read property 'name' of undefined" error when getting the assessment names in the modeling assessment service.

Related Sentry issue:
- https://sentry.io/organizations/ls1intum/issues/1088438631