### PR TITLE
Increase teardown timeout for K6 API tests

### DIFF
--- a/src/test/k6/ProgrammingExerciseAPIs.js
+++ b/src/test/k6/ProgrammingExerciseAPIs.js
@@ -9,7 +9,8 @@ export const options = {
     iterations: __ENV.ITERATIONS,
     vus: __ENV.ITERATIONS,
     rps: 4,
-    setupTimeout: '90s'
+    setupTimeout: '90s',
+    teardownTimeout: '90s'
 };
 
 const adminUsername = __ENV.ADMIN_USERNAME;


### PR DESCRIPTION
### Description
Since deleting the course and exercise after the API test run now takes longer (resulting in failed API tests, because if a timeout), I increased the teardown timeout for those tests.