### PR TITLE
Fix latest submission version query

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionVersionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionVersionRepository.java
@@ -15,7 +15,7 @@ import de.tum.in.www1.artemis.domain.SubmissionVersion;
 @Repository
 public interface SubmissionVersionRepository extends JpaRepository<SubmissionVersion, Long> {
 
-    @Query("select version from SubmissionVersion version left join version.submission submission left join submission.versions versions where submission.id = :#{#submissionId} and version.id = (select max(id) from versions)")
+    @Query("select version from SubmissionVersion version left join version.submission submission left join submission.versions where submission.id = :#{#submissionId} and version.id = (select max(id) from submission.versions)")
     Optional<SubmissionVersion> findLatestVersion(@Param("submissionId") long submissionId);
 
 }

--- a/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
@@ -292,6 +292,9 @@ public class TextSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         submission.setText(submission.getText() + " Extra contribution.");
         request.put("/api/exercises/" + releasedTextExercise.getId() + "/text-submissions", submission, HttpStatus.OK);
 
+        // create new submission to simulate other teams working at the same time
+        request.putWithResponseBody("/api/exercises/" + releasedTextExercise.getId() + "/text-submissions", textSubmission, TextSubmission.class, HttpStatus.OK);
+
         database.changeUser("student2");
         version = submissionVersionRepository.findLatestVersion(submission.getId());
         assertThat(version).as("submission version was created").isNotEmpty();


### PR DESCRIPTION
### Checklist
- [x] Server: I added multiple integration tests (Spring) related to the features

### Motivation and Context
Currently multiple submission version are being created sometimes even though the author remains the same (which should result in the last submission version being updated instead of a new version being created).

### Description
The issue lies in the JPA query `findLatestVersion` since the max condition refers to all versions instead of to only those versions of the matched submission.
