### PR TITLE
[Exam] Get studentExam for exam conduction follow-up

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -7,9 +7,10 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 
 /**
@@ -25,7 +26,8 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
     Optional<StudentExam> findWithExercisesAndStudentParticipationsAndSubmissionsById(Long id);
 
     @EntityGraph(type = LOAD, attributePaths = { "exercises", "exercises.studentParticipations", "exercises.studentParticipations.submissions" })
-    Optional<StudentExam> findWithExercisesAndStudentParticipationsAndSubmissionsByUser(User user);
+    @Query("SELECT studentExam FROM StudentExam studentExam WHERE studentExam.user.id = :#{#userId} AND studentExam.exam.id = :#{#examId}")
+    Optional<StudentExam> findWithExercisesAndStudentParticipationsAndSubmissionsByUserIdAndExamId(@Param("userId") long userId, @Param("examId") long examId);
 
     List<StudentExam> findByExamId(Long examId);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 
 /**
@@ -22,6 +23,9 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
 
     @EntityGraph(type = LOAD, attributePaths = { "exercises", "exercises.studentParticipations", "exercises.studentParticipations.submissions" })
     Optional<StudentExam> findWithExercisesAndStudentParticipationsAndSubmissionsById(Long id);
+
+    @EntityGraph(type = LOAD, attributePaths = { "exercises", "exercises.studentParticipations", "exercises.studentParticipations.submissions" })
+    Optional<StudentExam> findWithExercisesAndStudentParticipationsAndSubmissionsByUser(User user);
 
     List<StudentExam> findByExamId(Long examId);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
@@ -112,7 +112,8 @@ public class StudentExamAccessService {
         }
 
         // Check that the exam is live
-        if (exam.get().getStartDate().isAfter(ZonedDateTime.now()) || exam.get().getEndDate().isBefore(ZonedDateTime.now())) {
+        if (exam.get().getStartDate() != null && exam.get().getEndDate() != null
+                && (exam.get().getStartDate().isAfter(ZonedDateTime.now()) || exam.get().getEndDate().isBefore(ZonedDateTime.now()))) {
             return Optional.of(forbidden());
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
@@ -88,8 +88,7 @@ public class StudentExamAccessService {
 
         // TODO: filter attributes of exercises that should not be visible to the student.
 
-        Optional<ResponseEntity<StudentExam>> studentExamAccessFailure = checkStudentExamAccess(examId, currentUser, studentExam.get());
-        return studentExamAccessFailure.orElseGet(() -> ResponseEntity.ok(studentExam.get()));
+        return ResponseEntity.ok(studentExam.get());
     }
 
     private <T> Optional<ResponseEntity<T>> checkCourseAndExamAccess(Long courseId, Long examId, User currentUser) {

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
@@ -81,7 +81,7 @@ public class StudentExamAccessService {
             return courseAndExamAccessFailure.get();
         }
 
-        Optional<StudentExam> studentExam = studentExamRepository.findWithExercisesAndStudentParticipationsAndSubmissionsByUser(currentUser);
+        Optional<StudentExam> studentExam = studentExamRepository.findWithExercisesAndStudentParticipationsAndSubmissionsByUserIdAndExamId(currentUser.getId(), examId);
         if (studentExam.isEmpty()) {
             return notFound();
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
@@ -69,12 +69,11 @@ public class StudentExamAccessService {
     /**
      * Checks if the current user is allowed to see the requested student exam and returns it if he is allowed.
      *
-     * @param courseId      the if of the course
-     * @param examId        the id of the exam
-     * @param studentExamId the id of the student exam
+     * @param courseId  the if of the course
+     * @param examId    the id of the exam
      * @return the student exam wrapper in a ResponseEntity or an error response
      */
