### PR TITLE
Allow instructors to set the tutor for a team on creation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TeamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TeamResource.java
@@ -94,7 +94,10 @@ public class TeamResource {
         if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user)) {
             return forbidden();
         }
-        team.setOwner(user); // the TA (or above) who creates the team, is the owner of the team
+        // Tutors can only create teams for themselves while instructors can select any tutor as the team owner
+        if (!authCheckService.isAtLeastInstructorForExercise(exercise, user)) {
+            team.setOwner(user);
+        }
         Team result = teamService.save(exercise, team);
         result.filterSensitiveInformation();
         return ResponseEntity.created(new URI("/api/teams/" + result.getId()))


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
The PR addresses [this](https://github.com/ls1intum/Artemis/issues/1405) issue.

### Description
Right now, when creating a team, the team owner is always set to the current user. This is the correct behavior for tutors but not for instructors. If an instructor creates a team, the selected tutor should be the team owner (can also be left empty).

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Management
3. Create a team for a team exercise as an instructor and select a tutor as team owner
4. Check that the selected tutor was correctly saved as the team owner