### PR TITLE
Fix Java programming exercise package name pattern

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -89,9 +89,9 @@ public class ProgrammingExerciseResource {
 
     /**
      * Java package name Regex according to Java 14 JLS (https://docs.oracle.com/javase/specs/jls/se14/html/jls-7.html#jls-7.4.1),
-     * with the restriction to a-z,A-Z,_,$ as "Java letter" and 0-9 as digits due to JavaScript/Browser Unicode character class limitations
+     * with the restriction to a-z,A-Z,_ as "Java letter" and 0-9 as digits due to JavaScript/Browser Unicode character class limitations
      */
-    private final String packageNameRegex = "^(?!.*(?:\\.|^)(?:abstract|continue|for|new|switch|assert|default|if|package|synchronized|boolean|do|goto|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while|_|true|false|null)(?:\\.|$))[\\$A-Z_a-z][\\$0-9A-Z_a-z]*(?:\\.[\\$A-Z_a-z][\\$0-9A-Z_a-z]*)*$";
+    private final String packageNameRegex = "^(?!.*(?:\\.|^)(?:abstract|continue|for|new|switch|assert|default|if|package|synchronized|boolean|do|goto|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while|_|true|false|null)(?:\\.|$))[A-Z_a-z][0-9A-Z_a-z]*(?:\\.[A-Z_a-z][0-9A-Z_a-z]*)*$";
 
     private final Pattern packageNamePattern = Pattern.compile(packageNameRegex);
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -214,7 +214,7 @@ public class ProgrammingExerciseResource {
         // Check if package name is set
         if (programmingExercise.getProgrammingLanguage() == ProgrammingLanguage.JAVA) {
             // only Java needs a valid package name at the moment
-            if (programmingExercise.getPackageName() == null || programmingExercise.getPackageName().length() < 3) {
+            if (programmingExercise.getPackageName() == null) {
                 return ResponseEntity.badRequest().headers(HeaderUtil.createAlert(applicationName, "The package name is invalid", "packagenameInvalid")).body(null);
             }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -87,7 +87,11 @@ public class ProgrammingExerciseResource {
 
     private final StudentParticipationRepository studentParticipationRepository;
 
-    private final String packageNameRegex = "^[a-z][a-z0-9_]*(\\.[a-z0-9_]+)+[0-9a-z_]$";
+    /**
+     * Java package name Regex according to Java 14 JLS (https://docs.oracle.com/javase/specs/jls/se14/html/jls-7.html#jls-7.4.1),
+     * with the restriction to a-z,A-Z,_,$ as "Java letter" and 0-9 as digits due to JavaScript/Browser Unicode character class limitations
+     */
+    private final String packageNameRegex = "^(?!.*(?:\\.|^)(?:abstract|continue|for|new|switch|assert|default|if|package|synchronized|boolean|do|goto|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while|_|true|false|null)(?:\\.|$))[\\$A-Z_a-z][\\$0-9A-Z_a-z]*(?:\\.[\\$A-Z_a-z][\\$0-9A-Z_a-z]*)*$";
 
     private final Pattern packageNamePattern = Pattern.compile(packageNameRegex);
 

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -50,7 +50,8 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
     maxScorePattern = MAX_SCORE_PATTERN;
     // Java package name Regex according to Java 14 JLS (https://docs.oracle.com/javase/specs/jls/se14/html/jls-7.html#jls-7.4.1),
     // with the restriction to a-z,A-Z,_,$ as "Java letter" and 0-9 as digits due to JavaScript/Browser Unicode character class limitations
-    packageNamePattern = '^(?!.*(?:\\.|^)(?:abstract|continue|for|new|switch|assert|default|if|package|synchronized|boolean|do|goto|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while|_|true|false|null)(?:\\.|$))[\$A-Z_a-z][\$0-9A-Z_a-z]*(?:\\.[\$A-Z_a-z][\$0-9A-Z_a-z]*)*$';
+    packageNamePattern =
+        '^(?!.*(?:\\.|^)(?:abstract|continue|for|new|switch|assert|default|if|package|synchronized|boolean|do|goto|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while|_|true|false|null)(?:\\.|$))[$A-Z_a-z][$0-9A-Z_a-z]*(?:\\.[$A-Z_a-z][$0-9A-Z_a-z]*)*$';
     shortNamePattern = '^[a-zA-Z][a-zA-Z0-9]*'; // must start with a letter and cannot contain special characters
     titleNamePattern = '^[a-zA-Z0-9-_ ]+'; // must only contain alphanumeric characters, or whitespaces, or '_' or '-'
     exerciseCategories: ExerciseCategory[];

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -48,7 +48,9 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
     private selectedProgrammingLanguageValue: ProgrammingLanguage;
 
     maxScorePattern = MAX_SCORE_PATTERN;
-    packageNamePattern = '^[a-z][a-z0-9_]*(\\.[a-z0-9_]+)+[0-9a-z_]$'; // package name must have at least 1 dot and must not start with a number
+    // Java package name Regex according to Java 14 JLS (https://docs.oracle.com/javase/specs/jls/se14/html/jls-7.html#jls-7.4.1),
+    // with the restriction to a-z,A-Z,_,$ as "Java letter" and 0-9 as digits due to JavaScript/Browser Unicode character class limitations
+    packageNamePattern = '^(?!.*(?:\\.|^)(?:abstract|continue|for|new|switch|assert|default|if|package|synchronized|boolean|do|goto|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while|_|true|false|null)(?:\\.|$))[\$A-Z_a-z][\$0-9A-Z_a-z]*(?:\\.[\$A-Z_a-z][\$0-9A-Z_a-z]*)*$';
     shortNamePattern = '^[a-zA-Z][a-zA-Z0-9]*'; // must start with a letter and cannot contain special characters
     titleNamePattern = '^[a-zA-Z0-9-_ ]+'; // must only contain alphanumeric characters, or whitespaces, or '_' or '-'
     exerciseCategories: ExerciseCategory[];

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -49,9 +49,9 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
 
     maxScorePattern = MAX_SCORE_PATTERN;
     // Java package name Regex according to Java 14 JLS (https://docs.oracle.com/javase/specs/jls/se14/html/jls-7.html#jls-7.4.1),
-    // with the restriction to a-z,A-Z,_,$ as "Java letter" and 0-9 as digits due to JavaScript/Browser Unicode character class limitations
+    // with the restriction to a-z,A-Z,_ as "Java letter" and 0-9 as digits due to JavaScript/Browser Unicode character class limitations
     packageNamePattern =
-        '^(?!.*(?:\\.|^)(?:abstract|continue|for|new|switch|assert|default|if|package|synchronized|boolean|do|goto|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while|_|true|false|null)(?:\\.|$))[$A-Z_a-z][$0-9A-Z_a-z]*(?:\\.[$A-Z_a-z][$0-9A-Z_a-z]*)*$';
+        '^(?!.*(?:\\.|^)(?:abstract|continue|for|new|switch|assert|default|if|package|synchronized|boolean|do|goto|private|this|break|double|implements|protected|throw|byte|else|import|public|throws|case|enum|instanceof|return|transient|catch|extends|int|short|try|char|final|interface|static|void|class|finally|long|strictfp|volatile|const|float|native|super|while|_|true|false|null)(?:\\.|$))[A-Z_a-z][0-9A-Z_a-z]*(?:\\.[A-Z_a-z][0-9A-Z_a-z]*)*$';
     shortNamePattern = '^[a-zA-Z][a-zA-Z0-9]*'; // must start with a letter and cannot contain special characters
     titleNamePattern = '^[a-zA-Z0-9-_ ]+'; // must only contain alphanumeric characters, or whitespaces, or '_' or '-'
     exerciseCategories: ExerciseCategory[];

--- a/src/main/webapp/i18n/de/exercise.json
+++ b/src/main/webapp/i18n/de/exercise.json
@@ -123,7 +123,7 @@
                     "minlength": "Der Kurzname muss mindestens 3 Zeichen lang sein!"
                 },
                 "packageName": {
-                    "pattern": "Der Packagename muss mindestens einen Punkt enthalten und darf nicht mit einer Zahl anfangen!"
+                    "pattern": "Der Package Name muss aus einem oder mehreren gültigen Java-Bezeichnern bestehen, die mit '.' getrennt sind, z.B. \"net.java\"!"
                 },
                 "maxScore": {
                     "pattern": "Die maximale Punktzahl muss zwischen 1 und 9999 liegen!"

--- a/src/main/webapp/i18n/en/exercise.json
+++ b/src/main/webapp/i18n/en/exercise.json
@@ -123,7 +123,7 @@
                     "minlength": "The short name must be at least 3 characters long!"
                 },
                 "packageName": {
-                    "pattern": "The package name must have at least 1 dot and must not start with a number"
+                    "pattern": "The package name must consist of one or more valid Java identifiers separated by '.', e.g. \"net.java\"!"
                 },
                 "maxScore": {
                     "pattern": "The maximum score must be between 1 and 9999!"

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -526,6 +526,24 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void setupProgrammingExercise_packageNameContainsKeyword_badRequest() throws Exception {
+        programmingExercise.setId(null);
+        programmingExercise.setPackageName("abc.final.xyz");
+        programmingExercise.setShortName("testShortName");
+        request.post(ROOT + SETUP, programmingExercise, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void setupProgrammingExercise_packageNameElementBeginsWithDigit_badRequest() throws Exception {
+        programmingExercise.setId(null);
+        programmingExercise.setPackageName("eist.2020something");
+        programmingExercise.setShortName("testShortName");
+        request.post(ROOT + SETUP, programmingExercise, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void setupProgrammingExercise_packageNameIsNull_badRequest() throws Exception {
         programmingExercise.setId(null);
         programmingExercise.setPackageName(null);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest2.ase.in.tum.de and https://vmbruegge60.in.tum.de.
- [x] I also tested that the results still show up properly in Artemis for some different and exotic package names on both CI configurations.
- [x] Server: I added multiple integration tests related to the feature

### Motivation and Context
The current package name field does allow entering invalid Java package names such as `eist.2020` (this was the case where the bug was discovered) and rejects correct some ones, e.g. `calculator`. We should disallow all invalid names and allow as many valid names as possible (in the best case all).

Especially invalid names cause all builds to fail because the code does not compile.

### Description
I exchanged Java package name regex used both on client and server side, updated the English and German localization of the invalid package name error message. I also added some more server-side tests for that as well.

The regex used here is: https://regex101.com/r/kFY4Ec/2/tests (there are more tests as well)
The correct one would be https://regex101.com/r/h0JGDO/1/tests but that does not seem to be realizable in HTML/JavaScript, at least currently many Browsers do not support Unicode categories in regex correctly, so I had to reduce that part (conversion would be possible, but the Regex would get very, very long).

**The regex needs to be updated along with Java itself in the future, of course.**

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis as instructor
2. Go to "Generate new programming exercise" and enter all required fields correctly
3. Try entering different valid and invalid package names (see [JLS 14, 7.4.1](https://docs.oracle.com/javase/specs/jls/se14/html/jls-7.html#jls-7.4.1), if interested)
4. Try pressing Enter and creating a new exercise for invalid package names, you should get `The package name is invalid` at the top of the page.
5. Switch the language and check the error message there.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/11130248/84152767-5a340980-aa65-11ea-99b4-1a49d8819509.png)

