### PR TITLE
Throw exception if max retries for forking repo reached

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -208,7 +208,8 @@ public class BitbucketService extends AbstractVersionControlService {
                         return new BitbucketRepositoryUrl(targetProjectKey, targetRepoSlug);
                     }
                     else {
-                        log.warn("Invalid response code from Bitbucket while trying to fork repository {}: {}", sourceRepositoryName, response.getStatusCode());
+                        log.warn("Invalid response code from Bitbucket while trying to fork repository {}: {}. Body from Bitbucket: {}", sourceRepositoryName,
+                                response.getStatusCode(), new ObjectMapper().writeValueAsString(response.getBody()));
                     }
                 }
                 catch (HttpServerErrorException.InternalServerError e) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -26,7 +26,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 
-import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.Commit;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.domain.VcsRepositoryUrl;
 import de.tum.in.www1.artemis.exception.BitbucketException;
 import de.tum.in.www1.artemis.service.UserService;
 import de.tum.in.www1.artemis.service.connectors.bitbucket.dto.BitbucketBranchProtectionDTO;
@@ -204,6 +207,9 @@ public class BitbucketService extends AbstractVersionControlService {
                     if (response.getStatusCode().equals(HttpStatus.CREATED)) {
                         return new BitbucketRepositoryUrl(targetProjectKey, targetRepoSlug);
                     }
+                    else {
+                        log.warn("Invalid response code from Bitbucket while trying to fork repository {}: {}", sourceRepositoryName, response.getStatusCode());
+                    }
                 }
                 catch (HttpServerErrorException.InternalServerError e) {
 
@@ -250,7 +256,7 @@ public class BitbucketService extends AbstractVersionControlService {
             throw new BitbucketException("Error while forking repository", emAll);
         }
 
-        return null;
+        throw new BitbucketException("Max retries for forking reached. Could not fork repository " + sourceRepositoryName + " to " + targetRepositoryName);
     }
 
     /**


### PR DESCRIPTION
### Description 
We currently return `null` in the `BitbucketService` after we tried to fork a repository more than `MAX_RETRIES` times. This can lead to a NPE, which is not very descriptive when trying to find the cause of the problem. 
We now throw an exception if the maximum number is reached and also log a warning with the response status and the body.