### PR TITLE
Bugfix: TransientObjectException when submitting a modeling assessment

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -57,8 +57,14 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
     @Query("select r from Result r left join fetch r.feedbacks left join fetch r.assessor where r.id = :resultId")
     Optional<Result> findByIdWithEagerFeedbacksAndAssessor(@Param("resultId") Long id);
 
-    @Query("select r from Result r left join fetch r.submission left join fetch r.feedbacks left join fetch r.assessor where r.id = :resultId")
-    Optional<Result> findByIdWithEagerSubmissionAndFeedbacksAndAssessor(@Param("resultId") Long id);
+    /**
+     * Load a result from the database by its id together with the associated submission, the list of feedback items and the assessor.
+     *
+     * @param resultId the id of the result to load from the database
+     * @return an optional containing the result with submission, feedback list and assessor, or an empty optional if no result could be found for the given id
+     */
+    @EntityGraph(attributePaths = { "submission", "feedbacks", "assessor" })
+    Optional<Result> findWithEagerSubmissionAndFeedbackAndAssessorById(Long resultId);
 
     /**
      * This SQL query is used for inserting results if only one unrated result should exist per participation. This prevents multiple (concurrent) inserts with the same

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelAssessmentConflictService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelAssessmentConflictService.java
@@ -109,9 +109,9 @@ public class ModelAssessmentConflictService {
     private void loadSubmissionsAndFeedbacksAndAssessorOfConflictingResults(List<ModelAssessmentConflict> conflicts) {
         conflicts.forEach(conflict -> {
             conflict.getCausingConflictingResult()
-                    .setResult(resultRepository.findByIdWithEagerSubmissionAndFeedbacksAndAssessor(conflict.getCausingConflictingResult().getResult().getId()).get());
+                    .setResult(resultRepository.findWithEagerSubmissionAndFeedbackAndAssessorById(conflict.getCausingConflictingResult().getResult().getId()).get());
             conflict.getResultsInConflict().forEach(conflictingResult -> conflictingResult
-                    .setResult(resultRepository.findByIdWithEagerSubmissionAndFeedbacksAndAssessor(conflictingResult.getResult().getId()).get()));
+                    .setResult(resultRepository.findWithEagerSubmissionAndFeedbackAndAssessorById(conflictingResult.getResult().getId()).get()));
         });
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
@@ -47,23 +47,23 @@ public class ModelingAssessmentService extends AssessmentService {
     }
 
     /**
-     * This function is used for submitting a manual assessment/result. It updates the completion date, sets the assessment type to MANUAL and sets the assessor attribute.
-     * Furthermore, it saves the result in the database.
+     * This function is used for submitting a manual assessment/result. It gets the result that belongs to the submission of the given submissionId, updates the completion date,
+     * sets the assessment type to MANUAL and sets the assessor attribute and saves the result in the database.
      *
-     * @param result   the result the assessment belongs to
+     * @param submissionId the id of the submission for which the result should be submitted
      * @param exercise the exercise the assessment belongs to
      * @param submissionDate the date manual assessment was submitted
      * @return the ResponseEntity with result as body
      */
     @Transactional