-    public ResponseEntity<StudentExam> checkAndGetStudentExamAccessWithExercises(Long courseId, Long examId, Long studentExamId) {
+    public ResponseEntity<StudentExam> checkAndGetStudentExamAccessWithExercises(Long courseId, Long examId) {
         User currentUser = userService.getUserWithGroupsAndAuthorities();
 
         Optional<ResponseEntity<StudentExam>> courseAndExamAccessFailure = checkCourseAndExamAccess(courseId, examId, currentUser);
@@ -82,7 +81,7 @@ public class StudentExamAccessService {
             return courseAndExamAccessFailure.get();
         }
 
-        Optional<StudentExam> studentExam = studentExamRepository.findWithExercisesAndStudentParticipationsAndSubmissionsById(studentExamId);
+        Optional<StudentExam> studentExam = studentExamRepository.findWithExercisesAndStudentParticipationsAndSubmissionsByUser(currentUser);
         if (studentExam.isEmpty()) {
             return notFound();
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamAccessService.java
@@ -67,31 +67,16 @@ public class StudentExamAccessService {
     }
 
     /**
-     * Checks if the current user is allowed to see the requested student exam and returns it if he is allowed.
+     * Checks if the current user is allowed to access the requested exam.
      *
-     * @param courseId  the if of the course
-     * @param examId    the id of the exam
-     * @return the student exam wrapper in a ResponseEntity or an error response
+     * @param courseId      the if of the course
+     * @param examId        the id of the exam
+     * @param currentUser   the user
+     * @param <T>           The type of the return type of the requesting route so that the
+     *                      response can be returned there
+     * @return an Optional with a typed ResponseEntity. If it is empty all checks passed
      */
-    public ResponseEntity<StudentExam> checkAndGetStudentExamAccessWithExercises(Long courseId, Long examId) {
-        User currentUser = userService.getUserWithGroupsAndAuthorities();
-
-        Optional<ResponseEntity<StudentExam>> courseAndExamAccessFailure = checkCourseAndExamAccess(courseId, examId, currentUser);
-        if (courseAndExamAccessFailure.isPresent()) {
-            return courseAndExamAccessFailure.get();
-        }
-
-        Optional<StudentExam> studentExam = studentExamRepository.findWithExercisesAndStudentParticipationsAndSubmissionsByUserIdAndExamId(currentUser.getId(), examId);
-        if (studentExam.isEmpty()) {
-            return notFound();
-        }
-
-        // TODO: filter attributes of exercises that should not be visible to the student.
-
-        return ResponseEntity.ok(studentExam.get());
-    }
-
-    private <T> Optional<ResponseEntity<T>> checkCourseAndExamAccess(Long courseId, Long examId, User currentUser) {
+    public <T> Optional<ResponseEntity<T>> checkCourseAndExamAccess(Long courseId, Long examId, User currentUser) {
         // Check that the current user is at least student in the course.
         Course course = courseService.findOne(courseId);
         if (!authorizationCheckService.isAtLeastStudentInCourse(course, currentUser)) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -70,19 +70,18 @@ public class StudentExamResource {
     }
 
     /**
-     * GET /courses/{courseId}/exams/{examId}/studentExams/{studentExamId}/conduction : Find a student exam by id.
+     * GET /courses/{courseId}/exams/{examId}/studentExams/conduction : Find a student exam for the user.
      * This will be used for the actual conduction of the exam. The student exam will be returned with the exercises
      * and with the student participation and with the submissions.
      *
-     * @param courseId      the course to which the student exam belongs to
-     * @param examId        the exam to which the student exam belongs to
-     * @param studentExamId the id of the student exam to find
+     * @param courseId  the course to which the student exam belongs to
+     * @param examId    the exam to which the student exam belongs to
      * @return the ResponseEntity with status 200 (OK) and with the found student exam as body
      */
-    @GetMapping("/courses/{courseId}/exams/{examId}/studentExams/{studentExamId}/conduction")
+    @GetMapping("/courses/{courseId}/exams/{examId}/studentExams/conduction")
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<StudentExam> getStudentExamForConduction(@PathVariable Long courseId, @PathVariable Long examId, @PathVariable Long studentExamId) {
-        log.debug("REST request to get student exam : {}", studentExamId);
-        return studentExamAccessService.checkAndGetStudentExamAccessWithExercises(courseId, examId, studentExamId);
+    public ResponseEntity<StudentExam> getStudentExamForConduction(@PathVariable Long courseId, @PathVariable Long examId) {
+        log.debug("REST request to get a user's student exam for conduction of exam : {}", examId);
+        return studentExamAccessService.checkAndGetStudentExamAccessWithExercises(courseId, examId);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
@@ -103,7 +104,12 @@ public class StudentExamResource {
             return notFound();
         }
 
-        // TODO: filter attributes of exercises that should not be visible to the student.
+        // Filter attributes of exercises that should not be visible to the student
+        if (studentExam.get().getExercises() != null) {
+            for (Exercise exercise : studentExam.get().getExercises()) {
+                exercise.filterSensitiveInformation();
+            }
+        }
 
         return ResponseEntity.ok(studentExam.get());
     }

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -110,11 +110,12 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void testGetStudentExamForConduction() throws Exception {
-        StudentExam studentExam = database.addStudentExamWithExercisesAndParticipationAndSubmission(exam1, users.get(0));
-
-        var response = request.get("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/studentExams/" + studentExam.getId() + "/conduction", HttpStatus.OK,
-                StudentExam.class);
-        verify(studentExamAccessService, times(1)).checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId());
+        Course course = database.addEmptyCourse();
+        Exam exam = database.addActiveExamWithRegisteredUser(course, users.get(0));
+        StudentExam studentExam = database.addStudentExamWithExercisesAndParticipationAndSubmission(exam, users.get(0));
+        var response = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/studentExams/conduction", HttpStatus.OK, StudentExam.class);
+        verify(studentExamAccessService, times(1)).checkAndGetStudentExamAccessWithExercises(course.getId(), exam.getId());
+        assertThat(response).isEqualTo(studentExam);
         assertThat(response.getExercises().size()).isEqualTo(1);
         assertThat(response.getExercises().get(0).getStudentParticipations().size()).isEqualTo(1);
         Exercise exercise = response.getExercises().get(0);

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -114,7 +114,7 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
 
         var response = request.get("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/studentExams/" + studentExam.getId() + "/conduction", HttpStatus.OK,
                 StudentExam.class);
-        verify(studentExamAccessService, times(1)).checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId(), studentExam.getId());
+        verify(studentExamAccessService, times(1)).checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId());
         assertThat(response.getExercises().size()).isEqualTo(1);
         assertThat(response.getExercises().get(0).getStudentParticipations().size()).isEqualTo(1);
         Exercise exercise = response.getExercises().get(0);

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -114,7 +114,7 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
         Exam exam = database.addActiveExamWithRegisteredUser(course, users.get(0));
         StudentExam studentExam = database.addStudentExamWithExercisesAndParticipationAndSubmission(exam, users.get(0));
         var response = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/studentExams/conduction", HttpStatus.OK, StudentExam.class);
-        verify(studentExamAccessService, times(1)).checkAndGetStudentExamAccessWithExercises(course.getId(), exam.getId());
+        verify(studentExamAccessService, times(1)).checkCourseAndExamAccess(course.getId(), exam.getId(), users.get(0));
         assertThat(response).isEqualTo(studentExam);
         assertThat(response.getExercises().size()).isEqualTo(1);
         assertThat(response.getExercises().get(0).getStudentParticipations().size()).isEqualTo(1);

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
+import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
@@ -118,6 +119,12 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
         assertThat(response).isEqualTo(studentExam);
         assertThat(response.getExercises().size()).isEqualTo(1);
         assertThat(response.getExercises().get(0).getStudentParticipations().size()).isEqualTo(1);
+        // Check that sensitive information has been removed
+        TextExercise textExercise = (TextExercise) response.getExercises().get(0);
+        assertThat(textExercise.getGradingCriteria()).isEmpty();
+        assertThat(textExercise.getGradingInstructions()).isEqualTo(null);
+        assertThat(textExercise.getSampleSolution()).isEqualTo(null);
+        // Clean up
         Exercise exercise = response.getExercises().get(0);
         for (StudentParticipation s : response.getExercises().get(0).getStudentParticipations()) {
             assertThat(s.getSubmissions().size()).isEqualTo(1);

--- a/src/test/java/de/tum/in/www1/artemis/service/StudentExamAccessServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/StudentExamAccessServiceTest.java
@@ -75,28 +75,34 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void testIsAtLeastStudentInCourse() {
-        Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course2.getId(), exam2.getId(), studentExam1.getId());
-        assertThat(accessFailure.isPresent()).isTrue();
-        assertThat(accessFailure.get()).isEqualTo(forbidden());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course2.getId(), exam2.getId())).isEqualTo(forbidden());
+        Optional<ResponseEntity<Void>> accessFailure1 = studentExamAccessService.checkCourseAndExamAccess(course2.getId(), exam2.getId(), users.get(0));
+        assertThat(accessFailure1.isPresent()).isTrue();
+        assertThat(accessFailure1.get()).isEqualTo(forbidden());
+        Optional<ResponseEntity<Void>> accessFailure2 = studentExamAccessService.checkStudentExamAccess(course2.getId(), exam2.getId(), studentExam1.getId());
+        assertThat(accessFailure2.isPresent()).isTrue();
+        assertThat(accessFailure2.get()).isEqualTo(forbidden());
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void testExamExists() {
-        Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), 55L, studentExam1.getId());
-        assertThat(accessFailure.isPresent()).isTrue();
-        assertThat(accessFailure.get()).isEqualTo(notFound());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), 55L)).isEqualTo(notFound());
+        Optional<ResponseEntity<Void>> accessFailure1 = studentExamAccessService.checkCourseAndExamAccess(course1.getId(), 55L, users.get(0));
+        assertThat(accessFailure1.isPresent()).isTrue();
+        assertThat(accessFailure1.get()).isEqualTo(notFound());
+        Optional<ResponseEntity<Void>> accessFailure2 = studentExamAccessService.checkStudentExamAccess(course1.getId(), 55L, studentExam1.getId());
+        assertThat(accessFailure2.isPresent()).isTrue();
+        assertThat(accessFailure2.get()).isEqualTo(notFound());
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void testExamBelongsToCourse() {
-        Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), exam2.getId(), studentExam1.getId());
-        assertThat(accessFailure.isPresent()).isTrue();
-        assertThat(accessFailure.get()).isEqualTo(conflict());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam2.getId())).isEqualTo(conflict());
+        Optional<ResponseEntity<Void>> accessFailure1 = studentExamAccessService.checkCourseAndExamAccess(course1.getId(), exam2.getId(), users.get(0));
+        assertThat(accessFailure1.isPresent()).isTrue();
+        assertThat(accessFailure1.get()).isEqualTo(conflict());
+        Optional<ResponseEntity<Void>> accessFailure2 = studentExamAccessService.checkStudentExamAccess(course1.getId(), exam2.getId(), studentExam1.getId());
+        assertThat(accessFailure2.isPresent()).isTrue();
+        assertThat(accessFailure2.get()).isEqualTo(conflict());
     }
 
     @Test
