### PR TITLE
Prepare manual reviews for programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
@@ -304,7 +304,7 @@ public class ResultResource {
             final var exercise = (ProgrammingExercise) exerciseToBeChecked;
             final var relevantDueDate = exercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null ? exercise.getBuildAndTestStudentSubmissionsAfterDueDate()
                     : exercise.getDueDate();
-            return exercise.getAssessmentType() == AssessmentType.SEMI_AUTOMATIC && !relevantDueDate.isBefore(ZonedDateTime.now());
+            return exercise.getAssessmentType() == AssessmentType.SEMI_AUTOMATIC && (relevantDueDate == null || !relevantDueDate.isBefore(ZonedDateTime.now()));
         }
 
         return true;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
@@ -108,7 +108,7 @@ public class ResultResource {
         final var participation = result.getParticipation();
         final var course = participation.getExercise().getCourse();
         final var user = userService.getUserWithGroupsAndAuthorities();
-        final var exercise = exerciseService.findOne(participation.getExercise().getId());
+        final var exercise = participation.getExercise();
         if (!userHasPermissions(course, user) || areManualResultsAllowed(exercise))
             return forbidden();
 
@@ -285,7 +285,7 @@ public class ResultResource {
         log.debug("REST request to update Result : {}", result);
         final var participation = result.getParticipation();
         final var course = participation.getExercise().getCourse();
-        final var exercise = exerciseService.findOne(participation.getExercise().getId());
+        final var exercise = participation.getExercise();
         if (!userHasPermissions(course) || !areManualResultsAllowed(exercise)) {
             return forbidden();
         }

--- a/src/main/webapp/app/entities/exercise/exercise-utils.ts
+++ b/src/main/webapp/app/entities/exercise/exercise-utils.ts
@@ -125,7 +125,7 @@ export const areManualResultsAllowed = (exercise: Exercise) => {
         // Only allow new results if manual reviews are activated and the due date/after due date has passed
         const exc = exercise as ProgrammingExercise;
         const relevantDueDate = exc.buildAndTestStudentSubmissionsAfterDueDate ? exc.buildAndTestStudentSubmissionsAfterDueDate : exc.dueDate;
-        return exc.isAtLeastTutor && exc.assessmentType === AssessmentType.SEMI_AUTOMATIC && moment(relevantDueDate!).isBefore(now());
+        return exc.isAtLeastTutor && exc.assessmentType === AssessmentType.SEMI_AUTOMATIC && (!relevantDueDate || moment(relevantDueDate).isBefore(now()));
     }
 
     return exercise.isAtLeastTutor;

--- a/src/main/webapp/app/entities/exercise/exercise-utils.ts
+++ b/src/main/webapp/app/entities/exercise/exercise-utils.ts
@@ -1,8 +1,11 @@
 import { SimpleChanges } from '@angular/core';
 import { Exercise, ExerciseType, ParticipationStatus } from 'app/entities/exercise/exercise.model';
-import { InitializationState, hasResults } from 'app/entities/participation';
+import { hasResults, InitializationState } from 'app/entities/participation';
 import { QuizExercise } from 'app/entities/quiz-exercise';
 import * as moment from 'moment';
+import { ProgrammingExercise } from 'app/entities/programming-exercise';
+import { now } from 'moment';
+import { AssessmentType } from 'app/entities/assessment-type';
 
 export const hasExerciseChanged = (changes: SimpleChanges) => {
     return changes.exercise && changes.exercise.currentValue && (!changes.exercise.previousValue || changes.exercise.previousValue.id !== changes.exercise.currentValue.id);
@@ -107,4 +110,23 @@ const participationStatusForModelingTextFileUploadExercise = (exercise: Exercise
     } else {
         return ParticipationStatus.UNINITIALIZED;
     }
+};
+
+/**
+ * Checks whether the given exercise is eligible for receiving manual results.
+ * This is the case if the user is at least a tutor and the exercise itself is a regular exercise, or a programming
+ * exercise for which manual reviews have been enabled. For programming exercises, the due date also has to be in the
+ * past.
+ *
+ * @param exercise
+ */
+export const areManualResultsAllowed = (exercise: Exercise) => {
+    if (exercise.type === ExerciseType.PROGRAMMING) {
+        // Only allow new results if manual reviews are activated and the due date/after due date has passed
+        const exc = exercise as ProgrammingExercise;
+        const relevantDueDate = exc.buildAndTestStudentSubmissionsAfterDueDate ? exc.buildAndTestStudentSubmissionsAfterDueDate : exc.dueDate;
+        return exc.isAtLeastTutor && exc.assessmentType === AssessmentType.SEMI_AUTOMATIC && relevantDueDate!.isBefore(now());
+    }
+
+    return exercise.isAtLeastTutor;
 };

--- a/src/main/webapp/app/entities/exercise/exercise-utils.ts
+++ b/src/main/webapp/app/entities/exercise/exercise-utils.ts
@@ -125,7 +125,7 @@ export const areManualResultsAllowed = (exercise: Exercise) => {
         // Only allow new results if manual reviews are activated and the due date/after due date has passed
         const exc = exercise as ProgrammingExercise;
         const relevantDueDate = exc.buildAndTestStudentSubmissionsAfterDueDate ? exc.buildAndTestStudentSubmissionsAfterDueDate : exc.dueDate;
-        return exc.isAtLeastTutor && exc.assessmentType === AssessmentType.SEMI_AUTOMATIC && relevantDueDate!.isBefore(now());
+        return exc.isAtLeastTutor && exc.assessmentType === AssessmentType.SEMI_AUTOMATIC && moment(relevantDueDate!).isBefore(now());
     }
 
     return exercise.isAtLeastTutor;

--- a/src/main/webapp/app/entities/participation/participation.component.html
+++ b/src/main/webapp/app/entities/participation/participation.component.html
@@ -89,7 +89,7 @@
                             </ng-container>
                             <button
                                 type="submit"
-                                *ngIf="exercise?.type === PROGRAMMING && exercise.isAtLeastTutor"
+                                *ngIf="newResultAllowed"
                                 [routerLink]="['/', { outlets: { popup: ['participation', participation.id, 'result', 'new'] } }]"
                                 class="btn btn-warning btn-sm mr-1"
                             >

--- a/src/main/webapp/app/entities/participation/participation.component.html
+++ b/src/main/webapp/app/entities/participation/participation.component.html
@@ -89,7 +89,7 @@
                             </ng-container>
                             <button
                                 type="submit"
-                                *ngIf="newResultAllowed"
+                                *ngIf="newManualResultAllowed"
                                 [routerLink]="['/', { outlets: { popup: ['participation', participation.id, 'result', 'new'] } }]"
                                 class="btn btn-warning btn-sm mr-1"
                             >

--- a/src/main/webapp/app/entities/participation/participation.component.ts
+++ b/src/main/webapp/app/entities/participation/participation.component.ts
@@ -5,8 +5,8 @@ import { JhiAlertService, JhiEventManager } from 'ng-jhipster';
 import { Participation } from './participation.model';
 import { ParticipationService } from './participation.service';
 import { ActivatedRoute } from '@angular/router';
-import { Exercise, ExerciseType } from '../exercise';
-import { ExerciseService } from '../exercise/exercise.service';
+import { areManualResultsAllowed, Exercise, ExerciseType } from '../exercise';
+import { ExerciseService } from 'app/entities/exercise';
 import { HttpErrorResponse } from '@angular/common/http';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { ProgrammingSubmissionService } from 'app/programming-submission/programming-submission.service';
@@ -27,6 +27,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     exercise: Exercise;
     predicate: string;
     reverse: boolean;
+    newResultAllowed: boolean;
 
     hasLoadedPendingSubmissions = false;
     presentationScoreEnabled = false;
@@ -63,6 +64,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
                 if (this.exercise.type === this.PROGRAMMING) {
                     this.programmingSubmissionService.getSubmissionStateOfExercise(this.exercise.id).subscribe(() => (this.hasLoadedPendingSubmissions = true));
                 }
+                this.newResultAllowed = areManualResultsAllowed(this.exercise);
                 this.presentationScoreEnabled = this.checkPresentationScoreConfig();
             });
         });

