### PR TITLE
Bugfix/Code-Editor/Fix 0 height issue in Safari

### DIFF
--- a/src/main/webapp/app/code-editor/ace/code-editor-ace.component.html
+++ b/src/main/webapp/app/code-editor/ace/code-editor-ace.component.html
@@ -20,7 +20,12 @@
             class="code-editor-ace__content__editor"
         >
         </ace-editor>
-        <p *ngIf="!selectedFile && !isLoading" id="no-file-selected" class="text-center lead text-muted pt-5" jhiTranslate="artemisApp.editor.selectFile">
+        <p
+            *ngIf="!selectedFile && !isLoading"
+            id="no-file-selected"
+            class="code-editor-ace__content__no-selected text-center lead text-muted pt-5"
+            jhiTranslate="artemisApp.editor.selectFile"
+        >
             Select a file to get started!
         </p>
     </div>

--- a/src/main/webapp/app/code-editor/ace/code-editor-ace.scss
+++ b/src/main/webapp/app/code-editor/ace/code-editor-ace.scss
@@ -4,11 +4,17 @@ Ace Editor
 
 .code-editor-ace {
     flex: 1 1 auto;
-    height: 100%;
+    display: flex;
     &__content {
         padding: 0;
+        display: flex;
+        flex: 1 1 auto;
         &__editor {
-            height: 100%;
+            flex: 1 1 auto;
+        }
+        &__no-selected {
+            justify-self: center;
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

https://github.com/ls1intum/Artemis/issues/797

New approach to solving the issue: Use flex containers analogous to the other uses of the markdown editor (e.g. in the creation forms).
Thanks for help to @krusche!