@@ -104,26 +110,32 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
     public void testExamIsLive() {
         // Exam has not started.
         Exam examNotStarted = database.addExam(course1, users.get(0), ZonedDateTime.now().plusHours(1), ZonedDateTime.now().plusHours(3));
-        Optional<ResponseEntity<Void>> accessFailure1 = studentExamAccessService.checkStudentExamAccess(course1.getId(), examNotStarted.getId(), studentExam1.getId());
-        assertThat(accessFailure1.isPresent()).isTrue();
-        assertThat(accessFailure1.get()).isEqualTo(forbidden());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), examNotStarted.getId())).isEqualTo(forbidden());
+        Optional<ResponseEntity<Void>> accessFailure1_1 = studentExamAccessService.checkCourseAndExamAccess(course1.getId(), examNotStarted.getId(), users.get(0));
+        assertThat(accessFailure1_1.isPresent()).isTrue();
+        assertThat(accessFailure1_1.get()).isEqualTo(forbidden());
+        Optional<ResponseEntity<Void>> accessFailure1_2 = studentExamAccessService.checkStudentExamAccess(course1.getId(), examNotStarted.getId(), studentExam1.getId());
+        assertThat(accessFailure1_2.isPresent()).isTrue();
+        assertThat(accessFailure1_2.get()).isEqualTo(forbidden());
         // Exam has ended.
         Exam examEnded = database.addExam(course1, users.get(0), ZonedDateTime.now().minusHours(3), ZonedDateTime.now().minusHours(1));
