### PR TITLE
Programming-Exercise/Remove exception from result finding service method

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
@@ -99,17 +99,10 @@ public class ResultService {
      * Get the latest result from the database by participation id together with the list of feedback items.
      *
      * @param participationId the id of the participation to load from the database
-     * @return the result with feedback list
-     * @throws EntityNotFoundException when result for participation could not be found
+     * @return an optional result (might exist or not).
      */
-    public Result findLatestResultWithFeedbacksForParticipation(Long participationId) throws EntityNotFoundException {
-        Optional<Result> result = resultRepository.findFirstWithFeedbacksByParticipationIdOrderByCompletionDateDesc(participationId);
-        if (!result.isPresent()) {
-            throw new EntityNotFoundException("result for participation " + participationId + " could not be found");
-        }
-        else {
-            return result.get();
-        }
+    public Optional<Result> findLatestResultWithFeedbacksForParticipation(Long participationId) {
+        return resultRepository.findFirstWithFeedbacksByParticipationIdOrderByCompletionDateDesc(participationId);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseParticipationResource.java
@@ -119,13 +119,7 @@ public class ProgrammingExerciseParticipationResource {
         if (!programmingExerciseParticipationService.canAccessParticipation(participation)) {
             return forbidden();
         }
-        Result result;
-        try {
-            result = resultService.findLatestResultWithFeedbacksForParticipation(participation.getId());
-        }
-        catch (EntityNotFoundException ex) {
-            return ResponseEntity.ok(null);
-        }
-        return ResponseEntity.ok(result);
+        Optional<Result> result = resultService.findLatestResultWithFeedbacksForParticipation(participation.getId());
+        return result.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.ok(null));
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to ArTEMiS! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

Instead of throwing an exception in the `ResultService.findLatestResultWithFeedbacksForParticipation`, just return an Optional.
This way no exception is logged on the server.

A participation without a result is a normal case, so no exception is necessary.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to ArTEMiS
2. Navigate to Course Administration > Programming-Exercise view
3. Result should be shown correctly for template & solution participation

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
