### PR TITLE
Hotfix/Programming-Exercise/Fix instruction render when no exerciseHints are fetched

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/instructions/instructions-editor/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/instructions-editor/programming-exercise-editable-instruction.component.ts
@@ -105,6 +105,8 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
             this.setupTestCaseSubscription();
             if (this.exercise.id) {
                 this.loadExerciseHints(this.exercise.id);
+            } else {
+                this.exerciseHints = [];
             }
         }
     }


### PR DESCRIPTION
Hotfix, set the exerciseHints to an empty array when no loading is done.
Otherwise the plain markdown preview is used which does not have the parsing modules of programming exercises.