### PR TITLE
Hotfix/guided tour/arrow navigation and tour trigger

### DIFF
--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -47,7 +47,7 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
     handleKeyboardEvent(event: KeyboardEvent) {
         switch (event.code) {
             case 'ArrowRight': {
-                // Check if the currentTourStep is defined, else the guided tour can be started by pressing the right arrow
+                // Check if the currentTourStep is defined so that the guided tour cannot be started by pressing the right arrow
                 if (this.currentTourStep && this.guidedTourService.currentTourStepDisplay <= this.guidedTourService.currentTourStepCount) {
                     this.guidedTourService.nextStep();
                 }

--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -47,7 +47,8 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
     handleKeyboardEvent(event: KeyboardEvent) {
         switch (event.code) {
             case 'ArrowRight': {
-                if (this.guidedTourService.currentTourStepDisplay <= this.guidedTourService.currentTourStepCount) {
+                // Check if the currentTourStep is defined, else the guided tour can be started by pressing the right arrow
+                if (this.currentTourStep && this.guidedTourService.currentTourStepDisplay <= this.guidedTourService.currentTourStepCount) {
                     this.guidedTourService.nextStep();
                 }
                 break;

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -190,7 +190,7 @@ export class GuidedTourService {
      * Subscribe to the update method call
      * @param guidedTourState GuidedTourState.FINISHED if the tour is closed on the last step, otherwise GuidedTourState.STARTED
      */
-    private subscribeToAndUpdateGuidedTourSettings(guidedTourState: GuidedTourState) {
+    public subscribeToAndUpdateGuidedTourSettings(guidedTourState: GuidedTourState) {
         if (!this.currentTour) {
             return;
         }
@@ -245,7 +245,7 @@ export class GuidedTourService {
      * Checks if the current window size is supposed display the guided tour
      * @return true if the minimum screen size is not defined or greater than the current window.innerWidth, otherwise false
      */
-    public tourAllowedForWindowSize(): boolean {
+    private tourAllowedForWindowSize(): boolean {
         if (this.currentTour) {
             return !this.currentTour.minimumScreenSize || window.innerWidth >= this.currentTour!.minimumScreenSize;
         }
@@ -255,7 +255,7 @@ export class GuidedTourService {
     /**
      *  @return true if highlighted element is available, otherwise false
      */
-    public checkSelectorValidity(): boolean {
+    private checkSelectorValidity(): boolean {
         if (!this.currentTour) {
             return false;
         }
@@ -376,7 +376,7 @@ export class GuidedTourService {
      * @param guidedTourState displays whether the user has finished (FINISHED) the current tour or only STARTED it and cancelled it in the middle
      * @return Observable<EntityResponseType>: updated guided tour settings
      */
-    public updateGuidedTourSettings(guidedTourKey: string, guidedTourStep: number, guidedTourState: GuidedTourState): Observable<EntityResponseType> {
+    private updateGuidedTourSettings(guidedTourKey: string, guidedTourStep: number, guidedTourState: GuidedTourState): Observable<EntityResponseType> {
         if (!this.guidedTourSettings) {
             this.resetTour();
             throw new Error('Cannot update non existing guided tour settings');

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -214,7 +214,7 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit {
      */
     startCloneRepositoryGuidedTour() {
         const tourSetting = this.guidedTourService.guidedTourSettings.filter(setting => setting.guidedTourKey === courseExerciseOverviewTour.settingsKey);
-        if (tourSetting.length > 0 && tourSetting[0].guidedTourState.toString() === GuidedTourState[GuidedTourState.FINISHED]) {
+        if (tourSetting.length > 0 && tourSetting[0].guidedTourState.toString() !== GuidedTourState[GuidedTourState.FINISHED]) {
             this.guidedTourService.enableTour(cloneRepositoryTour);
             // Set timeout for clone repository button to render
             setTimeout(() => {

--- a/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
+++ b/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
@@ -120,7 +120,7 @@ describe('Component Tests', () => {
                 expect(guidedTourComponent.currentTourStep).to.exist;
             });
 
-            it('should navigate next with the right arrow key', () => {
+            it('should not trigger the guided tour with the right arrow key', () => {
                 guidedTourComponent.currentTourStep = null;
                 const nextStep = spyOn(guidedTourService, 'nextStep');
                 const eventMock = new KeyboardEvent('keydown', { code: 'ArrowRight' });

--- a/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
+++ b/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
@@ -103,7 +103,7 @@ describe('Component Tests', () => {
         describe('Keydown Element', () => {
             beforeEach(async () => {
                 // Prepare guided tour service
-                spyOn(guidedTourService, 'updateGuidedTourSettings');
+                spyOn<any>(guidedTourService, 'updateGuidedTourSettings');
                 spyOn(guidedTourService, 'init').and.returnValue(of());
                 spyOn(guidedTourService, 'enableTour').and.callFake(() => {
                     guidedTourService.currentTour = courseOverviewTour;
@@ -118,6 +118,15 @@ describe('Component Tests', () => {
                 guidedTourService.startTour();
                 guidedTourComponentFixture.detectChanges();
                 expect(guidedTourComponent.currentTourStep).to.exist;
+            });
+
+            it('should navigate next with the right arrow key', () => {
+                guidedTourComponent.currentTourStep = null;
+                const nextStep = spyOn(guidedTourService, 'nextStep');
+                const eventMock = new KeyboardEvent('keydown', { code: 'ArrowRight' });
+                guidedTourComponent.handleKeyboardEvent(eventMock);
+                expect(nextStep.calls.count()).to.equal(0);
+                nextStep.calls.reset();
             });
 
             it('should navigate next with the right arrow key', () => {


### PR DESCRIPTION
### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] I documented my source code using the JavaDoc / JSDoc style.
- [x] ~~I added integration test cases for the server (Spring) related to the features~~
- [x] I added integration test cases for the client (Jest) related to the features
- [x] ~~I added screenshots/screencast of my UI changes~~
- [x] ~~I translated all the newly inserted strings~~

### Description
Bugfix for https://github.com/ls1intum/Artemis/issues/792
Also while fixing this bug, I discovered that the clone repository is wrongly triggered every time a user clicks on 'start exercise' for programming exercises, which is also fixed now.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Overview or Course Exercise Overview Page (the two pages where guided tours are currently available)
3. Click on the right arrow
4. The tour should not be started
5. Click on 'Start tour' in the account menu and navigate through the tour with arrow keys
---
1. Go to Course Exercise Overview Page
2. Start a programming exercise
3. No tour is displayed
