### PR TITLE
Bugfix/#1439

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ plugins {
 }
 
 group = "de.tum.in.www1.artemis"
-version = "4.0.5"
+version = "4.0.6"
 description = "Interactive Learning with Individual Feedback"
 
 sourceCompatibility=14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "artemis",
-    "version": "4.0.5",
+    "version": "4.0.6",
     "description": "Interactive Learning with Individual Feedback",
     "private": true,
     "license": "MIT",

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
@@ -316,7 +316,7 @@ public class TextAssessmentResource extends AssessmentResource {
         textSubmission.setResult(null);
 
         // If we did not call AutomaticTextFeedbackService::suggestFeedback, we need to fetch them now.
-        if (!computeFeedbackSuggestions) {
+        if (!result.getFeedbacks().isEmpty() || !computeFeedbackSuggestions) {
             final List<TextBlock> textBlocks = textBlockRepository.findAllBySubmissionId(textSubmission.getId());
             textSubmission.setBlocks(textBlocks);
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Server: I added multiple integration tests (Spring) related to the features
- [X] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [X] Server: I implemented the changes with a good performance and prevented too many database calls
- [X] ~Server: I documented the Java code using JavaDoc style.~

### Motivation and Context
Fixes #1439

### Description
In some cases, Text Blocks were not loaded from the database. This resulted in the fallback algorithm computing them, leading to different Text Blocks.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Find a Submission with Text Blocks from the Athene Segmentation (so Automatic Assessment enabled) where the Text Block is different from the Syntax based approach.
2. Assess the Submission and Submit
3. Open the same Submission again
4. Find all feedbacks displayed as expected.

