### PR TITLE
Use UNIX style (instead of platform dependent) line separator when generating text blocks

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
@@ -21,6 +21,7 @@ public class TextBlockService {
      * As line breaks are stored and handled in UNIX style (also on Windows), we always use '\n' instead of the platform-dependent separator.
      */
     private static final String LINE_SEPARATOR = "\\n";
+
     private static final int LINE_SEPARATOR_LENGTH = LINE_SEPARATOR.length();
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
@@ -18,6 +18,12 @@ import de.tum.in.www1.artemis.domain.TextSubmission;
 public class TextBlockService {
 
     /**
+     * As line breaks are stored and handled in UNIX style (also on Windows), we always use '\n' instead of the platform-dependent separator.
+     */
+    private static final String LINE_SEPARATOR = "\\n";
+    private static final int LINE_SEPARATOR_LENGTH = LINE_SEPARATOR.length();
+
+    /**
      * Splits TextSubmission for a given Result into TextBlocks and saves them in the TextSubmission
      * @param result the result, which correspond to the TextSubmission, that gets split
      * @throws ClassCastException if Result doesn't correspond to a TextSubmission
@@ -54,8 +60,6 @@ public class TextBlockService {
         breakIterator.setText(submissionText);
         List<TextBlock> blocks = new ArrayList<>();
 
-        final String LINE_SEPARATOR = System.lineSeparator();
-        final int LINE_SEPARATOR_LENGTH = LINE_SEPARATOR.length();
         int start = breakIterator.first();
 
         // Iterate over Sentences


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
As line separators are stored in UNIX style (also on Windows systems), using the platform-dependent line separator when automatically generating the text blocks in text assessments does not behave correctly (compare screenshots). Therefore, we always use `\n` as line separator. This also fixes two failing tests on Windows.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
With platform-dependent line separator
![line separator issue](https://user-images.githubusercontent.com/5919138/65524441-148edb00-deee-11e9-8ce5-61674fb35876.PNG)

With line separator `\n`
![fixed line separator issue](https://user-images.githubusercontent.com/5919138/65524509-312b1300-deee-11e9-8d34-2fa422e69eb5.PNG)
