### PR TITLE
Increase memory limit for node to avoid build crashes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
     directories:
         - $HOME/.gradle/caches/
         - $HOME/.gradle/wrapper/
+env:
+    - NODE_OPTIONS=--max_old_space_size=4096
 
 jobs:
     include:


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] ~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

I had the issue in a couple of my PRs that travis would crash in the build stage because node ran out of memory:
`FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`

An easy fix is to increase the memory for node (see commit).

Here a comparison of two builds with and without the new env variable:
With: https://github.com/ls1intum/Artemis/runs/171036777
Without: https://github.com/ls1intum/Artemis/runs/171097033
(They are both from this PR: https://github.com/ls1intum/Artemis/pull/648)

Here some information about the env variable:
https://medium.com/@vuongtran/how-to-solve-process-out-of-memory-in-node-js-5f0de8f8464c

By default the memory limit in Node.js is 512 mb, to solve this issue you need to increasing the memory limit use command —- max-old-space-size .It can be avoid the memory limit issue.

```
node --max-old-space-size=1024 index.js #increase to 1gb
node --max-old-space-size=2048 index.js #increase to 2gb
node --max-old-space-size=3072 index.js #increase to 3gb
node --max-old-space-size=4096 index.js #increase to 4gb
node --max-old-space-size=5120 index.js #increase to 5gb
node --max-old-space-size=6144 index.js #increase to 6gb
node --max-old-space-size=7168 index.js #increase to 7gb
node --max-old-space-size=8192 index.js #increase to 8gb
```

About the issue:
There must be something in our compilation process that requires a lot of Memor, but I don't see any easy fix to reduce it.
It might be worth it throw out components that are not used anymore (e.g. old course area) and try to find areas where we e.g. import the same css into different files.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
