### PR TITLE
Bugfix/fix jhipster needle and add exerciseHint cache

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
@@ -155,8 +155,9 @@ public class CacheConfiguration {
             createIfNotExists(cm, ModelAssessmentConflict.class.getName() + ".resultsInConflict", jcacheConfiguration);
             createIfNotExists(cm, ConflictingResult.class.getName(), jcacheConfiguration);
             createIfNotExists(cm, ExampleSubmission.class.getName() + ".tutorParticipations", jcacheConfiguration);
-            createIfNotExists(cm, de.tum.in.www1.artemis.domain.ProgrammingExerciseTestCase.class.getName(), jcacheConfiguration);
-            // createIfNotExists(cm, );thipster-needle-ehcache-add-entry
+            createIfNotExists(cm, ProgrammingExerciseTestCase.class.getName(), jcacheConfiguration);
+            createIfNotExists(cm, ExerciseHint.class.getName(), jcacheConfiguration);
+            // jhipster-needle-ehcache-add-entry
             createIfNotExists(cm, "files", jcacheConfiguration);
         };
     }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

When I added the programming exercise test cases in https://github.com/ls1intum/Artemis/pull/495, I made a search & replace error on the jhipster cache needle. This way new jhipster entities would not automatically generate the cache anymore.
The only concerned entity is ExerciseHints (https://github.com/ls1intum/Artemis/pull/646), other entities are not concerned as none were created since then.

3 fixes:
- Restore jhipster needle
- Add cache for ExerciseHints 
- Shorten ProgrammingExerciseTestCase path

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
