### PR TITLE
Bugfix/Programming-Exercise/Fix linking programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -150,6 +150,9 @@ public class ProgrammingExerciseResource {
             return errorResponse;
         }
 
+        // We need to save the programming exercise BEFORE saving the participations to avoid transient state exceptions.
+        // This is only necessary for linked exercises, however we don't differentiate this with a separate endpoint.
+        programmingExercise = programmingExerciseRepository.save(programmingExercise);
         // Only save after checking for errors
         programmingExerciseService.saveParticipations(programmingExercise);
 


### PR DESCRIPTION
…ansient state exception

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] ~I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.~
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] ~I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

Linking a programming exercise currently does not work, because the template & solution participations are saved before the exercise (`object is in a transient state`).
This issue does not appear when a programming exercise is created through the automated setup as it is already persisted in the database at this point.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis > Course Administration
2. Link a programming exercise to an existing one
3. Save should not create an error

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
