### PR TITLE
Subsequent submissions on same page failing for Text / Modeling / File Upload

### DIFF
--- a/src/main/webapp/app/entities/file-upload-submission/file-upload-submission.service.ts
+++ b/src/main/webapp/app/entities/file-upload-submission/file-upload-submission.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs/Observable';
 
 import { FileUploadSubmission } from './file-upload-submission.model';
 import { createRequestOption } from 'app/shared';
+import { stringifyCircular } from 'app/shared/util/utils';
 
 export type EntityResponseType = HttpResponse<FileUploadSubmission>;
 
@@ -20,7 +21,7 @@ export class FileUploadSubmissionService {
     update(fileUploadSubmission: FileUploadSubmission, exerciseId: number, submissionFile: Blob | File): Observable<EntityResponseType> {
         const copy = this.convert(fileUploadSubmission);
         const formData = new FormData();
-        const submissionBlob = new Blob([JSON.stringify(copy)], { type: 'application/json' });
+        const submissionBlob = new Blob([stringifyCircular(copy)], { type: 'application/json' });
         formData.append('file', submissionFile);
         formData.append('submission', submissionBlob);
         return this.http

--- a/src/main/webapp/app/entities/modeling-submission/modeling-submission.service.ts
+++ b/src/main/webapp/app/entities/modeling-submission/modeling-submission.service.ts
@@ -5,6 +5,7 @@ import { SERVER_API_URL } from 'app/app.constants';
 
 import { ModelingSubmission } from './modeling-submission.model';
 import { createRequestOption } from 'app/shared';
+import { stringifyCircular } from 'app/shared/util/utils';
 
 export type EntityResponseType = HttpResponse<ModelingSubmission>;
 
@@ -26,7 +27,8 @@ export class ModelingSubmissionService {
     update(modelingSubmission: ModelingSubmission, exerciseId: number): Observable<EntityResponseType> {
         const copy = this.convert(modelingSubmission);
         return this.http
-            .put<ModelingSubmission>(`api/exercises/${exerciseId}/modeling-submissions`, copy, {
+            .put<ModelingSubmission>(`api/exercises/${exerciseId}/modeling-submissions`, stringifyCircular(copy), {
+                headers: { 'Content-Type': 'application/json' },
                 observe: 'response',
             })
             .map((res: EntityResponseType) => this.convertResponse(res));

--- a/src/main/webapp/app/entities/text-submission/text-submission.service.ts
+++ b/src/main/webapp/app/entities/text-submission/text-submission.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs/Observable';
 
 import { TextSubmission } from './text-submission.model';
 import { createRequestOption } from 'app/shared';
+import { stringifyCircular } from 'app/shared/util/utils';
 
 export type EntityResponseType = HttpResponse<TextSubmission>;
 
@@ -23,7 +24,8 @@ export class TextSubmissionService {
     update(textSubmission: TextSubmission, exerciseId: number): Observable<EntityResponseType> {
         const copy = this.convert(textSubmission);
         return this.http
-            .put<TextSubmission>(`api/exercises/${exerciseId}/text-submissions`, copy, {
+            .put<TextSubmission>(`api/exercises/${exerciseId}/text-submissions`, stringifyCircular(copy), {
+                headers: { 'Content-Type': 'application/json' },
                 observe: 'response',
             })
             .map((res: EntityResponseType) => this.convertResponse(res));

--- a/src/main/webapp/app/shared/util/utils.ts
+++ b/src/main/webapp/app/shared/util/utils.ts
@@ -19,19 +19,19 @@ export const cartesianProduct = (a: any[], b: any[], ...c: any[][]): any[] => {
 };
 
 /**
- * https://stackoverflow.com/questions/11616630/how-can-i-print-a-circular-structure-in-a-json-like-format
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value
  * Stringify a circular JSON structure by omitting keys that would close a circle
  *
- * @param value The object you want to stringify
+ * @param val The object you want to stringify
  */
 export const stringifyCircular = (val: any): string => {
-    const cache: any[] = [];
+    const seen = new WeakSet();
     return JSON.stringify(val, (key, value) => {
         if (typeof value === 'object' && value !== null) {
-            if (cache.indexOf(value) !== -1) {
+            if (seen.has(value)) {
                 return;
             }
-            cache.push(value);
+            seen.add(value);
         }
         return value;
     });


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Currently, a submission for Text, Modeling and File Upload Exercises can only be made once from the same page. Subsequent submissions fail silently (without console error or any network request) but do show an error alert in the frontend. The reason for this is the reconnect of the submission participation with the submission itself, leading to a circular structure that fails when the json conversion happens for the update request.

### Description
- Use the existing utility function `stringifyCircular` in the update method of the respective services to prevent the error due to circular JSON. What this method does is remove key/values pairs where the value object is already contained in the JSON.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Overview
3. Click on a Course
4. Start a Text/Modeling/File Upload Exercise
5. Submit a solution
6. Click "Submit" again on the same page and verify that it worked correctly
