### PR TITLE
No Mocking of Connector Services in Spring Tests

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/AbstractVersionControlService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/AbstractVersionControlService.java
@@ -51,7 +51,6 @@ public abstract class AbstractVersionControlService implements VersionControlSer
 
     @Override
     public void addWebHooksForExercise(ProgrammingExercise exercise) {
-        final var projectKey = exercise.getProjectKey();
         final var artemisTemplateHookPath = ARTEMIS_BASE_URL + PROGRAMMING_SUBMISSION_RESOURCE_API_PATH + exercise.getTemplateParticipation().getId();
         final var artemisSolutionHookPath = ARTEMIS_BASE_URL + PROGRAMMING_SUBMISSION_RESOURCE_API_PATH + exercise.getSolutionParticipation().getId();
         final var artemisTestsHookPath = ARTEMIS_BASE_URL + TEST_CASE_CHANGED_API_PATH + exercise.getId();

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
@@ -336,7 +336,6 @@ public class BambooService implements ContinuousIntegrationService {
     public void enablePlan(String projectKey, String planKey) throws BambooException {
         try {
             log.debug("Enable build plan " + planKey);
-            //TODO use REST API PUT "/rest/api/latest/clone/{projectKey}-{buildKey}"
             String message = bambooClient.getPlanHelper().enablePlan(planKey, true);
             log.info("Enable build plan " + planKey + " was successful. " + message);
         } catch (CliClient.ClientException | CliClient.RemoteRestException e) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
@@ -336,6 +336,7 @@ public class BambooService implements ContinuousIntegrationService {
     public void enablePlan(String projectKey, String planKey) throws BambooException {
         try {
             log.debug("Enable build plan " + planKey);
+            //TODO use REST API PUT "/rest/api/latest/clone/{projectKey}-{buildKey}"
             String message = bambooClient.getPlanHelper().enablePlan(planKey, true);
             log.info("Enable build plan " + planKey + " was successful. " + message);
         } catch (CliClient.ClientException | CliClient.RemoteRestException e) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -686,7 +686,7 @@ public class BitbucketService extends AbstractVersionControlService {
      * @param repositorySlug The repository's slug.
      */
     private void deleteRepositoryImpl(String projectKey, String repositorySlug) {
-        String baseUrl = BITBUCKET_SERVER_URL + "/rest/api/1.0/projects/" + projectKey + "/repos/" + repositorySlug;
+        String baseUrl = BITBUCKET_SERVER_URL + "/rest/api/1.0/projects/" + projectKey + "/repos/" + repositorySlug.toLowerCase();
         log.info("Delete repository " + baseUrl);
         HttpHeaders headers = HeaderUtil.createAuthorization(BITBUCKET_USER, BITBUCKET_PASSWORD);
         HttpEntity<?> entity = new HttpEntity<>(headers);

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
@@ -25,9 +25,11 @@ public abstract class AbstractSpringIntegrationTest {
     @SpyBean
     protected LtiService ltiService;
 
+    // please only use this to verify method calls using Mockito. Do not mock methods, instead mock the communication with Bamboo using the corresponding RestTemplate.
     @SpyBean
     protected BambooService continuousIntegrationService;
 
+    // please only use this to verify method calls using Mockito. Do not mock methods, instead mock the communication with Bitbucket using the corresponding RestTemplate.
     @SpyBean
     protected BitbucketService versionControlService;
 

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationTest.java
@@ -25,11 +25,9 @@ public abstract class AbstractSpringIntegrationTest {
     @SpyBean
     protected LtiService ltiService;
 
-    // TODO: we should not really mock BambooService, but only the API calls to Bamboo (e.g. based on the used RestTemplate)
     @SpyBean
     protected BambooService continuousIntegrationService;
 
-    // TODO: we should not really mock BitbucketService, but only the API calls to Bitbucket (e.g. based on the used RestTemplate)
     @SpyBean
     protected BitbucketService versionControlService;
 

--- a/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
@@ -33,6 +33,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.appfire.bamboo.cli.BambooClient;
 import com.appfire.bamboo.cli.helpers.PlanHelper;
+import com.appfire.bamboo.cli.helpers.ProjectHelper;
 import com.appfire.bamboo.cli.helpers.RepositoryHelper;
 import com.appfire.bamboo.cli.helpers.TriggerHelper;
 import com.appfire.bamboo.cli.objects.RemoteRepository;
@@ -61,6 +62,9 @@ public class BambooRequestMockProvider {
 
     @Mock
     private TriggerHelper triggerHelper;
+
+    @Mock
+    private ProjectHelper projectHelper;
 
     @Value("${artemis.continuous-integration.url}")
     private URL BAMBOO_SERVER_URL;
@@ -313,5 +317,15 @@ public class BambooRequestMockProvider {
         doReturn("foobar").when(planHelper).enablePlan(planKey, true);
 
         return () -> verify(planHelper, times(1)).enablePlan(eq(planKey), eq(true));
+    }
+
+    public Verifiable mockDeleteProject(String projectKey) throws CliClient.RemoteRestException, CliClient.ClientException {
+        doReturn("foobar").when(projectHelper).deleteProject(projectKey);
+        return () -> verify(projectHelper).deleteProject(projectKey);
+    }
+
+    public Verifiable mockDeletePlan(String planKey) throws CliClient.RemoteRestException, CliClient.ClientException {
+        doReturn("foobar").when(planHelper).deletePlan(planKey);
+        return () -> verify(planHelper).deletePlan(planKey);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
@@ -34,6 +34,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import com.appfire.bamboo.cli.BambooClient;
 import com.appfire.bamboo.cli.helpers.PlanHelper;
 import com.appfire.bamboo.cli.helpers.RepositoryHelper;
+import com.appfire.bamboo.cli.helpers.TriggerHelper;
 import com.appfire.bamboo.cli.objects.RemoteRepository;
 import com.appfire.common.cli.CliClient;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -57,6 +58,9 @@ public class BambooRequestMockProvider {
 
     @Mock
     private RepositoryHelper repositoryHelper;
+
+    @Mock
+    private TriggerHelper triggerHelper;
 
     @Value("${artemis.continuous-integration.url}")
     private URL BAMBOO_SERVER_URL;
@@ -154,23 +158,50 @@ public class BambooRequestMockProvider {
 
     public List<Verifiable> mockUpdatePlanRepositoryForParticipation(ProgrammingExercise exercise, String username)
             throws CliClient.RemoteRestException, CliClient.ClientException {
-        final var verifications = new LinkedList<Verifiable>();
         final var projectKey = exercise.getProjectKey();
         final var bambooRepoName = Constants.ASSIGNMENT_REPO_NAME;
-        final var planKey = (projectKey + "-" + username).toUpperCase();
-        final var repositoryResponse = new RemoteRepository(null, null, "testName");
         final var bitbucketRepoName = projectKey.toLowerCase() + "-" + username;
 
-        when(repositoryHelper.getRemoteRepository(anyString(), anyString(), anyBoolean())).thenReturn(repositoryResponse);
+        return mockUpdatePlanRepository(exercise, username, bambooRepoName, bitbucketRepoName, List.of());
+    }
+
+    public List<Verifiable> mockUpdatePlanRepository(ProgrammingExercise exercise, String planName, String bambooRepoName, String bitbucketRepoName, List<String> triggeredBy)
+            throws CliClient.RemoteRestException, CliClient.ClientException {
+        final var verifications = new LinkedList<Verifiable>();
+        final var projectKey = exercise.getProjectKey();
+        final var planKey = (projectKey + "-" + planName).toUpperCase();
+        final var repositoryResponse = new RemoteRepository(null, null, "testName");
+
+        when(repositoryHelper.getRemoteRepository(bambooRepoName, planKey, false)).thenReturn(repositoryResponse);
         verifications.add(() -> verify(repositoryHelper, times(1)).getRemoteRepository(bambooRepoName, planKey, false));
 
-        doNothing().when(bambooBuildPlanUpdateProvider).updateRepository(repositoryResponse, bitbucketRepoName, projectKey.toUpperCase(), planKey);
+        doNothing().when(bambooBuildPlanUpdateProvider).updateRepository(any(), eq(bitbucketRepoName), eq(projectKey.toUpperCase()), eq(planKey));
+
+        if (!triggeredBy.isEmpty()) {
+            // Bamboo specific format for the used CLI dependency. Nothing we can improve here
+            final var oldTriggers = "foo,123,artemis\nbar,456,artemis";
+            doReturn(oldTriggers).when(triggerHelper).getTriggerList(anyString(), isNull(), isNull(), anyInt(), any());
+            doReturn("foobar").when(triggerHelper).removeTrigger(planKey, null, null, 123L, null, false);
+            doReturn("foobar").when(triggerHelper).removeTrigger(planKey, null, null, 456L, null, false);
+            verifications.add(() -> {
+                verify(triggerHelper).removeTrigger(planKey, null, null, 123L, null, false);
+                verify(triggerHelper).removeTrigger(planKey, null, null, 456L, null, false);
+            });
+            for (final var repo : triggeredBy) {
+                doReturn("foobar").when(triggerHelper).addTrigger(planKey, null, "remoteBitbucketServer", null, null, repo, null, null, false);
+                verifications.add(() -> verify(triggerHelper).addTrigger(planKey, null, "remoteBitbucketServer", null, null, repo, null, null, false));
+            }
+        }
 
         return verifications;
     }
 
     public void mockTriggerBuild(ProgrammingExerciseParticipation participation) throws URISyntaxException {
         final var buildPlan = participation.getBuildPlanId();
+        mockTriggerBuild(buildPlan);
+    }
+
+    public void mockTriggerBuild(String buildPlan) throws URISyntaxException {
         final var triggerBuildPath = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/queue/").pathSegment(buildPlan).build().toUri();
 
         mockServer.expect(requestTo(triggerBuildPath)).andExpect(method(HttpMethod.POST)).andRespond(withStatus(HttpStatus.OK));

--- a/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
@@ -267,4 +267,20 @@ public class BambooRequestMockProvider {
 
         mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(isValid ? HttpStatus.OK : HttpStatus.BAD_REQUEST));
     }
+
+    public Verifiable mockCopyBuildPlan(String sourceProjectKey, String sourcePlanName, String targetProjectKey, String targetPlanName)
+            throws CliClient.RemoteRestException, CliClient.ClientException {
+        final var targetPlanKey = targetProjectKey + "-" + targetPlanName;
+        final var sourcePlanKey = sourceProjectKey + "-" + sourcePlanName;
+        doReturn(targetPlanKey).when(planHelper).clonePlan(eq(sourcePlanKey), eq(targetPlanKey), eq(targetPlanName), eq(""), anyString(), eq(true));
+
+        return () -> verify(planHelper, times(1)).clonePlan(eq(sourcePlanKey), eq(targetPlanKey), eq(targetPlanName), eq(""), anyString(), eq(true));
+    }
+
+    public Verifiable mockEnablePlan(String projectKey, String planName) throws CliClient.RemoteRestException, CliClient.ClientException {
+        final var planKey = projectKey + "-" + planName;
+        doReturn("foobar").when(planHelper).enablePlan(planKey, true);
+
+        return () -> verify(planHelper, times(1)).enablePlan(eq(planKey), eq(true));
+    }
 }

--- a/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
@@ -210,4 +210,12 @@ public class BitbucketRequestMockProvider {
 
         mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(HttpStatus.OK));
     }
+
+    public void mockSetRepositoryPermissionsToReadOnly(String projectKey, String username) throws URISyntaxException {
+        final var uri = UriComponentsBuilder.fromUri(BITBUCKET_SERVER_URL.toURI()).path("/rest/api/1.0/projects").pathSegment(projectKey).path("repos")
+                .pathSegment((projectKey + "-" + username).toLowerCase()).path("permissions/users").queryParam("name", username).queryParam("permission", "REPO_READ").build()
+                .toUri();
+
+        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.PUT)).andRespond(withStatus(HttpStatus.OK));
+    }
 }

--- a/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
@@ -110,9 +110,17 @@ public class BitbucketRequestMockProvider {
         final var projectKey = exercise.getProjectKey();
         final var templateRepoName = exercise.getProjectKey().toLowerCase() + "-" + RepositoryType.TEMPLATE.getName();
         final var clonedRepoName = projectKey.toLowerCase() + "-" + username.toLowerCase();
-        final var copyRepoPath = UriComponentsBuilder.fromUri(BITBUCKET_SERVER_URL.toURI()).path("/rest/api/1.0/projects/").pathSegment(projectKey).path("/repos/")
-                .pathSegment(templateRepoName).build().toUri();
-        final var cloneBody = new BitbucketCloneDTO(clonedRepoName, new BitbucketCloneDTO.CloneDetailsDTO(projectKey));
+
+        mockCopyRepository(projectKey, projectKey, templateRepoName, clonedRepoName);
+    }
+
+    public void mockCopyRepository(String sourceProjectKey, String targetProjectKey, String sourceRepoName, String targetRepoName)
+            throws JsonProcessingException, URISyntaxException {
+        sourceRepoName = sourceRepoName.toLowerCase();
+        targetRepoName = targetRepoName.toLowerCase();
+        final var copyRepoPath = UriComponentsBuilder.fromUri(BITBUCKET_SERVER_URL.toURI()).path("/rest/api/1.0/projects/").pathSegment(sourceProjectKey).path("/repos/")
+                .pathSegment(sourceRepoName).build().toUri();
+        final var cloneBody = new BitbucketCloneDTO(targetRepoName, new BitbucketCloneDTO.CloneDetailsDTO(targetProjectKey));
 
         mockServer.expect(requestTo(copyRepoPath)).andExpect(method(HttpMethod.POST)).andExpect(content().json(mapper.writeValueAsString(cloneBody)))
                 .andRespond(withStatus(HttpStatus.CREATED));

--- a/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
@@ -172,4 +172,21 @@ public class BitbucketRequestMockProvider {
         mockServer.expect(requestTo(uniqueUri)).andExpect(method(HttpMethod.GET))
                 .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(searchResults)));
     }
+
+    public void mockGetExistingWebhooks(String projectKey, String repositoryName) throws URISyntaxException {
+        final var uri = UriComponentsBuilder.fromUri(BITBUCKET_SERVER_URL.toURI()).path("/rest/api/1.0/projects").pathSegment(projectKey).path("repos").pathSegment(repositoryName)
+                .path("webhooks").build().toUri();
+        final var existingHooks = "{\"values\": []}";
+
+        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).body(existingHooks).contentType(MediaType.APPLICATION_JSON));
+    }
+
+    public void mockAddWebhook(String projectKey, String repositoryName, String url) throws JsonProcessingException, URISyntaxException {
+        final var uri = UriComponentsBuilder.fromUri(BITBUCKET_SERVER_URL.toURI()).path("/rest/api/1.0/projects").pathSegment(projectKey).path("repos").pathSegment(repositoryName)
+                .path("webhooks").build().toUri();
+        final var body = Map.of("name", "Artemis WebHook", "url", url, "events", List.of("repo:refs_changed"));
+
+        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.POST)).andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(mapper.writeValueAsString(body))).andRespond(withStatus(HttpStatus.OK));
+    }
 }

--- a/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
@@ -189,4 +189,17 @@ public class BitbucketRequestMockProvider {
         mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.POST)).andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(mapper.writeValueAsString(body))).andRespond(withStatus(HttpStatus.OK));
     }
