### PR TITLE
Bugfix/text editor cannot unproxy result and submissions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Participation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Participation.java
@@ -6,14 +6,12 @@ import java.util.*;
 
 import javax.persistence.*;
 
-import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import com.fasterxml.jackson.annotation.*;
 
 import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
-import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -223,43 +221,6 @@ public abstract class Participation implements Serializable {
             }
             return s1.getSubmissionDate().compareTo(s2.getSubmissionDate());
         });
-    }
-
-    private <T extends Submission> Optional<T> findLatestSubmissionOfType(Class<T> submissionType) {
-        Optional<Submission> optionalSubmission = findLatestSubmission();
-        if (!optionalSubmission.isPresent()) {
-            return Optional.empty();
-        }
-
-        Submission submission = optionalSubmission.get();
-        // This unproxy is necessary to retrieve the right type of submission (e.g. TextSubmission) to be able to
-        // compare it with the `submissionType` argument
-        submission = (Submission) Hibernate.unproxy(submission);
-
-        if (submissionType.isInstance(submission)) {
-            return Optional.of(submissionType.cast(submission));
-        }
-        else {
-            return Optional.empty();
-        }
-    }
-
-    /**
-     * Same functionality as findLatestSubmission() with the difference that this function only returns the found submission, if it is a modeling submission.
-     *
-     * @return the latest modeling submission or null
-     */
-    public Optional<ModelingSubmission> findLatestModelingSubmission() {
-        return findLatestSubmissionOfType(ModelingSubmission.class);
-    }
-
-    /**
-     * Same functionality as findLatestSubmission() with the difference that this function only returns the found submission, if it is a text submission.
-     *
-     * @return the latest text submission or null
-     */
-    public Optional<TextSubmission> findLatestTextSubmission() {
-        return findLatestSubmissionOfType(TextSubmission.class);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/StudentParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/StudentParticipation.java
@@ -1,8 +1,14 @@
 package de.tum.in.www1.artemis.domain;
 
+import java.util.Optional;
+
 import javax.persistence.*;
 
+import org.hibernate.Hibernate;
+
 import com.fasterxml.jackson.annotation.JsonView;
+
+import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 @Entity
@@ -79,6 +85,43 @@ public class StudentParticipation extends Participation {
      */
     public void filterSensitiveInformation() {
         setStudent(null);
+    }
+
+    private <T extends Submission> Optional<T> findLatestSubmissionOfType(Class<T> submissionType) {
+        Optional<Submission> optionalSubmission = findLatestSubmission();
+        if (!optionalSubmission.isPresent()) {
+            return Optional.empty();
+        }
+
+        Submission submission = optionalSubmission.get();
+        // This unproxy is necessary to retrieve the right type of submission (e.g. TextSubmission) to be able to
+        // compare it with the `submissionType` argument
+        submission = (Submission) Hibernate.unproxy(submission);
+
+        if (submissionType.isInstance(submission)) {
+            return Optional.of(submissionType.cast(submission));
+        }
+        else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Same functionality as findLatestSubmission() with the difference that this function only returns the found submission, if it is a modeling submission.
+     *
+     * @return the latest modeling submission or null
+     */
+    public Optional<ModelingSubmission> findLatestModelingSubmission() {
+        return findLatestSubmissionOfType(ModelingSubmission.class);
+    }
+
+    /**
+     * Same functionality as findLatestSubmission() with the difference that this function only returns the found submission, if it is a text submission.
+     *
+     * @return the latest text submission or null
+     */
+    public Optional<TextSubmission> findLatestTextSubmission() {
+        return findLatestSubmissionOfType(TextSubmission.class);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
@@ -75,6 +75,16 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
     @EntityGraph(attributePaths = { "submissions", "submissions.result", "results" })
     Optional<StudentParticipation> findWithEagerSubmissionsAndResultsById(Long participationId);
 
+    /**
+     * Find the participation with the given id. Additionally, load all the submissions and results of the participation from the database.
+     * Further, load the exercise and its course. Returns an empty Optional if the participation could not be found.
+     *
+     * @param participationId the id of the participation
+     * @return the participation with eager submissions, results, exercise and course or an empty Optional
+     */
+    @EntityGraph(attributePaths = { "submissions", "submissions.result", "results", "exercise", "exercise.course" })
+    Optional<StudentParticipation> findWithEagerSubmissionsAndResultsAndExerciseAndCourseById(Long participationId);
+
     @Query("select distinct participation from StudentParticipation participation left join fetch participation.submissions left join fetch participation.results r left join fetch r.assessor where participation.id = :#{#participationId}")
     Optional<StudentParticipation> findByIdWithEagerSubmissionsAndEagerResultsAndEagerAssessors(@Param("participationId") Long participationId);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -63,7 +63,7 @@ public class ModelingSubmissionService extends SubmissionService {
     public List<ModelingSubmission> getModelingSubmissions(Long exerciseId, boolean submittedOnly) {
         List<StudentParticipation> participations = studentParticipationRepository.findAllByExerciseIdWithEagerSubmissionsAndEagerResultsAndEagerAssessor(exerciseId);
         List<ModelingSubmission> submissions = new ArrayList<>();
-        for (Participation participation : participations) {
+        for (StudentParticipation participation : participations) {
             Optional<ModelingSubmission> submission = participation.findLatestModelingSubmission();
             if (submission.isPresent()) {
                 if (submittedOnly && !submission.get().isSubmitted()) {
@@ -146,7 +146,7 @@ public class ModelingSubmissionService extends SubmissionService {
 
         // otherwise return a random submission that is not manually assessed or an empty optional if there is none
         List<ModelingSubmission> submissionsWithoutResult = participationService.findByExerciseIdWithEagerSubmittedSubmissionsWithoutManualResults(modelingExercise.getId())
-                .stream().map(Participation::findLatestModelingSubmission).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+                .stream().map(StudentParticipation::findLatestModelingSubmission).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
 
         if (submissionsWithoutResult.isEmpty()) {
             return Optional.empty();
@@ -230,7 +230,7 @@ public class ModelingSubmissionService extends SubmissionService {
             messagingTemplate.convertAndSendToUser(participation.getStudent().getLogin(), "/topic/exercise/" + participation.getExercise().getId() + "/participation",
                     participation);
         }
-        Participation savedParticipation = studentParticipationRepository.save(participation);
+        StudentParticipation savedParticipation = studentParticipationRepository.save(participation);
         if (modelingSubmission.getId() == null) {
             Optional<ModelingSubmission> optionalModelingSubmission = savedParticipation.findLatestModelingSubmission();
             if (optionalModelingSubmission.isPresent()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -454,7 +454,7 @@ public class ParticipationService {
     }
 
     /**
-     * Get one student participation by id with fetched Result and Submissions.
+     * Get one student participation by id with fetched Result, Submissions, Exercise and Course.
      *
      * @param participationId the id of the entity
      * @return the entity

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -454,6 +454,22 @@ public class ParticipationService {
     }
 
     /**
+     * Get one student participation by id with fetched Result and Submissions.
+     *
+     * @param participationId the id of the entity
+     * @return the entity
+     **/
+    @Transactional(readOnly = true)
+    public StudentParticipation findOneStudentParticipationWithEagerSubmissionsResultsExerciseAndCourse(Long participationId) {
+        log.debug("Request to get Participation : {}", participationId);
+        Optional<StudentParticipation> participation = studentParticipationRepository.findWithEagerSubmissionsAndResultsAndExerciseAndCourseById(participationId);
+        if (!participation.isPresent()) {
+            throw new EntityNotFoundException("StudentParticipation with " + participationId + " was not found!");
+        }
+        return participation.get();
+    }
+
+    /**
      * Get one programming exercise participation by id.
      *
      * @param participationId the id of the entity

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -102,7 +102,7 @@ public class TextSubmissionService extends SubmissionService {
             messagingTemplate.convertAndSendToUser(participation.getStudent().getLogin(), "/topic/exercise/" + participation.getExercise().getId() + "/participation",
                     participation);
         }
-        Participation savedParticipation = studentParticipationRepository.save(participation);
+        StudentParticipation savedParticipation = studentParticipationRepository.save(participation);
         if (textSubmission.getId() == null) {
             Optional<TextSubmission> optionalTextSubmission = savedParticipation.findLatestTextSubmission();
             if (optionalTextSubmission.isPresent()) {
@@ -145,7 +145,7 @@ public class TextSubmissionService extends SubmissionService {
     public Optional<TextSubmission> getTextSubmissionWithoutManualResult(TextExercise textExercise) {
         Random r = new Random();
         List<TextSubmission> submissionsWithoutResult = participationService.findByExerciseIdWithEagerSubmittedSubmissionsWithoutManualResults(textExercise.getId()).stream()
-                .map(Participation::findLatestTextSubmission).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+                .map(StudentParticipation::findLatestTextSubmission).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
 
         if (submissionsWithoutResult.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -260,7 +260,7 @@ public class ModelingSubmissionResource {
         else {
             // otherwise get a random (non-optimal) submission that is not assessed
             List<ModelingSubmission> submissionsWithoutResult = participationService.findByExerciseIdWithEagerSubmittedSubmissionsWithoutManualResults(modelingExercise.getId())
-                    .stream().map(Participation::findLatestModelingSubmission).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+                    .stream().map(StudentParticipation::findLatestModelingSubmission).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
 
             if (submissionsWithoutResult.isEmpty()) {
                 return ResponseEntity.ok(new Long[] {}); // empty

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -240,7 +240,7 @@ public class TextExerciseResource {
     @GetMapping("/text-editor/{participationId}")
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<StudentParticipation> getDataForTextEditor(@PathVariable Long participationId) {
-        StudentParticipation participation = participationService.findOneStudentParticipation(participationId);
+        StudentParticipation participation = participationService.findOneStudentParticipationWithEagerSubmissionsResultsExerciseAndCourse(participationId);
         if (participation == null) {
             return ResponseEntity.badRequest()
                     .headers(HeaderUtil.createFailureAlert(applicationName, true, ENTITY_NAME, "participationNotFound", "No participation was found for the given ID.")).body(null);

--- a/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
@@ -1,9 +1,13 @@
 package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -89,6 +93,20 @@ public class TextSubmissionIntegrationTest {
         Exercise returnedExercise = request.get("/api/exercises/" + textExercise.getId() + "/results", HttpStatus.OK, Exercise.class);
 
         assertThat(returnedExercise.getParticipations().iterator().next().getResults().iterator().next().getAssessor()).as("assessor is null").isNull();
+    }
+
+    @Test
+    @WithMockUser(value = "student1", roles = "USER")
+    public void getDataForTextEditorWithResult() throws Exception {
+        TextSubmission textSubmission = database.addTextSubmissionWithResultAndAssessor(textExercise, this.textSubmission, "student1", "tutor1");
+        Long participationId = textSubmission.getParticipation().getId();
+
+        StudentParticipation participation = request.get("/api/text-editor/" + participationId, HttpStatus.OK, StudentParticipation.class);
+
+        Assert.assertThat(participation.getResults(), is(notNullValue()));
+        Assert.assertThat(participation.getResults(), hasSize(1));
+
+        Assert.assertThat(participation.getSubmissions(), is(notNullValue()));
     }
 
 }

--- a/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
@@ -4,10 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -103,10 +103,10 @@ public class TextSubmissionIntegrationTest {
 
         StudentParticipation participation = request.get("/api/text-editor/" + participationId, HttpStatus.OK, StudentParticipation.class);
 
-        Assert.assertThat(participation.getResults(), is(notNullValue()));
-        Assert.assertThat(participation.getResults(), hasSize(1));
+        assertThat(participation.getResults(), is(notNullValue()));
+        assertThat(participation.getResults(), hasSize(1));
 
-        Assert.assertThat(participation.getSubmissions(), is(notNullValue()));
+        assertThat(participation.getSubmissions(), is(notNullValue()));
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [X] I documented my source code using the JavaDoc / JSDoc style.
- [X] I added integration test cases for the server (Spring) related to the features
- [X] ~I added integration test cases for the client (Jest) related to the features~
- [X] ~I added screenshots/screencast of my UI changes~
- [X] ~I translated all the newly inserted strings~

### Motivation and Context
Follow up to #623

### Description
Opening the result of a Text Exercise lead to an error, as Hibernate could not unproxy the Result (and the Submissions also, but it failed before).

In this PR, we update the Query to request all necessary information in the first request and thereby circumvent proxies.

Once we are at it, this also refactored some methods from `Participation` to `StudentParticipation`.

The test case, for some reason, does not catch the fault. I added it nevertheless. Maybe someone more experienced with our integration test setup can point out my fault. @ls1intum/artemis 

### Steps for Testing

1. Log in to ArTEMiS
2. Find a Text Exercise with an assessment in your account (if you don't have one, create it)
3. Open the result.
4. Find **no** error.
