### PR TITLE
Fix programming exercise template setup on Windows machines

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/File.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/File.java
@@ -22,6 +22,10 @@ public class File extends java.io.File {
 
     @Override
     public String toString() {
-        return super.toString().replaceFirst(repository.getLocalPath().toString(), "").replaceAll("^/+", "");
+        //Make windows paths safe
+        String safeFilename = super.toString().replaceAll("\\\\", "/");
+        String safeRepositoryPath = repository.getLocalPath().toString().replaceAll("\\\\", "/");
+
+        return safeFilename.replaceFirst(safeRepositoryPath, "").replaceAll("^/+", "");
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/File.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/File.java
@@ -22,7 +22,7 @@ public class File extends java.io.File {
 
     @Override
     public String toString() {
-        //Make windows paths safe
+        // Make windows paths safe
         String safeFilename = super.toString().replaceAll("\\\\", "/");
         String safeRepositoryPath = repository.getLocalPath().toString().replaceAll("\\\\", "/");
 

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -294,10 +294,10 @@ public class FileService {
 
         for (Resource resource : resources) {
 
-            String fileUrl = java.net.URLDecoder.decode(resource.getURL().toString(), "UTF-8");
+            String filePath = resource.getFile().getAbsolutePath();
             // cut the prefix (e.g. 'exercise', 'solution', 'test') from the actual path
-            int index = fileUrl.indexOf(prefix);
-            String targetFilePath = keepParentFolder ? fileUrl.substring(index + prefix.length()) : "/" + resource.getFilename();
+            int index = filePath.indexOf(prefix);
+            String targetFilePath = keepParentFolder ? filePath.substring(index + prefix.length()) : "/" + resource.getFilename();
             // special case for '.git.ignore.file' file which would not be included in build otherwise
             if (targetFilePath.endsWith("git.ignore.file")) {
                 targetFilePath = targetFilePath.replaceAll("git.ignore.file", ".gitignore");
@@ -408,7 +408,9 @@ public class FileService {
 
                 line = reader.readLine();
             }
-
+            // Accessing already opened files will cause an exception on Windows machines, therefore close the streams
+            reader.close();
+            writer.close();
             Files.delete(file.toPath());
             FileUtils.moveFile(tempFile, new File(filePath));
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -294,10 +294,11 @@ public class FileService {
 
         for (Resource resource : resources) {
 
-            String filePath = resource.getFile().getAbsolutePath();
+            //Replace windows seperator with "/"
+            String fileUrl = java.net.URLDecoder.decode(resource.getURL().toString(), "UTF-8").replaceAll("\\\\", "/");
             // cut the prefix (e.g. 'exercise', 'solution', 'test') from the actual path
-            int index = filePath.indexOf(prefix);
-            String targetFilePath = keepParentFolder ? filePath.substring(index + prefix.length()) : "/" + resource.getFilename();
+            int index = fileUrl.indexOf(prefix);
+            String targetFilePath = keepParentFolder ? fileUrl.substring(index + prefix.length()) : "/" + resource.getFilename();
             // special case for '.git.ignore.file' file which would not be included in build otherwise
             if (targetFilePath.endsWith("git.ignore.file")) {
                 targetFilePath = targetFilePath.replaceAll("git.ignore.file", ".gitignore");

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -294,7 +294,7 @@ public class FileService {
 
         for (Resource resource : resources) {
 
-            //Replace windows seperator with "/"
+            // Replace windows seperator with "/"
             String fileUrl = java.net.URLDecoder.decode(resource.getURL().toString(), "UTF-8").replaceAll("\\\\", "/");
             // cut the prefix (e.g. 'exercise', 'solution', 'test') from the actual path
             int index = fileUrl.indexOf(prefix);

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -215,9 +215,9 @@ public class ProgrammingExerciseService {
         Repository solutionRepo = gitService.getOrCheckoutRepository(solutionRepoUrl, true);
 
         try {
-            String exercisePrefix = programmingLanguage + File.separator + "exercise";
-            String testPrefix = programmingLanguage + File.separator + "test";
-            String solutionPrefix = programmingLanguage + File.separator + "solution";
+            String exercisePrefix = programmingLanguage + "/exercise";
+            String testPrefix = programmingLanguage + "/test";
+            String solutionPrefix = programmingLanguage + "/solution";
             setupTemplateAndPush(exerciseRepo, exerciseResources, exercisePrefix, "Exercise", programmingExercise, user);
             setupTemplateAndPush(solutionRepo, solutionResources, solutionPrefix, "Solution", programmingExercise, user);
             setupTestTemplateAndPush(testRepo, testResources, testPrefix, "Test", programmingExercise, user);

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis.service;
 import static de.tum.in.www1.artemis.domain.enumeration.BuildPlanType.SOLUTION;
 import static de.tum.in.www1.artemis.domain.enumeration.BuildPlanType.TEMPLATE;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;

--- a/src/main/java/de/tum/in/www1/artemis/service/RepositoryService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/RepositoryService.java
@@ -78,8 +78,9 @@ public class RepositoryService {
             throw new FileNotFoundException();
         }
         InputStream inputStream = new FileInputStream(file.get());
-
-        return org.apache.commons.io.IOUtils.toByteArray(inputStream);
+        byte[] fileInBytes = org.apache.commons.io.IOUtils.toByteArray(inputStream);
+        inputStream.close();
+        return fileInBytes;
     }
 
     /**
@@ -102,6 +103,7 @@ public class RepositoryService {
 
         Files.copy(inputStream, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
         repository.setContent(null); // invalidate cache
+        inputStream.close();
     }
 
     /**
@@ -125,6 +127,7 @@ public class RepositoryService {
         File keep = new File(new java.io.File(repository.getLocalPath() + File.separator + folderName + File.separator + ".keep"), repository);
         Files.copy(inputStream, keep.toPath(), StandardCopyOption.REPLACE_EXISTING);
         repository.setContent(null); // invalidate cache
+        inputStream.close();
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -497,7 +497,10 @@ public class GitService {
 
             while (itr.hasNext()) {
                 File nextFile = new File(itr.next(), repo);
-                files.put(nextFile, nextFile.isFile() ? FileType.FILE : FileType.FOLDER);
+                 // Files starting with a '.' are not marked as hidden in Windows. WE must exclude these
+                if (nextFile.getName().charAt(0) != '.') {
+                    files.put(nextFile, nextFile.isFile() ? FileType.FILE : FileType.FOLDER);
+                }
             }
 
             // Cache the list of files

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -497,7 +497,7 @@ public class GitService {
 
             while (itr.hasNext()) {
                 File nextFile = new File(itr.next(), repo);
-                 // Files starting with a '.' are not marked as hidden in Windows. WE must exclude these
+                // Files starting with a '.' are not marked as hidden in Windows. WE must exclude these
                 if (nextFile.getName().charAt(0) != '.') {
                     files.put(nextFile, nextFile.isFile() ? FileType.FILE : FileType.FOLDER);
                 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
@@ -139,7 +139,6 @@ public abstract class RepositoryResource {
             Repository repository = getRepository(domainId, RepositoryActionType.WRITE, true);
             InputStream inputStream = request.getInputStream();
             repositoryService.createFile(repository, filename, inputStream);
-            inputStream.close();
             return new ResponseEntity<>(HttpStatus.OK);
         });
     }
@@ -159,7 +158,6 @@ public abstract class RepositoryResource {
             Repository repository = getRepository(domainId, RepositoryActionType.WRITE, true);
             InputStream inputStream = request.getInputStream();
             repositoryService.createFolder(repository, folderName, inputStream);
-            inputStream.close();
             return new ResponseEntity<>(HttpStatus.OK);
         });
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
@@ -139,6 +139,7 @@ public abstract class RepositoryResource {
             Repository repository = getRepository(domainId, RepositoryActionType.WRITE, true);
             InputStream inputStream = request.getInputStream();
             repositoryService.createFile(repository, filename, inputStream);
+            inputStream.close();
             return new ResponseEntity<>(HttpStatus.OK);
         });
     }
@@ -158,6 +159,7 @@ public abstract class RepositoryResource {
             Repository repository = getRepository(domainId, RepositoryActionType.WRITE, true);
             InputStream inputStream = request.getInputStream();
             repositoryService.createFolder(repository, folderName, inputStream);
+            inputStream.close();
             return new ResponseEntity<>(HttpStatus.OK);
         });
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
@@ -212,6 +212,7 @@ public class RepositoryWebsocketResource {
 
         InputStream inputStream = new ByteArrayInputStream(submission.getFileContent().getBytes(StandardCharsets.UTF_8));
         Files.copy(inputStream, file.get().toPath(), StandardCopyOption.REPLACE_EXISTING);
+        inputStream.close();
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest2.ase.in.tum.de.

### Motivation and Context
Templates are not pushed to template, test and solution repositories when a new programming exercise is created on Windows machines. This makes working on programming exercises slow and tedious.
Also described in [Issue 1494](https://github.com/ls1intum/Artemis/issues/1494)
Additionally, the code editor is not working properly on Windows.

### Description
FileService.replacePlaceholderSections throws an IOException("The process cannot access the file because it is being used by another process") as streams are not properly closed before being accessed again.

FileService.copyResources uses an URL representation of a Path. URLs use '/' as a File separator. Prefix is constructed using File.separator (\ on Windows)
Operations on the String URL will show unexpected behavior, because of the File separator mismatch.
-> Template copy destination path won't match the set up local repository -> empty commit

### Steps for Testing
Behavior of Artemis, running on MAC or Linux systems, should not change. 
Repositories for programming exercises should be set up correctly on Windows now.
Code Editor should work on all systems.

Please test on Test Server 1 (Bitbucket + Bamboo) and Test Server 2 (Gitlab + Jenkins)

**Test repository setup**
1. Log in to Artemis
2. Navigate to Course Management
3. Create a programming exercise, allowing the online code editor
4. Inspect created repositories
--> Templates are correctly set up for the template, solution and test repository.
4. Navigate to Course Management Exercise Details
5. Inspect template and solution results
--> Template result is at 0% and solution result is at 100%

**Test code editor**
1. Log in to Artemis
2. Participate in a programming exercise with code editor enabled
3. Open the code editor
-> Files starting with a dot are not displayed in the browser on the left side
4. Change the content of a file and save it
-> File is saved
5. Submit the changes
-> Build process is triggered and the results are displayed

