### PR TITLE
Hotfix/Color of repository password field

### DIFF
--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -517,17 +517,17 @@ pre {
 }
 
 code.password {
-    color: transparent;
+    color: transparent !important;
     background: black;
 }
 
 code.password::selection {
     background: #3297fd;
-    color: white;
+    color: white !important;
 }
 
 code.password:hover {
-    color: white;
+    color: white !important;
 }
 
 .apollon-editor label {


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

The text was no longer transparent, but pink. This is probably an issue with the bootstrap CSS, but it was hard to pin down. I just set the color attributes to important here which should be enough.

![image](https://user-images.githubusercontent.com/28230611/65613902-fe008680-dfb6-11e9-91e2-02c85c5ec7dd.png)



