### PR TITLE
Tests/Replace manual onChanges calls with util method

### DIFF
--- a/src/test/javascript/spec/component/code-editor/code-editor-ace.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-ace.spec.ts
@@ -14,6 +14,7 @@ import { ArtemisTestModule } from '../../test.module';
 import { MockCodeEditorRepositoryFileService } from '../../mocks';
 import { CreateFileChange, FileType, RenameFileChange } from 'app/entities/ace-editor/file-change.model';
 import { AnnotationArray } from 'app/entities/ace-editor';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -86,13 +87,10 @@ describe('CodeEditorAceComponent', () => {
         const loadFileSubject = new Subject();
         const initEditorAfterFileChangeSpy = spy(comp, 'initEditorAfterFileChange');
         loadRepositoryFileStub.returns(loadFileSubject);
-
-        const changes: SimpleChanges = {
-            selectedFile: new SimpleChange(undefined, selectedFile, true),
-        };
         comp.selectedFile = selectedFile;
         comp.fileSession = fileSession;
-        comp.ngOnChanges(changes);
+
+        triggerChanges(comp, { property: 'selectedFile', currentValue: selectedFile });
         fixture.detectChanges();
 
         expect(comp.isLoading).to.be.true;
@@ -110,13 +108,10 @@ describe('CodeEditorAceComponent', () => {
         const fileSession = { [selectedFile]: { code: 'lorem ipsum', cursor: { column: 0, row: 0 } } };
         const initEditorAfterFileChangeSpy = spy(comp, 'initEditorAfterFileChange');
         const loadFileSpy = spy(comp, 'loadFile');
-
-        const changes: SimpleChanges = {
-            selectedFile: new SimpleChange(undefined, selectedFile, true),
-        };
         comp.selectedFile = selectedFile;
         comp.fileSession = fileSession;
-        comp.ngOnChanges(changes);
+
+        triggerChanges(comp, { property: 'selectedFile', currentValue: selectedFile });
         fixture.detectChanges();
 
         expect(initEditorAfterFileChangeSpy).to.have.been.calledOnceWithExactly();
@@ -128,14 +123,11 @@ describe('CodeEditorAceComponent', () => {
         const newFileName = 'newFilename';
         const fileChange = new RenameFileChange(FileType.FILE, selectedFile, newFileName);
         const fileSession = { [selectedFile]: { code: 'lorem ipsum', cursor: { column: 0, row: 0 } }, anotherFile: { code: 'lorem ipsum 2', cursor: { column: 0, row: 0 } } };
-
-        const changes: SimpleChanges = {
-            fileChange: new SimpleChange(undefined, fileChange, false),
-        };
         comp.selectedFile = newFileName;
         comp.fileSession = fileSession;
         comp.fileChange = fileChange;
-        comp.ngOnChanges(changes);
+
+        triggerChanges(comp, { property: 'fileChange', currentValue: fileChange, firstChange: false });
         fixture.detectChanges();
 
         expect(comp.fileSession).to.deep.equal({ anotherFile: fileSession.anotherFile, [fileChange.newFileName]: fileSession[selectedFile] });
@@ -146,14 +138,11 @@ describe('CodeEditorAceComponent', () => {
         const fileChange = new CreateFileChange(FileType.FILE, selectedFile);
         const fileSession = { anotherFile: { code: 'lorem ipsum 2', cursor: { column: 0, row: 0 } } };
         const initEditorAfterFileChangeSpy = spy(comp, 'initEditorAfterFileChange');
-
-        const changes: SimpleChanges = {
-            fileChange: new SimpleChange(undefined, fileChange, false),
-        };
         comp.selectedFile = selectedFile;
         comp.fileSession = fileSession;
         comp.fileChange = fileChange;
-        comp.ngOnChanges(changes);
+
+        triggerChanges(comp, { property: 'fileChange', currentValue: fileChange, firstChange: false });
         fixture.detectChanges();
 
         expect(initEditorAfterFileChangeSpy).to.have.been.calledOnceWithExactly();

--- a/src/test/javascript/spec/component/code-editor/code-editor-build-output.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-build-output.spec.ts
@@ -18,6 +18,7 @@ import { ResultService } from 'app/entities/result';
 import { Feedback } from 'app/entities/feedback';
 import { BuildLogEntryArray } from 'app/entities/build-log';
 import { AnnotationArray } from 'app/entities/ace-editor';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -108,10 +109,7 @@ describe('CodeEditorBuildOutputComponent', () => {
         loadSessionStub.returns({ errors: {}, timestamp: 0 });
 
         comp.participation = participation;
-        const changes: SimpleChanges = {
-            participation: new SimpleChange(undefined, participation, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
 
         expect(getFeedbackDetailsForResultStub).to.have.been.calledOnceWithExactly(result.id);
@@ -136,11 +134,7 @@ describe('CodeEditorBuildOutputComponent', () => {
         comp.participation = participation;
         subscribeForLatestResultOfParticipationStub.returns(Observable.of(null));
         getFeedbackDetailsForResultStub.returns(of({ ...result, feedbacks: [] }));
-        const changes: SimpleChanges = {
-            participation: new SimpleChange(undefined, participation, true),
-        };
-        comp.ngOnChanges(changes);
-        fixture.detectChanges();
+        triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
         expect(getFeedbackDetailsForResultStub).to.have.been.calledOnceWithExactly(result.id);
         expect(loadSessionStub).to.not.have.been.called;
@@ -164,10 +158,7 @@ describe('CodeEditorBuildOutputComponent', () => {
         subscribeForLatestResultOfParticipationStub.returns(Observable.of(null));
         getFeedbackDetailsForResultStub.returns(of({ body: [feedback] }));
 
-        const changes: SimpleChanges = {
-            participation: new SimpleChange(undefined, participation, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
 
         expect(getFeedbackDetailsForResultStub).to.have.been.calledOnceWithExactly(result.id);
@@ -219,10 +210,7 @@ describe('CodeEditorBuildOutputComponent', () => {
         subscribeForLatestResultOfParticipationStub.returns(of(result));
 
         comp.participation = participation;
-        const changes: SimpleChanges = {
-            participation: new SimpleChange(undefined, participation, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
 
         expect(getBuildLogsStub).to.have.been.calledOnceWithExactly();

--- a/src/test/javascript/spec/component/code-editor/code-editor-file-browser.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-file-browser.spec.ts
@@ -28,6 +28,7 @@ import {
 import { ArtemisTestModule } from '../../test.module';
 import { MockCodeEditorConflictStateService, MockCodeEditorRepositoryFileService, MockCodeEditorRepositoryService, MockCookieService, MockSyncStorage } from '../../mocks';
 import { FileType } from 'app/entities/ace-editor/file-change.model';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -99,10 +100,8 @@ describe('CodeEditorFileBrowserComponent', () => {
         getRepositoryContentStub.returns(Observable.of(repositoryContent));
         isCleanStub.returns(Observable.of({ repositoryStatus: CommitState.CLEAN }));
         comp.commitState = CommitState.UNDEFINED;
-        const changes: SimpleChanges = {
-            commitState: new SimpleChange(undefined, CommitState.UNDEFINED, true),
-        };
-        comp.ngOnChanges(changes);
+
+        triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
 
         expect(comp.isLoadingFiles).to.equal(false);
@@ -119,10 +118,8 @@ describe('CodeEditorFileBrowserComponent', () => {
         getRepositoryContentStub.returns(Observable.of(repositoryContent));
         isCleanStub.returns(Observable.of({ repositoryStatus: CommitState.CLEAN }));
         comp.commitState = CommitState.UNDEFINED;
-        const changes: SimpleChanges = {
-            commitState: new SimpleChange(undefined, CommitState.UNDEFINED, true),
-        };
-        comp.ngOnChanges(changes);
+
+        triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
         expect(comp.isLoadingFiles).to.equal(false);
         expect(comp.repositoryFiles).to.deep.equal(repositoryContent);
@@ -244,10 +241,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         getRepositoryContentStub.returns(Observable.of(repositoryContent));
         isCleanStub.returns(Observable.of({ repositoryStatus: CommitState.CLEAN }));
         comp.commitState = CommitState.UNDEFINED;
-        const changes: SimpleChanges = {
-            commitState: new SimpleChange(undefined, CommitState.UNDEFINED, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
         expect(comp.isLoadingFiles).to.equal(false);
         expect(comp.repositoryFiles).to.deep.equal(allowedFiles);
@@ -264,10 +258,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         const loadFilesSpy = spy(comp, 'loadFiles');
         isCleanStub.returns(isCleanSubject);
         comp.commitState = CommitState.UNDEFINED;
-        const changes: SimpleChanges = {
-            commitState: new SimpleChange(undefined, CommitState.UNDEFINED, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
         expect(comp.isLoadingFiles).to.equal(true);
         expect(comp.commitState).to.equal(CommitState.UNDEFINED);
@@ -293,10 +284,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         isCleanStub.returns(isCleanSubject);
         getRepositoryContentStub.returns(getRepositoryContentSubject);
         comp.commitState = CommitState.UNDEFINED;
-        const changes: SimpleChanges = {
-            commitState: new SimpleChange(undefined, CommitState.UNDEFINED, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
         expect(comp.isLoadingFiles).to.equal(true);
         expect(comp.commitState).to.equal(CommitState.UNDEFINED);
@@ -341,10 +329,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         comp.filesTreeViewItem = treeItems;
         comp.repositoryFiles = repositoryFiles;
         comp.selectedFile = selectedFile;
-        const changes: SimpleChanges = {
-            selectedFile: new SimpleChange(undefined, 'folder/file2', false),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'selectedFile', currentValue: 'folder/file2', firstChange: false });
         fixture.detectChanges();
         expect(comp.selectedFile).to.equal(selectedFile);
         const selectedTreeItem = comp.filesTreeViewItem.find(({ value }) => value === 'folder').children.find(({ value }) => value === selectedFile);
@@ -715,10 +700,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         getRepositoryContentStub.returns(Observable.of(repositoryContent));
         comp.commitState = CommitState.UNDEFINED;
 
-        let changes: SimpleChanges = {
-            commitState: new SimpleChange(undefined, CommitState.UNDEFINED, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
 
         expect(comp.commitState).to.equal(CommitState.CONFLICT);
@@ -733,10 +715,7 @@ describe('CodeEditorFileBrowserComponent', () => {
 
         comp.commitState = CommitState.UNDEFINED;
 
-        changes = {
-            commitState: new SimpleChange(undefined, CommitState.UNDEFINED, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
 
         expect(comp.commitState).to.equal(CommitState.CLEAN);

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.spec.ts
@@ -23,6 +23,7 @@ import {
     ProgrammingExerciseEditableInstructionComponent,
     ProgrammingExerciseInstructionAnalysisComponent,
 } from 'app/entities/programming-exercise/instructions/instructions-editor';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -78,10 +79,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         comp.exercise = exercise;
         comp.participation = participation;
 
-        const changes: SimpleChanges = {
-            exercise: new SimpleChange(undefined, exercise, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'exercise', currentValue: exercise });
         fixture.detectChanges();
         tick();
 
@@ -96,10 +94,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         comp.exercise = exercise;
         comp.participation = participation;
 
-        const changes: SimpleChanges = {
-            exercise: new SimpleChange(undefined, exercise, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'exercise', currentValue: exercise });
 
         (testCaseService as MockProgrammingExerciseTestCaseService).next(testCases);
 
@@ -118,10 +113,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         comp.exercise = exercise;
         comp.participation = participation;
 
-        const changes: SimpleChanges = {
-            exercise: new SimpleChange(undefined, exercise, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'exercise', currentValue: exercise });
 
         (testCaseService as MockProgrammingExerciseTestCaseService).next(testCases);
 
@@ -149,10 +141,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         const subject = new Subject<Result>();
         getLatestResultWithFeedbacksStub.returns(subject);
 
-        const changes: SimpleChanges = {
-            exercise: new SimpleChange(undefined, exercise, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'exercise', currentValue: exercise });
 
         // No test cases available, might be that the solution build never ran to create tests...
         (testCaseService as MockProgrammingExerciseTestCaseService).next(null);
@@ -177,10 +166,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         comp.participation = participation;
         comp.editMode = false;
 
-        const changes: SimpleChanges = {
-            exercise: new SimpleChange(undefined, exercise, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'exercise', currentValue: exercise });
 
         fixture.detectChanges();
         tick();
@@ -203,10 +189,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         comp.exercise = exercise;
         comp.participation = participation;
 
-        const changes: SimpleChanges = {
-            exercise: new SimpleChange(undefined, exercise, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'exercise', currentValue: exercise });
 
         fixture.detectChanges();
         tick();

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction-analysis.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction-analysis.spec.ts
@@ -14,6 +14,7 @@ import { ExerciseHint } from 'app/entities/exercise-hint/exercise-hint.model';
 import { TaskCommand } from 'app/markdown-editor/domainCommands/programming-exercise/task.command';
 import { ExerciseHintService, IExerciseHintService } from 'app/entities/exercise-hint';
 import { HttpResponse } from '@angular/common/http';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -88,10 +89,7 @@ describe('ProgrammingExerciseInstructionInstructorAnalysis', () => {
 
             comp.ngOnInit();
 
-            const changes: SimpleChanges = {
-                problemStatement: new SimpleChange('dolet amat', problemStatement, false),
-            };
-            comp.ngOnChanges(changes);
+            triggerChanges(comp, { property: 'problemStatement', currentValue: problemStatement, previousValue: 'dolet amat', firstChange: false });
             tick(500); // Update is debounced, otherwise we would send updates on every change.
             fixture.detectChanges();
 
@@ -146,8 +144,7 @@ describe('ProgrammingExerciseInstructionInstructorAnalysis', () => {
         it('should not render if no test cases were provided', () => {
             comp.problemStatement = problemStatement;
             comp.taskRegex = taskRegex;
-            const changes = { problemStatement: new SimpleChange(undefined, problemStatement, true) };
-            comp.ngOnChanges(changes);
+            triggerChanges(comp, { property: 'problemStatement', currentValue: problemStatement });
             fixture.detectChanges();
 
             expect(debugElement.nativeElement.innerHtml).to.be.undefined;
@@ -161,8 +158,13 @@ describe('ProgrammingExerciseInstructionInstructorAnalysis', () => {
             comp.exerciseTestCases = exerciseTestCases;
             comp.exerciseHints = exerciseHints;
             comp.ngOnInit();
-            const changes = { problemStatement: new SimpleChange(undefined, problemStatement, false), exerciseTestCases: new SimpleChange(undefined, exerciseTestCases, false) };
-            comp.ngOnChanges(changes);
+
+            triggerChanges(
+                comp,
+                { property: 'problemStatement', currentValue: problemStatement, firstChange: false },
+                { property: 'exerciseTestCases', currentValue: exerciseTestCases },
+            );
+
             fixture.detectChanges();
             tick(500);
 

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction-step-wizard.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction-step-wizard.spec.ts
@@ -12,6 +12,7 @@ import { ArtemisTestModule } from '../../test.module';
 import { ArtemisSharedModule } from 'src/main/webapp/app/shared';
 import { ProgrammingExerciseInstructionStepWizardComponent } from 'app/entities/programming-exercise/instructions/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.component';
 import { ProgrammingExerciseInstructionService } from 'app/entities/programming-exercise/instructions/instructions-render/service/programming-exercise-instruction.service';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -54,13 +55,10 @@ describe('ProgrammingExerciseInstructionStepWizard', () => {
             { completeString: '[task][Implement BubbleSort](testBubbleSort)', taskName: 'Implement BubbleSort', tests: ['testBubbleSort'] },
             { completeString: '[task][Implement MergeSort](testMergeSort)', taskName: 'Implement MergeSort', tests: ['testMergeSort'] },
         ];
-        const changes: SimpleChanges = {
-            tasks: new SimpleChange(undefined, tasks, true),
-            latestResult: new SimpleChange(undefined, result, true),
-        };
         comp.latestResult = result;
         comp.tasks = tasks;
-        comp.ngOnChanges(changes);
+
+        triggerChanges(comp, { property: 'tasks', currentValue: tasks }, { property: 'latestResult', currentValue: result });
         fixture.detectChanges();
 
         const steps = debugElement.queryAll(By.css(stepWizardStep));
@@ -78,13 +76,10 @@ describe('ProgrammingExerciseInstructionStepWizard', () => {
             completionDate: moment('2019-01-06T22:15:29.203+02:00'),
             feedbacks: [{ text: 'testBubbleSort', detail_text: 'lorem ipsum' }],
         } as any;
-        const changes: SimpleChanges = {
-            tasks: new SimpleChange(undefined, [], true),
-            latestResult: new SimpleChange(undefined, result, true),
-        };
         comp.latestResult = result;
         comp.tasks = [];
-        comp.ngOnChanges(changes);
+
+        triggerChanges(comp, { property: 'tasks', currentValue: [] }, { property: 'latestResult', currentValue: result });
         fixture.detectChanges();
 
         const steps = debugElement.queryAll(By.css(stepWizardStep));

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-status.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-status.spec.ts
@@ -15,6 +15,7 @@ import { SinonStub, stub } from 'sinon';
 import { Result } from 'app/entities/result';
 import { ParticipationWebsocketService } from 'app/entities/participation';
 import { ProgrammingExerciseInstructorStatusComponent } from 'app/entities/programming-exercise/status';
+import { triggerChanges } from '../../utils/general.utils';
 
 const expect = chai.expect;
 
@@ -91,12 +92,10 @@ describe('ProgrammingExerciseInstructorStatusComponent', () => {
         comp.participationType = ParticipationType.TEMPLATE;
         comp.participation = { id: 1, results: [latestResult, { id: 2, successful: false, score: 99 }] };
         comp.exercise = { id: 99 };
-        const changes: SimpleChanges = {
-            participationType: new SimpleChange(undefined, comp.participationType, true),
-            participation: new SimpleChange(undefined, comp.participation, true),
-        };
-        comp.ngOnChanges(changes);
+
+        triggerChanges(comp, { property: 'participationType', currentValue: comp.participationType }, { property: 'participation', currentValue: comp.participation });
         fixture.detectChanges();
+
         expect(comp.latestResult).to.deep.equal(latestResult);
         const templateStatus = fixture.debugElement.query(By.css('#instructor-status-template'));
         expect(templateStatus).to.not.exist;
@@ -109,11 +108,11 @@ describe('ProgrammingExerciseInstructorStatusComponent', () => {
         comp.participationType = ParticipationType.SOLUTION;
         comp.participation = { id: 1, results: [{ id: 2, successful: false, score: 99 }, latestResult] };
         comp.exercise = { id: 99 };
-        const changes: SimpleChanges = {
-            participationType: new SimpleChange(undefined, comp.participationType, false),
-            participation: new SimpleChange(undefined, comp.participation, false),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(
+            comp,
+            { property: 'participationType', currentValue: comp.participationType, firstChange: false },
+            { property: 'participation', currentValue: comp.participationType, firstChange: false },
+        );
         fixture.detectChanges();
         expect(comp.latestResult).to.deep.equal(latestResult);
         const templateStatus = fixture.debugElement.query(By.css('#instructor-status-template'));
@@ -127,12 +126,14 @@ describe('ProgrammingExerciseInstructorStatusComponent', () => {
         comp.participationType = ParticipationType.TEMPLATE;
         comp.participation = { id: 1, results: [latestResult, { id: 2, successful: false, score: 99 }] };
         comp.exercise = { id: 99 };
-        const changes: SimpleChanges = {
-            participationType: new SimpleChange(undefined, comp.participationType, false),
-            participation: new SimpleChange(undefined, comp.participation, false),
-        };
-        comp.ngOnChanges(changes);
+
+        triggerChanges(
+            comp,
+            { property: 'participationType', currentValue: comp.participationType, firstChange: false },
+            { property: 'participation', currentValue: comp.participationType, firstChange: false },
+        );
         fixture.detectChanges();
+
         expect(comp.latestResult).to.deep.equal(latestResult);
         const templateStatus = fixture.debugElement.query(By.css('#instructor-status-template'));
         expect(templateStatus).to.exist;
@@ -145,12 +146,14 @@ describe('ProgrammingExerciseInstructorStatusComponent', () => {
         comp.participationType = ParticipationType.SOLUTION;
         comp.participation = { id: 1, results: [{ id: 2, successful: false, score: 99 }, latestResult] };
         comp.exercise = { id: 99 };
-        const changes: SimpleChanges = {
-            participationType: new SimpleChange(undefined, comp.participationType, true),
-            participation: new SimpleChange(undefined, comp.participation, true),
-        };
-        comp.ngOnChanges(changes);
+
+        triggerChanges(
+            comp,
+            { property: 'participationType', currentValue: comp.participationType, firstChange: false },
+            { property: 'participation', currentValue: comp.participationType, firstChange: false },
+        );
         fixture.detectChanges();
+
         expect(comp.latestResult).to.deep.equal(latestResult);
         const templateStatus = fixture.debugElement.query(By.css('#instructor-status-template'));
         expect(templateStatus).to.not.exist;
@@ -164,11 +167,12 @@ describe('ProgrammingExerciseInstructorStatusComponent', () => {
         comp.participationType = ParticipationType.TEMPLATE;
         comp.participation = { id: 1, results: [latestResult, { id: 2, successful: false, score: 99 }] };
         comp.exercise = { id: 99 };
-        const changes: SimpleChanges = {
-            participationType: new SimpleChange(undefined, comp.participationType, false),
-            participation: new SimpleChange(undefined, comp.participation, false),
-        };
-        comp.ngOnChanges(changes);
+
+        triggerChanges(
+            comp,
+            { property: 'participationType', currentValue: comp.participationType, firstChange: false },
+            { property: 'participation', currentValue: comp.participationType, firstChange: false },
+        );
         latestResultSubject.next(newResult);
 
         expect(comp.latestResult).to.deep.equal(newResult);

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-submission-state.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-submission-state.spec.ts
@@ -15,6 +15,7 @@ import { Exercise } from 'app/entities/exercise';
 import { ExerciseSubmissionState, ProgrammingSubmissionService, ProgrammingSubmissionState } from 'app/programming-submission/programming-submission.service';
 import { ArtemisProgrammingExerciseActionsModule } from 'app/entities/programming-exercise/actions/programming-exercise-actions.module';
 import { ProgrammmingExerciseInstructorSubmissionStateComponent } from 'app/entities/programming-exercise/actions/programmming-exercise-instructor-submission-state.component';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -93,11 +94,8 @@ describe('ProgrammingExerciseInstructorSubmissionState', () => {
         } as ExerciseSubmissionState;
         const compressedSummary = { [ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION]: 2 };
         comp.exerciseId = exercise.id;
-        const changes: SimpleChanges = {
-            exerciseId: new SimpleChange(undefined, comp.exerciseId, true),
-        };
-        comp.ngOnChanges(changes);
 
+        triggerChanges(comp, { property: 'exerciseId', currentValue: comp.exerciseId });
         getExerciseSubmissionStateSubject.next(noPendingSubmissionState);
 
         // Wait for a second as the view is updated with a debounce.
@@ -125,11 +123,8 @@ describe('ProgrammingExerciseInstructorSubmissionState', () => {
         } as ExerciseSubmissionState;
         const compressedSummary = { [ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION]: 1, [ProgrammingSubmissionState.HAS_FAILED_SUBMISSION]: 1 };
         comp.exerciseId = exercise.id;
-        const changes: SimpleChanges = {
-            exerciseId: new SimpleChange(undefined, comp.exerciseId, true),
-        };
-        comp.ngOnChanges(changes);
 
+        triggerChanges(comp, { property: 'exerciseId', currentValue: comp.exerciseId });
         getExerciseSubmissionStateSubject.next(noPendingSubmissionState);
 
         // Wait for a second as the view is updated with a debounce.

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-build-button.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-build-button.spec.ts
@@ -21,6 +21,7 @@ import { Exercise } from 'app/entities/exercise';
 import { ProgrammingSubmissionService, ProgrammingSubmissionState, ProgrammingSubmissionStateObj } from 'app/programming-submission/programming-submission.service';
 import { ArtemisProgrammingExerciseActionsModule } from 'app/entities/programming-exercise/actions/programming-exercise-actions.module';
 import { ProgrammingExerciseStudentTriggerBuildButtonComponent } from 'app/entities/programming-exercise/actions';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -88,11 +89,8 @@ describe('TriggerBuildButtonSpec', () => {
     it('should not show the trigger button if there is no pending submission and no build is running', () => {
         comp.participation = { ...participation, results: [gradedResult1], initializationState: InitializationState.INITIALIZED };
         comp.exercise = { id: 4 };
-        const changes: SimpleChanges = {
-            participation: new SimpleChange(undefined, comp.participation, true),
-        };
-        comp.ngOnChanges(changes);
 
+        triggerChanges(comp, { property: 'participation', currentValue: comp.participation });
         fixture.detectChanges();
 
         // Button should not show if there is no failed submission.
@@ -110,13 +108,9 @@ describe('TriggerBuildButtonSpec', () => {
     it('should be enabled and trigger the build on click if it is provided with a participation including results', () => {
         comp.participation = { ...participation, results: [gradedResult1], initializationState: InitializationState.INITIALIZED };
         comp.exercise = { id: 5 };
-        const changes: SimpleChanges = {
-            participation: new SimpleChange(undefined, comp.participation, true),
-        };
-        comp.ngOnChanges(changes);
 
+        triggerChanges(comp, { property: 'participation', currentValue: comp.participation });
         getLatestPendingSubmissionSubject.next({ submissionState: ProgrammingSubmissionState.HAS_FAILED_SUBMISSION, submission: null, participationId: comp.participation.id });
-
         fixture.detectChanges();
 
         let triggerButton = getTriggerButton();

--- a/src/test/javascript/spec/component/shared/secured-image.spec.ts
+++ b/src/test/javascript/spec/component/shared/secured-image.spec.ts
@@ -10,6 +10,7 @@ import { ArtemisTestModule } from '../../test.module';
 import { ResultComponent, UpdatingResultComponent } from 'app/entities/result';
 import { ArtemisSharedModule, CacheableImageService, CachingStrategy, ImageLoadingStatus, SecuredImageComponent } from 'app/shared';
 import { MockCacheableImageService } from '../../mocks/mock-cacheable-image.service';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -68,7 +69,7 @@ describe('SecuredImageComponent', () => {
 
         // @ts-ignore
         comp.src = src;
-        comp.ngOnChanges();
+        triggerChanges(comp);
 
         fixture.detectChanges();
 
@@ -84,7 +85,7 @@ describe('SecuredImageComponent', () => {
 
         // @ts-ignore
         comp.src = src;
-        comp.ngOnChanges();
+        triggerChanges(comp);
 
         fixture.detectChanges();
 
@@ -100,7 +101,7 @@ describe('SecuredImageComponent', () => {
 
         // @ts-ignore
         comp.src = src;
-        comp.ngOnChanges();
+        triggerChanges(comp);
 
         fixture.detectChanges();
 
@@ -115,7 +116,7 @@ describe('SecuredImageComponent', () => {
 
         // @ts-ignore
         comp.src = src;
-        comp.ngOnChanges();
+        triggerChanges(comp);
 
         fixture.detectChanges();
 

--- a/src/test/javascript/spec/component/shared/updating-result.spec.ts
+++ b/src/test/javascript/spec/component/shared/updating-result.spec.ts
@@ -19,6 +19,7 @@ import { MockAccountService } from '../../mocks/mock-account.service';
 import { Exercise, ExerciseType } from 'app/entities/exercise';
 import { ProgrammingSubmissionState, ProgrammingSubmissionService } from 'app/programming-submission/programming-submission.service';
 import { MockProgrammingSubmissionService } from '../../mocks/mock-programming-submission.service';
+import { triggerChanges } from '../../utils/general.utils';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -92,28 +93,19 @@ describe('UpdatingResultComponent', () => {
 
     const cleanInitializeGraded = (participation = initialParticipation) => {
         comp.participation = participation;
-        const changes: SimpleChanges = {
-            participation: new SimpleChange(undefined, participation, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
     };
 
     const cleanInitializeUngraded = (participation = initialParticipation) => {
         comp.participation = participation;
         comp.showUngradedResults = true;
-        const changes: SimpleChanges = {
-            participation: new SimpleChange(undefined, participation, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
     };
 
     it('should not try to subscribe for new results if no participation is provided', () => {
-        const changes: SimpleChanges = {
-            participation: new SimpleChange(undefined, undefined, true),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'participation', currentValue: undefined, firstChange: true });
         fixture.detectChanges();
 
         expect(subscribeForLatestResultOfParticipationStub).to.not.have.been.called;

--- a/src/test/javascript/spec/component/table/table-editable-field.spec.ts
+++ b/src/test/javascript/spec/component/table/table-editable-field.spec.ts
@@ -6,6 +6,7 @@ import * as chai from 'chai';
 import { ArtemisTestModule } from '../../test.module';
 import { ArtemisTableModule } from 'app/components/table/table.module';
 import { TableEditableFieldComponent } from 'app/components/table';
+import { triggerChanges } from '../../utils/general.utils';
 
 const expect = chai.expect;
 
@@ -54,10 +55,7 @@ describe('TableEditableFieldComponent', () => {
         comp.onValueUpdate = fakeUpdateValue;
         comp.isEditing = true;
 
-        const changes: SimpleChanges = {
-            isEditing: new SimpleChange(false, true, false),
-        };
-        comp.ngOnChanges(changes);
+        triggerChanges(comp, { property: 'isEditing', currentValue: true, previousValue: false, firstChange: false });
         fixture.detectChanges();
         tick();
         fixture.detectChanges();

--- a/src/test/javascript/spec/utils/general.utils.ts
+++ b/src/test/javascript/spec/utils/general.utils.ts
@@ -1,4 +1,4 @@
-import { DebugElement } from '@angular/core';
+import { DebugElement, OnChanges, SimpleChanges, SimpleChange } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import * as chai from 'chai';
 
@@ -7,4 +7,16 @@ const expect = chai.expect;
 export const getFocusedElement = (debugElement: DebugElement) => {
     const focusedElement = debugElement.query(By.css(':focus')).nativeElement;
     expect(focusedElement).to.deep.equal(debugElement.nativeElement);
+};
+
+/**
+ * Construct a changes obj and trigger ngOnChanges of the provided comp.
+ * @param comp Angular Component that implements OnChanges
+ * @param changes object with data needed to construct SimpleChange objects.
+ */
+export const triggerChanges = (comp: OnChanges, ...changes: Array<{ property: string; currentValue: any; previousValue?: any; firstChange?: boolean }>) => {
+    const simpleChanges: SimpleChanges = changes.reduce((acc, { property, currentValue, previousValue, firstChange = true }) => {
+        return { ...acc, [property]: new SimpleChange(previousValue, currentValue, firstChange) };
+    }, {});
+    comp.ngOnChanges(simpleChanges);
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Description
<!-- Describe your changes in detail -->

In many tests we call `onChanges` manually. This is always a bit more effort, because the SimpleChange(s) types need to be imported and the objects need to be constructed.

The new util `triggerChanges` can do this in one line without additional imports.
