### PR TITLE
Generate participations for all exercises in student exams

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -30,4 +30,5 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
     Optional<StudentExam> findWithExercisesAndStudentParticipationsAndSubmissionsByUserIdAndExamId(@Param("userId") long userId, @Param("examId") long examId);
 
     List<StudentExam> findByExamId(Long examId);
+
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -23,6 +23,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
     @EntityGraph(type = LOAD, attributePaths = { "exercises", "exercises.studentParticipations", "exercises.studentParticipations.submissions" })
     Optional<StudentExam> findWithExercisesAndStudentParticipationsAndSubmissionsById(Long id);
 
+    @EntityGraph(type = LOAD, attributePaths = { "exercises", "exercises.studentParticipations" })
     List<StudentExam> findByExamId(Long examId);
 
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -303,6 +303,12 @@ public class ExamService {
         return exercises.get(randomIndex);
     }
 
+    /**
+     * Starts all the exercises of all the student exams of an exam
+     *
+     * @param examId exam to which the student exams belong
+     * @return list of generated participations
+     */
     @Transactional
     public List<Participation> startExercises(Long examId) {
         List<StudentExam> studentExams = studentExamRepository.findByExamId(examId);

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -310,7 +310,7 @@ public class ExamService {
 
         for (StudentExam studentExam : studentExams) {
             User student = studentExam.getUser();
-            studentExam.getExercises().stream().filter(exercise -> !exercise.getStudentParticipations().isEmpty())
+            studentExam.getExercises().stream().filter(exercise -> exercise.getStudentParticipations().isEmpty())
                     .forEach(exercise -> generatedParticipations.add(participationService.startExercise(exercise, student)));
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -304,7 +304,7 @@ public class ExamService {
     }
 
     @Transactional
-    public List<Participation> generateParticipations(Long examId) {
+    public List<Participation> startExercises(Long examId) {
         List<StudentExam> studentExams = studentExamRepository.findByExamId(examId);
         List<Participation> generatedParticipations = new ArrayList<>();
 

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.service;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.validation.constraints.NotNull;
@@ -8,12 +7,8 @@ import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
-import de.tum.in.www1.artemis.domain.participation.Participation;
-import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
@@ -27,12 +22,8 @@ public class StudentExamService {
 
     private final StudentExamRepository studentExamRepository;
 
-    private final ParticipationService participationService;
-
-    public StudentExamService(StudentExamRepository studentExamRepository, ExamAccessService examAccessService, ExerciseRepository exerciseRepository,
-            ParticipationService participationService) {
+    public StudentExamService(StudentExamRepository studentExamRepository, ParticipationService participationService) {
         this.studentExamRepository = studentExamRepository;
-        this.participationService = participationService;
     }
 
     /**
@@ -79,20 +70,6 @@ public class StudentExamService {
     public void deleteStudentExam(Long studentExamId) {
         log.debug("Request to delete the student exam with Id : {}", studentExamId);
         studentExamRepository.deleteById(studentExamId);
-    }
-
-    @Transactional
-    public List<Participation> generateParticipations(Long examId) {
-        List<StudentExam> studentExams = studentExamRepository.findByExamId(examId);
-        List<Participation> generatedParticipations = new ArrayList<>();
-
-        for (StudentExam studentExam : studentExams) {
-            User student = studentExam.getUser();
-            studentExam.getExercises().stream().filter(exercise -> !exercise.getStudentParticipations().isEmpty())
-                    .forEach(exercise -> generatedParticipations.add(participationService.startExercise(exercise, student)));
-        }
-
-        return generatedParticipations;
     }
 
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -286,24 +286,23 @@ public class ExamResource {
     }
 
     /**
-     * POST /courses/{courseId}/exams/{examId}/studentExams/generate-participations : Generate the participation objects
+     * POST /courses/{courseId}/exams/{examId}/student-exams/start-exercises : Generate the participation objects
      * for all the student exams belonging to the exam
      *
      * @param courseId the course to which the exam belongs to
      * @param examId   the exam to which the student exam belongs to
      * @return ResponsEntity containing the list of generated participations
      */
-    @PostMapping(value = "/courses/{courseId}/exams/{examId}/student-exams/generate-participations")
+    @PostMapping(value = "/courses/{courseId}/exams/{examId}/student-exams/start-exercises")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<List<Participation>> generateParticipations(@PathVariable Long courseId, @PathVariable Long examId) {
-        log.info("REST request to generate participations for student exams of exam {}", examId);
+    public ResponseEntity<List<Participation>> startExercises(@PathVariable Long courseId, @PathVariable Long examId) {
+        log.info("REST request to start exercises for student exams of exam {}", examId);
 
-        // Checking if the user has necessary permissions to generate participations
         Optional<ResponseEntity<List<Participation>>> courseAndExamAccessFailure = examAccessService.checkCourseAndExamAccess(courseId, examId);
         if (courseAndExamAccessFailure.isPresent())
             return courseAndExamAccessFailure.get();
 
-        List<Participation> generatedParticipations = examService.generateParticipations(examId);
+        List<Participation> generatedParticipations = examService.startExercises(examId);
 
         log.info("Generated {} participations for student exams of exam {}", generatedParticipations.size(), examId);
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -21,6 +21,7 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
+import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.repository.ExamRepository;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.dto.StudentDTO;
@@ -282,6 +283,31 @@ public class ExamResource {
 
         log.info("Generated {} student exams for exam {}", studentExams.size(), examId);
         return ResponseEntity.ok().body(studentExams);
+    }
+
+    /**
+     * POST /courses/{courseId}/exams/{examId}/studentExams/generate-participations : Generate the participation objects
+     * for all the student exams belonging to the exam
+     *
+     * @param courseId the course to which the exam belongs to
+     * @param examId   the exam to which the student exam belongs to
+     * @return ResponsEntity containing the list of generated participations
+     */
+    @PostMapping(value = "/courses/{courseId}/exams/{examId}/student-exams/generate-participations")
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
+    public ResponseEntity<List<Participation>> generateParticipations(@PathVariable Long courseId, @PathVariable Long examId) {
+        log.info("REST request to generate participations for student exams of exam {}", examId);
+
+        // Checking if the user has necessary permissions to generate participations
+        Optional<ResponseEntity<List<Participation>>> courseAndExamAccessFailure = examAccessService.checkCourseAndExamAccess(courseId, examId);
+        if (courseAndExamAccessFailure.isPresent())
+            return courseAndExamAccessFailure.get();
+
+        List<Participation> generatedParticipations = examService.generateParticipations(examId);
+
+        log.info("Generated {} participations for student exams of exam {}", generatedParticipations.size(), examId);
+
+        return ResponseEntity.ok().body(generatedParticipations);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.web.rest;
 
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
+
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -10,7 +10,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
-import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.service.ExamAccessService;
 import de.tum.in.www1.artemis.service.StudentExamAccessService;
 import de.tum.in.www1.artemis.service.StudentExamService;
@@ -82,30 +81,5 @@ public class StudentExamResource {
     public ResponseEntity<StudentExam> getStudentExamForConduction(@PathVariable Long courseId, @PathVariable Long examId, @PathVariable Long studentExamId) {
         log.debug("REST request to get student exam : {}", studentExamId);
         return studentExamAccessService.checkAndGetStudentExamAccessWithExercises(courseId, examId, studentExamId);
-    }
-
-    /**
-     * POST /courses/{courseId}/exams/{examId}/studentExams/generate-participations : Generate the participation objects
-     * for all the student exams belonging to the exam
-     *
-     * @param courseId the course to which the exam belongs to
-     * @param examId   the exam to which the student exam belongs to
-     * @return ResponsEntity containing the list of generated participations
-     */
-    @PostMapping(value = "/courses/{courseId}/exams/{examId}/studentExams/generate-participations")
-    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<List<Participation>> generateParticipations(@PathVariable Long courseId, @PathVariable Long examId) {
-        log.info("REST request to generate participations for student exams of exam {}", examId);
-
-        // Checking if the user has necessary permissions to generate participations
-        Optional<ResponseEntity<List<Participation>>> courseAndExamAccessFailure = examAccessService.checkCourseAndExamAccess(courseId, examId);
-        if (courseAndExamAccessFailure.isPresent())
-            return courseAndExamAccessFailure.get();
-
-        List<Participation> generatedParticipations = studentExamService.generateParticipations(examId);
-
-        log.info("Generated {} participations for student exams of exam {}", generatedParticipations.size(), examId);
-
-        return ResponseEntity.ok().body(generatedParticipations);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,13 +8,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
-import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.domain.participation.Participation;
+import de.tum.in.www1.artemis.service.ExamAccessService;
+import de.tum.in.www1.artemis.service.StudentExamAccessService;
+import de.tum.in.www1.artemis.service.StudentExamService;
 
 /**
  * REST controller for managing ExerciseGroup.
@@ -57,8 +56,8 @@ public class StudentExamResource {
     /**
      * GET /courses/{courseId}/exams/{examId}/studentExams : Get all student exams for the given exam
      *
-     * @param courseId  the course to which the student exams belong to
-     * @param examId    the exam to which the student exams belong to
+     * @param courseId the course to which the student exams belong to
+     * @param examId   the exam to which the student exams belong to
      * @return the ResponseEntity with status 200 (OK) and a list of student exams. The list can be empty
      */
     @GetMapping("/courses/{courseId}/exams/{examId}/studentExams")
@@ -84,5 +83,30 @@ public class StudentExamResource {
     public ResponseEntity<StudentExam> getStudentExamForConduction(@PathVariable Long courseId, @PathVariable Long examId, @PathVariable Long studentExamId) {
         log.debug("REST request to get student exam : {}", studentExamId);
         return studentExamAccessService.checkAndGetStudentExamAccessWithExercises(courseId, examId, studentExamId);
+    }
+
+    /**
+     * POST /courses/{courseId}/exams/{examId}/studentExams/generate-participations : Generate the participation objects
+     * for all the student exams belonging to the exam
+     *
+     * @param courseId the course to which the exam belongs to
+     * @param examId   the exam to which the student exam belongs to
+     * @return ResponsEntity containing the list of generated participations
+     */
+    @PostMapping(value = "/courses/{courseId}/exams/{examId}/studentExams/generate-participations")
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
+    public ResponseEntity<List<Participation>> generateParticipations(@PathVariable Long courseId, @PathVariable Long examId) {
+        log.info("REST request to generate participations for student exams of exam {}", examId);
+
+        Optional<ResponseEntity<List<Participation>>> courseAndExamAccessFailure = examAccessService.checkCourseAndExamAccess(courseId, examId);
+        if (courseAndExamAccessFailure.isPresent())
+            return courseAndExamAccessFailure.get();
+
+        // Todo Generate Participation for all the exercises of the student exams belong to the exam
+        List<Participation> generatedParticipations = new ArrayList<>();
+
+        log.info("Generated {} participations for student exams of exam {}", 0, examId);
+
+        return ResponseEntity.ok().body(generatedParticipations);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -98,14 +97,14 @@ public class StudentExamResource {
     public ResponseEntity<List<Participation>> generateParticipations(@PathVariable Long courseId, @PathVariable Long examId) {
         log.info("REST request to generate participations for student exams of exam {}", examId);
 
+        // Checking if the user has necessary permissions to generate participations
         Optional<ResponseEntity<List<Participation>>> courseAndExamAccessFailure = examAccessService.checkCourseAndExamAccess(courseId, examId);
         if (courseAndExamAccessFailure.isPresent())
             return courseAndExamAccessFailure.get();
 
-        // Todo Generate Participation for all the exercises of the student exams belong to the exam
-        List<Participation> generatedParticipations = new ArrayList<>();
+        List<Participation> generatedParticipations = studentExamService.generateParticipations(examId);
 
-        log.info("Generated {} participations for student exams of exam {}", 0, examId);
+        log.info("Generated {} participations for student exams of exam {}", generatedParticipations.size(), examId);
 
         return ResponseEntity.ok().body(generatedParticipations);
     }

--- a/src/main/webapp/app/exam/manage/exam-management.service.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.service.ts
@@ -9,6 +9,7 @@ import { Exam } from 'app/entities/exam.model';
 import { createRequestOption } from 'app/shared/util/request-util';
 import { StudentDTO } from 'app/entities/student-dto.model';
 import { StudentExam } from 'app/entities/student-exam.model';
+import { Participation } from 'app/entities/participation/participation.model';
 
 type EntityResponseType = HttpResponse<Exam>;
 type EntityArrayResponseType = HttpResponse<Exam[]>;
@@ -125,7 +126,17 @@ export class ExamManagementService {
      * @returns a list with the generate student exams
      */
     generateStudentExams(courseId: number, examId: number): Observable<HttpResponse<StudentExam[]>> {
-        return this.http.post<any>(`${this.resourceUrl}/${courseId}/exams/${examId}/generate-student-exams`, { observe: 'response' });
+        return this.http.post<any>(`${this.resourceUrl}/${courseId}/exams/${examId}/generate-student-exams`, {}, { observe: 'response' });
+    }
+
+    /**
+     * Start all the exercises for all the student exams belonging to the exam
+     * @param courseId course to which the exam belongs
+     * @param examId exam to which the student exams belong
+     * @returns a list of the generated participations
+     */
+    startExercises(courseId: number, examId: number): Observable<HttpResponse<Participation[]>> {
+        return this.http.post<any>(`${this.resourceUrl}/${courseId}/exams/${examId}/student-exams/start-exercises`, {}, { observe: 'response' });
     }
 
     private static convertDateFromClient(exam: Exam): Exam {

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
@@ -9,6 +9,9 @@
             <button class="btn btn-primary" style="height: 40px;" (click)="generateStudentExams()" *ngIf="course?.isAtLeastInstructor">
                 <span jhiTranslate="artemisApp.studentExams.generateStudentExams">Generate student exams</span>
             </button>
+            <button class="btn btn-secondary" style="height: 40px;" (click)="startExercises()" *ngIf="course?.isAtLeastInstructor">
+                <span jhiTranslate="artemisApp.studentExams.startExercises">Start Exercises</span>
+            </button>
         </div>
     </div>
     <jhi-alert></jhi-alert>

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
@@ -9,7 +9,7 @@
             <button class="btn btn-primary" style="height: 40px;" (click)="generateStudentExams()" *ngIf="course?.isAtLeastInstructor">
                 <span jhiTranslate="artemisApp.studentExams.generateStudentExams">Generate student exams</span>
             </button>
-            <button class="btn btn-secondary" style="height: 40px;" (click)="startExercises()" *ngIf="course?.isAtLeastInstructor">
+            <button class="btn btn-secondary ml-1" style="height: 40px;" (click)="startExercises()" *ngIf="course?.isAtLeastInstructor">
                 <span jhiTranslate="artemisApp.studentExams.startExercises">Start Exercises</span>
             </button>
         </div>

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
@@ -62,7 +62,7 @@ export class StudentExamsComponent implements OnInit {
      */
     generateStudentExams() {
         this.examManagementService.generateStudentExams(this.courseId, this.examId).subscribe(
-            (res) => this.setStudentExams(res),
+            (_) => this.loadAll(),
             (err) => this.handleError(err.error),
         );
     }
@@ -72,7 +72,9 @@ export class StudentExamsComponent implements OnInit {
      */
     startExercises() {
         this.examManagementService.startExercises(this.courseId, this.examId).subscribe(
-            (res) => {},
+            (_) => {
+                this.loadAll();
+            },
             (err) => this.handleError(err.error),
         );
     }

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
@@ -62,7 +62,7 @@ export class StudentExamsComponent implements OnInit {
      */
     generateStudentExams() {
         this.examManagementService.generateStudentExams(this.courseId, this.examId).subscribe(
-            (_) => this.loadAll(),
+            () => this.loadAll(),
             (err) => this.handleError(err.error),
         );
     }
@@ -72,7 +72,7 @@ export class StudentExamsComponent implements OnInit {
      */
     startExercises() {
         this.examManagementService.startExercises(this.courseId, this.examId).subscribe(
-            (_) => {
+            () => {
                 this.loadAll();
             },
             (err) => this.handleError(err.error),

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
@@ -63,7 +63,17 @@ export class StudentExamsComponent implements OnInit {
     generateStudentExams() {
         this.examManagementService.generateStudentExams(this.courseId, this.examId).subscribe(
             (res) => this.setStudentExams(res),
-            (err) => this.handleStudentExamGenerationError(err.error),
+            (err) => this.handleError(err.error),
+        );
+    }
+
+    /**
+     * Starts all the exercises of the student exams that belong to the exam
+     */
+    startExercises() {
+        this.examManagementService.startExercises(this.courseId, this.examId).subscribe(
+            (res) => {},
+            (err) => this.handleError(err.error),
         );
     }
 
@@ -106,7 +116,7 @@ export class StudentExamsComponent implements OnInit {
         }
     }
 
-    private handleStudentExamGenerationError(error: any): void {
+    private handleError(error: any): void {
         this.jhiAlertService.error(error.errorKey);
     }
 }

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -35,6 +35,7 @@
         "studentExams": {
             "title": "Klausuren",
             "generateStudentExams": "Klausuren erstellen",
+            "startExercises": "Aufgaben starten",
             "searchForStudents": "Suche nach Studenten Logins oder Namen (Komma getrennt)",
             "student": "Student",
             "result": "Ergebnis",

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -34,8 +34,8 @@
         },
         "studentExams": {
             "title": "Klausuren",
-            "generateStudentExams": "Klausuren erstellen",
-            "startExercises": "Aufgaben starten",
+            "generateStudentExams": "Individuelle Klausuren erstellen",
+            "startExercises": "Aufgabenstart vorbereiten",
             "searchForStudents": "Suche nach Studenten Logins oder Namen (Komma getrennt)",
             "student": "Student",
             "result": "Ergebnis",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -34,8 +34,8 @@
         },
         "studentExams": {
             "title": "Student exams",
-            "generateStudentExams": "Generate student exams",
-            "startExercises": "Start exercises",
+            "generateStudentExams": "Generate individual exams",
+            "startExercises": "Prepare exercise start",
             "searchForStudents": "Search for students by login or name (comma separated)",
             "student": "Student",
             "result": "Result",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -35,6 +35,7 @@
         "studentExams": {
             "title": "Student exams",
             "generateStudentExams": "Generate student exams",
+            "startExercises": "Start exercises",
             "searchForStudents": "Search for students by login or name (comma separated)",
             "student": "Student",
             "result": "Result",

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -201,8 +201,8 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         exam2 = examRepository.save(exam2);
 
         // invoke generate student exams
-        List<Participation> participations = request.postListWithResponseBody(
-                "/api/courses/" + course1.getId() + "/exams/" + exam2.getId() + "/student-exams/generate-participations", Optional.empty(), Participation.class, HttpStatus.OK);
+        List<Participation> participations = request.postListWithResponseBody("/api/courses/" + course1.getId() + "/exams/" + exam2.getId() + "/student-exams/start-exercises",
+                Optional.empty(), Participation.class, HttpStatus.OK);
         assertThat(participations).hasSize(exam2.getStudentExams().size());
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -174,6 +174,9 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testStartExercisesWithTextExercise() throws Exception {
+
+        // TODO IMPORTANT test more complex exam configurations (mixed exercise type, more variants and more registered students)
+
         // registering users
         var student1 = database.getUserByLogin("student1");
         var student2 = database.getUserByLogin("student2");
@@ -202,7 +205,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
 
         exam2 = examRepository.save(exam2);
 
-        // invoke generate student exams
+        // invoke start exercises
         List<Participation> participations = request.postListWithResponseBody("/api/courses/" + course1.getId() + "/exams/" + exam2.getId() + "/student-exams/start-exercises",
                 Optional.empty(), Participation.class, HttpStatus.OK);
         assertThat(participations).hasSize(exam2.getStudentExams().size());
@@ -210,12 +213,15 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
             assertThat(participation.getExercise().equals(textExercise));
             assertThat(participation.getExercise().getCourse() == null);
             assertThat(participation.getExercise().getExerciseGroup() == exam2.getExerciseGroups().get(0));
+            // TODO: check that submissions have been created to the participations of text exercises
         }
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testStartExercisesWithModelingExercise() throws Exception {
+        // TODO IMPORTANT test more complex exam configurations (mixed exercise type, more variants and more registered students)
+
         // registering users
         var student1 = database.getUserByLogin("student1");
         var student2 = database.getUserByLogin("student2");
@@ -244,7 +250,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
 
         exam2 = examRepository.save(exam2);
 
-        // invoke generate student exams
+        // invoke start exercises
         List<Participation> participations = request.postListWithResponseBody("/api/courses/" + course1.getId() + "/exams/" + exam2.getId() + "/student-exams/start-exercises",
                 Optional.empty(), Participation.class, HttpStatus.OK);
         assertThat(participations).hasSize(exam2.getStudentExams().size());
@@ -252,6 +258,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
             assertThat(participation.getExercise().equals(modelingExercise));
             assertThat(participation.getExercise().getCourse() == null);
             assertThat(participation.getExercise().getExerciseGroup() == exam2.getExerciseGroups().get(0));
+            // TODO: check that submissions have been created to the participations of modeling exercises
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -20,8 +20,10 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.connector.jira.JiraRequestMockProvider;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.TextExercise;
+import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
+import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.ExamAccessService;
 import de.tum.in.www1.artemis.service.dto.StudentDTO;
@@ -165,6 +167,43 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
             user = userRepo.findOneWithGroupsAndAuthoritiesByLogin(user.getLogin()).get();
             assertThat(user.getGroups()).contains(course1.getStudentGroupName());
         }
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testGenerateParticipations() throws Exception {
+        // registering users
+        var student1 = database.getUserByLogin("student1");
+        var student2 = database.getUserByLogin("student2");
+        var registeredUsers = Set.of(student1, student2);
+        exam2.setRegisteredUsers(registeredUsers);
+        // setting dates
+        exam2.setStartDate(ZonedDateTime.now().plusHours(2));
+        exam2.setEndDate(ZonedDateTime.now().plusHours(3));
+        exam2.setVisibleDate(ZonedDateTime.now().plusHours(1));
+
+        // creating exercise
+        TextExercise textExercise = ModelFactory.generateTextExerciseForExam(exam2.getStartDate(), exam2.getEndDate(), exam2.getEndDate().plusWeeks(2),
+                exam2.getExerciseGroups().get(0));
+        exam2.getExerciseGroups().get(0).addExercise(textExercise);
+        exerciseGroupRepository.save(exam2.getExerciseGroups().get(0));
+        textExercise = exerciseRepo.save(textExercise);
+
+        // creating student exams
+        for (User user : registeredUsers) {
+            StudentExam studentExam = new StudentExam();
+            studentExam.addExercise(textExercise);
+            studentExam.setUser(user);
+            exam2.addStudentExam(studentExam);
+            studentExamRepository.save(studentExam);
+        }
+
+        exam2 = examRepository.save(exam2);
+
+        // invoke generate student exams
+        List<Participation> participations = request.postListWithResponseBody(
+                "/api/courses/" + course1.getId() + "/exams/" + exam2.getId() + "/student-exams/generate-participations", Optional.empty(), Participation.class, HttpStatus.OK);
+        assertThat(participations).hasSize(exam2.getStudentExams().size());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
@@ -71,10 +71,29 @@ public class ModelFactory {
         return programmingExercise;
     }
 
+    public static ProgrammingExercise generateProgrammingExerciseForExam(ZonedDateTime releaseDate, ZonedDateTime dueDate, ExerciseGroup exerciseGroup) {
+        ProgrammingExercise programmingExercise = new ProgrammingExercise();
+        programmingExercise = (ProgrammingExercise) populateExerciseForExam(programmingExercise, releaseDate, dueDate, null, exerciseGroup);
+        programmingExercise.generateAndSetProjectKey();
+        programmingExercise.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
+        programmingExercise.setProgrammingLanguage(ProgrammingLanguage.JAVA);
+        programmingExercise.setPackageName("de.test");
+        programmingExercise.setTestRepositoryUrl("test@url");
+        return programmingExercise;
+    }
+
     public static ModelingExercise generateModelingExercise(ZonedDateTime releaseDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, DiagramType diagramType,
             Course course) {
         ModelingExercise modelingExercise = new ModelingExercise();
         modelingExercise = (ModelingExercise) populateExercise(modelingExercise, releaseDate, dueDate, assessmentDueDate, course);
+        modelingExercise.setDiagramType(diagramType);
+        return modelingExercise;
+    }
+
+    public static ModelingExercise generateModelingExerciseForExam(ZonedDateTime releaseDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, DiagramType diagramType,
+            ExerciseGroup exerciseGroup) {
+        ModelingExercise modelingExercise = new ModelingExercise();
+        modelingExercise = (ModelingExercise) populateExerciseForExam(modelingExercise, releaseDate, dueDate, assessmentDueDate, exerciseGroup);
         modelingExercise.setDiagramType(diagramType);
         return modelingExercise;
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Server: I added multiple integration tests (Spring) related to the features
- [X] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [X] Server: I implemented the changes with a good performance and prevented too many database calls
- [X] Server: I documented the Java code using JavaDoc style.

- [X] Client: I added multiple screenshots/screencasts of my UI changes
- [X] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

To reduce the load on the server at exam time, instructors should be able to generate the necessary participation objects manually by clicking a button in the exam management UI.

### Description
<!-- Describe your changes in detail -->
Closes #1616

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create an Exam with some Exercises
4. Create the student exams 
5. Click the Start Exercises Button and look in the network tab. The generated participations will be in the response

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/29718932/85199305-c7119400-b2ee-11ea-8feb-2b8b1e77e481.png)
