### PR TITLE
Hotfix/Remove transactional annotation from resource that causes null pointer on user groups

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -177,7 +177,6 @@ public class TextSubmissionResource {
      */
     @GetMapping(value = "/exercises/{exerciseId}/text-submissions")
     @PreAuthorize("hasAnyRole('TA', 'INSTRUCTOR', 'ADMIN')")
-    @Transactional(readOnly = true)
     public ResponseEntity<List<TextSubmission>> getAllTextSubmissions(@PathVariable Long exerciseId, @RequestParam(defaultValue = "false") boolean submittedOnly,
             @RequestParam(defaultValue = "false") boolean assessedByTutor) {
         log.debug("REST request to get all TextSubmissions");


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [ ] I documented my source code using the JavaDoc / JSDoc style.
- [ ] I added integration test cases for the server (Spring) related to the features
- [ ] I added integration test cases for the client (Jest) related to the features
- [ ] I added screenshots/screencast of my UI changes
- [ ] I translated all the newly inserted strings

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

Regression from https://github.com/ls1intum/Artemis/pull/656.
Codeline: https://github.com/ls1intum/Artemis/pull/656/files#diff-9e25b16bdd8057d80cbc0c1277d7026eR200

The issue is the Transactional annotation of the Resource I think.
In the `UserService.getUserWithGroupsAndAuthorities` a null pointer happened because the groups could not be eagerly loaded:
```
    @Transactional(readOnly = true)
    public User getUserWithGroupsAndAuthorities() {
        User user = userRepository.findOneByLogin(SecurityUtils.getCurrentUserLogin().get()).get();
        user.getGroups().size(); // eagerly load the association
        user.getAuthorities().size(); // eagerly load the association
        return user;
    }
```

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Open the assessment dashboard for a text exercise (/text/5/assessment)
3. Call to endpoint should not fail: /api/exercises/5/text-submissions?submittedOnly=true

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
