### PR TITLE
Bugfix: Fix text highlighting for text example assessments

### DIFF
--- a/src/main/webapp/app/text-assessment/highlighted-text-area/highlighted-text-area.component.ts
+++ b/src/main/webapp/app/text-assessment/highlighted-text-area/highlighted-text-area.component.ts
@@ -45,7 +45,7 @@ export class HighlightedTextAreaComponent implements OnChanges, DoCheck {
         }
 
         return this.assessments.reduce((content: string, assessment: Feedback, currentIndex: number) => {
-            if (assessment.reference == null || !this.blocks || currentIndex >= this.blocks.length) {
+            if (assessment.reference == null) {
                 return content;
             }
 
@@ -55,7 +55,7 @@ export class HighlightedTextAreaComponent implements OnChanges, DoCheck {
              * (2) feedback.reference contains a text block id.
              * Matching for ids is done in the `TextAssessmentComponent` and `this.blocks[currentIndex]` is only defined for case (2).
              */
-            const replacementString: string = this.blocks[currentIndex] ? this.blocks[currentIndex]!.text : assessment.reference;
+            const replacementString: string = this.blocks && this.blocks[currentIndex] ? this.blocks[currentIndex]!.text : assessment.reference;
 
             return content.replace(replacementString, `<span class="highlight ${HighlightColors.forIndex(currentIndex)}">${replacementString}</span>`);
         }, this.submissionTextWithHtmlLinebreaks);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~~Client: I added multiple integration tests (Jest) related to the features~~
- [x] ~~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~~
- [x] ~~Client: I documented the TypeScript code using JSDoc style.~~
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] ~~Client: I translated all the newly inserted strings into German and English~~

### Motivation and Context
Regression from: https://github.com/ls1intum/Artemis/commit/641d64f6d554b5f40f44d874c82685a522e0d2d0#diff-be0f52dfc3ec89b44b153c03f97b53a5

The text highlighting in the example assessment was not working. This PR fixes this issue.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Create Text Exercise
4. Start Text Exercise
5. Edit Text Exercise and add example assessment with tutorial
6. Go to Tutor Dashboard and assess the example assessment

### Screenshots
Issue (assessed text in text editor is not highlighted in yellow):
![image](https://user-images.githubusercontent.com/33764166/70999752-47ee9980-20da-11ea-9e85-07ff1040a784.png)

Fixed highlighting
![image](https://user-images.githubusercontent.com/33764166/71001185-04e1f580-20dd-11ea-9a47-08178220b43d.png)
