### PR TITLE
Fixed: The default course color was not shown in the Course Administration page

### DIFF
--- a/src/main/webapp/app/entities/course/course.component.html
+++ b/src/main/webapp/app/entities/course/course.component.html
@@ -57,7 +57,7 @@
                 <tr *ngFor="let course of courses | sortBy: predicate:reverse; trackBy: trackId">
                     <ng-container *ngIf="!showOnlyActive || !course.endDate || (course.endDate | amIsAfter: today:'second')">
                         <td>
-                            <div [ngStyle]="{ backgroundColor: course.color, width: '15px', height: '20px' }">&nbsp;</div>
+                            <div [ngStyle]="{ backgroundColor: course.color || ARTEMIS_DEFAULT_COLOR, width: '15px', height: '20px' }">&nbsp;</div>
                         </td>
                         <td>
                             <a [routerLink]="['/course', course.id, 'view']">{{ course.id }}</a>

--- a/src/main/webapp/app/entities/course/course.component.ts
+++ b/src/main/webapp/app/entities/course/course.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { JhiAlertService, JhiEventManager } from 'ng-jhipster';
 import { Course } from './course.model';
 import { CourseService } from './course.service';
+import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-course',
@@ -17,6 +18,8 @@ export class CourseComponent implements OnInit, OnDestroy {
 
     courses: Course[];
     eventSubscriber: Subscription;
+
+    readonly ARTEMIS_DEFAULT_COLOR = ARTEMIS_DEFAULT_COLOR;
 
     constructor(private courseService: CourseService, private jhiAlertService: JhiAlertService, private eventManager: JhiEventManager) {
         this.predicate = 'id';


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~Server: I added multiple integration tests (Spring) related to the features~
- [x] ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- [x] ~Server: I implemented the changes with a good performance and prevented too many database calls~
- [x] ~Server: I documented the Java code using JavaDoc style.~
- [x] ~Client: I added multiple integration tests (Jest) related to the features~
- [x] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [x] ~Client: I documented the TypeScript code using JSDoc style.~
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] ~Client: I translated all the newly inserted strings into German and English~

### Motivation and Context
Small bugfix related to PR #978 - The default course color was not shown in the Course Administration page.

### Description
The default course color is now shown in the Course Administration page.

### Steps for Testing
1. Log into Artemis
2. Navigate to Course Administration
3. Create a course without choosing a color 
4. Navigate back to the Course Administration overview page - you should be able to see the default color on the row of the course you created. All courses should have a color.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![default course color](https://user-images.githubusercontent.com/33368508/68599487-efa3f680-04a0-11ea-80d3-86bbcfc7d9b2.png)
