### PR TITLE
Enhancement/Programming Exercises/Don't show the trigger button for inactive participations

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-instructor-trigger-build-button.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-instructor-trigger-build-button.component.ts
@@ -9,7 +9,7 @@ import { ProgrammingSubmissionService } from 'app/programming-submission/program
 export class ProgrammingExerciseInstructorTriggerBuildButtonComponent extends ProgrammingExerciseTriggerBuildButtonComponent {
     constructor(submissionService: ProgrammingSubmissionService) {
         super(submissionService);
-        this.alwaysShowTriggerButton = true;
+        this.showForSuccessfulSubmissions = true;
     }
     triggerBuild = (event: any) => {
         // The button might be placed in other elements that have a click listener, so catch the click here.

--- a/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-trigger-build-button.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-trigger-build-button.component.html
@@ -1,5 +1,5 @@
 <jhi-button
-    *ngIf="alwaysShowTriggerButton || (participationIsActive && participationHasLatestSubmissionWithoutResult)"
+    *ngIf="participationIsActive && (showForSuccessfulSubmissions || participationHasLatestSubmissionWithoutResult)"
     [btnSize]="btnSize"
     [btnType]="participationHasLatestSubmissionWithoutResult ? ButtonType.ERROR : ButtonType.PRIMARY"
     [icon]="'redo'"

--- a/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-trigger-build-button.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-trigger-build-button.component.ts
@@ -22,7 +22,8 @@ export abstract class ProgrammingExerciseTriggerBuildButtonComponent implements 
     participationIsActive: boolean;
     participationHasLatestSubmissionWithoutResult: boolean;
     isBuilding: boolean;
-    alwaysShowTriggerButton: boolean;
+    // If true, the trigger button is also displayed for successful submissions.
+    showForSuccessfulSubmissions = false;
 
     private submissionSubscription: Subscription;
     private resultSubscription: Subscription;


### PR DESCRIPTION
Fixes issue https://github.com/ls1intum/Artemis/issues/968.
Don't show the trigger button if the participation is not active.