### PR TITLE
Feature/programming exercise/test case dirty warning triangle

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
@@ -396,7 +396,7 @@ public class ProgrammingExercise extends Exercise {
         this.buildAndTestStudentSubmissionsAfterDueDate = buildAndTestStudentSubmissionsAfterDueDate;
     }
 
-    public boolean haveTestCasesChanged() {
+    public boolean getTestCasesChanged() {
         if (testCasesChanged == null) {
             return false;
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -388,7 +388,7 @@ public class ProgrammingSubmissionService {
 
         // If the programming exercise is not released / has no results, there is no point in setting the dirty flag. It is only relevant when there are student submissions that
         // should get an updated result.
-        if (testCasesChanged == programmingExercise.haveTestCasesChanged() || !programmingExerciseService.hasAtLeastOneStudentResult(programmingExercise)) {
+        if (testCasesChanged == programmingExercise.getTestCasesChanged() || !programmingExerciseService.hasAtLeastOneStudentResult(programmingExercise)) {
             return programmingExercise;
         }
         programmingExercise.setTestCasesChanged(testCasesChanged);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -720,7 +720,7 @@ public class ProgrammingExerciseResource {
         boolean hasAtLeastOneStudentResult = programmingExerciseService.hasAtLeastOneStudentResult(programmingExercise.get());
         boolean isReleased = programmingExercise.get().isReleased();
         ProgrammingExerciseTestCaseStateDTO testCaseDTO = new ProgrammingExerciseTestCaseStateDTO().released(isReleased).studentResult(hasAtLeastOneStudentResult)
-                .testCasesChanged(programmingExercise.get().haveTestCasesChanged())
+                .testCasesChanged(programmingExercise.get().getTestCasesChanged())
                 .buildAndTestStudentSubmissionsAfterDueDate(programmingExercise.get().getBuildAndTestStudentSubmissionsAfterDueDate());
         return ResponseEntity.ok(testCaseDTO);
     }

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.html
@@ -76,6 +76,10 @@
                     </td>
                     <td>
                         <a [routerLink]="['/course', programmingExercise.course.id, 'programming-exercise', programmingExercise.id, 'view']">{{ programmingExercise.title }}</a>
+                        <jhi-programming-exercise-test-cases-dirty-warning
+                            class="ml-2"
+                            [programmingExerciseId]="programmingExercise.id"
+                        ></jhi-programming-exercise-test-cases-dirty-warning>
                     </td>
                     <td>{{ programmingExercise.shortName }}</td>
                     <td>{{ programmingExercise.releaseDate | date: 'medium' }}</td>

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.html
@@ -79,6 +79,7 @@
                         <jhi-programming-exercise-test-cases-dirty-warning
                             class="ml-2"
                             [programmingExerciseId]="programmingExercise.id"
+                            [hasUpdatedTestCasesInitialValue]="programmingExercise.testCasesChanged"
                         ></jhi-programming-exercise-test-cases-dirty-warning>
                     </td>
                     <td>{{ programmingExercise.shortName }}</td>

--- a/src/main/webapp/app/entities/programming-exercise/services/programming-exercise-websocket.service.ts
+++ b/src/main/webapp/app/entities/programming-exercise/services/programming-exercise-websocket.service.ts
@@ -53,6 +53,9 @@ export class ProgrammingExerciseWebsocketService implements OnDestroy, IProgramm
      */
     getTestCaseState(programmingExerciseId: number) {
         const existingSubject = this.subjects[programmingExerciseId];
-        return (existingSubject || this.initTestCaseStateSubscription(programmingExerciseId)).asObservable().pipe(filter(val => val !== undefined)) as Observable<boolean>;
+        return (existingSubject || this.initTestCaseStateSubscription(programmingExerciseId)).asObservable().pipe(
+            tap(console.log),
+            filter(val => val !== undefined),
+        ) as Observable<boolean>;
     }
 }

--- a/src/main/webapp/app/entities/programming-exercise/services/programming-exercise-websocket.service.ts
+++ b/src/main/webapp/app/entities/programming-exercise/services/programming-exercise-websocket.service.ts
@@ -53,9 +53,6 @@ export class ProgrammingExerciseWebsocketService implements OnDestroy, IProgramm
      */
     getTestCaseState(programmingExerciseId: number) {
         const existingSubject = this.subjects[programmingExerciseId];
-        return (existingSubject || this.initTestCaseStateSubscription(programmingExerciseId)).asObservable().pipe(
-            tap(console.log),
-            filter(val => val !== undefined),
-        ) as Observable<boolean>;
+        return (existingSubject || this.initTestCaseStateSubscription(programmingExerciseId)).asObservable().pipe(filter(val => val !== undefined)) as Observable<boolean>;
     }
 }

--- a/src/main/webapp/app/entities/programming-exercise/test-cases/index.ts
+++ b/src/main/webapp/app/entities/programming-exercise/test-cases/index.ts
@@ -1,3 +1,4 @@
 export * from './programming-exercise-manage-test-cases.component';
 export * from './programming-exercise-manage-test-cases-status.component';
 export * from './programming-exercise-manage-test-cases-actions.component';
+export * from './programming-exercise-test-cases-dirty-warning.component';

--- a/src/main/webapp/app/entities/programming-exercise/test-cases/programming-exercise-test-case.module.ts
+++ b/src/main/webapp/app/entities/programming-exercise/test-cases/programming-exercise-test-case.module.ts
@@ -1,7 +1,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
-import { ProgrammingExerciseManageTestCasesActionsComponent, ProgrammingExerciseManageTestCasesComponent, ProgrammingExerciseManageTestCasesStatusComponent } from './';
+import {
+    ProgrammingExerciseManageTestCasesActionsComponent,
+    ProgrammingExerciseManageTestCasesComponent,
+    ProgrammingExerciseManageTestCasesStatusComponent,
+    ProgrammingExerciseTestCasesDirtyWarningComponent,
+} from './';
 import { ArtemisTableModule } from 'app/components/table/table.module';
 import { ArtemisSharedModule } from 'app/shared';
 import { ArtemisProgrammingExerciseActionsModule } from 'app/entities/programming-exercise/actions/programming-exercise-actions.module';
@@ -19,7 +24,12 @@ import { ArtemisSharedComponentModule } from 'app/shared/components/shared-compo
         // programming exercise sub modules.
         ArtemisProgrammingExerciseActionsModule,
     ],
-    declarations: [ProgrammingExerciseManageTestCasesComponent, ProgrammingExerciseManageTestCasesStatusComponent, ProgrammingExerciseManageTestCasesActionsComponent],
-    exports: [ProgrammingExerciseManageTestCasesComponent],
+    declarations: [
+        ProgrammingExerciseManageTestCasesComponent,
+        ProgrammingExerciseManageTestCasesStatusComponent,
+        ProgrammingExerciseManageTestCasesActionsComponent,
+        ProgrammingExerciseTestCasesDirtyWarningComponent,
+    ],
+    exports: [ProgrammingExerciseManageTestCasesComponent, ProgrammingExerciseTestCasesDirtyWarningComponent],
 })
 export class ArtemisProgrammingExerciseTestCaseModule {}

