### PR TITLE
Fix text overflow of instructions in code editor sidebar

### DIFF
--- a/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
+++ b/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
@@ -178,6 +178,10 @@ Collapsable styling
     .card-title span {
         display: none !important;
     }
+
+    .editable-instruction-container__status {
+        display: none !important;
+    }
 }
 
 .editor-sidebar-right:not(.collapsed--horizontal) {

--- a/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
+++ b/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
@@ -157,7 +157,7 @@ Collapsable styling
     }
     .instructions-wrapper__content {
         height: auto !important;
-        overflow: auto;
+        overflow: hidden;
 
         .editable-instruction-container__save,
         .editable-instruction-container__editor {

--- a/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
+++ b/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
@@ -157,6 +157,7 @@ Collapsable styling
     }
     .instructions-wrapper__content {
         height: auto !important;
+        overflow: auto;
 
         .editable-instruction-container__save,
         .editable-instruction-container__editor {

--- a/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
+++ b/src/main/webapp/app/code-editor/layout/code-editor-grid.scss
@@ -61,6 +61,10 @@ Code-Editor Layout Styles
             flex-flow: row nowrap;
             width: 500px;
 
+            .instructions-wrapper__content {
+                overflow: hidden;
+            }
+
             > *:last-child {
                 flex: 1 1 auto;
                 width: 90%;
@@ -157,7 +161,6 @@ Collapsable styling
     }
     .instructions-wrapper__content {
         height: auto !important;
-        overflow: hidden;
 
         .editable-instruction-container__save,
         .editable-instruction-container__editor {

--- a/src/main/webapp/app/entities/programming-exercise/instructions/instructions-editor/programming-exercise-editable-instruction.scss
+++ b/src/main/webapp/app/entities/programming-exercise/instructions/instructions-editor/programming-exercise-editable-instruction.scss
@@ -19,6 +19,7 @@
         flex-flow: column nowrap;
         flex: 1 1 auto;
         height: 100%;
+        overflow: hidden;
     }
 
     .instructions__content__markdown {

--- a/src/main/webapp/app/markdown-editor/markdown-editor.component.scss
+++ b/src/main/webapp/app/markdown-editor/markdown-editor.component.scss
@@ -18,8 +18,8 @@
         display: flex;
         flex-flow: column nowrap;
         flex: 1 1 auto;
-        // This is needed so the preview doesn't overflow the container.
         height: 100%;
+        overflow: hidden;
     }
 
     .markdown-editor {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~Server: I added multiple integration tests (Spring) related to the features~
- [x] ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- [x] ~Server: I implemented the changes with a good performance and prevented too many database calls~
- [x] ~Server: I documented the Java code using JavaDoc style.~
- [x] ~Client: I added multiple integration tests (Jest) related to the features~
- [x] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [x] ~Client: I documented the TypeScript code using JSDoc style.~
- [x] ~Client: I added multiple screenshots/screencasts of my UI changes~
- [x] ~Client: I translated all the newly inserted strings into German and English~

### Motivation and Context
This PR solves issues #910 and #966.

### Description
Adding `overflow: hidden` to the container elements that are not supposed to overflow achieves the desired behavior. Apart from fixing the unwanted overflow, it also adds the currently missing horizontal scrollbar when needed. I tested it in Chromium and Firefox (would be great if a Mac user can test it in Safari although I see no reason why it wouldn't work there).

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Click on a course that has a programming exercise
4. Open the code editor for the programming exercise
5. Verify that instructions no longer overflow their container

### Screenshots
**Before:**
![OnPaste 20191127-210803](https://user-images.githubusercontent.com/7109225/69757052-390c6b00-115c-11ea-8ff9-48a303cea6bb.png)
**After:**
![OnPaste 20191127-212447](https://user-images.githubusercontent.com/7109225/69757102-5d684780-115c-11ea-8840-6b7cbad4a129.png)
**Instructor view:**
![OnPaste 20191127-222327](https://user-images.githubusercontent.com/7109225/69760430-d4a1d980-1164-11ea-8157-d8e6386c0cdc.png)
