### PR TITLE
Bugfix/Fix issue where user is not retrieved properly in the navbar on page reload

### DIFF
--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -29,7 +29,7 @@ export interface IAccountService {
 export class AccountService implements IAccountService {
     private userIdentityValue: User | null;
     private authenticated = false;
-    private authenticationState: BehaviorSubject<User | null>;
+    private authenticationState = new BehaviorSubject<User | null>(null);
 
     constructor(
         private languageService: JhiLanguageService,
@@ -45,11 +45,7 @@ export class AccountService implements IAccountService {
     set userIdentity(user: User | null) {
         this.userIdentityValue = user;
         // Alert subscribers about user updates, that is when the user logs in or logs out (null).
-        if (!this.authenticationState) {
-            this.authenticationState = new BehaviorSubject<User | null>(this.userIdentity);
-        } else {
-            this.authenticationState.next(this.userIdentity);
-        }
+        this.authenticationState.next(this.userIdentity);
     }
 
     fetch(): Observable<HttpResponse<User>> {

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -44,7 +44,7 @@ export class AccountService implements IAccountService {
 
     set userIdentity(user: User | null) {
         this.userIdentityValue = user;
-        // Alert subscribers about new users.
+        // Alert subscribers about user updates, that is when the user logs in or logs out (null).
         if (!this.authenticationState) {
             this.authenticationState = new BehaviorSubject<User | null>(this.userIdentity);
         } else {

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -28,7 +28,7 @@ export interface IAccountService {
 
 @Injectable({ providedIn: 'root' })
 export class AccountService implements IAccountService {
-    private userIdentityValue: User | null;
+    private userIdentityValue: User | null = null;
     private authenticated = false;
     private authenticationState = new BehaviorSubject<User | null>(null);
 

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -6,7 +6,7 @@ import { SERVER_API_URL } from 'app/app.constants';
 import { JhiLanguageService } from 'ng-jhipster';
 import { SessionStorageService } from 'ngx-webstorage';
 import { of, Observable, BehaviorSubject } from 'rxjs';
-import { map, catchError } from 'rxjs/operators';
+import { distinctUntilChanged, map, catchError } from 'rxjs/operators';
 import { JhiWebsocketService } from '../websocket/websocket.service';
 import { User } from '../../core';
 import { Course } from '../../entities/course';
@@ -161,7 +161,10 @@ export class AccountService implements IAccountService {
     }
 
     getAuthenticationState(): Observable<User | null> {
-        return this.authenticationState.asObservable();
+        return this.authenticationState.asObservable().pipe(
+            // We don't want to emit here e.g. [null, null] as it is still the same information [logged out, logged out].
+            distinctUntilChanged(),
+        );
     }
 
     /**

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -140,7 +140,6 @@ export class AccountService implements IAccountService {
                     this.userIdentity = null;
                     this.authenticated = false;
                 }
-                this.authenticationState.next(this.userIdentity);
                 return this.userIdentity;
             })
             .catch(err => {
@@ -149,7 +148,6 @@ export class AccountService implements IAccountService {
                 }
                 this.userIdentity = null;
                 this.authenticated = false;
-                this.authenticationState.next(this.userIdentity);
                 return null;
             });
     }

--- a/src/main/webapp/app/layouts/connection-notification/connection-notification.component.ts
+++ b/src/main/webapp/app/layouts/connection-notification/connection-notification.component.ts
@@ -14,7 +14,7 @@ export class ConnectionNotificationComponent implements OnInit, OnDestroy {
     constructor(private accountService: AccountService, private jhiWebsocketService: JhiWebsocketService) {}
 
     ngOnInit() {
-        this.accountService.getAuthenticationState().subscribe((user: User) => {
+        this.accountService.getAuthenticationState().subscribe((user: User | null) => {
             if (user) {
                 // listen to connect / disconnect events
                 this.jhiWebsocketService.enableReconnect();

--- a/src/main/webapp/app/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/layouts/navbar/navbar.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { distinctUntilChanged, tap } from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { JhiLanguageService } from 'ng-jhipster';
 import { SessionStorageService } from 'ngx-webstorage';
@@ -59,10 +59,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
         // The current user is needed to hide menu items for not logged in users.
         this.authStateSubscription = this.accountService
             .getAuthenticationState()
-            .pipe(
-                distinctUntilChanged(),
-                tap((user: User) => (this.currAccount = user)),
-            )
+            .pipe(tap((user: User) => (this.currAccount = user)))
             .subscribe();
     }
 

--- a/src/main/webapp/app/layouts/notification-container/notification-container.component.ts
+++ b/src/main/webapp/app/layouts/notification-container/notification-container.component.ts
@@ -22,7 +22,7 @@ export class NotificationContainerComponent implements OnInit {
         if (this.accountService.isAuthenticated()) {
             this.loadNotifications();
         }
-        this.accountService.getAuthenticationState().subscribe((user: User) => {
+        this.accountService.getAuthenticationState().subscribe((user: User | null) => {
             if (user) {
                 this.loadNotifications();
             }

--- a/src/main/webapp/app/layouts/system-notification/system-notification.component.ts
+++ b/src/main/webapp/app/layouts/system-notification/system-notification.component.ts
@@ -24,7 +24,7 @@ export class SystemNotificationComponent implements OnInit {
     ) {}
 
     ngOnInit() {
-        this.accountService.getAuthenticationState().subscribe((user: User) => {
+        this.accountService.getAuthenticationState().subscribe((user: User | null) => {
             if (user) {
                 this.loadActiveNotification();
                 // maybe use connectedPromise as a set function

--- a/src/main/webapp/app/shared/auth/has-any-authority.directive.ts
+++ b/src/main/webapp/app/shared/auth/has-any-authority.directive.ts
@@ -25,7 +25,7 @@ export class HasAnyAuthorityDirective {
         this.authorities = typeof value === 'string' ? [<string>value] : <string[]>value;
         this.updateView();
         // Get notified each time authentication state changes.
-        this.accountService.getAuthenticationState().subscribe(identity => this.updateView());
+        this.accountService.getAuthenticationState().subscribe(() => this.updateView());
     }
 
     private updateView(): void {

--- a/src/test/javascript/spec/mocks/mock-websocket.service.ts
+++ b/src/test/javascript/spec/mocks/mock-websocket.service.ts
@@ -4,7 +4,7 @@ import { IWebsocketService } from '../../../../main/webapp/app/core';
 export class MockWebsocketService implements IWebsocketService {
     bind(event: string, callback: () => void): void {}
 
-    connect(): void {}
+    connect = () => {};
 
     disableReconnect(): void {}
 

--- a/src/test/javascript/spec/service/account-service.spec.ts
+++ b/src/test/javascript/spec/service/account-service.spec.ts
@@ -1,0 +1,78 @@
+import { async } from '@angular/core/testing';
+import * as chai from 'chai';
+import { SinonStub, stub } from 'sinon';
+import { Observable, of } from 'rxjs';
+import * as sinonChai from 'sinon-chai';
+import { MockWebsocketService } from '../mocks/mock-websocket.service';
+import { AccountService, User } from '../../../../main/webapp/app/core';
+import { MockLanguageService } from '../helpers/mock-language.service';
+import { MockSyncStorage } from '../mocks';
+import { MockHttpService } from '../mocks/mock-http.service';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('AccountService', () => {
+    let accountService: AccountService;
+    let httpService: MockHttpService;
+    let getStub: SinonStub;
+    let getAuthenticated: Observable<User | null>;
+
+    const getUserUrl = 'undefinedapi/account';
+    const user = { id: 1, groups: ['USER'] } as User;
+    const user2 = { id: 2, groups: ['USER'] } as User;
+
+    beforeEach(async(() => {
+        httpService = new MockHttpService();
+        // @ts-ignore
+        accountService = new AccountService(new MockLanguageService(), new MockSyncStorage(), httpService, new MockWebsocketService());
+        getStub = stub(httpService, 'get');
+        getAuthenticated = accountService.getAuthenticationState();
+
+        expect(accountService.userIdentity).to.deep.equal(null);
+        expect(accountService.isAuthenticated()).to.be.false;
+    }));
+
+    afterEach(() => {
+        getStub.restore();
+    });
+
+    it('should fetch the user on identity if the userIdentity is not defined yet', async () => {
+        getStub.returns(of({ body: user }));
+
+        const userReceived = await accountService.identity(false);
+
+        expect(getStub).to.have.been.calledOnceWithExactly(getUserUrl, { observe: 'response' });
+        expect(userReceived).to.deep.equal(user);
+        expect(accountService.userIdentity).to.deep.equal(user);
+        expect(accountService.isAuthenticated()).to.be.true;
+    });
+
+    it('should fetch the user on identity if the userIdentity is defined yet (force=true)', async () => {
+        accountService.userIdentity = user;
+        expect(accountService.userIdentity).to.deep.equal(user);
+        expect(accountService.isAuthenticated()).to.be.true;
+        getStub.returns(of({ body: user2 }));
+
+        const userReceived = await accountService.identity(true);
+
+        expect(getStub).to.have.been.calledOnceWithExactly(getUserUrl, { observe: 'response' });
+        expect(userReceived).to.deep.equal(user2);
+        expect(accountService.userIdentity).to.deep.equal(user2);
+        expect(accountService.isAuthenticated()).to.be.true;
+    });
+
+    it('should NOT fetch the user on identity if the userIdentity is defined (force=false)', async () => {
+        accountService.userIdentity = user;
+        expect(accountService.userIdentity).to.deep.equal(user);
+        expect(accountService.isAuthenticated()).to.be.true;
+        getStub.returns(of({ body: user2 }));
+
+        const userReceived = await accountService.identity(false);
+
+        expect(getStub).not.to.have.been.called;
+        expect(userReceived).to.deep.equal(user);
+        expect(accountService.userIdentity).to.deep.equal(user);
+        expect(accountService.isAuthenticated()).to.be.true;
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] I added integration test cases for the client (Jest) related to the features
- [x] I added screenshots/screencast of my UI changes
- [x] I translated all the newly inserted strings

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

Regression from https://github.com/ls1intum/Artemis/pull/694.

User does not see the overview page and the account info after reloading the page (see screenshot below). Pages are still accessible though if you know the URL OR by clicking on the Artemis logo in the header.

In detail:
The issue was that the authenticationState Subject in the `account.service.ts` was not a BehaviorSubject but a Subject. This way subscribers would not receive the most current user when subscribing but just nothing until the next authenticationState update (log in / log out).
I have also moved all the single emits in the service into a setter.
Also we now have a couple of tests for the account service.

In short:
- make authenticated subject in account service a behavior subject so the latest user value is emitted on subscribe
- correct typing for user subscription (can be null!)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Reload the page
3. User should still be visible in the top right in account menu, overview should also still be available

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/28230611/62232031-8d2d5b80-b3c5-11e9-9b93-834755d7f592.png)
