### PR TITLE
Prepare for MySQL 8

### DIFF
--- a/gradle/liquibase.gradle
+++ b/gradle/liquibase.gradle
@@ -43,7 +43,7 @@ def liquibaseCommand(command) {
         main = "liquibase.integration.commandline.Main"
 
         args "--changeLogFile=src/main/resources/config/liquibase/changelog/" + buildTimestamp() +"_changelog.xml"
-        args "--referenceUrl=hibernate:spring:de.tum.in.www1.artemis.domain?dialect=org.hibernate.dialect.MySQL5InnoDBDialect&hibernate.physical_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy&hibernate.implicit_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy"
+        args "--referenceUrl=hibernate:spring:de.tum.in.www1.artemis.domain?dialect=org.hibernate.dialect.MySQL8Dialect&hibernate.physical_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy&hibernate.implicit_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy"
         args "--username=root"
         args "--password="
         args "--url=jdbc:mysql://localhost:3306/Artemis"

--- a/src/main/java/de/tum/in/www1/artemis/domain/User.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/User.java
@@ -90,6 +90,11 @@ public class User extends AbstractAuditingEntity implements Serializable {
     @Column(name = "last_notification_read")
     private ZonedDateTime lastNotificationRead = null;
 
+    /**
+     * Word "GROUPS" is being added as a restricted word starting in MySQL 8.0.2
+     * Workaround: Annotation @Column(name = "`groups`") escapes this word using backticks.
+     */
+    @Column(name = "`groups`")
     @ElementCollection
     private List<String> groups = new ArrayList<>();
 

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -44,7 +44,7 @@ spring:
                 prepStmtCacheSqlLimit: 2048
                 useServerPrepStmts: true
     jpa:
-        database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+        database-platform: org.hibernate.dialect.MySQL8Dialect
         database: MYSQL
         show-sql: false
         properties:

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -45,7 +45,7 @@ spring:
                 prepStmtCacheSqlLimit: 2048
                 useServerPrepStmts: true
     jpa:
-        database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+        database-platform: org.hibernate.dialect.MySQL8Dialect
         database: MYSQL
         show-sql: false
         properties:

--- a/src/main/resources/config/liquibase/changelog/20190705114935_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20190705114935_changelog.xml
@@ -10,7 +10,7 @@
 <changeSet author="krusche" id="1562320394217-2">
     <sql>update participation set discriminator = 'TPEP', exercise_id = null where build_plan_id like '%-BASE';</sql>
     <sql>update participation set discriminator = 'SPEP', exercise_id = null where build_plan_id like '%-SOLUTION';</sql>
-    <sql>update participation p, exercise e set p.discriminator = 'PESP' where discriminator = "" and p.exercise_id = e.id and e.discriminator = 'P';</sql>
+    <sql>update participation p, exercise e set p.discriminator = 'PESP' where p.discriminator = "" and p.exercise_id = e.id and e.discriminator = 'P';</sql>
     <sql>update participation set discriminator = 'SP' where discriminator = ""</sql>
 </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [X] I documented my source code using the JavaDoc / JSDoc style.
- [X] ~I added integration test cases for the server (Spring) related to the features~
- [X] ~I added integration test cases for the client (Jest) related to the features~
- [X] ~I added screenshots/screencast of my UI changes~
- [X] ~I translated all the newly inserted strings~

### Motivation and Context
MySQL8 was released 16 months ago (April 19, 2018) and therefore it would be nice to upgrade to a newer version.

### Description
- Fix small mistake in Database Migration.
  ⚠️ Required update of  Checkum for Changelog Entry `1562320394217-2`
  to `8:6e07f15d0a7f89c7647ddbab8e798a01`

- Update MySQL Dialect to `org.hibernate.dialect.MySQL8Dialect`

- Add Workaround for word “GROUPS” being reserved starting in MySQL 8.0.2
  We use groups as a column name in `User::groups` / `user_groups.groups`
  Add `@Column` Annotation to include Backtick in column name

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Upgrade MySQL to Version 8.
2. Check that everything is working as before.

---

⚠️ We will upgrade the Testserver and test once that is done.