### PR TITLE
Add autoincrement property to migration file (programming exercise test cases)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
         - $HOME/.gradle/caches/
         - $HOME/.gradle/wrapper/
 env:
-    - NODE_OPTIONS=--max_old_space_size=5120
+    - NODE_OPTIONS=--max_old_space_size=6144
 
 jobs:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
         - $HOME/.gradle/caches/
         - $HOME/.gradle/wrapper/
 env:
-    - NODE_OPTIONS=--max_old_space_size=4096
+    - NODE_OPTIONS=--max_old_space_size=5120
 
 jobs:
     include:

--- a/src/main/resources/config/liquibase/changelog/20190603142500_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20190603142500_changelog.xml
@@ -1,5 +1,4 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
     <property name="autoIncrement" value="true"/>

--- a/src/main/resources/config/liquibase/changelog/20190603142500_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20190603142500_changelog.xml
@@ -1,38 +1,34 @@
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
-                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
     <property name="autoIncrement" value="true"/>
-    <changeSet id="201905026142600" author="behnke">
-        <!-- create new entity programming exercise test case -->
-        <createTable tableName="programming_exercise_test_case">
-            <column name="id" type="bigint" autoIncrement="${autoIncrement}">
-                <constraints primaryKey="true" nullable="false"/>
-            </column>
-            <column name="test_name" type="varchar(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="weight" type="integer">
-                <constraints nullable="false"/>
-            </column>
-            <column name="active" type="boolean">
-                <constraints nullable="false"/>
-            </column>
-            <column name="exercise_id" type="bigint">
-                <constraints nullable="true"/>
-            </column>
-        </createTable>
-        <addUniqueConstraint tableName="programming_exercise_test_case" columnNames="test_name, exercise_id"
-                             constraintName="exercise_test_case"/>
-        <!-- add foreign key constraint from test cases to programming exercises -->
-        <addForeignKeyConstraint baseColumnNames="exercise_id"
-                                 baseTableName="programming_exercise_test_case"
-                                 constraintName="fk_programming_exercise_test_case_exercise_id"
-                                 referencedColumnNames="id"
-                                 referencedTableName="exercise"/>
-        <!-- add sequential test run boolean flag to exercise -->
-        <addColumn tableName="exercise">
-            <column name="sequential_test_runs" type="Boolean"/>
-        </addColumn>
-    </changeSet>
+<changeSet id="201905026142600" author="behnke">
+    <!-- create new entity programming exercise test case -->
+    <createTable tableName="programming_exercise_test_case">
+        <column name="id" type="bigint" autoIncrement="${autoIncrement}">
+            <constraints primaryKey="true" nullable="false"/>
+        </column>
+        <column name="test_name" type="varchar(255)">
+            <constraints nullable="false" />
+        </column>
+        <column name="weight" type="integer">
+            <constraints nullable="false" />
+        </column>
+        <column name="active" type="boolean">
+            <constraints nullable="false" />
+        </column>
+        <column name="exercise_id" type="bigint">
+            <constraints nullable="true" />
+        </column>
+    </createTable>
+    <addUniqueConstraint tableName="programming_exercise_test_case" columnNames="test_name, exercise_id" constraintName="exercise_test_case" />
+    <!-- add foreign key constraint from test cases to programming exercises -->
+    <addForeignKeyConstraint baseColumnNames="exercise_id"
+                             baseTableName="programming_exercise_test_case"
+                             constraintName="fk_programming_exercise_test_case_exercise_id"
+                             referencedColumnNames="id"
+                             referencedTableName="exercise"/>
+    <!-- add sequential test run boolean flag to exercise -->
+    <addColumn tableName="exercise">
+        <column name="sequential_test_runs" type="Boolean"/>
+    </addColumn>
+</changeSet>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20190603142500_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20190603142500_changelog.xml
@@ -1,4 +1,5 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
     <property name="autoIncrement" value="true"/>

--- a/src/main/resources/config/liquibase/changelog/20190603142500_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20190603142500_changelog.xml
@@ -1,33 +1,38 @@
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-<changeSet id="201905026142600" author="behnke">
-    <!-- create new entity programming exercise test case -->
-    <createTable tableName="programming_exercise_test_case">
-        <column name="id" type="bigint" autoIncrement="${autoIncrement}">
-            <constraints primaryKey="true" nullable="false"/>
-        </column>
-        <column name="test_name" type="varchar(255)">
-            <constraints nullable="false" />
-        </column>
-        <column name="weight" type="integer">
-            <constraints nullable="false" />
-        </column>
-        <column name="active" type="boolean">
-            <constraints nullable="false" />
-        </column>
-        <column name="exercise_id" type="bigint">
-            <constraints nullable="true" />
-        </column>
-    </createTable>
-    <addUniqueConstraint tableName="programming_exercise_test_case" columnNames="test_name, exercise_id" constraintName="exercise_test_case" />
-    <!-- add foreign key constraint from test cases to programming exercises -->
-    <addForeignKeyConstraint baseColumnNames="exercise_id"
-                             baseTableName="programming_exercise_test_case"
-                             constraintName="fk_programming_exercise_test_case_exercise_id"
-                             referencedColumnNames="id"
-                             referencedTableName="exercise"/>
-    <!-- add sequential test run boolean flag to exercise -->
-    <addColumn tableName="exercise">
-        <column name="sequential_test_runs" type="Boolean"/>
-    </addColumn>
-</changeSet>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <property name="autoIncrement" value="true"/>
+    <changeSet id="201905026142600" author="behnke">
+        <!-- create new entity programming exercise test case -->
+        <createTable tableName="programming_exercise_test_case">
+            <column name="id" type="bigint" autoIncrement="${autoIncrement}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="test_name" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="weight" type="integer">
+                <constraints nullable="false"/>
+            </column>
+            <column name="active" type="boolean">
+                <constraints nullable="false"/>
+            </column>
+            <column name="exercise_id" type="bigint">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="programming_exercise_test_case" columnNames="test_name, exercise_id"
+                             constraintName="exercise_test_case"/>
+        <!-- add foreign key constraint from test cases to programming exercises -->
+        <addForeignKeyConstraint baseColumnNames="exercise_id"
+                                 baseTableName="programming_exercise_test_case"
+                                 constraintName="fk_programming_exercise_test_case_exercise_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="exercise"/>
+        <!-- add sequential test run boolean flag to exercise -->
+        <addColumn tableName="exercise">
+            <column name="sequential_test_runs" type="Boolean"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

When we rolled out the programming exercise test case commit to production, auto increment was not working for the test cases.
The issue was that the autoincrement property generated by jhipster was removed from the changelog file when I did the merge of the 2 changelog files.

:warning: Note: We need to clear the checksums on the test and production server when this is merged. :warning: 
