### PR TITLE
Bugfix/guided tour/could not initialize proxy

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/UserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/UserService.java
@@ -552,10 +552,26 @@ public class UserService {
         return userRepository.findAllByGroups(course.getTeachingAssistantGroupName());
     }
 
-    public User updateGuidedTourSettings(List<GuidedTourSettings> guidedTourSettings) {
+    /**
+     * Get all guided tour settings of the current user as a list
+     *
+     * @return the guided tour settings of the current user
+     */
+    public List<GuidedTourSettings> getGuidedTourSettings() {
+        User loggedInUser = getUserWithGroupsAndAuthorities();
+        return loggedInUser.getGuidedTourSettings();
+    }
+
+    /**
+     * Update all guided tour settings of the current user
+     *
+     * @param guidedTourSettings new list of guided tour settings
+     * @return updated guided tour settings list
+     */
+    public List<GuidedTourSettings> updateGuidedTourSettings(List<GuidedTourSettings> guidedTourSettings) {
         User loggedInUser = getUserWithGroupsAndAuthorities();
         loggedInUser.setGuidedTourSettings(guidedTourSettings);
         userRepository.save(loggedInUser);
-        return loggedInUser;
+        return loggedInUser.getGuidedTourSettings();
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/UserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/UserService.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.Hibernate;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -559,6 +560,7 @@ public class UserService {
      */
     public List<GuidedTourSettings> getGuidedTourSettings() {
         User loggedInUser = getUserWithGroupsAndAuthorities();
+        Hibernate.initialize(loggedInUser.getGuidedTourSettings());
         return loggedInUser.getGuidedTourSettings();
     }
 
@@ -572,6 +574,7 @@ public class UserService {
         User loggedInUser = getUserWithGroupsAndAuthorities();
         loggedInUser.setGuidedTourSettings(guidedTourSettings);
         userRepository.save(loggedInUser);
+        Hibernate.initialize(loggedInUser.getGuidedTourSettings());
         return loggedInUser.getGuidedTourSettings();
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/GuidedTourSettingsResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/GuidedTourSettingsResource.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.web.rest;
 
 import java.util.List;
 
+import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -42,6 +43,7 @@ public class GuidedTourSettingsResource {
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<List<GuidedTourSettings>> getGuidedTourSettings() {
         log.debug("REST request to get all guided tour settings of the current user");
+        Hibernate.initialize(userService.getGuidedTourSettings());
         return new ResponseEntity<>(userService.getGuidedTourSettings(), null, HttpStatus.OK);
     }
 
@@ -54,6 +56,7 @@ public class GuidedTourSettingsResource {
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<List<GuidedTourSettings>> updateGuidedTourSettings(@RequestBody List<GuidedTourSettings> guidedTourSettings) {
         log.debug("REST request to update GuidedTourSettings : {}", guidedTourSettings);
+        Hibernate.initialize(userService.getGuidedTourSettings());
         return new ResponseEntity<>(userService.updateGuidedTourSettings(guidedTourSettings), null, HttpStatus.OK);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/GuidedTourSettingsResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/GuidedTourSettingsResource.java
@@ -2,7 +2,6 @@ package de.tum.in.www1.artemis.web.rest;
 
 import java.util.List;
 
-import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,7 +42,6 @@ public class GuidedTourSettingsResource {
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<List<GuidedTourSettings>> getGuidedTourSettings() {
         log.debug("REST request to get all guided tour settings of the current user");
-        Hibernate.initialize(userService.getGuidedTourSettings());
         return new ResponseEntity<>(userService.getGuidedTourSettings(), null, HttpStatus.OK);
     }
 
@@ -56,7 +54,6 @@ public class GuidedTourSettingsResource {
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<List<GuidedTourSettings>> updateGuidedTourSettings(@RequestBody List<GuidedTourSettings> guidedTourSettings) {
         log.debug("REST request to update GuidedTourSettings : {}", guidedTourSettings);
-        Hibernate.initialize(userService.getGuidedTourSettings());
         return new ResponseEntity<>(userService.updateGuidedTourSettings(guidedTourSettings), null, HttpStatus.OK);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/GuidedTourSettingsResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/GuidedTourSettingsResource.java
@@ -8,11 +8,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.GuidedTourSettings;
-import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.service.UserService;
 
 /**
@@ -42,11 +40,9 @@ public class GuidedTourSettingsResource {
      */
     @GetMapping("/guided-tour-settings")
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
-    @Transactional(readOnly = true)
     public ResponseEntity<List<GuidedTourSettings>> getGuidedTourSettings() {
         log.debug("REST request to get all guided tour settings of the current user");
-        User currentUser = userService.getUser();
-        return new ResponseEntity<>(currentUser.getGuidedTourSettings(), null, HttpStatus.OK);
+        return new ResponseEntity<>(userService.getGuidedTourSettings(), null, HttpStatus.OK);
     }
 
     /**
@@ -56,10 +52,8 @@ public class GuidedTourSettingsResource {
      */
     @PutMapping("/guided-tour-settings")
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
-    @Transactional
     public ResponseEntity<List<GuidedTourSettings>> updateGuidedTourSettings(@RequestBody List<GuidedTourSettings> guidedTourSettings) {
         log.debug("REST request to update GuidedTourSettings : {}", guidedTourSettings);
-        User currentUser = userService.updateGuidedTourSettings(guidedTourSettings);
-        return new ResponseEntity<>(currentUser.getGuidedTourSettings(), null, HttpStatus.OK);
+        return new ResponseEntity<>(userService.updateGuidedTourSettings(guidedTourSettings), null, HttpStatus.OK);
     }
 }

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -142,9 +142,8 @@ export class GuidedTourService {
     /**
      * Trigger callback method if there is one and finish the current guided tour by updating the guided tour settings in the database
      * and calling the reset tour method to remove current tour elements
-     *
      */
-    private finishGuidedTour() {
+    public finishGuidedTour() {
         if (!this.currentTour) {
             return;
         }
@@ -164,6 +163,30 @@ export class GuidedTourService {
             }
             this.subscribeToAndUpdateGuidedTourSettings(false);
         }
+    }
+
+    /**
+     * Subscribe to the update method call
+     * @param tourFinished: true if the user finishes the guided tour with all steps
+     */
+    public subscribeToAndUpdateGuidedTourSettings(tourFinished: boolean) {
+        if (!this.currentTour) {
+            return;
+        }
+
+        const guidedTourState = tourFinished ? GuidedTourState.FINISHED : GuidedTourState.STARTED;
+        this.updateGuidedTourSettings(this.currentTour.settingsKey, this.currentTourStepDisplay, guidedTourState).subscribe(
+            guidedTourSettings => {
+                if (guidedTourSettings.body) {
+                    this.guidedTourSettings = guidedTourSettings.body;
+                }
+            },
+            error => {
+                this.resetTour();
+                throw new Error('Updating the guided tour settings has failed ' + error.status);
+            },
+        );
+        this.resetTour();
     }
 
     /**
@@ -204,7 +227,7 @@ export class GuidedTourService {
 
     /**
      * Checks if the current window size is supposed display the guided tour
-     * @return {boolean} returns true if the minimum screen size is not defined or greater than the current window.innerWidth
+     * @return returns true if the minimum screen size is not defined or greater than the current window.innerWidth
      */
     public tourAllowedForWindowSize(): boolean {
         if (this.currentTour) {
@@ -214,7 +237,7 @@ export class GuidedTourService {
     }
 
     /**
-     *  @return {boolean} if highlighted element is available
+     *  @return true if highlighted element is available, otherwise false
      */
     public checkSelectorValidity(): boolean {
         if (!this.currentTour) {
@@ -238,7 +261,7 @@ export class GuidedTourService {
     }
 
     /**
-     * @return {boolean} if the current step is the last tour step
+     * @return true if the current step is the last tour step, otherwise false
      */
     public get isOnLastStep(): boolean {
         if (!this.currentTour) {
@@ -289,7 +312,7 @@ export class GuidedTourService {
 
     /**
      * Get the tour step with defined orientation
-     * @param index current tour step index
+     * @param index: current tour step index
      * @return prepared current tour step or null
      */
     private getPreparedTourStep(index: number): TourStep | null {
@@ -302,7 +325,7 @@ export class GuidedTourService {
 
     /**
      * Set orientation of the passed on tour step
-     * @param {step} passed on tour step of a guided tour
+     * @param step: passed on tour step of a guided tour
      * @return guided tour step with defined orientation
      */
     private setTourOrientation(step: TourStep): TourStep {
@@ -346,30 +369,10 @@ export class GuidedTourService {
         );
     }
 
-    public subscribeToAndUpdateGuidedTourSettings(tourFinished: boolean) {
-        if (!this.currentTour) {
-            return;
-        }
-
-        const guidedTourState = tourFinished ? GuidedTourState.FINISHED : GuidedTourState.STARTED;
-        this.updateGuidedTourSettings(this.currentTour.settingsKey, this.currentTourStepDisplay, guidedTourState).subscribe(
-            guidedTourSettings => {
-                if (guidedTourSettings.body) {
-                    this.guidedTourSettings = guidedTourSettings.body;
-                }
-            },
-            error => {
-                this.resetTour();
-                throw new Error('Updating the guided tour settings has failed ' + error.status);
-            },
-        );
-        this.resetTour();
-    }
-
     /**
      * Send a GET request for the guided tour settings of the current user
      *
-     * @return {Observable GuidedTourSetting[] } guided tour settings
+     * @return Observable GuidedTourSetting[]: guided tour settings
      */
     private fetchGuidedTourSettings(): Observable<GuidedTourSetting[]> {
         return this.http.get<GuidedTourSetting[]>(this.resourceUrl, { observe: 'response' }).map(res => {

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -357,13 +357,13 @@ export class GuidedTourService {
                 if (guidedTourSettings.body) {
                     this.guidedTourSettings = guidedTourSettings.body;
                 }
-                this.resetTour();
             },
             error => {
                 this.resetTour();
                 throw new Error('Updating the guided tour settings has failed ' + error.status);
             },
         );
+        this.resetTour();
     }
 
     /**

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -393,6 +393,7 @@ export class GuidedTourService {
      */
     public updateGuidedTourSettings(guidedTourKey: string, guidedTourStep: number, guidedTourState: GuidedTourState): Observable<EntityResponseType> {
         if (!this.guidedTourSettings) {
+            this.resetTour();
             throw new Error('Cannot update non existing guided tour settings');
         }
         const existingSettingIndex = this.guidedTourSettings.findIndex(setting => setting.guidedTourKey === guidedTourKey);

--- a/src/test/javascript/spec/service/guided-tour.service.spec.ts
+++ b/src/test/javascript/spec/service/guided-tour.service.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { of, Observable } from 'rxjs';
+import { of } from 'rxjs';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import { CookieService } from 'ngx-cookie';
@@ -153,27 +153,11 @@ describe('Service Tests', () => {
                     expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.not.exist;
                 });
 
-                it('should be able to skip the tour even if the REST call is failing', () => {
-                    guidedTourService.updateGuidedTourSettings = jasmine.createSpy().and.returnValue(Observable.throwError(500));
-                    guidedTourService.finishGuidedTour();
-                    guidedTourComponentFixture.detectChanges();
-                    // tslint:disable-next-line:no-unused-expression
-                    expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.not.exist;
-                });
-
                 it('should start and skip the tour', () => {
                     const skipButton = guidedTourComponentFixture.debugElement.query(By.css('.close'));
                     // tslint:disable-next-line:no-unused-expression
                     expect(skipButton).to.exist;
                     skipButton.nativeElement.click();
-                    guidedTourComponentFixture.detectChanges();
-                    // tslint:disable-next-line:no-unused-expression
-                    expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.not.exist;
-                });
-
-                it('should be able to skip the tour even if the REST call is failing', () => {
-                    guidedTourService.updateGuidedTourSettings = jasmine.createSpy().and.returnValue(Observable.throwError(500));
-                    guidedTourService.skipTour();
                     guidedTourComponentFixture.detectChanges();
                     // tslint:disable-next-line:no-unused-expression
                     expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.not.exist;

--- a/src/test/javascript/spec/service/guided-tour.service.spec.ts
+++ b/src/test/javascript/spec/service/guided-tour.service.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { of } from 'rxjs';
+import { of, Observable } from 'rxjs';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import { CookieService } from 'ngx-cookie';
@@ -123,11 +123,15 @@ describe('Service Tests', () => {
                     });
 
                     // Start course overview tour
+                    // tslint:disable-next-line:no-unused-expression
                     expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.not.exist;
+                    // tslint:disable-next-line:no-unused-expression
                     expect(guidedTourService.checkGuidedTourAvailabilityForCurrentRoute()).to.be.true;
                     guidedTourService.startGuidedTourForCurrentRoute();
                     guidedTourComponentFixture.detectChanges();
+                    // tslint:disable-next-line:no-unused-expression
                     expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.exist;
+                    // tslint:disable-next-line:no-unused-expression
                     expect(guidedTourService.isOnFirstStep).to.be.true;
                     expect(guidedTourService.currentTourStepDisplay).to.equal(1);
                     expect(guidedTourService.currentTourStepCount).to.equal(2);
@@ -136,29 +140,52 @@ describe('Service Tests', () => {
                 it('should start and finish the course overview guided tour', () => {
                     // Navigate to next tour step
                     const nextButton = guidedTourComponentFixture.debugElement.query(By.css('.next-button'));
+                    // tslint:disable-next-line:no-unused-expression
                     expect(nextButton).to.exist;
                     nextButton.nativeElement.click();
+                    // tslint:disable-next-line:no-unused-expression
                     expect(guidedTourService.isOnLastStep).to.be.true;
 
                     // Finish guided tour
                     nextButton.nativeElement.click();
                     guidedTourComponentFixture.detectChanges();
+                    // tslint:disable-next-line:no-unused-expression
+                    expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.not.exist;
+                });
+
+                it('should be able to skip the tour even if the REST call is failing', () => {
+                    guidedTourService.updateGuidedTourSettings = jasmine.createSpy().and.returnValue(Observable.throwError(500));
+                    guidedTourService.finishGuidedTour();
+                    guidedTourComponentFixture.detectChanges();
+                    // tslint:disable-next-line:no-unused-expression
                     expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.not.exist;
                 });
 
                 it('should start and skip the tour', () => {
                     const skipButton = guidedTourComponentFixture.debugElement.query(By.css('.close'));
+                    // tslint:disable-next-line:no-unused-expression
                     expect(skipButton).to.exist;
                     skipButton.nativeElement.click();
                     guidedTourComponentFixture.detectChanges();
+                    // tslint:disable-next-line:no-unused-expression
+                    expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.not.exist;
+                });
+
+                it('should be able to skip the tour even if the REST call is failing', () => {
+                    guidedTourService.updateGuidedTourSettings = jasmine.createSpy().and.returnValue(Observable.throwError(500));
+                    guidedTourService.skipTour();
+                    guidedTourComponentFixture.detectChanges();
+                    // tslint:disable-next-line:no-unused-expression
                     expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).to.not.exist;
                 });
 
                 it('should prevent backdrop from advancing', () => {
                     const backdrop = guidedTourComponentFixture.debugElement.query(By.css('.guided-tour-user-input-mask'));
+                    // tslint:disable-next-line:no-unused-expression
                     expect(backdrop).to.exist;
                     backdrop.nativeElement.click();
                     guidedTourComponentFixture.detectChanges();
+                    // tslint:disable-next-line:no-unused-expression
                     expect(guidedTourService.isOnFirstStep).to.be.true;
                 });
             });


### PR DESCRIPTION
### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~~I added integration test cases for the server (Spring) related to the features~~
- [x] ~~I added integration test cases for the client (Jest) related to the features~~
- [x] ~~I added screenshots/screencast of my UI changes~~
- [x] ~~I translated all the newly inserted strings~~

### Description
The guided tour settings couldn't be eagerly loaded with the `@Transactional` annotation and therefore threw an `Internal Server Error (500) Could not write JSON: failed to lazily initialise a collection of role: de.tum.in.www1.artemis.domain.User.guidedTourSetting`, see screenshot.
![image](https://user-images.githubusercontent.com/33764166/63722905-70fdcc80-c854-11e9-873f-a382de406d23.png)

I therefore moved the get and update call for the guided tour settings to the `UserService.java` file and added `Hibernate.initialize()` to force the initialization of a proxy and load the guided tour settings.

Moreover I added some error handling on the client side for the get and update methods, so that the tour can be skipped/finished, even if the REST calls fail.

Regression from #669

### Steps for Testing
1. Log in to ArTEMiS
2. Click on Administration Menu
3. Click on Start Tour
4. Navigate through guided tour

### Screenshots
![image](https://user-images.githubusercontent.com/33764166/63758425-0a13fe00-c8bc-11e9-9bf9-f1a66a82be43.png)
