### PR TITLE
Update docker image for c & python to ls1tum.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooBuildPlanService.java
@@ -126,7 +126,7 @@ public class BambooBuildPlanService {
         }
         case PYTHON:
         case C: {
-            defaultJob.dockerConfiguration(new DockerConfiguration().image("com8/artemis-gbs:latest"));
+            defaultJob.dockerConfiguration(new DockerConfiguration().image("ls1tum/artemis-python-docker"));
             final var testParserTask = new TestParserTask(TestParserTaskProperties.TestType.JUNIT).resultDirectories("test-reports/*results.xml");
             var tasks = readScriptTasksFromTemplate(programmingLanguage, sequentialBuildRuns == null ? false : sequentialBuildRuns);
             tasks.add(0, checkoutTask);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
The current image used by c & python programming exercises (com8/artemis-gbs) does not include `pytest`.


### Description
We should use an image controlled by the LS1 chair to update to our own needs.
The image can be found here (https://github.com/ls1intum/artemis-python-docker) and is based on com8/artemis-gbs.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Create a programming exercise using python
4. The build for the solution repository should succeed.