--- a/src/main/webapp/app/entities/programming-exercise/test-cases/programming-exercise-test-cases-dirty-warning.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/test-cases/programming-exercise-test-cases-dirty-warning.component.ts
@@ -12,7 +12,13 @@ import { Subscription } from 'rxjs';
     selector: 'jhi-programming-exercise-test-cases-dirty-warning',
     template: `
         <ng-container *ngIf="hasUpdatedTestCases">
-            <fa-icon icon="exclamation-triangle" class="text-warning" size="2x" ngbTooltip="'test'"> </fa-icon>
+            <fa-icon
+                icon="exclamation-triangle"
+                class="text-warning"
+                size="2x"
+                ngbTooltip="{{ 'artemisApp.programmingExercise.manageTestCases.updatedTestCasesTooltip' | translate }}"
+            >
+            </fa-icon>
         </ng-container>
     `,
 })
@@ -20,7 +26,7 @@ export class ProgrammingExerciseTestCasesDirtyWarningComponent implements OnChan
     @Input() programmingExerciseId: number;
     @Input() hasUpdatedTestCasesInitialValue: boolean;
 
-    hasUpdatedTestCases: boolean;
+    hasUpdatedTestCases?: boolean;
     testCaseStateSubscription: Subscription;
 
     constructor(private programmingExerciseWebsocketService: ProgrammingExerciseWebsocketService) {}
@@ -32,14 +38,9 @@ export class ProgrammingExerciseTestCasesDirtyWarningComponent implements OnChan
      * @param changes
      */
     ngOnChanges(changes: SimpleChanges) {
-        if (
-            changes.hasUpdatedTestCasesInitialValue &&
-            changes.hasUpdatedTestCasesInitialValue.currentValue !== undefined &&
-            changes.hasUpdatedTestCasesInitialValue.isFirstChange()
-        ) {
-            this.hasUpdatedTestCases = this.hasUpdatedTestCasesInitialValue;
-        }
+        // When the programming exercise changes, both set the hasUpdatedTestCases property to undefined and set up a subscription.
         if (this.programmingExerciseId && changes.programmingExerciseId.previousValue !== this.programmingExerciseId) {
+            this.hasUpdatedTestCases = undefined;
             this.unsubscribeSubscriptions();
             this.testCaseStateSubscription = this.programmingExerciseWebsocketService
                 .getTestCaseState(this.programmingExerciseId)
@@ -49,6 +50,14 @@ export class ProgrammingExerciseTestCasesDirtyWarningComponent implements OnChan
                     }),
                 )
                 .subscribe();
