### PR TITLE
Text Assessments: Same logic to retrieve new Text Submission and specific submission by id

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
@@ -23,7 +23,7 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     Optional<Submission> findWithEagerResultById(Long submissionId);
 
     @Query("select distinct submission from Submission submission left join fetch submission.result r left join fetch r.feedbacks where submission.exampleSubmission = true and submission.id = :#{#submissionId}")
-    Optional<Submission> findSubmissionWithExampleSubmissionByIdWithEagerResult(long submissionId);
+    Optional<Submission> findExampleSubmissionByIdWithEagerResult(long submissionId);
 
     /* Get all submissions from a participation_id and load result at the same time */
     @EntityGraph(type = LOAD, attributePaths = { "result" })

--- a/src/main/java/de/tum/in/www1/artemis/service/AssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AssessmentService.java
@@ -30,7 +30,7 @@ public class AssessmentService {
 
     private final StudentParticipationRepository studentParticipationRepository;
 
-    private final ResultService resultService;
+    protected final ResultService resultService;
 
     private final SubmissionRepository submissionRepository;
 
@@ -144,7 +144,7 @@ public class AssessmentService {
      * @return The example result, which is linked to the submission
      */
     public Submission getSubmissionOfExampleSubmissionWithResult(long submissionId) {
-        return submissionRepository.findSubmissionWithExampleSubmissionByIdWithEagerResult(submissionId)
+        return submissionRepository.findExampleSubmissionByIdWithEagerResult(submissionId)
                 .orElseThrow(() -> new EntityNotFoundException("Example Submission with id \"" + submissionId + "\" does not exist"));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
@@ -105,6 +105,15 @@ public class TextAssessmentService extends AssessmentService {
         return this.feedbackRepository.findByResult(result);
     }
 
+    /**
+     * Load entities from database needed for text assessment & compute Feedback suggestions (Athene):
+     *   1. Create or load the result
+     *   2. Compute Feedback Suggestions
+     *   3. Load Text Blocks
+     *   4. Compute Fallback Text Blocks if needed
+     *
+     * @param textSubmission Text Submission to be assessed
+     */
     public void prepareSubmissionForAssessment(TextSubmission textSubmission) {
         final Participation participation = textSubmission.getParticipation();
         final TextExercise exercise = (TextExercise) participation.getExercise();

--- a/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
@@ -15,6 +15,7 @@ import de.tum.in.www1.artemis.domain.Feedback;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.TextBlock;
 import de.tum.in.www1.artemis.domain.TextSubmission;
+import de.tum.in.www1.artemis.repository.TextBlockRepository;
 
 @Service
 public class TextBlockService {
@@ -27,6 +28,16 @@ public class TextBlockService {
     private static final int LINE_SEPARATOR_LENGTH = LINE_SEPARATOR.length();
 
     public static final Comparator<TextBlock> compareByStartIndexReversed = (TextBlock first, TextBlock second) -> compare(second.getStartIndex(), first.getStartIndex());
+
+    private final TextBlockRepository textBlockRepository;
+
+    TextBlockService(TextBlockRepository textBlockRepository) {
+        this.textBlockRepository = textBlockRepository;
+    }
+
+    public List<TextBlock> findAllBySubmissionId(Long id) {
+        return this.textBlockRepository.findAllBySubmissionId(id);
+    }
 
     /**
      * Splits TextSubmission for a given Result into TextBlocks and saves them in the TextSubmission

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -37,6 +37,7 @@ import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.CourseService;
 import de.tum.in.www1.artemis.service.ExerciseService;
 import de.tum.in.www1.artemis.service.GradingCriterionService;
+import de.tum.in.www1.artemis.service.TextAssessmentService;
 import de.tum.in.www1.artemis.service.TextExerciseService;
 import de.tum.in.www1.artemis.service.TextSubmissionService;
 import de.tum.in.www1.artemis.service.UserService;
@@ -71,6 +72,8 @@ public class TextSubmissionResource {
 
     private final TextSubmissionService textSubmissionService;
 
+    private final TextAssessmentService textAssessmentService;
+
     private final UserService userService;
 
     private final GradingCriterionService gradingCriterionService;
@@ -79,7 +82,7 @@ public class TextSubmissionResource {
 
     public TextSubmissionResource(TextSubmissionRepository textSubmissionRepository, ExerciseService exerciseService, TextExerciseService textExerciseService,
             CourseService courseService, AuthorizationCheckService authorizationCheckService, TextSubmissionService textSubmissionService, UserService userService,
-            GradingCriterionService gradingCriterionService, Optional<TextClusteringScheduleService> textClusteringScheduleService) {
+            GradingCriterionService gradingCriterionService, TextAssessmentService textAssessmentService, Optional<TextClusteringScheduleService> textClusteringScheduleService) {
         this.textSubmissionRepository = textSubmissionRepository;
         this.exerciseService = exerciseService;
         this.textExerciseService = textExerciseService;
@@ -89,6 +92,7 @@ public class TextSubmissionResource {
         this.userService = userService;
         this.gradingCriterionService = gradingCriterionService;
         this.textClusteringScheduleService = textClusteringScheduleService;
+        this.textAssessmentService = textAssessmentService;
     }
 
     /**
@@ -227,9 +231,8 @@ public class TextSubmissionResource {
             @RequestParam(value = "head", defaultValue = "false") boolean skipAssessmentOrderOptimization,
             @RequestParam(value = "lock", defaultValue = "false") boolean lockSubmission) {
         log.debug("REST request to get a text submission without assessment");
-        Exercise exercise = exerciseService.findOneWithAdditionalElements(exerciseId);
-        List<GradingCriterion> gradingCriteria = gradingCriterionService.findByExerciseIdWithEagerGradingCriteria(exerciseId);
-        exercise.setGradingCriteria(gradingCriteria);
+        Exercise exercise = exerciseService.findOne(exerciseId);
+
         if (!authorizationCheckService.isAtLeastTeachingAssistantForExercise(exercise)) {
             return forbidden();
         }
@@ -267,6 +270,11 @@ public class TextSubmissionResource {
             }
             textSubmission = optionalTextSubmission.get();
         }
+
+        textAssessmentService.prepareSubmissionForAssessment(textSubmission);
+
+        List<GradingCriterion> gradingCriteria = gradingCriterionService.findByExerciseIdWithEagerGradingCriteria(exerciseId);
+        exercise.setGradingCriteria(gradingCriteria);
 
         // Make sure the exercise is connected to the participation in the json response
         final StudentParticipation studentParticipation = (StudentParticipation) textSubmission.getParticipation();

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +38,9 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
 
     @Autowired
     ExerciseRepository exerciseRepo;
+
+    @Autowired
+    FeedbackRepository feedbackRepository;
 
     @Autowired
     RequestUtilService request;
@@ -188,7 +192,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
 
     @Test
     @WithMockUser(value = "tutor1", roles = "TA")
-    public void getResultWithPredefinedTextblocks_studentHidden() throws Exception {
+    public void getResult_studentHidden() throws Exception {
         int submissionCount = 5;
         int submissionSize = 4;
         int[] clusterSizes = new int[] { 4, 5, 10, 1 };
@@ -201,8 +205,8 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
 
         StudentParticipation studentParticipation = (StudentParticipation) textSubmissionRepository.findAll().get(0).getParticipation();
 
-        // connect it with the user
-        User user = database.getUserByLogin("tutor1");
+        // connect it with a student (!= tutor assessing it)
+        User user = database.getUserByLogin("student1");
         studentParticipation.setInitializationDate(ZonedDateTime.now());
         studentParticipation.setParticipant(user);
         studentParticipationRepository.save(studentParticipation);
@@ -212,16 +216,16 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
 
         TextSubmission submissionWithoutAssessment = request.get("/api/exercises/" + textExercise.getId() + "/text-submission-without-assessment", HttpStatus.OK,
                 TextSubmission.class, params);
-
-        Result result = request.get("/api/text-assessments/result/" + submissionWithoutAssessment.getResult().getId() + "/with-textblocks", HttpStatus.OK, Result.class);
+        final Result result = submissionWithoutAssessment.getResult();
 
         assertThat(result).as("saved result found").isNotNull();
-        assertThat(((StudentParticipation) result.getParticipation()).getStudent()).as("student of participation is hidden").isEmpty();
+        assertThat(((StudentParticipation) submissionWithoutAssessment.getParticipation()).getStudent()).as("student of participation is hidden").isEmpty();
+        assertThat(result.getParticipation()).isNull();
     }
 
     @Test
     @WithMockUser(value = "tutor1", roles = "TA")
-    public void getResultWithPredefinedTextblocksForNonTextExercise() throws Exception {
+    public void getParticipationForNonTextExercise() throws Exception {
         FileUploadExercise fileUploadExercise = ModelFactory.generateFileUploadExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1),
                 ZonedDateTime.now().plusDays(2), "png,pdf", textExercise.getCourse());
         exerciseRepo.save(fileUploadExercise);
@@ -229,12 +233,10 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         FileUploadSubmission fileUploadSubmission = ModelFactory.generateFileUploadSubmission(true);
         database.addFileUploadSubmissionWithResultAndAssessorFeedback(fileUploadExercise, fileUploadSubmission, "student1", "tutor1", new ArrayList<Feedback>());
 
-        request.get("/api/exercises/" + fileUploadExercise.getId() + "/text-submission-without-assessment", HttpStatus.BAD_REQUEST, Participation.class);
+        final Participation participation = request.get("/api/exercises/" + fileUploadExercise.getId() + "/text-submission-without-assessment", HttpStatus.BAD_REQUEST,
+                Participation.class);
 
-        Result result = request.get("/api/text-assessments/result/" + fileUploadSubmission.getParticipation().getResults().iterator().next().getId() + "/with-textblocks",
-                HttpStatus.BAD_REQUEST, Result.class);
-
-        assertThat(result).as("no result should be returned when exercise is not a text exercise").isNull();
+        assertThat(participation).as("no result should be returned when exercise is not a text exercise").isNull();
     }
 
     @Test
@@ -255,7 +257,6 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
     public void getDataForTextEditor_hasTextBlocks() throws Exception {
         TextSubmission textSubmission = ModelFactory.generateTextSubmission("Some text", Language.ENGLISH, true);
         ArrayList<TextBlock> textBlocks = textExerciseUtilService.generateTextBlocks(1);
-        textBlocks.forEach(TextBlock::computeId);
         textSubmission = database.addTextSubmissionWithResultAndAssessor(textExercise, textSubmission, "student1", "tutor1");
         database.addTextBlocksToTextSubmission(textBlocks, textSubmission);
 
@@ -489,15 +490,9 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         database.addTextSubmission(textExercise, textSubmission, "student1");
         exerciseDueDatePassed();
 
-        var textBlock1 = new TextBlock().startIndex(0).endIndex(14).submission(textSubmission).automatic();
-        var textBlock2 = new TextBlock().startIndex(16).endIndex(34).submission(textSubmission).automatic();
-        var textBlock3 = new TextBlock().startIndex(36).endIndex(56).submission(textSubmission).automatic();
-        var blocks = asList(textBlock1, textBlock2, textBlock3);
-        blocks.forEach(b -> {
-            b.setTextFromSubmission();
-            b.computeId();
-        });
-        textBlockRepository.saveAll(blocks);
+        var blocks = asList(new TextBlock().startIndex(0).endIndex(15).automatic(), new TextBlock().startIndex(16).endIndex(35).automatic(),
+                new TextBlock().startIndex(36).endIndex(57).automatic());
+        database.addTextBlocksToTextSubmission(blocks, textSubmission);
 
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("lock", "true");
@@ -509,7 +504,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         assertThat(blocksFrom1stRequest.toArray()).containsExactlyInAnyOrder(blocks.toArray());
 
         final TextAssessmentDTO textAssessmentDTO = new TextAssessmentDTO();
-        textAssessmentDTO.setFeedbacks(asList(new Feedback().detailText("Test").credits(1d).reference(textBlock1.getId()).type(FeedbackType.MANUAL)));
+        textAssessmentDTO.setFeedbacks(asList(new Feedback().detailText("Test").credits(1d).reference(blocksFrom1stRequest.get(0).getId()).type(FeedbackType.MANUAL)));
         textAssessmentDTO.setTextBlocks(blocksFrom1stRequest);
         Result result = request.putWithResponseBody("/api/text-assessments/exercise/" + textExercise.getId() + "/result/" + submission1stRequest.getResult().getId() + "/submit",
                 textAssessmentDTO, Result.class, HttpStatus.OK);
@@ -518,5 +513,53 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         TextSubmission submission2ndRequest = (TextSubmission) (participation2ndRequest).getSubmissions().iterator().next();
         var blocksFrom2ndRequest = submission2ndRequest.getBlocks();
         assertThat(blocksFrom2ndRequest.toArray()).containsExactlyInAnyOrder(blocks.toArray());
+    }
+
+    @Test
+    @WithMockUser(value = "tutor1", roles = "TA")
+    public void checkTextSubmissionWithoutAssessmentAndRetrieveParticipationForSubmissionReturnSameBlocksAndFeedback() throws Exception {
+        TextSubmission textSubmission1 = ModelFactory.generateTextSubmission("This is Part 1, and this is Part 2. There is also Part 3.", Language.ENGLISH, true);
+        TextSubmission textSubmission2 = ModelFactory.generateTextSubmission("This is another Submission.", Language.ENGLISH, true);
+        database.addTextSubmission(textExercise, textSubmission1, "student1");
+        database.addTextSubmission(textExercise, textSubmission2, "student2");
+        exerciseDueDatePassed();
+
+        final TextCluster cluster = new TextCluster().exercise(textExercise);
+        textClusterRepository.save(cluster);
+
+        final TextBlock textBlockSubmission1 = new TextBlock().startIndex(0).endIndex(15).automatic().cluster(cluster);
+        final TextBlock textBlockSubmission2 = new TextBlock().startIndex(0).endIndex(27).automatic().cluster(cluster);
+
+        cluster.blocks(asList(textBlockSubmission1, textBlockSubmission2)).distanceMatrix(new double[][] { { 0.1, 0.1 }, { 0.1, 0.1 } });
+
+        database.addTextBlocksToTextSubmission(
+                asList(textBlockSubmission1, new TextBlock().startIndex(16).endIndex(35).automatic(), new TextBlock().startIndex(36).endIndex(57).automatic()), textSubmission1);
+
+        database.addTextBlocksToTextSubmission(asList(textBlockSubmission2), textSubmission2);
+
+        textClusterRepository.save(cluster);
+
+        final Feedback feedback = new Feedback().detailText("Foo Bar.").credits(2d).reference(textBlockSubmission2.getId());
+        database.addTextSubmissionWithResultAndAssessorAndFeedbacks(textExercise, textSubmission2, "student2", "tutor1", asList(feedback));
+        feedbackRepository.save(feedback);
+
+        TextSubmission textSubmissionWithoutAssessment = request.get("/api/exercises/" + textExercise.getId() + "/text-submission-without-assessment", HttpStatus.OK,
+                TextSubmission.class);
+
+        request.put("/api/text-assessments/exercise/" + textExercise.getId() + "/submission/" + textSubmission1.getId() + "/cancel-assessment", null, HttpStatus.OK);
+
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("lock", "true");
+        Participation participation = request.get("/api/text-assessments/submission/" + textSubmission1.getId(), HttpStatus.OK, Participation.class, params);
+        final TextSubmission submissionFromParticipation = (TextSubmission) participation.getSubmissions().toArray()[0];
+        final Result resultFromParticipation = (Result) participation.getResults().toArray()[0];
+
+        assertThat(textSubmissionWithoutAssessment.getId()).isEqualTo(submissionFromParticipation.getId());
+        assertThat(Arrays.equals(textSubmissionWithoutAssessment.getBlocks().toArray(), submissionFromParticipation.getBlocks().toArray())).isTrue();
+        final Feedback feedbackFromSubmissionWithoutAssessment = textSubmissionWithoutAssessment.getResult().getFeedbacks().get(0);
+        final Feedback feedbackFromParticipation = resultFromParticipation.getFeedbacks().get(0);
+        assertThat(feedbackFromSubmissionWithoutAssessment.getCredits()).isEqualTo(feedbackFromParticipation.getCredits());
+        assertThat(feedbackFromSubmissionWithoutAssessment.getDetailText()).isEqualTo(feedbackFromParticipation.getDetailText());
+        assertThat(feedbackFromSubmissionWithoutAssessment.getType()).isEqualTo(feedbackFromParticipation.getType());
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
@@ -174,7 +174,7 @@ public class TextSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         // set dates to UTC and round to milliseconds for comparison
         textSubmission.setSubmissionDate(ZonedDateTime.ofInstant(textSubmission.getSubmissionDate().truncatedTo(ChronoUnit.MILLIS).toInstant(), ZoneId.of("UTC")));
         storedSubmission.setSubmissionDate(ZonedDateTime.ofInstant(storedSubmission.getSubmissionDate().truncatedTo(ChronoUnit.MILLIS).toInstant(), ZoneId.of("UTC")));
-        assertThat(storedSubmission).as("submission was found").isEqualToIgnoringGivenFields(textSubmission, "result");
+        assertThat(storedSubmission).as("submission was found").isEqualToIgnoringGivenFields(textSubmission, "result", "blocks");
         assertThat(storedSubmission.getResult()).as("result is set").isNotNull();
         assertThat(storedSubmission.getResult().getAssessor()).as("assessor is tutor1").isEqualTo(user);
         checkDetailsHidden(storedSubmission, false);
@@ -338,8 +338,9 @@ public class TextSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void deleteTextSubmissionWithTextBlocks() throws Exception {
+        textSubmission.setText("Lorem Ipsum dolor sit amet");
         textSubmission = database.addTextSubmission(textExerciseBeforeDueDate, textSubmission, "student1");
-        final List<TextBlock> blocks = List.of(ModelFactory.generateTextBlock(0, 9), ModelFactory.generateTextBlock(10, 19), ModelFactory.generateTextBlock(20, 29));
+        final List<TextBlock> blocks = List.of(ModelFactory.generateTextBlock(0, 11), ModelFactory.generateTextBlock(12, 21), ModelFactory.generateTextBlock(22, 26));
         database.addTextBlocksToTextSubmission(blocks, textSubmission);
 
         request.delete("/api/submissions/" + textSubmission.getId(), HttpStatus.OK);

--- a/src/test/java/de/tum/in/www1/artemis/service/TextBlockServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/TextBlockServiceTest.java
@@ -7,17 +7,22 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tum.in.www1.artemis.domain.TextBlock;
 import de.tum.in.www1.artemis.domain.TextSubmission;
+import de.tum.in.www1.artemis.repository.TextBlockRepository;
 
 public class TextBlockServiceTest {
+
+    @Autowired
+    private TextBlockRepository textBlockRepository;
 
     TextBlockService textBlockService;
 
     @BeforeEach
     public void prepareFreshService() {
-        textBlockService = new TextBlockService();
+        textBlockService = new TextBlockService(textBlockRepository);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -1058,6 +1058,7 @@ public class DatabaseUtilService {
         submission = textSubmissionRepo.save(submission);
         result = resultRepo.save(result);
         studentParticipationRepo.save(participation);
+        submission.setResult(result);
         return submission;
     }
 
@@ -1069,8 +1070,24 @@ public class DatabaseUtilService {
         return addTextSubmissionWithResultAndAssessor(exercise, submission, null, teamId, assessorLogin);
     }
 
+    public TextSubmission addTextSubmissionWithResultAndAssessorAndFeedbacks(TextExercise exercise, TextSubmission submission, String studentLogin, String assessorLogin,
+            List<Feedback> feedbacks) {
+        submission = addTextSubmissionWithResultAndAssessor(exercise, submission, studentLogin, null, assessorLogin);
+        Result result = submission.getResult();
+        for (Feedback f : feedbacks)
+            f.setResult(result);
+        feedbackRepo.saveAll(feedbacks);
+        result.setFeedbacks(feedbacks);
+        resultRepo.save(result);
+        return submission;
+    }
+
     public TextSubmission addTextBlocksToTextSubmission(List<TextBlock> blocks, TextSubmission submission) {
-        blocks.forEach(block -> block.setSubmission(submission));
+        blocks.forEach(block -> {
+            block.setSubmission(submission);
+            block.setTextFromSubmission();
+            block.computeId();
+        });
         submission.setBlocks(blocks);
         textBlockRepo.saveAll(blocks);
         textSubmissionRepo.save(submission);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Server: I added multiple integration tests (Spring) related to the features
- [X] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [X] Server: I implemented the changes with a good performance and prevented too many database calls
- [X] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
- #1466
- Getting the next submission for assessment behaved slightly different than getting a submission by id, so by refactoring the logic behind this, both endpoints behave the same and have the same entities loaded.

### Description
Extract fetching/creating a result, text blocks and feedback suggestions into one service method to be called from `GET /submission/{submissionId}` and `GET /exercises/{exerciseId}/text-submission-without-assessment`

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Submit a text exercise with multiple users. Make sure to have multiple sentences in each submission.
3. Open some specific submissions (e.g. from "Submissions" button in Course Management)
4. Open some submissions using the Next button in the tutor exercise dashboard / in an assessment.
5. Find text blocks to always display for each sentence.
6. Every submission can be opened without an error.

### Screenshots
No UI Changes.