--- a/src/main/webapp/app/entities/participation/participation.component.ts
+++ b/src/main/webapp/app/entities/participation/participation.component.ts
@@ -27,7 +27,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     exercise: Exercise;
     predicate: string;
     reverse: boolean;
-    newResultAllowed: boolean;
+    newManualResultAllowed: boolean;
 
     hasLoadedPendingSubmissions = false;
     presentationScoreEnabled = false;
@@ -64,7 +64,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
                 if (this.exercise.type === this.PROGRAMMING) {
                     this.programmingSubmissionService.getSubmissionStateOfExercise(this.exercise.id).subscribe(() => (this.hasLoadedPendingSubmissions = true));
                 }
-                this.newResultAllowed = areManualResultsAllowed(this.exercise);
+                this.newManualResultAllowed = areManualResultsAllowed(this.exercise);
                 this.presentationScoreEnabled = this.checkPresentationScoreConfig();
             });
         });

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-form.scss
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-form.scss
@@ -9,3 +9,7 @@
 .label-preview {
     font-size: 9pt;
 }
+
+.markdown-editor {
+    height: 350px;
+}

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
@@ -168,6 +168,15 @@
                         class="form__editable-instructions"
                     ></jhi-programming-exercise-editable-instructions>
                 </div>
+                <div *ngIf="programmingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC" class="form-group" id="field_gradingInstructions">
+                    <label class="form-control-label" jhiTranslate="artemisApp.exercise.gradingInstructions" for="field_gradingInstructions">Grading instructions</label>
+                    <jhi-markdown-editor
+                        class="markdown-editor"
+                        [domainCommands]="domainCommandsGradingInstructions"
+                        [(markdown)]="programmingExercise.gradingInstructions"
+                        [editorMode]="EditorMode.LATEX"
+                    ></jhi-markdown-editor>
+                </div>
                 <!--        It would be very complicated to change the sequential test run feature after an exercise is created, which is why it can only be activated if the exercise was not yet created.-->
                 <div class="form-group-narrow">
                     <div class="form-check">

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.ts
@@ -11,6 +11,9 @@ import { FileService } from 'app/shared/http/file.service';
 import { MAX_SCORE_PATTERN } from 'app/app.constants';
 import { TranslateService } from '@ngx-translate/core';
 import { switchMap, tap } from 'rxjs/operators';
