### PR TITLE
Fix collapsed appearance of instructions panel for text assessment editor

### DIFF
--- a/src/main/webapp/app/text-assessment/text-assessment.component.scss
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.scss
@@ -52,9 +52,15 @@
     height: 7px;
 }
 
-.card.collapsed .card-body,
-.card.collapsed .card-second-header,
-.card.collapsed .card-header .float-right,
-.card.collapsed .card-header h3 span {
-    display: none;
+.card.collapsed {
+    .card-body,
+    .card-second-header,
+    .card-header .float-right,
+    .card-header h3 span {
+        display: none;
+    }
+
+    .card-title {
+        text-align: center;
+    }
 }

--- a/src/main/webapp/app/text-assessment/text-assessment.component.ts
+++ b/src/main/webapp/app/text-assessment/text-assessment.component.ts
@@ -1,7 +1,7 @@
 import * as $ from 'jquery';
 import * as moment from 'moment';
 
-import { AfterViewInit, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { Location } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TextExercise } from 'app/entities/text-exercise';
@@ -32,6 +32,7 @@ import { AccountService } from 'app/core/auth/account.service';
     providers: [TextAssessmentsService, WindowRef],
     templateUrl: './text-assessment.component.html',
     styleUrls: ['./text-assessment.component.scss'],
+    encapsulation: ViewEncapsulation.None,
 })
 export class TextAssessmentComponent implements OnInit, OnDestroy, AfterViewInit {
     text: string;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~Server: I added multiple integration tests (Spring) related to the features~
- [x] ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- [x] ~Server: I implemented the changes with a good performance and prevented too many database calls~
- [x] ~Server: I documented the Java code using JavaDoc style.~
- [x] ~Client: I added multiple integration tests (Jest) related to the features~
- [x] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [x] ~Client: I documented the TypeScript code using JSDoc style.~
- [x] ~Client: I added multiple screenshots/screencasts of my UI changes~
- [x] ~Client: I translated all the newly inserted strings into German and English~

### Motivation and Context
On the assessment page for text exercises, collapsing the instruction panel should hide its header and body text but it doesn't. 

### Description
Ensure that already defined collapsed styles are not ignored due to view encapsulation. Also center align the panel icon when it is collapsed since it looks better.

### Steps for Testing
1. Log in to Artemis as an instructor
2. Click on one of your courses that has a text exercise
3. Click on "Assessments" in the instructor actions
4. Toggle instruction panel

### Screenshots
**Before:**
![captured (1)](https://user-images.githubusercontent.com/7109225/69833558-e3f05800-1234-11ea-8eb6-d0a318f0c21e.gif)
**After:**
![captured (2)](https://user-images.githubusercontent.com/7109225/69833560-e5218500-1234-11ea-9216-16212bf8fc99.gif)

