### PR TITLE
Hotfix/build plan links in lists

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/utils/build-plan-button.directive.ts
+++ b/src/main/webapp/app/entities/programming-exercise/utils/build-plan-button.directive.ts
@@ -6,10 +6,10 @@ import { createBuildPlanUrl } from 'app/entities/programming-exercise/utils/buil
 
 @Directive({ selector: 'button[jhiBuildPlanButton], jhi-button[jhiBuildPlanButton]' })
 export class BuildPlanButtonDirective implements OnInit {
-    @Input() projectKey: string;
-    @Input() buildPlanId: string;
-
-    private linkToBuildPlan: string;
+    private participationBuildPlanId: string;
+    private exerciseProjectKey: string;
+    private linkToBuildPlan: string | null;
+    private templateLink: string;
 
     constructor(private profileService: ProfileService) {}
 
@@ -19,7 +19,8 @@ export class BuildPlanButtonDirective implements OnInit {
             .pipe(
                 take(1),
                 tap((info: ProfileInfo) => {
-                    this.linkToBuildPlan = createBuildPlanUrl(info.buildPlanURLTemplate, this.projectKey, this.buildPlanId);
+                    this.templateLink = info.buildPlanURLTemplate;
+                    this.linkToBuildPlan = createBuildPlanUrl(this.templateLink, this.exerciseProjectKey, this.participationBuildPlanId);
                 }),
             )
             .subscribe();
@@ -27,6 +28,20 @@ export class BuildPlanButtonDirective implements OnInit {
 
     @HostListener('click')
     onClick() {
-        window.open(this.linkToBuildPlan);
+        if (this.linkToBuildPlan) {
+            window.open(this.linkToBuildPlan);
+        }
+    }
+
+    @Input()
+    set projectKey(key: string) {
+        this.exerciseProjectKey = key;
+        this.linkToBuildPlan = createBuildPlanUrl(this.templateLink, this.exerciseProjectKey, this.participationBuildPlanId);
+    }
+
+    @Input()
+    set buildPlanId(planId: string) {
+        this.participationBuildPlanId = planId;
+        this.linkToBuildPlan = createBuildPlanUrl(this.templateLink, this.exerciseProjectKey, this.participationBuildPlanId);
     }
 }

--- a/src/test/javascript/spec/component/programming-exercise/build-plan-link.directive.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/build-plan-link.directive.spec.ts
@@ -64,12 +64,18 @@ describe('BuildPlanLinkDirective', () => {
     });
 
     it('should inject the correct build plan URL', fakeAsync(() => {
+        const open = stub(window, 'open');
+        window.open = open;
+
         fixture.detectChanges();
         tick();
 
-        const linkEl = debugElement.query(By.css('a'));
-        expect(linkEl.attributes['href']).to.be.equal(correctBuildPlan);
-        expect(linkEl.attributes['target']).to.be.equal('_blank');
-        expect(linkEl.attributes['rel']).to.be.equal('noopener noreferrer');
+        const link = debugElement.query(By.css('a'));
+        link.triggerEventHandler('click', { preventDefault: () => {} });
+
+        fixture.detectChanges();
+        tick();
+
+        expect(open).to.be.calledOnce;
     }));
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Description
We had the problem, that build plan links/buttons did not route to the correct build plan (mainly in tables), or just routed to an `undefined` plan. This had two reasons:
1. Sorting a table did not update the directive for the row, which led to the old plan of the previous user in the row.
2. If the `ProfileService` returned the template link before the directive got the `projectKey` and/or `buildPlanId`, the plan led to `undefined` since we only updated the value in the `onInit` method.

### Changes
I now update the link on every change (template link, projectKey, buildPlanId). I also had to overwrite the `click` event of the anchor (`<a>`) links, because Angular's `@HostBinding` does not update the rendered HTML on changes. Because of that, we have to listen to the `click` event and have open the link on the window object manually.