### PR TITLE
Fix: Exercise filter "Hide full score" not working correctly

### DIFF
--- a/src/main/webapp/app/overview/course-exercises/course-exercises.component.ts
+++ b/src/main/webapp/app/overview/course-exercises/course-exercises.component.ts
@@ -1,13 +1,13 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Course } from 'app/entities/course.model';
-import { CourseManagementService } from '../../course/manage/course-management.service';
+import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 import { TranslateService } from '@ngx-translate/core';
 import { HttpResponse } from '@angular/common/http';
 import * as moment from 'moment';
 import { AccountService } from 'app/core/auth/account.service';
-import { sum } from 'lodash';
+import { sum, flatten, maxBy } from 'lodash';
 import { GuidedTourService } from 'app/guided-tour/guided-tour.service';
 import { courseExerciseOverviewTour } from 'app/guided-tour/tours/course-exercise-overview-tour';
 import { isOrion } from 'app/shared/orion/orion';
@@ -134,13 +134,12 @@ export class CourseExercisesComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Checks if the given exercise still needs work, i.e. is not graded with 100%, or wasn't even started, yet.
+     * Checks if the given exercise still needs work, i.e. wasn't even started yet or is not graded with 100%
      * @param exercise The exercise which should get checked
      */
     private needsWork(exercise: Exercise): boolean {
-        const notFullPoints = exercise.studentParticipations.some(participation => participation.results && participation.results.some(result => result.score !== 100));
-        const notStartedYet = exercise.studentParticipations.every(participation => !participation.results.length);
-        return notFullPoints || notStartedYet;
+        const latestResult = maxBy(flatten(exercise.studentParticipations.map(participation => participation.results)), 'completionDate');
+        return !latestResult || latestResult.score !== 100;
     }
 
     /**


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
This PR fixes issue #990.

### Description
I changed the logic for the predicate `needsWork` in the client. Before it was true if any of the results didn't have a full score. This was incorrect since we only care about the latest result for an exercise and not about the previous results.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Overview
3. Click on a Course
4. Do not (!) refresh the page from now on since the bug is websocket related
5. For a programming exercise, submit a solution that will not (!) receive a full score.
6. Now submit a solution that will receive a full score.
7. Go back to the exercise overview of the course
8. Activate the filter "Hide full score"
9. Check that the programming exercise from before is correctly hidden (since the latest result received a full score)