### PR TITLE
Add two missing resetLocalRepo calls

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -156,6 +156,8 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
         exerciseRepo.resetLocalRepo();
         testRepo.resetLocalRepo();
         solutionRepo.resetLocalRepo();
+        studentRepo.resetLocalRepo();
+        studentTeamRepo.resetLocalRepo();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Motivation and Context
Some temporary directories are currently not being deleted after the tests, so they stay there and accumulate. If an Artemis developer works and tests often, I would expect the count to amount to over 100k small git repositories.

### How this looks currently
- Linux `/tmp/`:
   ![image](https://user-images.githubusercontent.com/11130248/82523540-d5706280-9b2c-11ea-9d50-22b3da63d0e2.png)
- Windows `C:\Users\<name>\AppData\Local\Temp\`
- Mac probably `/var/folders/` and then distributed in cryptic subfolders like `Ob/Ob-aqIAEG2WghTa5ezd5qU+++TM/-Tmp-/`, you might need to search for the repo names.

### Description
Add two lines to reset the `LocalRepository`s to they get deleted after each test.

### Steps for Testing
Run the test class with e.g. `gradlew test --tests de.tum.in.www1.artemis.programmingexercise.ProgrammingExerciseBitbucketBambooIntegrationTest`

With this change, the number of folders that remain after tests should reduce. This might not solve all problems concerning remaining temporary directories, but most of it. (Some similar problems need to be investigated but are more difficult to find)

### Alternatives to consider
- Give each reset call its own `@AfterEach` in case the previous fails, e.g. with an `IOException`. This is more verbose, though.
- Use a custom folder and not the system default
- Develop a JUnit 5 Extension to automatically close explicitly annotated `AutoCloseable` members during the specific lifecycle safely