### PR TITLE
User resource test coverage

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -65,7 +65,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Page<User> findAllWithGroups(Pageable pageable);
 
     @Modifying
-    @Query("Update User user set user.lastNotificationRead = utc_timestamp where user.id = :#{#userId}")
+    @Query("Update User user set user.lastNotificationRead = current_timestamp() where user.id = :#{#userId}")
     void updateUserNotificationReadDate(@Param("userId") Long userId);
 
     @EntityGraph(attributePaths = { "groups" })

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserIntegrationTest.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.artemis.authentication;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -249,5 +250,13 @@ public class UserIntegrationTest extends AbstractSpringIntegrationTest {
         final String userLogin = "student1";
         UserDTO userDTO = request.get("/api/users/" + userLogin, HttpStatus.OK, UserDTO.class);
         assertThat(userDTO.getLogin()).isEqualTo(userLogin);
+    }
+
+    @Test
+    @WithMockUser(username = "student1", roles = "USER")
+    public void updateUserNotificationDate_asStudent_isSuccessful() throws Exception {
+        UserDTO userDTO = request.putWithResponseBody("/api/users/notification-date", null, UserDTO.class, HttpStatus.OK);
+        User userInDB = userRepository.findById(userDTO.getId()).get();
+        assertThat(userInDB.getLastNotificationRead()).isAfterOrEqualTo(ZonedDateTime.now().minusMinutes(1));
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserIntegrationTest.java
@@ -23,6 +23,7 @@ import de.tum.in.www1.artemis.repository.AuthorityRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.security.AuthoritiesConstants;
 import de.tum.in.www1.artemis.service.UserService;
+import de.tum.in.www1.artemis.service.dto.UserDTO;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 import de.tum.in.www1.artemis.web.rest.vm.ManagedUserVM;
@@ -54,9 +55,15 @@ public class UserIntegrationTest extends AbstractSpringIntegrationTest {
 
     private User student;
 
+    private final int numberOfStudents = 1;
+
+    private final int numberOfTutors = 1;
+
+    private final int numberOfInstructors = 1;
+
     @BeforeEach
     public void setUp() {
-        users = database.addUsers(1, 1, 1);
+        users = database.addUsers(numberOfStudents, numberOfTutors, numberOfInstructors);
         student = users.get(0);
         users.forEach(user -> cacheManager.getCache(UserRepository.USERS_CACHE).evict(user.getLogin()));
         jiraRequestMockProvider.enableMockingOfRequests();
@@ -197,5 +204,50 @@ public class UserIntegrationTest extends AbstractSpringIntegrationTest {
         request.delete("/api/users/" + student.getLogin(), HttpStatus.OK);
 
         verifyNoInteractions(versionControlService);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    public void getUsers_asAdmin_isSuccessful() throws Exception {
+        List<User> users = request.getList("/api/users", HttpStatus.OK, User.class);
+        assertThat(users).hasSize(numberOfStudents + numberOfTutors + numberOfInstructors + 1); // +1 for admin user himself
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    public void getAuthorities_asAdmin_isSuccessful() throws Exception {
+        List<String> authorities = request.getList("/api/users/authorities", HttpStatus.OK, String.class);
+        assertThat(authorities).isEqualTo(List.of("ROLE_ADMIN", "ROLE_INSTRUCTOR", "ROLE_TA", "ROLE_USER"));
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void getUsersOrAuthorities_asInstructor_forbidden() throws Exception {
+        getUsersOrAuthorities_forbidden();
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void getUsersOrAuthorities_asTutor_forbidden() throws Exception {
+        getUsersOrAuthorities_forbidden();
+    }
+
+    @Test
+    @WithMockUser(username = "student1", roles = "USER")
+    public void getUsersOrAuthorities_asStudent_forbidden() throws Exception {
+        getUsersOrAuthorities_forbidden();
+    }
+
+    private void getUsersOrAuthorities_forbidden() throws Exception {
+        request.getList("/api/users", HttpStatus.FORBIDDEN, User.class);
+        request.getList("/api/users/authorities", HttpStatus.FORBIDDEN, String.class);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    public void getUser_asAdmin_isSuccessful() throws Exception {
+        final String userLogin = "student1";
+        UserDTO userDTO = request.get("/api/users/" + userLogin, HttpStatus.OK, UserDTO.class);
+        assertThat(userDTO.getLogin()).isEqualTo(userLogin);
     }
 }


### PR DESCRIPTION
### Checklist
- [x] Server: I added multiple integration tests (Spring) related to the features

### Motivation and Context
This PR is part of the [initiative](https://confluence.ase.in.tum.de/display/ArTEMiS/Test+Coverage) to increase the test coverage for the REST controllers.

### Description
- Added tests for not yet covered methods in user resource
- Used current_timestamp instead of utc_timestamp when setting ZonedDateTime `lastNotificationRead`