### PR TITLE
update jenkins dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@ This application was generated using JHipster 6.9.0. ([Documentation and help](h
 
 ## Main features
 Artemis supports the following exercises:
-1. **[Programming exercises](/doc/exerciseTypes/programmingExercise/PROGRAMMING_EXERCISE.md)** with version control and automatic assessment with test cases and continuous integration
-2. **Quiz exercises** with multiple choice, drag and drop and short answer quiz questions 
-3. **Modeling exercises** with semi-automatic assessment using machine learning concepts
-4. **Text exercises** with manual (and experimental semi-automatic) assessment
-5. **File upload exercises** with manual assessment
+1. **Programming exercises(docs/user/exercises/programming.rst)** with version control and automatic assessment with test cases and continuous integration
+2. **Quiz exercises(docs/user/exercises/quiz.rst)** with multiple choice, drag and drop and short answer quiz questions 
+3. **Modeling exercises(docs/user/exercises/modeling.rst)** with semi-automatic assessment using machine learning concepts
+4. **Text exercises(docs/user/exercises/textual.rst)** with manual (and experimental semi-automatic) assessment
+5. **File upload exercises(docs/user/exercises/file-upload.rst)** with manual assessment
 
 All these exercises are supposed to be run either live in the lecture with instant feedback or as homework. Students can submit their solutions multiple times within the due date and use the (semi-)automatically provided feedback to improve their solution.
 
 ## Development setup
 
-Find here a guide on [how to set up your local development environment](/doc/setup/SETUP.md).
+Find here a guide on [how to set up your local development environment](docs/dev/setup.rst).
 
 ## Server Setup for Programming Exercises
 
-You can find the guide for setting up Artemis in conjunction with Jenkins and GitLab [here](doc/jenkins-gitlab/JENKINS_AND_GITLAB_SETUP.md) and Bamboo/Bitbucket/Jira [here](doc/bamboo-bitbucket-jira/BAMBOO_BITBUCKET_JIRA_SETUP.md)
+You can find the guide for setting up Artemis in conjunction with Jenkins and GitLab [here](docs/dev/setup/jenkins-gitlab.rst) and Bamboo/Bitbucket/Jira [here](docs/dev/setup/bamboo-bitbucket-jira.rst)
 
 ## Contributing 
 
@@ -56,7 +56,7 @@ This will compile the TypeScript into JavaScript files, concatenate and minify t
 java -jar build/libs/*.war --spring.profiles.active=dev,artemis,bamboo,bitbucket,jira
 ```
 
-(You might need to copy a yml file into the folder build/libs before, also see [development setup](/doc/setup/SETUP.md))
+(You might need to copy a yml file into the folder build/libs before, also see [development setup](/docs/dev/setup.rst))
 
 Then navigate to [http://localhost:8080](http://localhost:8080) in your browser.
 

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -299,7 +299,7 @@ Jenkins Server Setup
    To perform all these steps automatically, you can prepare a Docker
    image:
 
-   Create a dockerfile with the content found [here](src/main/docker/jenkins/Dockerfile). Copy it in a file named ``Dockerfile``, e.g. in
+   Create a dockerfile with the content found `here <src/main/docker/jenkins/Dockerfile>`. Copy it in a file named ``Dockerfile``, e.g. in
    the folder ``/opt/jenkins/`` using ``vim Dockerfile``.
 
    Now run the command ``docker build --no-cache -t jenkins-artemis .``

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -299,38 +299,8 @@ Jenkins Server Setup
    To perform all these steps automatically, you can prepare a Docker
    image:
 
-   Copy the following content in a file named ``Dockerfile``, e.g. in
+   Create a dockerfile with the content found [here](src/main/docker/jenkins/Dockerfile). Copy it in a file named ``Dockerfile``, e.g. in
    the folder ``/opt/jenkins/`` using ``vim Dockerfile``.
-
-   ::
-
-       FROM jenkins/jenkins:lts
-
-       LABEL description="Jenkins with maven pre-installed for Artemis"
-
-       USER root
-
-       RUN apt update
-
-       # Install Java and Maven dependencies
-       RUN apt-get install -y maven
-       RUN cd /usr/lib/jvm && \
-           wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36.1_openj9-0.19.0/OpenJDK14U-jdk_x64_linux_openj9_14_36_openj9-0.19.0.tar.gz && \
-           tar -zxf OpenJDK14U-jdk_x64_linux_openj9_14_36_openj9-0.19.0.tar.gz \
-           && mv jdk-14+36 java-14-openjdk-amd64 \
-           && rm OpenJDK14U-jdk_x64_linux_openj9_14_36_openj9-0.19.0.tar.gz
-       RUN chown -R root:root /usr/lib/jvm/java-14-openjdk-amd64
-       RUN JAVA_HOME="/usr/lib/jvm/java-14-openjdk-amd64" && export JAVA_HOME
-       ENV JAVA_HOME /usr/lib/jvm/java-14-openjdk-amd64
-
-       # Install Python dependecies
-       RUN apt install -y python3 python3-pip
-       # Install C dependencies
-       RUN apt install -y gcc-8 gdb make libasan5 libubsan0 liblsan0 libtsan0
-       # Install pytest for python exercises
-       RUN pip3 install -U pytest
-
-       USER jenkins
 
    Now run the command ``docker build --no-cache -t jenkins-artemis .``
 

--- a/src/main/docker/jenkins/Dockerfile
+++ b/src/main/docker/jenkins/Dockerfile
@@ -1,24 +1,42 @@
 FROM jenkins/jenkins:lts
-
-LABEL description="Jenkins with maven pre-installed for Artemis"
-
-USER root
-
-RUN apt update
-RUN apt-get install -y maven
- # Install Python dependecies
-RUN apt install -y python3 python3-pip
+ 
+ LABEL description="Jenkins with maven, python3.6 and gcc libraries pre-installed for Artemis"
+ 
+ USER root
+ 
+ RUN apt update
+ 
+ # Install Java and Maven dependencies
+ RUN apt-get install -y maven
+ RUN cd /usr/lib/jvm && \
+     wget https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14%2B36.1_openj9-0.19.0/OpenJDK14U-jdk_x64_linux_openj9_14_36_openj9-0.19.0.tar.gz && \
+     tar -zxf OpenJDK14U-jdk_x64_linux_openj9_14_36_openj9-0.19.0.tar.gz \
+     && mv jdk-14+36 java-14-openjdk-amd64 \
+     && rm OpenJDK14U-jdk_x64_linux_openj9_14_36_openj9-0.19.0.tar.gz
+ RUN chown -R root:root /usr/lib/jvm/java-14-openjdk-amd64
+ RUN JAVA_HOME="/usr/lib/jvm/java-14-openjdk-amd64" && export JAVA_HOME
+ ENV JAVA_HOME /usr/lib/jvm/java-14-openjdk-amd64
+ 
  # Install C dependencies
-RUN apt install -y gcc-6 gdb make libubsan0 liblsan0 libtsan0
- # Install pytest for python exercises
-RUN pip3 install -U pytest
-RUN cd /usr/lib/jvm && \
-    wget https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.2%2B10/OpenJDK12U-jdk_x64_linux_hotspot_12.0.2_10.tar.gz && \
-    tar -zxf OpenJDK12U-jdk_x64_linux_hotspot_12.0.2_10.tar.gz \
-    && mv jdk-12.0.2+10 java-12-openjdk-amd64 \
-    && rm OpenJDK12U-jdk_x64_linux_hotspot_12.0.2_10.tar.gz
-RUN chown -R root:root /usr/lib/jvm/java-12-openjdk-amd64
-RUN JAVA_HOME="/usr/lib/jvm/java-12-openjdk-amd64" && export JAVA_HOME
-ENV JAVA_HOME /usr/lib/jvm/java-12-openjdk-amd64
+ RUN apt install -y gcc gdb make libubsan0 liblsan0 libtsan0
 
-USER jenkins
+  # Some packages need to be installed to avoid some known problems for python3.6, see: https://github.com/pyenv/pyenv/wiki/Common-build-problems
+ RUN apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+ libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+ xz-utils tk-dev libffi-dev liblzma-dev
+
+ # Install Python3.6
+ RUN wget https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
+	 tar xvf Python-3.6.9.tgz \
+	 && cd Python-3.6.9 \
+	 && ./configure --enable-optimizations --enable-shared \
+	 && make -j8 \
+	 && make altinstall
+ RUN apt install -y python3 python3-pip
+ RUN cd ..
+ RUN rm -r -f Python3.6.9/ && rm -f Python-3.6.9.tgz
+ 
+ # Install pytest for python exercises
+ RUN pip3 install -U pytest
+ 
+ USER jenkins


### PR DESCRIPTION
### Motivation and Context
The old dockerfile did not install python3.6 which is required to run the libraries on which the c testing suite relies.


### Description
As python3.6 is not officially supported for debian 9, we need to install it manually (without apt-get)

### Steps for Testing
If you have a local setup for gitlab-jenkins, you can start the container, and check that all exercise test suites do not throw any erors.

### Note
On the testserver 2 they were manually installed before the migration. We should install them there too.

**Update**
In this PR, we also update the references to setup guides
