### PR TITLE
Bugfix: Resize editor for quizzes

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
@@ -94,9 +94,11 @@
                     #markdownEditor
                     [markdown]="questionEditorText"
                     [showPreviewButton]="false"
+                    [enableResize]="true"
                     [domainCommands]="dragAndDropQuestionDomainCommands"
                     (markdownChange)="changesInMarkdown()"
                     (textWithDomainCommandsFound)="domainCommandsFound($event)"
+                    class="h-auto"
                 ></jhi-markdown-editor>
             </div>
             <div class="markupEditorArea" *ngIf="reEvaluationInProgress">
@@ -105,9 +107,11 @@
                         #markdownEditor
                         [markdown]="questionEditorText"
                         [showPreviewButton]="false"
+                        [enableResize]="true"
                         [domainCommands]="dragAndDropQuestionDomainCommands"
                         (markdownChange)="changesInMarkdown()"
                         (textWithDomainCommandsFound)="domainCommandsFound($event)"
+                        class="h-auto"
                     ></jhi-markdown-editor>
                     <span class="input-group-btn" style="vertical-align: top;">
                         <button class="btn btn-outline-secondary btn-lg" type="button" (click)="resetQuestionText()">

--- a/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
@@ -60,6 +60,7 @@
                     #markdownEditor
                     [markdown]="questionEditorText"
                     [showPreviewButton]="true"
+                    [enableResize]="true"
                     [domainCommands]="commandMultipleChoiceQuestions"
                     (markdownChange)="prepareForSave()"
                     (textWithDomainCommandsFound)="domainCommandsFound($event)"

--- a/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.ts
@@ -154,8 +154,8 @@ export class ReEvaluateMultipleChoiceQuestionComponent implements OnInit, AfterV
      *
      * The markdown rules are as follows:
      *
-     * 1. Text is split at [correct] and [wrong]
-     *    => The first part (any text before the first [correct] or [wrong]) is the question text
+     * 1. Text is split at [x] and [ ] (also accepts [X] and [])
+     *    => The first part (any text before the first [x] or [ ]) is the question text
      * 2. The question text is parsed with ArtemisMarkdown
      *
      * @param text {string} the markdown text to parse
@@ -171,8 +171,8 @@ export class ReEvaluateMultipleChoiceQuestionComponent implements OnInit, AfterV
      *
      * The markdown rules are as follows:
      *
-     * 1. Text starts with [correct] or [wrong]
-     *    => Answer options are marked as isCorrect depending on [wrong] or [correct]
+     * 1. Text starts with [x] or [ ] (also accepts [X] and [])
+     *    => Answer options are marked as isCorrect depending on [ ] or [x]
      * 2. The answer text is parsed with ArtemisMarkdown
      *
      * @param text {string} the markdown text to parse
@@ -186,7 +186,7 @@ export class ReEvaluateMultipleChoiceQuestionComponent implements OnInit, AfterV
         const startOfThisPart = text.indexOf(answerOptionText);
         const box = text.substring(0, startOfThisPart);
         // Check if box says this answer option is correct or not
-        answer.isCorrect = box === '[correct]';
+        answer.isCorrect = box === '[x]' || box === '[X]';
         this.artemisMarkdown.parseTextHintExplanation(answerOptionText, answer);
     }
 

--- a/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.ts
@@ -154,8 +154,8 @@ export class ReEvaluateMultipleChoiceQuestionComponent implements OnInit, AfterV
      *
      * The markdown rules are as follows:
      *
-     * 1. Text is split at [x] and [ ] (also accepts [X] and [])
-     *    => The first part (any text before the first [x] or [ ]) is the question text
+     * 1. Text is split at [correct] and [wrong]
+     *    => The first part (any text before the first [correct] or [wrong]) is the question text
      * 2. The question text is parsed with ArtemisMarkdown
      *
      * @param text {string} the markdown text to parse
@@ -171,8 +171,8 @@ export class ReEvaluateMultipleChoiceQuestionComponent implements OnInit, AfterV
      *
      * The markdown rules are as follows:
      *
-     * 1. Text starts with [x] or [ ] (also accepts [X] and [])
-     *    => Answer options are marked as isCorrect depending on [ ] or [x]
+     * 1. Text starts with [correct] or [wrong]
+     *    => Answer options are marked as isCorrect depending on [wrong] or [correct]
      * 2. The answer text is parsed with ArtemisMarkdown
      *
      * @param text {string} the markdown text to parse
@@ -186,7 +186,7 @@ export class ReEvaluateMultipleChoiceQuestionComponent implements OnInit, AfterV
         const startOfThisPart = text.indexOf(answerOptionText);
         const box = text.substring(0, startOfThisPart);
         // Check if box says this answer option is correct or not
-        answer.isCorrect = box === '[x]' || box === '[X]';
+        answer.isCorrect = box === '[correct]';
         this.artemisMarkdown.parseTextHintExplanation(answerOptionText, answer);
     }
 

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.scss
@@ -27,7 +27,7 @@
         flex-flow: column nowrap;
         flex: 1 1 auto;
         touch-action: none;
-        min-height: 100px;
+        min-height: 200px;
 
         // Fix for full screen mode, otherwise the color is black.
         background-color: white;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The default text in the mc question wasn't displayed without scrolling.

### Description
<!-- Describe your changes in detail -->
Increased the minimum height of the markdown editor and added the possibility to resize the mc-quiz-question-editor and drag-and-drop-quiz-question-editor

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to the exercises of the course management
3. Create a new quiz
4. Create a new MC-question
5. Create a new drag-and-drop-question
6. play around with the editors and see if the text is displayed properly
