### PR TITLE
ngx-device-detector issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "ngx-chips": "2.1.0",
         "ngx-clipboard": "12.2.1",
         "ngx-cookie": "4.1.2",
-        "ngx-device-detector": "1.3.12",
+        "ngx-device-detector": "1.3.11",
         "ngx-image-cropper": "2.0.2",
         "ngx-infinite-scroll": "8.0.1",
         "ngx-moment": "3.4.0",


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) 

### Motivation and Context
The new update of the ngx-device-detector causes an error for the `guided tour` since the `isDesktop` call is not working (on Mac devices), see https://github.com/KoderLabs/ngx-device-detector/issues/115

I will write a test the covers this issue in a follow-up PR.

### Steps for Testing
1. Log in to Artemis
2. Start Guided Tutorial is displayed in the account menu
