### PR TITLE
Bugfix/Show feedback with minus credits for File Upload Exercise

### DIFF
--- a/src/main/webapp/app/file-upload-submission/file-upload-result/file-upload-result.component.ts
+++ b/src/main/webapp/app/file-upload-submission/file-upload-result/file-upload-result.component.ts
@@ -16,7 +16,7 @@ export class FileUploadResultComponent {
         if (!result) {
             return;
         }
-        const [feedbackWithCredits, feedbackWithoutCredits] = partition(result.feedbacks, feedback => feedback.credits > 0);
+        const [feedbackWithCredits, feedbackWithoutCredits] = partition(result.feedbacks, feedback => feedback.credits !== 0);
         this.feedbacks = feedbackWithCredits;
         this.generalFeedback = feedbackWithoutCredits[0] ? feedbackWithoutCredits[0] : null;
     }

--- a/src/test/javascript/spec/component/file-upload-submission/file-upload-result.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-submission/file-upload-result.spec.ts
@@ -1,0 +1,64 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AccountService } from 'app/core/auth/account.service';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import { ArtemisTestModule } from '../../test.module';
+import { Result } from 'app/entities/result';
+import { ArtemisSharedModule } from 'app/shared';
+import { MockAlertService } from '../../helpers/mock-alert.service';
+import { JhiAlertService } from 'ng-jhipster';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { MockAccountService } from '../../mocks/mock-account.service';
+import { NgxDatatableModule } from '@swimlane/ngx-datatable';
+import { FileUploadSubmissionComponent } from 'app/file-upload-submission/file-upload-submission.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { FileUploadResultComponent } from 'app/file-upload-submission/file-upload-result/file-upload-result.component';
+import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
+import { Feedback } from 'app/entities/feedback';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('FileUploadSubmissionComponent', () => {
+    let comp: FileUploadResultComponent;
+    let fixture: ComponentFixture<FileUploadResultComponent>;
+    let debugElement: DebugElement;
+
+    beforeEach(async () => {
+        return TestBed.configureTestingModule({
+            imports: [ArtemisTestModule, NgxDatatableModule, ArtemisSharedModule, TranslateModule.forRoot(), ArtemisSharedComponentModule],
+            declarations: [FileUploadResultComponent],
+            providers: [
+                { provide: JhiAlertService, useClass: MockAlertService },
+                { provide: AccountService, useClass: MockAccountService },
+            ],
+        })
+            .overrideModule(ArtemisTestModule, { set: { declarations: [], exports: [] } })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(FileUploadResultComponent);
+                comp = fixture.componentInstance;
+                debugElement = fixture.debugElement;
+            });
+    });
+
+    it('should show feedback items', () => {
+        const f1 = new Feedback(-2, 'Example');
+        const f2 = new Feedback(2, 'Example2');
+        const generalFeedback = new Feedback(0, 'General');
+        comp.result = <Result>{ feedbacks: [f1, f2, generalFeedback] };
+
+        // check that feedback items are correctly split in the component
+        expect(comp.feedbacks[0]).to.be.equal(f1);
+        expect(comp.feedbacks[1]).to.be.equal(f2);
+        expect(comp.generalFeedback).to.be.equal(generalFeedback);
+
+        fixture.detectChanges();
+
+        const groupedFeedbackElements = debugElement.query(By.css('div'));
+        expect(groupedFeedbackElements).to.exist;
+        // exactly two feedback items are displayed
+        expect(groupedFeedbackElements.childNodes.length).to.be.equal(2);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple integration tests (Jest) related to the features
- [x] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [x] ~Client: I documented the TypeScript code using JSDoc style.~
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] ~Client: I translated all the newly inserted strings into German and English~

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want to address issue mentioned in #1119 

### Description
<!-- Describe your changes in detail -->
Feedback with minus points should show up for students. Previously, only feedbacks with more than 0 points were shown to the student.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Open Tutor Dashboard
4. Asses any File Upload Exercise and give minus points in the feedback item
5. Login as a student
6. Go to Overview
7. Select the course with the assessed File Upload Exercise
8. Open the exercise and check that you can see all the feedback
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![Screenshot_2019-12-04 File Upload Exercises](https://user-images.githubusercontent.com/17262376/70177691-22758f00-16db-11ea-8411-165a149e5cf1.png)
