### PR TITLE
Bugfix Guided Tour: Fix cancel tour step

### DIFF
--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -244,15 +244,18 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
     public backdropClick(event: Event): void {
         if (this.guidedTourService.preventBackdropFromAdvancing) {
             event.stopPropagation();
-            // When the user clicks on the backdrop while seeing the cancel tour step or last tour step, the cancel tour will be finished automatically
-            if (this.isCancelTour() || this.guidedTourService.isOnLastStep) {
-                this.guidedTourService.finishGuidedTour();
-            }
         } else {
             this.guidedTourService.nextStep();
         }
+        // When the user clicks on the backdrop or tour step while seeing the cancel tour step, the cancel tour will be finished automatically
+        if (this.isCancelTour()) {
+            this.guidedTourService.finishGuidedTour();
+        }
     }
 
+    /**
+     * Determines if the cancel tour is currently displayed
+     */
     private isCancelTour() {
         return this.currentTourStep.headlineTranslateKey === 'tour.cancel.headline';
     }

--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -77,7 +77,7 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
             case 'Escape': {
                 if (this.currentTourStep && !this.isCancelTour()) {
                     this.guidedTourService.skipTour();
-                } else if (this.isCancelTour() || this.guidedTourService.isOnLastStep) {
+                } else if (this.currentTourStep && (this.isCancelTour() || this.guidedTourService.isOnLastStep)) {
                     // The escape key event finishes the tour when the user is seeing the cancel tour step or last tour step
                     this.guidedTourService.finishGuidedTour();
                 }

--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -5,6 +5,7 @@ import { LinkType, Orientation, OverlayPosition, UserInteractionEvent } from './
 import { GuidedTourService } from './guided-tour.service';
 import { AccountService } from 'app/core';
 import { ImageTourStep, TextLinkTourStep, TextTourStep, VideoTourStep } from 'app/guided-tour/guided-tour-step.model';
+import { clickOnElement } from 'app/guided-tour/guided-tour.utils';
 
 @Component({
     selector: 'jhi-guided-tour',
@@ -74,8 +75,11 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
                 break;
             }
             case 'Escape': {
-                if (this.currentTourStep) {
+                if (this.currentTourStep && !this.isCancelTour()) {
                     this.guidedTourService.skipTour();
+                } else if (this.isCancelTour() || this.guidedTourService.isOnLastStep) {
+                    // The escape key event finishes the tour when the user is seeing the cancel tour step or last tour step
+                    this.guidedTourService.finishGuidedTour();
                 }
                 break;
             }
@@ -240,9 +244,17 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
     public backdropClick(event: Event): void {
         if (this.guidedTourService.preventBackdropFromAdvancing) {
             event.stopPropagation();
+            // When the user clicks on the backdrop while seeing the cancel tour step or last tour step, the cancel tour will be finished automatically
+            if (this.isCancelTour() || this.guidedTourService.isOnLastStep) {
+                this.guidedTourService.finishGuidedTour();
+            }
         } else {
             this.guidedTourService.nextStep();
         }
+    }
+
+    private isCancelTour() {
+        return this.currentTourStep.headlineTranslateKey === 'tour.cancel.headline';
     }
 
     /**

--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -257,7 +257,7 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
      * Determines if the cancel tour is currently displayed
      */
     private isCancelTour() {
-        return this.currentTourStep.headlineTranslateKey === 'tour.cancel.headline';
+        return this.currentTourStep ? this.currentTourStep.headlineTranslateKey === 'tour.cancel.headline' : false;
     }
 
     /**

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -55,7 +55,7 @@ export class GuidedTourService {
 
         // Reset guided tour availability on router navigation
         this.router.events.subscribe(event => {
-            if (event instanceof NavigationStart) {
+            if (this.currentTour && event instanceof NavigationStart) {
                 this.finishGuidedTour();
                 this.guidedTourAvailability.next(false);
             }

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -181,7 +181,7 @@ export class GuidedTourService {
      * and calling the reset tour method to remove current tour elements
      *
      */
-    private finishGuidedTour() {
+    public finishGuidedTour() {
         if (!this.currentTour) {
             return;
         }
@@ -212,7 +212,7 @@ export class GuidedTourService {
      * Show the cancel hint every time a user skips a tour
      */
     private showCancelHint(): void {
-        clickOnElement('#account-menu');
+        clickOnElement('#account-menu[aria-expanded="false"]');
         setTimeout(() => {
             this.currentTour = cloneDeep(cancelTour);
             // Proceed with tour if it has tour steps and the tour display is allowed for current window size

--- a/src/main/webapp/app/guided-tour/tours/general-tour.ts
+++ b/src/main/webapp/app/guided-tour/tours/general-tour.ts
@@ -15,7 +15,7 @@ export const cancelTour: GuidedTour = {
             highlightPadding: 10,
             orientation: Orientation.LEFT,
             closeAction: () => {
-                clickOnElement('#account-menu');
+                clickOnElement('#account-menu[aria-expanded="true"]');
             },
         }),
     ],

--- a/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
+++ b/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
@@ -164,6 +164,7 @@ describe('GuidedTourComponent', () => {
 
         it('should skip the tour with the escape key', () => {
             const skipTour = spyOn(guidedTourService, 'skipTour');
+            spyOn<any>(guidedTourComponent, 'isCancelTour').and.returnValue(false);
             const eventMock = new KeyboardEvent('keydown', { code: 'Escape' });
 
             guidedTourComponent.handleKeyboardEvent(eventMock);
@@ -176,6 +177,22 @@ describe('GuidedTourComponent', () => {
             // Skip tour with ESC key should not be possible when the component is not active
             guidedTourComponent.handleKeyboardEvent(eventMock);
             expect(skipTour.calls.count()).to.equal(0);
+        });
+
+        it('should not skip but finish the cancel tour with the escape key', () => {
+            const skipTour = spyOn(guidedTourService, 'skipTour');
+            const finishTour = spyOn(guidedTourService, 'finishGuidedTour');
+            spyOn<any>(guidedTourComponent, 'isCancelTour').and.returnValue(true);
+            const eventMock = new KeyboardEvent('keydown', { code: 'Escape' });
+
+            guidedTourComponent.handleKeyboardEvent(eventMock);
+            expect(skipTour.calls.count()).to.equal(0);
+            expect(finishTour.calls.count()).to.equal(1);
+
+            // Reset component
+            skipTour.calls.reset();
+            finishTour.calls.reset();
+            guidedTourComponent.currentTourStep = null;
         });
     });
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~~Server: I added multiple integration tests (Spring) related to the features~~
- [x] ~~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~~
- [x] ~~Server: I implemented the changes with a good performance and prevented too many database calls~~
- [x] ~~Server: I documented the Java code using JavaDoc style.~~
- [x] Client: I added client tests (Jest) related to the features
- [x] ~~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~~
- [x] ~~Client: I documented the TypeScript code using JSDoc style.~~
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] ~~Client: I translated all the newly inserted strings into German and English~~

### Description
- The dropdown for the `account-menu` closes automatically when clicking inside or outside of the dropdown. So the dropdown can be closed during the `cancel` tour step, while the tour component is still active, see screenshot:
![image](https://user-images.githubusercontent.com/33764166/66391866-8a0aa900-e9ce-11e9-9dd5-c0eecf2c652f.png)
- This PR fixes this issue and closes the `cancel` tour when the user clicks anywhere on the backdrop or on the tour step itself.
Furthermore it fixes the issue that the `cancel` tour could be triggered endlessly from the cancel tour step with the `escape` key, see gif:
![cancel](https://user-images.githubusercontent.com/33764166/66392553-795b3280-e9d0-11e9-95d8-7d0364e2156b.gif)
- When the user is on the last tour step, the `escape` key triggers the `finishGuidedTour` call and closes the tour

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Overview Page
3. Start or continue tour from the `account-menu`
4. Click on `x` or press the `escape` key to trigger the cancel tour
5. Press the `escape` key again / click on the backdrop or tour step
6. Tour should be finished 
