### PR TITLE
Bugfix: update pop-up on Submit

### DIFF
--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -264,12 +264,19 @@ export class ModelingAssessmentEditorComponent implements OnInit {
     onSubmitAssessment() {
         if (this.referencedFeedback.length < this.model!.elements.length || !this.assessmentsAreValid) {
             const confirmationMessage = this.translateService.instant('modelingAssessmentEditor.messages.confirmSubmission');
-            const confirm = window.confirm(confirmationMessage);
-            if (confirm) {
+
+            // if the assessment is before the assessment due date, don't show the confirm submission button
+            const isBeforeAssessmentDueDate = this.modelingExercise && this.modelingExercise.assessmentDueDate && moment().isBefore(this.modelingExercise.assessmentDueDate);
+            if (isBeforeAssessmentDueDate) {
                 this.submitAssessment();
             } else {
-                this.highlightMissingFeedback = true;
-                this.highlightElementsWithMissingFeedback();
+                const confirm = window.confirm(confirmationMessage);
+                if (confirm) {
+                    this.submitAssessment();
+                } else {
+                    this.highlightMissingFeedback = true;
+                    this.highlightElementsWithMissingFeedback();
+                }
             }
         } else {
             this.submitAssessment();


### PR DESCRIPTION
fixes #1479. added logic to only show the confirmation pop-up if the assessment is after the assessment due date

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Removes an unnecessary step when modeling assessments before the assessment due date.

<!-- If it fixes an open issue, please link to the issue here. -->
#1479

### Description
<!-- Describe your changes in detail -->
Added an if statement to check whether it is before the assessment due date. If so, then the pop-up is not added. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Pre-requirement: there is a modeling exercise and current date is before/after the due date (test both scenarios)
As a student: 
1. Submit a modeling exercise answer
As a tutor/lecturer: 
1. Assess the submission and click on "Submit"
2. Confirm the pop-up isn't shown when it's before the due date 
3. Confirm the pop-up is shown when it's after the due date 
4. Confirm the same behavior when clicking on "Override assessment" 


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
After clicking the submit button when it's before the due date
<img width="1329" alt="image" src="https://user-images.githubusercontent.com/63906424/83355838-2e789b80-a362-11ea-99af-760c061ce1b5.png">

<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
After clicking override assessment (behavior is same for submit) 
![assess-behavior](https://user-images.githubusercontent.com/63906424/83355894-8d3e1500-a362-11ea-9d5f-930ac1520a93.gif)

