### PR TITLE
Bugfix/Disable login button after first click

### DIFF
--- a/src/main/webapp/app/home/home.component.html
+++ b/src/main/webapp/app/home/home.component.html
@@ -82,11 +82,13 @@
                         </div>
                         <button
                             type="submit"
-                            [disabled]="!acceptTerms || (!password || password.length < 4) || (!username || username.length < 4)"
+                            [disabled]="isSubmittingLogin || !acceptTerms || (!password || password.length < 4) || (!username || username.length < 4)"
                             class="btn btn-primary"
-                            jhiTranslate="login.form.button"
                         >
-                            Sign in
+                            <span *ngIf="isSubmittingLogin" class="mr-1"><fa-icon icon="circle-notch" spin="true"></fa-icon></span>
+                            <span jhiTranslate="login.form.button">
+                                Sign in
+                            </span>
                         </button>
                     </form>
                 </div>

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -23,6 +23,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
     captchaRequired = false;
     credentials: Credentials;
 
+    isSubmittingLogin = false;
+
     constructor(
         private router: Router,
         private accountService: AccountService,
@@ -53,6 +55,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
     }
 
     login() {
+        this.isSubmittingLogin = true;
         this.loginService
             .login({
                 username: this.username,
@@ -89,7 +92,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
                 }
                 this.authenticationError = true;
                 this.authenticationAttempts++;
-            });
+            })
+            .finally(() => (this.isSubmittingLogin = false));
     }
 
     currentUserCallback(account: User) {


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] I added screenshots/screencast of my UI changes
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

From Sentry: https://sentry.io/organizations/ls1intum/issues/1126963197/?project=1440029&query=is%3Aunresolved&statsPeriod=14d
The user can e.g. double click the login button, executing two requests.
I disable the login button now after the first click and show a circle icon to show the process.

This issue only happens on first login when the jhi_user is created.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

:information_source: The actual bug can only be tested if your user is not already in jhi_user.

1. Go to Artemis home screen ('/') when logged out
2. Enter your credentials and login
3. While the login REST call is being processed and the client is waiting for a response, the login button should be disabled.
Also: Double clicking the login button should not execute 2 rest calls!

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/28230611/61951867-8d3aef00-afb2-11e9-92a2-229336e49863.png)
