### PR TITLE
Always reload the page after deleting participations for the guided tour

### DIFF
--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -841,19 +841,14 @@ export class GuidedTourService {
      * Navigate to page after resetting a guided tour participation
      */
     private navigateToUrlAfterRestart(url: string) {
-        if (window.location.href.endsWith(url)) {
-            this.router.navigateByUrl(url).then(() => {
+        this.router.navigateByUrl(url).then(() => {
                 location.reload();
             });
 
-            // Keep loading icon until the page is being refreshed
-            window.onload = function() {
-                this['restartIsLoading'] = false;
-            };
-        } else {
-            this.router.navigateByUrl(url).then();
+        // Keep loading icon until the page is being refreshed
+        window.onload = function() {
             this['restartIsLoading'] = false;
-        }
+        };
     }
 
     public getFilteredTourSteps(): TourStep[] {

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -842,8 +842,8 @@ export class GuidedTourService {
      */
     private navigateToUrlAfterRestart(url: string) {
         this.router.navigateByUrl(url).then(() => {
-                location.reload();
-            });
+            location.reload();
+        });
 
         // Keep loading icon until the page is being refreshed
         window.onload = function() {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
This PR changes the logic of the guided tour a little bit and always reloads the page after deleting a participation for a guided tour.
