### PR TITLE
Reset feedback items on next submission for file uploads

### DIFF
--- a/src/main/webapp/app/file-upload-assessment/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/file-upload-assessment/file-upload-assessment.component.ts
@@ -265,6 +265,8 @@ export class FileUploadAssessmentComponent implements OnInit, AfterViewInit, OnD
      * For the new submission to appear on the same page, the url has to be reloaded.
      */
     assessNextOptimal() {
+        this.generalFeedback = new Feedback();
+        this.referencedFeedback = [];
         this.fileUploadSubmissionService.getFileUploadSubmissionForExerciseWithoutAssessment(this.exercise.id).subscribe(
             (response: FileUploadSubmission) => {
                 this.unassessedSubmission = response;


### PR DESCRIPTION
Fixes #1051. 
The assessment page for file upload exercises didn't clear the old feedback items, if the tutor/instructor selected "next assessment". This is fixed by just resetting the variables in the component.