### PR TITLE
Resume exercise for build triggers for inactive participations

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.artemis.service;
 
+import static de.tum.in.www1.artemis.config.Constants.ASSIGNMENT_REPO_NAME;
 import static de.tum.in.www1.artemis.config.Constants.PROGRAMMING_SUBMISSION_RESOURCE_API_PATH;
 import static de.tum.in.www1.artemis.domain.enumeration.InitializationState.*;
 
@@ -15,7 +16,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.enumeration.*;
+import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
+import de.tum.in.www1.artemis.domain.enumeration.BuildPlanType;
+import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
+import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
@@ -388,7 +392,13 @@ public class ParticipationService {
             return null;
         }
         participation = copyBuildPlan(participation);
-        participation = configureBuildPlan(participation);
+        continuousIntegrationService.get().enablePlan(participation.getBuildPlanId());
+
+        final var projectKey = participation.getProgrammingExercise().getProjectKey();
+        final var planKey = participation.getBuildPlanId();
+        final var repoName = versionControlService.get().getRepositoryName(participation.getRepositoryUrlAsUrl());
+        continuousIntegrationService.get().updatePlanRepository(projectKey, planKey, ASSIGNMENT_REPO_NAME, projectKey, repoName);
+
         participation.setInitializationState(INITIALIZED);
         if (participation.getInitializationDate() == null) {
             // only set the date if it was not set before (which should NOT be the case)

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -904,6 +904,7 @@ public class ProgrammingExerciseService {
      * @param templateExercise The template exercise which plans should get copied
      * @param newExercise The new exercise to which all plans should get copied
      * @throws HttpException If the copied build plans could not get triggered
+     * @throws BuildPlanNotFoundException If any of the build plans can not be found.
      */
     public void importBuildPlans(final ProgrammingExercise templateExercise, final ProgrammingExercise newExercise) throws HttpException, BuildPlanNotFoundException {
         final var templateParticipation = newExercise.getTemplateParticipation();

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -48,6 +48,7 @@ import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.*;
 import de.tum.in.www1.artemis.exception.GitException;
 import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.service.connectors.BuildPlanNotFoundException;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
@@ -904,7 +905,7 @@ public class ProgrammingExerciseService {
      * @param newExercise The new exercise to which all plans should get copied
      * @throws HttpException If the copied build plans could not get triggered
      */
-    public void importBuildPlans(final ProgrammingExercise templateExercise, final ProgrammingExercise newExercise) throws HttpException {
+    public void importBuildPlans(final ProgrammingExercise templateExercise, final ProgrammingExercise newExercise) throws HttpException, BuildPlanNotFoundException {
         final var templateParticipation = newExercise.getTemplateParticipation();
         final var solutionParticipation = newExercise.getSolutionParticipation();
         final var templatePlanName = BuildPlanType.TEMPLATE.getName();
@@ -932,7 +933,7 @@ public class ProgrammingExerciseService {
             continuousIntegrationService.get().triggerBuild(templateParticipation);
             continuousIntegrationService.get().triggerBuild(solutionParticipation);
         }
-        catch (HttpException e) {
+        catch (HttpException | BuildPlanNotFoundException e) {
             log.error("Unable to trigger imported build plans", e);
             throw e;
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
@@ -203,7 +203,7 @@ public class BambooService implements ContinuousIntegrationService {
      * @param participation the participation with the id of the build plan that should be triggered.
      */
     @Override
-    public void triggerBuild(ProgrammingExerciseParticipation participation) throws HttpException {
+        public void triggerBuild(ProgrammingExerciseParticipation participation) throws HttpException, BuildPlanNotFoundException {
         var buildPlan = participation.getBuildPlanId();
         HttpHeaders headers = HeaderUtil.createAuthorization(BAMBOO_USER, BAMBOO_PASSWORD);
         HttpEntity<?> entity = new HttpEntity<>(headers);
@@ -213,6 +213,9 @@ public class BambooService implements ContinuousIntegrationService {
                 HttpMethod.POST,
                 entity,
                 Map.class);
+        } catch (HttpClientErrorException.NotFound e) {
+            // Build plan does not exist, wrap and forward exception
+            throw new BuildPlanNotFoundException(e.getMessage(), e);
         } catch (RestClientException e) {
             log.error("HttpError while triggering build plan " + buildPlan + " with error: " + e.getMessage());
             throw new HttpException("Communication failed when trying to trigger the Bamboo build plan " + buildPlan + " with the error: " + e.getMessage());

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
@@ -203,7 +203,7 @@ public class BambooService implements ContinuousIntegrationService {
      * @param participation the participation with the id of the build plan that should be triggered.
      */
     @Override
-        public void triggerBuild(ProgrammingExerciseParticipation participation) throws HttpException, BuildPlanNotFoundException {
+    public void triggerBuild(ProgrammingExerciseParticipation participation) throws HttpException, BuildPlanNotFoundException {
         var buildPlan = participation.getBuildPlanId();
         HttpHeaders headers = HeaderUtil.createAuthorization(BAMBOO_USER, BAMBOO_PASSWORD);
         HttpEntity<?> entity = new HttpEntity<>(headers);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BuildPlanNotFoundException.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BuildPlanNotFoundException.java
@@ -1,0 +1,19 @@
+package de.tum.in.www1.artemis.service.connectors;
+
+public class BuildPlanNotFoundException extends Exception {
+
+    public BuildPlanNotFoundException() {
+    }
+
+    public BuildPlanNotFoundException(String message) {
+        super(message);
+    }
+
+    public BuildPlanNotFoundException(Throwable cause) {
+        super(cause);
+    }
+
+    public BuildPlanNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
@@ -54,6 +54,7 @@ public interface ContinuousIntegrationService {
      * 
      * @param participation the participation with the id of the build plan that should be triggered
      * @throws HttpException if the request to the CI failed.
+     * @throws BuildPlanNotFoundException if the participation's build plan can not be found (e.g. if deleted on archive).
      */
     void triggerBuild(ProgrammingExerciseParticipation participation) throws HttpException, BuildPlanNotFoundException;
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
@@ -55,7 +55,7 @@ public interface ContinuousIntegrationService {
      * @param participation the participation with the id of the build plan that should be triggered
      * @throws HttpException if the request to the CI failed.
      */
-    void triggerBuild(ProgrammingExerciseParticipation participation) throws HttpException;
+    void triggerBuild(ProgrammingExerciseParticipation participation) throws HttpException, BuildPlanNotFoundException;
 
     /**
      * Delete project with given identifier from CI system.

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -35,6 +35,7 @@ import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.service.connectors.BuildPlanNotFoundException;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
 import de.tum.in.www1.artemis.service.scheduled.ProgrammingExerciseScheduleService;
@@ -346,7 +347,7 @@ public class ProgrammingExerciseResource {
             programmingExerciseService.importBuildPlans(template, imported);
             responseHeaders = HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, imported.getTitle());
         }
-        catch (HttpException e) {
+        catch (HttpException | BuildPlanNotFoundException e) {
             responseHeaders = HeaderUtil.createFailureAlert(applicationName, true, ENTITY_NAME, "importExerciseTriggerPlanFail", "Unable to trigger imported build plans");
         }
 

--- a/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-trigger-build-button.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-trigger-build-button.component.html
@@ -1,5 +1,5 @@
 <jhi-button
-    *ngIf="participationIsActive && (showForSuccessfulSubmissions || participationHasLatestSubmissionWithoutResult)"
+    *ngIf="showForSuccessfulSubmissions || participationHasLatestSubmissionWithoutResult"
     [btnSize]="btnSize"
     [btnType]="participationHasLatestSubmissionWithoutResult ? ButtonType.ERROR : ButtonType.PRIMARY"
     [icon]="'redo'"

--- a/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-trigger-build-button.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/actions/programming-exercise-trigger-build-button.component.ts
@@ -19,7 +19,6 @@ export abstract class ProgrammingExerciseTriggerBuildButtonComponent implements 
     @Input() participation: Participation;
     @Input() btnSize = ButtonSize.SMALL;
 
-    participationIsActive: boolean;
     participationHasLatestSubmissionWithoutResult: boolean;
     isBuilding: boolean;
     // If true, the trigger button is also displayed for successful submissions.
@@ -37,10 +36,7 @@ export abstract class ProgrammingExerciseTriggerBuildButtonComponent implements 
      */
     ngOnChanges(changes: SimpleChanges): void {
         if (hasParticipationChanged(changes)) {
-            this.participationIsActive = this.participation.initializationState === InitializationState.INITIALIZED;
-            if (this.participationIsActive) {
-                this.setupSubmissionSubscription();
-            }
+            this.setupSubmissionSubscription();
         }
     }
 


### PR DESCRIPTION
Show trigger button for inactive participations
Correctly notify trigger all button about finished trigger run
No setup commit on resume exercise

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Description

 Fixes #1001. We now resume an exercise after triggering a build for an inactive exercise (i.e. copy the build plan again and set it up correctly). We also now don't actually make an empty commit (which is only needed for setting up a new exercise) on resuming the exercise and by that correctly notify the trigger button (and trigger all button) only about the automatic submission created by triggering a new build.