### PR TITLE
Fix testutils on windows

### DIFF
--- a/src/main/resources/templates/java/test/testutils/ClassNameScanner.java
+++ b/src/main/resources/templates/java/test/testutils/ClassNameScanner.java
@@ -228,6 +228,10 @@ public class ClassNameScanner {
                 packageName.lastIndexOf(File.separator + className));
             packageName = packageName.replace(File.separatorChar, '.');
 
+            if (packageName.charAt(0) == '.') {
+                packageName = packageName.substring(1);
+            }
+            
             if(foundTypes.containsKey(className)) {
                 foundTypes.get(className).add(packageName);
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Server: I added multiple integration tests (Spring) related to the features
- [ ] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] Server: I documented the Java code using JavaDoc style.
- [ ] Client: I added multiple integration tests (Jest) related to the features
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [ ] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
On windows the package name is reported with a leading `.`
This change handles the situation and makes structural tests run on windows

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Run structural tests on a windows machine


_Note:_ feel free to reject this pull request if you need it additional test or anything for this, I just wanted to raise the issue and propose a fix
