### PR TITLE
Enable Markdown for Text Exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/TextExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TextExercise.java
@@ -24,6 +24,9 @@ public class TextExercise extends Exercise implements Serializable {
     @JsonIgnore
     private List<TextCluster> clusters;
 
+    @Column(name = "markdown_enabled")
+    private boolean markdownEnabled;
+
     public String getSampleSolution() {
         return sampleSolution;
     }
@@ -35,6 +38,19 @@ public class TextExercise extends Exercise implements Serializable {
 
     public void setSampleSolution(String sampleSolution) {
         this.sampleSolution = sampleSolution;
+    }
+
+    public boolean isMarkdownEnabled() {
+        return markdownEnabled;
+    }
+
+    public TextExercise markdownEnabled(boolean markdownEnabled) {
+        this.markdownEnabled = markdownEnabled;
+        return this;
+    }
+
+    public void setMarkdownEnabled(boolean markdownEnabled) {
+        this.markdownEnabled = markdownEnabled;
     }
 
     public boolean isAutomaticAssessmentEnabled() {

--- a/src/main/resources/config/liquibase/changelog/20200425184923_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20200425184923_changelog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.8.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet author="madwau" id="20200425184923">
+        <addColumn tableName="exercise">
+            <column name="markdown_enabled" type="boolean" defaultValueBoolean="false"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -56,4 +56,5 @@
     <include file="classpath:config/liquibase/changelog/20200413162034_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20200412173108_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20200416184036_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20200425184923_changelog.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/main/webapp/app/entities/text-exercise.model.ts
+++ b/src/main/webapp/app/entities/text-exercise.model.ts
@@ -3,6 +3,7 @@ import { Course } from 'app/entities/course.model';
 
 export class TextExercise extends Exercise {
     public sampleSolution: string;
+    public markdownEnabled = false;
 
     constructor(course?: Course) {
         super(ExerciseType.TEXT);

--- a/src/main/webapp/app/exercises/shared/team-config-form-group/team-config-form-group.component.html
+++ b/src/main/webapp/app/exercises/shared/team-config-form-group/team-config-form-group.component.html
@@ -1,4 +1,4 @@
-<div class="form-group-narrow">
+<div class="form-group">
     <div class="row">
         <div class="col-auto">
             <div>

--- a/src/main/webapp/app/exercises/text/assess/highlighted-text-area/highlighted-text-area.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/highlighted-text-area/highlighted-text-area.component.ts
@@ -3,6 +3,7 @@ import { Feedback } from 'app/entities/feedback.model';
 import { HighlightColors } from 'app/exercises/text/assess/highlight-colors';
 import { TextBlock } from 'app/entities/text-block.model';
 import { escapeString, convertToHtmlLinebreaks, sanitize } from 'app/utils/text.utils';
+import { ArtemisMarkdownService } from 'app/shared/markdown.service';
 
 @Component({
     selector: 'jhi-highlighted-text-area',
@@ -11,16 +12,20 @@ import { escapeString, convertToHtmlLinebreaks, sanitize } from 'app/utils/text.
 })
 export class HighlightedTextAreaComponent implements OnChanges, DoCheck {
     @Input() public submissionText: string;
+    @Input() public markdownEnabled = false;
     @Input() public assessments: Feedback[];
     @Input() public blocks: (TextBlock | undefined)[];
     public displayedText: string;
     private differ: any;
 
-    constructor(differs: IterableDiffers) {
+    constructor(differs: IterableDiffers, private artemisMarkdown: ArtemisMarkdownService) {
         this.differ = differs.find([]).create(undefined);
     }
 
     private get submissionTextWithHtmlLinebreaks(): string {
+        if (this.markdownEnabled) {
+            return this.artemisMarkdown.htmlForMarkdown(this.submissionText || '');
+        }
         return convertToHtmlLinebreaks(escapeString(this.submissionText || ''));
     }
 

--- a/src/main/webapp/app/exercises/text/assess/text-assessment-editor/text-assessment-editor.component.html
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment-editor/text-assessment-editor.component.html
@@ -1,5 +1,5 @@
 <div (jhiTextSelect)="didSelectSolutionText($event)">
-    <jhi-highlighted-text-area [submissionText]="submissionText" [assessments]="assessments" [blocks]="blocks"></jhi-highlighted-text-area>
+    <jhi-highlighted-text-area [submissionText]="submissionText" [markdownEnabled]="markdownEnabled" [assessments]="assessments" [blocks]="blocks"></jhi-highlighted-text-area>
 
     <div
         *ngIf="hostRectangle"

--- a/src/main/webapp/app/exercises/text/assess/text-assessment-editor/text-assessment-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment-editor/text-assessment-editor.component.ts
@@ -12,6 +12,7 @@ import { convertToHtmlLinebreaks } from 'app/utils/text.utils';
 export class TextAssessmentEditorComponent {
     public hostRectangle: SelectionRectangle | null;
     @Input() public submissionText: string;
+    @Input() public markdownEnabled = false;
     @Input() public assessments: Feedback[];
     @Input() public blocks: (TextBlock | undefined)[];
     @Input() public disabled = false;

--- a/src/main/webapp/app/exercises/text/assess/text-assessment.component.html
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment.component.html
@@ -97,6 +97,7 @@
             <div class="card-body">
                 <jhi-text-assessment-editor
                     [submissionText]="submission?.text"
+                    [markdownEnabled]="exercise.markdownEnabled"
                     [assessments]="referencedFeedback"
                     [blocks]="referencedTextBlocks"
                     (assessedText)="addAssessment($event)"

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -28,6 +28,19 @@
             </div>
         </div>
         <jhi-team-config-form-group [exercise]="textExercise"></jhi-team-config-form-group>
+        <div class="form-group">
+            <div class="form-check custom-control custom-checkbox">
+                <input
+                    type="checkbox"
+                    id="markdown_enabled"
+                    [ngModel]="textExercise.markdownEnabled"
+                    (ngModelChange)="textExercise.markdownEnabled = $event"
+                    class="form-check-input custom-control-input"
+                    name="markdownEnabled"
+                />
+                <label class="form-check-label custom-control-label" for="markdown_enabled" jhiTranslate="artemisApp.textExercise.markdownEnabled"></label>
+            </div>
+        </div>
         <div class="d-flex">
             <div class="form-group flex-grow-1">
                 <jhi-date-time-picker

--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.html
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.html
@@ -32,14 +32,23 @@
     <div class="row">
         <ng-container *ngIf="!result; else hasFeedback">
             <div class="col-12 col-lg-9 col-xl-8">
-                <textarea
-                    #textEditor
-                    class="text-editor-textarea"
-                    [(ngModel)]="answer"
-                    [readonly]="!isActive || !submission"
-                    [disabled]="!isActive || !submission"
-                    (keydown.tab)="onTextEditorTab(textEditor, $event)"
-                ></textarea>
+                <jhi-markdown-editor
+                    class="markdown-editor"
+                    *ngIf="textExercise?.markdownEnabled; else plainTextEditor"
+                    [(markdown)]="answer"
+                    [initialHeight]="500"
+                    [enableResize]="true"
+                ></jhi-markdown-editor>
+                <ng-template #plainTextEditor>
+                    <textarea
+                        #textEditor
+                        class="text-editor-textarea"
+                        [(ngModel)]="answer"
+                        [readonly]="!isActive || !submission"
+                        [disabled]="!isActive || !submission"
+                        (keydown.tab)="onTextEditorTab(textEditor, $event)"
+                    ></textarea>
+                </ng-template>
             </div>
         </ng-container>
 

--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
@@ -21,6 +21,8 @@ import { TextExercise } from 'app/entities/text-exercise.model';
 import { ButtonType } from 'app/shared/components/button.component';
 import { Result } from 'app/entities/result.model';
 import { TextSubmission } from 'app/entities/text-submission.model';
+import { AssessmentType } from 'app/entities/assessment-type.model';
+import { MarkdownEditorHeight } from 'app/shared/markdown-editor/markdown-editor.component';
 
 @Component({
     templateUrl: './text-editor.component.html',
@@ -29,6 +31,8 @@ import { TextSubmission } from 'app/entities/text-submission.model';
 })
 export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeactivate {
     readonly ButtonType = ButtonType;
+    readonly AssessmentType = AssessmentType;
+    readonly MarkdownEditorHeight = MarkdownEditorHeight;
     textExercise: TextExercise;
     participation: StudentParticipation;
     result: Result;

--- a/src/main/webapp/app/exercises/text/participate/text-participation.module.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-participation.module.ts
@@ -11,6 +11,7 @@ import { TextEditorScoreCardComponent } from 'app/exercises/text/participate/tex
 import { TextResultComponent } from 'app/exercises/text/participate/text-result/text-result.component';
 import { ArtemisTeamModule } from 'app/exercises/shared/team/team.module';
 import { ArtemisHeaderExercisePageWithDetailsModule } from 'app/exercises/shared/exercise-headers/exercise-headers.module';
+import { ArtemisMarkdownEditorModule } from 'app/shared/markdown-editor/markdown-editor.module';
 
 const ENTITY_STATES = [...textEditorRoute];
 
@@ -24,6 +25,7 @@ const ENTITY_STATES = [...textEditorRoute];
         MomentModule,
         ArtemisTeamModule,
         ArtemisHeaderExercisePageWithDetailsModule,
+        ArtemisMarkdownEditorModule,
     ],
     declarations: [TextEditorComponent, TextEditorScoreCardComponent, TextResultComponent],
 })

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
@@ -70,7 +70,7 @@
                     </div>
                 </div>
             </div>
-            <div class="height-100 border-0 markdown-editor d-flex flex-column">
+            <div class="height-100 border-0 markdown-editor d-flex flex-column" [ngStyle]="{ 'height.px': initialHeight }">
                 <ace-editor
                     #aceEditor
                     [mode]="aceEditorOptions.mode"

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
@@ -44,7 +44,7 @@
         }
 
         &__commands {
-            margin: 0 5px 5px 5px;
+            padding: 0 5px 5px 5px;
 
             &-default,
             &-domain {
@@ -66,5 +66,5 @@
 
 .background-editor-high {
     min-height: 150px;
-    overflow: scroll;
+    overflow: auto;
 }

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -76,6 +76,7 @@ export class MarkdownEditorComponent implements AfterViewInit {
     @Input() markdown: string;
     @Input() editorMode = EditorMode.NONE;
     @Input() showLineNumbers = false;
+    @Input() initialHeight = 100;
     @Output() markdownChange = new EventEmitter<string>();
     @Output() html = new EventEmitter<SafeHtml | null>();
 

--- a/src/main/webapp/i18n/de/textExercise.json
+++ b/src/main/webapp/i18n/de/textExercise.json
@@ -16,6 +16,7 @@
             "exampleSubmissions": "Beispielabgabe",
             "assessedSubmission": "Deine bewertete Abgabe",
             "createExampleSubmissions": "Beispielabgabe erstellen",
+            "markdownEnabled": "Markdown-Editor aktiviert",
             "automaticAssessmentEnabled": "Automatische Bewertung aktiviert",
             "exampleSubmissionsRequireExercise": "Um eine Beispielabgabe zu erstellen, musst du zunächst die Erstellung der Textaufgabe abschließen.",
             "saveSuccessful": "Dein Antwort wurde erfolgreich gespeichert!",

--- a/src/main/webapp/i18n/en/textExercise.json
+++ b/src/main/webapp/i18n/en/textExercise.json
@@ -16,6 +16,7 @@
             "exampleSubmissions": "Example submissions",
             "assessedSubmission": "Your assessed submission",
             "createExampleSubmissions": "Create example submission",
+            "markdownEnabled": "Markdown Editor enabled",
             "automaticAssessmentEnabled": "Automatic Assessment enabled",
             "exampleSubmissionsRequireExercise": "To create an example submission, you first need to finish creating the text exercise.",
             "saveSuccessful": "Your answer was saved successfully!",

--- a/src/test/javascript/spec/component/text-editor/text-editor.spec.ts
+++ b/src/test/javascript/spec/component/text-editor/text-editor.spec.ts
@@ -29,6 +29,7 @@ import { ComplaintsComponent } from 'app/complaints/complaints.component';
 import { TextSubmission } from 'app/entities/text-submission.model';
 import { ArtemisTeamModule } from 'app/exercises/shared/team/team.module';
 import { ArtemisHeaderExercisePageWithDetailsModule } from 'app/exercises/shared/exercise-headers/exercise-headers.module';
+import { ArtemisMarkdownEditorModule } from 'app/shared/markdown-editor/markdown-editor.module';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -61,6 +62,7 @@ describe('TableEditableFieldComponent', () => {
                 ArtemisSharedModule,
                 ArtemisTeamModule,
                 ArtemisHeaderExercisePageWithDetailsModule,
+                ArtemisMarkdownEditorModule,
                 RouterTestingModule.withRoutes([textEditorRoute[0]]),
             ],
             declarations: [


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Client: I added multiple integration tests (Jest) related to the features
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
Right now, students can only use plain text when working on Text Exercises. This PR aims at adding the option of allowing markdown input for a text exercise, so that students can create more structured documents in their submission.

### Description
1. Add field `markdownEnabled` to `Exercise` model
2. Add option to enable markdown to Text Exercise create form
3. Conditionally show markdown editor on Text Exercise participation page
4. Show rendered markdown when assessing a submission for a markdown-enabled Text Exercise

### Help wanted
The highlighting of the submission text when assessing does not yet work correctly if the highlighted part spans across multiple HTML elements (e.g. selecting two bullet points, or selecting a regular word and an adjacent word in bold text). This is due to the assessment references being saved without HTML elements (only with line breaks) but the content in which they get injected via replacements does contain HTML elements and thus the replace operation does not work.

I only played around briefly since some of us are much more focused on the topic of text assessment in Artemis and have more insight here how a solution could look like. My basic understanding is that we would need to adapt the replacement logic in the method `highlightText` in `highlighted-text-area.component.ts`. The highlighting would need to be applied recursively on every DOM node for the submission text segment that matches the assessment reference. The actual challenge here is probably the matching itself.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Management
3. Create a Text Exercise with the setting "Markdown Editor enabled" checked
4. Participate in the exercise as a student
5. Assess the submission as a tutor

### Screenshots
![OnPaste 20200426-141644](https://user-images.githubusercontent.com/7109225/80307679-db438400-87ca-11ea-8f82-25cda71c4856.png)
![OnPaste 20200426-141735](https://user-images.githubusercontent.com/7109225/80307680-dc74b100-87ca-11ea-937d-d88ec6b55c85.png)
![OnPaste 20200426-143153](https://user-images.githubusercontent.com/7109225/80307681-dc74b100-87ca-11ea-9df7-ecad08ec799e.png)
![OnPaste 20200426-143247](https://user-images.githubusercontent.com/7109225/80307682-dd0d4780-87ca-11ea-89d7-657337171d15.png)

