### PR TITLE
Show success message after team import

### DIFF
--- a/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-dialog.component.ts
+++ b/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, ViewChild, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { NgForm } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { JhiAlertService } from 'ng-jhipster';
+import { AlertService } from 'app/core/alert/alert.service';
 import { HttpResponse } from '@angular/common/http';
 import { Subject } from 'rxjs';
 import { TeamService } from 'app/exercises/shared/team/team.service';
@@ -49,7 +49,7 @@ export class TeamsImportDialogComponent implements OnInit, OnDestroy {
     private dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
 
-    constructor(private teamService: TeamService, private activeModal: NgbActiveModal, private jhiAlertService: JhiAlertService) {}
+    constructor(private teamService: TeamService, private activeModal: NgbActiveModal, private jhiAlertService: AlertService) {}
 
     ngOnInit() {
         this.computePotentialConflictsBasedOnExistingTeams();
@@ -238,6 +238,10 @@ export class TeamsImportDialogComponent implements OnInit, OnDestroy {
     onSaveSuccess(teams: HttpResponse<Team[]>) {
         this.activeModal.close(teams.body);
         this.isImporting = false;
+
+        setTimeout(() => {
+            this.jhiAlertService.success('artemisApp.team.importSuccess', { numberOfImportedTeams: this.numberOfTeamsToBeImported });
+        }, 500);
     }
 
     onSaveError() {

--- a/src/main/webapp/i18n/de/team.json
+++ b/src/main/webapp/i18n/de/team.json
@@ -142,7 +142,8 @@
                 "question": "Sollen alle Teams der Übung <strong>{{ title }}</strong> und ihre Teilnahmen an der Aufgabe wirklich dauerhaft gelöscht werden? Diese Aktion kann NICHT rückgängig gemacht werden!",
                 "typeNameToConfirm": "Bitte gib den Titel der Übung zur Bestätigung ein."
             },
-            "importError": "Import fehlgeschlagen. Bitte versuche es nochmal oder kontaktiere einen Administrator für Hilfe."
+            "importError": "Import fehlgeschlagen. Bitte versuche es nochmal oder kontaktiere einen Administrator für Hilfe.",
+            "importSuccess": "Import war erfolgreich! {{ numberOfImportedTeams }} Teams wurden importiert."
         }
     }
 }

--- a/src/main/webapp/i18n/en/team.json
+++ b/src/main/webapp/i18n/en/team.json
@@ -142,7 +142,8 @@
                 "question": "Are you sure you want to delete all teams of exercise <strong>{{ title }}</strong> and their participations in the exercise? This action can NOT be undone!",
                 "typeNameToConfirm": "Please type in the title of the exercise to confirm."
             },
-            "importError": "Import failed. Please try again or contact an administrator for assistance."
+            "importError": "Import failed. Please try again or contact an administrator for assistance.",
+            "importSuccess": "Import was successful! {{ numberOfImportedTeams }} teams were imported."
         }
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
As suggested by @sleiss in [this](https://github.com/ls1intum/Artemis/pull/1302#issuecomment-612955734) PR, it would be nice if the instructor receives a success message after the team import is finished. This PR adds this success message. It is shown after the team import dialog has closed.

### Description
Added success alert that is shown shortly after the dialog has closed in the success case.

### Steps for Testing
1. Log in to Artemis as an instructor (or admin)
2. Navigate to Course Management
3. Create a team-based exercise ([how?](https://github.com/ls1intum/Artemis/pull/1282#issuecomment-605954482))
4. Create a couple of teams for the new exercise
5. Create another team-based exercise
6. Instead of creating teams again, use the button "Import teams" on the teams overview page of the new exercise
7. Select the previously created exercise with teams as the "source exercise" for the import
8. Click on the submit button "Import"
9. Verify that the success message is shown

### Screenshots
![OnPaste 20200421-151953](https://user-images.githubusercontent.com/7109225/79870644-904cf980-83e3-11ea-9405-2c258a2dba51.png)

**Screencast:** https://imgur.com/a/jlT5jU8