+        }
+        // On the first change of the updatedTestCasesInitialValue property, use it to initialize hasUpdatedTestCases.
+        if (
+            changes.hasUpdatedTestCasesInitialValue &&
+            changes.hasUpdatedTestCasesInitialValue.currentValue !== undefined &&
+            changes.hasUpdatedTestCasesInitialValue.isFirstChange()
+        ) {
+            this.hasUpdatedTestCases = this.hasUpdatedTestCasesInitialValue;
         }
     }
 

--- a/src/main/webapp/app/entities/programming-exercise/test-cases/programming-exercise-test-cases-dirty-warning.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/test-cases/programming-exercise-test-cases-dirty-warning.component.ts
@@ -18,6 +18,7 @@ import { Subscription } from 'rxjs';
 })
 export class ProgrammingExerciseTestCasesDirtyWarningComponent implements OnChanges, OnDestroy {
     @Input() programmingExerciseId: number;
+    @Input() hasUpdatedTestCasesInitialValue: boolean;
 
     hasUpdatedTestCases: boolean;
     testCaseStateSubscription: Subscription;
@@ -25,11 +26,19 @@ export class ProgrammingExerciseTestCasesDirtyWarningComponent implements OnChan
     constructor(private programmingExerciseWebsocketService: ProgrammingExerciseWebsocketService) {}
 
     /**
+     * Set the initial updated test case value on the first change of the property.
      * Subscribe for the test case state. This component is only visible if the programming exercise has updated (= dirty) test cases.
      *
      * @param changes
      */
     ngOnChanges(changes: SimpleChanges) {
+        if (
+            changes.hasUpdatedTestCasesInitialValue &&
+            changes.hasUpdatedTestCasesInitialValue.currentValue !== undefined &&
+            changes.hasUpdatedTestCasesInitialValue.isFirstChange()
+        ) {
+            this.hasUpdatedTestCases = this.hasUpdatedTestCasesInitialValue;
+        }
         if (this.programmingExerciseId && changes.programmingExerciseId.previousValue !== this.programmingExerciseId) {
             this.unsubscribeSubscriptions();
             this.testCaseStateSubscription = this.programmingExerciseWebsocketService

--- a/src/main/webapp/app/entities/programming-exercise/test-cases/programming-exercise-test-cases-dirty-warning.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/test-cases/programming-exercise-test-cases-dirty-warning.component.ts
@@ -1,0 +1,55 @@
+import { Component, HostBinding, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { ProgrammingExerciseWebsocketService } from 'app/entities/programming-exercise/services/programming-exercise-websocket.service';
+import { tap } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
+
+/**
+ * Two status indicators for the test case table:
+ * - Are there unsaved changes?
+ * - Have test cases been changed but the student submissions were not triggered?
+ */
+@Component({
+    selector: 'jhi-programming-exercise-test-cases-dirty-warning',
+    template: `
+        <ng-container *ngIf="hasUpdatedTestCases">
+            <fa-icon icon="exclamation-triangle" class="text-warning" size="2x" ngbTooltip="'test'"> </fa-icon>
+        </ng-container>
+    `,
+})
+export class ProgrammingExerciseTestCasesDirtyWarningComponent implements OnChanges, OnDestroy {
+    @Input() programmingExerciseId: number;
+
+    hasUpdatedTestCases: boolean;
+    testCaseStateSubscription: Subscription;
+
+    constructor(private programmingExerciseWebsocketService: ProgrammingExerciseWebsocketService) {}
+
+    /**
+     * Subscribe for the test case state. This component is only visible if the programming exercise has updated (= dirty) test cases.
+     *
+     * @param changes
+     */
+    ngOnChanges(changes: SimpleChanges) {
+        if (this.programmingExerciseId && changes.programmingExerciseId.previousValue !== this.programmingExerciseId) {
+            this.unsubscribeSubscriptions();
+            this.testCaseStateSubscription = this.programmingExerciseWebsocketService
+                .getTestCaseState(this.programmingExerciseId)
+                .pipe(
+                    tap((hasUpdatedTestCases: boolean) => {
+                        this.hasUpdatedTestCases = hasUpdatedTestCases;
+                    }),
+                )
+                .subscribe();
+        }
+    }
+
+    ngOnDestroy(): void {
+        this.unsubscribeSubscriptions();
+    }
+
+    private unsubscribeSubscriptions() {
+        if (this.testCaseStateSubscription) {
+            this.testCaseStateSubscription.unsubscribe();
+        }
+    }
+}

--- a/src/test/java/de/tum/in/www1/artemis/ProgrammingExerciseTestCaseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ProgrammingExerciseTestCaseServiceTest.java
@@ -149,14 +149,14 @@ public class ProgrammingExerciseTestCaseServiceTest {
         database.addParticipationWithResultForExercise(programmingExercise, "student1");
         new ArrayList<>(testCaseRepository.findByExerciseId(programmingExercise.getId())).get(0).weight(50);
 
-        assertThat(programmingExercise.haveTestCasesChanged()).isFalse();
+        assertThat(programmingExercise.getTestCasesChanged()).isFalse();
 
         testCaseService.resetWeights(programmingExercise.getId());
 
         Set<ProgrammingExerciseTestCase> testCases = testCaseRepository.findByExerciseId(programmingExercise.getId());
         ProgrammingExercise updatedProgrammingExercise = programmingExerciseRepository.findById(programmingExercise.getId()).get();
         assertThat(testCases.stream().mapToInt(ProgrammingExerciseTestCase::getWeight).sum()).isEqualTo(testCases.size());
-        assertThat(updatedProgrammingExercise.haveTestCasesChanged()).isTrue();
+        assertThat(updatedProgrammingExercise.getTestCasesChanged()).isTrue();
         verify(groupNotificationService, times(1)).notifyInstructorGroupAboutExerciseUpdate(updatedProgrammingExercise, Constants.TEST_CASES_CHANGED_NOTIFICATION);
         verify(websocketMessagingService, times(1)).sendMessage("/topic/programming-exercises/" + programmingExercise.getId() + "/test-cases-changed", true);
 
@@ -183,14 +183,14 @@ public class ProgrammingExerciseTestCaseServiceTest {
         programmingExerciseTestCaseDTO.setWeight(400);
         programmingExerciseTestCaseDTOS.add(programmingExerciseTestCaseDTO);
 
-        assertThat(programmingExercise.haveTestCasesChanged()).isFalse();
+        assertThat(programmingExercise.getTestCasesChanged()).isFalse();
 
         testCaseService.update(programmingExercise.getId(), programmingExerciseTestCaseDTOS);
 
         ProgrammingExercise updatedProgrammingExercise = programmingExerciseRepository.findById(programmingExercise.getId()).get();
 
         assertThat(testCaseRepository.findById(testCase.getId()).get().getWeight()).isEqualTo(400);
-        assertThat(updatedProgrammingExercise.haveTestCasesChanged()).isTrue();
+        assertThat(updatedProgrammingExercise.getTestCasesChanged()).isTrue();
         verify(groupNotificationService, times(1)).notifyInstructorGroupAboutExerciseUpdate(updatedProgrammingExercise, Constants.TEST_CASES_CHANGED_NOTIFICATION);
         verify(websocketMessagingService, times(1)).sendMessage("/topic/programming-exercises/" + programmingExercise.getId() + "/test-cases-changed", true);
 

--- a/src/test/java/de/tum/in/www1/artemis/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ProgrammingSubmissionIntegrationTest.java
@@ -171,7 +171,7 @@ public class ProgrammingSubmissionIntegrationTest {
 
         SecurityUtils.setAuthorizationObject();
         ProgrammingExercise updatedProgrammingExercise = exerciseRepository.findById(exercise.getId()).get();
-        assertThat(updatedProgrammingExercise.haveTestCasesChanged()).isFalse();
+        assertThat(updatedProgrammingExercise.getTestCasesChanged()).isFalse();
         verify(groupNotificationService, times(1)).notifyInstructorGroupAboutExerciseUpdate(updatedProgrammingExercise, Constants.TEST_CASES_CHANGED_RUN_COMPLETED_NOTIFICATION);
         verify(websocketMessagingService, times(1)).sendMessage("/topic/programming-exercises/" + exercise.getId() + "/test-cases-changed", false);
     }


### PR DESCRIPTION
Warning triangle in the programming exercise overview when `testCasesChanged` is true.
Is updated live through websockets.
Does not create any additional server load.

![warning-dirty](https://user-images.githubusercontent.com/28230611/66481132-834c6680-eaa0-11e9-9d97-50215ff10018.gif)