+
+    public void mockDeleteProject(String projectKey) throws URISyntaxException {
+        final var uri = UriComponentsBuilder.fromUri(BITBUCKET_SERVER_URL.toURI()).path("/rest/api/1.0/projects").pathSegment(projectKey).build().toUri();
+
+        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(HttpStatus.OK));
+    }
+
+    public void mockDeleteRepository(String projectKey, String repositoryName) throws URISyntaxException {
+        final var uri = UriComponentsBuilder.fromUri(BITBUCKET_SERVER_URL.toURI()).path("/rest/api/1.0/projects").pathSegment(projectKey).path("repos").pathSegment(repositoryName)
+                .build().toUri();
+
+        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(HttpStatus.OK));
+    }
 }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -35,6 +35,7 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationTest;
 import de.tum.in.www1.artemis.connector.bamboo.BambooRequestMockProvider;
 import de.tum.in.www1.artemis.connector.bitbucket.BitbucketRequestMockProvider;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.enumeration.RepositoryType;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
@@ -104,8 +105,7 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
         doNothing().when(gitService).commitAndPush(any(), anyString(), any());
 
         bambooRequestMockProvider.enableMockingOfRequests();
-        doNothing().when(versionControlService).deleteRepository(any(URL.class));
-        doNothing().when(versionControlService).deleteProject(anyString());
+        bitbucketRequestMockProvider.enableMockingOfRequests();
     }
 
     @AfterEach
