### PR TITLE
Indentation of switch statements

### DIFF
--- a/artemis-spotless-style.xml
+++ b/artemis-spotless-style.xml
@@ -225,7 +225,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>

--- a/src/main/java/de/tum/in/www1/artemis/config/SentryConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/SentryConfiguration.java
@@ -58,16 +58,16 @@ public class SentryConfiguration {
 
     private String getEnvironment() {
         switch (ARTEMIS_SERVER_URL) {
-        case "https://artemis.ase.in.tum.de":
-            return "prod";
-        case "https://artemistest.ase.in.tum.de":
-            return "test";
-        case "https://artemistest2.ase.in.tum.de":
-            return "test";
-        case "https://vmbruegge60.in.tum.de":
-            return "test";
-        default:
-            return "local";
+            case "https://artemis.ase.in.tum.de":
+                return "prod";
+            case "https://artemistest.ase.in.tum.de":
+                return "test";
+            case "https://artemistest2.ase.in.tum.de":
+                return "test";
+            case "https://vmbruegge60.in.tum.de":
+                return "test";
+            default:
+                return "local";
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelAssessmentConflictService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelAssessmentConflictService.java
@@ -131,17 +131,17 @@ public class ModelAssessmentConflictService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Conflict with id" + conflictId + "has already been resolved");
         }
         switch (storedConflict.getState()) {
-        case UNHANDLED:
-            // TODO Notify tutors
-            storedConflict.setState(EscalationState.ESCALATED_TO_TUTORS_IN_CONFLICT);
-            break;
-        case ESCALATED_TO_TUTORS_IN_CONFLICT:
-            // TODO Notify instructors
-            storedConflict.setState(EscalationState.ESCALATED_TO_INSTRUCTOR);
-            break;
-        default:
-            log.error("Escalating conflict {} with state {} failed .", conflictId, storedConflict.getState());
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Conflict: " + conflictId + " can´t be escalated");
+            case UNHANDLED:
+                // TODO Notify tutors
+                storedConflict.setState(EscalationState.ESCALATED_TO_TUTORS_IN_CONFLICT);
+                break;
+            case ESCALATED_TO_TUTORS_IN_CONFLICT:
+                // TODO Notify instructors
+                storedConflict.setState(EscalationState.ESCALATED_TO_INSTRUCTOR);
+                break;
+            default:
+                log.error("Escalating conflict {} with state {} failed .", conflictId, storedConflict.getState());
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Conflict: " + conflictId + " can´t be escalated");
         }
         modelAssessmentConflictRepository.save(storedConflict);
         return storedConflict;
@@ -201,12 +201,12 @@ public class ModelAssessmentConflictService {
             return true;
         }
         switch (conflict.getState()) {
-        case UNHANDLED:
-            return conflict.getCausingConflictingResult().getResult().getAssessor().equals(currentUser);
-        case ESCALATED_TO_TUTORS_IN_CONFLICT:
-            return conflict.getResultsInConflict().stream().anyMatch(conflictingResult -> conflictingResult.getResult().getAssessor().equals(currentUser));
-        default:
-            return false;
+            case UNHANDLED:
+                return conflict.getCausingConflictingResult().getResult().getAssessor().equals(currentUser);
+            case ESCALATED_TO_TUTORS_IN_CONFLICT:
+                return conflict.getResultsInConflict().stream().anyMatch(conflictingResult -> conflictingResult.getResult().getAssessor().equals(currentUser));
+            default:
+                return false;
         }
 
     }
@@ -231,21 +231,21 @@ public class ModelAssessmentConflictService {
      */
     private void resolveConflict(ModelAssessmentConflict conflict) {
         switch (conflict.getState()) {
-        case UNHANDLED:
-            conflict.setState(EscalationState.RESOLVED_BY_CAUSER);
-            conflict.setResolutionDate(ZonedDateTime.now());
-            break;
-        case ESCALATED_TO_TUTORS_IN_CONFLICT:
-            conflict.setState(EscalationState.RESOLVED_BY_OTHER_TUTORS);
-            conflict.setResolutionDate(ZonedDateTime.now());
-            break;
-        case ESCALATED_TO_INSTRUCTOR:
-            conflict.setState(EscalationState.RESOLVED_BY_INSTRUCTOR);
-            conflict.setResolutionDate(ZonedDateTime.now());
-            break;
-        default:
-            log.error("Tried to resolve already resolved conflict {}", conflict);
-            break;
+            case UNHANDLED:
+                conflict.setState(EscalationState.RESOLVED_BY_CAUSER);
+                conflict.setResolutionDate(ZonedDateTime.now());
+                break;
+            case ESCALATED_TO_TUTORS_IN_CONFLICT:
+                conflict.setState(EscalationState.RESOLVED_BY_OTHER_TUTORS);
+                conflict.setResolutionDate(ZonedDateTime.now());
+                break;
+            case ESCALATED_TO_INSTRUCTOR:
+                conflict.setState(EscalationState.RESOLVED_BY_INSTRUCTOR);
+                conflict.setResolutionDate(ZonedDateTime.now());
+                break;
+            default:
+                log.error("Tried to resolve already resolved conflict {}", conflict);
+                break;
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/TeamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TeamService.java
@@ -187,12 +187,12 @@ public class TeamService {
      */
     private TeamImportStrategy getTeamImportStrategy(TeamImportStrategyType importStrategyType) {
         switch (importStrategyType) {
-        case PURGE_EXISTING:
-            return new PurgeExistingStrategy(teamRepository, participationService);
-        case CREATE_ONLY:
-            return new CreateOnlyStrategy(teamRepository);
-        default:
-            throw new Error("Unknown team import strategy type: " + importStrategyType);
+            case PURGE_EXISTING:
+                return new PurgeExistingStrategy(teamRepository, participationService);
+            case CREATE_ONLY:
+                return new CreateOnlyStrategy(teamRepository);
+            default:
+                throw new Error("Unknown team import strategy type: " + importStrategyType);
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLRelationship.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLRelationship.java
@@ -26,22 +26,22 @@ public class UMLRelationship extends UMLElement {
          */
         public String toSymbol() {
             switch (this) {
-            case CLASS_DEPENDENCY:
-                return " ╌╌> ";
-            case CLASS_AGGREGATION:
-                return " --◇ ";
-            case CLASS_INHERITANCE:
-                return " --▷ ";
-            case CLASS_REALIZATION:
-                return " ╌╌▷ ";
-            case CLASS_COMPOSITION:
-                return " --◆ ";
-            case CLASS_UNIDIRECTIONAL:
-                return " --> ";
-            case CLASS_BIDIRECTIONAL:
-                return " <-> ";
-            default:
-                return " --- ";
+                case CLASS_DEPENDENCY:
+                    return " ╌╌> ";
+                case CLASS_AGGREGATION:
+                    return " --◇ ";
+                case CLASS_INHERITANCE:
+                    return " --▷ ";
+                case CLASS_REALIZATION:
+                    return " ╌╌▷ ";
+                case CLASS_COMPOSITION:
+                    return " --◆ ";
+                case CLASS_UNIDIRECTIONAL:
+                    return " --> ";
+                case CLASS_BIDIRECTIONAL:
+                    return " <-> ";
+                default:
+                    return " --- ";
             }
         }
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooBuildPlanService.java
@@ -123,34 +123,35 @@ public class BambooBuildPlanService {
         Collection<String> activeProfiles = Arrays.asList(env.getActiveProfiles());
 
         switch (programmingLanguage) {
-        case JAVA: {
-            // Do not run the builds in extra docker containers if the dev-profile is active
-            if (!activeProfiles.contains(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT)) {
-                defaultJob.dockerConfiguration(new DockerConfiguration().image("ls1tum/artemis-maven-template:latest"));
+            case JAVA: {
+                // Do not run the builds in extra docker containers if the dev-profile is active
+                if (!activeProfiles.contains(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT)) {
+                    defaultJob.dockerConfiguration(new DockerConfiguration().image("ls1tum/artemis-maven-template:latest"));
+                }
+                if (!sequentialBuildRuns) {
+                    return defaultStage
+                            .jobs(defaultJob.tasks(checkoutTask, new MavenTask().goal("clean test").jdk("JDK").executableLabel("Maven 3").description("Tests").hasTests(true)));
+                }
+                else {
+                    return defaultStage.jobs(defaultJob.tasks(checkoutTask,
+                            new MavenTask().goal("clean test").workingSubdirectory("structural").jdk("JDK").executableLabel("Maven 3").description("Structural tests")
+                                    .hasTests(true),
+                            new MavenTask().goal("clean test").workingSubdirectory("behavior").jdk("JDK").executableLabel("Maven 3").description("Behavior tests").hasTests(true)));
+                }
             }
-            if (!sequentialBuildRuns) {
-                return defaultStage
-                        .jobs(defaultJob.tasks(checkoutTask, new MavenTask().goal("clean test").jdk("JDK").executableLabel("Maven 3").description("Tests").hasTests(true)));
+            case PYTHON:
+            case C: {
+                // Do not run the builds in extra docker containers if the dev-profile is active
+                if (!activeProfiles.contains(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT)) {
+                    defaultJob.dockerConfiguration(new DockerConfiguration().image("ls1tum/artemis-python-docker:latest"));
+                }
+                final var testParserTask = new TestParserTask(TestParserTaskProperties.TestType.JUNIT).resultDirectories("test-reports/*results.xml");
+                var tasks = readScriptTasksFromTemplate(programmingLanguage, sequentialBuildRuns == null ? false : sequentialBuildRuns);
+                tasks.add(0, checkoutTask);
+                return defaultStage.jobs(defaultJob.tasks(tasks.toArray(new Task[0])).finalTasks(testParserTask));
             }
-            else {
-                return defaultStage.jobs(defaultJob.tasks(checkoutTask,
-                        new MavenTask().goal("clean test").workingSubdirectory("structural").jdk("JDK").executableLabel("Maven 3").description("Structural tests").hasTests(true),
-                        new MavenTask().goal("clean test").workingSubdirectory("behavior").jdk("JDK").executableLabel("Maven 3").description("Behavior tests").hasTests(true)));
-            }
-        }
-        case PYTHON:
-        case C: {
-            // Do not run the builds in extra docker containers if the dev-profile is active
-            if (!activeProfiles.contains(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT)) {
-                defaultJob.dockerConfiguration(new DockerConfiguration().image("ls1tum/artemis-python-docker:latest"));
-            }
-            final var testParserTask = new TestParserTask(TestParserTaskProperties.TestType.JUNIT).resultDirectories("test-reports/*results.xml");
-            var tasks = readScriptTasksFromTemplate(programmingLanguage, sequentialBuildRuns == null ? false : sequentialBuildRuns);
-            tasks.add(0, checkoutTask);
-            return defaultStage.jobs(defaultJob.tasks(tasks.toArray(new Task[0])).finalTasks(testParserTask));
-        }
-        default:
-            throw new IllegalArgumentException("No build stage setup for programming language " + programmingLanguage);
+            default:
+                throw new IllegalArgumentException("No build stage setup for programming language " + programmingLanguage);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
@@ -243,12 +243,12 @@ public interface ContinuousIntegrationService {
             @Override
             public String forProgrammingLanguage(ProgrammingLanguage language) {
                 switch (language) {
-                case JAVA:
-                case PYTHON:
-                case C:
-                    return Constants.ASSIGNMENT_CHECKOUT_PATH;
-                default:
-                    throw new IllegalArgumentException("Repository checkout path for assignment repo has not yet been defined for " + language);
+                    case JAVA:
+                    case PYTHON:
+                    case C:
+                        return Constants.ASSIGNMENT_CHECKOUT_PATH;
+                    default:
+                        throw new IllegalArgumentException("Repository checkout path for assignment repo has not yet been defined for " + language);
                 }
             }
         },
@@ -257,13 +257,13 @@ public interface ContinuousIntegrationService {
             @Override
             public String forProgrammingLanguage(ProgrammingLanguage language) {
                 switch (language) {
-                case JAVA:
-                case PYTHON:
-                    return "";
-                case C:
-                    return Constants.TESTS_CHECKOUT_PATH;
-                default:
-                    throw new IllegalArgumentException("Repository checkout path for test repo has not yet been defined for " + language);
+                    case JAVA:
+                    case PYTHON:
+                        return "";
+                    case C:
+                        return Constants.TESTS_CHECKOUT_PATH;
+                    default:
+                        throw new IllegalArgumentException("Repository checkout path for test repo has not yet been defined for " + language);
                 }
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreatorProvider.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreatorProvider.java
@@ -24,10 +24,10 @@ public class JenkinsBuildPlanCreatorProvider {
      */
     public JenkinsXmlConfigBuilder builderFor(ProgrammingLanguage programmingLanguage) {
         switch (programmingLanguage) {
-        case JAVA:
-            return javaJenkinsBuildPlanCreator;
-        default:
-            throw new IllegalArgumentException("Unsupported programming language for new Jenkins job!");
+            case JAVA:
+                return javaJenkinsBuildPlanCreator;
+            default:
+                throw new IllegalArgumentException("Unsupported programming language for new Jenkins job!");
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -271,46 +271,48 @@ public class QuizExerciseResource {
         }
 
         switch (action) {
-        case "start-now":
-            // check if quiz hasn't already started
-            if (quizExercise.isStarted()) {
-                return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "quizAlreadyStarted", "Quiz has already started."))
+            case "start-now":
+                // check if quiz hasn't already started
+                if (quizExercise.isStarted()) {
+                    return ResponseEntity.badRequest()
+                            .headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "quizAlreadyStarted", "Quiz has already started.")).build();
+                }
+
+                // set release date to now
+                quizExercise.setReleaseDate(ZonedDateTime.now());
+                quizExercise.setIsPlannedToStart(true);
+                groupNotificationService.notifyStudentGroupAboutExerciseStart(quizExercise);
+                break;
+            case "set-visible":
+                // check if quiz is already visible
+                if (quizExercise.isVisibleToStudents()) {
+                    return ResponseEntity.badRequest()
+                            .headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "quizAlreadyVisible", "Quiz is already visible to students.")).build();
+                }
+
+                // set quiz to visible
+                quizExercise.setIsVisibleBeforeStart(true);
+                break;
+            case "open-for-practice":
+                // check if quiz has ended
+                if (!quizExercise.isStarted() || quizExercise.getRemainingTime() > 0) {
+                    return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "quizNotEndedYet", "Quiz hasn't ended yet."))
+                            .build();
+                }
+                // check if quiz is already open for practice
+                if (quizExercise.isIsOpenForPractice()) {
+                    return ResponseEntity.badRequest()
+                            .headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "quizAlreadyOpenForPractice", "Quiz is already open for practice."))
+                            .build();
+                }
+
+                // set quiz to open for practice
+                quizExercise.setIsOpenForPractice(true);
+                groupNotificationService.notifyStudentGroupAboutExercisePractice(quizExercise);
+                break;
+            default:
+                return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "unknownAction", "Unknown action: " + action))
                         .build();
-            }
-
-            // set release date to now
-            quizExercise.setReleaseDate(ZonedDateTime.now());
-            quizExercise.setIsPlannedToStart(true);
-            groupNotificationService.notifyStudentGroupAboutExerciseStart(quizExercise);
-            break;
-        case "set-visible":
-            // check if quiz is already visible
-            if (quizExercise.isVisibleToStudents()) {
-                return ResponseEntity.badRequest()
-                        .headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "quizAlreadyVisible", "Quiz is already visible to students.")).build();
-            }
-
-            // set quiz to visible
-            quizExercise.setIsVisibleBeforeStart(true);
-            break;
-        case "open-for-practice":
-            // check if quiz has ended
-            if (!quizExercise.isStarted() || quizExercise.getRemainingTime() > 0) {
-                return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "quizNotEndedYet", "Quiz hasn't ended yet."))
-                        .build();
-            }
-            // check if quiz is already open for practice
-            if (quizExercise.isIsOpenForPractice()) {
-                return ResponseEntity.badRequest()
-                        .headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "quizAlreadyOpenForPractice", "Quiz is already open for practice.")).build();
-            }
-
-            // set quiz to open for practice
-            quizExercise.setIsOpenForPractice(true);
-            groupNotificationService.notifyStudentGroupAboutExercisePractice(quizExercise);
-            break;
-        default:
-            return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(applicationName, true, "quizExercise", "unknownAction", "Unknown action: " + action)).build();
         }
 
         // save quiz exercise

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionAndResultIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionAndResultIntegrationTest.java
@@ -491,12 +491,12 @@ class ProgrammingSubmissionAndResultIntegrationTest extends AbstractSpringIntegr
 
     private String getBuildPlanIdByParticipationType(IntegrationTestParticipationType participationType, int participationNumber) {
         switch (participationType) {
-        case TEMPLATE:
-            return "BASE";
-        case SOLUTION:
-            return "SOLUTION";
-        default:
-            return getStudentLoginFromParticipation(participationNumber);
+            case TEMPLATE:
+                return "BASE";
+            case SOLUTION:
+                return "SOLUTION";
+            default:
+                return getStudentLoginFromParticipation(participationNumber);
         }
     }
 
@@ -550,12 +550,12 @@ class ProgrammingSubmissionAndResultIntegrationTest extends AbstractSpringIntegr
 
     private Long getParticipationIdByType(IntegrationTestParticipationType participationType, int participationNumber) {
         switch (participationType) {
-        case SOLUTION:
-            return solutionParticipationId;
-        case TEMPLATE:
-            return templateParticipationId;
-        default:
-            return participationIds.get(participationNumber);
+            case SOLUTION:
+                return solutionParticipationId;
+            case TEMPLATE:
+                return templateParticipationId;
+            default:
+                return participationIds.get(participationNumber);
         }
     }
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Description
We are running spotless on every commit via `linting.sh` to *lint* our Java code. Currently spotless adds odd formatting to switch statements (`switch` and `case` are indented at the same level). Therefore I adjusted the `indent_switchstatements_compare_to_switch` setting in `artemis-spotless-style.xml`.

A side-effect is that all switch statements in the code will be re-formatted.  

### Steps for Testing
Simply check the changed files :-)