### PR TITLE
Programming Exercise/Only allow all repos for instructors

### DIFF
--- a/src/main/webapp/app/scores/exercise-scores-repo-export-dialog.component.html
+++ b/src/main/webapp/app/scores/exercise-scores-repo-export-dialog.component.html
@@ -8,7 +8,10 @@
         <p jhiTranslate="instructorDashboard.exportRepos.question" [translateValues]="{ exerciseTitle: exercise.title, courseTitle: exercise.course?.title }">Confirm export</p>
         <textarea name="studentIds" class="export-textarea" [(ngModel)]="studentIdList" required [disabled]="repositoryExportOptions.exportAllStudents"></textarea>
         <p jhiTranslate="instructorDashboard.exportRepos.timeWarning">(This action can take several minutes depending on number and size of repositories.)</p>
-        <div class="checkbox">
+        <!--
+        Only show download all checkbox for instructors & admins.
+-->
+        <div *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" class="checkbox">
             <label class="control-label">
                 <input type="checkbox" name="allStudents" [(ngModel)]="repositoryExportOptions.exportAllStudents" />
                 <strong jhiTranslate="artemisApp.programmingExercise.export.downloadAllStudents">Download the repositories of all students</strong>


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Ziping & downloading all student repos is a very expensive operation - we therefore hide it for tutors.
(Course Administration > Programming Exercise > Scores > Download Repos)

### Description
<!-- Describe your changes in detail -->

Add a permission check in the Angular template.