### PR TITLE
Add PGdP confirmation popup for course registration

### DIFF
--- a/src/main/webapp/app/components/course-registration-selector/course-registration-selector.component.ts
+++ b/src/main/webapp/app/components/course-registration-selector/course-registration-selector.component.ts
@@ -3,6 +3,7 @@ import { JhiAlertService } from 'ng-jhipster';
 import { TUM_USERNAME_REGEX } from 'app/app.constants';
 import { AccountService } from 'app/core';
 import { Course, CourseService } from 'app/entities/course';
+import { TranslateService } from '@ngx-translate/core';
 
 const DEFAULT_COLORS = ['#6ae8ac', '#9dca53', '#94a11c', '#691b0b', '#ad5658', '#1b97ca', '#0d3cc2', '#0ab84f'];
 
@@ -20,7 +21,12 @@ export class CourseRegistrationSelectorComponent implements OnInit {
     addedSuccessful = false;
     loading = false;
 
-    constructor(private accountService: AccountService, private courseService: CourseService, private jhiAlertService: JhiAlertService) {}
+    constructor(
+        private accountService: AccountService,
+        private courseService: CourseService,
+        private jhiAlertService: JhiAlertService,
+        private translateService: TranslateService,
+    ) {}
 
     ngOnInit(): void {
         this.accountService.identity().then(user => {
@@ -76,7 +82,8 @@ export class CourseRegistrationSelectorComponent implements OnInit {
     }
 
     registerForCourse() {
-        if (this.courseToRegister) {
+        // Special case for PGdP where we have to have a confirmation regarding the exam registration before registering to the course
+        if (this.courseToRegister && (this.courseToRegister.id !== 37 || confirm(this.translateService.instant('artemisApp.studentDashboard.register.examSignupConfirmation')))) {
             this.showCourseSelection = false;
             this.loading = true;
             this.courseService.registerForCourse(this.courseToRegister.id).subscribe(

--- a/src/main/webapp/i18n/de/student-dashboard.json
+++ b/src/main/webapp/i18n/de/student-dashboard.json
@@ -13,7 +13,8 @@
                 "cancel": "Abbrechen",
                 "noCourse": "Keine Kurse für eine Registrierung verfügbar",
                 "courseLoading": "Kurse werden geladen...",
-                "pleaseSelectCourse": "# Wähle einen Kurs aus"
+                "pleaseSelectCourse": "# Wähle einen Kurs aus",
+                "examSignupConfirmation": "Mit Anmeldung zu diesem Kurs erfolgt eine verbindliche Anmeldung zur Prüfung."
             }
         },
         "courseOverview": {

--- a/src/main/webapp/i18n/en/student-dashboard.json
+++ b/src/main/webapp/i18n/en/student-dashboard.json
@@ -13,7 +13,8 @@
                 "cancel": "Cancel",
                 "noCourse": "No course available to register to",
                 "courseLoading": "Courses are loading...",
-                "pleaseSelectCourse": "# Select a course"
+                "pleaseSelectCourse": "# Select a course",
+                "examSignupConfirmation": "By signing up for this course you also register bindingly to the exam."
             }
         },
         "courseOverview": {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
PGdP has a special requirement for a confirmation popup before registering to the course. There, they want the students to confirm to also sign up to the exam by registering to the course

### Description
<!-- Describe your changes in detail -->
There no is a confirmation popup before registering to the PGdP course on production.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![pgdp_confirm](https://user-images.githubusercontent.com/27979674/66748905-b28c1a80-ee88-11e9-8ced-29dd23995ab8.png)
