### PR TITLE
Bugfix/fix markdown editor in edit drag and drop

### DIFF
--- a/src/main/webapp/app/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/markdown-editor/markdown-editor.component.ts
@@ -262,7 +262,6 @@ export class MarkdownEditorComponent implements AfterViewInit {
         if (this.showDefaultPreview) {
             this.previewTextAsHtml = this.artemisMarkdown.htmlForMarkdown(this.markdown);
             this.html.emit(this.previewTextAsHtml);
-            return;
         }
         if (this.domainCommands && this.domainCommands.length) {
             /** create array with domain command identifier */

--- a/src/main/webapp/app/quiz/edit/drag-and-drop-question/edit-drag-and-drop-question.component.ts
+++ b/src/main/webapp/app/quiz/edit/drag-and-drop-question/edit-drag-and-drop-question.component.ts
@@ -778,6 +778,7 @@ export class EditDragAndDropQuestionComponent implements OnInit, OnChanges, Edit
      * @desc Toggles the preview in the template
      */
     togglePreview(): void {
+        resizeImage();
         this.showPreview = !this.showPreview;
         this.prepareForSave();
     }

--- a/src/main/webapp/app/utils/drag-and-drop.utils.ts
+++ b/src/main/webapp/app/utils/drag-and-drop.utils.ts
@@ -6,9 +6,10 @@ export function resizeImage() {
     setTimeout(() => {
         const image = document.querySelector('.background-area jhi-secured-image img') as HTMLImageElement;
         const clickLayer = document.getElementsByClassName('click-layer').item(0) as HTMLElement;
-        if (clickLayer) {
+
+        if (image && clickLayer) {
             clickLayer.style.width = image.width + 'px';
             clickLayer.style.height = image.height + 'px';
         }
-    }, 100);
+    }, 500);
 }


### PR DESCRIPTION
### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~~I documented my source code using the JavaDoc / JSDoc style.~~
- [x] ~~I added integration test cases for the server (Spring) related to the features~~
- [x] ~~I added integration test cases for the client (Jest) related to the features~~
- [x] ~~I added screenshots/screencast of my UI changes~~
- [x] ~~I translated all the newly inserted strings~~

### Description
Previous changes in the markdown-editor lead to the issue that the text for dnd questions aren't saved anymore. There was no event emitted from the markdown editor anymore about the found domain commands, so the question text & hint where not set.

Regression from https://github.com/ls1intum/Artemis/pull/622.

This PR also includes a small fix for the drag-and-drop utils to avoid an `undefined of...` if the clickLayer is not yet available due to rendering.

### Steps for Testing
1. Log in to ArTEMiS
2. Navigate to Course Administration
3. Create Quiz 
4. Create Drag-and-Drop-Question and add text to markdown-editor
5. Save quiz
6. Reload page and check that the markdown editor text is still set

### Screenshots
![image](https://user-images.githubusercontent.com/33764166/61584714-fce15200-ab4c-11e9-9d7d-f2b6a9d0597c.png)
![image](https://user-images.githubusercontent.com/33764166/61584710-ee933600-ab4c-11e9-9069-5ec88e2af5ff.png)