### PR TITLE
Add Hazelcast indicator translation.

### DIFF
--- a/src/main/webapp/i18n/de/health.json
+++ b/src/main/webapp/i18n/de/health.json
@@ -23,7 +23,8 @@
             "readinessState": "Bereitschaft",
             "continuousIntegrationServer": "Kontinuierlicher Integrationsserver",
             "versionControlServer": "Versionskontrollserver",
-            "userManagement": "Nutzerverwaltung"
+            "userManagement": "Nutzerverwaltung",
+            "hazelcast": "Hazelcast"
         },
         "table": {
             "service": "Dienst Name",

--- a/src/main/webapp/i18n/en/health.json
+++ b/src/main/webapp/i18n/en/health.json
@@ -23,7 +23,8 @@
             "readinessState": "Readiness",
             "continuousIntegrationServer": "Continuous Integration Server",
             "versionControlServer": "Version Control Server",
-            "userManagement": "User Management"
+            "userManagement": "User Management",
+            "hazelcast": "Hazelcast"
         },
         "table": {
             "service": "Service name",


### PR DESCRIPTION
### Checklist
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
In https://github.com/ls1intum/Artemis/pull/1586, Hazelcast was added. The status of Hazelcast is also shown in the Health dashboard, but the translations were missing.

### Description
Added missing translations from https://github.com/ls1intum/Artemis/pull/1586.

### Steps for Testing

1. Log in to Artemis
2. Navigate to Server Administration > Status
3. Valdiate that `Hazelcast` is displayed instead of `translation-not-found[health.indicator.hazelcast]`.

### Screenshots
Before:
![Screenshot at 19-52-44](https://user-images.githubusercontent.com/5084100/84600460-9b6b5580-ae79-11ea-8de0-da0d235529ac.png)
After:
![Screenshot at 19-56-34](https://user-images.githubusercontent.com/5084100/84600465-a1613680-ae79-11ea-864a-a3a2323b1d42.png)

