### PR TITLE
Disable registry by default.

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -178,7 +178,7 @@ jhipster:
 # Eureka configuration
 eureka:
     client:
-        enabled: true
+        enabled: false
         service-url:
             defaultZone: http://admin:${jhipster.registry.password}@localhost:8761/eureka/
         healthcheck:


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
The registry is currently automatically enabled in the prod-profile. The registry however should be opt-in, so we disable for all profiles now and expect manual interaction if the user wants to use it.

### Description
Disable the registry by default. To enable it, the value `eureka.client.enabled` must be set to `true`.

### Steps for Testing
Start the server in production profile, there should be no errors anymore if there is no registry configured.

Change the setting `eureka.client.enabled` and validate that the registry is working again as before.