### PR TITLE
Programming-Exercise: First checkout test then assignment repository

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooBuildPlanService.java
@@ -127,9 +127,10 @@ public class BambooBuildPlanService {
 
     private VcsCheckoutTask createCheckoutTask(String assignmentPath, String testPath) {
         return new VcsCheckoutTask().description("Checkout Default Repository").checkoutItems(
-                new CheckoutItem().repository(new VcsRepositoryIdentifier().name(ASSIGNMENT_REPO_NAME)).path(assignmentPath), // NOTE: this path needs to be specified in the Maven
-                                                                                                                              // pom.xml in the Tests Repo
-                new CheckoutItem().repository(new VcsRepositoryIdentifier().name(TEST_REPO_NAME)).path(testPath));
+                new CheckoutItem().repository(new VcsRepositoryIdentifier().name(TEST_REPO_NAME)).path(testPath),
+                new CheckoutItem().repository(new VcsRepositoryIdentifier().name(ASSIGNMENT_REPO_NAME)).path(assignmentPath) // NOTE: this path needs to be specified in the Maven
+                                                                                                                             // pom.xml in the Tests Repo
+        );
     }
 
     private PlanBranchManagement createPlanBranchManagement() {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] I added screenshots/screencast of my UI changes
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

This issue was reported by @krusche:
Because we first checkout the assignment (student participation) repository and then the test repository, the test repository might overwrite files from the assignment repo.

I changed the order (see screenshot below).

:warning: However I could not find a point in our git history where the order was this way :thinking:

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Create a programming exercise
3. Check that the checkout order in the template & solution jobs is now as defined in the screenshot below 

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/28230611/61541403-e0a3bf00-aa3f-11e9-86a6-8c1429e030d0.png)

