### PR TITLE
Remove deprecated build artifact column from Result

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Result.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Result.java
@@ -59,10 +59,6 @@ public class Result implements Serializable {
     @JsonView(QuizView.After.class)
     private Boolean successful;
 
-    @Column(name = "build_artifact")
-    @JsonView(QuizView.Before.class)
-    private Boolean buildArtifact;
-
     /**
      * Relative score in %
      */
@@ -200,19 +196,6 @@ public class Result implements Serializable {
 
     public void setSuccessful(Boolean successful) {
         this.successful = successful;
-    }
-
-    public Boolean isBuildArtifact() {
-        return buildArtifact;
-    }
-
-    public Result buildArtifact(Boolean buildArtifact) {
-        this.buildArtifact = buildArtifact;
-        return this;
-    }
-
-    public void setBuildArtifact(Boolean buildArtifact) {
-        this.buildArtifact = buildArtifact;
     }
 
     public Long getScore() {
@@ -548,9 +531,10 @@ public class Result implements Serializable {
 
     @Override
     public String toString() {
-        return "Result{" + "id=" + getId() + ", resultString='" + getResultString() + "'" + ", completionDate='" + getCompletionDate() + "'" + ", successful='" + isSuccessful()
-                + "'" + ", buildArtifact='" + isBuildArtifact() + "'" + ", score=" + getScore() + ", rated='" + isRated() + "'" + ", hasFeedback='" + getHasFeedback() + "'"
-                + ", hasComplaint='" + hasComplaint() + "'" + "}";
+        return "Result{" + "id=" + id + ", resultString='" + resultString + '\'' + ", completionDate=" + completionDate + ", successful=" + successful + ", score=" + score
+                + ", rated=" + rated + ", hasFeedback=" + hasFeedback + ", submission=" + submission + ", feedbacks=" + feedbacks + ", participation=" + participation
+                + ", assessor=" + assessor + ", assessmentType=" + assessmentType + ", hasComplaint=" + hasComplaint + ", exampleResult=" + exampleResult + ", submissionCount="
+                + submissionCount + '}';
     }
 
     /**

--- a/src/main/resources/config/liquibase/changelog/20200128141242_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20200128141242_changelog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <changeSet id="20200128141242" author="ungar">
+        <dropColumn tableName="result" columnName="build_artifact"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -43,4 +43,5 @@
     <include file="classpath:config/liquibase/changelog/20191215211735_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20200117211342_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20200117213324_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20200128141242_changelog.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>


### PR DESCRIPTION
### Description
This changelog removes the deprecated `buildArtifact` in the `Result` entity. The original migration happened in #1192 and this PR only performs the cleanup since all developers shoud have updated their database by now.