### PR TITLE
Consistent date formatting

### DIFF
--- a/src/main/webapp/app/admin/audits/audits.component.html
+++ b/src/main/webapp/app/admin/audits/audits.component.html
@@ -30,7 +30,7 @@
             </thead>
             <tr *ngFor="let audit of getAudits()">
                 <td>
-                    <span>{{ audit.timestamp | date: 'medium' }}</span>
+                    <span>{{ audit.timestamp | artemisDate }}</span>
                 </td>
                 <td>
                     <small>{{ audit.principal }}</small>

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management-detail.component.html
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management-detail.component.html
@@ -15,7 +15,7 @@
         <dt><span jhiTranslate="artemisApp.systemNotification.type">Type</span></dt>
         <dd>{{ notification.type }}</dd>
         <dt><span jhiTranslate="artemisApp.systemNotification.expireDate">Expire Date</span></dt>
-        <dd>{{ notification.expireDate | date: 'dd.MM.yyyy HH:mm' }}</dd>
+        <dd>{{ notification.expireDate | artemisDate }}</dd>
     </dl>
     <button type="submit" routerLink="/admin/system-notification-management" class="btn btn-info">
         <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.html
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.html
@@ -32,8 +32,8 @@
                             <span class="badge badge-danger">{{ 'artemisApp.systemNotification.notActive' | translate }}</span>
                         </ng-template>
                     </td>
-                    <td>{{ notification.notificationDate | date: 'dd.MM.yyyy HH:mm' }}</td>
-                    <td>{{ notification.expireDate | date: 'dd.MM.yyyy HH:mm' }}</td>
+                    <td>{{ notification.notificationDate | artemisDate }}</td>
+                    <td>{{ notification.expireDate | artemisDate }}</td>
                     <td class="text-right">
                         <div class="btn-group flex-btn-group-container">
                             <button type="submit" [routerLink]="['./', notification.id, 'view']" class="btn btn-info btn-sm">

--- a/src/main/webapp/app/admin/tracker/tracker.component.html
+++ b/src/main/webapp/app/admin/tracker/tracker.component.html
@@ -19,7 +19,7 @@
                     <td>{{ activity.userLogin }}</td>
                     <td>{{ activity.ipAddress }}</td>
                     <td>{{ activity.page }}</td>
