### PR TITLE
Fix Deletion of Text{Submission, Exercise} with Text Blocks

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/TextSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TextSubmission.java
@@ -22,7 +22,7 @@ public class TextSubmission extends Submission implements Serializable {
     @Lob
     private String text;
 
-    @OneToMany(mappedBy = "submission")
+    @OneToMany(mappedBy = "submission", cascade = CascadeType.REMOVE)
     @JsonIgnoreProperties("submission")
     private List<TextBlock> blocks = new ArrayList<>();
 

--- a/src/test/java/de/tum/in/www1/artemis/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextExerciseIntegrationTest.java
@@ -2,35 +2,35 @@ package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
+import de.tum.in.www1.artemis.domain.Course;
+import de.tum.in.www1.artemis.domain.TextBlock;
 import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.TextSubmission;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.domain.participation.Participation;
-import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 
-public class TextExerciseTest extends AbstractSpringIntegrationTest {
+public class TextExerciseIntegrationTest extends AbstractSpringIntegrationTest {
 
     @Autowired
     DatabaseUtilService database;
 
     @Autowired
     RequestUtilService request;
-
-    @Autowired
-    CourseRepository courseRepo;
 
     @Autowired
     TextExerciseRepository textExerciseRepository;
@@ -51,16 +51,29 @@ public class TextExerciseTest extends AbstractSpringIntegrationTest {
     @Test
     @WithMockUser(value = "tutor1", roles = "TA")
     public void submitEnglishTextExercise() throws Exception {
-        database.addCourseWithOneTextExercise();
+        final Course course = database.addCourseWithOneTextExercise();
         TextSubmission textSubmission = ModelFactory.generateTextSubmission("This Submission is written in English", Language.ENGLISH, false);
-        long courseID = courseRepo.findAllActive().get(0).getId();
-        TextExercise textExercise = textExerciseRepository.findByCourseId(courseID).get(0);
-        request.postWithResponseBody("/api/courses/" + courseID + "/exercises/" + textExercise.getId() + "/participations", null, Participation.class);
+        TextExercise textExercise = textExerciseRepository.findByCourseId(course.getId()).get(0);
+        request.postWithResponseBody("/api/courses/" + course.getId() + "/exercises/" + textExercise.getId() + "/participations", null, Participation.class);
         textSubmission = request.postWithResponseBody("/api/exercises/" + textExercise.getId() + "/text-submissions", textSubmission, TextSubmission.class);
 
         Optional<TextSubmission> result = textSubmissionRepository.findById(textSubmission.getId());
         assertThat(result.isPresent()).isEqualTo(true);
         result.ifPresent(submission -> assertThat(submission.getLanguage()).isEqualTo(Language.ENGLISH));
 
+    }
+
+    @Test
+    @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
+    public void deleteTextExerciseWithSubmissionWithTextBlocks() throws Exception {
+        final Course course = database.addCourseWithOneTextExercise();
+        TextExercise textExercise = textExerciseRepository.findByCourseId(course.getId()).get(0);
+        TextSubmission textSubmission = ModelFactory.generateTextSubmission("Lorem Ipsum Foo Bar", Language.ENGLISH, true);
+        textSubmission = database.addTextSubmission(textExercise, textSubmission, "student1");
+
+        final List<TextBlock> textBlocks = List.of(ModelFactory.generateTextBlock(0, 11, "Lorem Ipsum"), ModelFactory.generateTextBlock(12, 19, "Foo Bar"));
+        database.addTextBlocksToTextSubmission(textBlocks, textSubmission);
+
+        request.delete("/api/text-exercises/" + textExercise.getId(), HttpStatus.OK);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.domain.Exercise;
+import de.tum.in.www1.artemis.domain.TextBlock;
 import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.TextSubmission;
 import de.tum.in.www1.artemis.domain.User;
@@ -169,5 +170,15 @@ public class TextSubmissionIntegrationTest extends AbstractSpringIntegrationTest
         participationRepository.save(afterDueDateParticipation);
 
         request.put("/api/exercises/" + textExerciseBeforeDueDate.getId() + "/text-submissions", textSubmission, HttpStatus.OK);
+    }
+
+    @Test
+    @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
+    public void deleteTextSubmissionWithTextBlocks() throws Exception {
+        textSubmission = database.addTextSubmission(textExerciseBeforeDueDate, textSubmission, "student1");
+        final List<TextBlock> blocks = List.of(ModelFactory.generateTextBlock(0, 9), ModelFactory.generateTextBlock(10, 19), ModelFactory.generateTextBlock(20, 29));
+        database.addTextBlocksToTextSubmission(blocks, textSubmission);
+
+        request.delete("/api/submissions/" + textSubmission.getId(), HttpStatus.OK);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -84,6 +84,9 @@ public class DatabaseUtilService {
     TextSubmissionRepository textSubmissionRepo;
 
     @Autowired
+    TextBlockRepository textBlockRepo;
+
+    @Autowired
     FileUploadSubmissionRepository fileUploadSubmissionRepo;
 
     @Autowired
@@ -830,6 +833,14 @@ public class DatabaseUtilService {
         submission = textSubmissionRepo.save(submission);
         result = resultRepo.save(result);
         studentParticipationRepo.save(participation);
+        return submission;
+    }
+
+    public TextSubmission addTextBlocksToTextSubmission(List<TextBlock> blocks, TextSubmission submission) {
+        blocks.forEach(block -> block.setSubmission(submission));
+        submission.setBlocks(blocks);
+        textBlockRepo.saveAll(blocks);
+        textSubmissionRepo.save(submission);
         return submission;
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
@@ -267,4 +267,17 @@ public class ModelFactory {
         result.setScore(score);
         return result;
     }
+
+    public static TextBlock generateTextBlock(int startIndex, int endIndex, String text) {
+        final TextBlock textBlock = new TextBlock();
+        textBlock.setStartIndex(startIndex);
+        textBlock.setEndIndex(endIndex);
+        textBlock.setText(text);
+        textBlock.computeId();
+        return textBlock;
+    }
+
+    public static TextBlock generateTextBlock(int startIndex, int endIndex) {
+        return generateTextBlock(startIndex, endIndex, "");
+    }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Server: I added multiple integration tests (Spring) related to the features
- [X] Server: I implemented the changes with a good performance and prevented too many database calls

### Motivation and Context
Reported by @krusche in #1178:
> When deleting a course with a text exercise or a text exercise or a text submission with text blocks, the following exception occurs on the server:
```
Cannot delete or update a parent row: a foreign key constraint fails (`ArTEMiS`.`text_block`, CONSTRAINT `fk_text_block_submission_id` FOREIGN KEY (`submission_id`) REFERENCES `submission` (`id`) ON DELETE RESTRICT ON UPDATE RESTRICT)
Internal Server Error
  could not execute statement; SQL [n/a]; constraint [null]; nested exception is org.hibernate.exception.ConstraintViolationException: could not execute statement
```

### Description
Fixes #1178.
Add Cascade Remove for the `blocks` field in Text Submission.
➡️ Delete Linked Text Blocks when deleting a Text Submission.

### Steps for Testing
1. Create a Text Submission with Text Blocks. (e.g. by adding an assessment).
2. Delete ..
    1. Submission
    2. Participation
    3. Exercise
    4. Course
3. Find no errors.
