### PR TITLE
Don't log the default charset twice

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -71,7 +71,6 @@ public class GitService {
     private final Map<Path, Path> cloneInProgressOperations = new ConcurrentHashMap<>();
 
     public GitService() {
-        log.info("Default Charset=" + Charset.defaultCharset());
         log.info("file.encoding=" + System.getProperty("file.encoding"));
         log.info("sun.jnu.encoding=" + System.getProperty("sun.jnu.encoding"));
         log.info("Default Charset=" + Charset.defaultCharset());


### PR DESCRIPTION
### Description
Remove a duplicate logging entry.
```Java
log.info("Default Charset=" + Charset.defaultCharset()); 
```

### Steps for Testing
Run the test suite or a single Artemis test, these log lines should appear directly below the Artemis logo and now contain the default charset only once.
