### PR TITLE
Bugfix/programming exercise/fix bad request errors on create

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.html
@@ -14,7 +14,7 @@
         ></jhi-programming-exercise-instructions>
     </jhi-markdown-editor>
     <button
-        *ngIf="enableSave"
+        *ngIf="editMode"
         id="save-instructions-button"
         [disabled]="savingInstructions || !unsavedChanges"
         (click)="saveInstructions($event)"

--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
@@ -43,7 +43,8 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     @ViewChild(MarkdownEditorComponent, { static: false }) markdownEditor: MarkdownEditorComponent;
 
     @Input() showStatus = true;
-    @Input() enableSave = true;
+    // If the programming exercise is being created, some features have to be disabled (saving the problemStatement & querying test cases).
+    @Input() editMode = true;
     @Input() enableResize = true;
     @Input() showSaveButton = false;
     @Input() templateParticipation: Participation;
@@ -148,31 +149,34 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
             this.testCaseSubscription.unsubscribe();
         }
 
-        this.testCaseSubscription = this.testCaseService
-            .subscribeForTestCases(this.exercise.id)
-            .pipe(
-                switchMap((testCases: ProgrammingExerciseTestCase[] | null) => {
-                    // If there are test cases, map them to their names, sort them and use them for the markdown editor.
-                    if (testCases) {
-                        const sortedTestCaseNames = compose(
-                            map(({ testName }) => testName),
-                            filter(({ active }) => active),
-                            sortBy('testName'),
-                        )(testCases);
-                        return of(sortedTestCaseNames);
-                    } else if (this.exercise.templateParticipation) {
-                        // Legacy case: If there are no test cases, but a template participation, use its feedbacks for generating test names.
-                        return this.loadTestCasesFromTemplateParticipationResult(this.exercise.templateParticipation.id);
-                    }
-                    return of();
-                }),
-                tap((testCaseNames: string[]) => {
-                    this.exerciseTestCases = testCaseNames;
-                    this.testCaseCommand.setValues(this.exerciseTestCases);
-                }),
-                catchError(() => of()),
-            )
-            .subscribe();
+        // Only set up a subscription for test cases if the exercise already exists.
+        if (this.editMode) {
+            this.testCaseSubscription = this.testCaseService
+                .subscribeForTestCases(this.exercise.id)
+                .pipe(
+                    switchMap((testCases: ProgrammingExerciseTestCase[] | null) => {
+                        // If there are test cases, map them to their names, sort them and use them for the markdown editor.
+                        if (testCases) {
+                            const sortedTestCaseNames = compose(
+                                map(({ testName }) => testName),
+                                filter(({ active }) => active),
+                                sortBy('testName'),
+                            )(testCases);
+                            return of(sortedTestCaseNames);
+                        } else if (this.exercise.templateParticipation) {
+                            // Legacy case: If there are no test cases, but a template participation, use its feedbacks for generating test names.
+                            return this.loadTestCasesFromTemplateParticipationResult(this.exercise.templateParticipation.id);
+                        }
+                        return of();
+                    }),
+                    tap((testCaseNames: string[]) => {
+                        this.exerciseTestCases = testCaseNames;
+                        this.testCaseCommand.setValues(this.exerciseTestCases);
+                    }),
+                    catchError(() => of()),
+                )
+                .subscribe();
+        }
     }
 
     /**

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-dialog.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-dialog.component.html
@@ -70,7 +70,7 @@
                     [participation]="programmingExercise.templateParticipation"
                     [(exercise)]="programmingExercise"
                     [showStatus]="programmingExercise?.id"
-                    [enableSave]="programmingExercise?.id"
+                    [editMode]="programmingExercise?.id"
                     class="form__editable-instructions"
                 ></jhi-programming-exercise-editable-instructions>
             </div>

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
@@ -125,7 +125,7 @@
                         [participation]="programmingExercise.templateParticipation"
                         [(exercise)]="programmingExercise"
                         [showStatus]="programmingExercise?.id"
-                        [enableSave]="programmingExercise?.id"
+                        [editMode]="programmingExercise?.id"
                         class="form__editable-instructions"
                     ></jhi-programming-exercise-editable-instructions>
                 </div>

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { HttpResponse } from '@angular/common/http';
+import { By } from '@angular/platform-browser';
 import { MockComponent } from 'ng-mocks';
 import { of, Subject } from 'rxjs';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
@@ -165,5 +166,29 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
 
         expect(comp.exerciseTestCases).to.have.lengthOf(2);
         expect(comp.exerciseTestCases).to.deep.equal(['testX', 'testY']);
+    }));
+
+    it('should not try to query test cases or solution participation results if the exercise is being created (there can be no test cases yet)', fakeAsync(() => {
+        comp.exercise = exercise;
+        comp.participation = participation;
+        comp.editMode = false;
+
+        const changes: SimpleChanges = {
+            exercise: new SimpleChange(undefined, exercise, true),
+        };
+        comp.ngOnChanges(changes);
+
+        fixture.detectChanges();
+        tick();
+
+        expect(comp.exerciseTestCases).to.have.lengthOf(0);
+        expect(comp.exerciseTestCases).to.be.empty;
+
+        expect(comp.testCaseSubscription).to.be.undefined;
+        expect(subscribeForTestCaseSpy).not.to.have.been.called;
+        expect(getLatestResultWithFeedbacksStub).not.to.have.been.called;
+
+        const saveProblemStatementButton = debugElement.query(By.css('#save-instructions-button'));
+        expect(saveProblemStatementButton).not.to.exist;
     }));
 });


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] I added integration test cases for the client (Jest) related to the features
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

When opening the creation dialog of the programming-exercises, two unnecessary api calls executed:
1) Query test cases
2) Query latest result of template participation

This is a regression from https://github.com/ls1intum/Artemis/pull/648.
User impact is low, as programming exercises can still be created.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Open the programming exercise create dialog
3. Check the network tab -> no query for test cases or latest-result should be executed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