-    public Result submitManualAssessment(Result result, ModelingExercise exercise, ZonedDateTime submissionDate) {
+    public Result submitManualAssessment(long submissionId, ModelingExercise exercise, ZonedDateTime submissionDate) {
         // TODO CZ: use AssessmentService#submitResult() function instead
+        Result result = resultRepository.findDistinctBySubmissionId(submissionId).orElseThrow(() -> new EntityNotFoundException("No result for given submissionId could be found"));
         result.setRatedIfNotExceeded(exercise.getDueDate(), submissionDate);
         result.setCompletionDate(ZonedDateTime.now());
-        result.evaluateFeedback(exercise.getMaxScore()); // TODO CZ: move to AssessmentService class, as it's the same for
-        // modeling and text exercises (i.e. total score is sum of feedback credits)
-        resultRepository.save(result);
-        return result;
+        result.evaluateFeedback(exercise.getMaxScore()); // TODO CZ: move to AssessmentService class, as it's the same for modeling and text exercises (i.e. total score is sum of
+        // feedback credits)
+        return resultRepository.save(result);
     }
 
     /**
@@ -101,8 +101,7 @@ public class ModelingAssessmentService extends AssessmentService {
             modelingSubmission.setResult(result);
             modelingSubmissionRepository.save(modelingSubmission);
         }
-        // Note: This also saves the feedback objects in the database because of the 'cascade =
-        // CascadeType.ALL' option.
+        // Note: This also saves the feedback objects in the database because of the 'cascade = CascadeType.ALL' option.
         return resultRepository.save(result);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
@@ -59,7 +59,7 @@ public class ModelingAssessmentService extends AssessmentService {
     public Result submitManualAssessment(long resultId, ModelingExercise exercise, ZonedDateTime submissionDate) {
         // TODO CZ: use AssessmentService#submitResult() function instead
         Result result = resultRepository.findWithEagerSubmissionAndFeedbackAndAssessorById(resultId)
-            .orElseThrow(() -> new EntityNotFoundException("No result for the given resultId could be found"));
+                .orElseThrow(() -> new EntityNotFoundException("No result for the given resultId could be found"));
         result.setRatedIfNotExceeded(exercise.getDueDate(), submissionDate);
         result.setCompletionDate(ZonedDateTime.now());
         result.evaluateFeedback(exercise.getMaxScore()); // TODO CZ: move to AssessmentService class, as it's the same for modeling and text exercises (i.e. total score is sum of

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingAssessmentService.java
@@ -47,18 +47,19 @@ public class ModelingAssessmentService extends AssessmentService {
     }
 
     /**
-     * This function is used for submitting a manual assessment/result. It gets the result that belongs to the submission of the given submissionId, updates the completion date,
-     * sets the assessment type to MANUAL and sets the assessor attribute and saves the result in the database.
+     * This function is used for submitting a manual assessment/result. It gets the result that belongs to the given resultId, updates the completion date, sets the assessment type
+     * to MANUAL and sets the assessor attribute. Afterwards, it saves the update result in the database again.
      *
-     * @param submissionId the id of the submission for which the result should be submitted
+     * @param resultId the id of the result that should be submitted
      * @param exercise the exercise the assessment belongs to
      * @param submissionDate the date manual assessment was submitted
      * @return the ResponseEntity with result as body
      */
     @Transactional
-    public Result submitManualAssessment(long submissionId, ModelingExercise exercise, ZonedDateTime submissionDate) {
+    public Result submitManualAssessment(long resultId, ModelingExercise exercise, ZonedDateTime submissionDate) {
         // TODO CZ: use AssessmentService#submitResult() function instead
-        Result result = resultRepository.findDistinctBySubmissionId(submissionId).orElseThrow(() -> new EntityNotFoundException("No result for given submissionId could be found"));
+        Result result = resultRepository.findWithEagerSubmissionAndFeedbackAndAssessorById(resultId)
+            .orElseThrow(() -> new EntityNotFoundException("No result for the given resultId could be found"));
         result.setRatedIfNotExceeded(exercise.getDueDate(), submissionDate);
         result.setCompletionDate(ZonedDateTime.now());
         result.evaluateFeedback(exercise.getMaxScore()); // TODO CZ: move to AssessmentService class, as it's the same for modeling and text exercises (i.e. total score is sum of

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
@@ -219,7 +219,7 @@ public class ModelingAssessmentResource extends AssessmentResource {
             // return ResponseEntity.status(HttpStatus.CONFLICT).body(conflicts);
             // }
             // else {
-            modelingAssessmentService.submitManualAssessment(modelingSubmission.getId(), modelingExercise, modelingSubmission.getSubmissionDate());
+            result = modelingAssessmentService.submitManualAssessment(result.getId(), modelingExercise, modelingSubmission.getSubmissionDate());
             if (compassService.isSupported(modelingExercise.getDiagramType())) {
                 compassService.addAssessment(exerciseId, submissionId, result.getFeedbacks());
             }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
@@ -219,7 +219,7 @@ public class ModelingAssessmentResource extends AssessmentResource {
             // return ResponseEntity.status(HttpStatus.CONFLICT).body(conflicts);
             // }
             // else {
-            modelingAssessmentService.submitManualAssessment(result, modelingExercise, modelingSubmission.getSubmissionDate());
+            modelingAssessmentService.submitManualAssessment(modelingSubmission.getId(), modelingExercise, modelingSubmission.getSubmissionDate());
             if (compassService.isSupported(modelingExercise.getDiagramType())) {
                 compassService.addAssessment(exerciseId, submissionId, result.getFeedbacks());
             }

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -585,6 +585,7 @@ public class DatabaseUtilService {
         Result result = modelingAssessmentService.saveManualAssessment(submission, assessment, exercise);
         result.setParticipation(submission.getParticipation().results(null));
         result.setAssessor(getUserByLogin(login));
+        resultRepo.save(result);
         if (submit) {
             result = modelingAssessmentService.submitManualAssessment(submission.getId(), exercise, submission.getSubmissionDate());
         }

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -586,7 +586,7 @@ public class DatabaseUtilService {
         result.setParticipation(submission.getParticipation().results(null));
         result.setAssessor(getUserByLogin(login));
         if (submit) {
-            result = modelingAssessmentService.submitManualAssessment(result, exercise, submission.getSubmissionDate());
+            result = modelingAssessmentService.submitManualAssessment(submission.getId(), exercise, submission.getSubmissionDate());
         }
         return result;
     }

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -587,9 +587,9 @@ public class DatabaseUtilService {
         result.setAssessor(getUserByLogin(login));
         resultRepo.save(result);
         if (submit) {
-            modelingAssessmentService.submitManualAssessment(submission.getId(), exercise, submission.getSubmissionDate());
+            modelingAssessmentService.submitManualAssessment(result.getId(), exercise, submission.getSubmissionDate());
         }
-        return resultRepo.findByIdWithEagerSubmissionAndFeedbacksAndAssessor(result.getId()).get();
+        return resultRepo.findWithEagerSubmissionAndFeedbackAndAssessorById(result.getId()).get();
     }
 
     public ExampleSubmission addExampleSubmission(ExampleSubmission exampleSubmission, String login) {

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -587,9 +587,9 @@ public class DatabaseUtilService {
         result.setAssessor(getUserByLogin(login));
         resultRepo.save(result);
         if (submit) {
-            result = modelingAssessmentService.submitManualAssessment(submission.getId(), exercise, submission.getSubmissionDate());
+            modelingAssessmentService.submitManualAssessment(submission.getId(), exercise, submission.getSubmissionDate());
         }
-        return result;
+        return resultRepo.findByIdWithEagerSubmissionAndFeedbacksAndAssessor(result.getId()).get();
     }
 
     public ExampleSubmission addExampleSubmission(ExampleSubmission exampleSubmission, String login) {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~Server: I added multiple integration tests (Spring) related to the features~
- [x] ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- [x] ~Server: I implemented the changes with a good performance and prevented too many database calls~
- [x] ~Server: I documented the Java code using JavaDoc style.~
- [x] ~Client: I added multiple integration tests (Jest) related to the features~
- [x] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [x] ~Client: I documented the TypeScript code using JSDoc style.~
- [x] ~Client: I added multiple screenshots/screencasts of my UI changes~
- [x] ~Client: I translated all the newly inserted strings into German and English~

### Description
<!-- Describe your changes in detail -->
When submitting a modeling assessment, the server ran into a `TransientObjectException: proxy was not associated with the session` and responded with 500 Internal Server Error. I think the problem occurred because the response entity is created/saved in `ModelingAssessmentService#saveManualAssessment` in one transaction and passed to another transaction in `ModelingAssessmentService#submitManualAssessment`. As it is not a good practice in general to pass entities between transactions, we adjust the `submitManualAssessment` method to get a `resultId` instead of the `result`. The corresponding result is then freshly loaded from the database using the given ID before setting the relevant fields and saving it to the database again.