-        Optional<ResponseEntity<Void>> accessFailure2 = studentExamAccessService.checkStudentExamAccess(course1.getId(), examEnded.getId(), studentExam1.getId());
-        assertThat(accessFailure2.isPresent()).isTrue();
-        assertThat(accessFailure2.get()).isEqualTo(forbidden());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), examEnded.getId())).isEqualTo(forbidden());
+        Optional<ResponseEntity<Void>> accessFailure2_1 = studentExamAccessService.checkCourseAndExamAccess(course1.getId(), examEnded.getId(), users.get(0));
+        assertThat(accessFailure2_1.isPresent()).isTrue();
+        assertThat(accessFailure2_1.get()).isEqualTo(forbidden());
+        Optional<ResponseEntity<Void>> accessFailure2_2 = studentExamAccessService.checkStudentExamAccess(course1.getId(), examEnded.getId(), studentExam1.getId());
+        assertThat(accessFailure2_2.isPresent()).isTrue();
+        assertThat(accessFailure2_2.get()).isEqualTo(forbidden());
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void testUserIsRegisteredForExam() {
         Exam examNotRegistered = database.addExam(course1, users.get(1), ZonedDateTime.now().minusHours(1), ZonedDateTime.now().plusHours(1));
-        Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), examNotRegistered.getId(), studentExam1.getId());
-        assertThat(accessFailure.isPresent()).isTrue();
-        assertThat(accessFailure.get()).isEqualTo(forbidden());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), examNotRegistered.getId())).isEqualTo(forbidden());
+        Optional<ResponseEntity<Void>> accessFailure1 = studentExamAccessService.checkCourseAndExamAccess(course1.getId(), examNotRegistered.getId(), users.get(0));
+        assertThat(accessFailure1.isPresent()).isTrue();
+        assertThat(accessFailure1.get()).isEqualTo(forbidden());
+        Optional<ResponseEntity<Void>> accessFailure2 = studentExamAccessService.checkStudentExamAccess(course1.getId(), examNotRegistered.getId(), studentExam1.getId());
+        assertThat(accessFailure2.isPresent()).isTrue();
+        assertThat(accessFailure2.get()).isEqualTo(forbidden());
     }
 
     @Test
