### PR TITLE
Enhancement/programming exercise/file service test improvements

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -20,38 +19,34 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 public class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     /*
-     * We have to save the content as a String as git will automatically convert the
-     * line endings based on the developer's OS, therefore we do not store it as a
-     * file in src/test/resources/test-data
+     * We have to save the content as a String as git will automatically convert the line endings based on the developer's OS, therefore we do not store it as a file in
+     * src/test/resources/test-data
      */
 
-    //@formatter:off
-    private static final String FILE_WITH_UNIX_LINE_ENDINGS =
-            "public class LineEndings {\n" +
-            "\n" +
-            "    public void someMethod() {\n" +
-            "        // Some logic inside here\n" +
-            "        someService.call();\n" +
-            "    }\n" +
-            "}\n";
+    private static final String FILE_WITH_UNIX_LINE_ENDINGS = //
+            "public class LineEndings {\n" + //
+                    "\n" + //
+                    "    public void someMethod() {\n" + //
+                    "        // Some logic inside here\n" + //
+                    "        someService.call();\n" + //
+                    "    }\n" + //
+                    "}\n";
 
-    private static final String FILE_WITH_WINDOWS_LINE_ENDINGS =
-            "public class LineEndings {\r\n" +
-            "\r\n" +
-            "    public void someMethod() {\r\n" +
-            "        // Some logic inside here\r\n" +
-            "        someService.call();\r\n" +
-            "    }\r\n" +
-            "}\r\n";
-    //@formatter:on
+    private static final String FILE_WITH_WINDOWS_LINE_ENDINGS = //
+            "public class LineEndings {\r\n" + //
+                    "\r\n" + //
+                    "    public void someMethod() {\r\n" + //
+                    "        // Some logic inside here\r\n" + //
+                    "        someService.call();\r\n" + //
+                    "    }\r\n" + //
+                    "}\r\n";
 
     @Autowired
     FileService fileService;
 
     private void copyFile(String filePath, String destinationPath) {
         try {
-            FileUtils.copyFile(ResourceUtils.getFile("classpath:test-data/repository-export/" + filePath),
-                    new File("./exportTest/" + destinationPath));
+            FileUtils.copyFile(ResourceUtils.getFile("classpath:test-data/repository-export/" + filePath), new File("./exportTest/" + destinationPath));
         }
         catch (IOException ex) {
             fail("Failed while copying test files", ex);

--- a/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -114,17 +113,17 @@ public class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJir
     public void normalizeEncodingUTF8() throws IOException {
         copyFile("EncodingUTF8.java", "EncodingUTF8.java");
         Charset charset = fileService.detectCharset(FileUtils.readFileToByteArray(new File("./exportTest/EncodingUTF8.java")));
-        assertThat(charset).isEqualTo(Charsets.UTF_8);
+        assertThat(charset).isEqualTo(StandardCharsets.UTF_8);
     }
 
     @Test
     public void normalizeEncodingISO_8559_1() throws IOException {
         copyFile("EncodingISO_8559_1.java", "EncodingISO_8559_1.java");
         Charset charset = fileService.detectCharset(FileUtils.readFileToByteArray(new File("./exportTest/EncodingISO_8559_1.java")));
-        assertThat(charset).isEqualTo(Charsets.ISO_8859_1);
+        assertThat(charset).isEqualTo(StandardCharsets.ISO_8859_1);
 
         fileService.convertToUTF8("./exportTest/EncodingISO_8559_1.java");
         charset = fileService.detectCharset(FileUtils.readFileToByteArray(new File("./exportTest/EncodingISO_8559_1.java")));
-        assertThat(charset).isEqualTo(Charsets.UTF_8);
+        assertThat(charset).isEqualTo(StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/FileServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.fail;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
@@ -19,21 +20,48 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 
 public class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
+    /*
+     * We have to save the content as a String as git will automatically convert the
+     * line endings based on the developer's OS, therefore we do not store it as a
+     * file in src/test/resources/test-data
+     */
+
+    //@formatter:off
+    private static final String FILE_WITH_UNIX_LINE_ENDINGS =
+            "public class LineEndings {\n" +
+            "\n" +
+            "    public void someMethod() {\n" +
+            "        // Some logic inside here\n" +
+            "        someService.call();\n" +
+            "    }\n" +
+            "}\n";
+
+    private static final String FILE_WITH_WINDOWS_LINE_ENDINGS =
+            "public class LineEndings {\r\n" +
+            "\r\n" +
+            "    public void someMethod() {\r\n" +
+            "        // Some logic inside here\r\n" +
+            "        someService.call();\r\n" +
+            "    }\r\n" +
+            "}\r\n";
+    //@formatter:on
+
     @Autowired
     FileService fileService;
 
     private void copyFile(String filePath, String destinationPath) {
         try {
-            FileUtils.copyFile(ResourceUtils.getFile("classpath:test-data/repository-export/" + filePath), new File("./exportTest/" + destinationPath));
+            FileUtils.copyFile(ResourceUtils.getFile("classpath:test-data/repository-export/" + filePath),
+                    new File("./exportTest/" + destinationPath));
         }
         catch (IOException ex) {
             fail("Failed while copying test files", ex);
         }
     }
 
-    private void writeFile(String destinationPath, byte[] content) {
+    private void writeFile(String destinationPath, String content) {
         try {
-            FileUtils.writeByteArrayToFile(new File("./exportTest/" + destinationPath), content);
+            FileUtils.writeByteArrayToFile(new File("./exportTest/" + destinationPath), content.getBytes(StandardCharsets.UTF_8));
         }
         catch (IOException ex) {
             fail("Failed while writing test files", ex);
@@ -48,40 +76,32 @@ public class FileServiceTest extends AbstractSpringIntegrationBambooBitbucketJir
 
     @Test
     public void normalizeFileEndingsUnix_noChange() throws IOException {
-        copyFile("LineEndingsUnix.java", "LineEndingsUnix.java");
+        writeFile("LineEndingsUnix.java", FILE_WITH_UNIX_LINE_ENDINGS);
         int size = FileUtils.readFileToByteArray(new File("./exportTest/LineEndingsUnix.java")).length;
         assertThat(size).isEqualTo(129);
     }
 
     @Test
     public void normalizeFileEndingsUnix_normalized() throws IOException {
-        copyFile("LineEndingsUnix.java", "LineEndingsUnix.java");
-        fileService.normalizeLineEndings("./exportTest/LineEndingsUnix.java");
+        writeFile("LineEndingsUnix.java", FILE_WITH_UNIX_LINE_ENDINGS);
         int size = FileUtils.readFileToByteArray(new File("./exportTest/LineEndingsUnix.java")).length;
+        assertThat(size).isEqualTo(129);
+
+        fileService.normalizeLineEndings("./exportTest/LineEndingsUnix.java");
+        size = FileUtils.readFileToByteArray(new File("./exportTest/LineEndingsUnix.java")).length;
         assertThat(size).isEqualTo(129);
     }
 
     @Test
     public void normalizeFileEndingsWindows_noChange() throws IOException {
-        // We have to save the array as byte as git will automatically convert CRLF -> LF, therefor we cannot use the version of the file stored in the test data
-        byte[] lineEndingsWindowsArray = new byte[] { 112, 117, 98, 108, 105, 99, 32, 99, 108, 97, 115, 115, 32, 76, 105, 110, 101, 69, 110, 100, 105, 110, 103, 115, 32, 123, 13,
-                10, 13, 10, 32, 32, 32, 32, 112, 117, 98, 108, 105, 99, 32, 118, 111, 105, 100, 32, 115, 111, 109, 101, 77, 101, 116, 104, 111, 100, 40, 41, 32, 123, 13, 10, 32,
-                32, 32, 32, 32, 32, 32, 32, 47, 47, 32, 83, 111, 109, 101, 32, 108, 111, 103, 105, 99, 32, 105, 110, 115, 105, 100, 101, 32, 104, 101, 114, 101, 13, 10, 32, 32, 32,
-                32, 32, 32, 32, 32, 115, 111, 109, 101, 83, 101, 114, 118, 105, 99, 101, 46, 99, 97, 108, 108, 40, 41, 59, 13, 10, 32, 32, 32, 32, 125, 13, 10, 125, 13, 10 };
-        System.out.println(lineEndingsWindowsArray.length);
-        writeFile("LineEndingsWindows.java", lineEndingsWindowsArray);
+        writeFile("LineEndingsWindows.java", FILE_WITH_WINDOWS_LINE_ENDINGS);
         int size = FileUtils.readFileToByteArray(new File("./exportTest/LineEndingsWindows.java")).length;
         assertThat(size).isEqualTo(136);
     }
 
     @Test
     public void normalizeFileEndingsWindows_normalized() throws IOException {
-        // We have to save the array as byte as git will automatically convert CRLF -> LF, therefor we cannot use the version of the file stored in the test data
-        byte[] lineEndingsWindowsArray = new byte[] { 112, 117, 98, 108, 105, 99, 32, 99, 108, 97, 115, 115, 32, 76, 105, 110, 101, 69, 110, 100, 105, 110, 103, 115, 32, 123, 13,
-                10, 13, 10, 32, 32, 32, 32, 112, 117, 98, 108, 105, 99, 32, 118, 111, 105, 100, 32, 115, 111, 109, 101, 77, 101, 116, 104, 111, 100, 40, 41, 32, 123, 13, 10, 32,
-                32, 32, 32, 32, 32, 32, 32, 47, 47, 32, 83, 111, 109, 101, 32, 108, 111, 103, 105, 99, 32, 105, 110, 115, 105, 100, 101, 32, 104, 101, 114, 101, 13, 10, 32, 32, 32,
-                32, 32, 32, 32, 32, 115, 111, 109, 101, 83, 101, 114, 118, 105, 99, 101, 46, 99, 97, 108, 108, 40, 41, 59, 13, 10, 32, 32, 32, 32, 125, 13, 10, 125, 13, 10 };
-        writeFile("LineEndingsWindows.java", lineEndingsWindowsArray);
+        writeFile("LineEndingsWindows.java", FILE_WITH_WINDOWS_LINE_ENDINGS);
         int size = FileUtils.readFileToByteArray(new File("./exportTest/LineEndingsWindows.java")).length;
         assertThat(size).isEqualTo(136);
 

--- a/src/test/resources/test-data/repository-export/LineEndingsUnix.java
+++ b/src/test/resources/test-data/repository-export/LineEndingsUnix.java
@@ -1,7 +1,0 @@
-public class LineEndings {
-
-    public void someMethod() {
-        // Some logic inside here
-        someService.call();
-    }
-}


### PR DESCRIPTION
### Checklist
- [x] I tested that the test (still) works both on Windows and Linux.

### Motivation and Context
The `LineEndingsUnix.java` file is cloned with `\r\n` on Windows, so the test `normalizeFileEndingsUnix_noChange` fails. In addition to that, the raw byte array is not very readable.

### Description
- Deleted the test file `LineEndingsUnix.java`
- Removed the long `byte[]` and use `String` for the content of both files.
- Made both `String`s private constants to avoid duplication.
- Addrf a more general documentation as to the whyness.
- Switched from the deprecated `org.apache.commons.io.Charsets` to the `java.nio` one.

### Steps for Testing
Run the test `gradlew test --tests de.tum.in.www1.artemis.service.FileServiceTest` (or all tests)