### PR TITLE
Hotfix/notifications/multiple fixes

### DIFF
--- a/src/main/webapp/app/layouts/notification-container/notification-container.component.html
+++ b/src/main/webapp/app/layouts/notification-container/notification-container.component.html
@@ -25,7 +25,12 @@
                         <span class="badge ml-1 badge-primary" *ngIf="!currentUser || notification.notificationDate.isAfter(currentUser.lastNotificationRead)">new</span>
                     </h5>
                     <div class="notification-description mb-1">{{ notification.text }}</div>
-                    <div class="notification-info">{{ notification.notificationDate | date: 'dd/MM/yy HH:mm' }} by {{ notification.author.firstName }}</div>
+                    <div class="notification-info">
+                        {{ notification.notificationDate | date: 'dd/MM/yy HH:mm' }} by <span *ngIf="notification.author; else noAuthor">{{ notification.author.firstName }}</span>
+                    </div>
+                    <ng-template #noAuthor>
+                        <span jhiTranslate="global.title"></span>
+                    </ng-template>
                 </div>
                 <div class="col-auto">
                     <fa-icon [icon]="'arrow-right'"></fa-icon>

--- a/src/main/webapp/app/layouts/notification-container/notification-container.component.ts
+++ b/src/main/webapp/app/layouts/notification-container/notification-container.component.ts
@@ -38,7 +38,8 @@ export class NotificationContainerComponent implements OnInit {
             this.notificationService.subscribeUserNotifications();
         }, 500);
         this.notificationService.subscribeToSocketMessages().subscribe((notification: Notification) => {
-            if (notification) {
+            // TODO: How can it happen that the same id comes twice through the channel?
+            if (notification && !this.notifications.some(({ id }) => id === notification.id)) {
                 notification.notificationDate = notification.notificationDate ? moment(notification.notificationDate) : null;
                 this.notifications.push(notification);
                 this.updateNotifications();


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

Hotfixes an issue from https://github.com/ls1intum/Artemis/issues/854.

**2 hotfixes here:**
- Don't allow the same notification to be shown twice
- Show `Artemis` as a default author if the notification does not have an author assigned (= user). Normally we have an author but e.g. in https://github.com/ls1intum/Artemis/pull/850 we have the case that the notification is created by the system. It could also be the case that for some reason the author of the notification can't be loaded, which causes the whole client app to crash.