### PR TITLE
Fix #1637: Complaints for Text Exercises with new Text Blocks cannot be accepted

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
@@ -29,8 +29,8 @@ public interface TextSubmissionRepository extends JpaRepository<TextSubmission, 
      * @param submissionId the submission id we are interested in
      * @return the submission with its feedback and assessor
      */
-    @Query("select distinct submission from TextSubmission submission left join fetch submission.result r left join fetch r.feedbacks left join fetch r.assessor where submission.id = :#{#submissionId}")
-    Optional<TextSubmission> findByIdWithEagerResultAndFeedback(@Param("submissionId") Long submissionId);
+    @Query("select distinct s from TextSubmission s left join fetch s.result r left join fetch r.feedbacks left join fetch r.assessor left join fetch s.blocks where s.id = :#{#submissionId}")
+    Optional<TextSubmission> findByIdWithEagerResultFeedbackAndTextBlocks(@Param("submissionId") Long submissionId);
 
     /**
      * Gets all open (without a result) TextSubmissions which are submitted and loads all blocks, results, and participation

--- a/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
@@ -22,9 +22,6 @@ public interface TextSubmissionRepository extends JpaRepository<TextSubmission, 
     @Query("select distinct submission from TextSubmission submission left join fetch submission.participation participation left join fetch participation.exercise left join fetch submission.result result left join fetch result.assessor left join fetch result.feedbacks where submission.id = :#{#submissionId}")
     Optional<TextSubmission> findByIdWithEagerParticipationExerciseResultAssessor(@Param("submissionId") Long submissionId);
 
-    @Query("select distinct submission from TextSubmission submission left join fetch submission.result r left join fetch r.assessor where submission.id = :#{#submissionId}")
-    Optional<TextSubmission> findByIdWithEagerResultAndAssessor(@Param("submissionId") Long submissionId);
-
     /**
      * @param submissionId the submission id we are interested in
      * @return the submission with its feedback and assessor

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -292,11 +292,6 @@ public class TextSubmissionService extends SubmissionService {
         return textSubmission;
     }
 
-    public TextSubmission findOneWithEagerResultAndAssessor(Long submissionId) {
-        return textSubmissionRepository.findByIdWithEagerResultAndAssessor(submissionId)
-                .orElseThrow(() -> new EntityNotFoundException("Text submission with id \"" + submissionId + "\" does not exist"));
-    }
-
     public TextSubmission findOneWithEagerResultFeedbackAndTextBlocks(Long submissionId) {
         return textSubmissionRepository.findByIdWithEagerResultFeedbackAndTextBlocks(submissionId)
                 .orElseThrow(() -> new EntityNotFoundException("Text submission with id \"" + submissionId + "\" does not exist"));

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -297,8 +297,8 @@ public class TextSubmissionService extends SubmissionService {
                 .orElseThrow(() -> new EntityNotFoundException("Text submission with id \"" + submissionId + "\" does not exist"));
     }
 
-    public TextSubmission findOneWithEagerResultAndFeedback(Long submissionId) {
-        return textSubmissionRepository.findByIdWithEagerResultAndFeedback(submissionId)
+    public TextSubmission findOneWithEagerResultFeedbackAndTextBlocks(Long submissionId) {
+        return textSubmissionRepository.findByIdWithEagerResultFeedbackAndTextBlocks(submissionId)
                 .orElseThrow(() -> new EntityNotFoundException("Text submission with id \"" + submissionId + "\" does not exist"));
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
@@ -174,7 +174,7 @@ public class TextAssessmentResource extends AssessmentResource {
     public ResponseEntity<Result> updateTextAssessmentAfterComplaint(@PathVariable Long submissionId, @RequestBody TextAssessmentUpdateDTO assessmentUpdate) {
         log.debug("REST request to update the assessment of submission {} after complaint.", submissionId);
         User user = userService.getUserWithGroupsAndAuthorities();
-        TextSubmission textSubmission = textSubmissionService.findOneWithEagerResultAndFeedback(submissionId);
+        TextSubmission textSubmission = textSubmissionService.findOneWithEagerResultFeedbackAndTextBlocks(submissionId);
         StudentParticipation studentParticipation = (StudentParticipation) textSubmission.getParticipation();
         long exerciseId = studentParticipation.getExercise().getId();
         TextExercise textExercise = textExerciseService.findOne(exerciseId);

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -171,7 +171,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
     @Test
     @WithMockUser(value = "tutor2", roles = "TA")
     public void updateTextAssessmentAfterComplaint_withTextBlocks() throws Exception {
-        // Seetup
+        // Setup
         TextSubmission textSubmission = ModelFactory.generateTextSubmission("This is Part 1, and this is Part 2. There is also Part 3.", Language.ENGLISH, true);
         textSubmission = database.addTextSubmissionWithResultAndAssessor(textExercise, textSubmission, "student1", "tutor1");
         database.addTextBlocksToTextSubmission(asList(new TextBlock().startIndex(0).endIndex(15).automatic(), new TextBlock().startIndex(16).endIndex(35).automatic(),
@@ -185,6 +185,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         final Result result = participation.getResults().iterator().next();
         final Complaint complaint = request.get("/api/complaints/result/" + result.getId(), HttpStatus.OK, Complaint.class);
 
+        // Accept Complaint and update Assessment
         ComplaintResponse complaintResponse = new ComplaintResponse().complaint(complaint.accepted(false)).responseText("rejected");
         TextAssessmentUpdateDTO assessmentUpdate = new TextAssessmentUpdateDTO();
         assessmentUpdate.feedbacks(new ArrayList<>()).complaintResponse(complaintResponse);

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -53,6 +53,7 @@ import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 import de.tum.in.www1.artemis.util.TextExerciseUtilService;
 import de.tum.in.www1.artemis.web.rest.dto.TextAssessmentDTO;
+import de.tum.in.www1.artemis.web.rest.dto.TextAssessmentUpdateDTO;
 
 public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
@@ -165,6 +166,34 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
 
         assertThat(updatedResult).as("updated result found").isNotNull();
         assertThat(((StudentParticipation) updatedResult.getParticipation()).getStudent()).as("student of participation is hidden").isEmpty();
+    }
+
+    @Test
+    @WithMockUser(value = "tutor2", roles = "TA")
+    public void updateTextAssessmentAfterComplaint_withTextBlocks() throws Exception {
+        // Seetup
+        TextSubmission textSubmission = ModelFactory.generateTextSubmission("This is Part 1, and this is Part 2. There is also Part 3.", Language.ENGLISH, true);
+        textSubmission = database.addTextSubmissionWithResultAndAssessor(textExercise, textSubmission, "student1", "tutor1");
+        database.addTextBlocksToTextSubmission(asList(new TextBlock().startIndex(0).endIndex(15).automatic(), new TextBlock().startIndex(16).endIndex(35).automatic(),
+                new TextBlock().startIndex(36).endIndex(57).automatic()), textSubmission);
+
+        Result textAssessment = textSubmission.getResult();
+        complaintRepo.save(new Complaint().result(textAssessment).complaintText("This is not fair"));
+
+        // Get Text Submission and Complaint
+        StudentParticipation participation = request.get("/api/text-assessments/submission/" + textSubmission.getId(), HttpStatus.OK, StudentParticipation.class);
+        final Result result = participation.getResults().iterator().next();
+        final Complaint complaint = request.get("/api/complaints/result/" + result.getId(), HttpStatus.OK, Complaint.class);
+
+        ComplaintResponse complaintResponse = new ComplaintResponse().complaint(complaint.accepted(false)).responseText("rejected");
+        TextAssessmentUpdateDTO assessmentUpdate = new TextAssessmentUpdateDTO();
+        assessmentUpdate.feedbacks(new ArrayList<>()).complaintResponse(complaintResponse);
+        assessmentUpdate.setTextBlocks(new ArrayList<>());
+
+        Result updatedResult = request.putWithResponseBody("/api/text-assessments/text-submissions/" + textSubmission.getId() + "/assessment-after-complaint", assessmentUpdate,
+                Result.class, HttpStatus.OK);
+
+        assertThat(updatedResult).as("updated result found").isNotNull();
     }
 
     @Test


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I added multiple integration tests (Spring) related to the features
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
#1637

### Description
Fetch Text Blocks when handling complaints on textual exercises so we do not run into an uninitialized proxy.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. As **Student 1**:
    1. Submit Text Exercise with multiple sentences.
2. As **Tutor 1**:
    1. Open Assessment previously created.
    2. Add Assessment (for one text block).
    3. Submit Assessment
3. As **Student 1**:
    1. See Assessment
    2. Submit Complaint
4. As **Tutor 2**:
    1. Open Complaint
    2. Correct Assessment (add something for second text block)
    3. Accept Complaint
3. As **Student 1**:
    1. View updated assessment
