### PR TITLE
Bugfix/programming exercises/Allow due date in past

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/form/programming-exercise-due-date-select.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/form/programming-exercise-due-date-select.component.ts
@@ -14,7 +14,6 @@ import { hasExerciseChanged } from 'app/entities/exercise';
         <jhi-date-time-picker
             labelName="{{ 'artemisApp.exercise.dueDate' | translate }}"
             [ngModel]="exercise.dueDate"
-            [min]="TODAY"
             (ngModelChange)="updateDueDate($event)"
             name="dueDate"
         ></jhi-date-time-picker>

--- a/src/main/webapp/app/entities/programming-exercise/form/programming-exercise-due-date-select.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/form/programming-exercise-due-date-select.component.ts
@@ -57,8 +57,6 @@ import { hasExerciseChanged } from 'app/entities/exercise';
     `,
 })
 export class ProgrammingExerciseDueDateSelectComponent implements OnChanges {
-    TODAY = moment();
-
     @Input() exercise: ProgrammingExercise;
     @Output() onProgrammingExerciseUpdate = new EventEmitter<ProgrammingExercise>();
     // true => Form is valid.


### PR DESCRIPTION
### Description

Regression from https://github.com/ls1intum/Artemis/pull/798.

I changed the due date select in the programming exercise forms to only offer dates after the current date. This setting has the side-effect that you won't be able to save programming exercises once their due date has passed.
I removed the filter from the datepicker.