### PR TITLE
Remove console warn and fix navigation issue

### DIFF
--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -62,7 +62,7 @@ export class GuidedTourService {
 
         // Reset guided tour availability on router navigation
         this.router.events.subscribe(event => {
-            if (this.currentTour && event instanceof NavigationStart) {
+            if (this.availableTourForComponent && event instanceof NavigationStart) {
                 this.finishGuidedTour();
                 this.guidedTourAvailability.next(false);
             }
@@ -466,11 +466,6 @@ export class GuidedTourService {
         if (selector) {
             const selectedElement = document.querySelector(selector);
             if (!selectedElement) {
-                console.warn(
-                    `Error finding selector ${this.currentTour.steps[this.currentTourStepIndex].highlightSelector} on step ${this.currentTourStepIndex + 1} during guided tour: ${
-                        this.currentTour.settingsKey
-                    }`,
-                );
                 return false;
             }
         }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~~Server: I added multiple integration tests (Spring) related to the features~~
- [x] ~~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~~
- [x] ~~Server: I implemented the changes with a good performance and prevented too many database calls~~
- [x] ~~Server: I documented the Java code using JavaDoc style.~~
- [x] ~~Client: I added multiple integration tests (Jest) related to the features~~
- [x] ~~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~~
- [x] ~~Client: I documented the TypeScript code using JSDoc style.~~
- [x] ~~Client: I added multiple screenshots/screencasts of my UI changes~~
- [x] ~~Client: I translated all the newly inserted strings into German and English~~

### Motivation and Context
If a highlight element for the guided tour cannot be found then a console.warn will be logged (see for example https://github.com/ls1intum/Artemis/issues/980 ). This is removed in this PR. I also included the bugfix for the guided tour which I fixed in #888, since I don't know when the other PR will be merged.

### Steps for Testing
1. Log in to Artemis
2. Remove the tutorial course from the HTML in your browser
3. Start the tour and watch the console tab 
4. There should be no warning
5. Navigating to course administration does not show `Start guided tutorial` in the account menu