### PR TITLE
Added back arrow as in other exercises

### DIFF
--- a/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.html
+++ b/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.html
@@ -1,5 +1,5 @@
 <jhi-assessment-layout
-    [hideBackButton]="true"
+    (navigateBack)="goToExerciseDashboard()"
     [isLoading]="isLoading"
     [saveBusy]="saveBusy"
     [submitBusy]="submitBusy"

--- a/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.ts
@@ -240,6 +240,14 @@ export class TextSubmissionAssessmentComponent implements OnInit {
         );
     }
 
+    goToExerciseDashboard() {
+        if (this.exercise && this.exercise.course) {
+            this.router.navigateByUrl(`/course-management/${this.exercise.course.id}/exercises/${this.exercise.id}/tutor-dashboard`);
+        } else {
+            this.location.back();
+        }
+    }
+
     private computeTotalScore() {
         const credits = this.assessments.map((feedback) => feedback.credits);
         this.totalScore = credits.reduce((a, b) => a + b, 0);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #1512

### Description
<!-- Describe your changes in detail -->
Added the back button to text exercises. Implementation is equal to other exercises

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Open a text exercise assessment. The back arrow should appear. Try it. It should redirect you to the dashboard of the exercise

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
