### PR TITLE
Enhancement/Execute external requests to VCS/CIS in batches

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -89,6 +89,11 @@ public final class Constants {
 
     public static final String TESTS_CHECKOUT_PATH = "tests";
 
+    public static final int EXTERNAL_SYSTEM_REQUEST_BATCH_SIZE = 100;
+
+    // Currently 10s.
+    public static final int EXTERNAL_SYSTEM_REQUEST_BATCH_WAIT_TIME_MS = 10000;
+
     private Constants() {
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -957,7 +957,7 @@ public class ProgrammingExerciseService {
         int index = 0;
         for (StudentParticipation studentParticipation : programmingExercise.getStudentParticipations()) {
             // Execute requests in batches instead all at once.
-            if (index % EXTERNAL_SYSTEM_REQUEST_BATCH_SIZE == 0) {
+            if (index > 0 && index % EXTERNAL_SYSTEM_REQUEST_BATCH_SIZE == 0) {
                 try {
                     Thread.sleep(EXTERNAL_SYSTEM_REQUEST_BATCH_WAIT_TIME_MS);
                 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -942,6 +942,8 @@ public class ProgrammingExerciseService {
      * Remove the write permissions for all students for their programming exercise repository.
      * They will still be able to read the code, but won't be able to change it.
      *
+     * Requests are executed in batches so that the VCS is not overloaded with requests.
+     *
      * @param programmingExerciseId     ProgrammingExercise id.
      * @return a list of participations for which the locking operation has failed. If everything went as expected, this should be an empty list.
      * @throws EntityNotFoundException  if the programming exercise can't be found.
@@ -951,7 +953,19 @@ public class ProgrammingExerciseService {
 
         ProgrammingExercise programmingExercise = findByIdWithEagerStudentParticipations(programmingExerciseId);
         List<ProgrammingExerciseStudentParticipation> failedLockOperations = new LinkedList<>();
+
+        int index = 0;
         for (StudentParticipation studentParticipation : programmingExercise.getStudentParticipations()) {
+            // Execute requests in batches instead all at once.
+            if (index % EXTERNAL_SYSTEM_REQUEST_BATCH_SIZE == 0) {
+                try {
+                    Thread.sleep(EXTERNAL_SYSTEM_REQUEST_BATCH_WAIT_TIME_MS);
+                }
+                catch (InterruptedException ex) {
+                    log.error("Exception encountered when pausing before locking the student repositories for exercise " + programmingExerciseId, ex);
+                }
+            }
+
             ProgrammingExerciseStudentParticipation programmingExerciseStudentParticipation = (ProgrammingExerciseStudentParticipation) studentParticipation;
             try {
                 versionControlService.get().setRepositoryPermissionsToReadOnly(programmingExerciseStudentParticipation.getRepositoryUrlAsUrl(), programmingExercise.getProjectKey(),
@@ -962,6 +976,7 @@ public class ProgrammingExerciseService {
                         + studentParticipation.getId());
                 failedLockOperations.add(programmingExerciseStudentParticipation);
             }
+            index++;
         }
         return failedLockOperations;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -328,7 +328,7 @@ public class ProgrammingSubmissionService {
         int index = 0;
         for (ProgrammingSubmission submission : submissions) {
             // Execute requests in batches instead all at once.
-            if (index % EXTERNAL_SYSTEM_REQUEST_BATCH_SIZE == 0) {
+            if (index > 0 && index % EXTERNAL_SYSTEM_REQUEST_BATCH_SIZE == 0) {
                 try {
                     Thread.sleep(EXTERNAL_SYSTEM_REQUEST_BATCH_WAIT_TIME_MS);
                 }


### PR DESCRIPTION
Attempt to improve reliability of submission/result handling.
Fixes issue: https://github.com/ls1intum/Artemis/issues/1000

Requests to the VCS (lock repos), CIS (trigger builds) are now executed in batches, before which we wait a specified delay to not overload the external systems with requests.

Note: This means that some student repositories would be locked earlier than others (at most 2.5 minutes difference for 1600 students). 