### PR TITLE
GitHub actions upload artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,8 @@ jobs:
       run: ./gradlew -Pprod -Pwar clean bootWar
       env:
         CI: true
-    - run: ln -s `ls build/libs/` ./build/libs/Artemis.war
+    - name: Make .war file accessible
+      run: ln -s `ls build/libs/` ./build/libs/Artemis.war
     - name: Upload Artifact
       uses: actions/upload-artifact@master
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,10 @@ jobs:
       run: ./gradlew -Pprod -Pwar clean bootWar
       env:
         CI: true
+    - name: Make .war file accessible
+      run: ln -s `ls build/libs/` ./build/libs/Artemis.war
     - name: Upload Artifact
       uses: actions/upload-artifact@master
       with:
         name: Artemis.war
-        path: build/libs/
+        path: build/libs/Artemis.war

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,6 @@ jobs:
       run: ./gradlew -Pprod -Pwar clean bootWar
       env:
         CI: true
-    - name: Make .war file accessible
-      run: ln -s `ls build/libs/` ./build/libs/Artemis.war
     - name: Upload Artifact
       uses: actions/upload-artifact@master
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,9 @@ jobs:
       run: ./gradlew -Pprod -Pwar clean bootWar
       env:
         CI: true
+    - run: ln -s `ls build/libs/` ./build/libs/Artemis.war
+    - name: Upload Artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: Artemis.war
+        path: build/libs/


### PR DESCRIPTION
GitHub Actions already perform our Production Build. Now, we also upload the artifact, so we can download a WAR for every build.