### PR TITLE
Check if student on complaint is not null

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResponseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResponseResource.java
@@ -148,7 +148,7 @@ public class ComplaintResponseResource {
         User originalAuthor = complaintResponse.getComplaint().getStudent();
         StudentParticipation studentParticipation = (StudentParticipation) complaintResponse.getComplaint().getResult().getParticipation();
         Exercise exercise = studentParticipation.getExercise();
-        if (!authorizationCheckService.isAtLeastTeachingAssistantForExercise(exercise) && (originalAuthor.getLogin() == null || !originalAuthor.getLogin().equals(username))) {
+        if (!authorizationCheckService.isAtLeastTeachingAssistantForExercise(exercise) && originalAuthor.getLogin() != null && !originalAuthor.getLogin().equals(username)) {
             throw new AccessForbiddenException("Insufficient permission for this complaint response");
         }
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResponseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResponseResource.java
@@ -123,7 +123,7 @@ public class ComplaintResponseResource {
         log.debug("REST request to get ComplaintResponse associated to complaint : {}", complaintId);
         Optional<ComplaintResponse> complaintResponse = complaintResponseRepository.findByComplaint_Id(complaintId);
 
-        if (!complaintResponse.isPresent()) {
+        if (complaintResponse.isEmpty()) {
             throw new EntityNotFoundException("ComplaintResponse with " + complaintId + " was not found!");
         }
 
@@ -148,7 +148,7 @@ public class ComplaintResponseResource {
         User originalAuthor = complaintResponse.getComplaint().getStudent();
         StudentParticipation studentParticipation = (StudentParticipation) complaintResponse.getComplaint().getResult().getParticipation();
         Exercise exercise = studentParticipation.getExercise();
-        if (!authorizationCheckService.isAtLeastTeachingAssistantForExercise(exercise) && !originalAuthor.getLogin().equals(username)) {
+        if (!authorizationCheckService.isAtLeastTeachingAssistantForExercise(exercise) && (originalAuthor.getLogin() == null || !originalAuthor.getLogin().equals(username))) {
             throw new AccessForbiddenException("Insufficient permission for this complaint response");
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Description
<!-- Describe your changes in detail -->
We received `NullPointerException`, when one of the tutors were trying to get complaint response for complaint. For some reason the complaint didn't store the student. I couldn't reproduce it yet, but this fix will allow us to at least avoid further `NullPointerException` until we find the actual reason.
