### PR TITLE
Bugfix/Account service: Check if userIdentity is null to avoid null pointer

### DIFF
--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -138,15 +138,15 @@ export class AccountService {
         return this.authenticated;
     }
 
-    isIdentityResolved(): boolean {
-        return this.userIdentity !== undefined;
-    }
-
     getAuthenticationState(): Observable<User> {
         return this.authenticationState.asObservable();
     }
 
+    /**
+     * Returns the image url of the user or null.
+     * Returns null if the user not not authenticated or the user does not have an image.
+     */
     getImageUrl(): string | null {
-        return this.isIdentityResolved() ? this.userIdentity!.imageUrl : null;
+        return this.isAuthenticated() && this.userIdentity ? this.userIdentity.imageUrl : null;
     }
 }

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -144,7 +144,8 @@ export class AccountService {
 
     /**
      * Returns the image url of the user or null.
-     * Returns null if the user not not authenticated or the user does not have an image.
+     *
+     * Returns null if the user is not authenticated or the user does not have an image.
      */
     getImageUrl(): string | null {
         return this.isAuthenticated() && this.userIdentity ? this.userIdentity.imageUrl : null;

--- a/src/main/webapp/app/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.ts
@@ -90,7 +90,7 @@ export class NavbarComponent implements OnInit {
         this.isNavbarCollapsed = !this.isNavbarCollapsed;
     }
 
-    getImageUrl() {
-        return this.isAuthenticated() ? this.accountService.getImageUrl() : null;
+    getImageUrl(): string | null {
+        return this.accountService.getImageUrl();
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

userIdentity can be null, so userIdentity.imageUrl causes a null pointer.
This issue appeared 1.5k times in Sentry: https://sentry.io/organizations/ls1intum/issues/?project=1440029&query=Cannot+read+property+%27imageUrl%27+of+null&statsPeriod=14d

It is however not reproducible for me. It can only happen if the user is logged out while the getImageUrl method is called. Might only happen in a lecture when there is more load on the server.
The proposed fix should be fine.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. ???

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
