### PR TITLE
Use safeHtmlForMarkdown to display Katex command correctly

### DIFF
--- a/src/main/webapp/app/assessment-instructions/assessment-instructions/assessment-instructions.component.ts
+++ b/src/main/webapp/app/assessment-instructions/assessment-instructions/assessment-instructions.component.ts
@@ -27,8 +27,8 @@ export class AssessmentInstructionsComponent {
 
     @Input('exercise') set exerciseInput(exercise: Exercise) {
         this.exercise = exercise;
-        this.problemStatement = this.markdownService.htmlForMarkdown(exercise.problemStatement);
-        this.gradingInstructions = this.markdownService.htmlForMarkdown(exercise.gradingInstructions);
+        this.problemStatement = this.markdownService.safeHtmlForMarkdown(exercise.problemStatement);
+        this.gradingInstructions = this.markdownService.safeHtmlForMarkdown(exercise.gradingInstructions);
 
         let sampleSolutionMarkdown: string | undefined;
         switch (exercise.type) {
@@ -52,7 +52,7 @@ export class AssessmentInstructionsComponent {
                 this.programmingExercise = exercise as ProgrammingExercise;
         }
         if (sampleSolutionMarkdown) {
-            this.sampleSolution = this.markdownService.htmlForMarkdown(sampleSolutionMarkdown);
+            this.sampleSolution = this.markdownService.safeHtmlForMarkdown(sampleSolutionMarkdown);
         }
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Katex commands in the assessment instructions are not displayed correctly:
![image](https://user-images.githubusercontent.com/33764166/72355222-52a34b00-36e7-11ea-8f12-c8d1cbe531fb.png)
Instead of using `safeHtmlForMarkdown`, `htmlForMarkdown` was used for sanitation and lead to formatting errors.

### Steps for Testing
1. Log in to Artemis
2. Create exercise and use katex command in problem statement, example submission and grading instruction (e.g. https://artemistest.ase.in.tum.de/#/course/47/exercise/1415/tutor-dashboard)
3. Go to tutor dashboard and view instructions

### Screenshots
![image](https://user-images.githubusercontent.com/33764166/72355582-0b698a00-36e8-11ea-9b1c-5dcec8088f8e.png)