-                    <td>{{ activity.time | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+                    <td>{{ activity.time | artemisDate }}</td>
                 </tr>
             </tbody>
         </table>

--- a/src/main/webapp/app/admin/user-management/user-management-detail.component.html
+++ b/src/main/webapp/app/admin/user-management/user-management-detail.component.html
@@ -20,11 +20,11 @@
         <dt><span jhiTranslate="userManagement.createdBy">Created By</span></dt>
         <dd>{{ user.createdBy }}</dd>
         <dt><span jhiTranslate="userManagement.createdDate">Created Date</span></dt>
-        <dd>{{ user.createdDate | date: 'dd.MM.yy HH:mm' }}</dd>
+        <dd>{{ user.createdDate | artemisDate }}</dd>
         <dt><span jhiTranslate="userManagement.lastModifiedBy">Last Modified By</span></dt>
         <dd>{{ user.lastModifiedBy }}</dd>
         <dt><span jhiTranslate="userManagement.lastModifiedDate">Last Modified Date</span></dt>
-        <dd>{{ user.lastModifiedDate | date: 'dd.MM.yy HH:mm' }}</dd>
+        <dd>{{ user.lastModifiedDate | artemisDate }}</dd>
         <dt><span jhiTranslate="userManagement.profiles">Profiles</span></dt>
         <dd>
             <ul class="list-unstyled">

--- a/src/main/webapp/app/admin/user-management/user-management.component.html
+++ b/src/main/webapp/app/admin/user-management/user-management.component.html
@@ -85,9 +85,9 @@
                             <span class="badge badge-info">{{ group }}</span>
                         </div>
                     </td>
-                    <td>{{ user.createdDate | date: 'dd.MM.yy HH:mm' }}</td>
+                    <td>{{ user.createdDate | artemisDate }}</td>
                     <td>{{ user.lastModifiedBy }}</td>
-                    <td>{{ user.lastModifiedDate | date: 'dd.MM.yy HH:mm' }}</td>
+                    <td>{{ user.lastModifiedDate | artemisDate }}</td>
                     <td class="text-right">
                         <div class="btn-group flex-btn-group-container">
                             <button type="submit" [routerLink]="['./', user.login, 'view']" class="btn btn-info btn-sm">

--- a/src/main/webapp/app/course/dashboards/instructor-course-dashboard/instructor-course-dashboard.component.html
+++ b/src/main/webapp/app/course/dashboards/instructor-course-dashboard/instructor-course-dashboard.component.html
@@ -97,8 +97,8 @@
                             <fa-icon [icon]="getIcon(exercise.type)" placement="right" [ngbTooltip]="getIconTooltip(exercise.type) | translate" container="body"></fa-icon>
                         </td>
                         <td>{{ exercise.title }}</td>
-                        <td>{{ exercise.dueDate | date: 'medium' }}</td>
-                        <td>{{ exercise.assessmentDueDate | date: 'medium' }}</td>
+                        <td>{{ exercise.dueDate | artemisDate }}</td>
+                        <td>{{ exercise.assessmentDueDate | artemisDate }}</td>
                         <td>{{ exercise.numberOfParticipations }}</td>
                         <td>{{ exercise.numberOfComplaints }}</td>
                         <td>{{ exercise.numberOfMoreFeedbackRequests }}</td>

--- a/src/main/webapp/app/course/manage/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/course-detail.component.html
@@ -31,11 +31,11 @@
                 </dd>
                 <dt><span jhiTranslate="artemisApp.course.startDate">Start Date</span></dt>
                 <dd>
-                    <span>{{ course.startDate | date: 'medium' }}</span>
+                    <span>{{ course.startDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.course.endDate">End Date</span></dt>
                 <dd>
-                    <span>{{ course.endDate | date: 'medium' }}</span>
+                    <span>{{ course.endDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.course.onlineCourse">Online Course</span></dt>
                 <dd>

--- a/src/main/webapp/app/course/manage/course-management.component.html
+++ b/src/main/webapp/app/course/manage/course-management.component.html
@@ -101,8 +101,8 @@
                                 {{ course.instructorGroupName }} ({{ course.numberOfInstructors }})
                             </div>
                         </td>
-                        <td>{{ course.startDate | date: 'medium' }}</td>
-                        <td>{{ course.endDate | date: 'medium' }}</td>
+                        <td>{{ course.startDate | artemisDate }}</td>
+                        <td>{{ course.endDate | artemisDate }}</td>
                         <td class="d-none d-md-table-cell">
                             <span *ngIf="course.onlineCourse">{{ 'artemisApp.course.onlineCourseTrue' | translate }}</span>
                             <span *ngIf="!course.onlineCourse">{{ 'artemisApp.course.onlineCourseFalse' | translate }}</span>

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
@@ -35,7 +35,7 @@
             <tbody>
                 <tr [ngStyle]="submission.optimal && { 'font-weight': 'bold' }" *ngFor="let submission of filteredSubmissions | sortBy: predicate:reverse; let i = index">
                     <td>{{ i + 1 }}</td>
-                    <td>{{ submission.submissionDate | date: 'MMM d, y HH:mm:ss' }}</td>
+                    <td>{{ submission.submissionDate | artemisDate }}</td>
                     <td>
                         <jhi-result [participation]="submission.participation"></jhi-result>
                     </td>

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-detail.component.html
@@ -27,11 +27,11 @@
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.releaseDate">Release Date</span></dt>
                 <dd>
-                    <span>{{ fileUploadExercise.releaseDate | date: 'medium' }}</span>
+                    <span>{{ fileUploadExercise.releaseDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.dueDate">Due Date</span></dt>
                 <dd>
-                    <span>{{ fileUploadExercise.dueDate | date: 'medium' }}</span>
+                    <span>{{ fileUploadExercise.dueDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.maxScore">Max Score</span></dt>
                 <dd>

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
@@ -42,9 +42,9 @@
                         <a [routerLink]="['/course-management', fileUploadExercise.course.id, 'file-upload-exercises', fileUploadExercise.id]">{{ fileUploadExercise.id }}</a>
                     </td>
                     <td>{{ fileUploadExercise.title }}</td>
-                    <td>{{ fileUploadExercise.releaseDate | date: 'medium' }}</td>
-                    <td>{{ fileUploadExercise.dueDate | date: 'medium' }}</td>
-                    <td>{{ fileUploadExercise.assessmentDueDate | date: 'medium' }}</td>
+                    <td>{{ fileUploadExercise.releaseDate | artemisDate }}</td>
+                    <td>{{ fileUploadExercise.dueDate | artemisDate }}</td>
+                    <td>{{ fileUploadExercise.assessmentDueDate | artemisDate }}</td>
                     <td>{{ fileUploadExercise.maxScore }}</td>
                     <td *ngIf="course.presentationScore !== 0">{{ fileUploadExercise.presentationScoreEnabled }}</td>
                     <td>{{ fileUploadExercise.filePattern }}</td>

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
@@ -141,7 +141,7 @@
                 <tr [ngStyle]="submission.optimal && { 'font-weight': 'bold' }" *ngFor="let submission of otherSubmissions | sortBy: predicate:reverse; let i = index">
                     <td>{{ i + 1 }}</td>
                     <td>{{ submission.participation.participantName }}</td>
-                    <td>{{ submission.submissionDate | date: 'MMM d, y HH:mm:ss' }}</td>
+                    <td>{{ submission.submissionDate | artemisDate }}</td>
                     <td>
                         <jhi-result [participation]="submission.participation"></jhi-result>
                     </td>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.html
@@ -19,11 +19,11 @@
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.releaseDate">Release Date</span></dt>
                 <dd>
-                    <span>{{ modelingExercise.releaseDate | date: 'medium' }}</span>
+                    <span>{{ modelingExercise.releaseDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.dueDate">Due Date</span></dt>
                 <dd>
-                    <span>{{ modelingExercise.dueDate | date: 'medium' }}</span>
+                    <span>{{ modelingExercise.dueDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.maxScore">Max Score</span></dt>
                 <dd>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
@@ -42,9 +42,9 @@
                         <a [routerLink]="['/course-management', modelingExercise.course.id, 'modeling-exercises', modelingExercise.id]">{{ modelingExercise.id }}</a>
                     </td>
                     <td>{{ modelingExercise.title }}</td>
-                    <td>{{ modelingExercise.releaseDate | date: 'medium' }}</td>
-                    <td>{{ modelingExercise.dueDate | date: 'medium' }}</td>
-                    <td>{{ modelingExercise.assessmentDueDate | date: 'medium' }}</td>
+                    <td>{{ modelingExercise.releaseDate | artemisDate }}</td>
+                    <td>{{ modelingExercise.dueDate | artemisDate }}</td>
+                    <td>{{ modelingExercise.assessmentDueDate | artemisDate }}</td>
                     <td>{{ modelingExercise.maxScore }}</td>
                     <td *ngIf="course.presentationScore !== 0">{{ modelingExercise.presentationScoreEnabled }}</td>
                     <td jhiTranslate="{{ 'artemisApp.DiagramType.' + modelingExercise.diagramType }}">{{ modelingExercise.diagramType }}</td>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -49,16 +49,16 @@
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.releaseDate">Release Date</span></dt>
                 <dd>
-                    <span>{{ programmingExercise.releaseDate | date: 'medium' }}</span>
+                    <span>{{ programmingExercise.releaseDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.dueDate">Due Date</span></dt>
                 <dd>
-                    <span>{{ programmingExercise.dueDate | date: 'medium' }}</span>
+                    <span>{{ programmingExercise.dueDate | artemisDate }}</span>
                 </dd>
                 <ng-container *ngIf="programmingExercise.dueDate">
                     <dt><span jhiTranslate="artemisApp.programmingExercise.timeline.afterDueDate">Automatic Submission Run After Due Date</span></dt>
                     <dd>
-                        <span>{{ programmingExercise.buildAndTestStudentSubmissionsAfterDueDate | date: 'medium' }}</span>
+                        <span>{{ programmingExercise.buildAndTestStudentSubmissionsAfterDueDate | artemisDate }}</span>
                     </dd>
                 </ng-container>
                 <dt><span jhiTranslate="artemisApp.exercise.maxScore">Max Score</span></dt>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -78,8 +78,8 @@
                         ></jhi-programming-exercise-test-cases-dirty-warning>
                     </td>
                     <td class="d-none d-md-table-cell">{{ programmingExercise.shortName }}</td>
-                    <td>{{ programmingExercise.releaseDate | date: 'medium' }}</td>
-                    <td>{{ programmingExercise.dueDate | date: 'medium' }}</td>
+                    <td>{{ programmingExercise.releaseDate | artemisDate }}</td>
+                    <td>{{ programmingExercise.dueDate | artemisDate }}</td>
                     <td class="d-none d-md-table-cell">{{ programmingExercise.maxScore }}</td>
                     <td *ngIf="!isOrion" class="d-flex flex-column">
                         <div class="d-flex justify-content-between">

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/build-output/code-editor-build-output.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/build-output/code-editor-build-output.component.html
@@ -15,7 +15,7 @@
     <div class="card-body build-output__content" *ngIf="!isBuilding && rawBuildLogs.length">
         <div class="buildoutput d-flex flex-column">
             <span *ngFor="let logEntry of rawBuildLogs" class="build-output__entry">
-                <span class="build-output__entry-date">{{ logEntry.time | date: 'yyyy-MM-dd HH:mm:ss' }}</span>
+                <span class="build-output__entry-date">{{ logEntry.time | artemisDate }}</span>
                 <span class="build-output__entry-text">{{ logEntry.log }}</span>
             </span>
         </div>

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
@@ -63,7 +63,7 @@
                         <span *ngIf="quizExercise.status === QuizStatus.ACTIVE">{{ 'artemisApp.quizExercise.quizStatus.active' | translate }}</span>
                         <span *ngIf="quizExercise.status === QuizStatus.OPEN_FOR_PRACTICE">{{ 'artemisApp.quizExercise.quizStatus.openForPractice' | translate }}</span>
                     </td>
-                    <td>{{ quizExercise.isPlannedToStart ? (quizExercise.releaseDate | date: 'medium') : '-' }}</td>
+                    <td>{{ quizExercise.isPlannedToStart ? (quizExercise.releaseDate | artemisDate) : '-' }}</td>
                     <td>
                         {{ fullMinutesForSeconds(quizExercise.duration) }}
                         <span jhiTranslate="{{ quizExercise.duration % 60 ? 'artemisApp.quizExercise.minutesShort' : 'artemisApp.quizExercise.minutes' }}"></span>

--- a/src/main/webapp/app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.component.html
@@ -26,7 +26,7 @@
             </div>
             <div class="form-group">
                 <span jhiTranslate="artemisApp.quizExercise.startTime" class="colon-suffix"></span>
-                <span>{{ quizExercise.releaseDate | date: 'yyyy-MM-dd HH:mm:ss' }}</span>
+                <span>{{ quizExercise.releaseDate | artemisDate }}</span>
             </div>
         </div>
         <div *ngFor="let question of quizExercise.quizQuestions; let i = index" style="width: 100%;">

--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
@@ -120,7 +120,7 @@
                 </div>
                 <div *ngIf="mode === 'live' && !waitingForQuizStart">
                     <span *ngIf="isSaving" jhiTranslate="artemisApp.quizExercise.isSaving">Saving answers...</span>
-                    <span *ngIf="!isSaving && !isMobile()" ngbTooltip="{{ submission.adjustedSubmissionDate | date: 'MMM d, y HH:mm:ss' }}" placement="right">
+                    <span *ngIf="!isSaving && !isMobile()" ngbTooltip="{{ submission.adjustedSubmissionDate | artemisDate }}" placement="right">
                         <span *ngIf="!submission.submitted" jhiTranslate="artemisApp.quizExercise.lastSaved" class="colon-suffix"></span>
                         <span *ngIf="submission.submitted" jhiTranslate="artemisApp.quizExercise.submitted" class="colon-suffix"></span>
                         <span *ngIf="justSaved" jhiTranslate="justNow"></span>
@@ -128,7 +128,7 @@
                         <span *ngIf="!justSaved && lastSavedTimeText === ''" jhiTranslate="artemisApp.quizExercise.lastSavedTimeNever"></span>
                     </span>
                     <!-- Only display save and submission hint without time stamps for mobile -->
-                    <span *ngIf="!isSaving && isMobile()" ngbTooltip="{{ submission.adjustedSubmissionDate | date: 'MMM d, y HH:mm:ss' }}" placement="right">
+                    <span *ngIf="!isSaving && isMobile()" ngbTooltip="{{ submission.adjustedSubmissionDate | artemisDate }}" placement="right">
                         <span *ngIf="!submission.submitted" jhiTranslate="artemisApp.quizExercise.lastSaved"></span>
                         <span *ngIf="submission.submitted" jhiTranslate="artemisApp.quizExercise.submitted"></span>
                     </span>

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/tutor-exercise-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/tutor-exercise-dashboard.component.html
@@ -219,7 +219,7 @@
                     <tbody>
                         <tr *ngFor="let submission of submissions; let i = index">
                             <td>{{ i + 1 }}</td>
-                            <td>{{ submission.submissionDate | date: 'MMM d, y HH:mm:ss' }}</td>
+                            <td>{{ submission.submissionDate | artemisDate }}</td>
                             <td>
                                 <jhi-result [participation]="submission.participation"></jhi-result>
                             </td>
@@ -259,7 +259,7 @@
                         </tr>
                         <tr *ngIf="unassessedSubmission && unassessedSubmission?.id > 0">
                             <td></td>
-                            <td>{{ unassessedSubmission?.submissionDate | date: 'MMM d, y HH:mm:ss' }}</td>
+                            <td>{{ unassessedSubmission?.submissionDate | artemisDate }}</td>
                             <td></td>
                             <td>{{ 'artemisApp.tutorExerciseDashboard.new' | translate }}</td>
                             <td></td>
@@ -318,7 +318,7 @@
                         <tbody>
                             <tr *ngFor="let complaint of complaints; let i = index">
                                 <td>{{ i + 1 }}</td>
-                                <td>{{ complaint.submittedTime | date: 'MMM d, y HH:mm:ss' }}</td>
+                                <td>{{ complaint.submittedTime | artemisDate }}</td>
                                 <td>
                                     <jhi-result [result]="complaint.result" [participation]="complaint.result.participation"></jhi-result>
                                 </td>
@@ -372,7 +372,7 @@
                         <tbody>
                             <tr *ngFor="let moreFeedbackRequest of moreFeedbackRequests; let i = index">
                                 <td>{{ i + 1 }}</td>
-                                <td>{{ moreFeedbackRequest.submittedTime | date: 'MMM d, y HH:mm:ss' }}</td>
+                                <td>{{ moreFeedbackRequest.submittedTime | artemisDate }}</td>
                                 <td>
                                     <jhi-result [result]="moreFeedbackRequest.result"></jhi-result>
                                 </td>

--- a/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
+++ b/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
@@ -36,7 +36,7 @@
                 <span jhiTranslate="artemisApp.participation.participationSubmission.submissionDate"></span>
             </ng-template>
             <ng-template ngx-datatable-cell-template let-value="value">
-                {{ value | date: 'medium' }}
+                {{ value | artemisDate }}
             </ng-template>
         </ngx-datatable-column>
         <ngx-datatable-column prop="result">

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.html
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.html
@@ -135,7 +135,7 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
-                        {{ value | date: 'medium' }}
+                        {{ value | artemisDate }}
                     </ng-template>
                 </ngx-datatable-column>
 

--- a/src/main/webapp/app/exercises/shared/result/result-detail.component.html
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.component.html
@@ -43,7 +43,7 @@
             <dl class="buildoutput dl-horizontal">
                 <ng-container *ngFor="let logEntry of buildLogs; let i = index">
                     <!--Don't show the timestamp again if it is the same as the last entry's.-->
-                    <dt class="mb-1" *ngIf="i === 0 || logEntry.time !== buildLogs[i - 1].time">{{ logEntry.time | date: 'yyyy-MM-dd HH:mm:ss' }}</dt>
+                    <dt class="mb-1" *ngIf="i === 0 || logEntry.time !== buildLogs[i - 1].time">{{ logEntry.time | artemisDate }}</dt>
                     <dd
                         [class.text-danger]="logEntry.type === BuildLogType.ERROR"
                         [class.font-weight-bold]="logEntry.type === BuildLogType.ERROR"

--- a/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
@@ -37,7 +37,7 @@
             <tbody>
                 <tr [ngStyle]="submission.optimal && { 'font-weight': 'bold' }" *ngFor="let submission of filteredSubmissions | sortBy: predicate:reverse; let i = index">
                     <td>{{ i + 1 }}</td>
-                    <td>{{ submission.submissionDate | date: 'MMM d, y HH:mm:ss' }}</td>
+                    <td>{{ submission.submissionDate | artemisDate }}</td>
                     <td>
                         <jhi-result [participation]="submission.participation"></jhi-result>
                     </td>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.html
@@ -19,11 +19,11 @@
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.releaseDate">Release Date</span></dt>
                 <dd>
-                    <span>{{ textExercise.releaseDate | date: 'medium' }}</span>
+                    <span>{{ textExercise.releaseDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.dueDate">Due Date</span></dt>
                 <dd>
-                    <span>{{ textExercise.dueDate | date: 'medium' }}</span>
+                    <span>{{ textExercise.dueDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.exercise.maxScore">Max Score</span></dt>
                 <dd>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.html
@@ -40,9 +40,9 @@
                         <a [routerLink]="['/course-management', course.id, 'text-exercises', textExercise.id]">{{ textExercise.id }}</a>
                     </td>
                     <td>{{ textExercise.title }}</td>
-                    <td>{{ textExercise.releaseDate | date: 'medium' }}</td>
-                    <td>{{ textExercise.dueDate | date: 'medium' }}</td>
-                    <td>{{ textExercise.assessmentDueDate | date: 'medium' }}</td>
+                    <td>{{ textExercise.releaseDate | artemisDate }}</td>
+                    <td>{{ textExercise.dueDate | artemisDate }}</td>
+                    <td>{{ textExercise.assessmentDueDate | artemisDate }}</td>
                     <td>{{ textExercise.maxScore }}</td>
                     <td *ngIf="course.presentationScore !== 0">{{ textExercise.presentationScoreEnabled }}</td>
                     <td class="text-right">

--- a/src/main/webapp/app/lecture/lecture-attachments.component.html
+++ b/src/main/webapp/app/lecture/lecture-attachments.component.html
@@ -8,13 +8,13 @@
                 <div class="col-6">
                     <dt><span jhiTranslate="artemisApp.lecture.startDate">Start Date</span></dt>
                     <dd>
-                        <span>{{ lecture.startDate | date: 'dd.MM.yy HH:mm' }}</span>
+                        <span>{{ lecture.startDate | artemisDate }}</span>
                     </dd>
                 </div>
                 <div class="col-6">
                     <dt><span jhiTranslate="artemisApp.lecture.endDate">End Date</span></dt>
                     <dd>
-                        <span>{{ lecture.endDate | date: 'dd.MM.yy HH:mm' }}</span>
+                        <span>{{ lecture.endDate | artemisDate }}</span>
                     </dd>
                 </div>
             </div>
@@ -65,8 +65,8 @@
                                             <fa-icon [icon]="'spinner'" [spin]="true"></fa-icon> {{ 'artemisApp.courseOverview.lectureDetails.isDownloading' | translate }}
                                         </a>
                                     </td>
-                                    <td>{{ attachment.releaseDate | date: 'dd.MM.yy HH:mm' }}</td>
-                                    <td>{{ attachment.uploadDate | date: 'dd.MM.yy HH:mm' }}</td>
+                                    <td>{{ attachment.releaseDate | artemisDate }}</td>
+                                    <td>{{ attachment.uploadDate | artemisDate }}</td>
                                     <td>
                                         {{ attachment.version }}
                                     </td>

--- a/src/main/webapp/app/lecture/lecture-detail.component.html
+++ b/src/main/webapp/app/lecture/lecture-detail.component.html
@@ -13,11 +13,11 @@
                 <dd class="markdown-preview editor-outline-background" [innerHTML]="lecture.description | htmlForMarkdown"></dd>
                 <dt><span jhiTranslate="artemisApp.lecture.startDate">Start Date</span></dt>
                 <dd>
-                    <span>{{ lecture.startDate | date: 'medium' }}</span>
+                    <span>{{ lecture.startDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.lecture.endDate">End Date</span></dt>
                 <dd>
-                    <span>{{ lecture.endDate | date: 'medium' }}</span>
+                    <span>{{ lecture.endDate | artemisDate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.lecture.course">Course</span></dt>
                 <dd>

--- a/src/main/webapp/app/lecture/lecture.component.html
+++ b/src/main/webapp/app/lecture/lecture.component.html
@@ -30,8 +30,8 @@
                     </td>
                     <td>{{ lecture.title }}</td>
                     <td [innerHTML]="lecture.description | htmlForMarkdown"></td>
-                    <td>{{ lecture.startDate | date: 'medium' }}</td>
-                    <td>{{ lecture.endDate | date: 'medium' }}</td>
+                    <td>{{ lecture.startDate | artemisDate }}</td>
+                    <td>{{ lecture.endDate | artemisDate }}</td>
                     <td>
                         <div *ngIf="lecture.course">
                             <a [routerLink]="['../view']">{{ lecture.course?.title }}</a>

--- a/src/main/webapp/app/overview/course-exercises/course-exercises.component.html
+++ b/src/main/webapp/app/overview/course-exercises/course-exercises.component.html
@@ -23,7 +23,7 @@
                         'artemisApp.courseOverview.exerciseList.currentExerciseGroupHeader'
                             | translate
                                 : {
-                                      date: nextRelevantExercise.dueDate | date: 'dd.MM.yy HH:mm'
+                                      date: nextRelevantExercise.dueDate | artemisDate: 'short'
                                   }
                     }}
                 </h3>
@@ -83,17 +83,17 @@
             </div>
             <div class="row mb-1" *ngIf="course?.startDate">
                 <div class="col-8">{{ 'artemisApp.courseOverview.exerciseList.details.startDate' | translate }}</div>
-                <div class="col-4">{{ course?.startDate | date: 'dd.MM.yy' }}</div>
+                <div class="col-4">{{ course?.startDate | artemisDate }}</div>
             </div>
             <div class="row" *ngIf="course?.endDate">
                 <div class="col-8">{{ 'artemisApp.courseOverview.exerciseList.details.endDate' | translate }}</div>
-                <div class="col-4">{{ course?.endDate | date: 'dd.MM.yy' }}</div>
+                <div class="col-4">{{ course?.endDate | artemisDate }}</div>
             </div>
         </jhi-side-panel>
         <div class="guided-tour exercise-panel mt-3">
             <jhi-side-panel [panelHeader]="'artemisApp.courseOverview.exerciseList.details.upcomingDeadlines' | translate">
                 <div class="row mb-1 has-exercises align-items-center" *ngFor="let exercise of upcomingExercises" [routerLink]="[exercise.id]">
-                    <div class="col-5">{{ exercise.dueDate | date: 'dd.MM.yy HH:mm' }}</div>
+                    <div class="col-5">{{ exercise.dueDate | artemisDate: 'short' }}</div>
                     <div class="col-5">{{ exercise.title }}</div>
                     <div class="col-2 icon">
                         <fa-icon [icon]="'play-circle'"></fa-icon>

--- a/src/main/webapp/app/overview/notification/notification.component.html
+++ b/src/main/webapp/app/overview/notification/notification.component.html
@@ -25,7 +25,7 @@
                 <tr *ngFor="let notification of notifications; trackBy: trackId">
                     <td>{{ notification.title }}</td>
                     <td>{{ notification.text }}</td>
-                    <td>{{ notification.notificationDate | date: 'medium' }}</td>
+                    <td>{{ notification.notificationDate | artemisDate }}</td>
                     <td>
                         <button class="btn btn-block btn-primary" *ngIf="getTargetMessage(notification.target)" (click)="notificationService.interpretNotification(notification)">
                             {{ 'artemisApp.notification.target.' + getTargetMessage(notification.target) | translate }}

--- a/src/main/webapp/app/shared/layouts/notification-sidebar/notification-sidebar.component.html
+++ b/src/main/webapp/app/shared/layouts/notification-sidebar/notification-sidebar.component.html
@@ -41,7 +41,7 @@
                 {{ notification.text }}
             </div>
             <div class="notification-info">
-                {{ notification.notificationDate | date: 'dd.MM.yy HH:mm' }} by <span *ngIf="notification.author; else noAuthor">{{ notification.author.name }}</span>
+                {{ notification.notificationDate | artemisDate: 'short':true:false }} by <span *ngIf="notification.author; else noAuthor">{{ notification.author.name }}</span>
                 <ng-template #noAuthor>
                     <span jhiTranslate="global.title"></span>
                 </ng-template>

--- a/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
@@ -20,13 +20,13 @@ import * as moment from 'moment';
     pure: false,
 })
 export class ArtemisDatePipe implements PipeTransform, OnDestroy {
-    dateTime: moment.Moment;
-    short = false;
-    time = true;
-    seconds = true;
-    locale: string;
-    localizedDateTime: string;
-    onLangChange: Subscription | undefined;
+    private dateTime: moment.Moment;
+    private short = false;
+    private time = true;
+    private seconds = true;
+    private locale: string;
+    private localizedDateTime: string;
+    private onLangChange: Subscription | undefined;
 
     constructor(private translateService: TranslateService) {}
 

--- a/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
@@ -66,7 +66,8 @@ export class ArtemisDatePipe implements PipeTransform, OnDestroy {
     }
 
     private updateLocalizedDateTime(): void {
-        this.localizedDateTime = this.dateTime == null ? '' : this.dateTime.locale(this.locale).format(this.format());
+        this.dateTime.locale(this.locale);
+        this.localizedDateTime = this.dateTime == null ? '' : this.dateTime.format(this.format());
     }
 
     private format(): string {

--- a/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
@@ -38,12 +38,12 @@ export class ArtemisDatePipe implements PipeTransform, OnDestroy {
      * @param seconds Should seconds be displayed? Defaults to true.
      * @return string
      */
-    transform(dateTime: Date | moment.Moment | string | number, format: 'short' | 'long' = 'long', time = true, seconds = true): string {
-        this.dateTime = moment(dateTime);
+    transform(dateTime: Date | moment.Moment | string | number | null, format: 'short' | 'long' = 'long', time = true, seconds = true): string {
         // Return empty string if given dateTime is not convertible to moment or equals null.
-        if (!this.dateTime.isValid()) {
+        if (dateTime === null || !moment(dateTime).isValid()) {
             return '';
         }
+        this.dateTime = moment(dateTime);
         this.short = format === 'short';
         this.time = time;
         this.seconds = seconds;

--- a/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
@@ -1,0 +1,115 @@
+import { OnDestroy, Pipe, PipeTransform } from '@angular/core';
+import { LangChangeEvent, TranslateService } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
+import * as moment from 'moment';
+
+/**
+ * Format a given date time that must be convertible to a moment object to a localized date time
+ * string based on the current language setting.
+ * This pipe is stateful (pure = false) so that it can adapt to changes of the current locale.
+ * Usage:
+ *   dateTime | artemisDate:format:time:seconds
+ * Examples (for locale == 'en'):
+ *   {{ course.startDate | artemisDate }}
+ *   formats to: Dec 17, 2019 12:43:05 AM
+ *   {{ course.startDate | artemisDate:'short' }}
+ *   formats to: 17/12/19 00:43:05
+ */
+@Pipe({
+    name: 'artemisDate',
+    pure: false,
+})
+export class ArtemisDatePipe implements PipeTransform, OnDestroy {
+    dateTime: moment.Moment;
+    short = false;
+    time = true;
+    seconds = true;
+    locale: string;
+    localizedDateTime: string;
+    onLangChange: Subscription | undefined;
+
+    constructor(private translateService: TranslateService) {}
+
+    /**
+     * Format a given dateTime to a localized date time string based on the current language setting.
+     * @param dateTime The date time that should be formatted. Must be convertible to moment().
+     * @param format Defines the length of the localized format. Defaults to 'long'.
+     * @param time Should the time be displayed? Defaults to true.
+     * @param seconds Should seconds be displayed? Defaults to true.
+     * @return string
+     */
+    transform(dateTime: Date | moment.Moment | string | number, format: 'short' | 'long' = 'long', time = true, seconds = true): string {
+        this.dateTime = moment(dateTime);
+        this.short = format === 'short';
+        this.time = time;
+        this.seconds = seconds;
+
+        // Set locale to current language.
+        this.updateLocale(this.translateService.currentLang);
+
+        // Clean up existing subscription to onLangChange.
+        this.cleanUpSubscription();
+
+        // Subscribe to onLangChange event, in case the language changes.
+        if (!this.onLangChange) {
+            this.onLangChange = this.translateService.onLangChange.subscribe((event: LangChangeEvent) => this.updateLocale(event.lang));
+        }
+
+        return this.localizedDateTime;
+    }
+
+    private updateLocale(lang: string): void {
+        if (lang !== this.locale) {
+            this.locale = lang;
+            this.updateLocalizedDateTime();
+        }
+    }
+
+    private updateLocalizedDateTime(): void {
+        this.localizedDateTime = this.dateTime == null ? '' : this.dateTime.locale(this.locale).format(this.format());
+    }
+
+    private format(): string {
+        // Evaluate date format.
+        let dateFormat = 'll';
+        if (this.short) {
+            switch (this.locale) {
+                case 'de':
+                    dateFormat = 'D.M.YY';
+                    break;
+                default:
+                    dateFormat = 'D/M/YY';
+            }
+        }
+
+        // Return date format immediately if time is set to false.
+        if (!this.time) {
+            return dateFormat;
+        }
+
+        // Evaluate time format.
+        let timeFormat = 'LTS';
+        if (!this.short && !this.seconds) {
+            timeFormat = 'LT';
+        } else if (this.short && this.seconds) {
+            timeFormat = 'HH:mm:ss';
+        } else if (this.short && !this.seconds) {
+            timeFormat = 'HH:mm';
+        }
+        return dateFormat + ' ' + timeFormat;
+    }
+
+    private cleanUpSubscription(): void {
+        if (typeof this.onLangChange !== 'undefined') {
+            this.onLangChange.unsubscribe();
+            this.onLangChange = undefined;
+        }
+    }
+
+    /**
+     * Unsubscribe from onLangChange event of translation service on pipe destruction.
+     */
+    ngOnDestroy(): void {
+        this.cleanUpSubscription();
+    }
+}

--- a/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/artemis-date.pipe.ts
@@ -40,6 +40,10 @@ export class ArtemisDatePipe implements PipeTransform, OnDestroy {
      */
     transform(dateTime: Date | moment.Moment | string | number, format: 'short' | 'long' = 'long', time = true, seconds = true): string {
         this.dateTime = moment(dateTime);
+        // Return empty string if given dateTime is not convertible to moment or equals null.
+        if (!this.dateTime.isValid()) {
+            return '';
+        }
         this.short = format === 'short';
         this.time = time;
         this.seconds = seconds;
@@ -67,7 +71,7 @@ export class ArtemisDatePipe implements PipeTransform, OnDestroy {
 
     private updateLocalizedDateTime(): void {
         this.dateTime.locale(this.locale);
-        this.localizedDateTime = this.dateTime == null ? '' : this.dateTime.format(this.format());
+        this.localizedDateTime = this.dateTime.format(this.format());
     }
 
     private format(): string {

--- a/src/main/webapp/app/shared/shared.module.ts
+++ b/src/main/webapp/app/shared/shared.module.ts
@@ -14,10 +14,12 @@ import { ArtemisSharedLibsModule } from 'app/shared/shared-libs.module';
 import { SlideToggleComponent } from 'app/exercises/shared/slide-toggle/slide-toggle.component';
 import { AlertErrorComponent } from 'app/shared/alert/alert-error.component';
 import { JhiConnectionStatusComponent } from 'app/shared/connection-status/connection-status.component';
+import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 
 @NgModule({
     imports: [ArtemisSharedLibsModule, ArtemisSharedCommonModule, ArtemisSharedPipesModule],
     declarations: [
+        ArtemisDatePipe,
         HasAnyAuthorityDirective,
         SecuredImageComponent,
         DeleteDialogComponent,
@@ -30,6 +32,7 @@ import { JhiConnectionStatusComponent } from 'app/shared/connection-status/conne
     providers: [DatePipe],
     entryComponents: [DeleteDialogComponent],
     exports: [
+        ArtemisDatePipe,
         ArtemisSharedLibsModule,
         FindLanguageFromKeyPipe,
         AlertComponent,

--- a/src/test/javascript/jest.config.js
+++ b/src/test/javascript/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
         '<rootDir>/src/test/javascript/spec/component/**/*.ts',
         '<rootDir>/src/test/javascript/spec/directive/**/*.ts',
         '<rootDir>/src/test/javascript/spec/integration/**/*.ts',
+        '<rootDir>/src/test/javascript/spec/pipe/**/*.ts',
         '<rootDir>/src/test/javascript/spec/service/**/*.ts',
     ],
     moduleNameMapper: {

--- a/src/test/javascript/spec/helpers/mocks/service/mock-translate.service.ts
+++ b/src/test/javascript/spec/helpers/mocks/service/mock-translate.service.ts
@@ -1,9 +1,57 @@
 import { Injectable, NgModule, Pipe, PipeTransform } from '@angular/core';
-import { TranslateLoader, TranslateModule, TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { Observable, of } from 'rxjs';
+import { TranslateLoader, TranslateModule, TranslatePipe, TranslateService, LangChangeEvent } from '@ngx-translate/core';
+import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
+
+export const TRANSLATED_STRING = '';
 
 export class MockTranslateService {
-    instant = (s: string, params: any) => s;
+    onLangChangeSubject: Subject<LangChangeEvent> = new Subject();
+    onTranslationChangeSubject: Subject<string> = new Subject();
+    onDefaultLangChangeSubject: Subject<string> = new Subject();
+    isLoadedSubject: BehaviorSubject<boolean> = new BehaviorSubject(true);
+
+    onLangChange: Observable<LangChangeEvent> = this.onLangChangeSubject.asObservable();
+    onTranslationChange: Observable<string> = this.onTranslationChangeSubject.asObservable();
+    onDefaultLangChange: Observable<string> = this.onDefaultLangChangeSubject.asObservable();
+    isLoaded: Observable<boolean> = this.isLoadedSubject.asObservable();
+
+    currentLang: string;
+
+    languages: string[] = ['de'];
+
+    get(content: string): Observable<string> {
+        return of(TRANSLATED_STRING + content);
+    }
+
+    use(lang: string): void {
+        this.currentLang = lang;
+        this.onLangChangeSubject.next({ lang } as LangChangeEvent);
+    }
+
+    addLangs(langs: string[]): void {
+        this.languages = [...this.languages, ...langs];
+    }
+
+    getBrowserLang(): string {
+        return '';
+    }
+
+    getLangs(): string[] {
+        return this.languages;
+    }
+
+    // tslint:disable-next-line:no-any
+    getTranslation(): Observable<any> {
+        return of({});
+    }
+
+    instant(key: string | string[], interpolateParams?: object): string {
+        return TRANSLATED_STRING + key.toString();
+    }
+
+    setDefaultLang(lang: string): void {
+        this.onDefaultLangChangeSubject.next(lang);
+    }
 }
 
 const translations: any = {};

--- a/src/test/javascript/spec/pipe/artemis-date.pipe.spec.ts
+++ b/src/test/javascript/spec/pipe/artemis-date.pipe.spec.ts
@@ -1,0 +1,234 @@
+import { TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import * as moment from 'moment';
+import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
+import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('ArtemisDatePipe', () => {
+    let pipe: ArtemisDatePipe;
+    let translateService: TranslateService;
+    const dateTime = moment({
+        year: 2020,
+        month: 3,
+        day: 14,
+        hour: 15,
+        minute: 27,
+        seconds: 33,
+    }); // 14/04/2020 15:27:33
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [ArtemisDatePipe],
+            providers: [{ provide: TranslateService, useClass: MockTranslateService }],
+        });
+        translateService = TestBed.inject(TranslateService);
+        pipe = new ArtemisDatePipe(translateService);
+    });
+
+    describe('en locale', () => {
+        beforeEach(() => {
+            dateTime.locale('en');
+            translateService.currentLang = 'en';
+        });
+
+        describe('long format', () => {
+            it('Should return format equal to "Apr 14, 2020 3:27:33 PM" when no parameter is set', () => {
+                const localizedDateTime = pipe.transform(dateTime);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LTS'));
+                expect(localizedDateTime).to.be.equal('Apr 14, 2020 3:27:33 PM');
+            });
+
+            it('Should return format equal to "Apr 14, 2020 3:27:33 PM" with parameter set { format: "long" }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long');
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LTS'));
+                expect(localizedDateTime).to.be.equal('Apr 14, 2020 3:27:33 PM');
+            });
+
+            it('Should return format equal to "Apr 14, 2020 3:27:33 PM" with parameter set { format: "long", time: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long');
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LTS'));
+                expect(localizedDateTime).to.be.equal('Apr 14, 2020 3:27:33 PM');
+            });
+
+            it('Should return format equal to "Apr 14, 2020" with parameter set { format: "long", time: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll'));
+                expect(localizedDateTime).to.be.equal('Apr 14, 2020');
+            });
+
+            it('Should return format equal to "Apr 14, 2020 3:27:33 PM" with parameter set { format: "long", time: true, seconds: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', true, true);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LTS'));
+                expect(localizedDateTime).to.be.equal('Apr 14, 2020 3:27:33 PM');
+            });
+
+            it('Should return format equal to "Apr 14, 2020" with parameter set { format: "long", time: false, seconds: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', false, true);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll'));
+                expect(localizedDateTime).to.be.equal('Apr 14, 2020');
+            });
+
+            it('Should return format equal to "Apr 14, 2020 3:27 PM" with parameter set { format: "long", time: true, seconds: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', true, false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LT'));
+                expect(localizedDateTime).to.be.equal('Apr 14, 2020 3:27 PM');
+            });
+
+            it('Should return format equal to "Apr 14, 2020" with parameter set { format: "long", time: false, seconds: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', false, false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll'));
+                expect(localizedDateTime).to.be.equal('Apr 14, 2020');
+            });
+        });
+
+        describe('short format', () => {
+            it('Should return format equal to "14/4/20 15:27:33" with parameter set { format: "short" }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short');
+                expect(localizedDateTime).to.be.equal(dateTime.format('D/M/YY HH:mm:ss'));
+                expect(localizedDateTime).to.be.equal('14/4/20 15:27:33');
+            });
+
+            it('Should return format equal to "14/4/20 15:27:33" with parameter set { format: "short", time: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short');
+                expect(localizedDateTime).to.be.equal(dateTime.format('D/M/YY HH:mm:ss'));
+                expect(localizedDateTime).to.be.equal('14/4/20 15:27:33');
+            });
+
+            it('Should return format equal to "14/4/20" with parameter set { format: "short", time: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D/M/YY'));
+                expect(localizedDateTime).to.be.equal('14/4/20');
+            });
+
+            it('Should return format equal to "14/4/20 15:27:33" with parameter set { format: "short", time: true, seconds: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', true, true);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D/M/YY HH:mm:ss'));
+                expect(localizedDateTime).to.be.equal('14/4/20 15:27:33');
+            });
+
+            it('Should return format equal to "14/4/20" with parameter set { format: "short", time: false, seconds: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', false, true);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D/M/YY'));
+                expect(localizedDateTime).to.be.equal('14/4/20');
+            });
+
+            it('Should return format equal to "14/4/20 15:27" with parameter set { format: "short", time: true, seconds: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', true, false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D/M/YY HH:mm'));
+                expect(localizedDateTime).to.be.equal('14/4/20 15:27');
+            });
+
+            it('Should return format equal to "14/4/20" with parameter set { format: "short", time: false, seconds: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', false, false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D/M/YY'));
+                expect(localizedDateTime).to.be.equal('14/4/20');
+            });
+        });
+    });
+
+    describe('de locale', () => {
+        beforeEach(() => {
+            dateTime.locale('de');
+            translateService.currentLang = 'de';
+        });
+
+        describe('long format', () => {
+            it('Should return format equal to "14. Apr. 2020 15:27:33" when no parameter is set', () => {
+                const localizedDateTime = pipe.transform(dateTime);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LTS'));
+                expect(localizedDateTime).to.be.equal('14. Apr. 2020 15:27:33');
+            });
+
+            it('Should return format equal to "14. Apr. 2020 15:27:33" with parameter set { format: "long" }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long');
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LTS'));
+                expect(localizedDateTime).to.be.equal('14. Apr. 2020 15:27:33');
+            });
+
+            it('Should return format equal to "14. Apr. 2020 15:27:33" with parameter set { format: "long", time: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long');
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LTS'));
+                expect(localizedDateTime).to.be.equal('14. Apr. 2020 15:27:33');
+            });
+
+            it('Should return format equal to "14. Apr. 2020" with parameter set { format: "long", time: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll'));
+                expect(localizedDateTime).to.be.equal('14. Apr. 2020');
+            });
+
+            it('Should return format equal to "14. Apr. 2020 15:27:33" with parameter set { format: "long", time: true, seconds: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', true, true);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LTS'));
+                expect(localizedDateTime).to.be.equal('14. Apr. 2020 15:27:33');
+            });
+
+            it('Should return format equal to "14. Apr. 2020" with parameter set { format: "long", time: false, seconds: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', false, true);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll'));
+                expect(localizedDateTime).to.be.equal('14. Apr. 2020');
+            });
+
+            it('Should return format equal to "14. Apr. 2020 15:27" with parameter set { format: "long", time: true, seconds: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', true, false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll LT'));
+                expect(localizedDateTime).to.be.equal('14. Apr. 2020 15:27');
+            });
+
+            it('Should return format equal to "14. Apr. 2020" with parameter set { format: "long", time: false, seconds: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'long', false, false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('ll'));
+                expect(localizedDateTime).to.be.equal('14. Apr. 2020');
+            });
+        });
+
+        describe('short format', () => {
+            it('Should return format equal to "14.4.20 15:27:33" with parameter set { format: "short" }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short');
+                expect(localizedDateTime).to.be.equal(dateTime.format('D.M.YY HH:mm:ss'));
+                expect(localizedDateTime).to.be.equal('14.4.20 15:27:33');
+            });
+
+            it('Should return format equal to "14.4.20 15:27:33" with parameter set { format: "short", time: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short');
+                expect(localizedDateTime).to.be.equal(dateTime.format('D.M.YY HH:mm:ss'));
+                expect(localizedDateTime).to.be.equal('14.4.20 15:27:33');
+            });
+
+            it('Should return format equal to "14.4.20" with parameter set { format: "short", time: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D.M.YY'));
+                expect(localizedDateTime).to.be.equal('14.4.20');
+            });
+
+            it('Should return format equal to "14.4.20 15:27:33" with parameter set { format: "short", time: true, seconds: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', true, true);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D.M.YY HH:mm:ss'));
+                expect(localizedDateTime).to.be.equal('14.4.20 15:27:33');
+            });
+
+            it('Should return format equal to "14.4.20" with parameter set { format: "short", time: false, seconds: true }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', false, true);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D.M.YY'));
+                expect(localizedDateTime).to.be.equal('14.4.20');
+            });
+
+            it('Should return format equal to "14.4.20 15:27" with parameter set { format: "short", time: true, seconds: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', true, false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D.M.YY HH:mm'));
+                expect(localizedDateTime).to.be.equal('14.4.20 15:27');
+            });
+
+            it('Should return format equal to "14.4.20" with parameter set { format: "short", time: false, seconds: false }', () => {
+                const localizedDateTime = pipe.transform(dateTime, 'short', false, false);
+                expect(localizedDateTime).to.be.equal(dateTime.format('D.M.YY'));
+                expect(localizedDateTime).to.be.equal('14.4.20');
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple integration tests (Jest) related to the features
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Currently, we are using more than 7 different date and time formats. Additionally, [Angular's date pipe](https://angular.io/api/common/DatePipe), that is used to format dates throughout the project, does not apply the current user's language setting.

### Description
- [x] I've implemented a custom `ArtemisDatePipe` that basically supports a long and a short format and is aware of the current user's language setting.
- [x] I've added test cases for alle parameter combinations of the `ArtemisDatePipe` for the `en` and `de` locales.
- [ ] I've replaced all usages of Angular's date pipe with the new `ArtemisDatePipe`.
- [ ] I've replaced the existing `DatePipe` in `format-date.pipe.ts`, that is only used for the `date-picker.component`, with the new `ArtemisDatePipe`.

**Why have I implemented a custom `ArtemisDatePipe`?**
- [Angular's Date Pipe](https://github.com/angular/angular/blob/master/packages/common/src/pipes/date_pipe.ts) cannot be extended to apply the current user's language setting as it is a stateless (`pure: true`) pipe.
- In contrast to the formats available with Angular's date pipe, moment.js provides localized date and time formats.
- Single point for extension and changes in the future.
- Pleasant side-effect: the IDE recognizes the import of the custom pipe.

**Date formats**
|    |       **short**      |           **long**          |
|:--:|:----------------:|:-----------------------:|
| **en** | 14/4/20 15:27:33 | Apr 14, 2020 3:27:33 PM |
| **de** | 14.4.20 15:27:33 |  14. Apr. 2020 15:27:33 |

- the time can be removed by setting the `time` parameter to `false` (defaults to `true`)
- the seconds can be removed from the time by setting the `seconds` parameter to `false` (defaults to `true`)

**Usage examples and output**
`{{ course.startDate | artemisDate:format:time:seconds }}`
- `{{ course.startDate | artemisDate }}`
   - `en` locale: `Apr 14, 2020 3:27:33 PM`
   - `de` locale: `14. Apr. 2020 15:27:33`
- `{{ course.startDate | artemisDate:'short' }}`
   - `en` locale: `14/4/20 15:27:33`
   - `de` locale: `14.4.20 15:27:33`
- `{{ course.startDate | artemisDate:'long':false }}`
   - `en` locale: `Apr 14, 2020`
   - `de` locale: `14. Apr. 2020`
- `{{ course.startDate | artemisDate:'short':true:false }}`
   - `en` locale: `14/4/20 15:27`
   - `de` locale: `14.4.20 15:27`

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Screenshots
English language setting:
![image](https://user-images.githubusercontent.com/15168372/81946771-1386f700-9600-11ea-944d-99ed0a9b1705.png)

German language setting:
![image](https://user-images.githubusercontent.com/15168372/81946751-0cf87f80-9600-11ea-953a-dcaf337a2e53.png)