### PR TITLE
Fix Referential Equality Comparison (of Boolean)

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -650,7 +650,7 @@ public abstract class Exercise implements Serializable {
             }
             // NOTE: for the dashboard we only use rated results with completion date
             boolean isAssessmentOver = ignoreAssessmentDueDate || getAssessmentDueDate() == null || getAssessmentDueDate().isBefore(ZonedDateTime.now());
-            if (result.getCompletionDate() != null && result.isRated() == Boolean.TRUE && isAssessmentOver) {
+            if (result.getCompletionDate() != null && Boolean.TRUE.equals(result.isRated()) && isAssessmentOver) {
                 // take the first found result that fulfills the above requirements
                 if (latestSubmission == null) {
                     latestSubmission = submission;
@@ -795,7 +795,7 @@ public abstract class Exercise implements Serializable {
         for (Submission submission : submissions) {
             Result result = submission.getResult();
             if (result != null) {
-                if (result.isRated() == Boolean.TRUE) {
+                if (Boolean.TRUE.equals(result.isRated())) {
                     submissionsWithRatedResult.add(submission);
                 }
                 else {

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
@@ -450,7 +450,7 @@ public class QuizExercise extends Exercise implements Serializable {
                 if (result == null) {
                     continue;
                 }
-                if (result.isRated() == Boolean.TRUE && result.getCompletionDate() != null) {
+                if (Boolean.TRUE.equals(result.isRated()) && result.getCompletionDate() != null) {
                     // take the first found result that fulfills the above requirements
                     if (latestSubmission == null) {
                         latestSubmission = submission;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizPointStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizPointStatistic.java
@@ -151,7 +151,7 @@ public class QuizPointStatistic extends QuizStatistic implements Serializable {
 
         Double points = (double) Math.round(((double) quiz.getMaxTotalScore()) * ((double) score / 100));
 
-        if (rated == Boolean.TRUE) {
+        if (Boolean.TRUE.equals(rated)) {
             // change rated participants
             setParticipantsRated(getParticipantsRated() + change);
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestionStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestionStatistic.java
@@ -11,6 +11,7 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+
 import de.tum.in.www1.artemis.domain.SubmittedAnswer;
 
 /**
@@ -185,7 +186,7 @@ public class ShortAnswerQuestionStatistic extends QuizQuestionStatistic implemen
                     }
                     for (ShortAnswerSolution solution : shortAnswerSolutions) {
                         if (shortAnswerSubmittedText.isSubmittedTextCorrect(shortAnswerSubmittedText.getText(), solution.getText())
-                                && Boolean.TRUE == shortAnswerSubmittedText.isIsCorrect()) {
+                                && Boolean.TRUE.equals(shortAnswerSubmittedText.isIsCorrect())) {
                             spotCounter.setUnRatedCounter(spotCounter.getUnRatedCounter() + change);
                         }
                     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestionStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestionStatistic.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-
 import de.tum.in.www1.artemis.domain.SubmittedAnswer;
 
 /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyShortAnswerUtil.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyShortAnswerUtil.java
@@ -10,7 +10,7 @@ public class ScoringStrategyShortAnswerUtil {
 
     /**
      * Get number of correct and incorrect solutions for the short answer question
-     * 
+     *
      * @param shortAnswerQuestion for which the correct and incorrect solutions should be counted
      * @param shortAnswerAnswer for the given short answer question
      * @return array with correct and incorrect solution count
@@ -24,7 +24,7 @@ public class ScoringStrategyShortAnswerUtil {
 
         // iterate through each spot and compare its correct solutions with the submitted texts
         for (ShortAnswerSpot spot : shortAnswerQuestion.getSpots()) {
-            if (spot.isInvalid() == Boolean.TRUE) {
+            if (Boolean.TRUE.equals(spot.isInvalid())) {
                 correctSolutionsCount++;
                 continue;
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExampleSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExampleSubmissionService.java
@@ -73,7 +73,7 @@ public class ExampleSubmissionService {
         Result result = submission.getResult();
 
         // result.isExampleResult() can have 3 values: null, false, true. We return if it is not true
-        if (result == null || result.isExampleResult() != Boolean.TRUE) {
+        if (result == null || !Boolean.TRUE.equals(result.isExampleResult())) {
             return null;
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -847,7 +847,7 @@ public class ParticipationService {
                     // this for loop is optimized for performance and thus not very easy to understand ;)
                     for (Result result : participation.getResults()) {
                         // this should not happen because the database call above only retrieves rated results
-                        if (result.isRated() == Boolean.FALSE) {
+                        if (Boolean.FALSE.equals(result.isRated())) {
                             continue;
                         }
                         if (result.getCompletionDate() == null || result.getScore() == null) {

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizStatisticService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizStatisticService.java
@@ -77,11 +77,11 @@ public class QuizStatisticService {
             for (Result result : resultRepository.findAllByParticipationIdOrderByCompletionDateDesc(participation.getId())) {
 
                 // find latest rated Result
-                if (result.isRated() == Boolean.TRUE && (latestRatedResult == null || latestRatedResult.getCompletionDate().isBefore(result.getCompletionDate()))) {
+                if (Boolean.TRUE.equals(result.isRated()) && (latestRatedResult == null || latestRatedResult.getCompletionDate().isBefore(result.getCompletionDate()))) {
                     latestRatedResult = result;
                 }
                 // find latest unrated Result
-                if (result.isRated() == Boolean.FALSE && (latestUnratedResult == null || latestUnratedResult.getCompletionDate().isBefore(result.getCompletionDate()))) {
+                if (Boolean.FALSE.equals(result.isRated()) && (latestUnratedResult == null || latestUnratedResult.getCompletionDate().isBefore(result.getCompletionDate()))) {
                     latestUnratedResult = result;
                 }
             }
@@ -116,7 +116,7 @@ public class QuizStatisticService {
             for (Result result : results) {
                 // check if the result is rated
                 // NOTE: there is never an old Result if the new result is rated
-                if (result.isRated() == Boolean.FALSE) {
+                if (Boolean.FALSE.equals(result.isRated())) {
                     removeResultFromAllStatistics(quiz, getPreviousResult(result));
                 }
                 addResultToAllStatistics(quiz, result);

--- a/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ResultService.java
@@ -295,7 +295,7 @@ public class ResultService {
         savedResult = savedResultOpt.get();
 
         // if it is an example result we do not have any participation (isExampleResult can be also null)
-        if (savedResult.isExampleResult() == Boolean.FALSE || savedResult.isExampleResult() == null) {
+        if (Boolean.FALSE.equals(savedResult.isExampleResult()) || savedResult.isExampleResult() == null) {
 
             if (savedResult.getParticipation() instanceof ProgrammingExerciseStudentParticipation) {
                 ltiService.onNewResult((ProgrammingExerciseStudentParticipation) savedResult.getParticipation());

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -87,7 +87,7 @@ public class TextSubmissionService extends SubmissionService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN);
         }
 
-        if (textSubmission.isExampleSubmission() == Boolean.TRUE) {
+        if (Boolean.TRUE.equals(textSubmission.isExampleSubmission())) {
             textSubmission = save(textSubmission);
         }
         else {
@@ -270,7 +270,7 @@ public class TextSubmissionService extends SubmissionService {
                 continue;
             }
 
-            if (submittedOnly && optionalTextSubmission.get().isSubmitted() != Boolean.TRUE) {
+            if (submittedOnly && !Boolean.TRUE.equals(optionalTextSubmission.get().isSubmitted())) {
                 continue;
             }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/TutorParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TutorParticipationService.java
@@ -159,7 +159,7 @@ public class TutorParticipationService {
         }
 
         // Check if it is a tutorial or not
-        boolean isTutorial = originalExampleSubmission.isUsedForTutorial() == Boolean.TRUE;
+        boolean isTutorial = Boolean.TRUE.equals(originalExampleSubmission.isUsedForTutorial());
 
         // If it is a tutorial we check the assessment
         if (isTutorial) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BambooService.java
@@ -168,7 +168,7 @@ public class BambooService implements ContinuousIntegrationService {
                     //only delete the git repository, if the online editor is NOT allowed
                     //this saves some performance on the server, when the student opens the online editor, because the repo does not need to be cloned again
                     //Note: the null check is necessary, because otherwise we might get a null pointer exception
-                    if (exercise.isAllowOnlineEditor() == null || exercise.isAllowOnlineEditor() == Boolean.FALSE) {
+                    if (exercise.isAllowOnlineEditor() == null || Boolean.FALSE.equals(exercise.isAllowOnlineEditor())) {
                         gitService.deleteLocalRepository(repo);
                     }
                 }

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticBuildPlanCleanupService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticBuildPlanCleanupService.java
@@ -90,7 +90,7 @@ public class AutomaticBuildPlanCleanupService {
                     }
                 }
 
-                if (programmingExercise.isPublishBuildPlanUrl() == Boolean.TRUE) {
+                if (Boolean.TRUE.equals(programmingExercise.isPublishBuildPlanUrl())) {
                     // this was an exercise where students needed to configure the build plan, therefore we should not clean it up
                     continue;
                 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -355,7 +355,7 @@ public class CourseResource {
                     .headers(HeaderUtil.createFailureAlert(applicationName, false, ENTITY_NAME, "courseAlreadyFinished", "The course has already finished. Cannot register user"))
                     .body(null);
         }
-        if (course.isRegistrationEnabled() != Boolean.TRUE) {
+        if (!Boolean.TRUE.equals(course.isRegistrationEnabled())) {
             return ResponseEntity.badRequest().headers(
                     HeaderUtil.createFailureAlert(applicationName, false, ENTITY_NAME, "registrationDisabled", "The course does not allow registration. Cannot register user"))
                     .body(null);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I checked that all tests still work

### Motivation and Context
This fixes an issue that first occurred in #1644 and currently blocks it:

Comparing only references in Java is strongly discouraged, and likely leads to undesirable behavior.
This also applies to `java.lang.Boolean`-Objects. In our case, this became noticeable by deserialization of some domain objects. 

### Description
Replaced (including swapped sides)
- `x == Boolean.TRUE` by `Boolean.TRUE.equals(x)`
- `x == Boolean.FALSE` by `Boolean.FALSE.equals(x)`
- `x != Boolean.TRUE` by `!Boolean.TRUE.equals(x)`
- `x != Boolean.FALSE` by `!Boolean.FALSE.equals(x)`

### Steps for Testing
- (Run the tests)
- **Carefully review the source code that there are no mistakes**
- Maybe test general functionality on one of the test servers
- Maybe check again that there are none left (e.g. via Regex)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/11130248/84733611-fd71ab00-af9e-11ea-8845-d3e03f0aacd3.png)