@@ -132,8 +144,6 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), exam1.getId(), 55L);
         assertThat(accessFailure.isPresent()).isTrue();
         assertThat(accessFailure.get()).isEqualTo(notFound());
-        studentExamRepository.delete(studentExam1);
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId())).isEqualTo(notFound());
     }
 
     @Test
@@ -154,11 +164,5 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), exam1.getId(), studentExamWithOtherUser.getId());
         assertThat(accessFailure.isPresent()).isTrue();
         assertThat(accessFailure.get()).isEqualTo(forbidden());
-    }
-
-    @Test
-    @WithMockUser(username = "student1", roles = "USER")
-    public void testReturnsStudentExam() {
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId())).isEqualTo(ResponseEntity.ok(studentExam1));
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/StudentExamAccessServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/StudentExamAccessServiceTest.java
@@ -78,7 +78,7 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course2.getId(), exam2.getId(), studentExam1.getId());
         assertThat(accessFailure.isPresent()).isTrue();
         assertThat(accessFailure.get()).isEqualTo(forbidden());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course2.getId(), exam2.getId(), studentExam1.getId())).isEqualTo(forbidden());
+        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course2.getId(), exam2.getId())).isEqualTo(forbidden());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), 55L, studentExam1.getId());
         assertThat(accessFailure.isPresent()).isTrue();
         assertThat(accessFailure.get()).isEqualTo(notFound());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), 55L, studentExam1.getId())).isEqualTo(notFound());
+        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), 55L)).isEqualTo(notFound());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), exam2.getId(), studentExam1.getId());
         assertThat(accessFailure.isPresent()).isTrue();
         assertThat(accessFailure.get()).isEqualTo(conflict());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam2.getId(), studentExam1.getId())).isEqualTo(conflict());
+        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam2.getId())).isEqualTo(conflict());
     }
 
     @Test
@@ -107,13 +107,13 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure1 = studentExamAccessService.checkStudentExamAccess(course1.getId(), examNotStarted.getId(), studentExam1.getId());
         assertThat(accessFailure1.isPresent()).isTrue();
         assertThat(accessFailure1.get()).isEqualTo(forbidden());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), examNotStarted.getId(), studentExam1.getId())).isEqualTo(forbidden());
