### PR TITLE
Pre-fill Email from Footer Link with note regarding purpose of address.

### DIFF
--- a/src/main/webapp/app/layouts/footer/footer.component.ts
+++ b/src/main/webapp/app/layouts/footer/footer.component.ts
@@ -6,7 +6,8 @@ import { VERSION } from 'app/app.constants';
     templateUrl: './footer.component.html',
 })
 export class FooterComponent {
-    readonly email = 'mailto:artemis.in@tum.de';
+    readonly email =
+        'mailto:artemis.in@tum.de?body=Note%3A%20Please%20send%20only%20support%2Ffeature%20request%20or%20bug%20reports%20regarding%20the%20Artemis%20Platform%20to%20this%20address.%20Please%20check%20our%20public%20bug%20tracker%20at%20https%3A%2F%2Fgithub.com%2Fls1intum%2FArtemis%20for%20known%20bugs.%0AFor%20questions%20regarding%20exercises%20and%20their%20content%2C%20please%20contact%20your%20instructors.';
     readonly imprintUrl = 'https://ase.in.tum.de/lehrstuhl_1/component/content/article/179-imprint';
     private readonly issueBaseUrl = 'https://github.com/ls1intum/Artemis/issues/new?projects=ls1intum/1';
     readonly bugReportUrl = `${this.issueBaseUrl}&labels=bug&template=bug-report.md`;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- ~Server: I added multiple integration tests (Spring) related to the features~
- ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- ~Server: I implemented the changes with a good performance and prevented too many database calls~
- ~Server: I documented the Java code using JavaDoc style.~
- ~Client: I added multiple integration tests (Jest) related to the features~
- ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- ~Client: I documented the TypeScript code using JSDoc style.~
- ~Client: I added multiple screenshots/screencasts of my UI changes~
- ~Client: I translated all the newly inserted strings into German and English~

### Motivation and Context
We keep getting emails at our support address `artemis.in@tum.de` for questions regarding some exercises. Those questions should be directed at the instructors of the course. This is getting more important with courses not offered by our chair as it gets harder to direct those requests to the responsible persons.

### Description
Update the Email link to pre-fill the mail with a note regarding the purpose of the mail:
>Note: Please send only support/feature request or bug reports regarding the Artemis Platform to this address. Please check our public bug tracker at https://github.com/ls1intum/Artemis for known bugs.
>For questions regarding exercises and their content, please contact your instructors.

(https://mailtolink.me by @mckeever02 is a good tool to create those links, best one I have used so far.)

### Steps for Testing
1. Open Artemis
2. Click "Contact us" in Footer
3. See open Mail client pre-filled with Note

### Screenshots
<img width="488" alt="Screen Shot 2019-10-17 at 11 15 13" src="https://user-images.githubusercontent.com/6382716/66995543-7dbdd480-f0cf-11e9-8170-1ab8961a4ff5.png">
<img width="907" alt="Screen Shot 2019-10-17 at 11 13 36" src="https://user-images.githubusercontent.com/6382716/66995421-46e7be80-f0cf-11e9-9d45-699be7495bee.png">

