### PR TITLE
Dont allow to close manual result dialog on click outside the modal

### DIFF
--- a/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-button.component.ts
+++ b/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-button.component.ts
@@ -63,7 +63,7 @@ export class ProgrammingAssessmentManualResultButtonComponent implements OnChang
 
     openManualResultDialog(event: MouseEvent) {
         event.stopPropagation();
-        const modalRef: NgbModalRef = this.modalService.open(ProgrammingAssessmentManualResultDialogComponent, { keyboard: true, size: 'lg' });
+        const modalRef: NgbModalRef = this.modalService.open(ProgrammingAssessmentManualResultDialogComponent, { keyboard: true, size: 'lg', backdrop: 'static' });
         modalRef.componentInstance.participationId = this.participationId;
         modalRef.componentInstance.result = this.latestResult;
         modalRef.result.then(


### PR DESCRIPTION
### Description
Should fix #1025.
Manual result modals should can no longer (accidentally) be dismissed by clicking outside of the popup. 
@krusche we can also add a warning as suggested in the issue. The user already has to actively click on the "X" in the upper right corner or on "Cancel", so I don't know if this is really helpful or just adds an "annoying" popup?  