### PR TITLE
Extend jhi-button to use it in file-upload-exercise

### DIFF
--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.html
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.html
@@ -47,45 +47,47 @@
                     <td>{{ fileUploadExercise.filePattern }}</td>
                     <td *ngIf="course.presentationScore !== 0">{{ fileUploadExercise.presentationScoreEnabled }}</td>
                     <td class="text-right">
-                        <div class="btn-group flex-btn-group-container">
-                            <button
-                                type="submit"
+                        <div class="jhi-btn-group jhi-btn-group--block">
+                            <jhi-button
                                 *ngIf="fileUploadExercise.isAtLeastTutor"
                                 [routerLink]="['/course', fileUploadExercise.course.id, 'exercise', fileUploadExercise.id, 'dashboard']"
-                                class="btn btn-info btn-sm mr-1"
+                                [btnSize]="ButtonSize.SMALL"
+                                [btnType]="ButtonType.INFO"
+                                icon="eye"
+                                title="entity.action.scores"
+                                class="mr-1"
                             >
-                                <fa-icon icon="eye"></fa-icon>
-                                <span class="d-none d-md-inline" jhiTranslate="entity.action.scores">Scores</span>
-                            </button>
-                            <button
-                                type="submit"
+                            </jhi-button>
+                            <jhi-button
                                 *ngIf="fileUploadExercise.isAtLeastTutor"
                                 [routerLink]="['/exercise', fileUploadExercise.id, 'participation']"
-                                class="btn btn-primary btn-sm mr-1"
+                                [btnSize]="ButtonSize.SMALL"
+                                [btnType]="ButtonType.PRIMARY"
+                                [icon]="['far', 'list-alt']"
+                                title="artemisApp.exercise.participations"
+                                class="mr-1"
                             >
-                                <fa-icon [icon]="['far', 'list-alt']"></fa-icon>
-                                <span class="d-none d-md-inline" jhiTranslate="artemisApp.exercise.participations">Participations</span>
-                            </button>
-                            <button
-                                type="submit"
+                            </jhi-button>
+                            <jhi-button
                                 *ngIf="fileUploadExercise.isAtLeastInstructor"
                                 [routerLink]="['/file-upload-exercise', fileUploadExercise.id]"
-                                class="btn btn-info btn-sm mr-1"
+                                class="mr-1"
+                                [btnType]="ButtonType.INFO"
+                                [btnSize]="ButtonSize.SMALL"
+                                icon="eye"
+                                title="entity.action.view"
                             >
-                                <fa-icon icon="eye"></fa-icon>
-                                <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
-                            </button>
-                            <button
-                                type="submit"
+                            </jhi-button>
+                            <jhi-button
                                 *ngIf="fileUploadExercise.isAtLeastInstructor"
                                 [routerLink]="['/file-upload-exercise/' + fileUploadExercise.id + '/edit']"
-                                replaceUrl="true"
-                                queryParamsHandling="merge"
-                                class="btn btn-primary btn-sm mr-1"
+                                [btnSize]="ButtonSize.SMALL"
+                                [btnType]="ButtonType.PRIMARY"
+                                icon="pencil-alt"
+                                title="entity.action.edit"
+                                class="mr-1"
                             >
-                                <fa-icon icon="pencil-alt"></fa-icon>
-                                <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
-                            </button>
+                            </jhi-button>
                             <button
                                 *ngIf="fileUploadExercise.isAtLeastInstructor"
                                 jhiDeleteButton

--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.scss
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.scss
@@ -1,0 +1,10 @@
+.jhi-btn-group {
+    display: flex;
+    overflow: hidden;
+}
+
+.jhi-btn-group--block > jhi-button,
+button {
+    flex: 1 1 auto;
+    position: relative;
+}

--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.ts
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.component.ts
@@ -9,13 +9,17 @@ import { FileUploadExerciseService } from './file-upload-exercise.service';
 import { CourseExerciseService, CourseService } from '../course';
 import { ExerciseComponent } from 'app/entities/exercise/exercise.component';
 import { AccountService } from 'app/core';
