### PR TITLE
Bugfix/programming exercise/instruction loading when there is no participation

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
@@ -53,7 +53,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
     public renderedMarkdown: SafeHtml;
     private injectableContentForMarkdownCallbacks: Array<() => void> = [];
 
-    private markdownExtensions: ShowdownExtension[];
+    markdownExtensions: ShowdownExtension[];
     private injectableContentFoundSubscription: Subscription;
     private tasksSubscription: Subscription;
     private generateHtmlSubscription: Subscription;

--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
@@ -76,6 +76,10 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
      * @param changes
      */
     public ngOnChanges(changes: SimpleChanges) {
+        // Set up the markdown extensions if they are not set up yet so that tasks, UMLs, etc. can be parsed.
+        if (!this.markdownExtensions) {
+            this.setupMarkdownSubscriptions();
+        }
         const participationHasChanged = hasParticipationChanged(changes);
         // It is possible that the exercise does not have an id in case it is being created now.
         if (participationHasChanged) {
@@ -89,7 +93,6 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
                 });
             }
             this.setupResultWebsocket();
-            this.setupMarkdownSubscriptions();
         }
         // If the exercise is not loaded, the instructions can't be loaded and so there is no point in loading the results, etc, yet.
         if (!this.isLoading && this.exercise && this.participation && (this.isInitial || participationHasChanged)) {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.spec.ts
@@ -240,6 +240,7 @@ describe('ProgrammingExerciseInstructionComponent', () => {
                 firstChange: false,
             } as SimpleChange,
         } as SimpleChanges);
+        expect(comp.markdownExtensions).to.have.lengthOf(2);
         expect(updateMarkdownStub).to.have.been.called;
         expect(loadInitialResult).not.to.have.been.called;
     });
@@ -258,6 +259,7 @@ describe('ProgrammingExerciseInstructionComponent', () => {
         fixture.detectChanges();
         comp.ngOnChanges({} as SimpleChanges);
 
+        expect(comp.markdownExtensions).to.have.lengthOf(2);
         expect(getLatestResultWithFeedbacks).to.have.been.calledOnceWith(participation.id);
         expect(updateMarkdownStub).to.have.been.calledOnce;
         expect(comp.isInitial).to.be.false;


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] I added integration test cases for the client (Jest) related to the features
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

Markdown for programming exercises did not render on details page if there is no participation yet.
I changed the control flow and updated the tests.

![image](https://user-images.githubusercontent.com/28230611/62209954-4296e980-b39b-11e9-8d82-16474a651da8.png)


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Open the exercise detail page for a programming exercise where you have no participation
3. Instructions should still be rendered.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
