### PR TITLE
Enhancement Guided tour: Adjust tour step markdown and add final videos

### DIFF
--- a/src/main/webapp/app/components/util/markdown.service.ts
+++ b/src/main/webapp/app/components/util/markdown.service.ts
@@ -165,12 +165,7 @@ export class ArtemisMarkdown {
         if (markdownText == null || markdownText === '') {
             return '';
         }
-        const converter = new showdown.Converter({
-            backslashEscapesHTMLTags: true,
-            excludeTrailingPunctuationFromURLs: true,
-        });
-        const html = converter.makeHtml(markdownText);
-        const sanitized = DOMPurify.sanitize(html, { ALLOWED_TAGS: ['a', 'p', 'tt', 'span'], ALLOWED_ATTR: ['href', 'rel', 'target'] });
+        const sanitized = DOMPurify.sanitize(markdownText, { ALLOWED_TAGS: ['a', 'p', 'ul', 'li', 'tt', 'span'], ALLOWED_ATTR: ['href', 'rel', 'target'] });
         return this.sanitizer.bypassSecurityTrustHtml(sanitized);
     }
 

--- a/src/main/webapp/app/components/util/markdown.service.ts
+++ b/src/main/webapp/app/components/util/markdown.service.ts
@@ -156,6 +156,25 @@ export class ArtemisMarkdown {
     }
 
     /**
+     * Converts markdown into html, sanitizes it and then declares it as safe to bypass further security.
+     *
+     * @param {string} markdownText the original markdown text
+     * @returns {string} the resulting html as a string
+     */
+    htmlForGuidedTourMarkdown(markdownText: string | null) {
+        if (markdownText == null || markdownText === '') {
+            return '';
+        }
+        const converter = new showdown.Converter({
+            backslashEscapesHTMLTags: true,
+            excludeTrailingPunctuationFromURLs: true,
+        });
+        const html = converter.makeHtml(markdownText);
+        const sanitized = DOMPurify.sanitize(html, { ALLOWED_TAGS: ['a', 'p', 'tt', 'span'], ALLOWED_ATTR: ['href', 'rel', 'target'] });
+        return this.sanitizer.bypassSecurityTrustHtml(sanitized);
+    }
+
+    /**
      * This method is used to return sanitized html for markdown, that is not trusted by angular.
      * Angular might strip away styles or html tags!
      *

--- a/src/main/webapp/app/components/util/markdown.service.ts
+++ b/src/main/webapp/app/components/util/markdown.service.ts
@@ -165,7 +165,7 @@ export class ArtemisMarkdown {
         if (markdownText == null || markdownText === '') {
             return '';
         }
-        const sanitized = DOMPurify.sanitize(markdownText, { ALLOWED_TAGS: ['a', 'p', 'ul', 'li', 'tt', 'span'], ALLOWED_ATTR: ['href', 'rel', 'target'] });
+        const sanitized = DOMPurify.sanitize(markdownText, { ALLOWED_TAGS: ['a', 'p', 'ul', 'li', 'tt', 'span'], ALLOWED_ATTR: ['class', 'href', 'rel', 'target'] });
         return this.sanitizer.bypassSecurityTrustHtml(sanitized);
     }
 

--- a/src/main/webapp/app/guided-tour/dot-navigation.scss
+++ b/src/main/webapp/app/guided-tour/dot-navigation.scss
@@ -1,7 +1,7 @@
 /* Style for the navigation bubbles in the guided tour */
 
 .dotstyle {
-    width: 125px;
+    width: 260px;
     overflow: hidden;
     display: block;
     padding: 0;

--- a/src/main/webapp/app/guided-tour/guided-tour-step.model.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour-step.model.ts
@@ -43,20 +43,6 @@ export class TextTourStep extends TourStep {
     }
 }
 
-export class TextLinkTourStep extends TextTourStep {
-    /** External url **/
-    externalUrl: string;
-    /** Text for external url **/
-    externalUrlTranslateKey: string;
-    /** Link type, either link or button **/
-    linkType: LinkType;
-
-    constructor(tourStep: TextLinkTourStep) {
-        super(tourStep);
-        Object.assign(this, tourStep);
-    }
-}
-
 export class ImageTourStep extends TextTourStep {
     /** Image url **/
     imageUrl: string;

--- a/src/main/webapp/app/guided-tour/guided-tour.component.html
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.html
@@ -24,22 +24,13 @@
             </div>
             <div class="tour-block__content">
                 <h5 jhiTranslate="{{ currentTourStep.subHeadlineTranslateKey }}" class="sub-headline" *ngIf="currentTourStep.subHeadlineTranslateKey"></h5>
-                <div [innerHTML]="currentTourStep.contentTranslateKey | translate | htmlForMarkdown"></div>
-                <div class="step-link" *ngIf="currentTourStep.externalUrl && currentTourStep.externalUrlTranslateKey">
-                    <a
-                        [ngClass]="{ 'btn btn-primary': currentTourStep.linkType === LinkType.BUTTON }"
-                        jhiTranslate="{{ currentTourStep.externalUrlTranslateKey }}"
-                        [href]="currentTourStep.externalUrl"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    ></a>
-                </div>
+                <div [innerHTML]="currentTourStep.contentTranslateKey | translate | htmlForGuidedTourMarkdown"></div>
                 <div *ngIf="currentTourStep.hintTranslateKey" class="step-hint">
                     <div class="step-hint__icon">
                         <fa-icon icon="info-circle"></fa-icon>
                     </div>
                     <div class="step-hint__label">
-                        <div [innerHTML]="currentTourStep.hintTranslateKey | translate | htmlForMarkdown"></div>
+                        <div [innerHTML]="currentTourStep.hintTranslateKey | translate | htmlForGuidedTourMarkdown"></div>
                     </div>
                 </div>
                 <div *ngIf="currentTourStep.userInteractionEvent" class="step-hint interaction alert" [class.alert-success]="this.userInteractionFinished">

--- a/src/main/webapp/app/guided-tour/guided-tour.component.html
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.html
@@ -19,7 +19,9 @@
         <div *ngIf="currentTourStep.highlightSelector" class="tour-arrow"></div>
         <div class="tour-block">
             <div class="tour-block__header">
-                <h3 jhiTranslate="{{ currentTourStep.headlineTranslateKey }}" class="headline" *ngIf="currentTourStep.headlineTranslateKey"></h3>
+                <h3 class="headline" *ngIf="currentTourStep.headlineTranslateKey">
+                    {{ 'tour.step' | translate: { string: guidedTourService.getCurrentStepString() } }} {{ currentTourStep.headlineTranslateKey | translate }}
+                </h3>
                 <div *ngIf="guidedTourService.currentTour && guidedTourService.currentTour.steps.length > 1" class="close" (click)="guidedTourService.skipTour()"></div>
             </div>
             <div class="tour-block__content">

--- a/src/main/webapp/app/guided-tour/guided-tour.component.html
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.html
@@ -64,7 +64,7 @@
                     </div>
                 </div>
                 <div *ngIf="currentTourStep.videoUrl">
-                    <iframe [src]="currentTourStep.videoUrl | safeResourceUrl" frameborder="0" allowfullscreen></iframe>
+                    <iframe [src]="currentTourStep.videoUrl | translate | safeResourceUrl" frameborder="0" allowfullscreen></iframe>
                 </div>
             </div>
             <div class="tour-block__buttons">

--- a/src/main/webapp/app/guided-tour/guided-tour.component.html
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.html
@@ -20,7 +20,8 @@
         <div class="tour-block">
             <div class="tour-block__header">
                 <h3 class="headline" *ngIf="currentTourStep.headlineTranslateKey">
-                    <span *ngIf="guidedTourService.currentTour.steps.length > 1">{{ 'tour.step' | translate: { string: guidedTourService.getCurrentStepString() } }} </span
+                    <span *ngIf="guidedTourService.currentTour && guidedTourService.currentTour.steps.length > 1"
+                        >{{ 'tour.step' | translate: { string: guidedTourService.getCurrentStepString() } }} </span
                     >{{ currentTourStep.headlineTranslateKey | translate }}
                 </h3>
                 <div *ngIf="guidedTourService.currentTour && guidedTourService.currentTour.steps.length > 1" class="close" (click)="guidedTourService.skipTour()"></div>

--- a/src/main/webapp/app/guided-tour/guided-tour.component.html
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.html
@@ -20,7 +20,8 @@
         <div class="tour-block">
             <div class="tour-block__header">
                 <h3 class="headline" *ngIf="currentTourStep.headlineTranslateKey">
-                    {{ 'tour.step' | translate: { string: guidedTourService.getCurrentStepString() } }} {{ currentTourStep.headlineTranslateKey | translate }}
+                    <span *ngIf="guidedTourService.currentTour.steps.length > 1">{{ 'tour.step' | translate: { string: guidedTourService.getCurrentStepString() } }} </span
+                    >{{ currentTourStep.headlineTranslateKey | translate }}
                 </h3>
                 <div *ngIf="guidedTourService.currentTour && guidedTourService.currentTour.steps.length > 1" class="close" (click)="guidedTourService.skipTour()"></div>
             </div>

--- a/src/main/webapp/app/guided-tour/guided-tour.component.scss
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.scss
@@ -203,6 +203,14 @@ jhi-guided-tour {
                     margin: 0 5px;
                 }
 
+                ul {
+                    margin-right: 15px;
+
+                    li {
+                        padding: 4px;
+                    }
+                }
+
                 .red {
                     color: #ca2024;
                 }

--- a/src/main/webapp/app/guided-tour/guided-tour.component.scss
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.scss
@@ -133,6 +133,10 @@ jhi-guided-tour {
                     top: 10%;
                     transform: translate(0%, 0%);
                 }
+
+                @media (max-height: 700px) {
+                    top: 0;
+                }
             }
         }
 
