### PR TITLE
Prevent compass exceptions when a package is source or target of an association

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/compass/CompassCalculationEngine.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/CompassCalculationEngine.java
@@ -265,8 +265,8 @@ public class CompassCalculationEngine implements CalculationEngine {
     @Override
     public List<Feedback> convertToFeedback(Grade grade, long modelId, Result result) {
         UMLClassDiagram model = this.modelIndex.getModelMap().get(modelId);
-        if (model == null) {
-            return null;
+        if (model == null || grade == null || grade.getJsonIdPointsMapping() == null) {
+            return new ArrayList<>();
         }
 
         List<Feedback> feedbackList = new ArrayList<>();

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/CompassService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/CompassService.java
@@ -433,6 +433,10 @@ public class CompassService {
      * @return the rounded compass grade
      */
     private Grade roundGrades(Grade grade) {
+        if (grade == null) {
+            return null;
+        }
+
         Map<String, Double> jsonIdPointsMapping = grade.getJsonIdPointsMapping();
         BigDecimal pointsSum = new BigDecimal(0);
         for (Map.Entry<String, Double> entry : jsonIdPointsMapping.entrySet()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/controller/AutomaticAssessmentController.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/controller/AutomaticAssessmentController.java
@@ -37,7 +37,8 @@ public class AutomaticAssessmentController {
             UMLElement element = model.getElementByJSONID(jsonElementID);
 
             if (element == null) {
-                throw new IOException("Score for element was not fount");
+                log.warn("Element with id " + jsonElementID + " could not be found in model.");
+                continue;
             }
 
             Context context = element.getContext();

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/controller/JSONParser.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/controller/JSONParser.java
@@ -169,6 +169,11 @@ public class JSONParser {
                 umlAssociationList.add(newRelation);
             }
             else {
+                if (source == null && umlPackageMap.containsKey(sourceJSONID) || target == null && umlPackageMap.containsKey(targetJSONID)) {
+                    // workaround: prevent exception when a package is source or target of an association
+                    continue;
+                }
+
                 throw new IOException("Relationship source or target not part of model!");
             }
         }


### PR DESCRIPTION
There were some errors when a package in a UML class diagram is source or target of an association as Compass could not handle this. I added a fix and improved the error handling a bit. In such a situation, the corresponding association is simply ignored by Compass and the automatic assessment process. The rest of the model is still automatically assessed as usual.