### PR TITLE
Set  INDIVIDUAL team mode for API tests

### DIFF
--- a/src/test/k6/requests/programmingExercise.js
+++ b/src/test/k6/requests/programmingExercise.js
@@ -55,6 +55,7 @@ export function createExercise(artemis, courseId) {
         problemStatement: programmingExerciseProblemStatement,
         presentationScoreEnabled: false,
         sequentialTestRuns: true,
+        mode: 'INDIVIDUAL',
         course: {
             id: courseId
         }


### PR DESCRIPTION
### Description 
The server API tests are currently failing due to an outdated exercise model (missing `mode` of team-based exercises). Adding the `INDIVIDUAL` fixes the issues. 