### PR TITLE
Prettier error on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,8 @@
         ]
     },
     "scripts": {
+        "prettier:format": "prettier --write 'src/{main/webapp,test}/**/*.{json,ts,css,scss,html}'",
+        "prettier:check": "prettier --check 'src/{main/webapp,test}/**/*.{json,ts,css,scss,html}'",
         "lint": "tslint --project tsconfig.json -e 'node_modules/**'",
         "lint:doc": "tslint --config tslint-doc.json --project tsconfig.json -e 'node_modules/**'",
         "lint:fix": "yarn run lint --fix",

--- a/package.json
+++ b/package.json
@@ -181,8 +181,6 @@
         ]
     },
     "scripts": {
-        "prettier:format": "prettier --write 'src/main/webapp/**/*.{json,ts,css,scss,html}'",
-        "prettier:check": "prettier --check 'src/main/webapp/**/*.{json,ts,css,scss,html}'",
         "lint": "tslint --project tsconfig.json -e 'node_modules/**'",
         "lint:doc": "tslint --config tslint-doc.json --project tsconfig.json -e 'node_modules/**'",
         "lint:fix": "yarn run lint --fix",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ],
     "husky": {
         "hooks": {
-            "pre-commit": "lint-staged"
+            "pre-commit": "lint-staged --shell"
         }
     },
     "dependencies": {


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
On Windows, the prettier command in the lint-staged pre-commit hook failed because Windows cannot handle the parsed linter command properly. We add the option `--shell` to the `lint-staged` command in the pre-commit hook to skip parsing the linter command (see https://github.com/okonet/lint-staged#command-line-flags).