### PR TITLE
Update docu: deactivate prometheus in Gitlab.

### DIFF
--- a/doc/jenkins-gitlab/JENKINS_AND_GITLAB_SETUP.md
+++ b/doc/jenkins-gitlab/JENKINS_AND_GITLAB_SETUP.md
@@ -191,6 +191,17 @@ If you only want to allow the server that runs Artemis to query the information,
 
 If you use SSH and use a different port than `2222`, you have to adjust the port above.
 
+14. Disable prometheus.  
+    As we encountered issues with the prometheus log files not being deleted and therefore filling up the disk space, we decided to disable prometheus within Gitlab.
+    If you also want to disable prometheus, edit the configuration again using
+    
+        nano /etc/gitlab/gitlab.rb
+    
+    and add the following line
+        
+        prometheus_monitoring['enable'] = false
+        
+    The issue with more details can be found [here](https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/4166).
 
 Reconfigure Gitlab
     


### PR DESCRIPTION
### Motivation and Context
We faced an issue on the test server 2 where the prometheus log directory was never cleared which lead to a full disk of the VM.

### Description
This disables the prometheus service within Gitlab.  
More information of the issue can be found [here](https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/4166).

### Steps for Testing
Start a programming exercise on a gitlab+jenkins environment and verify that everything works as expected.
