### PR TITLE
Instructor-Dashboard/Remove loading indicator when there are no leader board entries

### DIFF
--- a/src/main/webapp/app/instructor-course-dashboard/instructor-course-dashboard.component.html
+++ b/src/main/webapp/app/instructor-course-dashboard/instructor-course-dashboard.component.html
@@ -7,7 +7,7 @@
     </div>
 
     <div class="container-fluid">
-        <div class="row mt-3" *ngIf="stats && stats.tutorLeaderboardEntries && stats.tutorLeaderboardEntries.length > 0; else loadingScreen">
+        <div class="row mt-3" *ngIf="!isLoading">
             <div class="col-md-8">
                 <div class="card">
                     <div class="card-header bg-primary text-white">
@@ -47,7 +47,7 @@
                 </div>
             </div>
 
-            <div class="col-md-4" *ngIf="stats && !loading">
+            <div class="col-md-4" *ngIf="stats && !isLoading">
                 <canvas baseChart [data]="dataForAssessmentPieChart" [labels]="['Open assessments', 'Completed assessments']" chartType="pie"> </canvas>
             </div>
         </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

If the leaderboard entries array is empty (see below), the loading animation on the instructor leaderboard does not stop.
I changed this logic in the template and refactored the control flow a bit.


```
{
  "numberOfStudents" : 0,
  "numberOfSubmissions" : 0,
  "numberOfAssessments" : 0,
  "numberOfComplaints" : 0,
  "numberOfOpenComplaints" : 0,
  "numberOfMoreFeedbackRequests" : 0,
  "numberOfOpenMoreFeedbackRequests" : 0,
  "tutorLeaderboardEntries" : [ ]
}
```



### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Open the instructor dashboard (#/course/1/instructor-dashboard
) for a course without an assigned tutor
4. Loading should stop after api calls are executed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/28230611/63413297-befc7580-c3f9-11e9-87ef-05948dc72398.png)
