### PR TITLE
Bugfix/delete course and exercise without transaction

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/CourseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/CourseRepository.java
@@ -33,6 +33,9 @@ public interface CourseRepository extends JpaRepository<Course, Long> {
     @Query("select distinct course from Course course left join fetch course.exercises where course.id = :#{#courseId}")
     Course findOneWithEagerExercises(@Param("courseId") Long courseId);
 
+    @Query("select distinct c from Course c left join fetch c.exercises left join fetch c.lectures where c.id = :#{#courseId}")
+    Course findOneWithEagerExercisesAndLectures(@Param("courseId") long courseId);
+
     @Query("select distinct course from Course course where course.startDate <= current_timestamp and course.endDate >= current_timestamp and course.onlineCourse = false and course.registrationEnabled = true")
     List<Course> findAllCurrentlyActiveAndNotOnlineAndEnabled();
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.service;
 
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -134,9 +137,14 @@ public class CourseService {
      * @param courseId the id of the entity
      * @return the entity
      */
-    public Course findOneWithExercises(Long courseId) {
+    public Course findOneWithExercises(long courseId) {
         log.debug("Request to get Course : {}", courseId);
         return courseRepository.findOneWithEagerExercises(courseId);
+    }
+
+    public Course findOneWithExercisesAndLectures(long courseId) {
+        log.debug("Request to get Course : {}", courseId);
+        return courseRepository.findOneWithEagerExercisesAndLectures(courseId);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.service;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -161,7 +160,6 @@ public class ExerciseService {
             // eagerly load templateParticipation and solutionParticipation
             programmingExercise.setTemplateParticipation(HibernateUtils.unproxy(programmingExercise.getTemplateParticipation()));
             programmingExercise.setSolutionParticipation(HibernateUtils.unproxy(programmingExercise.getSolutionParticipation()));
-            programmingExercise.setExampleSubmissions(new HashSet<>(programmingExercise.getExampleSubmissions()));
         }
         return exercise;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -237,12 +237,14 @@ public class ExerciseService {
     /**
      * Delete the exercise by id and all its participations.
      *
-     * @param exercise                     the exercise to be deleted
+     * @param exerciseId                     the exercise to be deleted
      * @param deleteStudentReposBuildPlans whether the student repos and build plans should be deleted
      * @param deleteBaseReposBuildPlans    whether the template and solution repos and build plans should be deleted
      */
     @Transactional
-    public void delete(Exercise exercise, boolean deleteStudentReposBuildPlans, boolean deleteBaseReposBuildPlans) {
+    public void delete(long exerciseId, boolean deleteStudentReposBuildPlans, boolean deleteBaseReposBuildPlans) {
+        // Delete has a transactional mechanism. Therefore, all lazy objects that are deleted below, should be fetched when needed.
+        final var exercise = findOne(exerciseId);
         // Delete has a transactional mechanism. Therefore, all lazy objects that are deleted below, should be fetched when needed.
         log.info("ExerciseService.Request to delete Exercise : {}", exercise.getTitle());
         // delete all participations belonging to this quiz

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -1,9 +1,11 @@
 package de.tum.in.www1.artemis.service;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -11,13 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
-import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
-import de.tum.in.www1.artemis.domain.participation.TemplateProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.TutorParticipationRepository;
 import de.tum.in.www1.artemis.service.scheduled.QuizScheduleService;
+import de.tum.in.www1.artemis.service.util.HibernateUtils;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 /**
@@ -158,8 +159,9 @@ public class ExerciseService {
         else if (exercise instanceof ProgrammingExercise) {
             ProgrammingExercise programmingExercise = (ProgrammingExercise) exercise;
             // eagerly load templateParticipation and solutionParticipation
-            programmingExercise.setTemplateParticipation((TemplateProgrammingExerciseParticipation) Hibernate.unproxy(programmingExercise.getTemplateParticipation()));
-            programmingExercise.setSolutionParticipation((SolutionProgrammingExerciseParticipation) Hibernate.unproxy(programmingExercise.getSolutionParticipation()));
+            programmingExercise.setTemplateParticipation(HibernateUtils.unproxy(programmingExercise.getTemplateParticipation()));
+            programmingExercise.setSolutionParticipation(HibernateUtils.unproxy(programmingExercise.getSolutionParticipation()));
+            programmingExercise.setExampleSubmissions(new HashSet<>(programmingExercise.getExampleSubmissions()));
         }
         return exercise;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -237,14 +237,13 @@ public class ExerciseService {
     /**
      * Delete the exercise by id and all its participations.
      *
-     * @param exerciseId                     the exercise to be deleted
+     * @param exercise                     the exercise to be deleted
      * @param deleteStudentReposBuildPlans whether the student repos and build plans should be deleted
      * @param deleteBaseReposBuildPlans    whether the template and solution repos and build plans should be deleted
      */
     @Transactional
-    public void delete(Long exerciseId, boolean deleteStudentReposBuildPlans, boolean deleteBaseReposBuildPlans) {
+    public void delete(Exercise exercise, boolean deleteStudentReposBuildPlans, boolean deleteBaseReposBuildPlans) {
         // Delete has a transactional mechanism. Therefore, all lazy objects that are deleted below, should be fetched when needed.
-        Exercise exercise = findOne(exerciseId);
         log.info("ExerciseService.Request to delete Exercise : {}", exercise.getTitle());
         // delete all participations belonging to this quiz
         participationService.deleteAllByExerciseId(exercise.getId(), deleteStudentReposBuildPlans, deleteStudentReposBuildPlans);

--- a/src/main/java/de/tum/in/www1/artemis/service/util/HibernateUtils.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/util/HibernateUtils.java
@@ -1,0 +1,22 @@
+package de.tum.in.www1.artemis.service.util;
+
+import org.hibernate.Hibernate;
+
+public class HibernateUtils {
+
+    /**
+     * Unproxies a {@link org.hibernate.proxy.HibernateProxy} and casts the result to the implied type.
+     * If you don't want to cast the object at all, just use {@link Hibernate#unproxy(Object)}
+     *
+     * @param proxy The object that should get unproxied
+     * @param <T> The type of the object after unproxying it
+     * @return the proxy's underlying implementation object
+     * @see Hibernate#unproxy(Object)
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T unproxy(Object proxy) {
+        // Note: This unchecked cast is fine in this case, since the caller would have to force cast the unproxied object anyway.
+        // It doesn't really matter if we throw the exception here, or in the calling block if the cast fails, the result is the same.
+        return (T) Hibernate.unproxy(proxy);
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -20,7 +20,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.enumeration.*;
+import de.tum.in.www1.artemis.domain.enumeration.ComplaintType;
+import de.tum.in.www1.artemis.domain.enumeration.TutorParticipationStatus;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.TutorParticipation;
@@ -588,7 +589,7 @@ public class CourseResource {
             return ResponseEntity.notFound().build();
         }
         for (Exercise exercise : course.getExercises()) {
-            exerciseService.delete(exercise.getId(), false, false);
+            exerciseService.delete(exercise, false, false);
         }
 
         for (Lecture lecture : course.getLectures()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -581,9 +581,9 @@ public class CourseResource {
      */
     @DeleteMapping("/courses/{courseId}")
     @PreAuthorize("hasAnyRole('ADMIN')")
-    public ResponseEntity<Void> deleteCourse(@PathVariable Long courseId) {
+    public ResponseEntity<Void> deleteCourse(@PathVariable long courseId) {
         log.debug("REST request to delete Course : {}", courseId);
-        Course course = courseService.findOne(courseId);
+        Course course = courseService.findOneWithExercisesAndLectures(courseId);
         if (course == null) {
             return ResponseEntity.notFound().build();
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -589,7 +589,7 @@ public class CourseResource {
             return ResponseEntity.notFound().build();
         }
         for (Exercise exercise : course.getExercises()) {
-            exerciseService.delete(exercise, false, false);
+            exerciseService.delete(exercise.getId(), false, false);
         }
 
         for (Lecture lecture : course.getLectures()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -260,7 +260,7 @@ public class ExerciseResource {
             if (!authCheckService.isAtLeastInstructorForExercise(exercise)) {
                 return forbidden();
             }
-            exerciseService.delete(exercise, true, false);
+            exerciseService.delete(exercise.getId(), true, false);
         }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, exerciseId.toString())).build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -260,7 +260,7 @@ public class ExerciseResource {
             if (!authCheckService.isAtLeastInstructorForExercise(exercise)) {
                 return forbidden();
             }
-            exerciseService.delete(exercise.getId(), true, false);
+            exerciseService.delete(exercise, true, false);
         }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, exerciseId.toString())).build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -31,7 +31,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.Course;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
@@ -531,22 +533,16 @@ public class ProgrammingExerciseResource {
     public ResponseEntity<Void> deleteProgrammingExercise(@PathVariable Long id, @RequestParam(defaultValue = "false") boolean deleteStudentReposBuildPlans,
             @RequestParam(defaultValue = "false") boolean deleteBaseReposBuildPlans) {
         log.info("REST request to delete ProgrammingExercise : {}", id);
-        Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findById(id);
-        if (programmingExercise.isPresent()) {
-            log.info("Found ProgrammingExercise to delete with title: {}", programmingExercise.get().getTitle());
-            Course course = programmingExercise.get().getCourse();
-            User user = userService.getUserWithGroupsAndAuthorities();
-            if (!authCheckService.isInstructorInCourse(course, user) && !authCheckService.isAdmin()) {
-                return forbidden();
-            }
-            String title = programmingExercise.get().getTitle();
-            exerciseService.delete(programmingExercise.get(), deleteStudentReposBuildPlans, deleteBaseReposBuildPlans);
-            return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, title)).build();
+        final var programmingExercise = (ProgrammingExercise) exerciseService.findOneWithAdditionalElements(id);
+        log.info("Found ProgrammingExercise to delete with title: {}", programmingExercise.getTitle());
+        Course course = programmingExercise.getCourse();
+        User user = userService.getUserWithGroupsAndAuthorities();
+        if (!authCheckService.isInstructorInCourse(course, user) && !authCheckService.isAdmin()) {
+            return forbidden();
         }
-        else {
-            log.warn("ProgrammingExercise with id {} not found for delete request", id);
-            return ResponseEntity.notFound().build();
-        }
+        String title = programmingExercise.getTitle();
+        exerciseService.delete(programmingExercise, deleteStudentReposBuildPlans, deleteBaseReposBuildPlans);
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, title)).build();
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -541,7 +541,7 @@ public class ProgrammingExerciseResource {
             return forbidden();
         }
         String title = programmingExercise.getTitle();
-        exerciseService.delete(programmingExercise.getId(), deleteStudentReposBuildPlans, deleteBaseReposBuildPlans);
+        exerciseService.delete(programmingExercise, deleteStudentReposBuildPlans, deleteBaseReposBuildPlans);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, title)).build();
     }
 


### PR DESCRIPTION
### Description
After the removal of the `@Transactional` annotations for the delete methods for courses and (programming) exercises, we have some `LazyInitializationExceptions`, because some of our encapsulated entities are still proxied when trying to delete them.

This PR fixes the errors that occurred for the deletion of courses and programming exercises. I also added a new `HibernateUtil` that immediately casts the unproxied object to the correct type.