### PR TITLE
Use type operator instead of notification.class

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/NotificationRepository.java
@@ -21,18 +21,18 @@ import de.tum.in.www1.artemis.domain.notification.Notification;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     @Query("select notification from Notification notification left join notification.course left join notification.recipient "
-            + "where (notification.class = GroupNotification and ((notification.course.instructorGroupName in :#{#currentGroups} AND notification.type = 'INSTRUCTOR') "
+            + "where (type(notification) = GroupNotification and ((notification.course.instructorGroupName in :#{#currentGroups} AND notification.type = 'INSTRUCTOR') "
             + "or (notification.course.teachingAssistantGroupName in :#{#currentGroups} AND notification.type = 'TA') "
             + "or (notification.course.studentGroupName in :#{#currentGroups} AND notification.type = 'STUDENT')))"
-            + "or notification.class = SingleUserNotification and notification.recipient.login = :#{#login}")
+            + "or type(notification) = SingleUserNotification and notification.recipient.login = :#{#login}")
     Page<Notification> findAllNotificationsForRecipientWithLogin(@Param("currentGroups") Set<String> currentUserGroups, Pageable pageable, @Param("login") String login);
 
     @Query("select notification from Notification notification left join notification.course left join notification.recipient "
             + "where (:#{#lastNotificationRead} is null or notification.notificationDate > :#{#lastNotificationRead}) AND "
-            + "((notification.class = GroupNotification and ((notification.course.instructorGroupName in :#{#currentGroups} AND notification.type = 'INSTRUCTOR') "
+            + "((type(notification) = GroupNotification and ((notification.course.instructorGroupName in :#{#currentGroups} AND notification.type = 'INSTRUCTOR') "
             + "or (notification.course.teachingAssistantGroupName in :#{#currentGroups} AND notification.type = 'TA') "
             + "or (notification.course.studentGroupName in :#{#currentGroups} AND notification.type = 'STUDENT')))"
-            + "or notification.class = SingleUserNotification and notification.recipient.login = :#{#login})")
+            + "or type(notification) = SingleUserNotification and notification.recipient.login = :#{#login})")
     List<Notification> findAllRecentNotificationsForRecipientWithLogin(@Param("currentGroups") Set<String> currentUserGroups, @Param("login") String login,
             @Param("lastNotificationRead") ZonedDateTime lastNotificationRead);
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Description
Both native queries in the `NotificationRepository` used the `entity.class` which is deprecated. I replaced it with `type(entity).`

The corresponding warning was:
``
May 11 11:59:34 vmbruegge60 artemis.sh[85661]: 2020-05-11 11:59:34.786 WARN 85665 --- [      main] org.hibernate.orm.deprecation      : HHH90000017: Found use of deprecated entity-type selector syntax in HQL/JPQL query [‘notification.class’]; use TYPE operator instead : type(notification)
``

### Steps for Testing
1. Log in to Artemis
2. Open the notification sidebar by clicking on the notification bell in the top navigation
   a) If you have recent notifications you should see them in the notification sidebar
   b) Then click on `Show all notifications`. You should see a list of your notifications.