### PR TITLE
[Text] Also update score on invalid assessments.

### DIFF
--- a/src/main/webapp/app/text-assessment/text-assessment.component.ts
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.ts
@@ -350,7 +350,7 @@ export class TextAssessmentComponent implements OnInit, OnDestroy, AfterViewInit
      *   - Each reference feedback must have either a score or a feedback text or both.
      *   - The score must be a valid number.
      *
-     * Additionally, the total score is calculated if the current assessment is valid.
+     * Additionally, the total score is calculated for all numerical credits.
      */
     public validateAssessment() {
         this.assessmentsAreValid = true;

--- a/src/main/webapp/app/text-assessment/text-assessment.component.ts
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.ts
@@ -353,6 +353,9 @@ export class TextAssessmentComponent implements OnInit, OnDestroy, AfterViewInit
      * Additionally, the total score is calculated if the current assessment is valid.
      */
     public validateAssessment() {
+        this.assessmentsAreValid = true;
+        this.invalidError = null;
+
         if ((this.generalFeedback.detailText == null || this.generalFeedback.detailText.length === 0) && this.referencedFeedback && this.referencedFeedback.length === 0) {
             this.totalScore = 0;
             this.assessmentsAreValid = false;
@@ -362,26 +365,22 @@ export class TextAssessmentComponent implements OnInit, OnDestroy, AfterViewInit
         if (!this.referencedFeedback.every(f => f.reference != null && f.reference.length <= 2000)) {
             this.invalidError = 'artemisApp.textAssessment.error.feedbackReferenceTooLong';
             this.assessmentsAreValid = false;
-            return;
         }
 
-        const credits = this.referencedFeedback.map(assessment => assessment.credits);
+        let credits = this.referencedFeedback.map(assessment => assessment.credits);
 
-        if (!credits.every(credit => credit !== null && !isNaN(credit))) {
+        if (!this.invalidError && !credits.every(credit => credit !== null && !isNaN(credit))) {
             this.invalidError = 'artemisApp.textAssessment.error.invalidScoreMustBeNumber';
             this.assessmentsAreValid = false;
-            return;
+            credits = credits.filter(credit => credit !== null && !isNaN(credit));
         }
 
-        if (!this.referencedFeedback.every(f => f.credits !== 0 || (f.detailText != null && f.detailText.length > 0))) {
+        if (!this.invalidError && !this.referencedFeedback.every(f => f.credits !== 0 || (f.detailText != null && f.detailText.length > 0))) {
             this.invalidError = 'artemisApp.textAssessment.error.invalidNeedScoreOrFeedback';
             this.assessmentsAreValid = false;
-            return;
         }
 
-        this.totalScore = credits.reduce((a, b) => a! + b!, 0)!;
-        this.assessmentsAreValid = true;
-        this.invalidError = null;
+        this.totalScore = credits.reduce((a, b) => a + b, 0);
     }
 
     private checkPermissions() {


### PR DESCRIPTION
### Checklist
- [ ] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [X] I documented my source code using the JavaDoc / JSDoc style.
- [X] ~I added integration test cases for the server (Spring) related to the features~
- [ ] I added integration test cases for the client (Jest) related to the features
- [X] ~I added screenshots/screencast of my UI changes~
- [X] ~I translated all the newly inserted strings~

### Description
For Text Assessments, die score on the top is not updated if assessments are invalid.
With this change, we calculate the score based on all feedback items with a numerical credit value, even if the assessment is not valid. The assessments are still invalid and the submission can **not** be submitted.

### Steps for Testing
1. Log in to ArTEMiS and navigate to a Text Assessment
1. Add an assessment with an (invalid) alphabetical credit value and notice both error and updated score on top.
1. Add an assessment with an (invalid) long reference and notice both error and updated score on top.
1. Add multiple assessments, some leave empty (no feedback and 0 credits) and notice both error and updated score on top.