### PR TITLE
Bugfix/guided tour/overlay

### DIFF
--- a/src/main/webapp/app/guided-tour/guided-tour.component.html
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.html
@@ -28,7 +28,9 @@
                     *ngIf="guidedTourService.currentTour"
                     class="close"
                     (click)="
-                        guidedTourService.isCurrentTour(cancelTour) || guidedTourService.isCurrentTour(completedTour) ? guidedTourService.resetTour() : guidedTourService.skipTour()
+                        guidedTourService.isCurrentTour(cancelTour) || guidedTourService.isCurrentTour(completedTour)
+                            ? guidedTourService.resetTour()
+                            : guidedTourService.skipTour(true, false)
                     "
                 ></div>
             </div>

--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -76,7 +76,7 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
             }
             case 'Escape': {
                 if (this.currentTourStep && !this.guidedTourService.isCurrentTour(cancelTour) && !this.guidedTourService.isCurrentTour(completedTour)) {
-                    this.guidedTourService.skipTour(false);
+                    this.guidedTourService.skipTour(true, false);
                 } else if (this.currentTourStep && this.guidedTourService.isOnLastStep) {
                     // The escape key event finishes the tour when the user is seeing the cancel tour step or last tour step
                     this.guidedTourService.finishGuidedTour(false);

--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -75,12 +75,11 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
                 break;
             }
             case 'Escape': {
-                if (this.currentTourStep && !this.guidedTourService.isCurrentTour(cancelTour)) {
-                    this.guidedTourService.skipTour();
-                } else if (this.currentTourStep && (this.guidedTourService.isCurrentTour(cancelTour) || this.guidedTourService.isOnLastStep)) {
+                if (this.currentTourStep && !this.guidedTourService.isCurrentTour(cancelTour) && !this.guidedTourService.isCurrentTour(completedTour)) {
+                    this.guidedTourService.skipTour(false);
+                } else if (this.currentTourStep && this.guidedTourService.isOnLastStep) {
                     // The escape key event finishes the tour when the user is seeing the cancel tour step or last tour step
-                    const showCompletedTourStep = this.guidedTourService.isCurrentTour(cancelTour) ? false : this.guidedTourService.isOnLastStep;
-                    this.guidedTourService.finishGuidedTour(showCompletedTourStep);
+                    this.guidedTourService.finishGuidedTour(false);
                 }
                 break;
             }

--- a/src/main/webapp/app/guided-tour/guided-tour.component.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.component.ts
@@ -79,7 +79,8 @@ export class GuidedTourComponent implements AfterViewInit, OnDestroy {
                     this.guidedTourService.skipTour();
                 } else if (this.currentTourStep && (this.guidedTourService.isCurrentTour(cancelTour) || this.guidedTourService.isOnLastStep)) {
                     // The escape key event finishes the tour when the user is seeing the cancel tour step or last tour step
-                    this.guidedTourService.finishGuidedTour();
+                    const showCompletedTourStep = this.guidedTourService.isCurrentTour(cancelTour) ? false : this.guidedTourService.isOnLastStep;
+                    this.guidedTourService.finishGuidedTour(showCompletedTourStep);
                 }
                 break;
             }

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -83,6 +83,7 @@ export class GuidedTourService {
                 this.skipTour(false, false);
                 this.guidedTourAvailabilitySubject.next(false);
             }
+            // resets the cancel or complete tour step when the user navigates to another page
             if (this.currentTour) {
                 this.resetTour();
             }
@@ -287,6 +288,7 @@ export class GuidedTourService {
      * Trigger callback method if there is one and finish the current guided tour by updating the guided tour settings in the database
      * and calling the reset tour method to remove current tour elements
      *
+     * @param showCompletedTourStep defines whether the completed tour step should be displayed, the default value is true
      */
     public finishGuidedTour(showCompletedTourStep = true) {
         if (!this.currentTour) {
@@ -314,6 +316,9 @@ export class GuidedTourService {
 
     /**
      * Skip current guided tour after updating the guided tour settings in the database and calling the reset tour method to remove current tour elements.
+     *
+     * @param showCancelHint defines whether the cancel hint should be displayed, the default value is true
+     * @param showFinishStep defines whether the completed tour step should be displayed, the default value is true
      */
     public skipTour(showCancelHint = true, showFinishStep = true): void {
         if (this.currentTour) {
@@ -332,7 +337,7 @@ export class GuidedTourService {
     }
 
     /**
-     * Show the cancel hint every time a user skips a tour
+     * Show the cancel hint the first time a user skips a tour
      */
     private showCancelHint(): void {
         /** Do not show hint if the user has seen it already */

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -80,7 +80,7 @@ export class GuidedTourService {
         // Reset guided tour availability on router navigation
         this.router.events.subscribe(event => {
             if (this.availableTourForComponent && event instanceof NavigationStart) {
-                this.skipTour(false);
+                this.skipTour(false, false);
                 this.guidedTourAvailabilitySubject.next(false);
             }
             if (this.currentTour) {
@@ -311,7 +311,7 @@ export class GuidedTourService {
     /**
      * Skip current guided tour after updating the guided tour settings in the database and calling the reset tour method to remove current tour elements.
      */
-    public skipTour(showFinishStep = true): void {
+    public skipTour(showCancelHint = true, showFinishStep = true): void {
         if (this.currentTour) {
             if (this.currentTour.skipCallback) {
                 this.currentTour.skipCallback(this.currentTourStepIndex);
@@ -321,7 +321,9 @@ export class GuidedTourService {
             this.finishGuidedTour(showFinishStep);
         } else {
             this.subscribeToAndUpdateGuidedTourSettings(GuidedTourState.STARTED);
-            this.showCancelHint();
+            if (showCancelHint) {
+                this.showCancelHint();
+            }
         }
     }
 

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -289,8 +289,12 @@ export class GuidedTourService {
      *
      */
     public finishGuidedTour(showCompletedTourStep = true) {
-        if (!this.currentTour || this.isCurrentTour(completedTour)) {
+        if (!this.currentTour) {
             return;
+        }
+
+        if (this.isCurrentTour(completedTour)) {
+            this.resetTour();
         }
 
         if (this.currentTour.completeCallback) {

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -80,7 +80,7 @@ export class GuidedTourService {
         // Reset guided tour availability on router navigation
         this.router.events.subscribe(event => {
             if (this.availableTourForComponent && event instanceof NavigationStart) {
-                this.finishGuidedTour(false);
+                this.skipTour(false);
                 this.guidedTourAvailabilitySubject.next(false);
             }
             if (this.currentTour) {
@@ -288,12 +288,10 @@ export class GuidedTourService {
      * and calling the reset tour method to remove current tour elements
      *
      */
-    public finishGuidedTour(showCompletedTourStep?: boolean) {
+    public finishGuidedTour(showCompletedTourStep = true) {
         if (!this.currentTour || this.isCurrentTour(completedTour)) {
             return;
         }
-
-        const showCompletedStep = showCompletedTourStep !== undefined ? showCompletedTourStep : true;
 
         if (this.currentTour.completeCallback) {
             this.currentTour.completeCallback();
@@ -302,7 +300,7 @@ export class GuidedTourService {
         const nextStep = this.currentTour.steps[this.currentTourStepIndex + 1];
         if (!nextStep) {
             this.subscribeToAndUpdateGuidedTourSettings(GuidedTourState.FINISHED);
-            if (showCompletedStep) {
+            if (showCompletedTourStep) {
                 this.showCompletedTourStep();
             }
         } else {
@@ -313,14 +311,14 @@ export class GuidedTourService {
     /**
      * Skip current guided tour after updating the guided tour settings in the database and calling the reset tour method to remove current tour elements.
      */
-    public skipTour(): void {
+    public skipTour(showFinishStep = true): void {
         if (this.currentTour) {
             if (this.currentTour.skipCallback) {
                 this.currentTour.skipCallback(this.currentTourStepIndex);
             }
         }
         if (this.currentTourStepIndex + 1 === this.getFilteredTourSteps().length) {
-            this.finishGuidedTour();
+            this.finishGuidedTour(showFinishStep);
         } else {
             this.subscribeToAndUpdateGuidedTourSettings(GuidedTourState.STARTED);
             this.showCancelHint();

--- a/src/main/webapp/app/guided-tour/tours/course-exercise-detail-tour.ts
+++ b/src/main/webapp/app/guided-tour/tours/course-exercise-detail-tour.ts
@@ -51,9 +51,5 @@ export const programmingExerciseSuccess: GuidedTour = {
             contentTranslateKey: 'tour.programmingExercise.reviewResult.content',
             orientation: Orientation.TOP,
         }),
-        new TextTourStep({
-            headlineTranslateKey: 'tour.programmingExercise.exerciseSuccess.headline',
-            contentTranslateKey: 'tour.programmingExercise.exerciseSuccess.content',
-        }),
     ],
 };

--- a/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
+++ b/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
@@ -44,8 +44,6 @@ describe('GuidedTourComponent', () => {
     });
 
     const courseOverviewTour: GuidedTour = {
-        courseShortName: '',
-        exerciseShortName: '',
         settingsKey: 'course_overview_tour',
         steps: [
             tourStep,
@@ -213,6 +211,10 @@ describe('GuidedTourComponent', () => {
             const finishTour = spyOn(guidedTourService, 'finishGuidedTour');
             spyOn<any>(guidedTourService, 'isCurrentTour').and.returnValue(true);
             const eventMock = new KeyboardEvent('keydown', { code: 'Escape' });
+
+            while (!guidedTourService.isOnLastStep) {
+                guidedTourService.nextStep();
+            }
 
             guidedTourComponent.handleKeyboardEvent(eventMock);
             expect(skipTour.calls.count()).to.equal(0);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I updated integration tests (Jest) related to the features
- [x] ~~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~~
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] ~~Client: I added multiple screenshots/screencasts of my UI changes~~
- [x] ~~Client: I translated all the newly inserted strings into German and English~~

### Motivation and Context
Fix the error regarding the guided tour in https://github.com/ls1intum/Artemis/issues/1103

### Description
- If the user cancels a tour, then the cancel tour step will be displayed if the user has not seen it before
- If the user finishes the tour, then the finish tour step will be displayed

However this behavior was not correct when skipping the tour through navigating to other pages (e.g. through the arrow keys of the browser). Or when skipping the cancel / completed tour step.
Behavior now: 
- If a user navigates to another page -> the cancel or completed tour step is not displayed.
- If a user cancels the cancel / completed tour step -> the  completed tour step is not displayed.

### Screencast
Error
![error](https://user-images.githubusercontent.com/33764166/69875568-c2877e80-12bd-11ea-905c-453d508c5927.gif)