+import { ButtonSize, ButtonType } from 'app/shared/components';
 
 @Component({
     selector: 'jhi-file-upload-exercise',
     templateUrl: './file-upload-exercise.component.html',
+    styleUrls: ['./file-upload-exercise.component.scss'],
 })
 export class FileUploadExerciseComponent extends ExerciseComponent {
     @Input() fileUploadExercises: FileUploadExercise[] = [];
+    ButtonType = ButtonType;
+    ButtonSize = ButtonSize;
 
     constructor(
         private fileUploadExerciseService: FileUploadExerciseService,

--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.module.ts
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise.module.ts
@@ -9,6 +9,7 @@ import { ArtemisCategorySelectorModule } from 'app/components/category-selector/
 import { ArtemisDifficultyPickerModule } from 'app/components/exercise/difficulty-picker/difficulty-picker.module';
 import { ArtemisMarkdownEditorModule } from 'app/markdown-editor';
 import { ArtemisPresentationScoreModule } from 'app/components/exercise/presentation-score/presentation-score.module';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 
 const ENTITY_STATES = [...fileUploadExerciseRoute];
 
@@ -22,6 +23,7 @@ const ENTITY_STATES = [...fileUploadExerciseRoute];
         ArtemisDifficultyPickerModule,
         ArtemisMarkdownEditorModule,
         ArtemisPresentationScoreModule,
+        ArtemisSharedComponentModule,
     ],
     declarations: [FileUploadExerciseComponent, FileUploadExerciseDetailComponent, FileUploadExerciseUpdateComponent],
     exports: [FileUploadExerciseComponent],

--- a/src/main/webapp/app/shared/components/button.component.ts
+++ b/src/main/webapp/app/shared/components/button.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Router } from '@angular/router';
 
 export enum ButtonType {
     PRIMARY = 'btn-primary',
@@ -24,7 +25,13 @@ export enum ButtonSize {
 @Component({
     selector: 'jhi-button',
     template: `
-        <button [ngClass]="['jhi-btn', 'btn', btnType, btnSize]" ngbTooltip="{{ tooltip | translate }}" [disabled]="disabled || isLoading" (click)="onClick.emit($event)">
+        <button
+            style="width: 100%"
+            [ngClass]="['jhi-btn', 'btn', btnType, btnSize]"
+            ngbTooltip="{{ tooltip | translate }}"
+            [disabled]="disabled || isLoading"
+            (click)="routerLink ? navigate() : onClick.emit($event)"
+        >
             <fa-icon class="jhi-btn__loading" *ngIf="isLoading" icon="circle-notch" [spin]="true" size="sm"></fa-icon>
             <fa-icon class="jhi-btn__icon" *ngIf="icon && !isLoading" [icon]="icon" size="sm"></fa-icon>
             <span class="jhi-btn__title" [class.ml-1]="icon || isLoading" *ngIf="title" [jhiTranslate]="title"></span>
@@ -35,7 +42,7 @@ export class ButtonComponent {
     @Input() btnType = ButtonType.PRIMARY;
     @Input() btnSize = ButtonSize.MEDIUM;
     // Fa-icon name.
-    @Input() icon: string;
+    @Input() icon: string | string[];
     // Translation placeholders, will be translated in the component.
     @Input() title: string;
     @Input() tooltip: string;
@@ -43,5 +50,13 @@ export class ButtonComponent {
     @Input() disabled = false;
     @Input() isLoading = false;
 
+    @Input() routerLink: any[];
+
     @Output() onClick = new EventEmitter<MouseEvent>();
+
+    constructor(private router: Router) {}
+
+    navigate() {
+        this.router.navigate(this.routerLink).then();
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Server: I added multiple integration tests (Spring) related to the features
- [ ] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] Server: I documented the Java code using JavaDoc style.
- [ ] Client: I added multiple integration tests (Jest) related to the features
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [ ] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want to use `jhi-button` in more places. This PR aims to extend `jhi-button` functionality and find a way to replace `btn-group` with flex styling to be able to use it, e.g. on Course Administration Page

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
