### PR TITLE
Fix #1341: Course header too small for title

### DIFF
--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -2,7 +2,8 @@
     height: 320px;
     cursor: pointer;
     .card-header {
-        height: 60px;
+        min-height: 60px;
+        max-height: 100px;
         display: flex;
         justify-content: center;
         align-items: center;

--- a/src/main/webapp/app/overview/courses.component.html
+++ b/src/main/webapp/app/overview/courses.component.html
@@ -24,7 +24,11 @@
     <jhi-course-registration-selector [courses]="courses" (courseRegistered)="loadAndFilterCourses()" class="col-12 col-sm-auto d-flex"></jhi-course-registration-selector>
 </div>
 <div class="row">
-    <div class="col-12 col-md-6 col-lg-3 pr-2 pl-2 mb-2" *ngFor="let course of courses">
-        <jhi-overview-course-card [course]="course" [hasGuidedTour]="course === courseForGuidedTour"></jhi-overview-course-card>
-    </div>
+    <jhi-overview-course-card
+        *ngFor="let course of courses"
+        class="col-12 col-md-6 col-lg-4 col-xl-3 pr-2 pl-2 mb-2"
+        [course]="course"
+        [hasGuidedTour]="course === courseForGuidedTour"
+    >
+    </jhi-overview-course-card>
 </div>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] ~Server: I added multiple integration tests (Spring) related to the features~
- [X] ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- [X] ~Server: I implemented the changes with a good performance and prevented too many database calls~
- [X] ~Server: I documented the Java code using JavaDoc style.~
- [X] ~Client: I added multiple integration tests (Jest) related to the features~
- [X] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [X] ~Client: I documented the TypeScript code using JSDoc style.~
- [X] ~Client: I added multiple screenshots/screencasts of my UI changes~
- [X] ~Client: I translated all the newly inserted strings into German and English~

### Motivation and Context
Fixes #1341

### Description
- Update Breakpoints: 4 cols xl, 3 cols ls, 2 cols md, 1 col sm
- Make hight in course card dynamic (60px - 100px, before fix 60px) to make room for very long titles.
- Clean up unneeded div.

### Steps for Testing
1. Create a course with something like
    > Very very long course name to test the new feature. A course should not have such a long name.
2. Navigate to Course Overview
3. See that title is not cropped.

### Screenshots
<img width="504" alt="image" src="https://user-images.githubusercontent.com/6382716/80193230-b8716e00-8618-11ea-8fb8-ed632fe8c66a.png">
<img width="784" alt="image" src="https://user-images.githubusercontent.com/6382716/80193258-c45d3000-8618-11ea-9817-15bdd74299c7.png">
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/6382716/80193277-cc1cd480-8618-11ea-90ec-ba69d1239b22.png">
<img width="1370" alt="image" src="https://user-images.githubusercontent.com/6382716/80193297-d4750f80-8618-11ea-9f00-76a3f9ff4d33.png">

