### PR TITLE
Fix programming exercises without tutors for Bitbucket

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -350,6 +350,7 @@ public class ProgrammingExerciseService {
 
         // Give appropriate permissions for CI projects
         continuousIntegrationService.get().removeAllDefaultProjectPermissions(projectKey);
+
         giveCIProjectPermissions(programmingExercise);
 
         // save to get the id required for the webhook
@@ -964,7 +965,9 @@ public class ProgrammingExerciseService {
 
         continuousIntegrationService.get().giveProjectPermissions(exercise.getProjectKey(), List.of(instructorGroup),
                 List.of(CIPermission.CREATE, CIPermission.READ, CIPermission.ADMIN));
-        continuousIntegrationService.get().giveProjectPermissions(exercise.getProjectKey(), List.of(teachingAssistantGroup), List.of(CIPermission.READ));
+        if (teachingAssistantGroup != null) {
+            continuousIntegrationService.get().giveProjectPermissions(exercise.getProjectKey(), List.of(teachingAssistantGroup), List.of(CIPermission.READ));
+        }
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooBuildPlanService.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import com.atlassian.bamboo.specs.api.builders.AtlassianModule;
@@ -179,13 +180,15 @@ public class BambooBuildPlanService {
                 .changeDetection(new VcsChangeDetection());
     }
 
-    private PlanPermissions generatePlanPermissions(String bambooProjectKey, String bambooPlanKey, String teachingAssistantGroupName, String instructorGroupName,
+    private PlanPermissions generatePlanPermissions(String bambooProjectKey, String bambooPlanKey, @Nullable String teachingAssistantGroupName, String instructorGroupName,
             String adminGroupName) {
-        return new PlanPermissions(new PlanIdentifier(bambooProjectKey, bambooPlanKey)).permissions(
-                new Permissions().userPermissions(BAMBOO_USER, PermissionType.EDIT, PermissionType.BUILD, PermissionType.CLONE, PermissionType.VIEW, PermissionType.ADMIN)
-                        .groupPermissions(adminGroupName, PermissionType.CLONE, PermissionType.BUILD, PermissionType.EDIT, PermissionType.VIEW, PermissionType.ADMIN)
-                        .groupPermissions(instructorGroupName, PermissionType.CLONE, PermissionType.BUILD, PermissionType.EDIT, PermissionType.VIEW, PermissionType.ADMIN)
-                        .groupPermissions(teachingAssistantGroupName, PermissionType.BUILD, PermissionType.EDIT, PermissionType.VIEW));
+        var permissions = new Permissions().userPermissions(BAMBOO_USER, PermissionType.EDIT, PermissionType.BUILD, PermissionType.CLONE, PermissionType.VIEW, PermissionType.ADMIN)
+                .groupPermissions(adminGroupName, PermissionType.CLONE, PermissionType.BUILD, PermissionType.EDIT, PermissionType.VIEW, PermissionType.ADMIN)
+                .groupPermissions(instructorGroupName, PermissionType.CLONE, PermissionType.BUILD, PermissionType.EDIT, PermissionType.VIEW, PermissionType.ADMIN);
+        if (teachingAssistantGroupName != null) {
+            permissions = permissions.groupPermissions(teachingAssistantGroupName, PermissionType.BUILD, PermissionType.EDIT, PermissionType.VIEW);
+        }
+        return new PlanPermissions(new PlanIdentifier(bambooProjectKey, bambooPlanKey)).permissions(permissions);
     }
 
     private List<Task<?, ?>> readScriptTasksFromTemplate(final ProgrammingLanguage programmingLanguage, final boolean sequentialBuildRuns) {

--- a/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
@@ -111,13 +111,16 @@ public class BambooRequestMockProvider {
 
     public void mockGiveProjectPermissions(ProgrammingExercise exercise) throws URISyntaxException, IOException {
         final var projectKey = exercise.getProjectKey();
-        final var instructorURI = buildGivePermissionsURIFor(projectKey, exercise.getCourse().getInstructorGroupName());
-        final var tutorURI = buildGivePermissionsURIFor(projectKey, exercise.getCourse().getTeachingAssistantGroupName());
 
+        final var instructorURI = buildGivePermissionsURIFor(projectKey, exercise.getCourse().getInstructorGroupName());
         mockServer.expect(ExpectedCount.once(), requestTo(instructorURI)).andExpect(method(HttpMethod.PUT))
                 .andExpect(content().json(mapper.writeValueAsString(List.of("CREATE", "READ", "ADMINISTRATION")))).andRespond(withStatus(HttpStatus.NO_CONTENT));
-        mockServer.expect(ExpectedCount.once(), requestTo(tutorURI)).andExpect(method(HttpMethod.PUT)).andExpect(content().json(mapper.writeValueAsString(List.of("READ"))))
-                .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        if (exercise.getCourse().getTeachingAssistantGroupName() != null) {
+            final var tutorURI = buildGivePermissionsURIFor(projectKey, exercise.getCourse().getTeachingAssistantGroupName());
+            mockServer.expect(ExpectedCount.once(), requestTo(tutorURI)).andExpect(method(HttpMethod.PUT)).andExpect(content().json(mapper.writeValueAsString(List.of("READ"))))
+                    .andRespond(withStatus(HttpStatus.NO_CONTENT));
+        }
     }
 
     private URI buildGivePermissionsURIFor(String projectKey, String groupName) throws URISyntaxException {

--- a/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
@@ -83,7 +83,9 @@ public class BitbucketRequestMockProvider {
 
         mockGrantGroupPermissionToProject(exercise, ADMIN_GROUP_NAME, "PROJECT_ADMIN");
         mockGrantGroupPermissionToProject(exercise, exercise.getCourse().getInstructorGroupName(), "PROJECT_ADMIN");
-        mockGrantGroupPermissionToProject(exercise, exercise.getCourse().getTeachingAssistantGroupName(), "PROJECT_WRITE");
+        if (exercise.getCourse().getTeachingAssistantGroupName() != null) {
+            mockGrantGroupPermissionToProject(exercise, exercise.getCourse().getTeachingAssistantGroupName(), "PROJECT_WRITE");
+        }
     }
 
     public void mockGrantGroupPermissionToProject(ProgrammingExercise exercise, String groupName, String permission) throws URISyntaxException {

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -30,6 +30,7 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
 import de.tum.in.www1.artemis.domain.enumeration.RepositoryType;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
+import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.ModelFactory;
@@ -53,6 +54,9 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
 
     @Autowired
     private BitbucketRequestMockProvider bitbucketRequestMockProvider;
+
+    @Autowired
+    private CourseRepository courseRepository;
 
     private Course course;
 
@@ -88,6 +92,19 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
 
         exercise.setId(generated.getId());
         assertThat(exercise).isEqualTo(generated);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void setupProgrammingExercise_noTutors_created() throws Exception {
+        course.setTeachingAssistantGroupName(null);
+        courseRepository.save(course);
+        final var exercise = ModelFactory.generateProgrammingExercise(ZonedDateTime.now().plusDays(1), ZonedDateTime.now().plusDays(7), course);
+        mockConnectorRequestsForSetup(exercise);
+
+        request.post(ROOT + SETUP, exercise, HttpStatus.CREATED);
+
+        assertThat(programmingExerciseRepository.count()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
### Description
If a course has no teaching assistant group, then creation of a new programming exercise will fail, because we try to set some permissions for the build plan for a `null` group. 
This PR fixes the problem. Creation of exercises works again for both Atlassian and GitLab+Jenkins setups.