@@ -187,7 +191,7 @@ jhi-guided-tour {
             &__content {
                 min-height: 80px;
                 font-size: 16px;
-                padding-bottom: 28px;
+                padding-bottom: 20px;
 
                 p {
                     margin-bottom: 0;
@@ -216,7 +220,7 @@ jhi-guided-tour {
                 .step-hint {
                     border-radius: 3px;
                     display: flex;
-                    margin: 15px 0 0 0;
+                    margin: 10px 0 0 0;
                     padding: 8px;
 
                     &:not(.interaction) {

--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -4,8 +4,7 @@ import { fromEvent, Subscription } from 'rxjs';
 import { LinkType, Orientation, OverlayPosition, UserInteractionEvent } from './guided-tour.constants';
 import { GuidedTourService } from './guided-tour.service';
 import { AccountService } from 'app/core';
-import { ImageTourStep, TextLinkTourStep, TextTourStep, VideoTourStep } from 'app/guided-tour/guided-tour-step.model';
-import { clickOnElement } from 'app/guided-tour/guided-tour.utils';
+import { ImageTourStep, TextTourStep, VideoTourStep } from 'app/guided-tour/guided-tour-step.model';
 
 @Component({
     selector: 'jhi-guided-tour',
@@ -113,7 +112,7 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
      * Subscribe to guidedTourCurrentStepStream and scroll to set element if the user has the right permission
      */
     public subscribeToGuidedTourCurrentStepStream() {
-        this.guidedTourService.getGuidedTourCurrentStepStream().subscribe((step: TextTourStep | TextLinkTourStep | ImageTourStep | VideoTourStep) => {
+        this.guidedTourService.getGuidedTourCurrentStepStream().subscribe((step: TextTourStep | ImageTourStep | VideoTourStep) => {
             this.currentTourStep = step;
             if (!this.currentTourStep) {
                 return;

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -127,6 +127,18 @@ export class GuidedTourService {
     }
 
     /**
+     * Get the current step string for the headline, that shows which step is currently displayed, `currentStep / totalStep`
+     */
+    public getCurrentStepString() {
+        if (!this.currentTour) {
+            return;
+        }
+        const currentStep = this.currentTourStepIndex + 1;
+        const totalSteps = this.currentTour.steps.length;
+        return `${currentStep} / ${totalSteps}`;
+    }
+
+    /**
      * Navigate to previous tour step
      */
     public backStep(): void {
@@ -247,7 +259,6 @@ export class GuidedTourService {
             .subscribe(guidedTourSettings => {
                 this.guidedTourSettings = guidedTourSettings.body!;
             });
-
         this.resetTour();
     }
 

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -413,6 +413,10 @@ export class GuidedTourService {
 
         // Proceed with tour if it has tour steps and the tour display is allowed for current window size
         if (this.currentTour.steps.length > 0 && this.tourAllowedForWindowSize()) {
+            if (!this.currentTour.steps[this.currentTourStepIndex]) {
+                // Set current tour step index to 0 if the current tour step cannot be found
+                this.currentTourStepIndex = 0;
+            }
             const currentStep = this.currentTour.steps[this.currentTourStepIndex];
             if (currentStep.action) {
                 currentStep.action();

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -25,7 +25,7 @@ export type EntityResponseType = HttpResponse<GuidedTourSetting[]>;
 export class GuidedTourService {
     public resourceUrl = SERVER_API_URL + 'api/guided-tour-settings';
 
-    public maxDots = 5;
+    public maxDots = 10;
     public guidedTourSettings: GuidedTourSetting[];
     public currentTour: GuidedTour | null;
     private guidedTourCurrentStepSubject = new Subject<TourStep | null>();
@@ -696,9 +696,9 @@ export class GuidedTourService {
                 nextPlusOneDot.classList.add('n-small');
                 dotList.style.transform = 'translateX(' + this.transformCount + 'px)';
                 dotList.querySelectorAll('li').forEach((node, index) => {
-                    if (index === nextIndex - 4) {
+                    if (index === nextIndex - 9) {
                         node.classList.remove('p-small');
-                    } else if (index === nextIndex - 3) {
+                    } else if (index === nextIndex - 8) {
                         node.classList.add('p-small');
                     }
                 });
@@ -711,9 +711,9 @@ export class GuidedTourService {
                 nextPlusOneDot.classList.add('p-small');
                 dotList.style.transform = 'translateX(' + this.transformCount + 'px)';
                 dotList.querySelectorAll('li').forEach((node, index) => {
-                    if (index === nextIndex + 4) {
+                    if (index === nextIndex + 9) {
                         node.classList.remove('n-small');
-                    } else if (index === nextIndex + 3) {
+                    } else if (index === nextIndex + 8) {
                         node.classList.add('n-small');
                     }
                 });

--- a/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
+++ b/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
@@ -10,19 +10,7 @@ export const courseExerciseOverviewTour: GuidedTour = {
         new TextTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.content',
-        }),
-        new TextTourStep({
-            headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.headline',
-            contentTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.java.content',
-        }),
-        new TextTourStep({
-            headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.headline',
-            contentTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.eclipse.content',
-        }),
-        new TextTourStep({
-            headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.headline',
-            contentTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTree.content',
-            hintTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTree.hint',
+            hintTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.hint',
         }),
         new VideoTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTreeSetup.headline',

--- a/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
+++ b/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
@@ -92,27 +92,27 @@ export const courseExerciseOverviewTour: GuidedTour = {
         new VideoTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.cloneRepository.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.cloneRepository.content',
-            videoUrl: 'https://www.youtube.com/embed/pDBl-vSCveM',
+            videoUrl: 'tour.courseExerciseOverview.cloneRepository.videoUrl',
         }),
         new VideoTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.inspectSourceTree.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.inspectSourceTree.content',
-            videoUrl: 'https://www.youtube.com/embed/7ugt0k0Qa7Y',
+            videoUrl: 'tour.courseExerciseOverview.inspectSourceTree.videoUrl',
         }),
         new VideoTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.importEclipse.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.importEclipse.content',
-            videoUrl: 'https://www.youtube.com/embed/xl0lyV_IHzY',
+            videoUrl: 'tour.courseExerciseOverview.importEclipse.videoUrl',
         }),
         new VideoTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.inspectProject.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.inspectProject.content',
-            videoUrl: 'https://www.youtube.com/embed/qW9Tc-AYBH8',
+            videoUrl: 'tour.courseExerciseOverview.inspectProject.videoUrl',
         }),
         new VideoTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.commitAndPush.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.commitAndPush.content',
-            videoUrl: 'https://www.youtube.com/embed/iFRHdp8ozh4',
+            videoUrl: 'tour.courseExerciseOverview.commitAndPush.videoUrl',
         }),
         new TextTourStep({
             highlightSelector: '.row.guided-tour',

--- a/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
+++ b/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
@@ -1,6 +1,6 @@
 import { GuidedTour } from 'app/guided-tour/guided-tour.model';
-import { LinkType, Orientation, UserInteractionEvent } from 'app/guided-tour/guided-tour.constants';
-import { TextLinkTourStep, TextTourStep, VideoTourStep } from 'app/guided-tour/guided-tour-step.model';
+import { Orientation, UserInteractionEvent } from 'app/guided-tour/guided-tour.constants';
+import { TextTourStep, VideoTourStep } from 'app/guided-tour/guided-tour-step.model';
 
 export const courseExerciseOverviewTour: GuidedTour = {
     courseShortName: 'artemistutorial',
@@ -11,27 +11,18 @@ export const courseExerciseOverviewTour: GuidedTour = {
             headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.content',
         }),
-        new TextLinkTourStep({
+        new TextTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.java.content',
-            externalUrl: 'https://www.oracle.com/technetwork/java/javase/downloads/index.html',
-            externalUrlTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.java.linkText',
-            linkType: LinkType.LINK,
         }),
-        new TextLinkTourStep({
+        new TextTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.eclipse.content',
-            externalUrl: 'https://www.eclipse.org/downloads/packages/',
-            externalUrlTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.eclipse.linkText',
-            linkType: LinkType.LINK,
         }),
-        new TextLinkTourStep({
+        new TextTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTree.content',
             hintTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTree.hint',
-            externalUrl: 'https://www.sourcetreeapp.com',
-            externalUrlTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTree.linkText',
-            linkType: LinkType.LINK,
         }),
         new VideoTourStep({
             headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTreeSetup.headline',

--- a/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
+++ b/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
@@ -16,7 +16,7 @@ export const courseExerciseOverviewTour: GuidedTour = {
             headlineTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTreeSetup.headline',
             contentTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTreeSetup.content',
             hintTranslateKey: 'tour.courseExerciseOverview.installPrerequisites.sourceTreeSetup.hint',
-            videoUrl: 'https://www.youtube.com/embed/KKGuYVRIe-Y',
+            videoUrl: 'tour.courseExerciseOverview.installPrerequisites.sourceTreeSetup.videoUrl',
         }),
         new TextTourStep({
             highlightSelector: '.tab-item.exercises',

--- a/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
+++ b/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
@@ -4,7 +4,7 @@ import { TextTourStep, VideoTourStep } from 'app/guided-tour/guided-tour-step.mo
 
 export const courseExerciseOverviewTour: GuidedTour = {
     courseShortName: 'artemistutorial',
-    exerciseShortName: 'test',
+    exerciseShortName: 'tutorial',
     settingsKey: 'course_exercise_overview_tour',
     steps: [
         new TextTourStep({

--- a/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
+++ b/src/main/webapp/app/guided-tour/tours/course-exercise-overview-tour.ts
@@ -4,7 +4,7 @@ import { TextTourStep, VideoTourStep } from 'app/guided-tour/guided-tour-step.mo
 
 export const courseExerciseOverviewTour: GuidedTour = {
     courseShortName: 'artemistutorial',
-    exerciseShortName: 'tutorial',
+    exerciseShortName: 'test',
     settingsKey: 'course_exercise_overview_tour',
     steps: [
         new TextTourStep({

--- a/src/main/webapp/app/guided-tour/tours/course-overview-tour.ts
+++ b/src/main/webapp/app/guided-tour/tours/course-overview-tour.ts
@@ -1,7 +1,6 @@
-import { Orientation, UserInteractionEvent, LinkType } from 'app/guided-tour/guided-tour.constants';
+import { Orientation, UserInteractionEvent } from 'app/guided-tour/guided-tour.constants';
 import { GuidedTour } from 'app/guided-tour/guided-tour.model';
-import { ImageTourStep, TextTourStep, TextLinkTourStep } from 'app/guided-tour/guided-tour-step.model';
-import { clickOnElement } from 'app/guided-tour/guided-tour.utils';
+import { ImageTourStep, TextTourStep } from 'app/guided-tour/guided-tour-step.model';
 
 /**
  * This constant contains the guided tour configuration and steps for the course overview page
@@ -91,13 +90,10 @@ export const courseOverviewTour: GuidedTour = {
             highlightPadding: 10,
             disableStep: true,
         }),
-        new TextLinkTourStep({
+        new TextTourStep({
             highlightSelector: '.footer .col-sm-6',
             headlineTranslateKey: 'tour.courseOverview.contact.headline',
             contentTranslateKey: 'tour.courseOverview.contact.content',
-            externalUrlTranslateKey: 'tour.courseOverview.contact.link',
-            externalUrl: 'https://github.com/ls1intum/ArTEMiS',
-            linkType: LinkType.BUTTON,
             orientation: Orientation.TOPLEFT,
             disableStep: true,
         }),

--- a/src/main/webapp/app/shared/index.ts
+++ b/src/main/webapp/app/shared/index.ts
@@ -17,6 +17,7 @@ export * from './pipes/remove-keys.pipe';
 export * from './pipes/keys.pipe';
 export * from './pipes/type-check.pipe';
 export * from './pipes/html-for-markdown.pipe';
+export * from './pipes/html-for-guided-tour-markdown.pipe';
 export * from './pipes/truncate.pipe';
 export * from './shared-libs.module';
 export * from './shared-common.module';

--- a/src/main/webapp/app/shared/pipes/html-for-guided-tour-markdown.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/html-for-guided-tour-markdown.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { SafeHtml } from '@angular/platform-browser';
+import { ArtemisMarkdown } from 'app/components/util/markdown.service';
+
+@Pipe({
+    name: 'htmlForGuidedTourMarkdown',
+})
+export class HtmlForGuidedTourMarkdownPipe implements PipeTransform {
+    constructor(private markdownService: ArtemisMarkdown) {}
+    transform(markdown: string): SafeHtml | null {
+        return this.markdownService.htmlForGuidedTourMarkdown(markdown);
+    }
+}

--- a/src/main/webapp/app/shared/pipes/shared-pipes.module.ts
+++ b/src/main/webapp/app/shared/pipes/shared-pipes.module.ts
@@ -13,6 +13,7 @@ import {
     TypeCheckPipe,
 } from './';
 import { SafeResourceUrlPipe } from 'app/shared/pipes/safe-resource-url.pipe';
+import { HtmlForGuidedTourMarkdownPipe } from 'app/shared';
 
 @NgModule({
     declarations: [
@@ -25,6 +26,7 @@ import { SafeResourceUrlPipe } from 'app/shared/pipes/safe-resource-url.pipe';
         TypeCheckPipe,
         RemovePositiveAutomaticFeedbackPipe,
         HtmlForMarkdownPipe,
+        HtmlForGuidedTourMarkdownPipe,
         TruncatePipe,
         SanitizeHtmlPipe,
         AverageByPipe,
@@ -38,6 +40,7 @@ import { SafeResourceUrlPipe } from 'app/shared/pipes/safe-resource-url.pipe';
         TypeCheckPipe,
         RemovePositiveAutomaticFeedbackPipe,
         HtmlForMarkdownPipe,
+        HtmlForGuidedTourMarkdownPipe,
         TruncatePipe,
         SanitizeHtmlPipe,
         SafeResourceUrlPipe,

--- a/src/main/webapp/i18n/de/guidedTour.json
+++ b/src/main/webapp/i18n/de/guidedTour.json
@@ -1,5 +1,6 @@
 {
     "tour": {
+        "step": "Schritt {{ string }}:",
         "navigation": {
             "back": "Zurück",
             "next": "Weiter",

--- a/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
@@ -8,7 +8,7 @@
                 "sourceTreeSetup": {
                     "headline": "Konfiguriere SourceTree",
                     "content": "Schau dir bitte das Video an und folge den Schritten, um SourceTree richtig aufzusetzen. Mit diesem Schritt haben wir das Setup abgeschlossen und können uns die Kursseite und dessen Elemente genauer unter die Lupe nehmen.",
-                    "videoUrl": "https://www.youtube.com/embed/wfT_QX4jlZ0",
+                    "videoUrl": "https://www.youtube.com/embed/zVw-mMgQjPU",
                     "hint": "Kopiere und füge <tt>https://bitbucket.ase.in.tum.de</tt> als URL ein."
                 }
             },
@@ -55,27 +55,27 @@
             "cloneRepository": {
                 "headline": "Klone das Repository in SourceTree",
                 "content": "Schau dir das folgende Video an, um zu verstehen, wie man ein Git Repository in SourceTree klont. Danach solltest du auf das <tt>X</tt> oben rechts klicken um das Tutorial zu stoppen und die im Video angezeigten Schritte durchzuführen. Danach kannst du das Tutorial wieder von deinem Account Menü aus fortsetzen.",
-                "videoUrl": "https://www.youtube.com/embed/FefFxHkXVc0"
+                "videoUrl": "https://www.youtube.com/embed/0YYxgs14S6A"
             },
             "inspectSourceTree": {
                 "headline": "Lerne SourceTree kennen",
                 "content": "Schau dir das folgende Video, um die grundlegenden Funktionen von SourceTree kennenzulernen.",
-                "videoUrl": "https://www.youtube.com/embed/mQ3yvgxcrSY"
+                "videoUrl": "https://www.youtube.com/embed/Piu_UBK6d7c"
             },
             "importEclipse": {
                 "headline": "Importiere das Java Projekt in Eclipse",
                 "content": "Schau dir das folgende Video an, um zu sehen, wie man ein Projekt in Eclipse importiert.",
-                "videoUrl": "https://www.youtube.com/embed/vXRHF1ECIJc"
+                "videoUrl": "https://www.youtube.com/embed/5VrNNlEuCBo"
             },
             "inspectProject": {
                 "headline": "Untersuche das Projekt",
                 "content": "In diesem Video schauen wir uns das Projekt an und lösen die darin gegebene Aufgabe.",
-                "videoUrl": "https://www.youtube.com/embed/o3ITPmYVS-0"
+                "videoUrl": "https://www.youtube.com/embed/K-mX03gmNSk"
             },
             "commitAndPush": {
                 "headline": "Reiche deine Änderungen ein",
                 "content": "Schau dir das folgende Video an, um zu verstehen, wie man Änderungen committed und pushed.",
-                "videoUrl": "https://www.youtube.com/embed/xoWoDWhhZ68"
+                "videoUrl": "https://www.youtube.com/embed/sjT-S6AhQvM"
             },
             "reviewResult": {
                 "headline": "Überprüfe dein Ergebnis",

--- a/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
@@ -3,17 +3,8 @@
         "courseExerciseOverview": {
             "installPrerequisites": {
                 "headline": "Installiere die notwendigen Tools",
-                "content": "Bevor wir uns den Kurs und die darin enthaltene Beispielaufgabe anschauen, müssen wir zuerst die notwendigen Tools herunterladen und installieren. Du findest die Anweisungen in den folgenden Tutorialschritten.",
-                "java": {
-                    "content": "<a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>Installiere</a> das neueste Java JDK (mind. Java JDK 12). Stelle dabei sicher, dass du JDK und <span class='red'>nicht</span> JRE auswählst."
-                },
-                "eclipse": {
-                    "content": "<a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>Installiere</a> Eclipse IDE für Java Entwickler (2019‐09 oder neuer)"
-                },
-                "sourceTree": {
-                    "content": "<a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>Installiere</a> die neueste Version von SourceTree mit git (3.2.1 oder neuer für macOS oder Windows)",
-                    "hint": "Bitte stelle sicher, dass du auch die git Kommandozeilen Tools installierst, während du SourceTree aufsetzt. Solltest du Linux nutzen, kannst du z.B. <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> oder die <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>Kommandozeile</a> verwenden."
-                },
+                "content": "Bevor wir uns den Kurs und die darin enthaltene Beispielaufgabe anschauen, müssen wir zuerst die notwendigen Tools herunterladen und installieren.<ul><li><a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>Installiere</a> das neueste Java JDK (mind. Java JDK 12). Stelle dabei sicher, dass du JDK und <span class='red'>nicht</span> JRE auswählst.</li><li><a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>Installiere</a> Eclipse IDE für Java Entwickler (2019‐09 oder neuer)</li><li><a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>Installiere</a> die neueste Version von SourceTree mit git (3.2.1 oder neuer für macOS oder Windows)</li></ul>",
+                "hint": "Bitte stelle sicher, dass du auch die git Kommandozeilen Tools installierst, während du SourceTree aufsetzt. Solltest du Linux nutzen, kannst du z.B. <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> oder die <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>Kommandozeile</a> verwenden.",
                 "sourceTreeSetup": {
                     "headline": "Konfiguriere SourceTree",
                     "content": "Schau dir bitte das Video an und folge den Schritten, um SourceTree richtig aufzusetzen. Mit diesem Schritt haben wir das Setup abgeschlossen und können uns die Kursseite und dessen Elemente genauer unter die Lupe nehmen.",

--- a/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
@@ -3,7 +3,7 @@
         "courseExerciseOverview": {
             "installPrerequisites": {
                 "headline": "Installiere die notwendigen Tools",
-                "content": "Bevor wir uns den Kurs und die darin enthaltene Beispielaufgabe anschauen, müssen wir zuerst die notwendigen Tools herunterladen und installieren.<ul><li><a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>Installiere</a> das neueste Java JDK (mind. Java JDK 12). Stelle dabei sicher, dass du JDK und <span class='red bold'>nicht</span> JRE auswählst.</li><li><a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>Installiere</a> Eclipse IDE für Java Entwickler (2019‐09 oder neuer)</li><li><a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>Installiere</a> die neueste Version von SourceTree mit git (3.2.1 oder neuer für macOS oder Windows)</li></ul>",
+                "content": "Bevor wir uns den Kurs und die darin enthaltene Beispielaufgabe anschauen, müssen wir zuerst die notwendigen Tools herunterladen und installieren.<ul><li>Installiere das neueste <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>Java JDK</a> (mind. Java JDK 12). Stelle dabei sicher, dass du JDK und <span class='red bold'>nicht</span> JRE auswählst.</li><li>Installiere die <a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>Eclipse IDE für Java Entwickler</a> (2019‐09 oder neuer)</li><li>Installiere die neueste Version von <a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>SourceTree</a> mit git (3.2.1 oder neuer für macOS oder Windows)</li></ul>",
                 "hint": "Bitte stelle sicher, dass du auch die git Kommandozeilen Tools installierst, während du SourceTree aufsetzt. Solltest du Linux nutzen, kannst du z.B. <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> oder die <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>Kommandozeile</a> verwenden.",
                 "sourceTreeSetup": {
                     "headline": "Konfiguriere SourceTree",
@@ -50,11 +50,11 @@
             },
             "startExercise": {
                 "headline": "Beginne mit deiner ersten Programmieraufgabe",
-                "content": "Klicke auf den Button <tt>Aufgabe starten</tt> um an deiner Aufgabe zu arbeiten. Der Vorgang dauert einige Sekunden, da ein persönliches Repository für dich im Hintergrund aufgesetzt wird. Danach solltest du auf das <tt>X</tt> klicken um das Tutorial zu stoppen und die im Video angezeigten Schritte durchzuführen. Danach kannst du das Tutorial wieder von deinem Account Menü aus fortsetzen."
+                "content": "Klicke auf den Button <tt>Aufgabe starten</tt> um an deiner Aufgabe zu arbeiten. Der Vorgang dauert einige Sekunden, da ein persönliches Repository für dich im Hintergrund aufgesetzt wird."
             },
             "cloneRepository": {
                 "headline": "Klone das Repository in SourceTree",
-                "content": "Schau dir das folgende Video an, um zu verstehen, wie man ein Git Repository in SourceTree klont.",
+                "content": "Schau dir das folgende Video an, um zu verstehen, wie man ein Git Repository in SourceTree klont. Danach solltest du auf das <tt>X</tt> oben rechts klicken um das Tutorial zu stoppen und die im Video angezeigten Schritte durchzuführen. Danach kannst du das Tutorial wieder von deinem Account Menü aus fortsetzen.",
                 "videoUrl": "https://www.youtube.com/embed/FefFxHkXVc0"
             },
             "inspectSourceTree": {

--- a/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
@@ -8,6 +8,7 @@
                 "sourceTreeSetup": {
                     "headline": "Konfiguriere SourceTree",
                     "content": "Schau dir bitte das Video an und folge den Schritten, um SourceTree richtig aufzusetzen. Mit diesem Schritt haben wir das Setup abgeschlossen und können uns die Kursseite und dessen Elemente genauer unter die Lupe nehmen.",
+                    "videoUrl": "https://www.youtube.com/embed/wfT_QX4jlZ0",
                     "hint": "Kopiere und füge <tt>https://bitbucket.ase.in.tum.de</tt> als URL ein."
                 }
             },
@@ -49,32 +50,32 @@
             },
             "startExercise": {
                 "headline": "Beginne mit deiner ersten Programmieraufgabe",
-                "content": "Klicke auf den Button 'Aufgabe starten' um an deiner Aufgabe zu arbeiten. Der Vorgang dauert einige Sekunden, da ein persönliches Repository für dich im Hintergrund aufgesetzt wird."
+                "content": "Klicke auf den Button <tt>Aufgabe starten</tt> um an deiner Aufgabe zu arbeiten. Der Vorgang dauert einige Sekunden, da ein persönliches Repository für dich im Hintergrund aufgesetzt wird. Danach solltest du auf das <tt>X</tt> klicken um das Tutorial zu stoppen und die im Video angezeigten Schritte durchzuführen. Danach kannst du das Tutorial wieder von deinem Account Menü aus fortsetzen."
             },
             "cloneRepository": {
                 "headline": "Klone das Repository in SourceTree",
                 "content": "Schau dir das folgende Video an, um zu verstehen, wie man ein Git Repository in SourceTree klont.",
-                "videoUrl": "https://www.youtube.com/embed/pDBl-vSCveM"
+                "videoUrl": "https://www.youtube.com/embed/FefFxHkXVc0"
             },
             "inspectSourceTree": {
                 "headline": "Lerne SourceTree kennen",
                 "content": "Schau dir das folgende Video, um die grundlegenden Funktionen von SourceTree kennenzulernen.",
-                "videoUrl": "https://www.youtube.com/embed/7ugt0k0Qa7Y"
+                "videoUrl": "https://www.youtube.com/embed/mQ3yvgxcrSY"
             },
             "importEclipse": {
                 "headline": "Importiere das Java Projekt in Eclipse",
                 "content": "Schau dir das folgende Video an, um zu sehen, wie man ein Projekt in Eclipse importiert.",
-                "videoUrl": "https://www.youtube.com/embed/xl0lyV_IHzY"
+                "videoUrl": "https://www.youtube.com/embed/vXRHF1ECIJc"
             },
             "inspectProject": {
                 "headline": "Untersuche das Projekt",
                 "content": "In diesem Video schauen wir uns das Projekt an und lösen die darin gegebene Aufgabe.",
-                "videoUrl": "https://www.youtube.com/embed/qW9Tc-AYBH8"
+                "videoUrl": "https://www.youtube.com/embed/o3ITPmYVS-0"
             },
             "commitAndPush": {
                 "headline": "Reiche deine Änderungen ein",
                 "content": "Schau dir das folgende Video an, um zu verstehen, wie man Änderungen committed und pushed.",
-                "videoUrl": "https://www.youtube.com/embed/iFRHdp8ozh4"
+                "videoUrl": "https://www.youtube.com/embed/xoWoDWhhZ68"
             },
             "reviewResult": {
                 "headline": "Überprüfe dein Ergebnis",

--- a/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
@@ -3,7 +3,7 @@
         "courseExerciseOverview": {
             "installPrerequisites": {
                 "headline": "Installiere die notwendigen Tools",
-                "content": "Bevor wir uns den Kurs und die darin enthaltene Beispielaufgabe anschauen, müssen wir zuerst die notwendigen Tools herunterladen und installieren.<ul><li><a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>Installiere</a> das neueste Java JDK (mind. Java JDK 12). Stelle dabei sicher, dass du JDK und <span class='red'>nicht</span> JRE auswählst.</li><li><a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>Installiere</a> Eclipse IDE für Java Entwickler (2019‐09 oder neuer)</li><li><a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>Installiere</a> die neueste Version von SourceTree mit git (3.2.1 oder neuer für macOS oder Windows)</li></ul>",
+                "content": "Bevor wir uns den Kurs und die darin enthaltene Beispielaufgabe anschauen, müssen wir zuerst die notwendigen Tools herunterladen und installieren.<ul><li><a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>Installiere</a> das neueste Java JDK (mind. Java JDK 12). Stelle dabei sicher, dass du JDK und <span class='red bold'>nicht</span> JRE auswählst.</li><li><a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>Installiere</a> Eclipse IDE für Java Entwickler (2019‐09 oder neuer)</li><li><a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>Installiere</a> die neueste Version von SourceTree mit git (3.2.1 oder neuer für macOS oder Windows)</li></ul>",
                 "hint": "Bitte stelle sicher, dass du auch die git Kommandozeilen Tools installierst, während du SourceTree aufsetzt. Solltest du Linux nutzen, kannst du z.B. <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> oder die <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>Kommandozeile</a> verwenden.",
                 "sourceTreeSetup": {
                     "headline": "Konfiguriere SourceTree",
@@ -53,23 +53,28 @@
             },
             "cloneRepository": {
                 "headline": "Klone das Repository in SourceTree",
-                "content": "Schau dir das folgende Video an, um zu verstehen, wie man ein Git Repository in SourceTree klont."
+                "content": "Schau dir das folgende Video an, um zu verstehen, wie man ein Git Repository in SourceTree klont.",
+                "videoUrl": "https://www.youtube.com/embed/pDBl-vSCveM"
             },
             "inspectSourceTree": {
                 "headline": "Lerne SourceTree kennen",
-                "content": "Schau dir das folgende Video, um die grundlegenden Funktionen von SourceTree kennenzulernen."
+                "content": "Schau dir das folgende Video, um die grundlegenden Funktionen von SourceTree kennenzulernen.",
+                "videoUrl": "https://www.youtube.com/embed/7ugt0k0Qa7Y"
             },
             "importEclipse": {
                 "headline": "Importiere das Java Projekt in Eclipse",
-                "content": "Schau dir das folgende Video an, um zu sehen, wie man ein Projekt in Eclipse importiert."
+                "content": "Schau dir das folgende Video an, um zu sehen, wie man ein Projekt in Eclipse importiert.",
+                "videoUrl": "https://www.youtube.com/embed/xl0lyV_IHzY"
             },
             "inspectProject": {
                 "headline": "Untersuche das Projekt",
-                "content": "In diesem Video schauen wir uns das Projekt an und lösen die darin gegebene Aufgabe."
+                "content": "In diesem Video schauen wir uns das Projekt an und lösen die darin gegebene Aufgabe.",
+                "videoUrl": "https://www.youtube.com/embed/qW9Tc-AYBH8"
             },
             "commitAndPush": {
                 "headline": "Reiche deine Änderungen ein",
-                "content": "Schau dir das folgende Video an, um zu verstehen, wie man Änderungen committed und pushed."
+                "content": "Schau dir das folgende Video an, um zu verstehen, wie man Änderungen committed und pushed.",
+                "videoUrl": "https://www.youtube.com/embed/iFRHdp8ozh4"
             },
             "reviewResult": {
                 "headline": "Überprüfe dein Ergebnis",

--- a/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/de/guidedTourCourseExerciseOverview.json
@@ -5,17 +5,14 @@
                 "headline": "Installiere die notwendigen Tools",
                 "content": "Bevor wir uns den Kurs und die darin enthaltene Beispielaufgabe anschauen, müssen wir zuerst die notwendigen Tools herunterladen und installieren. Du findest die Anweisungen in den folgenden Tutorialschritten.",
                 "java": {
-                    "content": "Installiere das neueste Java JDK (mind. Java JDK 12). Stelle dabei sicher, dass du JDK und <span class='red'>nicht</span> JRE auswählst.",
-                    "linkText": "Lade Java JDK herunter"
+                    "content": "<a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>Installiere</a> das neueste Java JDK (mind. Java JDK 12). Stelle dabei sicher, dass du JDK und <span class='red'>nicht</span> JRE auswählst."
                 },
                 "eclipse": {
-                    "content": "Installiere Eclipse IDE für Java Entwickler (2019‐09 oder neuer)",
-                    "linkText": "Lade Eclipse IDE herunter"
+                    "content": "<a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>Installiere</a> Eclipse IDE für Java Entwickler (2019‐09 oder neuer)"
                 },
                 "sourceTree": {
-                    "content": "Installiere die neueste Version von SourceTree mit git (3.2.1 oder neuer für macOS oder Windows)",
-                    "hint": "Bitte stelle sicher, dass du auch die git Kommandozeilen Tools installierst, während du SourceTree aufsetzt. Solltest du Linux nutzen, kannst du z.B. <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> oder die <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>Kommandozeile</a> verwenden.",
-                    "linkText": "Lade SourceTree herunter"
+                    "content": "<a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>Installiere</a> die neueste Version von SourceTree mit git (3.2.1 oder neuer für macOS oder Windows)",
+                    "hint": "Bitte stelle sicher, dass du auch die git Kommandozeilen Tools installierst, während du SourceTree aufsetzt. Solltest du Linux nutzen, kannst du z.B. <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> oder die <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>Kommandozeile</a> verwenden."
                 },
                 "sourceTreeSetup": {
                     "headline": "Konfiguriere SourceTree",

--- a/src/main/webapp/i18n/en/guidedTour.json
+++ b/src/main/webapp/i18n/en/guidedTour.json
@@ -1,5 +1,6 @@
 {
     "tour": {
+        "step": "Step {{ string }}:",
         "navigation": {
             "back": "Back",
             "next": "Next",

--- a/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
@@ -49,11 +49,11 @@
             },
             "startExercise": {
                 "headline": "Start with your first programming exercise",
-                "content": "Click on the 'Start exercise' button to start working on the exercise. This action takes a few seconds, since a personal repository is setup for you in the background."
+                "content": "Click on the <tt>Start exercise</tt> button to start working on the exercise. This action takes a few seconds, since a personal repository is setup for you in the background"
             },
             "cloneRepository": {
                 "headline": "Clone repository in SourceTree",
-                "content": "Watch the following video to understand how to clone a git repository in SourceTree.",
+                "content": "Watch the following video to understand how to clone a git repository in SourceTree. After this step you should click on the <tt>X</tt> button to cancel the tutorial for now and apply the steps that you have seen in the video. Afterwards just continue the tutorial from your account menu",
                 "videoUrl": "https://www.youtube.com/embed/pDBl-vSCveM"
             },
             "inspectSourceTree": {

--- a/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
@@ -3,7 +3,7 @@
         "courseExerciseOverview": {
             "installPrerequisites": {
                 "headline": "Install required tools",
-                "content": "Before we have a look at this course and the example exercise, we need to download and install a few software tools.<ul><li>Please <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>download</a> and install the newest Java JDK (at least Java JDK 12). Make sure to choose JDK and <span class='red'>NOT</span> JRE.</li><li>Please <a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>download</a> and install Eclipse IDE for Java Developers (2019‐09 or later)</li><li>Please <a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>download</a> and install SourceTree with git (3.2.1 or later for macOS or Windows).</li></ul>",
+                "content": "Before we have a look at this course and the example exercise, we need to download and install a few software tools.<ul><li>Please <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>download</a> and install the newest Java JDK (at least Java JDK 12). Make sure to choose JDK and <span class='red bold'>not</span> JRE.</li><li>Please <a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>download</a> and install Eclipse IDE for Java Developers (2019‐09 or later)</li><li>Please <a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>download</a> and install SourceTree with git (3.2.1 or later for macOS or Windows).</li></ul>",
                 "hint": "Make sure that the git command line tools are also installed during the installation of SourceTree. In case you are using Linux, you can e.g. use <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> or the <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>command line</a>.",
                 "sourceTreeSetup": {
                     "headline": "Setup SourceTree",
@@ -53,23 +53,28 @@
             },
             "cloneRepository": {
                 "headline": "Clone repository in SourceTree",
-                "content": "Watch the following video to understand how to clone a git repository in SourceTree."
+                "content": "Watch the following video to understand how to clone a git repository in SourceTree.",
+                "videoUrl": "https://www.youtube.com/embed/pDBl-vSCveM"
             },
             "inspectSourceTree": {
                 "headline": "Inspect SourceTree",
-                "content": "Watch the following video to understand the basic functions in SourceTree."
+                "content": "Watch the following video to understand the basic functions in SourceTree.",
+                "videoUrl": "https://www.youtube.com/embed/7ugt0k0Qa7Y"
             },
             "importEclipse": {
                 "headline": "Import the Java project in Eclipse",
-                "content": "Watch the following video to understand how to import the project in Eclipse."
+                "content": "Watch the following video to understand how to import the project in Eclipse.",
+                "videoUrl": "https://www.youtube.com/embed/xl0lyV_IHzY"
             },
             "inspectProject": {
                 "headline": "Inspect Project",
-                "content": "In this video step we will inspect the project and solve the given task."
+                "content": "In this video step we will inspect the project and solve the given task.",
+                "videoUrl": "https://www.youtube.com/embed/qW9Tc-AYBH8"
             },
             "commitAndPush": {
                 "headline": "Submit your changes",
-                "content": "Watch the following video to understand how to commit and push your changes."
+                "content": "Watch the following video to understand how to commit and push your changes.",
+                "videoUrl": "https://www.youtube.com/embed/iFRHdp8ozh4"
             },
             "reviewResult": {
                 "headline": "Review your result",

--- a/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
@@ -53,7 +53,7 @@
             },
             "cloneRepository": {
                 "headline": "Clone repository in SourceTree",
-                "content": "Watch the following video to understand how to clone a git repository in SourceTree. After this step you should click on the <tt>X</tt> button to cancel the tutorial for now and apply the steps that you have seen in the video. Afterwards just continue the tutorial from your account menu",
+                "content": "Watch the following video to understand how to clone a git repository in SourceTree. After this step you should click on the <tt>X</tt> button on the top right to cancel the tutorial for now and apply the steps that you have seen in the video. Afterwards just continue the tutorial from your account menu",
                 "videoUrl": "https://www.youtube.com/embed/pDBl-vSCveM"
             },
             "inspectSourceTree": {

--- a/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
@@ -3,17 +3,8 @@
         "courseExerciseOverview": {
             "installPrerequisites": {
                 "headline": "Install required tools",
-                "content": "Before we have a look at this course and the example exercise, we need to download and install a few software tools. You can find the instructions in the next few steps.",
-                "java": {
-                    "content": "Please <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>download</a> and install the newest Java JDK (at least Java JDK 12). Make sure to choose JDK and <span class='red'>NOT</span> JRE."
-                },
-                "eclipse": {
-                    "content": "Please <a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>download</a> and install Eclipse IDE for Java Developers (2019‐09 or later)"
-                },
-                "sourceTree": {
-                    "content": "Please <a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>download</a> and install SourceTree with git (3.2.1 or later for macOS or Windows).",
-                    "hint": "Make sure that the git command line tools are also installed during the installation of SourceTree. In case you are using Linux, you can e.g. use <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> or the <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>command line</a>."
-                },
+                "content": "Before we have a look at this course and the example exercise, we need to download and install a few software tools.<ul><li>Please <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>download</a> and install the newest Java JDK (at least Java JDK 12). Make sure to choose JDK and <span class='red'>NOT</span> JRE.</li><li>Please <a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>download</a> and install Eclipse IDE for Java Developers (2019‐09 or later)</li><li>Please <a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>download</a> and install SourceTree with git (3.2.1 or later for macOS or Windows).</li></ul>",
+                "hint": "Make sure that the git command line tools are also installed during the installation of SourceTree. In case you are using Linux, you can e.g. use <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> or the <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>command line</a>.",
                 "sourceTreeSetup": {
                     "headline": "Setup SourceTree",
                     "content": "Watch the following video and follow the steps to setup SourceTree. Afterwards we are done with the setup and can have a look at the course page and its content.",

--- a/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
@@ -3,11 +3,12 @@
         "courseExerciseOverview": {
             "installPrerequisites": {
                 "headline": "Install required tools",
-                "content": "Before we have a look at this course and the example exercise, we need to download and install a few software tools.<ul><li>Please <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>download</a> and install the newest Java JDK (at least Java JDK 12). Make sure to choose JDK and <span class='red bold'>not</span> JRE.</li><li>Please <a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>download</a> and install Eclipse IDE for Java Developers (2019‐09 or later)</li><li>Please <a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>download</a> and install SourceTree with git (3.2.1 or later for macOS or Windows).</li></ul>",
+                "content": "Before we have a look at this course and the example exercise, we need to download and install a few software tools.<ul><li>Please download and install the newest <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>Java JDK</a> (at least Java JDK 12). Make sure to choose JDK and <span class='red bold'>not</span> JRE.</li><li>Please download and install <a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>Eclipse IDE for Java Developers</a> (2019‐09 or later)</li><li>Please download and install <a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>SourceTree</a> with git (3.2.1 or later for macOS or Windows).</li></ul>",
                 "hint": "Make sure that the git command line tools are also installed during the installation of SourceTree. In case you are using Linux, you can e.g. use <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> or the <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>command line</a>.",
                 "sourceTreeSetup": {
                     "headline": "Setup SourceTree",
                     "content": "Watch the following video and follow the steps to setup SourceTree. Afterwards we are done with the setup and can have a look at the course page and its content.",
+                    "videoUrl": "https://www.youtube.com/embed/YSywEAXKFVk",
                     "hint": "Copy and insert <tt>https://bitbucket.ase.in.tum.de</tt> as your base URL"
                 }
             },
@@ -54,27 +55,27 @@
             "cloneRepository": {
                 "headline": "Clone repository in SourceTree",
                 "content": "Watch the following video to understand how to clone a git repository in SourceTree. After this step you should click on the <tt>X</tt> button on the top right to cancel the tutorial for now and apply the steps that you have seen in the video. Afterwards just continue the tutorial from your account menu",
-                "videoUrl": "https://www.youtube.com/embed/pDBl-vSCveM"
+                "videoUrl": "https://www.youtube.com/embed/MtwpehC7fcA"
             },
             "inspectSourceTree": {
                 "headline": "Inspect SourceTree",
                 "content": "Watch the following video to understand the basic functions in SourceTree.",
-                "videoUrl": "https://www.youtube.com/embed/7ugt0k0Qa7Y"
+                "videoUrl": "https://www.youtube.com/embed/zky4NnIVzLw"
             },
             "importEclipse": {
                 "headline": "Import the Java project in Eclipse",
                 "content": "Watch the following video to understand how to import the project in Eclipse.",
-                "videoUrl": "https://www.youtube.com/embed/xl0lyV_IHzY"
+                "videoUrl": "https://www.youtube.com/embed/VOEJ84cWgK4"
             },
             "inspectProject": {
                 "headline": "Inspect Project",
                 "content": "In this video step we will inspect the project and solve the given task.",
-                "videoUrl": "https://www.youtube.com/embed/qW9Tc-AYBH8"
+                "videoUrl": "https://www.youtube.com/embed/DwSqaraLWIc"
             },
             "commitAndPush": {
                 "headline": "Submit your changes",
                 "content": "Watch the following video to understand how to commit and push your changes.",
-                "videoUrl": "https://www.youtube.com/embed/iFRHdp8ozh4"
+                "videoUrl": "https://www.youtube.com/embed/3bmaLuT7RNI"
             },
             "reviewResult": {
                 "headline": "Review your result",

--- a/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
+++ b/src/main/webapp/i18n/en/guidedTourCourseExerciseOverview.json
@@ -5,17 +5,14 @@
                 "headline": "Install required tools",
                 "content": "Before we have a look at this course and the example exercise, we need to download and install a few software tools. You can find the instructions in the next few steps.",
                 "java": {
-                    "content": "Please download and install the newest Java JDK (at least Java JDK 12). Make sure to choose JDK and <span class='red'>NOT</span> JRE.",
-                    "linkText": "Download Java JDK"
+                    "content": "Please <a href='https://www.oracle.com/technetwork/java/javase/downloads/index.html' target='_blank' rel='noopener noreferrer'>download</a> and install the newest Java JDK (at least Java JDK 12). Make sure to choose JDK and <span class='red'>NOT</span> JRE."
                 },
                 "eclipse": {
-                    "content": "Please download and install Eclipse IDE for Java Developers (2019‐09 or later)",
-                    "linkText": "Download Eclipse IDE"
+                    "content": "Please <a href='https://www.eclipse.org/downloads/packages/' target='_blank' rel='noopener noreferrer'>download</a> and install Eclipse IDE for Java Developers (2019‐09 or later)"
                 },
                 "sourceTree": {
-                    "content": "Please download and install SourceTree with git (3.2.1 or later for macOS or Windows).",
-                    "hint": "Make sure that the git command line tools are also installed during the installation of SourceTree. In case you are using Linux, you can e.g. use <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> or the <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>command line</a>.",
-                    "linkText": "Download SourceTree"
+                    "content": "Please <a href='https://www.sourcetreeapp.com' target='_blank' rel='noopener noreferrer'>download</a> and install SourceTree with git (3.2.1 or later for macOS or Windows).",
+                    "hint": "Make sure that the git command line tools are also installed during the installation of SourceTree. In case you are using Linux, you can e.g. use <a href='https://www.gitkraken.com/download' target='_blank' rel='noopener noreferrer'>Git Kraken</a> or the <a href='https://git-scm.com' target='_blank' rel='noopener noreferrer'>command line</a>."
                 },
                 "sourceTreeSetup": {
                     "headline": "Setup SourceTree",


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
- The tutorial videos for the `Hello World Java` programming exercise should be available in German as well.
- Moreover video tour steps should be optimized for smaller screens

### Description
- I reworked all tutorial videos with new screencasts (based on the `Hello World Java` project on the productive system) and created the videos in a higher sound quality and resolution (1080p) in both German and English
- The video tutorial steps are now completely visible for screens which have a height of at least 700px
- Since html can be parsed now in the tour step content, we do not need the `TextLinkTourStep` anymore, therefore I removed its usage (TODO resulting from #887)
- I also added current tour step number in the headline that should inform the student on which step he/she currently is and what the number of total steps is (TODO resulting from #887)
- I increased the amount of dots that should be displayed to 8 dots instead of 5 (TODO resulting from #887)

### Screenshots
Inline links instead of `TextLinkTourStep`
![image](https://user-images.githubusercontent.com/33764166/66722648-ebcc7800-edff-11e9-91a9-39cb6b5f92b9.png)
Display of a `VideoTourStep` on a smaller screen (width 1050px; height: 700px)
