### PR TITLE
Display images on modeling submission help modal

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,7 @@
                   "tsConfig": "tsconfig.json",
                   "assets": [
                       "./src/main/webapp/favicon.ico",
-                      "./src/main/webapp/images/**.*"
+                      "./src/main/webapp/content"
                   ],
                   "styles": [
                       "src/main/webapp/content/scss/global.scss"

--- a/src/main/webapp/app/modeling-editor/modeling-editor.component.html
+++ b/src/main/webapp/app/modeling-editor/modeling-editor.component.html
@@ -11,7 +11,7 @@
                     <td jhiTranslate="artemisApp.modelingEditor.helpModal.createElement.text">
                         To add a class, simply drag and drop one of the elements on the right side into the editor area on the left side.
                     </td>
-                    <td><img width="300" src="../../content/images/help-create-element.png" /></td>
+                    <td><img width="300" src="/content/images/help-create-element.png" /></td>
                 </tr>
                 <tr>
                     <th jhiTranslate="artemisApp.modelingEditor.helpModal.createRelationship.title">Add Association</th>
@@ -19,14 +19,14 @@
                         To add an association, select the source class with a single click and you will see four blue circles. Those are the possible connection points for
                         associations. Click and hold on one of those and drag it to another blue circle to create an association.
                     </td>
-                    <td><img width="300" src="../../content/images/help-create-relationship.jpg" /></td>
+                    <td><img width="300" src="/content/images/help-create-relationship.jpg" /></td>
                 </tr>
                 <tr>
                     <th jhiTranslate="artemisApp.modelingEditor.helpModal.updateElement.title">Edit Class</th>
                     <td jhiTranslate="artemisApp.modelingEditor.helpModal.updateElement.text">
                         To edit a class, double click it and a popup will open up, in which you can edit its components, e.g. name, attributes, methods, etc.
                     </td>
-                    <td><img width="300" src="../../content/images/help-update-element.jpg" /></td>
+                    <td><img width="300" src="/content/images/help-update-element.jpg" /></td>
                 </tr>
                 <tr>
                     <th jhiTranslate="artemisApp.modelingEditor.helpModal.deleteElement.title">Delete Class</th>
@@ -39,21 +39,21 @@
                     <td jhiTranslate="artemisApp.modelingEditor.helpModal.moveElement.text">
                         To move a class, select it with a single click and either use your keyboard arrows or drag and drop it.
                     </td>
-                    <td><img width="300" src="../../content/images/help-move-element.jpg" /></td>
+                    <td><img width="300" src="/content/images/help-move-element.jpg" /></td>
                 </tr>
                 <tr>
                     <th jhiTranslate="artemisApp.modelingEditor.helpModal.resizeElement.title">Move Class</th>
                     <td jhiTranslate="artemisApp.modelingEditor.helpModal.resizeElement.text">
                         To move a class, select it with a single click and either use your keyboard arrows or drag and drop it.
                     </td>
-                    <td><img width="300" src="../../content/images/help-resize-element.jpg" /></td>
+                    <td><img width="300" src="/content/images/help-resize-element.jpg" /></td>
                 </tr>
                 <tr>
                     <th jhiTranslate="artemisApp.modelingEditor.helpModal.reconnectRelationship.title">Move Class</th>
                     <td jhiTranslate="artemisApp.modelingEditor.helpModal.reconnectRelationship.text">
                         To move a class, select it with a single click and either use your keyboard arrows or drag and drop it.
                     </td>
-                    <td><img width="300" src="../../content/images/help-reconnect-relationship.jpg" /></td>
+                    <td><img width="300" src="/content/images/help-reconnect-relationship.jpg" /></td>
                 </tr>
                 <tr>
                     <th jhiTranslate="artemisApp.modelingEditor.helpModal.select.title">Undo & Redo</th>


### PR DESCRIPTION
### Description
The help modal for the modeling exercises contains images, which were not properly displayed. The reason was a wrongly configured content assets folder in our `angular.json` and relative paths for the image locations.
Fixing the `angular.json` and using absolute paths fixes the problem.

Thanks @HanyaElhashemy for finding this bug