### PR TITLE
Enhancement - Programming Exercise: More Toggled Features 

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -6,7 +6,10 @@ import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,8 +25,11 @@ import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.ComplaintType;
 import de.tum.in.www1.artemis.domain.enumeration.TutorParticipationStatus;
-import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.repository.ComplaintRepository;
+import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.service.feature.Feature;
+import de.tum.in.www1.artemis.service.feature.FeatureToggle;
 import de.tum.in.www1.artemis.web.rest.dto.StatsForInstructorDashboardDTO;
 import de.tum.in.www1.artemis.web.rest.dto.TutorLeaderboardDTO;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
@@ -282,6 +288,7 @@ public class ExerciseResource {
      */
     @DeleteMapping(value = "/exercises/{id}/cleanup")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
+    @FeatureToggle(Feature.PROGRAMMING_EXERCISES)
     public ResponseEntity<Resource> cleanup(@PathVariable Long id, @RequestParam(defaultValue = "false") boolean deleteRepositories) {
         log.info("Start to cleanup build plans for Exercise: {}, delete repositories: {}", id, deleteRepositories);
         Exercise exercise = exerciseService.findOne(id);
@@ -301,6 +308,7 @@ public class ExerciseResource {
      */
     @GetMapping(value = "/exercises/{id}/archive")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
+    @FeatureToggle(Feature.PROGRAMMING_EXERCISES)
     public ResponseEntity<Resource> archiveRepositories(@PathVariable Long id) throws IOException {
         log.info("Start to archive repositories for Exercise : {}", id);
         Exercise exercise = exerciseService.findOne(id);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -699,6 +699,7 @@ public class ProgrammingExerciseResource {
      */
     @GetMapping(value = "/programming-exercises/{id}/generate-tests", produces = MediaType.TEXT_PLAIN_VALUE)
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
+    @FeatureToggle(Feature.PROGRAMMING_EXERCISES)
     public ResponseEntity<String> generateStructureOracleForExercise(@PathVariable Long id) {
         log.debug("REST request to generate the structure oracle for ProgrammingExercise with id: {}", id);
 

--- a/src/main/webapp/app/entities/participation/participation.component.html
+++ b/src/main/webapp/app/entities/participation/participation.component.html
@@ -92,6 +92,8 @@
                             </ng-container>
                             <button
                                 *ngIf="exercise.isAtLeastInstructor"
+                                [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
+                                [skipFeatureToggle]="exercise.type !== PROGRAMMING"
                                 jhiDeleteButton
                                 [entityTitle]="participation.student.name"
                                 deleteQuestion="artemisApp.participation.delete.question"
@@ -107,6 +109,7 @@
                             <button
                                 type="submit"
                                 *ngIf="exercise?.type === PROGRAMMING && participation.buildPlanId != null && exercise.isAtLeastInstructor"
+                                [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                                 [routerLink]="['/', { outlets: { popup: ['participation', participation.id, 'cleanupBuildPlan'] } }]"
                                 class="btn btn-danger btn-sm mr-1"
                             >

--- a/src/main/webapp/app/entities/participation/participation.component.ts
+++ b/src/main/webapp/app/entities/participation/participation.component.ts
@@ -10,6 +10,7 @@ import { ExerciseService } from 'app/entities/exercise';
 import { HttpErrorResponse } from '@angular/common/http';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { ProgrammingSubmissionService } from 'app/programming-submission/programming-submission.service';
+import { FeatureToggle } from 'app/feature-toggle';
 
 @Component({
     selector: 'jhi-participation',
@@ -20,6 +21,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     readonly QUIZ = ExerciseType.QUIZ;
     readonly PROGRAMMING = ExerciseType.PROGRAMMING;
     readonly MODELING = ExerciseType.MODELING;
+    readonly FeatureToggle = FeatureToggle;
 
     participations: StudentParticipation[];
     eventSubscriber: Subscription;

--- a/src/main/webapp/app/entities/participation/participation.module.ts
+++ b/src/main/webapp/app/entities/participation/participation.module.ts
@@ -16,6 +16,7 @@ import { SortByModule } from 'app/components/pipes';
 import { ArtemisExerciseScoresModule } from 'app/scores';
 import { ArtemisProgrammingExerciseActionsModule } from 'app/entities/programming-exercise/actions/programming-exercise-actions.module';
 import { ArtemisParticipationSubmissionModule } from 'app/entities/participation-submission/participation-submission.module';
+import { FeatureToggleModule } from 'app/feature-toggle/feature-toggle.module';
 
 const ENTITY_STATES = [...participationRoute, ...participationPopupRoute];
 
@@ -27,6 +28,7 @@ const ENTITY_STATES = [...participationRoute, ...participationPopupRoute];
         ArtemisExerciseScoresModule,
         ArtemisProgrammingExerciseActionsModule,
         ArtemisParticipationSubmissionModule,
+        FeatureToggleModule,
     ],
 
     declarations: [ParticipationComponent, ParticipationCleanupBuildPlanDialogComponent, ParticipationCleanupBuildPlanPopupComponent],

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.html
@@ -203,13 +203,13 @@
                 <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
             </button>
             <span class="mr-1">
-                <button type="button" (click)="squashTemplateCommits()" class="btn btn-secondary">
+                <button [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES" type="button" (click)="squashTemplateCommits()" class="btn btn-secondary">
                     <span jhiTranslate="artemisApp.programmingExercise.squashTemplateCommits">Squash Template Commits</span>
                 </button>
                 <fa-icon [icon]="'question-circle'" class="text-secondary" ngbTooltip="{{ 'artemisApp.programmingExercise.squashTemplateCommitsWarning' | translate }}"></fa-icon>
             </span>
             <span *ngIf="programmingExercise.programmingLanguage == JAVA" class="mr-1">
-                <button type="button" (click)="generateStructureOracle()" class="btn btn-secondary">
+                <button [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES" type="button" (click)="generateStructureOracle()" class="btn btn-secondary">
                     <span jhiTranslate="artemisApp.programmingExercise.structureTestOracle">Update Structure Test Oracle</span>
                 </button>
                 <fa-icon [icon]="'question-circle'" class="text-secondary" ngbTooltip="{{ 'artemisApp.programmingExercise.structureTestOracleWarning' | translate }}"></fa-icon>

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.html
@@ -19,6 +19,7 @@
                 <button
                     type="submit"
                     *ngIf="programmingExercise.isAtLeastInstructor"
+                    [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                     [routerLink]="['/', { outlets: { popup: 'exercise/' + programmingExercise.id + '/archive' } }]"
                     replaceUrl="true"
                     queryParamsHandling="merge"
@@ -30,6 +31,7 @@
                 <button
                     type="submit"
                     *ngIf="programmingExercise.isAtLeastInstructor"
+                    [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                     [routerLink]="['/', { outlets: { popup: 'exercise/' + programmingExercise.id + '/cleanup' } }]"
                     replaceUrl="true"
                     queryParamsHandling="merge"

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise-detail.component.ts
@@ -11,6 +11,7 @@ import { ParticipationType } from './programming-exercise-participation.model';
 import { ProgrammingExerciseParticipationService } from 'app/entities/programming-exercise/services/programming-exercise-participation.service';
 import { ExerciseType } from 'app/entities/exercise';
 import { AccountService } from 'app/core/auth/account.service';
+import { FeatureToggle } from 'app/feature-toggle';
 
 @Component({
     selector: 'jhi-programming-exercise-detail',
@@ -19,6 +20,7 @@ import { AccountService } from 'app/core/auth/account.service';
 })
 export class ProgrammingExerciseDetailComponent implements OnInit {
     ParticipationType = ParticipationType;
+    readonly FeatureToggle = FeatureToggle;
     readonly JAVA = ProgrammingLanguage.JAVA;
     readonly PROGRAMMING = ExerciseType.PROGRAMMING;
 

--- a/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.html
+++ b/src/main/webapp/app/entities/programming-exercise/programming-exercise.component.html
@@ -160,6 +160,7 @@
                             </div>
                             <div class="btn-group-vertical mr-1 mb-1">
                                 <button
+                                    [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                                     type="submit"
                                     *ngIf="programmingExercise.isAtLeastInstructor && programmingExercise.templateParticipation"
                                     routerLink="/code-editor/{{ programmingExercise.id }}/admin/{{ programmingExercise.templateParticipation.id }}"
@@ -169,6 +170,7 @@
                                     <span class="d-none d-md-inline" jhiTranslate="entity.action.editInEditor">Edit in Editor</span>
                                 </button>
                                 <button
+                                    [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                                     type="submit"
                                     *ngIf="programmingExercise.isAtLeastInstructor"
                                     routerLink="programming-exercise/{{ programmingExercise.id }}/manage-test-cases"
@@ -211,6 +213,7 @@
                                 <button
                                     type="submit"
                                     *ngIf="programmingExercise.isAtLeastInstructor"
+                                    [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                                     [routerLink]="['/', { outlets: { popup: 'exercise/' + programmingExercise.id + '/reset' } }]"
                                     replaceUrl="true"
                                     queryParamsHandling="merge"
@@ -221,6 +224,7 @@
                                 </button>
                                 <button
                                     *ngIf="programmingExercise.isAtLeastInstructor"
+                                    [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                                     jhiDeleteButton
                                     [entityTitle]="programmingExercise.title"
                                     deleteQuestion="artemisApp.programmingExercise.delete.question"

--- a/src/main/webapp/app/feature-toggle/feature-toggle.directive.ts
+++ b/src/main/webapp/app/feature-toggle/feature-toggle.directive.ts
@@ -13,6 +13,12 @@ export class FeatureToggleDirective implements OnInit, OnDestroy {
      * If the normal [disabled] directive of Angular would be used, the HostBinding in this directive would always enable the element if the feature is active.
      */
     @Input() overwriteDisabled: boolean | null;
+    /**
+     * Condition to check even before checking for the feature toggle. If true, the feature toggle won't get checked.
+     * This can be useful e.g. if you use the same button for different features (like our delete button) and only want
+     * to check the toggle for programming exercises
+     */
+    @Input() skipFeatureToggle: boolean;
     private featureActive = true;
 
     private featureToggleActiveSubscription: Subscription;
@@ -27,7 +33,7 @@ export class FeatureToggleDirective implements OnInit, OnDestroy {
                 .pipe(
                     // Disable the element if the feature is inactive.
                     tap(active => {
-                        this.featureActive = active;
+                        this.featureActive = this.skipFeatureToggle || active;
                     }),
                 )
                 .subscribe();

--- a/src/main/webapp/app/programming-assessment/programming-assessment.module.ts
+++ b/src/main/webapp/app/programming-assessment/programming-assessment.module.ts
@@ -10,9 +10,10 @@ import { ArtemisSharedComponentModule } from 'app/shared/components/shared-compo
 import { FormDateTimePickerModule } from 'app/shared/date-time-picker/date-time-picker.module';
 import { FormsModule } from '@angular/forms';
 import { BuildLogService } from 'app/programming-assessment/build-logs/build-log.service';
+import { FeatureToggleModule } from 'app/feature-toggle/feature-toggle.module';
 
 @NgModule({
-    imports: [ArtemisSharedModule, ArtemisSharedComponentModule, FormDateTimePickerModule, FormsModule],
+    imports: [ArtemisSharedModule, ArtemisSharedComponentModule, FormDateTimePickerModule, FormsModule, FeatureToggleModule],
     declarations: [
         ProgrammingAssessmentManualResultButtonComponent,
         ProgrammingAssessmentManualResultDialogComponent,

--- a/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-button.component.ts
+++ b/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-button.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { ButtonSize, ButtonType } from 'app/shared/components';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ProgrammingAssessmentRepoExportDialogComponent } from 'app/programming-assessment/repo-export/programming-assessment-repo-export-dialog.component';
+import { FeatureToggle } from 'app/feature-toggle';
 
 @Component({
     selector: 'jhi-programming-assessment-repo-export',
@@ -10,6 +11,7 @@ import { ProgrammingAssessmentRepoExportDialogComponent } from 'app/programming-
             [disabled]="!exerciseId"
             [btnType]="ButtonType.INFO"
             [btnSize]="ButtonSize.SMALL"
+            [featureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
             [icon]="'download'"
             [title]="'instructorDashboard.exportRepos.title'"
             (onClick)="openRepoExportDialog($event)"
@@ -19,6 +21,7 @@ import { ProgrammingAssessmentRepoExportDialogComponent } from 'app/programming-
 export class ProgrammingAssessmentRepoExportButtonComponent {
     ButtonType = ButtonType;
     ButtonSize = ButtonSize;
+    readonly FeatureToggle = FeatureToggle;
 
     @Input() exerciseId: number;
     @Input() participationIdList: number[];

--- a/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-dialog.component.html
+++ b/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-dialog.component.html
@@ -76,7 +76,12 @@
         <button type="button" class="btn btn-default" data-dismiss="modal" (click)="clear()">
             <span class="glyphicon glyphicon-ban-circle"></span>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
         </button>
-        <button type="submit" [disabled]="!participationIdList && !studentIdList && !this.repositoryExportOptions.exportAllStudents && !exportInProgress" class="btn btn-default">
+        <button
+            [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
+            type="submit"
+            [disabled]="!participationIdList && !studentIdList && !this.repositoryExportOptions.exportAllStudents && !exportInProgress"
+            class="btn btn-default"
+        >
             <span *ngIf="this.exportInProgress" class="mr-1"><fa-icon [icon]="'circle-notch'" spin="true"></fa-icon></span>
             <span class="glyphicon glyphicon-download-alt"></span>&nbsp;<span jhiTranslate="entity.action.export">Export</span>
         </button>

--- a/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-dialog.component.ts
+++ b/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-dialog.component.ts
@@ -8,6 +8,7 @@ import { ProgrammingAssessmentRepoExportService, RepositoryExportOptions } from 
 import { catchError, tap } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { HttpResponse } from '@angular/common/http';
+import { FeatureToggle } from 'app/feature-toggle';
 
 @Component({
     selector: 'jhi-exercise-scores-repo-export-dialog',
@@ -21,6 +22,7 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
     @Input() participationIdList: number[];
     @Input() studentIdList: string; // TODO: Should be a list and not a comma separated string.
     @Input() singleStudentMode = false;
+    readonly FeatureToggle = FeatureToggle;
     exercise: Exercise;
     exportInProgress: boolean;
     repositoryExportOptions: RepositoryExportOptions;

--- a/src/main/webapp/app/scores/exercise-scores.component.html
+++ b/src/main/webapp/app/scores/exercise-scores.component.html
@@ -197,6 +197,7 @@
                         routerLink="/code-editor/{{ value.participation.id }}"
                         class="btn btn-info btn-sm mr-1"
                         *ngIf="exercise.type === PROGRAMMING && value.participation.exercise.allowOnlineEditor"
+                        [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                     >
                         <fa-icon class="mr-1" icon="folder-open" [fixedWidth]="true"></fa-icon>Online editor
                     </button>

--- a/src/main/webapp/app/scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/scores/exercise-scores.component.ts
@@ -19,6 +19,7 @@ import { AssessmentType } from 'app/entities/assessment-type';
 import { ColumnMode, SortType } from '@swimlane/ngx-datatable';
 import { SortByPipe } from 'app/components/pipes';
 import { compose, filter } from 'lodash/fp';
+import { FeatureToggle } from 'app/feature-toggle';
 
 enum FilterProp {
     ALL = 'all',
@@ -63,6 +64,7 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
     readonly QUIZ = ExerciseType.QUIZ;
     readonly PROGRAMMING = ExerciseType.PROGRAMMING;
     readonly MODELING = ExerciseType.MODELING;
+    readonly FeatureToggle = FeatureToggle;
     PAGING_VALUES = [10, 20, 50, 100, 200, 500, 1000, 2000];
     DEFAULT_PAGING_VALUE = 50;
 

--- a/src/main/webapp/app/scores/exercise-scores.module.ts
+++ b/src/main/webapp/app/scores/exercise-scores.module.ts
@@ -12,6 +12,7 @@ import { FormDateTimePickerModule } from 'app/shared/date-time-picker/date-time-
 import { ExerciseScoresPopupService } from 'app/scores';
 import { ArtemisProgrammingAssessmentModule } from 'app/programming-assessment/programming-assessment.module';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
+import { FeatureToggleModule } from 'app/feature-toggle/feature-toggle.module';
 
 const ENTITY_STATES = [
     {
@@ -36,6 +37,7 @@ const ENTITY_STATES = [
         FormDateTimePickerModule,
         NgxDatatableModule,
         ArtemisProgrammingAssessmentModule,
+        FeatureToggleModule,
     ],
     declarations: [ExerciseScoresComponent],
     entryComponents: [ExerciseScoresComponent],


### PR DESCRIPTION
### Description
Resolves #1071 
There were some features related to programming exercises that were not deactivated with the feature flag. These should now be disabled if the flag is deactivated:
* Click on "View" for an exercise, on the following page these should be deactivated:
    * Update Structure Oracle
    * Squash Template Commits
    * Archive
    * Reset
* On the course overview for the exercise:
    * Manage Test Cases
    * Edit in Editor
    * Delete
    * Reset
* For programming participations:
    * Delete
    * Cleanup Buildplan