### PR TITLE
Bugfix/Safe html in modeling exercise example submission

### DIFF
--- a/src/main/webapp/app/example-modeling-solution/example-modeling-solution.component.html
+++ b/src/main/webapp/app/example-modeling-solution/example-modeling-solution.component.html
@@ -18,14 +18,10 @@
     </div>
 
     <div class="col-12">
-        <p
-            *ngIf="formattedProblemStatement"
-            class="my-3"
-            jhiTranslate="artemisApp.modelingExercise.problemStatement"
-            [translateValues]="{ problemStatement: formattedProblemStatement }"
-        >
-            <strong>Problem Statement:</strong> {{ formattedProblemStatement }}<br />
-        </p>
+        <div *ngIf="formattedProblemStatement" class="my-3">
+            <strong jhiTranslate="artemisApp.modelingExercise.problemStatement">Problem Statement:</strong>
+            <span [innerHTML]="formattedProblemStatement"></span><br />
+        </div>
     </div>
 
     <div class="col-12 editor-container">

--- a/src/main/webapp/i18n/de/modelingExercise.json
+++ b/src/main/webapp/i18n/de/modelingExercise.json
@@ -16,7 +16,7 @@
                 "title": "Modellierungsaufgabe"
             },
             "diagramType": "Diagrammtyp",
-            "problemStatement": "<strong>Aufgabenstellung:</strong> {{ problemStatement }}",
+            "problemStatement": "Aufgabenstellung:",
             "exampleSolution": "Beispiel Lösung",
             "exampleSolutionExplanation": "Erklärung Beispiel Lösung",
             "createExampleSolution": "Beispiel Lösung erstellen",

--- a/src/main/webapp/i18n/en/modelingExercise.json
+++ b/src/main/webapp/i18n/en/modelingExercise.json
@@ -16,7 +16,7 @@
                 "title": "Modeling Exercise"
             },
             "diagramType": "Diagram Type",
-            "problemStatement": "<strong>Problem Statement:</strong> {{ problemStatement }}",
+            "problemStatement": "Problem Statement:",
             "exampleSolution": "Example Solution",
             "exampleSolutionExplanation": "Example Solution Explanation",
             "createExampleSolution": "Create Example Solution",


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] I added screenshots/screencast of my UI changes
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

Regression from: https://github.com/ls1intum/Artemis/pull/622

In the modeling exercise example solution page, the problem statement was not inserted using 
the `innerHTML` directive. This lead to the error:

```
Problem Statement: SafeValue must use [property]=binding:
test

(see http://g.co/ng/security#xss)
```

:information_source: I didn't find this issue anywhere else we use markdown.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Go to the example solution UI for a modeling exercise: #/modeling-exercise/455/example-solution
3. Check that the problem statement does not have the mentioned issue.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/28230611/61902346-22da6e00-af22-11e9-9168-834251fa34d0.png)

