### PR TITLE
Fix wrong URL (causes 404 error when assessing complaints)

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
@@ -151,7 +151,7 @@ public class TextAssessmentResource extends AssessmentResource {
      * @return the updated result
      */
     @ResponseStatus(HttpStatus.OK)
-    @PutMapping("/text-submission/{submissionId}/assessment-after-complaint")
+    @PutMapping("/text-submissions/{submissionId}/assessment-after-complaint")
     @PreAuthorize("hasAnyRole('TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<Result> updateTextAssessmentAfterComplaint(@PathVariable Long submissionId, @RequestBody AssessmentUpdate assessmentUpdate) {
         log.debug("REST request to update the assessment of submission {} after complaint.", submissionId);

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -97,7 +97,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationTest
         ComplaintResponse complaintResponse = new ComplaintResponse().complaint(complaint.accepted(false)).responseText("rejected");
         AssessmentUpdate assessmentUpdate = new AssessmentUpdate().feedbacks(new ArrayList<>()).complaintResponse(complaintResponse);
 
-        Result updatedResult = request.putWithResponseBody("/api/text-assessments/text-submission/" + textSubmission.getId() + "/assessment-after-complaint", assessmentUpdate,
+        Result updatedResult = request.putWithResponseBody("/api/text-assessments/text-submissions/" + textSubmission.getId() + "/assessment-after-complaint", assessmentUpdate,
                 Result.class, HttpStatus.OK);
 
         assertThat(updatedResult).as("updated result found").isNotNull();


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
![image](https://user-images.githubusercontent.com/33764166/72339824-51622600-36c7-11ea-963f-b6e2fe3cb1db.png)

Currently tutors cannot assess complaints of text exercises due to the wrong URL.
This PR fixes it.

### Steps for Testing
1. Log in to Artemis
2. Assess complaint for text exercise
