### PR TITLE
Chore: Add tests for ModelingExerciseResource

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -30,7 +30,6 @@ import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.repository.ModelingExerciseRepository;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.compass.CompassService;
-import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 import io.github.jhipster.web.util.ResponseUtil;
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -211,10 +211,6 @@ public class ModelingExerciseResource {
     @PreAuthorize("hasAnyRole('ADMIN')")
     public ResponseEntity<Void> getCompassStatisticForExercise(@PathVariable Long exerciseId) {
         ModelingExercise modelingExercise = modelingExerciseService.findOne(exerciseId);
-        if (!authCheckService.isAdmin()) {
-            throw new AccessForbiddenException("Insufficient permission for exercise: " + modelingExercise);
-        }
-
         compassService.printStatistic(modelingExercise.getId());
 
         // TODO: In the future, this endpoint should return the statistics to the client as well.

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
@@ -8,7 +8,6 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.atlassian.bamboo.specs.util.BambooServer;
 
-import de.tum.in.www1.artemis.service.CourseService;
 import de.tum.in.www1.artemis.service.GroupNotificationService;
 import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.connectors.*;

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
@@ -1,9 +1,11 @@
 package de.tum.in.www1.artemis;
 
+import de.tum.in.www1.artemis.service.CourseService;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.mock.mockito.SpyBeans;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.atlassian.bamboo.specs.util.BambooServer;
@@ -42,4 +44,7 @@ public abstract class AbstractSpringIntegrationTest {
 
     @SpyBean
     protected WebsocketMessagingService websocketMessagingService;
+
+    @SpyBean
+    protected CourseService courseService;
 }

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
@@ -43,7 +43,4 @@ public abstract class AbstractSpringIntegrationTest {
 
     @SpyBean
     protected WebsocketMessagingService websocketMessagingService;
-
-    @SpyBean
-    protected CourseService courseService;
 }

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
@@ -1,15 +1,14 @@
 package de.tum.in.www1.artemis;
 
-import de.tum.in.www1.artemis.service.CourseService;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.boot.test.mock.mockito.SpyBeans;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.atlassian.bamboo.specs.util.BambooServer;
 
+import de.tum.in.www1.artemis.service.CourseService;
 import de.tum.in.www1.artemis.service.GroupNotificationService;
 import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.connectors.*;

--- a/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
@@ -6,10 +6,12 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
+import de.tum.in.www1.artemis.service.CourseService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
@@ -32,6 +34,9 @@ public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTe
 
     @Autowired
     ModelingExerciseUtilService modelingExerciseUtilService;
+
+    @SpyBean
+    CourseService courseService;
 
     private ModelingExercise classExercise;
 

--- a/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
@@ -1,6 +1,11 @@
 package de.tum.in.www1.artemis;
 
-import de.tum.in.www1.artemis.util.ModelingExerciseUtilService;
+import static de.tum.in.www1.artemis.domain.enumeration.DiagramType.CommunicationDiagram;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,13 +16,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
+import de.tum.in.www1.artemis.util.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
-
-import java.util.List;
-
-import static de.tum.in.www1.artemis.domain.enumeration.DiagramType.CommunicationDiagram;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
 

--- a/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
@@ -1,13 +1,9 @@
 package de.tum.in.www1.artemis;
 
-import de.tum.in.www1.artemis.service.CourseService;
 import de.tum.in.www1.artemis.util.ModelingExerciseUtilService;
-import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;

--- a/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
@@ -12,6 +12,10 @@ import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 
+import java.util.List;
+
+import static de.tum.in.www1.artemis.domain.enumeration.DiagramType.CommunicationDiagram;
+
 public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
 
     @Autowired
@@ -63,7 +67,7 @@ public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTe
 
     @Test
     @WithMockUser(username = "user1", roles = "USER")
-    public void testGetModelingExercise_asStudent() throws Exception {
+    public void testGetModelingExercise_asStudent_Forbidden() throws Exception {
         request.get("/api/modeling-exercises/" + classExercise.getId(), HttpStatus.FORBIDDEN, ModelingExercise.class);
     }
 
@@ -71,6 +75,23 @@ public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTe
     @WithMockUser(username = "tutor1", roles = "TA")
     public void testGetModelingExercise_asTA() throws Exception {
         request.get("/api/modeling-exercises/" + classExercise.getId(), HttpStatus.OK, ModelingExercise.class);
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testGetModelingExerciseForCourse_asTA() throws Exception {
+        request.get("/api/courses/" + classExercise.getCourse().getId() + "/modeling-exercises", HttpStatus.OK, List.class);
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testGetModelingExerciseStatistics_asTA() throws Exception {
+        request.get("/api/modeling-exercises/" + classExercise.getId() + "/statistics", HttpStatus.OK, String.class);
+        request.get("/api/modeling-exercises/" + classExercise.getId() + 1 + "/statistics", HttpStatus.NOT_FOUND, String.class);
+
+        classExercise.setDiagramType(CommunicationDiagram);
+        exerciseRepo.save(classExercise);
+        request.get("/api/modeling-exercises/" + classExercise.getId() + "/statistics", HttpStatus.NOT_FOUND, String.class);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
-import de.tum.in.www1.artemis.service.CourseService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +16,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
+import de.tum.in.www1.artemis.service.CourseService;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.ModelingExerciseUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;

--- a/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
@@ -27,6 +27,7 @@ public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTe
 
     @BeforeEach
     public void initTestCase() throws Exception {
+        database.addUsers(1, 1, 1);
         database.addCourseWithOneModelingExercise();
         classExercise = (ModelingExercise) exerciseRepo.findAll().get(0);
     }
@@ -58,5 +59,18 @@ public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTe
     @WithMockUser(roles = "ADMIN")
     public void getCompassStatistic_asAdmin_Success() throws Exception {
         request.getNullable("/api/exercises/" + classExercise.getId() + "/compass-statistic", HttpStatus.OK, String.class);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testDeleteModelingExercise_asInstructor() throws Exception {
+        request.delete("/api/modeling-exercises/" + classExercise.getId(), HttpStatus.OK);
+        request.delete("/api/modeling-exercises/" + classExercise.getId(), HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testDeleteModelingExercise_asTutor_Forbidden() throws Exception {
+        request.delete("/api/modeling-exercises/" + classExercise.getId(), HttpStatus.FORBIDDEN);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
@@ -62,6 +62,18 @@ public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTe
     }
 
     @Test
+    @WithMockUser(username = "user1", roles = "USER")
+    public void testGetModelingExercise_asStudent() throws Exception {
+        request.get("/api/modeling-exercises/" + classExercise.getId(), HttpStatus.FORBIDDEN, ModelingExercise.class);
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testGetModelingExercise_asTA() throws Exception {
+        request.get("/api/modeling-exercises/" + classExercise.getId(), HttpStatus.OK, ModelingExercise.class);
+    }
+
+    @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testDeleteModelingExercise_asInstructor() throws Exception {
         request.delete("/api/modeling-exercises/" + classExercise.getId(), HttpStatus.OK);

--- a/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
@@ -1,9 +1,13 @@
 package de.tum.in.www1.artemis;
 
+import de.tum.in.www1.artemis.service.CourseService;
 import de.tum.in.www1.artemis.util.ModelingExerciseUtilService;
+import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -17,6 +21,7 @@ import java.util.List;
 
 import static de.tum.in.www1.artemis.domain.enumeration.DiagramType.CommunicationDiagram;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
 
@@ -122,8 +127,9 @@ public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationTe
         ModelingExercise returnedModelingExercise = request.putWithResponseBody("/api/modeling-exercises", modelingExerciseWithSubmission, ModelingExercise.class, HttpStatus.OK);
         assertThat(returnedModelingExercise.getExampleSubmissions().size()).isEqualTo(1);
 
+        when(courseService.findOne(classExercise.getCourse().getId())).thenReturn(null);
         modelingExercise = modelingExerciseUtilService.createModelingExercise(classExercise.getCourse().getId(), classExercise.getId());
-        request.put("/api/modeling-exercises", modelingExercise, HttpStatus.OK);
+        request.put("/api/modeling-exercises", modelingExercise, HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelingExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelingExerciseUtilService.java
@@ -1,0 +1,65 @@
+package de.tum.in.www1.artemis.util;
+
+import de.tum.in.www1.artemis.domain.Course;
+import de.tum.in.www1.artemis.domain.ExampleSubmission;
+import de.tum.in.www1.artemis.domain.enumeration.DiagramType;
+import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class ModelingExerciseUtilService {
+
+    @Autowired
+    DatabaseUtilService database;
+
+    /**
+     * Create modeling exercise for a given course
+     * @param courseId  id of the given course
+     * @return  created modeling exercise
+     */
+    public ModelingExercise createModelingExercise(Long courseId) {
+        return createModelingExercise(courseId, null);
+    }
+
+    /**
+     * Create modeling exercise with a given id for a given course
+     * @param courseId  id of the given course
+     * @param exerciseId  id of modeling exercise
+     * @return  created modeling exercise
+     */
+    public ModelingExercise createModelingExercise(Long courseId, Long exerciseId) {
+        ZonedDateTime pastTimestamp = ZonedDateTime.now().minusDays(5);
+        ZonedDateTime futureTimestamp = ZonedDateTime.now().plusDays(5);
+        ZonedDateTime futureFutureTimestamp = ZonedDateTime.now().plusDays(8);
+
+        Course course1 = ModelFactory.generateCourse(courseId, pastTimestamp, futureTimestamp, new HashSet<>(), "tumuser", "tutor", "instructor");
+        ModelingExercise modelingExercise = ModelFactory.generateModelingExercise(pastTimestamp, futureTimestamp, futureFutureTimestamp, DiagramType.ClassDiagram, course1);
+        modelingExercise.setGradingInstructions("Grading instructions");
+        modelingExercise.getCategories().add("Modeling");
+        modelingExercise.setId(exerciseId);
+        course1.addExercises(modelingExercise);
+
+        return modelingExercise;
+    }
+
+    /**
+     * Add example submission to modeling exercise
+     * @param modelingExercise  modeling exercise for which the example submission should be added
+     * @return  modeling exercise with example submission
+     * @throws Exception if the resources file is not found
+     */
+    public ModelingExercise addExampleSubmission(ModelingExercise modelingExercise) throws Exception {
+        Set<ExampleSubmission> exampleSubmissionSet = new HashSet<>();
+        String validModel = database.loadFileFromResources("test-data/model-submission/model.54727.json");
+        var exampleSubmission = database.generateExampleSubmission(validModel, modelingExercise, true);
+        exampleSubmission.assessmentExplanation("explanation");
+        exampleSubmissionSet.add(exampleSubmission);
+        modelingExercise.setExampleSubmissions(exampleSubmissionSet);
+        return modelingExercise;
+    }
+}

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelingExerciseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelingExerciseUtilService.java
@@ -1,15 +1,16 @@
 package de.tum.in.www1.artemis.util;
 
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ExampleSubmission;
 import de.tum.in.www1.artemis.domain.enumeration.DiagramType;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
-import java.time.ZonedDateTime;
-import java.util.HashSet;
-import java.util.Set;
 
 @Service
 public class ModelingExerciseUtilService {


### PR DESCRIPTION
### Checklist
- [x] Server: I added multiple integration tests (Spring) related to the features
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
This PR adds missing server tests to the `ModelingExerciseResource`.
Current test coverage:
![image](https://user-images.githubusercontent.com/33764166/72205972-330ee700-3489-11ea-8ff5-7e69e0707590.png)
Test coverage with PR:
![image](https://user-images.githubusercontent.com/33764166/72205975-3f933f80-3489-11ea-8bcf-32a25d208a0d.png)