### PR TITLE
Bugfix/programming exercise/multiple fixes

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseParticipationResource.java
@@ -66,7 +66,7 @@ public class ProgrammingExerciseParticipationResource {
     /**
      * Get the latest result for a given programming exercise participation including it's result.
      *
-     * @return the ResponseEntity with status 200 (OK) and the latest result with feedbacks in its body.
+     * @return the ResponseEntity with status 200 (OK) and the latest result with feedbacks in its body, 404 if the participation can't be found or 403 if the user is not allowed to access the participation.
      */
     @GetMapping(value = "/programming-exercises-participation/{participationId}/latest-result-with-feedbacks")
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
@@ -112,7 +112,7 @@ public class ProgrammingExerciseParticipationResource {
     /**
      * Util method for retrieving the latest result with feedbacks of participation. Generates the appropriate response type (ok, forbidden, notFound).
      *
-     * @param participation
+     * @param participation to retrieve the latest result for.
      * @return the appropriate ResponseEntity for the result request.
      */
     private ResponseEntity<Result> getLatestResultWithFeedbacks(ProgrammingExerciseParticipation participation) {
@@ -124,7 +124,7 @@ public class ProgrammingExerciseParticipationResource {
             result = resultService.findLatestResultWithFeedbacksForParticipation(participation.getId());
         }
         catch (EntityNotFoundException ex) {
-            return notFound();
+            return ResponseEntity.ok(null);
         }
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
@@ -285,13 +285,13 @@ public abstract class RepositoryResource {
         try {
             responseEntitySuccess = executor.exec();
         }
-        catch (IllegalArgumentException ex) {
+        catch (IllegalArgumentException | FileAlreadyExistsException ex) {
             return badRequest();
         }
         catch (IllegalAccessException ex) {
             return forbidden();
         }
-        catch (FileAlreadyExistsException | CheckoutConflictException | WrongRepositoryStateException ex) {
+        catch (CheckoutConflictException | WrongRepositoryStateException ex) {
             return new ResponseEntity<>(HttpStatus.CONFLICT);
         }
         catch (FileNotFoundException ex) {

--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
@@ -3,7 +3,7 @@ import { HttpResponse } from '@angular/common/http';
 import { JhiAlertService } from 'ng-jhipster';
 import Interactable from '@interactjs/core/Interactable';
 import interact from 'interactjs';
-import { Observable, of, Subject, Subscription } from 'rxjs';
+import { Observable, of, Subject, Subscription, throwError } from 'rxjs';
 import { catchError, filter as rxFilter, map as rxMap, switchMap, tap } from 'rxjs/operators';
 import { Participation } from 'app/entities/participation';
 import { compose, filter, map, sortBy } from 'lodash/fp';
@@ -197,7 +197,7 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     loadTestCasesFromTemplateParticipationResult = (templateParticipationId: number): Observable<string[]> => {
         // Fallback for exercises that don't have test cases yet.
         return this.programmingExerciseParticipationService.getLatestResultWithFeedback(templateParticipationId).pipe(
-            rxFilter((result: Result | null) => !!result && !!result.feedbacks),
+            rxMap((result: Result | null) => (!result || !result.feedbacks ? throwError('no result available') : result)),
             rxMap(({ feedbacks }: Result) =>
                 compose(
                     map(({ text }) => text),

--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
@@ -197,7 +197,7 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     loadTestCasesFromTemplateParticipationResult = (templateParticipationId: number): Observable<string[]> => {
         // Fallback for exercises that don't have test cases yet.
         return this.programmingExerciseParticipationService.getLatestResultWithFeedback(templateParticipationId).pipe(
-            rxFilter((result: Result) => !!result.feedbacks),
+            rxFilter((result: Result | null) => !!result && !!result.feedbacks),
             rxMap(({ feedbacks }: Result) =>
                 compose(
                     map(({ text }) => text),

--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-editable-instruction.component.ts
@@ -12,7 +12,7 @@ import { DomainCommand } from 'app/markdown-editor/domainCommands';
 import { TaskCommand } from 'app/markdown-editor/domainCommands/programming-exercise/task.command';
 import { TestCaseCommand } from 'app/markdown-editor/domainCommands/programming-exercise/testCase.command';
 import { MarkdownEditorComponent } from 'app/markdown-editor';
-import { ProgrammingExerciseService, ProgrammingExerciseTestCaseService } from 'app/entities/programming-exercise/services';
+import { ProgrammingExerciseParticipationService, ProgrammingExerciseService, ProgrammingExerciseTestCaseService } from 'app/entities/programming-exercise/services';
 import { ProgrammingExerciseTestCase } from 'app/entities/programming-exercise/programming-exercise-test-case.model';
 import { Result, ResultService } from 'app/entities/result';
 import { hasExerciseChanged } from 'app/entities/exercise';
@@ -78,7 +78,7 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     constructor(
         private programmingExerciseService: ProgrammingExerciseService,
         private jhiAlertService: JhiAlertService,
-        private resultService: ResultService,
+        private programmingExerciseParticipationService: ProgrammingExerciseParticipationService,
         private testCaseService: ProgrammingExerciseTestCaseService,
     ) {}
 
@@ -196,8 +196,7 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
      */
     loadTestCasesFromTemplateParticipationResult = (templateParticipationId: number): Observable<string[]> => {
         // Fallback for exercises that don't have test cases yet.
-        return this.resultService.getLatestResultWithFeedbacks(templateParticipationId).pipe(
-            rxMap((res: HttpResponse<Result>) => res.body),
+        return this.programmingExerciseParticipationService.getLatestResultWithFeedback(templateParticipationId).pipe(
             rxFilter((result: Result) => !!result.feedbacks),
             rxMap(({ feedbacks }: Result) =>
                 compose(

--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
@@ -204,6 +204,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
     loadLatestResult(): Observable<Result | null> {
         return this.programmingExerciseParticipationService.getLatestResultWithFeedback(this.participation.id).pipe(
             catchError(() => Observable.of(null)),
+            filter((result: Result | null) => !!result),
             flatMap((latestResult: Result) => (latestResult && !latestResult.feedbacks ? this.loadAndAttachResultDetails(latestResult) : Observable.of(latestResult))),
         );
     }

--- a/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/programming-exercise-instruction.component.ts
@@ -204,7 +204,6 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
     loadLatestResult(): Observable<Result | null> {
         return this.programmingExerciseParticipationService.getLatestResultWithFeedback(this.participation.id).pipe(
             catchError(() => Observable.of(null)),
-            filter((result: Result | null) => !!result),
             flatMap((latestResult: Result) => (latestResult && !latestResult.feedbacks ? this.loadAndAttachResultDetails(latestResult) : Observable.of(latestResult))),
         );
     }

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { filter } from 'rxjs/operators';
+import { catchError, filter } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 import { ProgrammingExercise, ProgrammingLanguage } from './programming-exercise.model';
 import { ProgrammingExerciseService } from 'app/entities/programming-exercise/services/programming-exercise.service';
@@ -39,14 +40,20 @@ export class ProgrammingExerciseDetailComponent implements OnInit {
 
             this.programmingExerciseParticipationService
                 .getLatestResultWithFeedback(this.programmingExercise.solutionParticipation.id)
-                .pipe(filter((result: Result) => !!result))
+                .pipe(
+                    catchError(() => of(null)),
+                    filter((result: Result) => !!result),
+                )
                 .subscribe((result: Result) => {
                     this.programmingExercise.solutionParticipation.results = [result];
                 });
 
             this.programmingExerciseParticipationService
                 .getLatestResultWithFeedback(this.programmingExercise.templateParticipation.id)
-                .pipe(filter((result: Result) => !!result))
+                .pipe(
+                    catchError(() => of(null)),
+                    filter((result: Result) => !!result),
+                )
                 .subscribe((result: Result) => {
                     this.programmingExercise.templateParticipation.results = [result];
                 });

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.ts
@@ -40,22 +40,16 @@ export class ProgrammingExerciseDetailComponent implements OnInit {
 
             this.programmingExerciseParticipationService
                 .getLatestResultWithFeedback(this.programmingExercise.solutionParticipation.id)
-                .pipe(
-                    catchError(() => of(null)),
-                    filter((result: Result) => !!result),
-                )
+                .pipe(catchError(() => of(null)))
                 .subscribe((result: Result) => {
-                    this.programmingExercise.solutionParticipation.results = [result];
+                    this.programmingExercise.solutionParticipation.results = result ? [result] : [];
                 });
 
             this.programmingExerciseParticipationService
                 .getLatestResultWithFeedback(this.programmingExercise.templateParticipation.id)
-                .pipe(
-                    catchError(() => of(null)),
-                    filter((result: Result) => !!result),
-                )
+                .pipe(catchError(() => of(null)))
                 .subscribe((result: Result) => {
-                    this.programmingExercise.templateParticipation.results = [result];
+                    this.programmingExercise.templateParticipation.results = result ? [result] : [];
                 });
         });
     }

--- a/src/main/webapp/app/entities/programming-exercise/services/programming-exercise-participation.service.ts
+++ b/src/main/webapp/app/entities/programming-exercise/services/programming-exercise-participation.service.ts
@@ -6,7 +6,7 @@ import { Result } from 'app/entities/result';
 import { Participation, ProgrammingExerciseStudentParticipation } from 'app/entities/participation';
 
 export interface IProgrammingExerciseParticipationService {
-    getLatestResultWithFeedback: (participationId: number) => Observable<Result>;
+    getLatestResultWithFeedback: (participationId: number) => Observable<Result | null>;
     getStudentParticipationWithLatestResult: (participationId: number) => Observable<ProgrammingExerciseStudentParticipation>;
 }
 
@@ -16,8 +16,8 @@ export class ProgrammingExerciseParticipationService implements IProgrammingExer
 
     constructor(private http: HttpClient) {}
 
-    getLatestResultWithFeedback(participationId: number): Observable<Result> {
-        return this.http.get<Result>(this.resourceUrl + participationId + '/latest-result-with-feedbacks');
+    getLatestResultWithFeedback(participationId: number): Observable<Result | null> {
+        return this.http.get<Result | null>(this.resourceUrl + participationId + '/latest-result-with-feedbacks');
     }
 
     getStudentParticipationWithLatestResult(participationId: number) {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
@@ -21,6 +21,7 @@ import {
     ProgrammingExerciseEditableInstructionComponent,
     ProgrammingExerciseInstructionComponent,
     ProgrammingExerciseInstructionTestcaseStatusComponent,
+    ProgrammingExerciseParticipationService,
     ProgrammingExerciseTestCaseService,
 } from 'src/main/webapp/app/entities/programming-exercise';
 import { MockParticipationWebsocketService } from '../../mocks';
@@ -39,7 +40,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
     let fixture: ComponentFixture<ProgrammingExerciseEditableInstructionComponent>;
     let debugElement: DebugElement;
     let testCaseService: ProgrammingExerciseTestCaseService;
-    let resultService: ResultService;
+    let programmingExerciseParticipationService: ProgrammingExerciseParticipationService;
 
     let subscribeForTestCaseSpy: SinonSpy;
     let getLatestResultWithFeedbacksStub: SinonStub;
@@ -78,9 +79,9 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
                 debugElement = fixture.debugElement;
                 testCaseService = debugElement.injector.get(ProgrammingExerciseTestCaseService);
                 (testCaseService as MockProgrammingExerciseTestCaseService).initSubject([]);
-                resultService = debugElement.injector.get(ResultService);
+                programmingExerciseParticipationService = debugElement.injector.get(ProgrammingExerciseParticipationService);
                 subscribeForTestCaseSpy = spy(testCaseService, 'subscribeForTestCases');
-                getLatestResultWithFeedbacksStub = stub(resultService, 'getLatestResultWithFeedbacks');
+                getLatestResultWithFeedbacksStub = stub(programmingExerciseParticipationService, 'getLatestResultWithFeedback');
             });
     });
 
@@ -153,7 +154,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
     it('should try to retreive the test case values from the solution repos last build result if there are no testCases (empty result)', fakeAsync(() => {
         comp.exercise = exercise;
         comp.participation = participation;
-        const subject = new Subject<HttpResponse<Result>>();
+        const subject = new Subject<Result>();
         getLatestResultWithFeedbacksStub.returns(subject);
 
         const changes: SimpleChanges = {
@@ -169,7 +170,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         expect(comp.exerciseTestCases).to.have.lengthOf(0);
         expect(getLatestResultWithFeedbacksStub).to.have.been.calledOnceWithExactly(exercise.templateParticipation.id);
 
-        subject.next({ body: { feedbacks: [{ text: 'testY' }, { text: 'testX' }] } } as HttpResponse<Result>);
+        subject.next({ feedbacks: [{ text: 'testY' }, { text: 'testX' }] } as Result);
         tick();
 
         expect(comp.exerciseTestCases).to.have.lengthOf(2);


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Some smaller issues that I noticed when testing the programming exercises.

### Description
<!-- Describe your changes in detail -->

1. Use the correct result retrieval call for the editable instructions test case fallback in editable-instructions (https://github.com/ls1intum/Artemis/pull/633, regression from https://github.com/ls1intum/Artemis/pull/623)
2. Don't return CONFLICT if an FileAlreadyExists exception occurs on a repository action (this issue currently cannot happen normally because the file browser also validates the file name)
3. Don't return notFound on the programmingExerciseParticipation result retrieval, instead return a null result to avoid piling up unnecessary errors (it is normal that a participation does not have a result)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

For 1:
- Create a new programming exercise, then quickly cancel the build for the solution participation so no test cases can be created.
=> Opening the editable instructions should not create a server error with "wrong class loaded..."

For 2:
- Currently not testable

For 3:
- Create a programming exercise, then quickly go to view
=> Instead of returning 404, a null result should be returned; the UI should show "no graded result"

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