@@ -214,10 +214,14 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
         params.add("deleteStudentReposBuildPlans", "true");
         params.add("deleteBaseReposBuildPlans", "true");
 
-        verifiables.add(bambooRequestMockProvider.mockDeleteProject(programmingExercise.getProjectKey()));
+        verifiables.add(bambooRequestMockProvider.mockDeleteProject(projectKey));
         for (final var planName : List.of("student1", "student2", TEMPLATE.getName(), SOLUTION.getName())) {
             verifiables.add(bambooRequestMockProvider.mockDeletePlan(projectKey + "-" + planName.toUpperCase()));
         }
+        for (final var repoName : List.of("student1", "student2", RepositoryType.TEMPLATE.getName(), RepositoryType.SOLUTION.getName(), RepositoryType.TESTS.getName())) {
+            bitbucketRequestMockProvider.mockDeleteRepository(projectKey, (projectKey + "-" + repoName).toLowerCase());
+        }
+        bitbucketRequestMockProvider.mockDeleteProject(projectKey);
 
         request.delete(path, HttpStatus.OK, params);
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.programmingexercise;
 
+import static de.tum.in.www1.artemis.domain.enumeration.BuildPlanType.SOLUTION;
+import static de.tum.in.www1.artemis.domain.enumeration.BuildPlanType.TEMPLATE;
 import static de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResource.Endpoints.*;
 import static de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResource.ErrorKeys.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,6 +15,8 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.ZonedDateTime;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
