### PR TITLE
Bugfix/Programming Exercise/add submission date to preliminary check

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/utils/programming-exercise.utils.ts
+++ b/src/main/webapp/app/entities/programming-exercise/utils/programming-exercise.utils.ts
@@ -8,6 +8,7 @@ import * as moment from 'moment';
 import { Participation, ParticipationType, StudentParticipation } from 'app/entities/participation';
 import { ExerciseType } from 'app/entities/exercise';
 import { ProgrammingSubmission } from 'app/entities/programming-submission';
+import { isMoment } from 'moment';
 
 const BAMBOO_RESULT_LEGACY_TIMESTAMP = 1557526348000;
 
@@ -32,9 +33,13 @@ export const isResultPreliminary = (result: Result, programmingExercise: Program
     }
     const { submission } = result;
     // We use the result completionDate as a fallback when the submissionDate is not available (edge case, every result should have a submission).
-    const referenceDate = submission && submission.submissionDate ? submission.submissionDate : result.completionDate;
+    let referenceDate = submission && submission.submissionDate ? submission.submissionDate : result.completionDate;
+    // If not a moment date already, try to convert it (e.g. when it is a string).
+    if (referenceDate && !isMoment(referenceDate)) {
+        referenceDate = moment(referenceDate);
+    }
     // When the result completionDate would be null, we have to return here (edge case, every result should have a completionDate).
-    if (!referenceDate) {
+    if (!referenceDate || !referenceDate.isValid()) {
         return false;
     }
     return !!programmingExercise.buildAndTestStudentSubmissionsAfterDueDate && referenceDate.isBefore(moment(programmingExercise.buildAndTestStudentSubmissionsAfterDueDate));

--- a/src/main/webapp/app/entities/programming-exercise/utils/programming-exercise.utils.ts
+++ b/src/main/webapp/app/entities/programming-exercise/utils/programming-exercise.utils.ts
@@ -18,26 +18,26 @@ export const isLegacyResult = (result: Result) => {
 /**
  * A result is preliminary if:
  * - The programming exercise buildAndTestAfterDueDate is set
- * - The submission date of the result is before the buildAndTestAfterDueDate
+ * - The submission date of the result / result completionDate is before the buildAndTestAfterDueDate
  *
  * Note: We check some error cases in this method as a null value for the given parameters, because the clients using this method might unwillingly provide them (result component).
  * TODO: Remove the null checks when the result component is refactored.
  *
- * @param result Result with attached Submission - if submission is null, method will return false.
+ * @param result Result with attached Submission - if submission is null, method will use the result completionDate as a reference.
  * @param programmingExercise ProgrammingExercise
  */
-export const isResultPreliminary = (result: Result | null, programmingExercise: ProgrammingExercise | null) => {
-    if (!programmingExercise || !result) {
+export const isResultPreliminary = (result: Result, programmingExercise: ProgrammingExercise | null) => {
+    if (!programmingExercise) {
         return false;
     }
     const { submission } = result;
-    if (!submission || !submission.submissionDate) {
+    // We use the result completionDate as a fallback when the submissionDate is not available (edge case, every result should have a submission).
+    const referenceDate = submission && submission.submissionDate ? submission.submissionDate : result.completionDate;
+    // When the result completionDate would be null, we have to return here (edge case, every result should have a completionDate).
+    if (!referenceDate) {
         return false;
     }
-    return (
-        !!programmingExercise.buildAndTestStudentSubmissionsAfterDueDate &&
-        submission.submissionDate.isBefore(moment(programmingExercise.buildAndTestStudentSubmissionsAfterDueDate))
-    );
+    return !!programmingExercise.buildAndTestStudentSubmissionsAfterDueDate && referenceDate.isBefore(moment(programmingExercise.buildAndTestStudentSubmissionsAfterDueDate));
 };
 
 export const isProgrammingExerciseStudentParticipation = (participation: Participation) => {

--- a/src/main/webapp/app/entities/result/result.component.ts
+++ b/src/main/webapp/app/entities/result/result.component.ts
@@ -12,7 +12,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { JhiWebsocketService } from 'app/core';
 import { ProgrammingExercise } from 'app/entities/programming-exercise/programming-exercise.model';
 import * as moment from 'moment';
-import { hasBuildAndTestAfterDueDatePassed, isProgrammingExerciseStudentParticipation } from 'app/entities/programming-exercise/utils/programming-exercise.utils';
+import { isResultPreliminary, isProgrammingExerciseStudentParticipation } from 'app/entities/programming-exercise/utils/programming-exercise.utils';
 
 enum ResultTemplateStatus {
     IS_BUILDING = 'IS_BUILDING',
@@ -203,7 +203,7 @@ export class ResultComponent implements OnInit, OnChanges {
         } else if (
             this.participation &&
             isProgrammingExerciseStudentParticipation(this.participation) &&
-            !hasBuildAndTestAfterDueDatePassed(getExercise(this.participation) as ProgrammingExercise)
+            !isResultPreliminary(this.result!, getExercise(this.participation) as ProgrammingExercise)
         ) {
             const preliminary = this.translate.instant('artemisApp.result.preliminary');
             return `${this.result!.resultString} ${preliminary}`;
@@ -216,7 +216,7 @@ export class ResultComponent implements OnInit, OnChanges {
         if (
             this.participation &&
             isProgrammingExerciseStudentParticipation(this.participation) &&
-            !hasBuildAndTestAfterDueDatePassed(getExercise(this.participation) as ProgrammingExercise)
+            !isResultPreliminary(this.result!, getExercise(this.participation) as ProgrammingExercise)
         ) {
             return this.translate.instant('artemisApp.result.preliminaryTooltip');
         }

--- a/src/main/webapp/app/entities/result/result.component.ts
+++ b/src/main/webapp/app/entities/result/result.component.ts
@@ -203,7 +203,7 @@ export class ResultComponent implements OnInit, OnChanges {
         } else if (
             this.participation &&
             isProgrammingExerciseStudentParticipation(this.participation) &&
-            !isResultPreliminary(this.result!, getExercise(this.participation) as ProgrammingExercise)
+            isResultPreliminary(this.result!, getExercise(this.participation) as ProgrammingExercise)
         ) {
             const preliminary = this.translate.instant('artemisApp.result.preliminary');
             return `${this.result!.resultString} ${preliminary}`;
@@ -216,7 +216,7 @@ export class ResultComponent implements OnInit, OnChanges {
         if (
             this.participation &&
             isProgrammingExerciseStudentParticipation(this.participation) &&
-            !isResultPreliminary(this.result!, getExercise(this.participation) as ProgrammingExercise)
+            isResultPreliminary(this.result!, getExercise(this.participation) as ProgrammingExercise)
         ) {
             return this.translate.instant('artemisApp.result.preliminaryTooltip');
         }


### PR DESCRIPTION
Fix regression: A result is only preliminary if its submission date is before the buildAndTestAfterDueDate (before we used the current date for comparison).
- If there is no submission, we use the result's completionDate (edge case).
- If there is no result completionDate or another problem with the date exists, we assume the result is not preliminary.