### PR TITLE
Changing rounding method for assessment progress

### DIFF
--- a/src/main/webapp/app/course/dashboards/instructor-course-dashboard/instructor-course-dashboard.component.ts
+++ b/src/main/webapp/app/course/dashboards/instructor-course-dashboard/instructor-course-dashboard.component.ts
@@ -76,16 +76,17 @@ export class InstructorCourseDashboardComponent implements OnInit {
     }
 
     /**
-     * Calculate percentage for given numerator an denominator.
+     * Calculate rounded towards zero percentage for given numerator and denominator.
      * @param numerator
      * @param denominator
+     * @return {number} percentage for given numerator and denominator that is rounded towards zero
      */
     calculatePercentage(numerator: number, denominator: number): number {
         if (denominator === 0) {
             return 0;
         }
 
-        return Math.round((numerator / denominator) * 100);
+        return Math.floor((numerator / denominator) * 100);
     }
 
     /**

--- a/src/main/webapp/app/course/dashboards/tutor-course-dashboard/tutor-course-dashboard.component.ts
+++ b/src/main/webapp/app/course/dashboards/tutor-course-dashboard/tutor-course-dashboard.component.ts
@@ -77,6 +77,7 @@ export class TutorCourseDashboardComponent implements OnInit, AfterViewInit {
 
     /**
      * Load all exercises and statistics for tutors of this course.
+     * Percentages are calculated and rounded towards zero.
      */
     loadAll() {
         this.courseService.getForTutors(this.courseId).subscribe(
@@ -124,7 +125,7 @@ export class TutorCourseDashboardComponent implements OnInit, AfterViewInit {
                 }
 
                 if (this.numberOfSubmissions > 0) {
-                    this.totalAssessmentPercentage = Math.round((this.numberOfAssessments / this.numberOfSubmissions) * 100);
+                    this.totalAssessmentPercentage = Math.floor((this.numberOfAssessments / this.numberOfSubmissions) * 100);
                 }
             },
             (response: string) => this.onError(response),

--- a/src/main/webapp/app/exercises/shared/dashboards/instructor/instructor-exercise-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/instructor/instructor-exercise-dashboard.component.ts
@@ -47,14 +47,15 @@ export class InstructorExerciseDashboardComponent implements OnInit {
     }
 
     /**
-     * Computes the stats for the assessment charts
+     * Computes the stats for the assessment charts.
+     * Percentages are rounded towards zero.
      */
     public setStatistics() {
         if (this.stats.numberOfSubmissions > 0) {
-            this.totalManualAssessmentPercentage = Math.round(
+            this.totalManualAssessmentPercentage = Math.floor(
                 ((this.stats.numberOfAssessments - this.stats.numberOfAutomaticAssistedAssessments) / this.stats.numberOfSubmissions) * 100,
             );
-            this.totalAutomaticAssessmentPercentage = Math.round((this.stats.numberOfAutomaticAssistedAssessments / this.stats.numberOfSubmissions) * 100);
+            this.totalAutomaticAssessmentPercentage = Math.floor((this.stats.numberOfAutomaticAssistedAssessments / this.stats.numberOfSubmissions) * 100);
         }
 
         this.dataForAssessmentPieChart = [

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/tutor-exercise-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/tutor-exercise-dashboard.component.ts
@@ -230,8 +230,8 @@ export class TutorExerciseDashboardComponent implements OnInit, AfterViewInit {
                 }
 
                 if (this.numberOfSubmissions > 0) {
-                    this.totalAssessmentPercentage = Math.round((this.numberOfAssessments / this.numberOfSubmissions) * 100);
-                    this.tutorAssessmentPercentage = Math.round((this.numberOfTutorAssessments / this.numberOfSubmissions) * 100);
+                    this.totalAssessmentPercentage = Math.floor((this.numberOfAssessments / this.numberOfSubmissions) * 100);
+                    this.tutorAssessmentPercentage = Math.floor((this.numberOfTutorAssessments / this.numberOfSubmissions) * 100);
                 }
             },
             (response: string) => this.onError(response),

--- a/src/main/webapp/app/shared/dashboards/tutor-participation-graph/tutor-participation-graph.component.ts
+++ b/src/main/webapp/app/shared/dashboards/tutor-participation-graph/tutor-participation-graph.component.ts
@@ -78,17 +78,18 @@ export class TutorParticipationGraphComponent implements OnInit, OnChanges {
      */
     calculatePercentageAssessmentProgress() {
         if (this.numberOfParticipations !== 0) {
-            this.percentageAssessmentProgress = Math.round((this.numberOfAssessments / this.numberOfParticipations) * 100);
+            this.percentageAssessmentProgress = Math.floor((this.numberOfAssessments / this.numberOfParticipations) * 100);
         }
     }
 
     /**
      * Function to calculate the percentage of responded complaints
-     * This is calculated adding the number of not evaluated complaints and feedback requests and dividing by the total number of complaints and feedbacks.
+     * This is calculated adding the number of not evaluated complaints and feedback requests and dividing
+     * by the total number of complaints and feedbacks and rounding it tpwards zero.
      */
     calculatePercentageComplaintsProgress() {
         if (this.numberOfComplaints + this.numberOfMoreFeedbackRequests !== 0) {
-            this.percentageComplaintsProgress = Math.round(
+            this.percentageComplaintsProgress = Math.floor(
                 ((this.numberOfComplaints -
                 this.numberOfOpenComplaints + // nr of evaluated complaints
                     (this.numberOfMoreFeedbackRequests - this.numberOfOpenMoreFeedbackRequests)) / // nr of evaluated more feedback requests

--- a/src/test/javascript/spec/component/instructor-dashboard/instructor-exercise-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/instructor-dashboard/instructor-exercise-dashboard.component.spec.ts
@@ -49,4 +49,18 @@ describe('InstructorExerciseDashboardComponent', () => {
         expect(comp.dataForAssessmentPieChart[1]).equal(291);
         expect(comp.dataForAssessmentPieChart[2]).equal(42);
     });
+
+    it('Statistics are calculated, and rounded towards zero correctly', () => {
+        const stats = new StatsForDashboard();
+        stats.numberOfSubmissions = 2162;
+        stats.numberOfAssessments = 2152;
+        stats.numberOfAutomaticAssistedAssessments = 4;
+        comp.stats = stats;
+        comp.setStatistics();
+        expect(comp.totalManualAssessmentPercentage).equal(99);
+        expect(comp.totalAutomaticAssessmentPercentage).equal(0);
+        expect(comp.dataForAssessmentPieChart[0]).equal(10);
+        expect(comp.dataForAssessmentPieChart[1]).equal(2148);
+        expect(comp.dataForAssessmentPieChart[2]).equal(4);
+    });
 });


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Tutors overlook assessments because the assessment progress bar shows 100% although not all assessments have been completed. This indication is displayed on the Tutor Dashboard. 

closes [#1484 ](https://github.com/ls1intum/Artemis/issues/1484)

### Description
Instead of using regular rounding for percentage calculation (_round_), rounding towards zero is used instead (_floor_).
This issue primarily applies to the Tutor Course Dashboard, but the changes were applied to the Instructor Course Dashboard, Tutor Exercise Dashboard, Instructor Exercise Dashboard, and Tutor Participation Graph in order to ensure consistency across the platform.


### Steps for Testing

You need 3 students and 1 instructor account to test this enhancement.
Because percentages are rounded down if they are >.5 it is sufficient to test that 2 of 3 assessments are displayed as 66% instead of 67%. It is probably not possible to recreate a realistic setting with 1200 assessments.

1. With the instructor account, navigate to _Course Management_ > _Exercises_ > _Text Exercises_
2. Create and release a new Text Exercise with any content
3. Participate in this exercise with 3 student accounts
4. With your instructor account, assess 2 submissions
5. Navigate to the Tutor Course Dashboard. The assessment progress bar for your exercise should look like this: 
![t1](https://user-images.githubusercontent.com/45300855/82733179-72402500-9d12-11ea-8fc9-dd3f3363448b.PNG)
The dashboard statistics should look like this:
![t2](https://user-images.githubusercontent.com/45300855/82733201-8d129980-9d12-11ea-8583-716384e9a499.PNG)
6. Navigate to the Instructor Course Dashboard. The assessment progress bar for your exercise should look like this:
![t3](https://user-images.githubusercontent.com/45300855/82733229-c0edbf00-9d12-11ea-9ada-bd4fe2c9e849.PNG)
7. Navigate back to the Tutor Exercise Dashboard and open the Tutor Exercise Dashboard for your exercise. The assessment progress bar should look like this:
![t5](https://user-images.githubusercontent.com/45300855/82733288-1c1fb180-9d13-11ea-8b79-c083b9176ca1.PNG)
8. Assess the last submission. With one student account, file a More Feedback Request. With another student account, file a complaint. With your instructor account, accept or reject the complaint. 
9. Navigate to the Tutor Course Dashboard. The assessment progress bar for your exercise should look like this: 
![t6](https://user-images.githubusercontent.com/45300855/82733379-aff17d80-9d13-11ea-8ec8-8d4277aa5247.PNG)
10. With your instructor account, provide more feedback on the More Feedback Request and navigate back to the Tutor Course Dashboard. The assessment progress bar for your exercise should look like this:
![t9](https://user-images.githubusercontent.com/45300855/82733438-019a0800-9d14-11ea-9beb-407340b99b14.PNG)
11. Navigate to the Tutor Exercise Dashboard for your exercise. The assessment progress bar should look like this:
![t8](https://user-images.githubusercontent.com/45300855/82733463-402fc280-9d14-11ea-83c3-7620d0e32197.PNG)



### Screenshots
Previous:
![1](https://user-images.githubusercontent.com/45300855/82732576-52a6fd80-9d0e-11ea-9991-c849778f35dd.png)
Now:
![2](https://user-images.githubusercontent.com/45300855/82732579-563a8480-9d0e-11ea-9f56-56035a880d93.PNG)
