### PR TITLE
Bugfix/Fix build output height & remove ng-deep

### DIFF
--- a/src/main/webapp/app/code-editor/layout/code-editor-grid.component.ts
+++ b/src/main/webapp/app/code-editor/layout/code-editor-grid.component.ts
@@ -1,5 +1,5 @@
 import * as $ from 'jquery';
-import { AfterViewInit, Component, ContentChild, ElementRef, Input } from '@angular/core';
+import { AfterViewInit, Component, ContentChild, ElementRef, Input, ViewEncapsulation } from '@angular/core';
 import { JhiAlertService } from 'ng-jhipster';
 
 import { WindowRef } from 'app/core/websocket/window.service';
@@ -12,6 +12,7 @@ import { CodeEditorGridService, ResizeType } from 'app/code-editor/service';
     templateUrl: './code-editor-grid.component.html',
     styleUrls: ['./code-editor-grid.scss'],
     providers: [JhiAlertService, WindowRef, CodeEditorGridService],
+    encapsulation: ViewEncapsulation.None,
 })
 export class CodeEditorGridComponent implements AfterViewInit {
     @ContentChild('editorSidebarRight', { static: false }) editorSidebarRight: ElementRef;

--- a/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
+++ b/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
@@ -41,7 +41,7 @@ Code-Editor Layout Styles
                 display: flex;
                 width: 310px;
 
-                ::ng-deep > *:first-child {
+                > *:first-child {
                     flex: 1 1 auto;
                     width: 90%;
                 }
@@ -61,7 +61,7 @@ Code-Editor Layout Styles
             flex-flow: row nowrap;
             width: 500px;
 
-            ::ng-deep > *:last-child {
+            > *:last-child {
                 flex: 1 1 auto;
                 width: 90%;
             }
@@ -78,12 +78,12 @@ Code-Editor Layout Styles
         .rg-bottom-bottom {
             display: none;
         }
-        ::ng-deep > * + .rg-bottom-bottom {
+        > * + .rg-bottom-bottom {
             display: inherit !important;
         }
 
-        ::ng-deep > * {
-            height: 100%;
+        > * {
+            height: inherit;
         }
     }
 }
@@ -94,7 +94,7 @@ Collapsable styling
 
 // File browser
 .editor-sidebar-left.collapsed--horizontal {
-    ::ng-deep > * {
+    > * {
         flex: none !important;
 
         .card-header {
@@ -117,7 +117,7 @@ Collapsable styling
 }
 
 .editor-sidebar-left:not(.collapsed--horizontal) {
-    ::ng-deep .code-editor-status {
+    .code-editor-status {
         display: grid;
         grid-template-columns: repeat(2, minmax(max-content, 1fr));
         grid-column-gap: 10px;
@@ -130,7 +130,7 @@ Collapsable styling
 }
 
 .editor-sidebar-left.collapsed--horizontal {
-    ::ng-deep .code-editor-status {
+    .code-editor-status {
         > :not(:last-child) {
             padding-bottom: 5px;
         }
@@ -145,7 +145,7 @@ Collapsable styling
 }
 
 // Instructions
-.editor-sidebar-right.collapsed--horizontal ::ng-deep {
+.editor-sidebar-right.collapsed--horizontal {
     flex: none !important;
 
     .card-header {
@@ -177,7 +177,7 @@ Collapsable styling
 }
 
 .editor-sidebar-right:not(.collapsed--horizontal) {
-    ::ng-deep .editable-instruction-container__status {
+    .editable-instruction-container__status {
         display: grid;
         grid-template-columns: repeat(2, minmax(max-content, 1fr));
         grid-column-gap: 10px;
@@ -190,10 +190,10 @@ Collapsable styling
 }
 
 .editor-sidebar-right.collapsed--horizontal {
-    ::ng-deep .instructions__content {
+    .instructions__content {
         height: auto;
     }
-    ::ng-deep .editable-instruction-container__status {
+    .editable-instruction-container__status {
         display: flex;
         flex-flow: column;
 
@@ -221,7 +221,7 @@ Collapsable styling
 
 // build-output
 .editor-bottom.collapsed--vertical {
-    ::ng-deep .card-body {
+    .card-body {
         display: none;
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

The buildoutput was broken by a recent update (unclear to me how, maybe just dependencies or browser rendering).
I also removed the ng-deep usage from the scss file while I was at it.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Open code-editor
3. Check that build ouput stretch vertically the whole height of the bottom grid area.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/28230611/62467107-3fcd3780-b793-11e9-9282-f8251cb9d5a8.png)

