### PR TITLE
Feature/programming exercise/complaints

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -91,6 +91,8 @@ public final class Constants {
 
     public static final int EXTERNAL_SYSTEM_REQUEST_BATCH_SIZE = 100;
 
+    public static final int MAX_COMPLAINT_TIME_WEEKS = 2;
+
     // Currently 10s.
     public static final int EXTERNAL_SYSTEM_REQUEST_BATCH_WAIT_TIME_MS = 10 * 1000; // 10s
 

--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -91,7 +91,7 @@ public final class Constants {
 
     public static final int EXTERNAL_SYSTEM_REQUEST_BATCH_SIZE = 100;
 
-    public static final int MAX_COMPLAINT_TIME_WEEKS = 2;
+    public static final int MAX_COMPLAINT_TIME_WEEKS = 3;
 
     // Currently 10s.
     public static final int EXTERNAL_SYSTEM_REQUEST_BATCH_WAIT_TIME_MS = 10 * 1000; // 10s

--- a/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.service;
 
 import static de.tum.in.www1.artemis.config.Constants.MAX_COMPLAINT_NUMBER_PER_STUDENT;
+import static de.tum.in.www1.artemis.config.Constants.MAX_COMPLAINT_TIME_WEEKS;
 
 import java.security.Principal;
 import java.time.ZonedDateTime;
@@ -282,8 +283,8 @@ public class ComplaintService {
      */
     private boolean isTimeOfComplaintValid(Result result, Exercise exercise) {
         if (exercise.getAssessmentDueDate() == null || result.getCompletionDate().isAfter(exercise.getAssessmentDueDate())) {
-            return result.getCompletionDate().isAfter(ZonedDateTime.now().minusWeeks(1));
+            return result.getCompletionDate().isAfter(ZonedDateTime.now().minusWeeks(MAX_COMPLAINT_TIME_WEEKS));
         }
-        return exercise.getAssessmentDueDate().isAfter(ZonedDateTime.now().minusWeeks(1));
+        return exercise.getAssessmentDueDate().isAfter(ZonedDateTime.now().minusWeeks(MAX_COMPLAINT_TIME_WEEKS));
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -15,7 +15,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.enumeration.*;
+import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
+import de.tum.in.www1.artemis.domain.enumeration.BuildPlanType;
+import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
+import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
@@ -825,13 +828,8 @@ public class ParticipationService {
             }
         }
 
-        if (participation.getExercise() instanceof ModelingExercise || participation.getExercise() instanceof TextExercise
-                || participation.getExercise() instanceof FileUploadExercise) {
-            // For modeling, text and file upload exercises students can send complaints about their assessments and we need to remove
-            // the complaints and the according responses belonging to a participation before deleting the participation itself.
-            complaintResponseRepository.deleteByComplaint_Result_Participation_Id(participationId);
-            complaintRepository.deleteByResult_Participation_Id(participationId);
-        }
+        complaintResponseRepository.deleteByComplaint_Result_Participation_Id(participationId);
+        complaintRepository.deleteByResult_Participation_Id(participationId);
 
         participation = (StudentParticipation) deleteResultsAndSubmissionsOfParticipation(participation.getId());
 

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/controller/ModelIndex.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/controller/ModelIndex.java
@@ -6,6 +6,8 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.springframework.data.util.Pair;
+
 import de.tum.in.www1.artemis.service.compass.umlmodel.UMLDiagram;
 import de.tum.in.www1.artemis.service.compass.umlmodel.UMLElement;
 import de.tum.in.www1.artemis.service.compass.utils.CompassConfiguration;
@@ -28,44 +30,81 @@ public class ModelIndex {
     }
 
     /**
-     * Get the internal similarity id for the given model element. If the element is similar to an existing one, they share the same similarity id. Otherwise, a new id is created.
+     * Get the internal similarity ID for the given model element. If the element is similar to an existing one, they share the same similarity id, i.e. they are in the same
+     * similarity set. Otherwise, the given element does not belong to an existing similarity set and a new similarity ID is created for the element.
      *
-     * @param element a model element for which the corresponding similarity id should be retrieved
-     * @return the similarity id for the given model element
+     * @param element a model element for which the corresponding similarity ID should be retrieved
+     * @return the similarity ID for the given model element, i.e. the ID of the similarity set the element belongs to
      */
     int retrieveSimilarityId(UMLElement element) {
         if (modelElementMapping.containsKey(element)) {
             return modelElementMapping.get(element);
         }
-        // element is similar to existing element
-        for (UMLElement knownElement : uniqueModelElementList) {
-            if (knownElement.similarity(element) > CompassConfiguration.EQUALITY_THRESHOLD) {
-                modelElementMapping.put(element, knownElement.getSimilarityID());
-                return knownElement.getSimilarityID();
+
+        // Pair of similarity value and similarity ID
+        var bestSimilarityFit = Pair.of(-1.0, -1);
+
+        for (final var knownElement : uniqueModelElementList) {
+            final var similarity = knownElement.similarity(element);
+            if (similarity > CompassConfiguration.EQUALITY_THRESHOLD && similarity > bestSimilarityFit.getFirst()) {
+                // element is similar to existing element and has a higher similarity than another element
+                bestSimilarityFit = Pair.of(similarity, knownElement.getSimilarityID());
             }
         }
-        // element does not fit already known element
+
+        if (bestSimilarityFit.getFirst() != -1.0) {
+            modelElementMapping.put(element, bestSimilarityFit.getSecond());
+            return bestSimilarityFit.getSecond();
+        }
+
+        // element does not fit already known element / similarity set
         uniqueModelElementList.add(element);
         modelElementMapping.put(element, uniqueModelElementList.size() - 1);
         return uniqueModelElementList.size() - 1;
     }
 
+    /**
+     * Add a new model to the model map.
+     *
+     * @param model the new model that should be added
+     */
     public void addModel(UMLDiagram model) {
         modelMap.put(model.getModelSubmissionId(), model);
     }
 
+    /**
+     * Get the model that belongs to the given submission ID from the model map.
+     *
+     * @param modelSubmissionId the ID of the submission to which the requested model belongs to
+     * @return the model that belong to the submission with the given ID
+     */
     public UMLDiagram getModel(long modelSubmissionId) {
         return modelMap.get(modelSubmissionId); // TODO MJ check if there? return Optional?
     }
 
+    /**
+     * Get the model map. It maps submission IDs to the models of the corresponding submissions.
+     *
+     * @return the model map
+     */
     public Map<Long, UMLDiagram> getModelMap() {
         return modelMap;
     }
 
+    /**
+     * Get the collection of all the models.
+     *
+     * @return the collection of models
+     */
     public Collection<UMLDiagram> getModelCollection() {
         return modelMap.values();
     }
 
+    /**
+     * Get the number of models.
+     *
+     * @return the number of models
+     */
     int getModelCollectionSize() {
         return modelMap.size();
     }
@@ -76,7 +115,7 @@ public class ModelIndex {
      * @return the number of unique model elements
      */
     public int getNumberOfUniqueElements() {
-        return this.uniqueModelElementList.size();
+        return uniqueModelElementList.size();
     }
 
     /**
@@ -85,9 +124,14 @@ public class ModelIndex {
      * @return the model element to similarity id mapping
      */
     public Map<UMLElement, Integer> getModelElementMapping() {
-        return this.modelElementMapping;
+        return modelElementMapping;
     }
 
+    /**
+     * Get the collection of unique elements. Each unique element represents a similarity set.
+     *
+     * @return the collection of unique elements
+     */
     public Collection<UMLElement> getUniqueElements() {
         return uniqueModelElementList;
     }

--- a/src/main/webapp/app/complaints/complaint-interactions.component.html
+++ b/src/main/webapp/app/complaints/complaint-interactions.component.html
@@ -1,33 +1,35 @@
-<div class="row mt-4" *ngIf="result && result.completionDate && !hasComplaint && !hasRequestMoreFeedback">
-    <button
-        class="btn btn-primary"
-        [class.not-allowed]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
-        (click)="toggleComplaintForm()"
-        [disabled]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
-        title="{{ numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid ? ('artemisApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
-    >
-        {{ 'artemisApp.complaint.moreInfo' | translate }}
-    </button>
-    <button
-        class="btn btn-primary ml-1"
-        [class.not-allowed]="!isTimeOfComplaintValid"
-        (click)="toggleRequestMoreFeedbackForm()"
-        [disabled]="!isTimeOfComplaintValid"
-        title="{{ !isTimeOfComplaintValid ? ('artemisApp.moreFeedback.notAllowedTooltip' | translate) : '' }}"
-    >
-        {{ 'artemisApp.moreFeedback.button' | translate }}
-    </button>
-</div>
+<div>
+    <div class="mt-4" *ngIf="result && result.completionDate && !hasComplaint && !hasRequestMoreFeedback">
+        <button
+            class="btn btn-primary"
+            [class.not-allowed]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
+            (click)="toggleComplaintForm()"
+            [disabled]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
+            title="{{ numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid ? ('artemisApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
+        >
+            {{ 'artemisApp.complaint.moreInfo' | translate }}
+        </button>
+        <button
+            class="btn btn-primary ml-1"
+            [class.not-allowed]="!isTimeOfComplaintValid"
+            (click)="toggleRequestMoreFeedbackForm()"
+            [disabled]="!isTimeOfComplaintValid"
+            title="{{ !isTimeOfComplaintValid ? ('artemisApp.moreFeedback.notAllowedTooltip' | translate) : '' }}"
+        >
+            {{ 'artemisApp.moreFeedback.button' | translate }}
+        </button>
+    </div>
 
-<div class="row" *ngIf="showComplaintForm || hasComplaint">
-    <jhi-complaint-form
-        class="flex-grow-1"
-        [resultId]="result?.id"
-        [allowedComplaints]="numberOfAllowedComplaints"
-        [complaintType]="ComplaintType.COMPLAINT"
-        (submit)="hasComplaint = true"
-    ></jhi-complaint-form>
-</div>
-<div class="row" *ngIf="showRequestMoreFeedbackForm || hasRequestMoreFeedback">
-    <jhi-complaint-form class="flex-grow-1" [resultId]="result?.id" [complaintType]="ComplaintType.MORE_FEEDBACK" (submit)="hasRequestMoreFeedback = true"></jhi-complaint-form>
+    <div class="row" *ngIf="showComplaintForm || hasComplaint">
+        <jhi-complaint-form
+            class="flex-grow-1"
+            [resultId]="result?.id"
+            [allowedComplaints]="numberOfAllowedComplaints"
+            [complaintType]="ComplaintType.COMPLAINT"
+            (submit)="hasComplaint = true"
+        ></jhi-complaint-form>
+    </div>
+    <div class="row" *ngIf="showRequestMoreFeedbackForm || hasRequestMoreFeedback">
+        <jhi-complaint-form class="flex-grow-1" [resultId]="result?.id" [complaintType]="ComplaintType.MORE_FEEDBACK" (submit)="hasRequestMoreFeedback = true"></jhi-complaint-form>
+    </div>
 </div>

--- a/src/main/webapp/app/complaints/complaint-interactions.component.html
+++ b/src/main/webapp/app/complaints/complaint-interactions.component.html
@@ -1,0 +1,33 @@
+<div class="row mt-4" *ngIf="result && result.completionDate && !hasComplaint && !hasRequestMoreFeedback">
+    <button
+        class="btn btn-primary"
+        [class.not-allowed]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
+        (click)="toggleComplaintForm()"
+        [disabled]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
+        title="{{ numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid ? ('artemisApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
+    >
+        {{ 'artemisApp.complaint.moreInfo' | translate }}
+    </button>
+    <button
+        class="btn btn-primary ml-1"
+        [class.not-allowed]="!isTimeOfComplaintValid"
+        (click)="toggleRequestMoreFeedbackForm()"
+        [disabled]="!isTimeOfComplaintValid"
+        title="{{ !isTimeOfComplaintValid ? ('artemisApp.moreFeedback.notAllowedTooltip' | translate) : '' }}"
+    >
+        {{ 'artemisApp.moreFeedback.button' | translate }}
+    </button>
+</div>
+
+<div class="row" *ngIf="showComplaintForm || hasComplaint">
+    <jhi-complaint-form
+        class="flex-grow-1"
+        [resultId]="result?.id"
+        [allowedComplaints]="numberOfAllowedComplaints"
+        [complaintType]="ComplaintType.COMPLAINT"
+        (submit)="hasComplaint = true"
+    ></jhi-complaint-form>
+</div>
+<div class="row" *ngIf="showRequestMoreFeedbackForm || hasRequestMoreFeedback">
+    <jhi-complaint-form class="flex-grow-1" [resultId]="result?.id" [complaintType]="ComplaintType.MORE_FEEDBACK" (submit)="hasRequestMoreFeedback = true"></jhi-complaint-form>
+</div>

--- a/src/main/webapp/app/complaints/complaint-interactions.component.ts
+++ b/src/main/webapp/app/complaints/complaint-interactions.component.ts
@@ -1,0 +1,62 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Result, ResultService } from 'app/entities/result';
+import { ComplaintService, ComplaintType } from 'app/entities/complaint';
+import { Exercise } from 'app/entities/exercise';
+import { StudentParticipation } from 'app/entities/participation';
+
+@Component({
+    selector: 'jhi-complaint-interactions',
+    templateUrl: './complaint-interactions.component.html',
+})
+export class ComplaintInteractionsComponent implements OnInit {
+    @Input() exercise: Exercise;
+    @Input() participation: StudentParticipation;
+    @Input() result: Result;
+
+    showRequestMoreFeedbackForm = false;
+    // indicates if there is a complaint for the result of the submission
+    hasComplaint = false;
+    // indicates if more feedback was requested already
+    hasRequestMoreFeedback = false;
+    // the number of complaints that the student is still allowed to submit in the course. this is used for disabling the complain button.
+    numberOfAllowedComplaints: number;
+    // indicates if the result is older than one week. if it is, the complain button is disabled
+    isTimeOfComplaintValid: boolean;
+    showComplaintForm = false;
+    ComplaintType = ComplaintType;
+
+    constructor(private complaintService: ComplaintService, private resultService: ResultService) {}
+
+    ngOnInit(): void {
+        if (this.exercise.course) {
+            this.complaintService.getNumberOfAllowedComplaintsInCourse(this.exercise.course.id).subscribe((allowedComplaints: number) => {
+                this.numberOfAllowedComplaints = allowedComplaints;
+            });
+
+            if (this.participation.submissions && this.participation.submissions.length > 0) {
+                if (this.result && this.result.completionDate) {
+                    this.isTimeOfComplaintValid = this.resultService.isTimeOfComplaintValid(this.result, this.exercise);
+                    this.complaintService.findByResultId(this.result.id).subscribe(res => {
+                        if (res.body) {
+                            if (res.body.complaintType == null || res.body.complaintType === ComplaintType.COMPLAINT) {
+                                this.hasComplaint = true;
+                            } else {
+                                this.hasRequestMoreFeedback = true;
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    toggleComplaintForm() {
+        this.showRequestMoreFeedbackForm = false;
+        this.showComplaintForm = !this.showComplaintForm;
+    }
+
+    toggleRequestMoreFeedbackForm() {
+        this.showComplaintForm = false;
+        this.showRequestMoreFeedbackForm = !this.showRequestMoreFeedbackForm;
+    }
+}

--- a/src/main/webapp/app/complaints/complaint-interactions.component.ts
+++ b/src/main/webapp/app/complaints/complaint-interactions.component.ts
@@ -3,6 +3,8 @@ import { Result, ResultService } from 'app/entities/result';
 import { ComplaintService, ComplaintType } from 'app/entities/complaint';
 import { Exercise } from 'app/entities/exercise';
 import { StudentParticipation } from 'app/entities/participation';
+import * as moment from 'moment';
+import { MAX_COMPLAINT_TIME_WEEKS } from 'app/complaints/complaint.constants';
 
 @Component({
     selector: 'jhi-complaint-interactions',
@@ -21,7 +23,7 @@ export class ComplaintInteractionsComponent implements OnInit {
     // the number of complaints that the student is still allowed to submit in the course. this is used for disabling the complain button.
     numberOfAllowedComplaints: number;
     // indicates if the result is older than one week. if it is, the complain button is disabled
-    isTimeOfComplaintValid: boolean;
+    // isTimeOfComplaintValid: boolean;
     showComplaintForm = false;
     ComplaintType = ComplaintType;
 
@@ -35,7 +37,6 @@ export class ComplaintInteractionsComponent implements OnInit {
 
             if (this.participation.submissions && this.participation.submissions.length > 0) {
                 if (this.result && this.result.completionDate) {
-                    this.isTimeOfComplaintValid = this.resultService.isTimeOfComplaintValid(this.result, this.exercise);
                     this.complaintService.findByResultId(this.result.id).subscribe(res => {
                         if (res.body) {
                             if (res.body.complaintType == null || res.body.complaintType === ComplaintType.COMPLAINT) {
@@ -47,6 +48,23 @@ export class ComplaintInteractionsComponent implements OnInit {
                     });
                 }
             }
+        }
+    }
+
+    /**
+     * This function is used to check whether the student is allowed to submit a complaint or not. Submitting a complaint is allowed within one week after the student received the
+     * result. If the result was submitted after the assessment due date or the assessment due date is not set, the completion date of the result is checked. If the result was
+     * submitted before the assessment due date, the assessment due date is checked, as the student can only see the result after the assessment due date.
+     */
+    get isTimeOfComplaintValid(): boolean {
+        if (this.result && this.result.completionDate) {
+            const resultCompletionDate = moment(this.result.completionDate!);
+            if (!this.exercise.assessmentDueDate || resultCompletionDate.isAfter(this.exercise.assessmentDueDate)) {
+                return resultCompletionDate.isAfter(moment().subtract(MAX_COMPLAINT_TIME_WEEKS, 'week'));
+            }
+            return moment(this.exercise.assessmentDueDate).isAfter(moment().subtract(MAX_COMPLAINT_TIME_WEEKS, 'week'));
+        } else {
+            return false;
         }
     }
 

--- a/src/main/webapp/app/complaints/complaint.constants.ts
+++ b/src/main/webapp/app/complaints/complaint.constants.ts
@@ -1,0 +1,1 @@
+export const MAX_COMPLAINT_TIME_WEEKS = 2;

--- a/src/main/webapp/app/complaints/complaint.constants.ts
+++ b/src/main/webapp/app/complaints/complaint.constants.ts
@@ -1,1 +1,1 @@
-export const MAX_COMPLAINT_TIME_WEEKS = 2;
+export const MAX_COMPLAINT_TIME_WEEKS = 3;

--- a/src/main/webapp/app/complaints/complaints.module.ts
+++ b/src/main/webapp/app/complaints/complaints.module.ts
@@ -6,11 +6,12 @@ import { ComplaintsComponent } from './complaints.component';
 import { MomentModule } from 'ngx-moment';
 import { ClipboardModule } from 'ngx-clipboard';
 import { ComplaintService } from 'app/entities/complaint/complaint.service';
+import { ComplaintInteractionsComponent } from 'app/complaints/complaint-interactions.component';
 
 @NgModule({
     imports: [ArtemisSharedModule, MomentModule, ClipboardModule],
-    declarations: [ComplaintsComponent],
-    exports: [ComplaintsComponent],
+    declarations: [ComplaintsComponent, ComplaintInteractionsComponent],
+    exports: [ComplaintsComponent, ComplaintInteractionsComponent],
     providers: [JhiAlertService, ComplaintService],
 })
 export class ArtemisComplaintsModule {}

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import { ProgrammingExercise, ProgrammingLanguage } from './programming-exercise.model';
 import { ProgrammingExerciseService } from 'app/entities/programming-exercise/services/programming-exercise.service';
-import { Result, ResultService } from 'app/entities/result';
+import { Result } from 'app/entities/result';
 import { JhiAlertService } from 'ng-jhipster';
 import { ParticipationType } from './programming-exercise-participation.model';
 import { ProgrammingExerciseParticipationService } from 'app/entities/programming-exercise/services/programming-exercise-participation.service';
@@ -31,7 +31,6 @@ export class ProgrammingExerciseDetailComponent implements OnInit {
         private activatedRoute: ActivatedRoute,
         private accountService: AccountService,
         private programmingExerciseService: ProgrammingExerciseService,
-        private resultService: ResultService,
         private jhiAlertService: JhiAlertService,
         private programmingExerciseParticipationService: ProgrammingExerciseParticipationService,
     ) {}
@@ -45,21 +44,14 @@ export class ProgrammingExerciseDetailComponent implements OnInit {
             this.programmingExercise.solutionParticipation.programmingExercise = this.programmingExercise;
             this.programmingExercise.templateParticipation.programmingExercise = this.programmingExercise;
 
-            this.programmingExerciseParticipationService
-                .getLatestResultWithFeedback(this.programmingExercise.solutionParticipation.id)
-                .pipe(catchError(() => of(null)))
-                .subscribe((result: Result) => {
-                    this.programmingExercise.solutionParticipation.results = result ? [result] : [];
-                    this.loadingSolutionParticipationResults = false;
-                });
-
-            this.programmingExerciseParticipationService
-                .getLatestResultWithFeedback(this.programmingExercise.templateParticipation.id)
-                .pipe(catchError(() => of(null)))
-                .subscribe((result: Result) => {
-                    this.programmingExercise.templateParticipation.results = result ? [result] : [];
-                    this.loadingTemplateParticipationResults = false;
-                });
+            this.loadLatestResultWithFeedback(this.programmingExercise.solutionParticipation.id).subscribe(results => {
+                this.programmingExercise.solutionParticipation.results = results;
+                this.loadingSolutionParticipationResults = false;
+            });
+            this.loadLatestResultWithFeedback(this.programmingExercise.templateParticipation.id).subscribe(results => {
+                this.programmingExercise.templateParticipation.results = results;
+                this.loadingTemplateParticipationResults = false;
+            });
         });
     }
 
@@ -68,7 +60,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit {
      * @param participationId of the given participation.
      * @return an empty array if there is no result or an array with the single latest result.
      */
-    private loadLatestResultWithFeedback(participationId: number) {
+    private loadLatestResultWithFeedback(participationId: number): Observable<Result[]> {
         return this.programmingExerciseParticipationService.getLatestResultWithFeedback(participationId).pipe(
             catchError(() => of(null)),
             map((result: Result | null) => {

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.module.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.module.ts
@@ -37,6 +37,7 @@ import { ProgrammingExerciseTestScheduleDatePickerComponent } from 'app/entities
 import { OwlDateTimeModule } from 'ng-pick-datetime';
 import { ProgrammingExercisePlansAndRepositoriesPreviewComponent } from 'app/entities/programming-exercise/programming-exercise-plans-and-repositories-preview.component';
 import { ArtemisMarkdownEditorModule } from 'app/markdown-editor';
+import { ArtemisComplaintsModule } from 'app/complaints';
 
 const ENTITY_STATES = [...programmingExerciseRoute, ...programmingExercisePopupRoute];
 
@@ -60,6 +61,7 @@ const ENTITY_STATES = [...programmingExerciseRoute, ...programmingExercisePopupR
         ArtemisPresentationScoreModule,
         OwlDateTimeModule,
         ArtemisMarkdownEditorModule,
+        ArtemisComplaintsModule,
     ],
     declarations: [
         ProgrammingExerciseComponent,

--- a/src/main/webapp/app/entities/result/result.service.ts
+++ b/src/main/webapp/app/entities/result/result.service.ts
@@ -9,9 +9,8 @@ import { Result } from './result.model';
 import { createRequestOption } from 'app/shared';
 import { Feedback } from 'app/entities/feedback';
 import { StudentParticipation } from 'app/entities/participation';
-import { Exercise, ExerciseService } from 'app/entities/exercise';
+import { ExerciseService } from 'app/entities/exercise';
 import { isMoment } from 'moment';
-import { MAX_COMPLAINT_TIME_WEEKS } from 'app/complaints/complaint.constants';
 
 export type EntityResponseType = HttpResponse<Result>;
 export type EntityArrayResponseType = HttpResponse<Result[]>;
@@ -116,18 +115,5 @@ export class ResultService implements IResultService {
             }
         }
         return participation;
-    }
-
-    /**
-     * This function is used to check whether the student is allowed to submit a complaint or not. Submitting a complaint is allowed within one week after the student received the
-     * result. If the result was submitted after the assessment due date or the assessment due date is not set, the completion date of the result is checked. If the result was
-     * submitted before the assessment due date, the assessment due date is checked, as the student can only see the result after the assessment due date.
-     */
-    isTimeOfComplaintValid(result: Result, exercise: Exercise): boolean {
-        const resultCompletionDate = moment(result.completionDate!);
-        if (!exercise.assessmentDueDate || resultCompletionDate.isAfter(exercise.assessmentDueDate)) {
-            return resultCompletionDate.isAfter(moment().subtract(MAX_COMPLAINT_TIME_WEEKS, 'week'));
-        }
-        return moment(exercise.assessmentDueDate).isAfter(moment().subtract(MAX_COMPLAINT_TIME_WEEKS, 'week'));
     }
 }

--- a/src/main/webapp/app/entities/result/result.service.ts
+++ b/src/main/webapp/app/entities/result/result.service.ts
@@ -11,6 +11,7 @@ import { Feedback } from 'app/entities/feedback';
 import { StudentParticipation } from 'app/entities/participation';
 import { Exercise, ExerciseService } from 'app/entities/exercise';
 import { isMoment } from 'moment';
+import { MAX_COMPLAINT_TIME_WEEKS } from 'app/complaints/complaint.constants';
 
 export type EntityResponseType = HttpResponse<Result>;
 export type EntityArrayResponseType = HttpResponse<Result[]>;
@@ -125,8 +126,8 @@ export class ResultService implements IResultService {
     isTimeOfComplaintValid(result: Result, exercise: Exercise): boolean {
         const resultCompletionDate = moment(result.completionDate!);
         if (!exercise.assessmentDueDate || resultCompletionDate.isAfter(exercise.assessmentDueDate)) {
-            return resultCompletionDate.isAfter(moment().subtract(1, 'week'));
+            return resultCompletionDate.isAfter(moment().subtract(MAX_COMPLAINT_TIME_WEEKS, 'week'));
         }
-        return moment(exercise.assessmentDueDate).isAfter(moment().subtract(1, 'week'));
+        return moment(exercise.assessmentDueDate).isAfter(moment().subtract(MAX_COMPLAINT_TIME_WEEKS, 'week'));
     }
 }

--- a/src/main/webapp/app/file-upload-submission/file-upload-submission.component.html
+++ b/src/main/webapp/app/file-upload-submission/file-upload-submission.component.html
@@ -79,5 +79,5 @@
         <h5><span jhiTranslate="artemisApp.fileUploadExercise.assessedSubmission">Your assessed submission</span>:</h5>
         <jhi-file-upload-result [result]="result"></jhi-file-upload-result>
     </div>
-    <jhi-complaint-interactions [result]="result" [participation]="participation" [exercise]="fileUploadExercise"> </jhi-complaint-interactions>
+    <jhi-complaint-interactions *ngIf="fileUploadExercise" [result]="result" [participation]="participation" [exercise]="fileUploadExercise"> </jhi-complaint-interactions>
 </div>

--- a/src/main/webapp/app/file-upload-submission/file-upload-submission.component.html
+++ b/src/main/webapp/app/file-upload-submission/file-upload-submission.component.html
@@ -79,37 +79,5 @@
         <h5><span jhiTranslate="artemisApp.fileUploadExercise.assessedSubmission">Your assessed submission</span>:</h5>
         <jhi-file-upload-result [result]="result"></jhi-file-upload-result>
     </div>
-    <div class="row mt-4" *ngIf="result && result.completionDate && !hasComplaint && !hasRequestMoreFeedback">
-        <button
-            class="btn btn-primary"
-            [class.not-allowed]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
-            (click)="toggleComplaintForm()"
-            [disabled]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
-            title="{{ numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid ? ('artemisApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
-        >
-            {{ 'artemisApp.complaint.moreInfo' | translate }}
-        </button>
-        <button
-            class="btn btn-primary ml-1"
-            [class.not-allowed]="!isTimeOfComplaintValid"
-            (click)="toggleRequestMoreFeedbackForm()"
-            [disabled]="!isTimeOfComplaintValid"
-            title="{{ !isTimeOfComplaintValid ? ('artemisApp.moreFeedback.notAllowedTooltip' | translate) : '' }}"
-        >
-            {{ 'artemisApp.moreFeedback.button' | translate }}
-        </button>
-    </div>
-
-    <div class="row" *ngIf="showComplaintForm || hasComplaint">
-        <jhi-complaint-form
-            class="flex-grow-1"
-            [resultId]="result?.id"
-            [allowedComplaints]="numberOfAllowedComplaints"
-            [complaintType]="ComplaintType.COMPLAINT"
-            (submit)="hasComplaint = true"
-        ></jhi-complaint-form>
-    </div>
-    <div class="row" *ngIf="showRequestMoreFeedbackForm || hasRequestMoreFeedback">
-        <jhi-complaint-form class="flex-grow-1" [resultId]="result?.id" [complaintType]="ComplaintType.MORE_FEEDBACK" (submit)="hasRequestMoreFeedback = true"></jhi-complaint-form>
-    </div>
+    <jhi-complaint-interactions [result]="result" [participation]="participation" [exercise]="fileUploadExercise"> </jhi-complaint-interactions>
 </div>

--- a/src/main/webapp/app/file-upload-submission/file-upload-submission.component.ts
+++ b/src/main/webapp/app/file-upload-submission/file-upload-submission.component.ts
@@ -31,18 +31,6 @@ export class FileUploadSubmissionComponent implements OnInit, ComponentCanDeacti
     result: Result;
     isActive: boolean;
     submissionFile: File | null;
-
-    ComplaintType = ComplaintType;
-    showComplaintForm = false;
-    showRequestMoreFeedbackForm = false;
-    // indicates if there is a complaint for the result of the submission
-    hasComplaint: boolean;
-    // indicates if there is a more feedback request for the result of the submission
-    hasRequestMoreFeedback: boolean;
-    // the number of complaints that the student is still allowed to submit in the course. this is used for disabling the complain button.
-    numberOfAllowedComplaints: number;
-    // indicates if the result is older than one week. if it is, the complain button is disabled
-    isTimeOfComplaintValid: boolean;
     // indicates if the assessment due date is in the past. the assessment will not be loaded and displayed to the student if it is not.
     isAfterAssessmentDueDate: boolean;
 
@@ -54,7 +42,6 @@ export class FileUploadSubmissionComponent implements OnInit, ComponentCanDeacti
         private route: ActivatedRoute,
         private fileUploadSubmissionService: FileUploadSubmissionService,
         private fileUploaderService: FileUploaderService,
-        private complaintService: ComplaintService,
         private resultService: ResultService,
         private jhiAlertService: JhiAlertService,
         private location: Location,
@@ -89,29 +76,13 @@ export class FileUploadSubmissionComponent implements OnInit, ComponentCanDeacti
                     .join(',');
                 this.isAfterAssessmentDueDate = !this.fileUploadExercise.assessmentDueDate || moment().isAfter(this.fileUploadExercise.assessmentDueDate);
 
-                if (this.fileUploadExercise.course) {
-                    this.complaintService.getNumberOfAllowedComplaintsInCourse(this.fileUploadExercise.course.id).subscribe((allowedComplaints: number) => {
-                        this.numberOfAllowedComplaints = allowedComplaints;
-                    });
-                }
                 if (this.submission.submitted) {
                     this.setSubmittedFile();
                 }
                 if (this.submission.submitted && this.result && this.result.completionDate) {
-                    this.isTimeOfComplaintValid = this.resultService.isTimeOfComplaintValid(this.result, this.fileUploadExercise);
                     this.fileUploadAssessmentService.getAssessment(this.submission.id).subscribe((assessmentResult: Result) => {
                         this.result = assessmentResult;
                     });
-                    this.complaintService
-                        .findByResultId(this.result.id)
-                        .pipe(filter(res => !!res.body))
-                        .subscribe(res => {
-                            if (res.body!.complaintType === ComplaintType.MORE_FEEDBACK) {
-                                this.hasRequestMoreFeedback = true;
-                            } else {
-                                this.hasComplaint = true;
-                            }
-                        });
                 }
                 this.isActive =
                     this.fileUploadExercise.dueDate === undefined || this.fileUploadExercise.dueDate === null || new Date() <= moment(this.fileUploadExercise.dueDate).toDate();
@@ -192,22 +163,6 @@ export class FileUploadSubmissionComponent implements OnInit, ComponentCanDeacti
 
     downloadFile(filePath: string) {
         this.fileService.downloadAttachment(filePath);
-    }
-
-    /**
-     * Hides more feedback form and shows complaint form
-     */
-    toggleComplaintForm() {
-        this.showRequestMoreFeedbackForm = false;
-        this.showComplaintForm = !this.showComplaintForm;
-    }
-
-    /**
-     * Hides complaint form and shows more feedback form
-     */
-    toggleRequestMoreFeedbackForm() {
-        this.showComplaintForm = false;
-        this.showRequestMoreFeedbackForm = !this.showRequestMoreFeedbackForm;
     }
 
     /**

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.html
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.html
@@ -120,38 +120,5 @@
             </ng-container>
         </div>
     </div>
-
-    <div class="row mt-2 ml-0" *ngIf="result && result.completionDate && !hasComplaint && !hasRequestMoreFeedback">
-        <button
-            class="btn btn-primary"
-            [class.not-allowed]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
-            (click)="toggleComplaintForm()"
-            [disabled]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
-            title="{{ numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid ? ('artemisApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
-        >
-            {{ 'artemisApp.complaint.moreInfo' | translate }}
-        </button>
-        <button
-            class="btn btn-primary ml-1"
-            [class.not-allowed]="!isTimeOfComplaintValid"
-            (click)="toggleRequestMoreFeedbackForm()"
-            [disabled]="!isTimeOfComplaintValid"
-            title="{{ !isTimeOfComplaintValid ? ('artemisApp.moreFeedback.notAllowedTooltip' | translate) : '' }}"
-        >
-            {{ 'artemisApp.moreFeedback.button' | translate }}
-        </button>
-    </div>
-</div>
-
-<div *ngIf="showComplaintForm || hasComplaint">
-    <jhi-complaint-form
-        class="row"
-        [resultId]="result?.id"
-        [allowedComplaints]="numberOfAllowedComplaints"
-        [complaintType]="ComplaintType.COMPLAINT"
-        (submit)="hasComplaint = true"
-    ></jhi-complaint-form>
-</div>
-<div class="row" *ngIf="showRequestMoreFeedbackForm || hasRequestMoreFeedback">
-    <jhi-complaint-form class="flex-grow-1" [resultId]="result?.id" [complaintType]="ComplaintType.MORE_FEEDBACK" (submit)="hasRequestMoreFeedback = true"></jhi-complaint-form>
+    <jhi-complaint-interactions [exercise]="modelingExercise" [participation]="participation" [result]="result"> </jhi-complaint-interactions>
 </div>

--- a/src/main/webapp/app/modeling-submission/modeling-submission.component.html
+++ b/src/main/webapp/app/modeling-submission/modeling-submission.component.html
@@ -120,5 +120,5 @@
             </ng-container>
         </div>
     </div>
-    <jhi-complaint-interactions [exercise]="modelingExercise" [participation]="participation" [result]="result"> </jhi-complaint-interactions>
+    <jhi-complaint-interactions *ngIf="modelingExercise" [exercise]="modelingExercise" [participation]="participation" [result]="result"> </jhi-complaint-interactions>
 </div>

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -160,8 +160,16 @@
                     <h3>{{ 'artemisApp.courseOverview.exerciseDetails.noResults' | translate }}</h3>
                 </div>
             </div>
+            <!-- RESULTS END -->
+            <jhi-complaint-interactions
+                *ngIf="currentResult && studentParticipation && currentResult.assessmentType === AssessmentType.MANUAL"
+                class="row mb-2 mt-2"
+                [exercise]="exercise"
+                [participation]="studentParticipation"
+                [result]="currentResult"
+            >
+            </jhi-complaint-interactions>
         </div>
-        <!-- RESULTS END -->
         <div class="col-sm-12 col-md-4 col-lg-4" jhiIdeFilter [showInIDE]="false">
             <jhi-student-questions [exercise]="exercise"></jhi-student-questions>
         </div>

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -162,8 +162,8 @@
             </div>
             <!-- RESULTS END -->
             <jhi-complaint-interactions
-                *ngIf="currentResult && studentParticipation && currentResult.assessmentType === AssessmentType.MANUAL"
-                class="row mb-2 mt-2"
+                *ngIf="exercise.type === PROGRAMMING && studentParticipation && currentResult && currentResult.assessmentType === AssessmentType.MANUAL"
+                class="mb-2 mt-2 ml-3"
                 [exercise]="exercise"
                 [participation]="studentParticipation"
                 [result]="currentResult"

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -152,16 +152,18 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
 
     sortResults() {
         if (this.studentParticipation && this.hasResults) {
-            this.studentParticipation.results = this.studentParticipation.results.sort((a, b) => {
-                const aValue = moment(a.completionDate!).valueOf();
-                const bValue = moment(b.completionDate!).valueOf();
-                return aValue - bValue;
-            });
+            this.studentParticipation.results = this.studentParticipation.results.sort(this.resultSortFunction);
             const sortedResultLength = this.studentParticipation.results.length;
             const startingElement = Math.max(sortedResultLength - MAX_RESULT_HISTORY_LENGTH, 0);
             this.sortedHistoryResult = this.studentParticipation.results.slice(startingElement, sortedResultLength);
         }
     }
+
+    private resultSortFunction = (a: Result, b: Result) => {
+        const aValue = moment(a.completionDate!).valueOf();
+        const bValue = moment(b.completionDate!).valueOf();
+        return aValue - bValue;
+    };
 
     mergeResultsAndSubmissionsForParticipations() {
         // if there are new student participation(s) from the server, we need to update this.studentParticipation
@@ -263,7 +265,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
             return this.studentParticipation.results.find((result: Result) => !!result.completionDate) || null;
         }
 
-        const ratedResults = this.studentParticipation.results.filter((result: Result) => result.rated);
+        const ratedResults = this.studentParticipation.results.filter((result: Result) => result.rated).sort(this.resultSortFunction);
         const latestResult = ratedResults.length ? ratedResults[ratedResults.length - 1] : null;
         if (latestResult) {
             latestResult.participation = this.studentParticipation;

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -20,6 +20,7 @@ import { GuidedTourService } from 'app/guided-tour/guided-tour.service';
 import { programmingExerciseFail, programmingExerciseSuccess } from 'app/guided-tour/tours/course-exercise-detail-tour';
 import { SourceTreeService } from 'app/components/util/sourceTree.service';
 import { CourseScoreCalculationService } from 'app/overview';
+import { AssessmentType } from 'app/entities/assessment-type';
 
 const MAX_RESULT_HISTORY_LENGTH = 5;
 
@@ -29,6 +30,7 @@ const MAX_RESULT_HISTORY_LENGTH = 5;
     styleUrls: ['../course-overview.scss'],
 })
 export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
+    readonly AssessmentType = AssessmentType;
     readonly QUIZ = ExerciseType.QUIZ;
     readonly PROGRAMMING = ExerciseType.PROGRAMMING;
     readonly MODELING = ExerciseType.MODELING;

--- a/src/main/webapp/app/overview/overview.module.ts
+++ b/src/main/webapp/app/overview/overview.module.ts
@@ -30,6 +30,7 @@ import { ArtemisHeaderExercisePageWithDetailsModule } from 'app/exercise-headers
 import { CourseLectureRowComponent } from 'app/overview/course-lectures/course-lecture-row.component';
 import { ArtemisCourseRegistrationSelector } from 'app/components/course-registration-selector/course-registration-selector.module';
 import { IntellijModule } from 'app/intellij/intellij.module';
+import { ArtemisComplaintsModule } from 'app/complaints';
 
 const ENTITY_STATES = [...OVERVIEW_ROUTES];
 
@@ -47,6 +48,7 @@ const ENTITY_STATES = [...OVERVIEW_ROUTES];
         ArtemisHeaderExercisePageWithDetailsModule,
         ArtemisCourseRegistrationSelector,
         IntellijModule,
+        ArtemisComplaintsModule,
     ],
     declarations: [
         OverviewComponent,

--- a/src/main/webapp/app/text-editor/text-editor.component.html
+++ b/src/main/webapp/app/text-editor/text-editor.component.html
@@ -70,37 +70,5 @@
         </ng-template>
     </div>
 
-    <div class="row mt-4" *ngIf="result && result.completionDate && !hasComplaint && !hasRequestMoreFeedback">
-        <button
-            class="btn btn-primary"
-            [class.not-allowed]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
-            (click)="toggleComplaintForm()"
-            [disabled]="numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid"
-            title="{{ numberOfAllowedComplaints <= 0 || !isTimeOfComplaintValid ? ('artemisApp.complaint.complaintNotAllowedTooltip' | translate) : '' }}"
-        >
-            {{ 'artemisApp.complaint.moreInfo' | translate }}
-        </button>
-        <button
-            class="btn btn-primary ml-1"
-            [class.not-allowed]="!isTimeOfComplaintValid"
-            (click)="toggleRequestMoreFeedbackForm()"
-            [disabled]="!isTimeOfComplaintValid"
-            title="{{ !isTimeOfComplaintValid ? ('artemisApp.moreFeedback.notAllowedTooltip' | translate) : '' }}"
-        >
-            {{ 'artemisApp.moreFeedback.button' | translate }}
-        </button>
-    </div>
-
-    <div class="row" *ngIf="showComplaintForm || hasComplaint">
-        <jhi-complaint-form
-            class="flex-grow-1"
-            [resultId]="result?.id"
-            [allowedComplaints]="numberOfAllowedComplaints"
-            [complaintType]="ComplaintType.COMPLAINT"
-            (submit)="hasComplaint = true"
-        ></jhi-complaint-form>
-    </div>
-    <div class="row" *ngIf="showRequestMoreFeedbackForm || hasRequestMoreFeedback">
-        <jhi-complaint-form class="flex-grow-1" [resultId]="result?.id" [complaintType]="ComplaintType.MORE_FEEDBACK" (submit)="hasRequestMoreFeedback = true"></jhi-complaint-form>
-    </div>
+    <jhi-complaint-interactions *ngIf="result && participation" [exercise]="textExercise" [result]="result" [participation]="participation"> </jhi-complaint-interactions>
 </div>

--- a/src/main/webapp/app/text-editor/text-editor.component.ts
+++ b/src/main/webapp/app/text-editor/text-editor.component.ts
@@ -12,9 +12,7 @@ import { TextEditorService } from 'app/text-editor/text-editor.service';
 import * as moment from 'moment';
 import { HighlightColors } from 'app/text-assessment/highlight-colors';
 import { ArtemisMarkdown } from 'app/components/util/markdown.service';
-import { ComplaintService } from 'app/entities/complaint/complaint.service';
 import { Feedback } from 'app/entities/feedback';
-import { ComplaintType } from 'app/entities/complaint';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { ComponentCanDeactivate } from 'app/shared';
 import { Observable } from 'rxjs/Observable';
@@ -31,20 +29,8 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
     isActive: boolean;
     isSaving: boolean;
     answer: string;
-    isExampleSubmission = false;
-    showComplaintForm = false;
-    showRequestMoreFeedbackForm = false;
-    // indicates if there is a complaint for the result of the submission
-    hasComplaint = false;
-    // indicates if more feedback was requested already
-    hasRequestMoreFeedback = false;
-    // the number of complaints that the student is still allowed to submit in the course. this is used for disabling the complain button.
-    numberOfAllowedComplaints: number;
-    // indicates if the result is older than one week. if it is, the complain button is disabled
-    isTimeOfComplaintValid: boolean;
     // indicates if the assessment due date is in the past. the assessment will not be loaded and displayed to the student if it is not.
     isAfterAssessmentDueDate: boolean;
-    ComplaintType = ComplaintType;
 
     public getColorForIndex = HighlightColors.forIndex;
     private submissionConfirmationText: string;
@@ -55,7 +41,6 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
         private participationService: ParticipationService,
         private textSubmissionService: TextSubmissionService,
         private textService: TextEditorService,
-        private complaintService: ComplaintService,
         private resultService: ResultService,
         private jhiAlertService: JhiAlertService,
         private artemisMarkdown: ArtemisMarkdown,
@@ -78,12 +63,6 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
                 this.textExercise = this.participation.exercise as TextExercise;
                 this.isAfterAssessmentDueDate = !this.textExercise.assessmentDueDate || moment().isAfter(this.textExercise.assessmentDueDate);
 
-                if (this.textExercise.course) {
-                    this.complaintService.getNumberOfAllowedComplaintsInCourse(this.textExercise.course.id).subscribe((allowedComplaints: number) => {
-                        this.numberOfAllowedComplaints = allowedComplaints;
-                    });
-                }
-
                 if (data.submissions && data.submissions.length > 0) {
                     this.submission = data.submissions[0] as TextSubmission;
                     if (this.submission && data.results && this.isAfterAssessmentDueDate) {
@@ -92,18 +71,6 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
 
                     if (this.submission && this.submission.text) {
                         this.answer = this.submission.text;
-                    }
-                    if (this.result && this.result.completionDate) {
-                        this.isTimeOfComplaintValid = this.resultService.isTimeOfComplaintValid(this.result, this.textExercise);
-                        this.complaintService.findByResultId(this.result.id).subscribe(res => {
-                            if (res.body) {
-                                if (res.body.complaintType == null || res.body.complaintType === ComplaintType.COMPLAINT) {
-                                    this.hasComplaint = true;
-                                } else {
-                                    this.hasRequestMoreFeedback = true;
-                                }
-                            }
-                        });
                     }
                 }
 
@@ -232,15 +199,5 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
 
     previous() {
         this.location.back();
-    }
-
-    toggleComplaintForm() {
-        this.showRequestMoreFeedbackForm = false;
-        this.showComplaintForm = !this.showComplaintForm;
-    }
-
-    toggleRequestMoreFeedbackForm() {
-        this.showComplaintForm = false;
-        this.showRequestMoreFeedbackForm = !this.showRequestMoreFeedbackForm;
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.util.LinkedMultiValueMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.ComplaintType;
 import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
@@ -139,8 +140,8 @@ public class AssessmentComplaintIntegrationTest {
     @Test
     @WithMockUser(username = "student1")
     public void submitComplaintAboutModelingAssessment_assessmentTooOld() throws Exception {
-        database.updateAssessmentDueDate(modelingExercise.getId(), ZonedDateTime.now().minusDays(8));
-        database.updateResultCompletionDate(modelingAssessment.getId(), ZonedDateTime.now().minusDays(8));
+        database.updateAssessmentDueDate(modelingExercise.getId(), ZonedDateTime.now().minusWeeks(Constants.MAX_COMPLAINT_TIME_WEEKS + 1));
+        database.updateResultCompletionDate(modelingAssessment.getId(), ZonedDateTime.now().minusWeeks(Constants.MAX_COMPLAINT_TIME_WEEKS + 1));
 
         request.post("/api/complaints", complaint, HttpStatus.BAD_REQUEST);
 

--- a/src/test/java/de/tum/in/www1/artemis/service/compass/controller/ModelIndexTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/compass/controller/ModelIndexTest.java
@@ -1,0 +1,97 @@
+package de.tum.in.www1.artemis.service.compass.controller;
+
+import static de.tum.in.www1.artemis.service.compass.utils.CompassConfiguration.EQUALITY_THRESHOLD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tum.in.www1.artemis.service.compass.umlmodel.UMLElement;
+
+@ExtendWith(MockitoExtension.class)
+class ModelIndexTest {
+
+    private ModelIndex modelIndex;
+
+    @Mock
+    UMLElement umlElement1;
+
+    @Mock
+    UMLElement umlElement2;
+
+    @Mock
+    UMLElement umlElement3;
+
+    @Mock
+    UMLElement umlElement4;
+
+    @BeforeEach
+    void setUp() {
+        modelIndex = new ModelIndex();
+    }
+
+    @Test
+    void retrieveSimilarityId_sameElementTwice() {
+        int similarityId1 = modelIndex.retrieveSimilarityId(umlElement1);
+        int similarityId2 = modelIndex.retrieveSimilarityId(umlElement1);
+
+        assertThat(similarityId1).isEqualTo(0);
+        assertThat(similarityId2).isEqualTo(0);
+        assertThat(modelIndex.getModelElementMapping().keySet()).containsExactly(umlElement1);
+        assertThat(modelIndex.getNumberOfUniqueElements()).isEqualTo(1);
+    }
+
+    @Test
+    void retrieveSimilarityId_twoSimilarElements() {
+        mockSimilarityBetweenElements(umlElement2, umlElement1, EQUALITY_THRESHOLD / 2);
+        mockSimilarityBetweenElements(umlElement3, umlElement1, EQUALITY_THRESHOLD / 2);
+        mockSimilarityBetweenElements(umlElement3, umlElement2, EQUALITY_THRESHOLD / 2);
+        mockSimilarityBetweenElements(umlElement4, umlElement1, EQUALITY_THRESHOLD / 2);
+        mockSimilarityBetweenElements(umlElement4, umlElement2, EQUALITY_THRESHOLD + 0.01);
+        mockSimilarityBetweenElements(umlElement4, umlElement3, EQUALITY_THRESHOLD / 2);
+
+        int similarityId1 = modelIndex.retrieveSimilarityId(umlElement1);
+        int similarityId2 = modelIndex.retrieveSimilarityId(umlElement2);
+        when(umlElement2.getSimilarityID()).thenReturn(similarityId2);
+        int similarityId3 = modelIndex.retrieveSimilarityId(umlElement3);
+        int similarityId4 = modelIndex.retrieveSimilarityId(umlElement4);
+
+        assertThat(similarityId1).isEqualTo(0);
+        assertThat(similarityId2).isEqualTo(1);
+        assertThat(similarityId3).isEqualTo(2);
+        assertThat(similarityId4).isEqualTo(1);
+        assertThat(modelIndex.getModelElementMapping().keySet()).containsExactlyInAnyOrder(umlElement1, umlElement2, umlElement3, umlElement4);
+        assertThat(modelIndex.getNumberOfUniqueElements()).isEqualTo(3);
+    }
+
+    @Test
+    void retrieveSimilarityId_multipleSimilarElements() {
+        mockSimilarityBetweenElements(umlElement2, umlElement1, EQUALITY_THRESHOLD / 2);
+        mockSimilarityBetweenElements(umlElement3, umlElement1, EQUALITY_THRESHOLD / 2);
+        mockSimilarityBetweenElements(umlElement3, umlElement2, EQUALITY_THRESHOLD / 2);
+        mockSimilarityBetweenElements(umlElement4, umlElement1, EQUALITY_THRESHOLD + 0.01);
+        mockSimilarityBetweenElements(umlElement4, umlElement2, EQUALITY_THRESHOLD + 0.03);
+        mockSimilarityBetweenElements(umlElement4, umlElement3, EQUALITY_THRESHOLD + 0.02);
+
+        int similarityId1 = modelIndex.retrieveSimilarityId(umlElement1);
+        int similarityId2 = modelIndex.retrieveSimilarityId(umlElement2);
+        when(umlElement2.getSimilarityID()).thenReturn(similarityId2);
+        int similarityId3 = modelIndex.retrieveSimilarityId(umlElement3);
+        int similarityId4 = modelIndex.retrieveSimilarityId(umlElement4);
+
+        assertThat(similarityId1).isEqualTo(0);
+        assertThat(similarityId2).isEqualTo(1);
+        assertThat(similarityId3).isEqualTo(2);
+        assertThat(similarityId4).isEqualTo(1);
+        assertThat(modelIndex.getModelElementMapping().keySet()).containsExactlyInAnyOrder(umlElement1, umlElement2, umlElement3, umlElement4);
+        assertThat(modelIndex.getNumberOfUniqueElements()).isEqualTo(3);
+    }
+
+    private void mockSimilarityBetweenElements(UMLElement element1, UMLElement element2, double similarity) {
+        when(element2.similarity(element1)).thenReturn(similarity);
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Client: I documented the TypeScript code using JSDoc style.
- [X] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We need to enable complaints for programming exercises (for manual results). For that, it would be best to use the complaint component on the exercise details page.

### Description
<!-- Describe your changes in detail -->
I created a new complaint interactions component (feedback + complaints) from the text exercises implementation (refactored the related code). This component is now also used on the course exercise details page if the exercise is a programming exercise. 

Disclaimer: There is a bug, where the `currentResult` in the `course-exercise-details.component` changes after a couple of cycles from the latest (correct in the beginning) to the oldest. Even after debugging and searching for a long time, I could not find the reason for this. If anyone has some insight on this, it would be much appreciated. For now, I just sort the array again before fetching the latest result.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create a programming exercise with manual reviews
3. Participate
4. You should not be able to submit a complaint
5. Submit a manual review (e.g. as an instructor action)
6. You should be able to complain or request more feedback on the details page (see screencast)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![complaint_programming](https://user-images.githubusercontent.com/27979674/68419854-540e3f80-019b-11ea-96ca-7672b8ea66ff.gif)
