### PR TITLE
Fix not updating result component in exercise scores

### DIFF
--- a/src/main/webapp/app/scores/exercise-scores.component.html
+++ b/src/main/webapp/app/scores/exercise-scores.component.html
@@ -135,7 +135,7 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
-                        <jhi-result [showTestNames]="true" [participation]="value.participation"></jhi-result>
+                        <jhi-result [result]="value" [showTestNames]="true" [participation]="value.participation"></jhi-result>
                     </ng-template>
                 </ngx-datatable-column>
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~Server: I added multiple integration tests (Spring) related to the features~
- [x] ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- [x] ~Server: I implemented the changes with a good performance and prevented too many database calls~
- [x] ~Server: I documented the Java code using JavaDoc style.~
- [x] ~Client: I added multiple integration tests (Jest) related to the features~
- [x] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [x] ~Client: I documented the TypeScript code using JSDoc style.~
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] ~Client: I translated all the newly inserted strings into German and English~

### Motivation and Context
The bug is that the result rows are not updating when sorting and thus "stay in their original place" from a user perspective. A user found this bug and created the issue #1136. This bug was introduced when switching from `jhi-updating-result` to `jhi-result` and not supplying `jhi-result` with the proper input that will trigger the change detection (in this case the `result` itself and not just the `participation`).

### Description
Add input `result` to `jhi-result` in `exercise-scores.component.html`.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Click on "Exercises" for a course with a programming exercise
4. Click on "Scores"
5. Sort by different columns and see if the cell order in the result column follows along

### Screencast
[Here](https://imgur.com/a/pVh2fZf) (too big).


