### PR TITLE
Bugfix/programming exercise/import reset project key

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -940,7 +940,7 @@ public class ProgrammingExerciseService {
                 ARTEMIS_BASE_URL + PROGRAMMING_SUBMISSION_RESOURCE_API_PATH + templateParticipation.getId(), "Artemis WebHook");
         versionControlService.get().addWebHook(solutionParticipation.getRepositoryUrlAsUrl(),
                 ARTEMIS_BASE_URL + PROGRAMMING_SUBMISSION_RESOURCE_API_PATH + solutionParticipation.getId(), "Artemis WebHook");
-        versionControlService.get().addWebHook(newExercise.getTemplateRepositoryUrlAsUrl(), ARTEMIS_BASE_URL + TEST_CASE_CHANGED_API_PATH + newExercise.getId(),
+        versionControlService.get().addWebHook(newExercise.getTestRepositoryUrlAsUrl(), ARTEMIS_BASE_URL + TEST_CASE_CHANGED_API_PATH + newExercise.getId(),
                 "Artemis Tests WebHook");
     }
 

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.ts
@@ -90,10 +90,13 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
                         this.courseService.find(targetCourseId).subscribe(res => (this.programmingExercise.course = res.body!));
 
                         this.programmingExercise.dueDate = null;
+                        this.programmingExercise.projectKey = null;
+                        this.programmingExercise.buildAndTestStudentSubmissionsAfterDueDate = null;
                         this.programmingExercise.assessmentDueDate = null;
                         this.programmingExercise.releaseDate = null;
                         this.programmingExercise.shortName = '';
                         this.programmingExercise.title = '';
+                        this.onProgrammingExerciseUpdate(this.programmingExercise);
                     } else {
                         if (params['courseId']) {
                             const courseId = params['courseId'];

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.model.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.model.ts
@@ -11,6 +11,7 @@ export const enum ProgrammingLanguage {
 }
 
 export class ProgrammingExercise extends Exercise {
+    public projectKey: string | null;
     public templateParticipation: TemplateProgrammingExerciseParticipation;
     public solutionParticipation: SolutionProgrammingExerciseParticipation;
     public testRepositoryUrl: string;


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->
I discovered some smaller bugs for the programming exercise import:
* One of the VCS webhooks referenced the wrong repository --> template instead of test
* By adding the project key as a property, which can only be set once, to the programming_exercise_details, the server was not able to set a new key for the imported project, so the exercise could not be imported
* The new after due date attribute has not been reset properly on the imported exercise.

### Fixes
* The webhooks now references the correct repository
* The project key is reset correctly in the client before sending the new exercise to the server
* The after due date is set to null on opening the import page for a new exercise.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Import a programming exercise with an after due date
2. The after due date of the original exercise should not be set on the page of the `update-exercise` component.
3. After importing the exercise all build plans and repositories have been generated under the new project key.