### PR TITLE
Parent components of data table should show the filtered number of entries

### DIFF
--- a/src/main/webapp/app/components/data-table/data-table.component.ts
+++ b/src/main/webapp/app/components/data-table/data-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, OnChanges, SimpleChanges, ContentChild, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ContentChild, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { debounceTime, distinctUntilChanged, map, tap } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 import { ColumnMode, SortType } from '@swimlane/ngx-datatable';
@@ -65,6 +65,11 @@ export class DataTableComponent implements OnInit, OnChanges {
     @Input() searchResultFormatter: (entity: BaseEntity) => string = entityToString;
     @Input() customFilter: (entity: BaseEntity) => boolean = () => true;
     @Input() customFilterKey: any = {};
+
+    /**
+     * @property entitiesSizeChange Emits an event when the number of entities displayed changes (e.g. by filtering)
+     */
+    @Output() entitiesSizeChange = new EventEmitter<number>();
 
     /**
      * @property PAGING_VALUES Possible values for the number of entities shown per page of the table
@@ -187,6 +192,7 @@ export class DataTableComponent implements OnInit, OnChanges {
             filter(this.customFilter),
         )(this.allEntities);
         this.entities = this.sortByPipe.transform(filteredEntities, this.entityCriteria.sortProp.field, this.entityCriteria.sortProp.order === SortOrder.ASC);
+        this.entitiesSizeChange.emit(this.entities.length);
     }
 
     /**

--- a/src/main/webapp/app/entities/participation/participation.component.html
+++ b/src/main/webapp/app/entities/participation/participation.component.html
@@ -1,7 +1,7 @@
 <div>
     <div class="d-flex">
         <h2>
-            <span>{{ exercise?.title }} - </span>{{ participations.length }} <span jhiTranslate="artemisApp.participation.home.title">Participations</span>
+            <span>{{ exercise?.title }} - </span>{{ filteredParticipationsSize }} <span jhiTranslate="artemisApp.participation.home.title">Participations</span>
         </h2>
         <jhi-programming-exercise-instructor-submission-state
             class="ml-auto"
@@ -21,6 +21,7 @@
         [searchFields]="['student.login', 'student.name']"
         [searchTextFromEntity]="searchTextFromParticipation"
         [searchResultFormatter]="searchResultFormatter"
+        (entitiesSizeChange)="handleParticipationsSizeChange($event)"
     >
         <ng-template let-settings="settings" let-controls="controls">
             <ngx-datatable

--- a/src/main/webapp/app/entities/participation/participation.component.ts
+++ b/src/main/webapp/app/entities/participation/participation.component.ts
@@ -25,6 +25,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     readonly FeatureToggle = FeatureToggle;
 
     participations: StudentParticipation[] = [];
+    filteredParticipationsSize = 0;
     eventSubscriber: Subscription;
     paramSub: Subscription;
     exercise: Exercise;
@@ -152,6 +153,15 @@ export class ParticipationComponent implements OnInit, OnDestroy {
             (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
         );
     }
+
+    /**
+     * Update the number of filtered participations
+     *
+     * @param filteredParticipationsSize Total number of participations after filters have been applied
+     */
+    handleParticipationsSizeChange = (filteredParticipationsSize: number) => {
+        this.filteredParticipationsSize = filteredParticipationsSize;
+    };
 
     /**
      * Formats the results in the autocomplete overlay.

--- a/src/main/webapp/app/scores/exercise-scores.component.html
+++ b/src/main/webapp/app/scores/exercise-scores.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="exercise">
     <h2>
         {{ exercise.course?.title }} - {{ exercise.title }}
-        <small jhiTranslate="artemisApp.exercise.resultCount" [translateValues]="{ resultsLength: results.length }">results</small>
+        <small jhiTranslate="artemisApp.exercise.resultCount" [translateValues]="{ resultsLength: filteredResultsSize }">results</small>
     </h2>
     <jhi-alert></jhi-alert>
     <div class="mb-2 clearfix">
@@ -62,6 +62,7 @@
         [searchResultFormatter]="searchResultFormatter"
         [customFilterKey]="resultCriteria.filterProp"
         [customFilter]="filterResultByProp"
+        (entitiesSizeChange)="handleResultsSizeChange($event)"
     >
         <ng-template let-settings="settings" let-controls="controls">
             <ngx-datatable

--- a/src/main/webapp/app/scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/scores/exercise-scores.component.ts
@@ -44,6 +44,7 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
     paramSub: Subscription;
     reverse: boolean;
     results: Result[];
+    filteredResultsSize: number;
     eventSubscriber: Subscription;
     newManualResultAllowed: boolean;
 
@@ -67,6 +68,7 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
             filterProp: FilterProp.ALL,
         };
         this.results = [];
+        this.filteredResultsSize = 0;
     }
 
     ngOnInit() {
@@ -145,6 +147,15 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
             default:
                 return true;
         }
+    };
+
+    /**
+     * Update the number of filtered results
+     *
+     * @param filteredResultsSize Total number of results after filters have been applied
+     */
+    handleResultsSizeChange = (filteredResultsSize: number) => {
+        this.filteredResultsSize = filteredResultsSize;
     };
 
     durationInMinutes(completionDate: Moment, initializationDate: Moment) {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~Server: I added multiple integration tests (Spring) related to the features~
- [x] ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- [x] ~Server: I implemented the changes with a good performance and prevented too many database calls~
- [x] ~Server: I documented the Java code using JavaDoc style.~
- [x] ~Client: I added multiple integration tests (Jest) related to the features~
- [x] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] ~Client: I translated all the newly inserted strings into German and English~

### Motivation and Context
With the introduction of the generic data table, the filtered result set is only available in the data table component and not in its parent component anymore. This means that the parent component only knows the total number of entities supplied to the data table but not the number of entities after filters have been applied. This number of filtered results should be used though in the parent components' templates in proximity to the headline.

### Description
This PR adds an event emitter to the data table component that notifies its parent component if the number of results after filters has changed. As its payload, it sends the new number of results which the parent then can store and use in its template.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Click on "Exercises" for a course
4. Click on "Scores" and "Participations" for a programming exercise
5. Check that the number of results next to the headline changes when applying filters

Or use this link: https://artemistest.ase.in.tum.de/#/course/78/exercise/1304/dashboard

### Screenshots
![captured](https://user-images.githubusercontent.com/7109225/70435635-a33fdc80-1a87-11ea-8783-4904aa240c10.gif)

