### PR TITLE
Add repo download button to complaints and feedbacks

### DIFF
--- a/src/main/webapp/app/list-of-complaints/list-of-complaints.component.ts
+++ b/src/main/webapp/app/list-of-complaints/list-of-complaints.component.ts
@@ -10,7 +10,7 @@ import { ExerciseType } from 'app/entities/exercise/exercise.model';
 import * as moment from 'moment';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { ProgrammingAssessmentManualResultDialogComponent } from 'app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { cloneDeep } from 'lodash';
 
 @Component({
@@ -106,11 +106,14 @@ export class ListOfComplaintsComponent implements OnInit {
         } else if (exercise.type === ExerciseType.FILE_UPLOAD) {
             route = `/file-upload-exercise/${exercise.id}/submission/${submissionId}/assessment`;
         } else if (exercise.type === ExerciseType.PROGRAMMING) {
-            const modalRef = this.modalService.open(ProgrammingAssessmentManualResultDialogComponent, { keyboard: true, size: 'lg' });
+            const modalRef: NgbModalRef = this.modalService.open(ProgrammingAssessmentManualResultDialogComponent, { keyboard: true, size: 'lg' });
             modalRef.componentInstance.participationId = studentParticipation.id;
             modalRef.componentInstance.result = cloneDeep(complaint.result);
             modalRef.componentInstance.onResultModified.subscribe(() => this.loadComplaints());
-            modalRef.result.then(() => this.loadComplaints());
+            modalRef.result.then(
+                _ => this.loadComplaints(),
+                () => {},
+            );
             return;
         }
         this.router.navigate([route!]);

--- a/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.html
+++ b/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.html
@@ -34,9 +34,9 @@
         </div>
         <div class="d-flex align-items-center mb-1 mt-1">
             <jhi-programming-assessment-repo-export
-                [exerciseId]="participation.exercise.id"
+                [exerciseId]="participation.exercise?.id"
                 [singleStudentMode]="true"
-                [participationIdList]="participation.id"
+                [participationIdList]="participation?.id"
             ></jhi-programming-assessment-repo-export>
             <a class="ml-2" [href]="repositoryUrl" target="_blank" rel="noopener noreferrer" jhiTranslate="artemisApp.tutorExerciseDashboard.programmingExercise.goToRepo"
                 >Go to repository</a

--- a/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.html
+++ b/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.html
@@ -38,7 +38,12 @@
                 [singleStudentMode]="true"
                 [participationIdList]="participation?.id"
             ></jhi-programming-assessment-repo-export>
-            <a class="ml-2" [href]="repositoryUrl" target="_blank" rel="noopener noreferrer" jhiTranslate="artemisApp.tutorExerciseDashboard.programmingExercise.goToRepo"
+            <a
+                class="ml-2"
+                href="{{ this.participation.repositoryUrl }}"
+                target="_blank"
+                rel="noopener noreferrer"
+                jhiTranslate="artemisApp.tutorExerciseDashboard.programmingExercise.goToRepo"
                 >Go to repository</a
             >
         </div>

--- a/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.html
+++ b/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.html
@@ -32,6 +32,16 @@
             <h3 for="id" jhiTranslate="artemisApp.exercise.gradingInstructions">Grading Instructions</h3>
             <span [innerHTML]="participation.exercise.gradingInstructions | htmlForMarkdown"></span>
         </div>
+        <div class="d-flex align-items-center mb-1 mt-1">
+            <jhi-programming-assessment-repo-export
+                [exerciseId]="participation.exercise.id"
+                [singleStudentMode]="true"
+                [participationIdList]="participation.id"
+            ></jhi-programming-assessment-repo-export>
+            <a class="ml-2" [href]="repositoryUrl" target="_blank" rel="noopener noreferrer" jhiTranslate="artemisApp.tutorExerciseDashboard.programmingExercise.goToRepo"
+                >Go to repository</a
+            >
+        </div>
         <div class="form-group">
             <h4 class="control-label" jhiTranslate="artemisApp.result.resultString">Result Text</h4>
             <input type="text" required class="form-control" name="resultString" id="resultString" [(ngModel)]="result.resultString" #resultString="ngModel" />

--- a/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.ts
+++ b/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.ts
@@ -31,7 +31,7 @@ export class ProgrammingAssessmentManualResultDialogComponent implements OnInit 
     @Input() result: Result;
     @Output() onResultModified = new EventEmitter<Result>();
 
-    participation: StudentParticipation;
+    participation: ProgrammingExerciseStudentParticipation;
     feedbacks: Feedback[] = [];
     isLoading = false;
     isSaving = false;
@@ -63,10 +63,6 @@ export class ProgrammingAssessmentManualResultDialogComponent implements OnInit 
         this.initializeForResultCreation();
     }
 
-    get repositoryUrl(): String {
-        return (this.participation as ProgrammingExerciseStudentParticipation).repositoryUrl;
-    }
-
     initializeForResultUpdate() {
         // Used to check if the assessor is the current user
         this.accountService.identity().then(user => {
@@ -89,7 +85,7 @@ export class ProgrammingAssessmentManualResultDialogComponent implements OnInit 
         if (this.result.hasComplaint) {
             this.getComplaint(this.result.id);
         }
-        this.participation = this.result.participation! as StudentParticipation;
+        this.participation = this.result.participation! as ProgrammingExerciseStudentParticipation;
     }
 
     initializeForResultCreation() {
@@ -103,7 +99,7 @@ export class ProgrammingAssessmentManualResultDialogComponent implements OnInit 
             .find(this.participationId)
             .pipe(
                 tap(({ body: participation }) => {
-                    this.participation = participation!;
+                    this.participation = participation! as ProgrammingExerciseStudentParticipation;
                     this.result.participation = this.participation;
                     this.isOpenForSubmission = this.participation.exercise.dueDate === null || this.participation.exercise.dueDate.isAfter(moment());
                 }),

--- a/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.ts
+++ b/src/main/webapp/app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component.ts
@@ -17,6 +17,7 @@ import { Complaint, ComplaintType } from 'app/entities/complaint/complaint.model
 import { ComplaintService } from 'app/entities/complaint/complaint.service';
 import { AccountService } from 'app/core/auth/account.service';
 import { ComplaintResponse } from 'app/entities/complaint-response/complaint-response.model';
+import { ProgrammingExerciseStudentParticipation } from 'app/entities/participation';
 
 @Component({
     selector: 'jhi-exercise-scores-result-dialog',
@@ -60,6 +61,10 @@ export class ProgrammingAssessmentManualResultDialogComponent implements OnInit 
             return;
         }
         this.initializeForResultCreation();
+    }
+
+    get repositoryUrl(): String {
+        return (this.participation as ProgrammingExerciseStudentParticipation).repositoryUrl;
     }
 
     initializeForResultUpdate() {

--- a/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-button.component.ts
+++ b/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-button.component.ts
@@ -11,6 +11,7 @@ import { FeatureToggle } from 'app/feature-toggle';
             [disabled]="!exerciseId"
             [btnType]="ButtonType.INFO"
             [btnSize]="ButtonSize.SMALL"
+            [shouldSubmit]="false"
             [featureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
             [icon]="'download'"
             [title]="'instructorDashboard.exportRepos.title'"

--- a/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-dialog.component.ts
+++ b/src/main/webapp/app/programming-assessment/repo-export/programming-assessment-repo-export-dialog.component.ts
@@ -45,7 +45,7 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
             filterLateSubmissionsDate: null,
             addStudentName: true,
             squashAfterInstructor: false, // disabled by default because it is rather unstable
-            normalizeCodeStyle: true,
+            normalizeCodeStyle: false, // disabled by default because it is rather unstable
         };
         this.exerciseService
             .find(this.exerciseId)

--- a/src/main/webapp/app/shared/components/button.component.ts
+++ b/src/main/webapp/app/shared/components/button.component.ts
@@ -27,6 +27,7 @@ export enum ButtonSize {
     template: `
         <button
             [ngClass]="['jhi-btn', 'btn', btnType, btnSize]"
+            [type]="shouldSubmit ? 'submit' : 'button'"
             ngbTooltip="{{ tooltip | translate }}"
             container="body"
             (click)="onClick.emit($event)"
@@ -51,6 +52,8 @@ export class ButtonComponent {
     @Input() disabled = false;
     @Input() isLoading = false;
     @Input() featureToggle: FeatureToggle; // Disable by feature toggle.
+
+    @Input() shouldSubmit = true;
 
     @Output() onClick = new EventEmitter<MouseEvent>();
 }

--- a/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.html
+++ b/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.html
@@ -225,11 +225,6 @@
                                     </ng-template>
                                 </ng-container>
                                 <ng-template #programmingAssessment>
-                                    <jhi-programming-assessment-repo-export
-                                        [exerciseId]="exercise.id"
-                                        [singleStudentMode]="true"
-                                        [participationIdList]="submission.participation.id"
-                                    ></jhi-programming-assessment-repo-export>
                                     <jhi-programming-assessment-manual-result
                                         [participationId]="submission.participation.id"
                                         [latestResult]="submission.result"
@@ -256,11 +251,6 @@
                                     <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>{{ 'artemisApp.tutorExerciseDashboard.startAssessment' | translate }}
                                 </button>
                                 <ng-template #programmingAssessment>
-                                    <jhi-programming-assessment-repo-export
-                                        [exerciseId]="exercise.id"
-                                        [singleStudentMode]="true"
-                                        [participationIdList]="unassessedSubmission.participation.id"
-                                    ></jhi-programming-assessment-repo-export>
                                     <jhi-programming-assessment-manual-result
                                         [participationId]="unassessedSubmission.participation.id"
                                         [latestResult]="unassessedSubmission.result"
@@ -306,11 +296,6 @@
                                     <span *ngIf="complaint.accepted === undefined">{{ 'artemisApp.tutorExerciseDashboard.complaintNotEvaluated' | translate }}</span>
                                 </td>
                                 <td>
-                                    <jhi-programming-assessment-repo-export
-                                        [exerciseId]="exercise.id"
-                                        [singleStudentMode]="true"
-                                        [participationIdList]="complaint.result.participation.id"
-                                    ></jhi-programming-assessment-repo-export>
                                     <button *ngIf="complaint.accepted === undefined; else continueButton" class="btn btn-success btn-sm" (click)="viewComplaint(complaint)">
                                         <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                         {{ 'artemisApp.tutorExerciseDashboard.evaluateComplaint' | translate }}
@@ -366,11 +351,6 @@
                                     </span>
                                 </td>
                                 <td>
-                                    <jhi-programming-assessment-repo-export
-                                        [exerciseId]="exercise.id"
-                                        [singleStudentMode]="true"
-                                        [participationIdList]="moreFeedbackRequest.result.participation.id"
-                                    ></jhi-programming-assessment-repo-export>
                                     <button
                                         *ngIf="moreFeedbackRequest.accepted === undefined; else continueButton"
                                         class="btn btn-success btn-sm"

--- a/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.html
+++ b/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.html
@@ -306,6 +306,11 @@
                                     <span *ngIf="complaint.accepted === undefined">{{ 'artemisApp.tutorExerciseDashboard.complaintNotEvaluated' | translate }}</span>
                                 </td>
                                 <td>
+                                    <jhi-programming-assessment-repo-export
+                                        [exerciseId]="exercise.id"
+                                        [singleStudentMode]="true"
+                                        [participationIdList]="complaint.result.participation.id"
+                                    ></jhi-programming-assessment-repo-export>
                                     <button *ngIf="complaint.accepted === undefined; else continueButton" class="btn btn-success btn-sm" (click)="viewComplaint(complaint)">
                                         <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                         {{ 'artemisApp.tutorExerciseDashboard.evaluateComplaint' | translate }}
@@ -361,6 +366,11 @@
                                     </span>
                                 </td>
                                 <td>
+                                    <jhi-programming-assessment-repo-export
+                                        [exerciseId]="exercise.id"
+                                        [singleStudentMode]="true"
+                                        [participationIdList]="moreFeedbackRequest.result.participation.id"
+                                    ></jhi-programming-assessment-repo-export>
                                     <button
                                         *ngIf="moreFeedbackRequest.accepted === undefined; else continueButton"
                                         class="btn btn-success btn-sm"

--- a/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.ts
+++ b/src/main/webapp/app/tutor-exercise-dashboard/tutor-exercise-dashboard.component.ts
@@ -28,7 +28,7 @@ import { ProgrammingExercise } from 'app/entities/programming-exercise/programmi
 import { ProgrammingSubmissionService } from 'app/programming-submission/programming-submission.service';
 import { Result } from 'app/entities/result/result.model';
 import { ProgrammingAssessmentManualResultDialogComponent } from 'app/programming-assessment/manual-result/programming-assessment-manual-result-dialog.component';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { AccountService } from 'app/core/auth/account.service';
 import { cloneDeep } from 'lodash';
 
@@ -371,11 +371,14 @@ export class TutorExerciseDashboardComponent implements OnInit {
     }
 
     private openManualResultDialog(result: Result) {
-        const modalRef = this.modalService.open(ProgrammingAssessmentManualResultDialogComponent, { keyboard: true, size: 'lg' });
+        const modalRef: NgbModalRef = this.modalService.open(ProgrammingAssessmentManualResultDialogComponent, { keyboard: true, size: 'lg' });
         modalRef.componentInstance.participationId = result.participation!.id;
         modalRef.componentInstance.result = cloneDeep(result);
         modalRef.componentInstance.onResultModified.subscribe(() => this.loadAll());
-        modalRef.result.then(() => this.loadAll());
+        modalRef.result.then(
+            _ => this.loadAll(),
+            () => {},
+        );
         return;
     }
 

--- a/src/main/webapp/i18n/de/tutorExerciseDashboard.json
+++ b/src/main/webapp/i18n/de/tutorExerciseDashboard.json
@@ -59,7 +59,8 @@
             "numberOfManualAssessedSubmissions": "Manuell bewertete Abgaben",
             "nextAssessment": "Nächste Abgabe bewerten",
             "programmingExercise": {
-                "exampleSolution": "Beispiellösungs-Repository"
+                "exampleSolution": "Beispiellösungs-Repository",
+                "goToRepo": "Repository anzeigen"
             },
             "language": "Sprache",
             "languages": {

--- a/src/main/webapp/i18n/en/tutorExerciseDashboard.json
+++ b/src/main/webapp/i18n/en/tutorExerciseDashboard.json
@@ -59,7 +59,8 @@
             "numberOfManualAssessedSubmissions": "Manual Assessed Submissions",
             "nextAssessment": "Assess next submission",
             "programmingExercise": {
-                "exampleSolution": "Example solution repository"
+                "exampleSolution": "Example solution repository",
+                "goToRepo": "Go to repository"
             },
             "language": "Language",
             "languages": {

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result-dialog.component.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result-dialog.component.ts
@@ -31,6 +31,8 @@ import { AccountService } from 'app/core/auth/account.service';
 import { SessionStorageService, LocalStorageService } from 'ngx-webstorage';
 import { By } from '@angular/platform-browser';
 import { JhiAlertService } from 'ng-jhipster';
+import { MockComponent } from 'ng-mocks';
+import { ProgrammingAssessmentRepoExportButtonComponent } from 'app/programming-assessment/repo-export';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -57,12 +59,12 @@ describe('ProgrammingAssessmentManualResultDialogComponent', () => {
         hasComplaint: true,
     };
     result.submission.id = 1;
-    const complaint = <Complaint>{ id: 1, complaintText: 'Why only 80%?', result: result };
+    const complaint = <Complaint>{ id: 1, complaintText: 'Why only 80%?', result };
 
     beforeEach(async () => {
         return TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), ArtemisTestModule, ArtemisSharedModule, NgbModule, FormDateTimePickerModule, FormsModule],
-            declarations: [ProgrammingAssessmentManualResultDialogComponent, ComplaintsForTutorComponent],
+            declarations: [ProgrammingAssessmentManualResultDialogComponent, ComplaintsForTutorComponent, MockComponent(ProgrammingAssessmentRepoExportButtonComponent)],
             providers: [
                 ProgrammingAssessmentManualResultService,
                 ComplaintService,
@@ -116,7 +118,7 @@ describe('ProgrammingAssessmentManualResultDialogComponent', () => {
         expect(comp.isAssessor).to.be.true;
         expect(comp.complaint).to.exist;
         fixture.detectChanges();
-        let complaintsForm = debugElement.query(By.css('jhi-complaints-for-tutor-form'));
+        const complaintsForm = debugElement.query(By.css('jhi-complaints-for-tutor-form'));
         expect(complaintsForm).to.exist;
         expect(comp.complaint).to.exist;
     }));
@@ -130,7 +132,7 @@ describe('ProgrammingAssessmentManualResultDialogComponent', () => {
         expect(findByResultId.notCalled).to.be.true;
         expect(comp.complaint).to.not.exist;
         fixture.detectChanges();
-        let complaintsForm = debugElement.query(By.css('jhi-complaints-for-tutor-form'));
+        const complaintsForm = debugElement.query(By.css('jhi-complaints-for-tutor-form'));
         expect(complaintsForm).to.not.exist;
     }));
 });


### PR DESCRIPTION
dow<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #1129 
Tutors are currently not able to view the repository of complaints they have to assess.

### Description
<!-- Describe your changes in detail -->
I added our download button component to the feedback and complaint rows in the tutor dashboard. That way, tutors can now take a look at the student's code before evaluating the complaint.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create a programming exercise with manual reviews
3. Assess a solution and complain about it, or request more feedback
4. As the tutor, next to the feedback/complain assessment button, there should be a download button for the repository

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![download_complaint](https://user-images.githubusercontent.com/27979674/70730721-cc6da080-1d05-11ea-9452-486159d5848d.gif)
