### PR TITLE
Bugfix/added the page titles for edit and create new user

### DIFF
--- a/src/main/webapp/app/admin/user-management/user-management.route.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.route.ts
@@ -52,6 +52,9 @@ export const userMgmtRoute3: Route = {
     resolve: {
         user: UserMgmtResolve,
     },
+    data: {
+        pageTitle: 'userManagement.home.createLabel',
+    },
 };
 
 export const userMgmtRoute4: Route = {
@@ -59,5 +62,8 @@ export const userMgmtRoute4: Route = {
     component: UserManagementUpdateComponent,
     resolve: {
         user: UserMgmtResolve,
+    },
+    data: {
+        pageTitle: 'userManagement.home.createOrEditLabel',
     },
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de. (Tested it on localhost)


### Motivation and Context
It fixes the missing display of the page title in the tab for the routes user-management/new and user-management/:login/edit: 
![image](https://user-images.githubusercontent.com/50466283/81161898-a08cd900-8f8c-11ea-8dc2-0b3f8f4b052e.png)


### Description
The data property containing the pageTitle were missing in both routes.
### Steps for Testing
1. Log in to Artemis as Admin
2. Navigate to Server Administration
3. Then go to User management
4. Click on Create a new user for the user-management/new route or on edit for the user-management/:login/edit route
5. The page title tab should now show the correct text (Create a new user or Create or edit a user)

### Screenshots
![image](https://user-images.githubusercontent.com/50466283/81162693-e5653f80-8f8d-11ea-8726-40416bca5400.png)
and 
![image](https://user-images.githubusercontent.com/50466283/81162733-f1e99800-8f8d-11ea-88e3-cf376dcde2c6.png)

