### PR TITLE
Feature/programming exercise/inverse result calculation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
@@ -28,7 +28,6 @@ import org.swift.bamboo.cli.BambooClient;
 import org.swift.common.cli.Base;
 import org.swift.common.cli.CliClient;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -544,6 +543,17 @@ public class BambooService implements ContinuousIntegrationService {
         }
     }
 
+    /**
+     * A result is rated if:
+     * - there is no buildAndTestAfterDueDate set and the due date has not passed OR
+     * - there is no buildAndTestAfterDueDate set and and the submission type is instructor / test
+     * - there is a buildAndTestAfterDueDate set and the buildAndTestAfterDueDate has passed and the submission type is instructor / test
+     *
+     * @param result the rest for which to set the rated attribute (mutates the original object!)
+     * @param programmingExercise to which the result belongs
+     * @param submissionType that determines if the result is rated or not (instructor / test have a special role here)
+     * @param resultReferenceDate that determines for programming exercises without a buildAndTestAfterDueDate if the submission was made after the due date.
+     */
     private void setResultRated(Result result, ProgrammingExercise programmingExercise, SubmissionType submissionType, ZonedDateTime resultReferenceDate) {
         // If the buildAndTestAfterDueDate is set, a result can only be rated if the result comes in after the date and was triggered by an instructor.
         if(programmingExercise.getDueDate() != null && programmingExercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
@@ -28,6 +28,7 @@ import org.swift.bamboo.cli.BambooClient;
 import org.swift.common.cli.Base;
 import org.swift.common.cli.CliClient;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -508,11 +509,13 @@ public class BambooService implements ContinuousIntegrationService {
             // Save result, otherwise the next database access programmingSubmissionRepository.findByCommitHash will throw an exception
             resultRepository.save(result);
 
+
+            ProgrammingExercise programmingExercise = participation.getProgrammingExercise();
             ProgrammingSubmission programmingSubmission;
             if (latestMatchingPendingSubmission.isPresent()) {
                 programmingSubmission = latestMatchingPendingSubmission.get();
                 // In this case we know the submission time, so we use it for determining the rated state.
-                result.setRatedIfNotExceeded(participation.getProgrammingExercise().getDueDate(), programmingSubmission);
+                setResultRated(result, programmingExercise, programmingSubmission.getType(), programmingSubmission.getSubmissionDate());
             } else {
                 // There can be two reasons for the case that there is no programmingSubmission:
                 // 1) Manual build triggered from Bamboo.
@@ -529,7 +532,7 @@ public class BambooService implements ContinuousIntegrationService {
                 // Save to avoid TransientPropertyValueException.
                 programmingSubmissionRepository.save(programmingSubmission);
                 // In this case we don't know the submission time, so we use the result completion time for determining the rated state.
-                result.setRatedIfNotExceeded(participation.getProgrammingExercise().getDueDate(), result.getCompletionDate());
+                setResultRated(result, programmingExercise, SubmissionType.OTHER, result.getCompletionDate());
             }
             programmingSubmission.setResult(result);
             result.setSubmission(programmingSubmission);
@@ -538,6 +541,18 @@ public class BambooService implements ContinuousIntegrationService {
         } catch (Exception e) {
             log.error("Error when getting build result: " + e.getMessage());
             throw new BambooException("Could not get build result", e);
+        }
+    }
+
+    private void setResultRated(Result result, ProgrammingExercise programmingExercise, SubmissionType submissionType, ZonedDateTime resultReferenceDate) {
+        // If the buildAndTestAfterDueDate is set, a result can only be rated if the result comes in after the date and was triggered by an instructor.
+        if(programmingExercise.getDueDate() != null && programmingExercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null) {
+            boolean hasBuildAndTestDatePassed = programmingExercise.getBuildAndTestStudentSubmissionsAfterDueDate().isBefore(ZonedDateTime.now());
+            boolean isInstructorResult = submissionType == SubmissionType.INSTRUCTOR || submissionType == SubmissionType.TEST;
+            result.setRated(hasBuildAndTestDatePassed && isInstructorResult);
+        } else {
+            // If the buildAndTestAfterDueDate is not set, all results before the due date passes are rated (inverse).
+            result.setRatedIfNotExceeded(programmingExercise.getDueDate(), resultReferenceDate);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Server: I added multiple integration tests (Spring) related to the features
- [ ] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] Server: I documented the Java code using JavaDoc style.
- [ ] Client: I added multiple integration tests (Jest) related to the features
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [ ] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

With the buildAndTestAfterDueDate imo we introduced a small issue when it comes to determining if a result is rated or not: We currently determine that a result is rated when it comes in before the due date passes, but with the buildAndTestAfterDueDate it is the other way round.

### Description
<!-- Describe your changes in detail -->

- If the buildAndTestAfterDueDate is set, the result is considered rated if it comes from the instructor and has a submissionDate after the buildAndTestAfterDueDate.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
