### PR TITLE
Bugfix: Fix the TypeError on Tutor Exercise Dashboard

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/utils/programming-exercise.utils.ts
+++ b/src/main/webapp/app/entities/programming-exercise/utils/programming-exercise.utils.ts
@@ -15,9 +15,12 @@ export const isLegacyResult = (result: Result) => {
 };
 
 export const hasBuildAndTestAfterDueDatePassed = (programmingExercise: ProgrammingExercise) => {
-    return !programmingExercise.buildAndTestStudentSubmissionsAfterDueDate || moment(programmingExercise.buildAndTestStudentSubmissionsAfterDueDate).isBefore(moment.now());
+    return (
+        !programmingExercise.buildAndTestStudentSubmissionsAfterDueDate ||
+        (programmingExercise.buildAndTestStudentSubmissionsAfterDueDate && moment(programmingExercise.buildAndTestStudentSubmissionsAfterDueDate).isBefore(moment.now()))
+    );
 };
 
 export const isProgrammingExerciseStudentParticipation = (participation: Participation) => {
-    return participation.type === ParticipationType.PROGRAMMING;
+    return participation.type && participation.type === ParticipationType.PROGRAMMING;
 };

--- a/src/main/webapp/app/entities/result/result.component.ts
+++ b/src/main/webapp/app/entities/result/result.component.ts
@@ -201,7 +201,11 @@ export class ResultComponent implements OnInit, OnChanges {
 
     buildResultTooltip() {
         // Only show the 'preliminary' tooltip for programming student participation results and if the buildAndTestAfterDueDate has not passed.
-        if (isProgrammingExerciseStudentParticipation(this.participation) && !hasBuildAndTestAfterDueDatePassed(this.participation.exercise as ProgrammingExercise)) {
+        if (
+            this.participation &&
+            isProgrammingExerciseStudentParticipation(this.participation) &&
+            !hasBuildAndTestAfterDueDatePassed(this.participation.exercise as ProgrammingExercise)
+        ) {
             return this.translate.instant('artemisApp.result.preliminaryTooltip');
         }
     }

--- a/src/main/webapp/app/entities/result/result.component.ts
+++ b/src/main/webapp/app/entities/result/result.component.ts
@@ -188,7 +188,11 @@ export class ResultComponent implements OnInit, OnChanges {
         if (this.result!.resultString === 'No tests found') {
             return this.translate.instant('artemisApp.editor.buildFailed');
             // Only show the 'preliminary' string for programming student participation results and if the buildAndTestAfterDueDate has not passed.
-        } else if (isProgrammingExerciseStudentParticipation(this.participation) && !hasBuildAndTestAfterDueDatePassed(this.participation.exercise as ProgrammingExercise)) {
+        } else if (
+            this.participation &&
+            isProgrammingExerciseStudentParticipation(this.participation) &&
+            !hasBuildAndTestAfterDueDatePassed(this.participation.exercise as ProgrammingExercise)
+        ) {
             const preliminary = this.translate.instant('artemisApp.result.preliminary');
             return `${this.result!.resultString} ${preliminary}`;
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
`TypeError` is thrown twice when tutor opens the Tutor Exercise Dashboard for Modeling, Text or File Upload exercises. These participations don't have type, but we try to check the type and get undefined. Additional null value check is introduced now.
Sentry: https://sentry.io/organizations/ls1intum/issues/1269715648/?project=1440029&query=is%3Aunresolved+assigned%3Ame&statsPeriod=24h

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Open Tutor Course Dashboard, e.g. in Artemis Test Course
4. Navigate to Exercise Dashboard.
5. No Type Errors shown in the console log

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
