### PR TITLE
Bugfix/Programming Exercise/Fix resume in course-exercise-row

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -119,6 +119,8 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit {
             .subscribe(
                 participation => {
                     if (participation) {
+                        // Otherwise the client would think that all results are loaded, but there would not be any (=> no graded result).
+                        participation.results = this.exercise.studentParticipations[0] ? this.exercise.studentParticipations[0].results : [];
                         this.exercise.studentParticipations = [participation];
                         this.exercise.participationStatus = participationStatus(this.exercise);
                     }


### PR DESCRIPTION
Fixes issue https://github.com/ls1intum/Artemis/issues/1027.
Make sure to reassign the existing result to the participation on resume (resume returns the participation as the response without eagerly loaded results).

Note: We currently have the issue that resume creates a setup commit on the repo, therefore `is building...` will be shown on the result component.