### PR TITLE
Bugfix/programming exercise/bitbucket internal error fork catch

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -207,7 +207,7 @@ public class BitbucketService implements VersionControlService {
              * repository, or the maximum amount of retries has been exceeded. There is no direct other solution as of now since this is a default Bitbucket behavior we cannot
              * control
              */
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < 5; i++) {
                 try {
                     final var response = restTemplate.postForEntity(new URI(repoUrl), entity, Map.class);
                     if (response.getStatusCode().equals(HttpStatus.CREATED)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -189,7 +189,7 @@ public class BitbucketService implements VersionControlService {
         sourceRepositoryName = sourceRepositoryName.toLowerCase();
         targetRepositoryName = targetRepositoryName.toLowerCase();
         final var targetRepoSlug = targetProjectKey.toLowerCase() + "-" + targetRepositoryName;
-        final Map<String, Object> body = new HashMap<>();
+        final Map<String, Object> body = new HashMap<String, Object>();
         body.put("name", targetRepoSlug);
         final var projectMap = new HashMap<>();
         projectMap.put("key", targetProjectKey);
@@ -199,10 +199,30 @@ public class BitbucketService implements VersionControlService {
 
         log.info("Try to copy repository " + sourceProjectKey + "/repos/" + sourceRepositoryName + " into " + targetRepoSlug);
         final String repoUrl = BITBUCKET_SERVER_URL + "/rest/api/1.0/projects/" + sourceProjectKey + "/repos/" + sourceRepositoryName;
+
         try {
-            final var response = restTemplate.postForEntity(new URI(repoUrl), entity, Map.class);
-            if (response.getStatusCode().equals(HttpStatus.CREATED)) {
-                return new BitbucketRepositoryUrl(targetProjectKey, targetRepoSlug);
+            /*
+             * There is an edge case occurring when multiple students fork a repository leading to a race condition on the filelock for the gitconfig of the base repository since
+             * Bitbucket always tries to set pruneexpire to never as soon as one forks a repository. We only catch this case and loop over the request until we managed to fork the
+             * repository, or the maximum amount of retries has been exceeded. There is no direct other solution as of now since this is a default Bitbucket behavior we cannot
+             * control
+             */
+            for (int i = 0; i < 10; i++) {
+                try {
+                    final var response = restTemplate.postForEntity(new URI(repoUrl), entity, Map.class);
+                    if (response.getStatusCode().equals(HttpStatus.CREATED)) {
+                        return new BitbucketRepositoryUrl(targetProjectKey, targetRepoSlug);
+                    }
+                }
+                catch (HttpServerErrorException.InternalServerError e) {
+
+                    if (e.getResponseBodyAsString().contains("code 255 saying: error: could not lock config file config: File exists")) {
+                        log.warn("Could not acquire lock for gitconfig in Bitbucket while forking the repository. Trying again");
+                    }
+                    else {
+                        throw e;
+                    }
+                }
             }
         }
         catch (URISyntaxException e) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -31,6 +31,8 @@ import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 @Profile("bitbucket")
 public class BitbucketService implements VersionControlService {
 
+    private static final int MAX_FORK_RETRIES = 5;
+
     private final Logger log = LoggerFactory.getLogger(BitbucketService.class);
 
     @Value("${artemis.jira.admin-group-name}")
@@ -207,7 +209,7 @@ public class BitbucketService implements VersionControlService {
              * repository, or the maximum amount of retries has been exceeded. There is no direct other solution as of now since this is a default Bitbucket behavior we cannot
              * control
              */
-            for (int i = 0; i < 5; i++) {
+            for (int i = 0; i < MAX_FORK_RETRIES; i++) {
                 try {
                     final var response = restTemplate.postForEntity(new URI(repoUrl), entity, Map.class);
                     if (response.getStatusCode().equals(HttpStatus.CREATED)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -189,12 +189,12 @@ public class BitbucketService implements VersionControlService {
         sourceRepositoryName = sourceRepositoryName.toLowerCase();
         targetRepositoryName = targetRepositoryName.toLowerCase();
         final var targetRepoSlug = targetProjectKey.toLowerCase() + "-" + targetRepositoryName;
-        final Map<String, Object> body = new HashMap<String, Object>();
+        final var body = new HashMap<String, Object>();
         body.put("name", targetRepoSlug);
         final var projectMap = new HashMap<>();
         projectMap.put("key", targetProjectKey);
         body.put("project", projectMap);
-        HttpHeaders headers = HeaderUtil.createAuthorization(BITBUCKET_USER, BITBUCKET_PASSWORD);
+        final var headers = HeaderUtil.createAuthorization(BITBUCKET_USER, BITBUCKET_PASSWORD);
         HttpEntity<?> entity = new HttpEntity<>(body, headers);
 
         log.info("Try to copy repository " + sourceProjectKey + "/repos/" + sourceRepositoryName + " into " + targetRepoSlug);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If multiple students try to participate in a programming exercise at the same time, there can be a race condition related to the the gitconfigure file lock on the Bitbucket server. Bitbucket always updates the config when a repository is forked. If the lock cannot be acquired, creating a new participation will fail.

### Description
<!-- Describe your changes in detail -->
I added a loop, which retries forking the base repository in the above mentioned case (max. 5 retries) and **only** in that case.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Start a new loadtest simulation: https://confluence.ase.in.tum.de/pages/viewpage.action?pageId=34373755 --> 100 users
2. All participants should be able to start the exercise
3. They all should get results for their commits
