### PR TITLE
Chore/add compass folder to gitignore only in project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,7 +146,7 @@ Desktop.ini
 .dbus/
 repos/
 repos-download/
-compass/
+/compass/
 
 ######################
 # Gradle Wrapper

--- a/.gitignore
+++ b/.gitignore
@@ -146,7 +146,7 @@ Desktop.ini
 .dbus/
 repos/
 repos-download/
-/compass/
+/compass
 
 ######################
 # Gradle Wrapper


### PR DESCRIPTION
When I merged develop into my branch today, I could not commit because the pre commit failed as the files in the artemis/service/compass folder were staged, but ignored in the .gitignore file.
I think we only meant to ignore the files in /compass (so in the project root).

Related to the changes from https://github.com/ls1intum/Artemis/pull/845