### PR TITLE
Show result badge on manual result trigger

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -17,7 +17,7 @@ import { SourceTreeService } from 'app/exercises/programming/shared/service/sour
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { CourseScoreCalculationService } from 'app/overview/course-score-calculation.service';
 import { InitializationState, Participation } from 'app/entities/participation/participation.model';
-import { Exercise, ExerciseCategory, ExerciseType } from 'app/entities/exercise.model';
+import { Exercise, ExerciseCategory, ExerciseType, ParticipationStatus } from 'app/entities/exercise.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { AssessmentType } from 'app/entities/assessment-type.model';
@@ -366,8 +366,16 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
     simulateResult() {
         this.programmingExerciseSimulationService.failsIfInProduction();
         this.courseExerciseSubmissionResultSimulationService.simulateResult(this.exerciseId).subscribe(
-            () => {
+            (result) => {
+                //set the value to false to deactivate the result button
                 this.wasSubmissionSimulated = false;
+
+                //set this values in order to visualize the result on the exercise details page
+                this.exercise!.participationStatus = ParticipationStatus.EXERCISE_SUBMITTED;
+                this.studentParticipation = <StudentParticipation>result.body!.participation;
+                this.studentParticipation.results = [];
+                this.studentParticipation.results[0] = result.body!;
+
                 this.jhiAlertService.success('artemisApp.exercise.resultCreationSuccessful');
             },
             () => {

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -367,10 +367,10 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
         this.programmingExerciseSimulationService.failsIfInProduction();
         this.courseExerciseSubmissionResultSimulationService.simulateResult(this.exerciseId).subscribe(
             (result) => {
-                //set the value to false to deactivate the result button
+                // set the value to false in order to deactivate the result button
                 this.wasSubmissionSimulated = false;
 
-                //set this values in order to visualize the result on the exercise details page
+                // set these values in order to visualize the simulated result on the exercise details page
                 this.exercise!.participationStatus = ParticipationStatus.EXERCISE_SUBMITTED;
                 this.studentParticipation = <StudentParticipation>result.body!.participation;
                 this.studentParticipation.results = [];


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As follow up PR to #1292 i enhanced the show result functionality. Prior to the newly added functionality it was necessary to refresh the browser in order to visualize the result badge.

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

On the test server(**Please test this with all roles: admin, instructor, tutor, student**):
1. Log in to Artemis
2. Navigate to Course Management
3. Create a programming exercise
4. Navigate to the Course Overview
5. Select the course with the created programming exercise
6. Open the programming exercise details page
=> nothing should happen, no exception in the development console or alert should be shown

Local testing:

0. Checkout this branch 
1. Start Artemis in your IDE
2. Log in to Artemis
3. Navigate to Course Management
4. Create a programming exercise without a connection to the vcs and ci 
-> normal creation procedure as for a normal programming exercise, but before you click on generate tick the checkbox "Setup without connection to the VCS and CI"

![Screenshot from 2020-04-30 18-23-16](https://user-images.githubusercontent.com/12066497/80735094-795b8500-8b10-11ea-8e3c-1fdcb8968453.png) 

5. Navigate to the Course Overview
6. Select the course with the created programming exercise
7. Open the programming exercise details page
->  Nothing should happen, no exception in the development console or alert should be shown
-> Two buttons (submission and result) should be visible
![Screenshot from 2020-04-30 18-27-55](https://user-images.githubusercontent.com/12066497/80735084-72347700-8b10-11ea-968d-0344957284b4.png)
8. If click on the submission and then on the result button an alert should be shown. 
![Screenshot from 2020-05-09 20-15-35](https://user-images.githubusercontent.com/12066497/81481665-f33aef00-9231-11ea-9f41-105490498473.png)
![Screenshot from 2020-05-09 20-15-43](https://user-images.githubusercontent.com/12066497/81481667-f59d4900-9231-11ea-8840-37d9a21d13d1.png)
In addition, after the result button click, the result badge should be visualized.
![Screenshot from 2020-05-10 23-26-33](https://user-images.githubusercontent.com/12066497/81510917-cbbd5280-9315-11ea-8eed-b5626a29886d.png)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![LocalSetup](https://user-images.githubusercontent.com/12066497/81510889-9dd80e00-9315-11ea-9411-e740c9fd82ea.gif)