@@ -36,6 +40,7 @@ import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
+import de.tum.in.www1.artemis.util.Verifiable;
 import de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResource.Endpoints;
 import de.tum.in.www1.artemis.web.rest.dto.RepositoryExportOptionsDTO;
 import de.tum.in.www1.artemis.web.websocket.dto.ProgrammingExerciseTestCaseStateDTO;
@@ -98,8 +103,7 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
         doNothing().when(gitService).pullIgnoreConflicts(any());
         doNothing().when(gitService).commitAndPush(any(), anyString(), any());
 
-        doNothing().when(continuousIntegrationService).deleteBuildPlan(anyString(), anyString());
-        doNothing().when(continuousIntegrationService).deleteProject(anyString());
+        bambooRequestMockProvider.enableMockingOfRequests();
         doNothing().when(versionControlService).deleteRepository(any(URL.class));
         doNothing().when(versionControlService).deleteProject(anyString());
     }
@@ -203,11 +207,23 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete() throws Exception {
+        final var verifiables = new LinkedList<Verifiable>();
+        final var projectKey = programmingExercise.getProjectKey();
         final var path = Endpoints.ROOT + Endpoints.PROGRAMMING_EXERCISE.replace("{exerciseId}", "" + programmingExercise.getId());
         var params = new LinkedMultiValueMap<String, String>();
         params.add("deleteStudentReposBuildPlans", "true");
         params.add("deleteBaseReposBuildPlans", "true");
+
+        verifiables.add(bambooRequestMockProvider.mockDeleteProject(programmingExercise.getProjectKey()));
+        for (final var planName : List.of("student1", "student2", TEMPLATE.getName(), SOLUTION.getName())) {
+            verifiables.add(bambooRequestMockProvider.mockDeletePlan(projectKey + "-" + planName.toUpperCase()));
+        }
+
         request.delete(path, HttpStatus.OK, params);
+
+        for (final var verifiable : verifiables) {
+            verifiable.performVerification();
+        }
     }
 
     @Test
