### PR TITLE
Hotfix/Fix save issue in code-editor admin view due to missing authentication object

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/QuizSubmissionWebsocketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/QuizSubmissionWebsocketService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Controller;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
+import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.service.QuizExerciseService;
@@ -53,8 +54,10 @@ public class QuizSubmissionWebsocketService {
      */
     @MessageMapping("/topic/quizExercise/{exerciseId}/submission")
     public void saveSubmission(@DestinationVariable Long exerciseId, @Payload QuizSubmission quizSubmission, Principal principal) {
-        String username = principal.getName();
+        // Without this, custom jpa repository methods don't work in websocket channel.
+        SecurityUtils.setAuthorizationObject();
 
+        String username = principal.getName();
         // check if submission is still allowed
         Optional<QuizExercise> quizExercise = quizExerciseService.findById(exerciseId);
         if (!quizExercise.isPresent()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
@@ -27,6 +27,7 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Controller;
 
 import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
@@ -77,6 +78,9 @@ public class RepositoryWebsocketResource {
      */
     @MessageMapping("/topic/repository/{participationId}/files")
     public void updateParticipationFiles(@DestinationVariable Long participationId, @Payload List<FileSubmission> submissions, Principal principal) {
+        // Without this, custom jpa repository methods don't work in a websocket channel.
+        SecurityUtils.setAuthorizationObject();
+
         String topic = "/topic/repository/" + participationId + "/files";
         Participation participation;
         try {
@@ -127,6 +131,9 @@ public class RepositoryWebsocketResource {
      */
     @MessageMapping("/topic/test-repository/{exerciseId}/files")
     public void updateTestFiles(@DestinationVariable Long exerciseId, @Payload List<FileSubmission> submissions, Principal principal) {
+        // Without this, custom jpa repository methods don't work in websocket channel.
+        SecurityUtils.setAuthorizationObject();
+
         ProgrammingExercise exercise = (ProgrammingExercise) exerciseService.findOne(exerciseId);
         String testRepoName = exercise.getProjectKey().toLowerCase() + "-tests";
         URL testsRepoUrl = versionControlService.get().getCloneURL(exercise.getProjectKey(), testRepoName);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested the changes and all related features on the test server https://artemistest.ase.in.tum.de.
- [x] ~I documented my source code using the JavaDoc / JSDoc style.~
- [x] ~I added integration test cases for the server (Spring) related to the features~
- [x] ~I added integration test cases for the client (Jest) related to the features~
- [x] I added screenshots/screencast of my UI changes~
- [x] ~I translated all the newly inserted strings~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Saving does not work in the edit in editor instructor interface.

This fixes the issue described in https://github.com/ls1intum/Artemis/issues/788 with approach 2:
Setting a dummy auth object.

### Description
<!-- Describe your changes in detail -->

I went through the `@MessageMapping` endpoints (except the activity tracker that doesn't use repositories) and added the dummy auth object to them. For more information see the linked issue.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration > Programming Exercise > Edit in Editor
3. Edit a file, click on save => Saving should happen after some seconds

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/28230611/64271675-075d7c80-cf3e-11e9-99e7-49785006a8cb.png)

