### PR TITLE
Bugfix/programming-exercises/preload submissions in score list + add loading indicator

### DIFF
--- a/src/main/webapp/app/scores/exercise-scores.component.html
+++ b/src/main/webapp/app/scores/exercise-scores.component.html
@@ -47,7 +47,7 @@
             {{ 'artemisApp.exercise.showAll' | translate }}
         </label>
     </div>
-    <div class="table-responsive" *ngIf="results">
+    <div *ngIf="results && !isLoading; else loadingContainer" class="table-responsive">
         <table class="table table-striped exercise-table">
             <thead>
                 <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="callback">
@@ -113,4 +113,7 @@
             </tbody>
         </table>
     </div>
+    <ng-template #loadingContainer>
+        <fa-icon size="lg" icon="question-circle" [spin]="true"></fa-icon>
+    </ng-template>
 </div>

--- a/src/main/webapp/app/scores/exercise-scores.component.html
+++ b/src/main/webapp/app/scores/exercise-scores.component.html
@@ -114,6 +114,8 @@
         </table>
     </div>
     <ng-template #loadingContainer>
-        <fa-icon size="lg" icon="circle-notch" [spin]="true"></fa-icon>
+        <div class="d-flex justify-content-center mt-3">
+            <fa-icon size="lg" icon="circle-notch" [spin]="true"></fa-icon>
+        </div>
     </ng-template>
 </div>

--- a/src/main/webapp/app/scores/exercise-scores.component.html
+++ b/src/main/webapp/app/scores/exercise-scores.component.html
@@ -114,6 +114,6 @@
         </table>
     </div>
     <ng-template #loadingContainer>
-        <fa-icon size="lg" icon="question-circle" [spin]="true"></fa-icon>
+        <fa-icon size="lg" icon="circle-notch" [spin]="true"></fa-icon>
     </ng-template>
 </div>

--- a/src/main/webapp/app/scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/scores/exercise-scores.component.ts
@@ -13,7 +13,7 @@ import { SourceTreeService } from 'app/components/util/sourceTree.service';
 import { ModelingAssessmentService } from 'app/entities/modeling-assessment';
 import { ParticipationService, ProgrammingExerciseStudentParticipation, StudentParticipation } from 'app/entities/participation';
 import { ProgrammingSubmissionService } from 'app/programming-submission';
-import { tap } from 'rxjs/operators';
+import { tap, take } from 'rxjs/operators';
 import { zip, of } from 'rxjs';
 
 @Component({
@@ -71,7 +71,9 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
                 const additionalLoadingOperation =
                     this.exercise.type === ExerciseType.PROGRAMMING ? this.programmingSubmissionService.getSubmissionStateOfExercise(this.exercise.id) : of(null);
                 // After both calls are done, the loading flag is removed. If the exercise is not a programming exercise, only the result call is needed.
-                zip(this.getResults(), additionalLoadingOperation).subscribe(() => (this.isLoading = false));
+                zip(this.getResults(), additionalLoadingOperation)
+                    .pipe(take(1))
+                    .subscribe(() => (this.isLoading = false));
             });
         });
         this.registerChangeInCourses();

--- a/src/main/webapp/app/scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/scores/exercise-scores.component.ts
@@ -67,16 +67,21 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
             });
             this.exerciseService.find(params['exerciseId']).subscribe((res: HttpResponse<Exercise>) => {
                 this.exercise = res.body!;
-                // We need to preload the pending submissions here, otherwise every updating-result would trigger a single REST call.
-                const additionalLoadingOperation =
-                    this.exercise.type === ExerciseType.PROGRAMMING ? this.programmingSubmissionService.getSubmissionStateOfExercise(this.exercise.id) : of(null);
                 // After both calls are done, the loading flag is removed. If the exercise is not a programming exercise, only the result call is needed.
-                zip(this.getResults(), additionalLoadingOperation)
+                zip(this.getResults(), this.loadAndCacheProgrammingExerciseSubmissionState())
                     .pipe(take(1))
                     .subscribe(() => (this.isLoading = false));
             });
         });
         this.registerChangeInCourses();
+    }
+
+    /**
+     * We need to preload the pending submissions here, otherwise every updating-result would trigger a single REST call.
+     * Will return immediately if the exercise is not of type PROGRAMMING.
+     */
+    private loadAndCacheProgrammingExerciseSubmissionState() {
+        return this.exercise.type === ExerciseType.PROGRAMMING ? this.programmingSubmissionService.getSubmissionStateOfExercise(this.exercise.id) : of(null);
     }
 
     registerChangeInCourses() {


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

Course Administration > Programming Exercise > Scores.
Currently we load every latest pending submission in the updating result with a separate call. This can be an issue with ~1000 entries.
Similar to the participations area, we need to preload the pending submissions here with one call.

E.g. #/course/13/exercise/882/dashboard

### Screenshots

Note: I have improved the ui so that the loading circle is in the middle now.

![score-loading](https://user-images.githubusercontent.com/28230611/65642662-25277a00-dff0-11e9-925e-cb8fd37ee988.gif)
