### PR TITLE
Hide build plan link button if plan does not exist

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise/utils/build-plan-button.directive.ts
+++ b/src/main/webapp/app/entities/programming-exercise/utils/build-plan-button.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, HostListener, Input, OnInit } from '@angular/core';
+import { Directive, HostBinding, HostListener, Input, OnInit } from '@angular/core';
 import { ProfileService } from 'app/layouts/profiles/profile.service';
 import { take, tap } from 'rxjs/operators';
 import { ProfileInfo } from 'app/layouts';
@@ -6,9 +6,12 @@ import { createBuildPlanUrl } from 'app/entities/programming-exercise/utils/buil
 
 @Directive({ selector: 'button[jhiBuildPlanButton], jhi-button[jhiBuildPlanButton]' })
 export class BuildPlanButtonDirective implements OnInit {
+    @HostBinding('style.visibility')
+    visibility = 'hidden';
+
     private participationBuildPlanId: string;
     private exerciseProjectKey: string;
-    private linkToBuildPlan: string | null;
+    private buildPlanLink: string | null;
     private templateLink: string;
 
     constructor(private profileService: ProfileService) {}
@@ -28,9 +31,7 @@ export class BuildPlanButtonDirective implements OnInit {
 
     @HostListener('click')
     onClick() {
-        if (this.linkToBuildPlan) {
-            window.open(this.linkToBuildPlan);
-        }
+        window.open(this.buildPlanLink!);
     }
 
     @Input()
@@ -43,5 +44,10 @@ export class BuildPlanButtonDirective implements OnInit {
     set buildPlanId(planId: string) {
         this.participationBuildPlanId = planId;
         this.linkToBuildPlan = createBuildPlanUrl(this.templateLink, this.exerciseProjectKey, this.participationBuildPlanId);
+    }
+
+    set linkToBuildPlan(link: string | null) {
+        this.buildPlanLink = link;
+        this.visibility = link ? 'visible' : 'hidden';
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Description
We currently always show the build link button, even if there is no plan on the CIS, e.g. if the participation is inactive. 
I added a small check to the button directive, which hides the whole button, if there is no plan.
