### PR TITLE
Fix false positive issue in database hook for team conflict detection

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20200504120935_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20200504120935_changelog.xml
@@ -1,0 +1,42 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="madwau" id="20200504120935">
+        <sql>
+            DROP TRIGGER uc_team_student_exercise_id_and_student_id;
+        </sql>
+        <sql endDelimiter="$$">
+            /*
+             * This trigger makes sure that no student is assigned to more than one team per exercise.
+             */
+            CREATE TRIGGER uc_team_student_exercise_id_and_student_id BEFORE INSERT ON team_student
+            FOR EACH ROW BEGIN
+                DECLARE conflict_exercise_id BIGINT(20);
+                DECLARE conflict_team_id BIGINT(20);
+                DECLARE error_message varchar(256);
+
+                /* get id of exercise for which the student should be added to a team */
+                SET @conflict_exercise_id :=
+                    (SELECT exercise_id FROM team WHERE team.id = NEW.team_id);
+
+                /* get id of other team to which the student already belongs to for exercise */
+                SET @conflict_team_id :=
+                    (SELECT team_student.team_id FROM team
+                     LEFT JOIN team_student ON team.id = team_student.team_id
+                     WHERE team.exercise_id = @conflict_exercise_id AND team_student.team_id != NEW.team_id AND team_student.student_id = NEW.student_id
+                     LIMIT 1);
+
+                /* if there is such a conflict team, abort the insert by throwing an error */
+                IF @conflict_team_id THEN
+                  SET @error_message := (
+                      CONCAT_WS(' ', 'Trying to add student', cast(NEW.student_id as char), 'to team', cast(NEW.team_id as char), 'but the student is already part of team',
+                                cast(@conflict_team_id as char), 'for exercise', cast(@conflict_exercise_id as char))
+                  );
+                  SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = @error_message;
+                END IF;
+            END
+            $$
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -56,4 +56,5 @@
     <include file="classpath:config/liquibase/changelog/20200413162034_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20200412173108_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20200416184036_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20200504120935_changelog.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
When querying for a conflict team, the extra condition `team_student.team_id != NEW.team_id` needs to be in place since a student being assigned to the same team is not an actual conflict.