+        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), examNotStarted.getId())).isEqualTo(forbidden());
         // Exam has ended.
         Exam examEnded = database.addExam(course1, users.get(0), ZonedDateTime.now().minusHours(3), ZonedDateTime.now().minusHours(1));
         Optional<ResponseEntity<Void>> accessFailure2 = studentExamAccessService.checkStudentExamAccess(course1.getId(), examEnded.getId(), studentExam1.getId());
         assertThat(accessFailure2.isPresent()).isTrue();
         assertThat(accessFailure2.get()).isEqualTo(forbidden());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), examEnded.getId(), studentExam1.getId())).isEqualTo(forbidden());
+        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), examEnded.getId())).isEqualTo(forbidden());
     }
 
     @Test
@@ -123,7 +123,7 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), examNotRegistered.getId(), studentExam1.getId());
         assertThat(accessFailure.isPresent()).isTrue();
         assertThat(accessFailure.get()).isEqualTo(forbidden());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), examNotRegistered.getId(), studentExam1.getId())).isEqualTo(forbidden());
+        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), examNotRegistered.getId())).isEqualTo(forbidden());
     }
 
     @Test
@@ -132,7 +132,8 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), exam1.getId(), 55L);
         assertThat(accessFailure.isPresent()).isTrue();
         assertThat(accessFailure.get()).isEqualTo(notFound());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId(), 55L)).isEqualTo(notFound());
+        studentExamRepository.delete(studentExam1);
+        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId())).isEqualTo(notFound());
     }
 
     @Test
@@ -142,7 +143,6 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), exam1.getId(), studentExamNotRelatedToExam1.getId());
         assertThat(accessFailure.isPresent()).isTrue();
         assertThat(accessFailure.get()).isEqualTo(conflict());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId(), studentExamNotRelatedToExam1.getId())).isEqualTo(conflict());
     }
 
     @Test
@@ -154,13 +154,11 @@ public class StudentExamAccessServiceTest extends AbstractSpringIntegrationBambo
         Optional<ResponseEntity<Void>> accessFailure = studentExamAccessService.checkStudentExamAccess(course1.getId(), exam1.getId(), studentExamWithOtherUser.getId());
         assertThat(accessFailure.isPresent()).isTrue();
         assertThat(accessFailure.get()).isEqualTo(forbidden());
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId(), studentExamWithOtherUser.getId())).isEqualTo(forbidden());
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void testReturnsStudentExam() {
-        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId(), studentExam1.getId()))
-                .isEqualTo(ResponseEntity.ok(studentExam1));
+        assertThat(studentExamAccessService.checkAndGetStudentExamAccessWithExercises(course1.getId(), exam1.getId())).isEqualTo(ResponseEntity.ok(studentExam1));
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -551,6 +551,10 @@ public class DatabaseUtilService {
     public StudentExam addStudentExamWithExercisesAndParticipationAndSubmission(Exam exam, User user) {
         TextExercise textExercise = ModelFactory.generateTextExerciseForExam(ZonedDateTime.now().minusDays(2), ZonedDateTime.now().plusDays(5), ZonedDateTime.now().plusDays(8),
                 null);
+        GradingCriterion gradingCriterion = ModelFactory.generateGradingCriterion("title");
+        textExercise.addGradingCriteria(gradingCriterion);
+        textExercise.setGradingInstructions("this is a grading instruction");
+        textExercise.setSampleSolution("this is a sample solution");
         textExercise = exerciseRepo.save(textExercise);
 
         Submission submission = ModelFactory.generateTextSubmission("", Language.ENGLISH, true);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I added multiple integration tests (Spring) related to the features
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
The current REST route to get the student exam as student during the exam conduction requires the studentExamId. As the id is not available in the client the route needs to be refactored.

Additionally sensitive information (e.g. grading instructions) is not removed from the exercises in the response.

### Description
- [x] I've changed the REST route so that the student exam for the requested exam will be retrieved via the current user (`/courses/{courseId}/exams/{examId}/studentExams/conduction`)
- [x] I've ensured that attributes of exercises that should not be visible to the student are filtered

The corresponding client functionality will be implemented by @TobiasPr. 

### Steps for Testing
Mainly code review. You can also do the REST request to `http://localhost:9000/api/courses/1/exams/8/studentExams/conduction` with a tool like Postman.