@@ -262,7 +278,6 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidTemplateBuildPlan_badRequest() throws Exception {
         database.addTemplateParticipationForProgrammingExercise(programmingExercise);
-        bambooRequestMockProvider.enableMockingOfRequests();
         bambooRequestMockProvider.mockBuildPlanIsValid(programmingExercise.getTemplateBuildPlanId(), false);
 
         request.putAndExpectError(ROOT + PROGRAMMING_EXERCISES, programmingExercise, HttpStatus.BAD_REQUEST, INVALID_TEMPLATE_BUILD_PLAN_ID);
@@ -272,7 +287,6 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidTemplateVcs_badRequest() throws Exception {
         database.addTemplateParticipationForProgrammingExercise(programmingExercise);
-        bambooRequestMockProvider.enableMockingOfRequests();
         bitbucketRequestMockProvider.enableMockingOfRequests();
         bambooRequestMockProvider.mockBuildPlanIsValid(programmingExercise.getTemplateBuildPlanId(), true);
         bitbucketRequestMockProvider.mockRepositoryUrlIsValid(programmingExercise.getTemplateRepositoryUrlAsUrl(), programmingExercise.getProjectKey(), false);
@@ -285,7 +299,6 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
     public void updateProgrammingExercise_invalidSolutionBuildPlan_badRequest() throws Exception {
         database.addTemplateParticipationForProgrammingExercise(programmingExercise);
         database.addSolutionParticipationForProgrammingExercise(programmingExercise);
-        bambooRequestMockProvider.enableMockingOfRequests();
         bitbucketRequestMockProvider.enableMockingOfRequests();
         bambooRequestMockProvider.mockBuildPlanIsValid(programmingExercise.getTemplateBuildPlanId(), true);
         bitbucketRequestMockProvider.mockRepositoryUrlIsValid(programmingExercise.getTemplateRepositoryUrlAsUrl(), programmingExercise.getProjectKey(), true);
@@ -299,7 +312,6 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationTest {
     public void updateProgrammingExercisei_invalidSolutionRepository_badRequest() throws Exception {
         database.addTemplateParticipationForProgrammingExercise(programmingExercise);
         database.addSolutionParticipationForProgrammingExercise(programmingExercise);
-        bambooRequestMockProvider.enableMockingOfRequests();
         bitbucketRequestMockProvider.enableMockingOfRequests();
         bambooRequestMockProvider.mockBuildPlanIsValid(programmingExercise.getTemplateBuildPlanId(), true);
         bambooRequestMockProvider.mockBuildPlanIsValid(programmingExercise.getSolutionBuildPlanId(), true);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationTest;
+import de.tum.in.www1.artemis.connector.bamboo.BambooRequestMockProvider;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
@@ -29,6 +30,9 @@ class ProgrammingExerciseTest extends AbstractSpringIntegrationTest {
     @Autowired
     ProgrammingExerciseRepository programmingExerciseRepository;
 
+    @Autowired
+    private BambooRequestMockProvider bambooRequestMockProvider;
+
     Long programmingExerciseId;
 
     @BeforeEach
@@ -44,11 +48,13 @@ class ProgrammingExerciseTest extends AbstractSpringIntegrationTest {
     }
 
     void updateProgrammingExercise(ProgrammingExercise programmingExercise, String newProblem, String newTitle) throws Exception {
+        bambooRequestMockProvider.enableMockingOfRequests();
         programmingExercise.setProblemStatement(newProblem);
         programmingExercise.setTitle(newTitle);
-        doReturn(true).when(continuousIntegrationService).buildPlanIdIsValid(programmingExercise.getProjectKey(), programmingExercise.getTemplateBuildPlanId());
+
+        bambooRequestMockProvider.mockBuildPlanIsValid(programmingExercise.getTemplateBuildPlanId(), true);
+        bambooRequestMockProvider.mockBuildPlanIsValid(programmingExercise.getSolutionBuildPlanId(), true);
         doReturn(true).when(versionControlService).repositoryUrlIsValid(programmingExercise.getTemplateRepositoryUrlAsUrl());
-        doReturn(true).when(continuousIntegrationService).buildPlanIdIsValid(programmingExercise.getProjectKey(), programmingExercise.getSolutionBuildPlanId());
         doReturn(true).when(versionControlService).repositoryUrlIsValid(programmingExercise.getSolutionRepositoryUrlAsUrl());
 
         ProgrammingExercise updatedProgrammingExercise = request.putWithResponseBody("/api/programming-exercises", programmingExercise, ProgrammingExercise.class, HttpStatus.OK);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTest.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.programmingexercise;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +12,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationTest;
 import de.tum.in.www1.artemis.connector.bamboo.BambooRequestMockProvider;
+import de.tum.in.www1.artemis.connector.bitbucket.BitbucketRequestMockProvider;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
@@ -33,6 +33,9 @@ class ProgrammingExerciseTest extends AbstractSpringIntegrationTest {
     @Autowired
     private BambooRequestMockProvider bambooRequestMockProvider;
 
+    @Autowired
+    private BitbucketRequestMockProvider bitbucketRequestMockProvider;
+
     Long programmingExerciseId;
 
     @BeforeEach
@@ -49,13 +52,14 @@ class ProgrammingExerciseTest extends AbstractSpringIntegrationTest {
 
     void updateProgrammingExercise(ProgrammingExercise programmingExercise, String newProblem, String newTitle) throws Exception {
         bambooRequestMockProvider.enableMockingOfRequests();
+        bitbucketRequestMockProvider.enableMockingOfRequests();
         programmingExercise.setProblemStatement(newProblem);
         programmingExercise.setTitle(newTitle);
 
         bambooRequestMockProvider.mockBuildPlanIsValid(programmingExercise.getTemplateBuildPlanId(), true);
         bambooRequestMockProvider.mockBuildPlanIsValid(programmingExercise.getSolutionBuildPlanId(), true);
-        doReturn(true).when(versionControlService).repositoryUrlIsValid(programmingExercise.getTemplateRepositoryUrlAsUrl());
-        doReturn(true).when(versionControlService).repositoryUrlIsValid(programmingExercise.getSolutionRepositoryUrlAsUrl());
+        bitbucketRequestMockProvider.mockRepositoryUrlIsValid(programmingExercise.getTemplateRepositoryUrlAsUrl(), programmingExercise.getProjectKey(), true);
+        bitbucketRequestMockProvider.mockRepositoryUrlIsValid(programmingExercise.getSolutionRepositoryUrlAsUrl(), programmingExercise.getProjectKey(), true);
 
         ProgrammingExercise updatedProgrammingExercise = request.putWithResponseBody("/api/programming-exercises", programmingExercise, ProgrammingExercise.class, HttpStatus.OK);
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestCaseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestCaseServiceTest.java
@@ -22,7 +22,6 @@ import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.connector.bamboo.BambooRequestMockProvider;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
-import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingSubmissionRepository;
@@ -140,7 +139,6 @@ public class ProgrammingExerciseTestCaseServiceTest extends AbstractSpringIntegr
         List<ProgrammingSubmission> submissions = programmingSubmissionRepository.findAll();
         assertThat(submissions).hasSize(1);
         assertThat(submissions.get(0).getCommitHash()).isEqualTo(dummyHash);
-        verify(continuousIntegrationService, times(1)).triggerBuild(ArgumentMatchers.any(SolutionProgrammingExerciseParticipation.class));
     }
 
     @Test
@@ -175,7 +173,6 @@ public class ProgrammingExerciseTestCaseServiceTest extends AbstractSpringIntegr
         List<ProgrammingSubmission> submissions = programmingSubmissionRepository.findAll();
         assertThat(submissions).hasSize(1);
         assertThat(submissions.get(0).getCommitHash()).isEqualTo(dummyHash);
-        verify(continuousIntegrationService, times(1)).triggerBuild(ArgumentMatchers.any(SolutionProgrammingExerciseParticipation.class));
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionAndResultIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionAndResultIntegrationTest.java
@@ -4,7 +4,6 @@ import static de.tum.in.www1.artemis.config.Constants.*;
 import static de.tum.in.www1.artemis.constants.ProgrammingSubmissionConstants.*;
 import static de.tum.in.www1.artemis.util.TestConstants.COMMIT_HASH_OBJECT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
 import java.net.URL;
@@ -109,7 +108,6 @@ class ProgrammingSubmissionAndResultIntegrationTest extends AbstractSpringIntegr
 
     @BeforeEach
     void setUp() {
-        doReturn(true).when(continuousIntegrationService).isBuildPlanEnabled(anyString(), anyString());
         bambooRequestMockProvider.enableMockingOfRequests();
 
         database.addUsers(3, 2, 2);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
@@ -88,9 +88,11 @@ public class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrat
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     void triggerBuildStudent() throws Exception {
+        bambooRequestMockProvider.enableMockingOfRequests();
         doReturn(COMMIT_HASH_OBJECT_ID).when(gitService).getLastCommitHash(any());
         String login = "student1";
         StudentParticipation participation = database.addStudentParticipationForProgrammingExercise(exercise, login);
+        bambooRequestMockProvider.mockTriggerBuild((ProgrammingExerciseParticipation) participation);
         request.postWithoutLocation("/api/programming-submissions/" + participation.getId() + "/trigger-build", null, HttpStatus.OK, new HttpHeaders());
 
         List<ProgrammingSubmission> submissions = submissionRepository.findAll();
@@ -105,9 +107,11 @@ public class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrat
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void triggerBuildInstructor() throws Exception {
+        bambooRequestMockProvider.enableMockingOfRequests();
         doReturn(COMMIT_HASH_OBJECT_ID).when(gitService).getLastCommitHash(any());
         String login = "student1";
         StudentParticipation participation = database.addStudentParticipationForProgrammingExercise(exercise, login);
+        bambooRequestMockProvider.mockTriggerBuild((ProgrammingExerciseParticipation) participation);
         request.postWithoutLocation("/api/programming-submissions/" + participation.getId() + "/trigger-build?submissionType=INSTRUCTOR", null, HttpStatus.OK, new HttpHeaders());
 
         List<ProgrammingSubmission> submissions = submissionRepository.findAll();

--- a/src/test/java/de/tum/in/www1/artemis/service/ProgrammingExerciseScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ProgrammingExerciseScheduleServiceTest.java
@@ -3,11 +3,12 @@ package de.tum.in.www1.artemis.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import org.apache.http.HttpException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationTest;
+import de.tum.in.www1.artemis.connector.bitbucket.BitbucketRequestMockProvider;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
@@ -42,6 +44,9 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationTe
     @Autowired
     TimeService timeService;
 
+    @Autowired
+    private BitbucketRequestMockProvider bitbucketRequestMockProvider;
+
     private ProgrammingExercise programmingExercise;
 
     // When the scheduler is invoked, there is a small delay until the runnable is called.
@@ -49,8 +54,8 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationTe
     private final long SCHEDULER_TASK_TRIGGER_DELAY_MS = 1200;
 
     @BeforeEach
-    void init() throws HttpException {
-        doNothing().when(versionControlService).setRepositoryPermissionsToReadOnly(any(), any(), any());
+    void init() {
+        bitbucketRequestMockProvider.enableMockingOfRequests();
         doReturn(ObjectId.fromString("fffb09455885349da6e19d3ad7fd9c3404c5a0df")).when(gitService).getLastCommitHash(any());
 
         database.addUsers(2, 2, 2);
@@ -68,7 +73,6 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationTe
     }
 
     private void verifyLockStudentRepositoryOperation(boolean wasCalled) {
-
         int callCount = wasCalled ? 1 : 0;
         Set<StudentParticipation> studentParticipations = programmingExercise.getStudentParticipations();
         for (StudentParticipation studentParticipation : studentParticipations) {
@@ -80,8 +84,15 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationTe
         }
     }
 
+    private void mockStudentRepoLocks() throws URISyntaxException {
+        for (final var login : programmingExercise.getStudentParticipations().stream().map(p -> p.getStudent().getLogin()).collect(Collectors.toList())) {
+            bitbucketRequestMockProvider.mockSetRepositoryPermissionsToReadOnly(programmingExercise.getProjectKey(), login);
+        }
+    }
+
     @Test
     void shouldExecuteScheduledBuildAndTestAfterDueDate() throws Exception {
+        mockStudentRepoLocks();
         long delayMS = 800;
         final var dueDateDelayMS = 200;
         programmingExercise.setDueDate(ZonedDateTime.now().plus(dueDateDelayMS / 2, ChronoUnit.MILLIS));
@@ -122,6 +133,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationTe
 
     @Test
     void shouldNotExecuteScheduledTwiceIfSameExercise() throws Exception {
+        mockStudentRepoLocks();
         long delayMS = 100; // 100 ms.
         programmingExercise.setDueDate(ZonedDateTime.now().plusNanos(timeService.milliSecondsToNanoSeconds(delayMS / 2)));
         // Setting it the first time.
@@ -158,6 +170,7 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationTe
 
     @Test
     void shouldScheduleExercisesWithBuildAndTestDateInFuture() throws Exception {
+        mockStudentRepoLocks();
         long delayMS = 200;
         programmingExercise.setDueDate(ZonedDateTime.now().plusNanos(timeService.milliSecondsToNanoSeconds(delayMS / 2)));
         programmingExercise.setBuildAndTestStudentSubmissionsAfterDueDate(ZonedDateTime.now().plusNanos(timeService.milliSecondsToNanoSeconds(delayMS)));

--- a/src/test/java/de/tum/in/www1/artemis/service/ProgrammingExerciseScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ProgrammingExerciseScheduleServiceTest.java
@@ -1,10 +1,7 @@
 package de.tum.in.www1.artemis.service;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -53,8 +50,6 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationTe
 
     @BeforeEach
     void init() throws HttpException {
-
-        doNothing().when(continuousIntegrationService).triggerBuild(any());
         doNothing().when(versionControlService).setRepositoryPermissionsToReadOnly(any(), any(), any());
         doReturn(ObjectId.fromString("fffb09455885349da6e19d3ad7fd9c3404c5a0df")).when(gitService).getLastCommitHash(any());
 

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -631,7 +631,7 @@ public class DatabaseUtilService {
         programmingExercise.setDueDate(ZonedDateTime.now().plusDays(2));
         programmingExercise.setAssessmentDueDate(ZonedDateTime.now().plusDays(3));
         programmingExercise.setCategories(new HashSet<>(Set.of("cat1", "cat2")));
-        programmingExercise.setTestRepositoryUrl("http://nadnasidni.sgiinssdgdg-tests.git");
+        programmingExercise.setTestRepositoryUrl("http://nadnasidni.tum/scm/" + programmingExercise.getProjectKey() + "/" + programmingExercise.getProjectKey() + "-tests.git");
         programmingExercise.setPresentationScoreEnabled(course.getPresentationScore() != 0);
 
         programmingExercise = programmingExerciseRepository.save(programmingExercise);


### PR DESCRIPTION
### Description 
This PR removes all mocked connector (Bamboo, Bitbucket) methods and instead only mocks the actual request to the external service. I left one mock for the `BambooService` as this method only calls the `GitService` and performs checkout, commit and push operations. As Git commands are also mocked in other places, we might want to think about mocking actual VCS operations on a lower level in a future PR.
We still need the reference to the services in the `AbstractSpringIntegrationTest` in order to verify calls to specific methods (nr. of calls, equal parameters).