### PR TITLE
Use full width of window for smaller sizes in programming exercise up…

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-update.component.html
@@ -1,5 +1,5 @@
 <div class="row justify-content-center">
-    <div class="col-8">
+    <div class="col-lg-8 col-sm-12">
         <form name="editForm" role="form" novalidate (ngSubmit)="save()" #editForm="ngForm">
             <h4 *ngIf="!programmingExercise.id" id="jhi-programming-exercise-heading-create" jhiTranslate="artemisApp.programmingExercise.home.generateLabel">
                 Generate new Programming Exercise


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For smaller windows, the programming exercise generation component does not utilize the full width of the screen. It would be better, if the component would automatically fill the whole screen as soon as the displayed elements get too cramped. See #947 

### Description
<!-- Describe your changes in detail -->
We now differentiate between the screen sizes using an additional bootstrap class, so that the content fills the whole screen as expected.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Open any programming exercise edit
4. Resize your browser window
5. As soon as the windows is about half the size of your full screenwidht, the content should fill the whole width. 

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![auto_adapt-progexc-width](https://user-images.githubusercontent.com/27979674/67045064-db810980-f12d-11e9-8cb0-7ef0e2cbbdb4.gif)

