### PR TITLE
Bugfix: Fix display of tutor participation graph on tutor course dashboard

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -29,6 +29,7 @@ import de.tum.in.www1.artemis.exception.ArtemisAuthenticationException;
 import de.tum.in.www1.artemis.repository.ComplaintRepository;
 import de.tum.in.www1.artemis.repository.ComplaintResponseRepository;
 import de.tum.in.www1.artemis.repository.CourseRepository;
+import de.tum.in.www1.artemis.repository.ExampleSubmissionRepository;
 import de.tum.in.www1.artemis.security.ArtemisAuthenticationProvider;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.web.rest.dto.StatsForInstructorDashboardDTO;
@@ -94,12 +95,15 @@ public class CourseResource {
 
     private final ProgrammingExerciseService programmingExerciseService;
 
+    private final ExampleSubmissionRepository exampleSubmissionRepository;
+
     public CourseResource(Environment env, UserService userService, CourseService courseService, ParticipationService participationService, CourseRepository courseRepository,
             ExerciseService exerciseService, AuthorizationCheckService authCheckService, TutorParticipationService tutorParticipationService,
             Optional<ArtemisAuthenticationProvider> artemisAuthenticationProvider, ComplaintRepository complaintRepository, ComplaintResponseRepository complaintResponseRepository,
             LectureService lectureService, NotificationService notificationService, TextSubmissionService textSubmissionService,
             FileUploadSubmissionService fileUploadSubmissionService, ModelingSubmissionService modelingSubmissionService, ResultService resultService,
-            ComplaintService complaintService, TutorLeaderboardService tutorLeaderboardService, ProgrammingExerciseService programmingExerciseService) {
+            ComplaintService complaintService, TutorLeaderboardService tutorLeaderboardService, ProgrammingExerciseService programmingExerciseService,
+            ExampleSubmissionRepository exampleSubmissionRepository) {
         this.env = env;
         this.userService = userService;
         this.courseService = courseService;
@@ -120,6 +124,7 @@ public class CourseResource {
         this.tutorLeaderboardService = tutorLeaderboardService;
         this.fileUploadSubmissionService = fileUploadSubmissionService;
         this.programmingExerciseService = programmingExerciseService;
+        this.exampleSubmissionRepository = exampleSubmissionRepository;
     }
 
     /**
@@ -370,9 +375,15 @@ public class CourseResource {
 
             long numberOfAssessments = resultService.countNumberOfFinishedAssessmentsForExercise(exercise.getId());
 
+            List<ExampleSubmission> exampleSubmissions = this.exampleSubmissionRepository.findAllByExerciseId(exercise.getId());
+            // Do not provide example submissions without any assessment
+            exampleSubmissions.removeIf(exampleSubmission -> exampleSubmission.getSubmission().getResult() == null);
+            exercise.setExampleSubmissions(new HashSet<>(exampleSubmissions));
+
             exercise.setNumberOfParticipations(numberOfSubmissions);
             exercise.setNumberOfAssessments(numberOfAssessments);
             exercise.setTutorParticipations(Collections.singleton(tutorParticipation));
+
         }
 
         return ResponseUtil.wrapOrNotFound(Optional.of(course));

--- a/src/main/webapp/app/tutor-course-dashboard/tutor-course-dashboard.component.ts
+++ b/src/main/webapp/app/tutor-course-dashboard/tutor-course-dashboard.component.ts
@@ -3,11 +3,12 @@ import { partition } from 'lodash';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Course, CourseService } from '../entities/course';
 import { JhiAlertService } from 'ng-jhipster';
-import { User } from '../core';
+import { User } from 'app/core';
 import { AccountService } from 'app/core/auth/account.service';
 import { HttpResponse } from '@angular/common/http';
-import { Exercise, getIcon, getIconTooltip } from 'app/entities/exercise';
+import { Exercise, getIcon, getIconTooltip } from 'app/entities/exercise/exercise.model';
 import { StatsForDashboard } from 'app/instructor-course-dashboard/stats-for-dashboard.model';
+import { ExerciseService } from 'app/entities/exercise/exercise.service';
 
 @Component({
     selector: 'jhi-courses',
@@ -46,6 +47,7 @@ export class TutorCourseDashboardComponent implements OnInit {
         private accountService: AccountService,
         private route: ActivatedRoute,
         private router: Router,
+        private exerciseService: ExerciseService,
     ) {}
 
     ngOnInit(): void {
@@ -68,6 +70,13 @@ export class TutorCourseDashboardComponent implements OnInit {
                     this.unfinishedExercises = unfinishedExercises;
                     // sort exercises by type to get a better overview in the dashboard
                     this.exercises = this.unfinishedExercises.sort((a, b) => (a.type > b.type ? 1 : b.type > a.type ? -1 : 0));
+
+                    this.exercises.forEach(exercise => {
+                        this.exerciseService.getForTutors(exercise.id).subscribe((exerciseRes: HttpResponse<Exercise>) => {
+                            const retrievedExercise = exerciseRes.body!;
+                            exercise.exampleSubmissions = retrievedExercise.exampleSubmissions;
+                        });
+                    });
                 }
             },
             (response: string) => this.onError(response),

--- a/src/main/webapp/app/tutor-course-dashboard/tutor-course-dashboard.component.ts
+++ b/src/main/webapp/app/tutor-course-dashboard/tutor-course-dashboard.component.ts
@@ -72,6 +72,7 @@ export class TutorCourseDashboardComponent implements OnInit {
                     this.exercises = this.unfinishedExercises.sort((a, b) => (a.type > b.type ? 1 : b.type > a.type ? -1 : 0));
 
                     this.exercises.forEach(exercise => {
+                        // Retrieve exampleSubmission for correct calculation of the jhi-tutor-participation-graph
                         this.exerciseService.getForTutors(exercise.id).subscribe((exerciseRes: HttpResponse<Exercise>) => {
                             const retrievedExercise = exerciseRes.body!;
                             exercise.exampleSubmissions = retrievedExercise.exampleSubmissions;

--- a/src/main/webapp/app/tutor-course-dashboard/tutor-course-dashboard.component.ts
+++ b/src/main/webapp/app/tutor-course-dashboard/tutor-course-dashboard.component.ts
@@ -8,7 +8,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { HttpResponse } from '@angular/common/http';
 import { Exercise, getIcon, getIconTooltip } from 'app/entities/exercise/exercise.model';
 import { StatsForDashboard } from 'app/instructor-course-dashboard/stats-for-dashboard.model';
-import { ExerciseService } from 'app/entities/exercise/exercise.service';
 
 @Component({
     selector: 'jhi-courses',
@@ -47,7 +46,6 @@ export class TutorCourseDashboardComponent implements OnInit {
         private accountService: AccountService,
         private route: ActivatedRoute,
         private router: Router,
-        private exerciseService: ExerciseService,
     ) {}
 
     ngOnInit(): void {

--- a/src/main/webapp/app/tutor-course-dashboard/tutor-course-dashboard.component.ts
+++ b/src/main/webapp/app/tutor-course-dashboard/tutor-course-dashboard.component.ts
@@ -70,14 +70,6 @@ export class TutorCourseDashboardComponent implements OnInit {
                     this.unfinishedExercises = unfinishedExercises;
                     // sort exercises by type to get a better overview in the dashboard
                     this.exercises = this.unfinishedExercises.sort((a, b) => (a.type > b.type ? 1 : b.type > a.type ? -1 : 0));
-
-                    this.exercises.forEach(exercise => {
-                        // Retrieve exampleSubmission for correct calculation of the jhi-tutor-participation-graph
-                        this.exerciseService.getForTutors(exercise.id).subscribe((exerciseRes: HttpResponse<Exercise>) => {
-                            const retrievedExercise = exerciseRes.body!;
-                            exercise.exampleSubmissions = retrievedExercise.exampleSubmissions;
-                        });
-                    });
                 }
             },
             (response: string) => this.onError(response),

--- a/src/main/webapp/app/tutor-course-dashboard/tutor-participation-graph/tutor-participation-graph.component.ts
+++ b/src/main/webapp/app/tutor-course-dashboard/tutor-participation-graph/tutor-participation-graph.component.ts
@@ -16,7 +16,7 @@ export class TutorParticipationGraphComponent implements OnInit, OnChanges {
     @Input() public numberOfAssessments: number;
     @Input() exercise: Exercise;
 
-    tutorParticipationStatus = this.tutorParticipation ? this.tutorParticipation.status : TutorParticipationStatus.NOT_PARTICIPATED;
+    tutorParticipationStatus: TutorParticipationStatus = TutorParticipationStatus.NOT_PARTICIPATED;
 
     ExerciseType = ExerciseType;
     NOT_PARTICIPATED = TutorParticipationStatus.NOT_PARTICIPATED;

--- a/src/main/webapp/app/tutor-course-dashboard/tutor-participation-graph/tutor-participation-graph.component.ts
+++ b/src/main/webapp/app/tutor-course-dashboard/tutor-participation-graph/tutor-participation-graph.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges, OnInit, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { TutorParticipation, TutorParticipationStatus } from 'app/entities/tutor-participation';
 import { Router } from '@angular/router';
-import * as _ from 'lodash';
+import { get } from 'lodash';
 import { Exercise, ExerciseType } from 'app/entities/exercise';
 
 @Component({
@@ -16,7 +16,7 @@ export class TutorParticipationGraphComponent implements OnInit, OnChanges {
     @Input() public numberOfAssessments: number;
     @Input() exercise: Exercise;
 
-    tutorParticipationStatus: TutorParticipationStatus = TutorParticipationStatus.NOT_PARTICIPATED;
+    tutorParticipationStatus = this.tutorParticipation ? this.tutorParticipation.status : TutorParticipationStatus.NOT_PARTICIPATED;
 
     ExerciseType = ExerciseType;
     NOT_PARTICIPATED = TutorParticipationStatus.NOT_PARTICIPATED;
@@ -32,8 +32,8 @@ export class TutorParticipationGraphComponent implements OnInit, OnChanges {
 
     ngOnInit() {
         this.tutorParticipationStatus = this.tutorParticipation.status;
-        const exerciseId = _.get(this.tutorParticipation, 'trainedExampleSubmissions[0].exercise.id');
-        const courseId = _.get(this.tutorParticipation, 'trainedExampleSubmissions[0].exercise.course.id');
+        const exerciseId = get(this.tutorParticipation, 'trainedExampleSubmissions[0].exercise.id');
+        const courseId = get(this.tutorParticipation, 'trainedExampleSubmissions[0].exercise.course.id');
 
         if (courseId && exerciseId) {
             this.routerLink = `/course/${courseId}/exercise/${exerciseId}/tutor-dashboard`;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] ~~Client: I added multiple integration tests (Jest) related to the features~~
- [x] ~~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~~
- [x] ~~Client: I documented the TypeScript code using JSDoc style.~~
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] ~~Client: I translated all the newly inserted strings into German and English~~

### Motivation and Context
The tutor participation graph display error was fixed through https://github.com/ls1intum/Artemis/pull/1065 for the tutor exercise dashboard. However, the status is inconsistent with the tutor course dashboard. This PR fixes this.

### Description
The `jhi-tutor-participation-graph` needs the example submission of the exercise to correctly calculate the `TRAINED` status in the graph. The REST call to `/courses/:id/for-tutor-dashboard` did not provide this information, therefore I added the example submission in the response body.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to Tutor Dashboard
4. View Tutor Participation Graph on `Course Dashboard` and compare it to the graph on the `Exercise Dashboard`

### Screenshots
TRAINED status is red on the Course Dashboard, but yellow on the Exercise Dashboard
![image](https://user-images.githubusercontent.com/33764166/71043638-8498b000-212f-11ea-9051-005280311441.png)
![image](https://user-images.githubusercontent.com/33764166/71043683-abef7d00-212f-11ea-8517-c3f8f85965cb.png)

The example submission is included in the response body and the status is correctly displayed in orange:
![image](https://user-images.githubusercontent.com/33764166/71171118-4dc0b800-225d-11ea-80cd-91c4ca4b8e1d.png)
