### PR TITLE
Bugfix/result/building state should have priority over other result states

### DIFF
--- a/src/main/webapp/app/entities/result/result.component.ts
+++ b/src/main/webapp/app/entities/result/result.component.ts
@@ -94,6 +94,12 @@ export class ResultComponent implements OnInit, OnChanges {
     ngOnChanges(changes: SimpleChanges) {
         if (changes.participation || changes.result) {
             this.ngOnInit();
+            // If is building, we change the templateStatus to building regardless of any other settings.
+        } else if (changes.isBuilding && changes.isBuilding.currentValue) {
+            this.templateStatus = ResultTemplateStatus.IS_BUILDING;
+            // When the result was building and is not building anymore, we evaluate the result status.
+        } else if (changes.isBuilding && changes.isBuilding.previousValue && !changes.isBuilding.currentValue) {
+            this.evaluate();
         }
     }
 


### PR DESCRIPTION
**Bug**: 
When clicking on submit in a programming exercise, the is building animation is no longer showing in the result component.

**Solution**:
When the isBuilding state changes, we need to update the result state of the result component; otherwise it will not update when the value changes.
