### PR TITLE
Programming Exercise/shorten error message string for feedback if too long

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -87,6 +87,8 @@ public final class Constants {
 
     public static final String PROGRAMMING_EXERCISE_SUCCESSFUL_LOCK_OPERATION_NOTIFICATION = "The student repositories for this programming exercise were locked successfully when the due date passed.";
 
+    public static final int FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS = 5000;
+
     private Constants() {
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
@@ -41,8 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static de.tum.in.www1.artemis.config.Constants.ASSIGNMENT_REPO_NAME;
-import static de.tum.in.www1.artemis.config.Constants.TEST_REPO_NAME;
+import static de.tum.in.www1.artemis.config.Constants.*;
 
 @Service
 @Profile("bamboo")
@@ -664,11 +663,15 @@ public class BambooService implements ContinuousIntegrationService {
      * @param result to which the feedback belongs.
      * @param methodName test case method name.
      * @param positive if the test case was successful.
-     * @param errorMessageString if there was an error what the error is.
+     * @param errorMessageString if there was an error what the error is. Will be shortened if longer than FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS.
      */
     private void createAutomaticFeedback(Result result, String methodName, boolean positive, String errorMessageString) {
         Feedback feedback = new Feedback();
         feedback.setText(methodName);
+        // The assertion message can be longer than the allowed char limit, so we shorten it here if needed.
+        if(errorMessageString.length() > FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS) {
+            errorMessageString = errorMessageString.substring(0, FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS);
+        }
         feedback.setDetailText(errorMessageString);
         feedback.setType(FeedbackType.AUTOMATIC);
         feedback.setPositive(positive);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
@@ -29,6 +29,7 @@ import org.swift.common.cli.Base;
 import org.swift.common.cli.CliClient;
 
 import javax.annotation.Nullable;
+import javax.validation.constraints.Null;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -665,11 +666,11 @@ public class BambooService implements ContinuousIntegrationService {
      * @param positive if the test case was successful.
      * @param errorMessageString if there was an error what the error is. Will be shortened if longer than FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS.
      */
-    private void createAutomaticFeedback(Result result, String methodName, boolean positive, String errorMessageString) {
+    private void createAutomaticFeedback(Result result, String methodName, boolean positive, @Nullable String errorMessageString) {
         Feedback feedback = new Feedback();
         feedback.setText(methodName);
         // The assertion message can be longer than the allowed char limit, so we shorten it here if needed.
-        if(errorMessageString.length() > FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS) {
+        if(errorMessageString != null && errorMessageString.length() > FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS) {
             errorMessageString = errorMessageString.substring(0, FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS);
         }
         feedback.setDetailText(errorMessageString);


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

If an assertion provides a very long error message, the processing of the result will fail due to its length:

```
ConstraintViolationImpl{interpolatedMessage='size must be between 0 and 5000', propertyPath=detailText, rootBeanClass=class de.tum.in.www1.artemis.domain.Feedback, 
```

### Description
<!-- Describe your changes in detail -->

We solve this issue by shortening the errorMessage if too long.
