### PR TITLE
Made prepareSubmissionForAssignment dependend on lockSubmission

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -256,6 +256,7 @@ public class TextSubmissionResource {
         final TextSubmission textSubmission;
         if (lockSubmission) {
             textSubmission = textSubmissionService.findAndLockTextSubmissionToBeAssessed((TextExercise) exercise);
+            textAssessmentService.prepareSubmissionForAssessment(textSubmission);
         }
         else {
             Optional<TextSubmission> optionalTextSubmission;
@@ -269,10 +270,6 @@ public class TextSubmissionResource {
                 return notFound();
             }
             textSubmission = optionalTextSubmission.get();
-        }
-
-        if (lockSubmission) {
-            textAssessmentService.prepareSubmissionForAssessment(textSubmission);
         }
 
         List<GradingCriterion> gradingCriteria = gradingCriterionService.findByExerciseIdWithEagerGradingCriteria(exerciseId);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -271,7 +271,9 @@ public class TextSubmissionResource {
             textSubmission = optionalTextSubmission.get();
         }
 
-        textAssessmentService.prepareSubmissionForAssessment(textSubmission);
+        if (lockSubmission) {
+            textAssessmentService.prepareSubmissionForAssessment(textSubmission);
+        }
 
         List<GradingCriterion> gradingCriteria = gradingCriterionService.findByExerciseIdWithEagerGradingCriteria(exerciseId);
         exercise.setGradingCriteria(gradingCriteria);

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -543,8 +543,10 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         database.addTextSubmissionWithResultAndAssessorAndFeedbacks(textExercise, textSubmission2, "student2", "tutor1", asList(feedback));
         feedbackRepository.save(feedback);
 
+        LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("lock", "true");
         TextSubmission textSubmissionWithoutAssessment = request.get("/api/exercises/" + textExercise.getId() + "/text-submission-without-assessment", HttpStatus.OK,
-                TextSubmission.class);
+                TextSubmission.class, parameters);
 
         request.put("/api/text-assessments/exercise/" + textExercise.getId() + "/submission/" + textSubmission1.getId() + "/cancel-assessment", null, HttpStatus.OK);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #1545

### Description
<!-- Describe your changes in detail -->

I think the problem is the following and the fix I provided seems to work:
In TextSubmissionResource.java, there is the method getTextSubmissionWithoutAssessment. One of the parameters for this method lockSubmission. Only when this is set, will the function findAndLockTextSubmissionToBeAssessed be called and a lock generated. HOWEVER, there was always the call to textAssessmentService.prepareSubmissionForAssessment(textSubmission) later in this method. And this method does always create a lock , no matter what. So I wrapped this method call in a if statement.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Open a Text exercise as a tutor with stuff to correct
4. Reload the page as often as you want, no lock should be generated

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
