### PR TITLE
Added validation for the file extensions in a file upload

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -54,6 +54,12 @@ public final class Constants {
 
     public static final Pattern SHORT_NAME_PATTERN = Pattern.compile(SHORT_NAME_REGEX);
 
+    public static final String FILE_PATTERN_REGEX = "(doc|DOC|docx|DOCX|dotx|DOTX|xml|XML|pdf|PDF|" + "wps|WPS|wpd|WPD|wp|WP|wp4|WP4|wp5|WP5|wp6|WP6|wp7|WP7|"
+            + "qxd|QXD|ps|PS|pub|PUB|tex|TEX|" + "vsd|VSD|bmp|BMP|jpg|JPG|jpeg|JPEG|pjpeg|PJEPG|gif|GIF|pgn|PGN|" + "txt|TXT|rtf|RTF|wav|WAV|mp3|MP3|html|HTML|"
+            + "odt|ODT|xls|XLS|xlsx|XLSX|wks|WKS|xlr|XLR|csv|CSV|" + "ppt|PPT|pps|PPS|ppsx|PPXS)$";
+
+    public static final Pattern FILE_PATTERN = Pattern.compile(FILE_PATTERN_REGEX);
+
     public static final String TUM_USERNAME_REGEX = "^([a-z]{2}\\d{2}[a-z]{3})";
 
     public static final Pattern TUM_USERNAME_PATTERN = Pattern.compile(TUM_USERNAME_REGEX);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -1,11 +1,13 @@
 package de.tum.in.www1.artemis.web.rest;
 
+import static de.tum.in.www1.artemis.config.Constants.FILE_PATTERN;
 import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +74,12 @@ public class FileUploadExerciseResource {
         if (fileUploadExercise.getId() != null) {
             throw new BadRequestAlertException("A new fileUploadExercise cannot already have an ID", ENTITY_NAME, "idexists");
         }
+
+        // Check if file pattern matches regex
+        Matcher filePatternMatcher = FILE_PATTERN.matcher(fileUploadExercise.getFilePattern());
+        if (!filePatternMatcher.matches()) {
+            return ResponseEntity.badRequest().headers(HeaderUtil.createAlert(applicationName, "The specified file patterns are invalid", "filePatternInvalid")).body(null);
+        }
         // fetch course from database to make sure client didn't change groups
         Course course = courseService.findOne(fileUploadExercise.getCourse().getId());
         if (course == null) {
@@ -116,6 +124,11 @@ public class FileUploadExerciseResource {
         User user = userService.getUserWithGroupsAndAuthorities();
         if (!authCheckService.isAtLeastInstructorInCourse(course, user)) {
             return forbidden();
+        }
+        // Check if file pattern matches regex
+        Matcher filePatternMatcher = FILE_PATTERN.matcher(fileUploadExercise.getFilePattern());
+        if (!filePatternMatcher.matches()) {
+            return ResponseEntity.badRequest().headers(HeaderUtil.createAlert(applicationName, "The specified file patterns are invalid", "filePatternInvalid")).body(null);
         }
         FileUploadExercise result = fileUploadExerciseRepository.save(fileUploadExercise);
         if (notificationText != null) {

--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise-update.component.html
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise-update.component.html
@@ -88,14 +88,31 @@
                     </select>
                 </div>
                 <div class="form-group">
-                    <label class="form-control-label" jhiTranslate="artemisApp.fileUploadExercise.filePattern" for="field_filePattern">File Pattern </label>
-                    <fa-icon
-                        [icon]="'question-circle'"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.fileUploadExercise.filePatternInfo' | translate }}"
-                    ></fa-icon>
-                    <input required minlength="2" type="text" class="form-control" name="filePattern" id="field_filePattern" [(ngModel)]="fileUploadExercise.filePattern" />
+                    <div>
+                        <label class="form-control-label" jhiTranslate="artemisApp.fileUploadExercise.filePattern" for="field_filePattern">File Pattern </label>
+                        <fa-icon
+                            [icon]="'question-circle'"
+                            class="text-secondary"
+                            placement="top"
+                            ngbTooltip="{{ 'artemisApp.fileUploadExercise.filePatternInfo' | translate }}"
+                        ></fa-icon>
+                    </div>
+                    <input
+                        required
+                        minlength="2"
+                        type="text"
+                        class="form-control"
+                        name="filePattern"
+                        id="field_filePattern"
+                        [pattern]="filePatternRegex"
+                        [(ngModel)]="fileUploadExercise.filePattern"
+                        #filePattern="ngModel"
+                    />
+                    <ng-container *ngFor="let e of filePattern.errors! | keyvalue | removekeys: ['required']">
+                        <div *ngIf="filePattern.invalid && (filePattern.dirty || filePattern.touched)" class="alert alert-danger">
+                            <div [jhiTranslate]="'artemisApp.fileUploadExercise.fileExtensionPattern' + '.' + e.key"></div>
+                        </div>
+                    </ng-container>
                 </div>
                 <jhi-presentation-score-checkbox [exercise]="fileUploadExercise"></jhi-presentation-score-checkbox>
                 <div class="form-group" id="field_problemStatement">

--- a/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise-update.component.ts
+++ b/src/main/webapp/app/entities/file-upload-exercise/file-upload-exercise-update.component.ts
@@ -28,6 +28,8 @@ export class FileUploadExerciseUpdateComponent implements OnInit {
     domainCommandsSampleSolution = [new KatexCommand()];
     domainCommandsGradingInstructions = [new KatexCommand()];
 
+    filePatternRegex = /(doc|DOC|docx|DOCX|dotx|DOTX|xml|XML|pdf|PDF|wps|WPS|wpd|WPD|wp|WP|wp4|WP4|wp5|WP5|wp6|WP6|wp7|WP7|qxd|QXD|ps|PS|pub|PUB|tex|TEX|vsd|VSD|bmp|BMP|jpg|JPG|jpeg|JPEG|pjpeg|PJEPG|gif|GIF|pgn|PGN|txt|TXT|rtf|RTF|wav|WAV|mp3|MP3|html|HTML|odt|ODT|xls|XLS|xlsx|XLSX|wks|WKS|xlr|XLR|csv|CSV|ppt|PPT|pps|PPS|ppsx|PPXS)$/;
+
     constructor(
         private fileUploadExerciseService: FileUploadExerciseService,
         private activatedRoute: ActivatedRoute,

--- a/src/main/webapp/i18n/de/fileUploadExercise.json
+++ b/src/main/webapp/i18n/de/fileUploadExercise.json
@@ -22,7 +22,10 @@
             "submitDeadlineMissed": "Deine Antwort wurde erfolgreich abgesendet! Du kannst es ändern oder auf dein Feedback warten. Da du die Deadline verpasst hast wird deine Bewertung nicht gezählt.",
             "error": "Ein Fehler ist aufgetreten. Bitte versuche es später noch einmal.",
             "assessedSubmission": "Deine bewertete Abgabe",
-            "supportedFileExtensions": "Unterstützte Dateierweiterungen: "
+            "supportedFileExtensions": "Unterstützte Dateierweiterungen: ",
+            "fileExtensionPattern": {
+                "pattern": "Ungültige Liste von Dateierweiterungen"
+            }
         }
     }
 }

--- a/src/main/webapp/i18n/en/fileUploadExercise.json
+++ b/src/main/webapp/i18n/en/fileUploadExercise.json
@@ -22,7 +22,10 @@
             "submitDeadlineMissed": "Your answer was submitted successfully! You can still submit again or  wait for your feedback. As you missed the deadline the score will not be counted.",
             "error": "An error occurred. Please try again later.",
             "assessedSubmission": "Your assessed submission",
-            "supportedFileExtensions": "Supported file extensions: "
+            "supportedFileExtensions": "Supported file extensions: ",
+            "fileExtensionPattern": {
+                "pattern": "The list of specified file extensions is invalid."
+            }
         }
     }
 }

--- a/src/test/resources/test-data/repository-export/EncodingISO_8559_1.java
+++ b/src/test/resources/test-data/repository-export/EncodingISO_8559_1.java
@@ -1,7 +1,7 @@
 public class LineEndings {
 
     public void someMethod() {
-        // THESE ARE SPECIAL LETTERS: ÄÜÖß
+        // THESE ARE SPECIAL LETTERS: ï¿½ï¿½ï¿½ï¿½
         someService.call();
     }
 }

--- a/src/test/resources/test-data/repository-export/EncodingISO_8559_1.java
+++ b/src/test/resources/test-data/repository-export/EncodingISO_8559_1.java
@@ -1,7 +1,7 @@
 public class LineEndings {
 
     public void someMethod() {
-        // THESE ARE SPECIAL LETTERS: ����
+        // THESE ARE SPECIAL LETTERS: ÄÜÖß
         someService.call();
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Server: I added multiple integration tests (Spring) related to the features
- [ ] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] Server: I documented the Java code using JavaDoc style.
- [ ] Client: I added multiple integration tests (Jest) related to the features
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [ ] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
Fixes #1019 
Right now, invalid extensions can be specified in the "File Pattern" field of the File Upload exercises, which leads to an error. 

### Description
This PR adds a validation which proves the specified extensions against a list of valid extensions and displays an error message when the input is invalid.

### Steps for Testing

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to Exercises of a Course
4. Create a File Upload Exercise (or open an existing one)
5. Write an invalid extension in the File Pattern field (e.g. pdf, doxfg)
- You should be able to see the error message and not be able to save the exercise

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