+import { KatexCommand } from 'app/markdown-editor/commands';
+import { EditorMode } from 'app/markdown-editor';
+import { AssessmentType } from 'app/entities/assessment-type';
 
 @Component({
     selector: 'jhi-programming-exercise-update',
@@ -32,6 +35,9 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
     problemStatementLoaded = false;
     templateParticipationResultLoaded = true;
     notificationText: string | null;
+    domainCommandsGradingInstructions = [new KatexCommand()];
+    EditorMode = EditorMode;
+    AssessmentType = AssessmentType;
     // This is used to revert the select if the user cancels to override the new selected programming language.
     private selectedProgrammingLanguageValue: ProgrammingLanguage;
 

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.module.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.module.ts
@@ -36,6 +36,7 @@ import { ProgrammingExerciseLifecycleComponent } from 'app/entities/programming-
 import { ProgrammingExerciseTestScheduleDatePickerComponent } from 'app/entities/programming-exercise/programming-exercise-test-schedule-picker';
 import { OwlDateTimeModule } from 'ng-pick-datetime';
 import { ProgrammingExercisePlansAndRepositoriesPreviewComponent } from 'app/entities/programming-exercise/programming-exercise-plans-and-repositories-preview.component';
+import { ArtemisMarkdownEditorModule } from 'app/markdown-editor';
 
 const ENTITY_STATES = [...programmingExerciseRoute, ...programmingExercisePopupRoute];
 
@@ -58,6 +59,7 @@ const ENTITY_STATES = [...programmingExerciseRoute, ...programmingExercisePopupR
         ArtemisSharedComponentModule,
         ArtemisPresentationScoreModule,
         OwlDateTimeModule,
+        ArtemisMarkdownEditorModule,
     ],
     declarations: [
         ProgrammingExerciseComponent,

--- a/src/main/webapp/app/scores/exercise-scores.component.html
+++ b/src/main/webapp/app/scores/exercise-scores.component.html
@@ -102,7 +102,7 @@
                             <fa-icon class="mr-1" icon="folder-open" [fixedWidth]="true"></fa-icon>Online editor
                         </button>
                         <button
-                            *ngIf="exercise.type === PROGRAMMING"
+                            *ngIf="newResultAllowed"
                             [routerLink]="['/', { outlets: { popup: 'participation/' + result.participation.id + '/result/new' } }]"
                             class="btn btn-warning btn-sm mr-1"
                         >

--- a/src/main/webapp/app/scores/exercise-scores.component.html
+++ b/src/main/webapp/app/scores/exercise-scores.component.html
@@ -102,7 +102,7 @@
                             <fa-icon class="mr-1" icon="folder-open" [fixedWidth]="true"></fa-icon>Online editor
                         </button>
                         <button
-                            *ngIf="newResultAllowed"
+                            *ngIf="newManualResultAllowed"
                             [routerLink]="['/', { outlets: { popup: 'participation/' + result.participation.id + '/result/new' } }]"
                             class="btn btn-warning btn-sm mr-1"
                         >

--- a/src/main/webapp/app/scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/scores/exercise-scores.component.ts
@@ -36,7 +36,7 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
     results: Result[];
     allResults: Result[];
     eventSubscriber: Subscription;
-    newResultAllowed: boolean;
+    newManualResultAllowed: boolean;
 
     isLoading: boolean;
 
@@ -72,7 +72,7 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
                 zip(this.getResults(), this.loadAndCacheProgrammingExerciseSubmissionState())
                     .pipe(take(1))
                     .subscribe(() => (this.isLoading = false));
-                this.newResultAllowed = areManualResultsAllowed(this.exercise);
+                this.newManualResultAllowed = areManualResultsAllowed(this.exercise);
             });
         });
         this.registerChangeInCourses();

