### PR TITLE
Bugfix: Overflow in mc-question preview

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
@@ -66,7 +66,13 @@
                 >
                     <!-- Preview -->
                     <ng-container #preview>
-                        <jhi-multiple-choice-question *ngIf="showMultipleChoiceQuestionPreview" [question]="question" [selectedAnswerOptions]="[]" [questionIndex]="questionIndex">
+                        <jhi-multiple-choice-question
+                            *ngIf="showMultipleChoiceQuestionPreview"
+                            [question]="question"
+                            [selectedAnswerOptions]="[]"
+                            [questionIndex]="questionIndex"
+                            class="overflow-auto"
+                        >
                         </jhi-multiple-choice-question>
                         <hr />
                     </ng-container>

--- a/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
@@ -63,16 +63,11 @@
                     [domainCommands]="commandMultipleChoiceQuestions"
                     (markdownChange)="prepareForSave()"
                     (textWithDomainCommandsFound)="domainCommandsFound($event)"
+                    class="h-auto"
                 >
                     <!-- Preview -->
                     <ng-container #preview>
-                        <jhi-multiple-choice-question
-                            *ngIf="showMultipleChoiceQuestionPreview"
-                            [question]="question"
-                            [selectedAnswerOptions]="[]"
-                            [questionIndex]="questionIndex"
-                            class="overflow-auto"
-                        >
+                        <jhi-multiple-choice-question *ngIf="showMultipleChoiceQuestionPreview" [question]="question" [selectedAnswerOptions]="[]" [questionIndex]="questionIndex">
                         </jhi-multiple-choice-question>
                         <hr />
                     </ng-container>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If the content of a mc-question was is big (which shouldn't even be the case) it overflows the container and breaks the layout (see https://github.com/ls1intum/Artemis/issues/1414)

### Description
<!-- Describe your changes in detail -->
Set the overflow of the generated component to `auto`.  The content is now scrollable if longer.
closes https://github.com/ls1intum/Artemis/issues/1414

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Exercise
3. Create new Quiz
4. Add new Multiple Choice Question
5. Write a really long text (or just copy paste 1000 word [lorem ipsum](https://loremipsum.de/))
6. Click on preview
7. Preview doesn't overflow but is scrollable

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Longer content is shown in its full length
<img width="1333" alt="Bildschirmfoto 2020-05-07 um 11 50 57" src="https://user-images.githubusercontent.com/51987021/81280710-29714680-9059-11ea-9e75-8ae59eec05dd.png">

