### PR TITLE
Fix due date condition and repository setup for external submissions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -262,6 +262,8 @@ public class ParticipationService {
             participation.setInitializationDate(ZonedDateTime.now());
             participation.setExercise(exercise);
             participation.setStudent(user);
+
+            participation = save(participation);
         }
         else {
             participation = optionalStudentParticipation.get();

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -259,6 +259,7 @@ public class ParticipationService {
             else {
                 participation = new StudentParticipation();
             }
+            participation.setInitializationState(UNINITIALIZED);
             participation.setInitializationDate(ZonedDateTime.now());
             participation.setExercise(exercise);
             participation.setStudent(user);

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -13,6 +13,7 @@
         "resultStringNull": "Fehler! Ein Ergebnis Text ist erforderlich.",
         "scoreNull": "Fehler! Eine Bewertung is erforderlich.",
         "submissionMissing": "Fehler! Die Abgabe ist nicht mehr mit dem Ergebnis verknüpft. Deine Änderungen wurden abgelehnt.",
+        "resultAlreadyExists": "Es existiert bereits ein Ergebnis für diesen Studenten für diese Übung.",
         "scoreAndSuccessfulNotMatching": "Fehler! Nur ein Ergebnise mit 100% kann erfolgreich sein.",
         "feedbackTextOrDetailTextNull": "Fehler! Wenn Feedback vorhanden ist, müssen der Feedback Text und die Feedback Details ausgefüllt werden.",
         "quizAlreadyVisible": "Das Quiz ist bereits sichtbar.",
@@ -21,7 +22,10 @@
         "quizAlreadyOpenForPractice": "Das Quiz ist bereits zur Übung geöffnet.",
         "unknownAction": "Diese Aktion kann nicht durchgeführt werden.",
         "groupNotFound": "Die von dir eingegebene Gruppe wurde nicht gefunden.",
+        "studentNotFound": "Der Student konnte in diesem Kurs nicht gefunden werden.",
         "cantSaveFile": "Die hochgeladene Datei {{ fileName }} konnte nicht gespeichert werden.",
-        "emptyFile": "Die hochgeladene Datei {{ fileName }} ist leer. Bitte überprüfe die Datei und versuche es erneut."
+        "emptyFile": "Die hochgeladene Datei {{ fileName }} ist leer. Bitte überprüfe die Datei und versuche es erneut.",
+        "externalSubmissionBeforeDueDate": "Externe Einreichungen können nur nach der Abgabefrist erstellt werden.",
+        "externalSubmissionForQuizExercise": "Externe Einreichungen können nicht für Quiz Übungen erstellt werden."
     }
 }

--- a/src/main/webapp/i18n/en/error.json
+++ b/src/main/webapp/i18n/en/error.json
@@ -13,6 +13,7 @@
         "resultStringNull": "Error! Result Text is required.",
         "scoreNull": "Error! Score is required.",
         "submissionMissing": "Error! The submission is not connected with the result any more. Your changes were rejected.",
+        "resultAlreadyExists": "A result already exists for this student in this exercise.",
         "scoreAndSuccessfulNotMatching": "Error! Only result with score 100% can be successful.",
         "feedbackTextOrDetailTextNull": "Error! In case feedback is present, feedback text and detail text are mandatory.",
         "quizAlreadyVisible": "The quiz is already visible.",
@@ -21,7 +22,10 @@
         "quizAlreadyOpenForPractice": "The quiz is already open for practice.",
         "unknownAction": "This action cannot be performed.",
         "groupNotFound": "The group you entered was not found.",
+        "studentNotFound": "The student could not be found in this course.",
         "cantSaveFile": "The uploaded file {{ fileName }} could not be saved.",
-        "emptyFile": "The uploaded file {{ fileName }} is empty. Please check the file and try again."
+        "emptyFile": "The uploaded file {{ fileName }} is empty. Please check the file and try again.",
+        "externalSubmissionBeforeDueDate": "External submissions are not supported before the exercise due date.",
+        "externalSubmissionForQuizExercise": "External submissions are not supported for Quiz exercises."
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I translated all the newly inserted strings into German and English

### Description
- Fix comparison of the current datetime and the exercise due date in `createResultForExternalSubmission` (parameters were swapped)
- Fix setup of repository by changing the sequence of preparing the participation (the participation needs a student before the repo is set up)
- Enhance the display of error messages so that the correct message is displayed in the alert box and is translated

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Click on Exercises for a Course
4. Click on View for different exercises
5. Click the yellow button "Add external submission"
