### PR TITLE
Fix: Tooltips get cut off within data table

### DIFF
--- a/src/main/webapp/app/entities/result/result.component.html
+++ b/src/main/webapp/app/entities/result/result.component.html
@@ -16,9 +16,9 @@
                 <fa-icon [icon]="resultIconClass" size="lg"></fa-icon>
                 <span class="score"> &nbsp;<span *ngIf="!short" jhiTranslate="artemisApp.result.score">Score:</span> {{ result.score }}%, </span>
                 <span *ngIf="hasFeedback">
-                    <span class="result" (click)="showDetails(result)" [ngbTooltip]="resultTooltip">{{ resultString }}</span>
+                    <span class="result" (click)="showDetails(result)" [ngbTooltip]="resultTooltip" container="body">{{ resultString }}</span>
                 </span>
-                <span *ngIf="!hasFeedback" [ngbTooltip]="resultTooltip">
+                <span *ngIf="!hasFeedback" [ngbTooltip]="resultTooltip" container="body">
                     {{ result.resultString }}
                 </span>
                 <span *ngIf="!short"> ({{ result.completionDate! | amTimeAgo }}) </span>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~Server: I added multiple integration tests (Spring) related to the features~
- [x] ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- [x] ~Server: I implemented the changes with a good performance and prevented too many database calls~
- [x] ~Server: I documented the Java code using JavaDoc style.~
- [x] ~Client: I added multiple integration tests (Jest) related to the features~
- [x] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [x] ~Client: I documented the TypeScript code using JSDoc style.~
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] ~Client: I translated all the newly inserted strings into German and English~

### Motivation and Context
Tooltips are cut off if they are within an element whose overflow is hidden, e.g. in an ngx-datatable.

### Description
1. Add `container="body"` to elements that use the directive `ngbTooltip`.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Click on "Exercises" for a course
4. Click on "Scores for an exercise
5. Hover over the first result in the table (make sure it has a tooltip)
6. Verify that the tooltip is no longer cut off

### Screenshots
1. Before (tooltip cut off):
![image](https://user-images.githubusercontent.com/7109225/70998082-bd586b00-20d6-11ea-9e29-8dabb40f6322.png)

___

2. After (tooltip not cut off):
![OnPaste 20191217-135017 (1)](https://user-images.githubusercontent.com/7109225/70998090-c8ab9680-20d6-11ea-87a7-a42c736da11c.png)
