### PR TITLE
Hotfix/Add null check for result iteration to avoid null pointer

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -355,7 +355,10 @@ public class ExerciseResource {
             for (Participation participation : participations) {
 
                 participation.setResults(exercise.findResultsFilteredForStudents(participation));
-                participation.getResults().forEach(r -> r.setAssessor(null));
+                // By filtering the results available yet, they can become null for the exercise.
+                if (participation.getResults() != null) {
+                    participation.getResults().forEach(r -> r.setAssessor(null));
+                }
                 exercise.addParticipation(participation);
             }
 


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

Regression from: https://github.com/ls1intum/Artemis/pull/656
Code line: https://github.com/ls1intum/Artemis/commit/d99d8e204083d81a47114af5eadcda37b5deb4d8#diff-16f1696b29d0f577752bb2107fb9b1e4R358

While the quiz is running, the results will become null here, causing a null pointer.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Create a quiz
3. Participate
4. Go to exercise detail page (route: "/overview/1/exercises/4", api call: "/api/exercises/4/results")
5. Page should be loaded without issues, api request should be 200 OK

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
