### PR TITLE
Bugfix/undefined manual review

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-test-schedule-picker/programming-exercise-lifecycle.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-test-schedule-picker/programming-exercise-lifecycle.component.html
@@ -61,7 +61,11 @@
                     <fa-icon class="icon-static" icon="user-check" size="lg"></fa-icon>
                     <fa-icon class="icon-remove" icon="user-minus" size="lg"></fa-icon>
                 </div>
-                <div *ngIf="exercise.assessmentType === assessmentType.AUTOMATIC" class="text-danger" jhiTranslate="artemisApp.programmingExercise.timeline.notSet">
+                <div
+                    *ngIf="!exercise.assessmentType || exercise.assessmentType === assessmentType.AUTOMATIC"
+                    class="text-danger"
+                    jhiTranslate="artemisApp.programmingExercise.timeline.notSet"
+                >
                     not set
                 </div>
             </div>

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-test-schedule-picker/programming-exercise-lifecycle.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-test-schedule-picker/programming-exercise-lifecycle.component.html
@@ -47,7 +47,7 @@
                     <jhi-help-icon placement="top" text="artemisApp.programmingExercise.timeline.manualReviewTooltip"></jhi-help-icon>
                 </div>
                 <div
-                    *ngIf="exercise.assessmentType === assessmentType.AUTOMATIC"
+                    *ngIf="!exercise.assessmentType || exercise.assessmentType === assessmentType.AUTOMATIC"
                     class="btn btn-light scheduled-test scheduled-test--can-toggle btn-lifecycle btn-lifecycle--deactivated"
                     (click)="toggleHasManualTests()"
                 >

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-test-schedule-picker/programming-exercise-lifecycle.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-test-schedule-picker/programming-exercise-lifecycle.component.ts
@@ -26,7 +26,7 @@ export class ProgrammingExerciseLifecycleComponent implements OnInit {
      *
      */
     toggleHasManualTests() {
-        this.exercise.assessmentType = this.exercise.assessmentType === AssessmentType.AUTOMATIC ? AssessmentType.SEMI_AUTOMATIC : AssessmentType.AUTOMATIC;
+        this.exercise.assessmentType = this.exercise.assessmentType === AssessmentType.SEMI_AUTOMATIC ? AssessmentType.AUTOMATIC : AssessmentType.SEMI_AUTOMATIC;
     }
 
     /**


### PR DESCRIPTION
### Description
The programming exercise lifecycle timeline had a bug, where the manual reviews button was not shown for older exercises since they have an assessment type of `undefined`. 
I also mapped `undefined` to "not set" so that it is treated the same as with assessment type = `AUTOMATIC`