### PR TITLE
update Apollon Version to 2.0.10, include SGI

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@fortawesome/fontawesome-svg-core": "1.2.28",
         "@fortawesome/free-regular-svg-icons": "5.13.0",
         "@fortawesome/free-solid-svg-icons": "5.13.0",
-        "@ls1intum/apollon": "2.0.8",
+        "@ls1intum/apollon": "2.0.9",
         "@ng-bootstrap/ng-bootstrap": "6.0.2",
         "@ngx-translate/core": "12.1.2",
         "@ngx-translate/http-loader": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@fortawesome/fontawesome-svg-core": "1.2.28",
         "@fortawesome/free-regular-svg-icons": "5.13.0",
         "@fortawesome/free-solid-svg-icons": "5.13.0",
-        "@ls1intum/apollon": "2.0.9",
+        "@ls1intum/apollon": "2.0.10",
         "@ng-bootstrap/ng-bootstrap": "6.0.2",
         "@ngx-translate/core": "12.1.2",
         "@ngx-translate/http-loader": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,10 +1377,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@ls1intum/apollon@2.0.9":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.9.tgz#bf190262f48dd3857ff6c0ac059551bc6c99a29f"
-  integrity sha512-M/7+WJDLqVCcz8EckM4KzS+r3yaLUzHnEKAkrYziv/QVedCKTjx96t9m6bOrYRs9noTYtlleZGQzNvV/PK4DOQ==
+"@ls1intum/apollon@2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.10.tgz#a4d88def11115857fd93fe32d416fd955a973b89"
+  integrity sha512-vYuLxqFljfZzhiKXZjwpsA+ee4AMc0dX4khWfYueRELByyBG3GzcXgkVhjvvkLua2aSb4pcAxiNwPK0TjnJvTQ==
   dependencies:
     pepjs "0.5.2"
     react "16.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,10 +1377,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@ls1intum/apollon@2.0.8":
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.8.tgz#02f722ef073fa1e66a0ceeea82b5393e1861e6e0"
-  integrity sha512-ri02mPpCScyHKP13Go9GhmE4PzXnWJM5u/p2yCIdGqBrKJLQP9PrtlNGf+zDCxgED5A7bFgg9g0YpKds8l+p/g==
+"@ls1intum/apollon@2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.0.9.tgz#bf190262f48dd3857ff6c0ac059551bc6c99a29f"
+  integrity sha512-M/7+WJDLqVCcz8EckM4KzS+r3yaLUzHnEKAkrYziv/QVedCKTjx96t9m6bOrYRs9noTYtlleZGQzNvV/PK4DOQ==
   dependencies:
     pepjs "0.5.2"
     react "16.13.1"


### PR DESCRIPTION
update Apollon Version to 2.0.10, which includes SGI Drag and Drop feature in Apollon

update to 2.0.10, because I included yarn in Apollon release 2.0.9 in dependencies instead of devDependencies