### PR TITLE
Fix caching issue when persisting team students

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Team.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Team.java
@@ -45,9 +45,8 @@ public class Team extends AbstractAuditingEntity implements Serializable, Partic
     @JsonIgnore
     private Exercise exercise;
 
-    @OrderColumn
     @ManyToMany(fetch = FetchType.EAGER)
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JoinTable(name = "team_student", joinColumns = @JoinColumn(name = "team_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "student_id", referencedColumnName = "id"))
     private Set<User> students = new HashSet<>();

--- a/src/main/java/de/tum/in/www1/artemis/domain/Team.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Team.java
@@ -45,6 +45,10 @@ public class Team extends AbstractAuditingEntity implements Serializable, Partic
     @JsonIgnore
     private Exercise exercise;
 
+    /**
+     * The cache concurrency strategy needs to be READ_WRITE (and not NONSTRICT_READ_WRITE) since the non-strict mode will cause an SQLIntegrityConstraintViolationException to
+     * occur when trying to persist the entity for the first time after changes have been made to the related entities of the ManyToMany relationship (users in this case).
+     */
     @ManyToMany(fetch = FetchType.EAGER)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/de/tum/in/www1/artemis/domain/Team.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Team.java
@@ -45,6 +45,7 @@ public class Team extends AbstractAuditingEntity implements Serializable, Partic
     @JsonIgnore
     private Exercise exercise;
 
+    @OrderColumn
     @ManyToMany(fetch = FetchType.EAGER)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonInclude(JsonInclude.Include.NON_NULL)


### PR DESCRIPTION
### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Right now, persisting a team fails on first attempt if changes to one of the students in the team have been made after the team was requested from the server. This is caused by the non-strict cache concurrency strategy. The resulting error looks like [this](https://sentry.io/organizations/ls1intum/issues/1635095598/?project=1440029&query=is%3Aunresolved&statsPeriod=1h).

### Discovery Scenario
A tutor or instructor has opened the teams overview page for an exercise. Now student A logs into Artemis. The tutor or instructor then tries to edit the team which student A is part of. The save request will fail the first time with a constraint exception due to a duplicate entry. The second click on save succeeds then (likely because the first attempt at a write operation cleared the stale cache entry).

### Solution
Switch the cache strategy of students on team from `NONSTRICT_READ_WRITE` to `READ_WRITE`