### PR TITLE
Tests/improve timed test case for programming exercise schedule

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/service/ProgrammingExerciseScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ProgrammingExerciseScheduleServiceTest.java
@@ -47,7 +47,7 @@ class ProgrammingExerciseScheduleServiceTest {
 
     // When the scheduler is invoked, there is a small delay until the runnable is called.
     // TODO: This could be improved by e.g. manually setting the system time instead of waiting for actual time to pass.
-    private final long SCHEDULER_TASK_TRIGGER_DELAY_MS = 10;
+    private final long SCHEDULER_TASK_TRIGGER_DELAY_MS = 100;
 
     @BeforeEach
     void init() {


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

I noticed that sometimes a test fails in the programming exercise scheduler tests because of a timing issue. I think the accepted delay due to the programming executing the code was too small with 10ms, so I changed it to 100ms which should be enough.
If this kind of issue comes up more often, we could think about implementing a service that actually changes the time instead of sleeping.