--- a/src/main/webapp/app/scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/scores/exercise-scores.component.ts
@@ -6,7 +6,7 @@ import { DifferencePipe } from 'ngx-moment';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { HttpResponse } from '@angular/common/http';
 import { Moment } from 'moment';
-import { Exercise, ExerciseService, ExerciseType } from 'app/entities/exercise';
+import { areManualResultsAllowed, Exercise, ExerciseService, ExerciseType } from 'app/entities/exercise';
 import { Course, CourseService } from 'app/entities/course';
 import { Result, ResultService } from 'app/entities/result';
 import { SourceTreeService } from 'app/components/util/sourceTree.service';
@@ -36,6 +36,7 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
     results: Result[];
     allResults: Result[];
     eventSubscriber: Subscription;
+    newResultAllowed: boolean;
 
     isLoading: boolean;
 
@@ -71,6 +72,7 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
                 zip(this.getResults(), this.loadAndCacheProgrammingExerciseSubmissionState())
                     .pipe(take(1))
                     .subscribe(() => (this.isLoading = false));
+                this.newResultAllowed = areManualResultsAllowed(this.exercise);
             });
         });
         this.registerChangeInCourses();

--- a/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -28,6 +28,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
@@ -37,6 +38,7 @@ import de.tum.in.www1.artemis.service.ProgrammingExerciseTestCaseService;
 import de.tum.in.www1.artemis.service.ResultService;
 import de.tum.in.www1.artemis.service.connectors.BambooService;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
+import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 
 @ExtendWith(SpringExtension.class)
@@ -178,6 +180,26 @@ public class ResultServiceIntegrationTest {
         result = database.addFeedbacksToResult(result);
 
         request.getList("/api/results/" + 66 + "/details", HttpStatus.NOT_FOUND, Feedback.class);
+    }
+
+    @Test
+    @WithMockUser(value = "student1", roles = "INSTRUCTOR")
+    public void programmingExerciseManualResultUpdate_noManualReviewsAllowed_forbidden() throws Exception {
+        final var result = ModelFactory.generateResult(true, 1);
+        result.setParticipation(programmingExerciseStudentParticipation);
+        result.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
+
+        request.post("/api/manual-results", result, HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @WithMockUser(value = "student1", roles = "INSTRUCTOR")
+    public void programmingExerciseManualResultNew_noManualReviewsAllowed_forbidden() throws Exception {
+        final var result = ModelFactory.generateResult(true, 1);
+        result.setParticipation(programmingExerciseStudentParticipation);
+        result.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
+
+        request.put("/api/manual-results", result, HttpStatus.FORBIDDEN);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Only allow manual reviews for passed due dates and SEMI_AUTOMATIC assessments
Add grading instructions to programming exercise update component

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I added multiple integration tests (Spring) related to the features
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In preparation of manual review for programming exercises, we need the possibility to add grading instructions when creating a programming exercise. 
It is also important that the button for adding a new result (i.e. a manual review) is only enabled for programming exercises, if the assessment type is `SEMI_AUTOMATIC` and the due date  (or after due date) has passed. The same goes for the result endpoints. Those should return forbidden in case the above mentioned requirements are not met.

### Description
<!-- Describe your changes in detail -->
I added a markdown component for adding grading instructions when creating/editing programming exercises, that only is enabled once the instructor clicks on "Manual Review" in the exercise timeline. 
The button for creating a new result is also only displayed if the above mentioned conditions have been fulfilled.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a new programming exercise and enable the manual review
4. You should be able to add grading instructions
5. Set a due date
6. The new result button on the participations overview should only be visible once the due date is in the past