### PR TITLE
Fix quiz route exercise ID params

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-management.route.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-management.route.ts
@@ -1,46 +1,10 @@
-import { Injectable } from '@angular/core';
-import { HttpResponse } from '@angular/common/http';
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot, Routes } from '@angular/router';
+import { Routes } from '@angular/router';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
-import { Observable } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
-import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
-import { QuizExerciseService } from './quiz-exercise.service';
 import { QuizExerciseComponent } from './quiz-exercise.component';
 import { QuizExerciseDetailComponent } from './quiz-exercise-detail.component';
 import { QuizExerciseExportComponent } from './quiz-exercise-export.component';
 import { PendingChangesGuard } from 'app/shared/guard/pending-changes.guard';
 import { QuizReEvaluateComponent } from 'app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.component';
-import { CourseManagementService } from '../../../course/manage/course-management.service';
-import { Course } from 'app/entities/course.model';
-
-@Injectable({ providedIn: 'root' })
-export class QuizExerciseResolve implements Resolve<QuizExercise> {
-    constructor(private quizExerciseService: QuizExerciseService, private courseService: CourseManagementService) {}
-
-    /**
-     * Resolves the route and initializes quiz exercise either from exerciseId (existing exercise) or
-     * from course id (new exercise)
-     * @param route
-     * @param state
-     */
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-        if (route.params['exerciseId']) {
-            return this.quizExerciseService.find(route.params['exerciseId']).pipe(
-                filter(res => !!res.body),
-                map((quizExercise: HttpResponse<QuizExercise>) => quizExercise.body!),
-            );
-        } else if (route.params['courseId']) {
-            return this.courseService.find(route.params['courseId']).pipe(
-                filter(res => !!res.body),
-                map((course: HttpResponse<Course>) => {
-                    return new QuizExercise(course.body!);
-                }),
-            );
-        }
-        return Observable.of(new QuizExercise());
-    }
-}
 
 export const quizManagementRoute: Routes = [
     {

--- a/src/main/webapp/app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.component.ts
@@ -48,7 +48,7 @@ export class QuizReEvaluateComponent implements OnInit, OnChanges, OnDestroy {
 
     ngOnInit(): void {
         this.subscription = this.route.params.subscribe(params => {
-            this.quizExerciseService.find(params['id']).subscribe((response: HttpResponse<QuizExercise>) => {
+            this.quizExerciseService.find(params['exerciseId']).subscribe((response: HttpResponse<QuizExercise>) => {
                 this.quizExercise = response.body!;
                 this.prepareEntity(this.quizExercise);
                 this.backupQuiz = JSON.parse(JSON.stringify(this.quizExercise));

--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts
@@ -127,7 +127,7 @@ export class QuizParticipationComponent implements OnInit, OnDestroy {
         this.subscriptionData = this.route.data.subscribe(data => {
             this.mode = data.mode;
             this.subscription = this.route.params.subscribe(params => {
-                this.quizId = params['id'];
+                this.quizId = params['exerciseId'];
                 // init according to mode
                 switch (this.mode) {
                     case 'practice':


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Our recent refactorings of the routes also changed the `id` param of all quiz routes to `exerciseId`. However, we update change the corresponding components if they fetched the ID from the `params` array of the route. 

### Description
<!-- Describe your changes in detail -->
If a quiz component tries to fetch the ID of an exercise, it now uses the correct value.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Start a quiz exercise
3. You should be able to participate without any errors