### PR TITLE
Allow instructors to enable / disable automatic assessment proposals

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseExportService.java
@@ -257,9 +257,9 @@ public class ProgrammingExerciseExportService {
     /**
      * Create a zipfile of the given paths and save it in the zipFilePath
      *
-     * @param zipFilePath path where the zipfile should be saved
+     * @param zipFilePath path where the zip file should be saved
      * @param paths the paths that should be zipped
-     * @throws IOException if an error occured while zipping
+     * @throws IOException if an error occurred while zipping
      */
     private void createZipFile(Path zipFilePath, List<Path> paths) throws IOException {
         try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFilePath))) {

--- a/src/main/webapp/app/entities/modeling-exercise.model.ts
+++ b/src/main/webapp/app/entities/modeling-exercise.model.ts
@@ -1,5 +1,6 @@
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { Course } from 'app/entities/course.model';
+import { AssessmentType } from 'app/entities/assessment-type.model';
 
 /**
  * The DiagramType enumeration. This has to be exactly the same as defined in Apollon (see diagram-type.d.ts)
@@ -19,13 +20,13 @@ export class ModelingExercise extends Exercise {
     public sampleSolutionModel: string;
     public sampleSolutionExplanation: string;
 
-    // helper attributs
-    public automaticAssessmentSupported = false;
-
     constructor(diagramType: UMLDiagramType, course?: Course) {
         super(ExerciseType.MODELING);
         this.course = course || null;
         this.diagramType = diagramType;
+        if (this.diagramType === UMLDiagramType.ClassDiagram || this.diagramType === UMLDiagramType.ActivityDiagram) {
+            this.assessmentType = AssessmentType.SEMI_AUTOMATIC;
+        }
     }
 }
 

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
@@ -5,8 +5,8 @@
     <jhi-assessment-filters [submissions]="submissions" (filterChange)="updateFilteredSubmissions($event)"></jhi-assessment-filters>
     <jhi-assessment-warning [exercise]="modelingExercise"></jhi-assessment-warning>
     <div>
-        <!-- These buttons only make sense when Compass is activated so for now we only use it for ClassDiagrams -->
-        <div class="button-toolbar float-right" *ngIf="modelingExercise.automaticAssessmentSupported">
+        <!-- These buttons only make sense when semi automatic assessment is possible -->
+        <div class="button-toolbar float-right" *ngIf="modelingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC">
             <button
                 [disabled]="busy || (optimalSubmissions && optimalSubmissions.length === 0 && assessedSubmissions === submissions.length)"
                 class="btn btn-success btn-sm mr-1"
@@ -28,7 +28,7 @@
     </h4>
     <jhi-alert></jhi-alert>
     <!-- These statements only make sense when Compass is activated so for now we only use it for ClassDiagrams -->
-    <div *ngIf="modelingExercise.automaticAssessmentSupported">
+    <div *ngIf="modelingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC">
         <h4>
             <span *ngIf="busy" style="color: grey;"><fa-icon [icon]="'spinner'" [spin]="true"></fa-icon>&nbsp;<span>Please wait while finding the next submission!</span></span>
         </h4>
@@ -91,19 +91,19 @@
             <p style="color: #5cb85c;"><strong>Congratulation all models have been assessed</strong></p>
         </div>
         <!-- This statement only makes sense when Compass is activated so for now we only use it for ClassDiagrams -->
-        <div *ngIf="modelingExercise.automaticAssessmentSupported && assessedSubmissions !== submissions.length">
+        <div *ngIf="modelingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC && assessedSubmissions !== submissions.length">
             <p><strong>Currently there are no models to assess. Try pushing the refresh button</strong></p>
         </div>
     </div>
-    <h5 *ngIf="modelingExercise.automaticAssessmentSupported && otherSubmissions.length > 0" style="padding-top: 5px;">
+    <h5 *ngIf="modelingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC && otherSubmissions.length > 0" style="padding-top: 5px;">
         Other submissions:
     </h5>
-    <p *ngIf="modelingExercise.automaticAssessmentSupported && !allSubmissionsVisible && otherSubmissions.length > 0">
+    <p *ngIf="modelingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC && !allSubmissionsVisible && otherSubmissions.length > 0">
         <strong
             ><a (click)="makeAllSubmissionsVisible()">Show {{ otherSubmissions.length }} other submissions</a></strong
         >
     </p>
-    <div class="table-responsive" *ngIf="otherSubmissions.length > 0 && (!modelingExercise.automaticAssessmentSupported || allSubmissionsVisible)">
+    <div class="table-responsive" *ngIf="otherSubmissions.length > 0 && (modelingExercise.assessmentType !== AssessmentType.SEMI_AUTOMATIC || allSubmissionsVisible)">
         <table class="table table-striped exercise-table">
             <thead>
                 <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="sortRows.bind(this)">
@@ -172,7 +172,7 @@
                     <td>
                         <span *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
                             <button
-                                *ngIf="modelingExercise.type === MODELING && submission && !submission.result"
+                                *ngIf="modelingExercise.type === ExerciseType.MODELING && submission && !submission.result"
                                 [routerLink]="[
                                     '/course-management',
                                     modelingExercise.course?.id,
@@ -190,7 +190,7 @@
                             </button>
                         </span>
                         <button
-                            *ngIf="modelingExercise.type === MODELING && submission && submission.result"
+                            *ngIf="modelingExercise.type === ExerciseType.MODELING && submission && submission.result"
                             [routerLink]="[
                                 '/course-management',
                                 modelingExercise.course?.id,

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.ts
@@ -15,7 +15,7 @@ import { ModelingAssessmentService } from 'app/exercises/modeling/assess/modelin
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { ModelingSubmission } from 'app/entities/modeling-submission.model';
 import { ResultService } from 'app/exercises/shared/result/result.service';
-import { ModelingExercise, UMLDiagramType } from 'app/entities/modeling-exercise.model';
+import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { AlertService } from 'app/core/alert/alert.service';
 import { AssessmentType } from 'app/entities/assessment-type.model';
 import { SortService } from 'app/shared/service/sort.service';
@@ -27,8 +27,8 @@ import { SortService } from 'app/shared/service/sort.service';
 })
 export class ModelingAssessmentDashboardComponent implements OnInit, OnDestroy {
     // make constants available to html for comparison
-    readonly MODELING = ExerciseType.MODELING;
-    readonly CLASS_DIAGRAM = UMLDiagramType.ClassDiagram;
+    ExerciseType = ExerciseType;
+    AssessmentType = AssessmentType;
 
     course: Course;
     modelingExercise: ModelingExercise;
@@ -87,7 +87,7 @@ export class ModelingAssessmentDashboardComponent implements OnInit, OnDestroy {
                 this.course = res.body!;
             });
             this.exerciseService.find(params['exerciseId']).subscribe((res: HttpResponse<Exercise>) => {
-                if (res.body!.type === this.MODELING) {
+                if (res.body!.type === ExerciseType.MODELING) {
                     this.modelingExercise = res.body as ModelingExercise;
                     this.getSubmissions(true);
                 } else {
@@ -137,7 +137,7 @@ export class ModelingAssessmentDashboardComponent implements OnInit, OnDestroy {
      * @param {boolean} forceReload force REST call to update nextOptimalSubmissionIds
      */
     filterSubmissions(forceReload: boolean) {
-        if (this.isCompassActive(this.modelingExercise) && (this.nextOptimalSubmissionIds.length < 3 || forceReload)) {
+        if (this.modelingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC && (this.nextOptimalSubmissionIds.length < 3 || forceReload)) {
             this.modelingAssessmentService.getOptimalSubmissions(this.modelingExercise.id).subscribe(
                 (optimal: number[]) => {
                     this.nextOptimalSubmissionIds = optimal;
@@ -150,13 +150,6 @@ export class ModelingAssessmentDashboardComponent implements OnInit, OnDestroy {
         } else {
             this.applyFilter();
         }
-    }
-
-    isCompassActive(modelingExercise: ModelingExercise) {
-        return (
-            modelingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC &&
-            (modelingExercise.diagramType === UMLDiagramType.ClassDiagram || modelingExercise.diagramType === UMLDiagramType.ActivityDiagram)
-        );
     }
 
     /**
@@ -185,7 +178,7 @@ export class ModelingAssessmentDashboardComponent implements OnInit, OnDestroy {
      * Reset optimality attribute of models
      */
     resetOptimality() {
-        if (this.modelingExercise.diagramType === this.CLASS_DIAGRAM) {
+        if (this.modelingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC) {
             this.modelingAssessmentService.resetOptimality(this.modelingExercise.id).subscribe(() => {
                 this.filterSubmissions(true);
             });

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
@@ -78,7 +78,7 @@
         </div>
         <div class="form-group-narrow">
             <label class="form-control-label" jhiTranslate="artemisApp.modelingExercise.diagramType" for="field_diagramType">Diagram Type</label>
-            <select class="form-control" name="diagramType" [(ngModel)]="modelingExercise.diagramType" id="field_diagramType">
+            <select class="form-control" name="diagramType" [(ngModel)]="modelingExercise.diagramType" (ngModelChange)="diagramTypeChanged()" id="field_diagramType">
                 <option value="ClassDiagram">{{ 'artemisApp.DiagramType.ClassDiagram' | translate }}</option>
                 <option value="ActivityDiagram">{{ 'artemisApp.DiagramType.ActivityDiagram' | translate }}</option>
                 <option value="ObjectDiagram">{{ 'artemisApp.DiagramType.ObjectDiagram' | translate }}</option>
@@ -87,6 +87,19 @@
                 <option value="ComponentDiagram">{{ 'artemisApp.DiagramType.ComponentDiagram' | translate }}</option>
                 <option value="DeploymentDiagram">{{ 'artemisApp.DiagramType.DeploymentDiagram' | translate }}</option>
             </select>
+        </div>
+        <div class="form-group" *ngIf="this.modelingExercise.diagramType === DiagramType.ClassDiagram || this.modelingExercise.diagramType === DiagramType.ActivityDiagram">
+            <div class="form-check custom-control custom-checkbox">
+                <input
+                    type="checkbox"
+                    id="automatic_assessment_enabled"
+                    [ngModel]="modelingExercise.assessmentType === AssessmentType.SEMI_AUTOMATIC"
+                    (ngModelChange)="modelingExercise.assessmentType = $event ? AssessmentType.SEMI_AUTOMATIC : AssessmentType.MANUAL"
+                    class="form-check-input custom-control-input"
+                    name="automaticAssessmentEnabled"
+                />
+                <label class="form-check-label custom-control-label" for="automatic_assessment_enabled" jhiTranslate="artemisApp.textExercise.automaticAssessmentEnabled"></label>
+            </div>
         </div>
         <jhi-presentation-score-checkbox [exercise]="modelingExercise"></jhi-presentation-score-checkbox>
         <div class="form-group" name="problemStatement" id="field_problemStatement">

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import { JhiEventManager } from 'ng-jhipster';
-import { ModelingExercise } from 'app/entities/modeling-exercise.model';
+import { DiagramType, ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { ModelingExerciseService } from './modeling-exercise.service';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ExampleSubmissionService } from 'app/exercises/shared/example-submission/example-submission.service';
@@ -14,6 +14,7 @@ import { ExerciseCategory } from 'app/entities/exercise.model';
 import { EditorMode } from 'app/shared/markdown-editor/markdown-editor.component';
 import { KatexCommand } from 'app/shared/markdown-editor/commands/katex.command';
 import { AlertService } from 'app/core/alert/alert.service';
+import { AssessmentType } from 'app/entities/assessment-type.model';
 
 @Component({
     selector: 'jhi-modeling-exercise-update',
@@ -22,6 +23,8 @@ import { AlertService } from 'app/core/alert/alert.service';
 })
 export class ModelingExerciseUpdateComponent implements OnInit {
     EditorMode = EditorMode;
+    AssessmentType = AssessmentType;
+    DiagramType = DiagramType;
     checkedFlag: boolean;
 
     modelingExercise: ModelingExercise;
@@ -144,10 +147,21 @@ export class ModelingExerciseUpdateComponent implements OnInit {
     private onError(error: HttpErrorResponse): void {
         this.jhiAlertService.error(error.message);
     }
+
     /**
      * gets the flag of the structured grading instructions slide toggle
      */
     getCheckedFlag(event: boolean) {
         this.checkedFlag = event;
+    }
+
+    /**
+     * when the diagram type changes, we need to
+     */
+    diagramTypeChanged() {
+        const semiAutomaticSupportPossible = this.modelingExercise.diagramType === DiagramType.ClassDiagram || this.modelingExercise.diagramType === DiagramType.ActivityDiagram;
+        if (!semiAutomaticSupportPossible) {
+            this.modelingExercise.assessmentType = AssessmentType.MANUAL;
+        }
     }
 }

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-statistics/modeling-statistics.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-statistics/modeling-statistics.component.ts
@@ -7,7 +7,7 @@ import { ModelingStatistic } from 'app/entities/modeling-statistic.model';
 import { ModelingExerciseService } from 'app/exercises/modeling/manage/modeling-exercise.service';
 
 @Component({
-    selector: 'jhi-assessment-dashboard',
+    selector: 'jhi-statistic-dashboard',
     templateUrl: './modeling-statistics.component.html',
     providers: [ModelingExerciseService],
 })

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -73,7 +73,7 @@
                 [(ngModel)]="textExercise.maxScore"
             />
         </div>
-        <div class="form-group" *jhiHasAnyAuthority="['ROLE_ADMIN']">
+        <div class="form-group">
             <div class="form-check custom-control custom-checkbox">
                 <input
                     type="checkbox"

--- a/src/main/webapp/i18n/de/textExercise.json
+++ b/src/main/webapp/i18n/de/textExercise.json
@@ -18,7 +18,7 @@
             "exampleSubmissions": "Beispielabgabe",
             "assessedSubmission": "Deine bewertete Abgabe",
             "createExampleSubmissions": "Beispielabgabe erstellen",
-            "automaticAssessmentEnabled": "Automatische Bewertung aktiviert",
+            "automaticAssessmentEnabled": "Automatische Bewertungsvorschläge aktiviert",
             "exampleSubmissionsRequireExercise": "Um eine Beispielabgabe zu erstellen, musst du zunächst die Erstellung der Textaufgabe abschließen.",
             "saveSuccessful": "Dein Antwort wurde erfolgreich gespeichert!",
             "error": "Ein Fehler ist aufgetreten. Bitte versuche es später noch einmal."

--- a/src/main/webapp/i18n/en/textExercise.json
+++ b/src/main/webapp/i18n/en/textExercise.json
@@ -18,10 +18,10 @@
             "exampleSubmissions": "Example submissions",
             "assessedSubmission": "Your assessed submission",
             "createExampleSubmissions": "Create example submission",
-            "automaticAssessmentEnabled": "Automatic Assessment enabled",
+            "automaticAssessmentEnabled": "Automatic assessment suggestions enabled",
             "exampleSubmissionsRequireExercise": "To create an example submission, you first need to finish creating the text exercise.",
             "saveSuccessful": "Your answer was saved successfully!",
-            "error": "An error occured. Please try again later."
+            "error": "An error occurred. Please try again later."
         }
     }
 }

--- a/src/test/gatling/user-files/simulations/ConflictSimulation.scala
+++ b/src/test/gatling/user-files/simulations/ConflictSimulation.scala
@@ -66,7 +66,7 @@ class ConflictSimulation extends Simulation {
         .exec((http("Create ModelingExercise"))
             .post("/api/modeling-exercises")
             .headers(headers_http_authenticated_JSON)
-            .body(StringBody("""{"isAtLeastTutor":false,"isAtLeastInstructor":false,"type":"modeling","automaticAssessmentSupported":false,"course":{"id":""" + "${course_id}" + ""","title":"CourseXY","shortName":"TTTXY","studentGroupName":"tumuser","instructorGroupName":"tumuser","onlineCourse":false,"registrationEnabled":false,"startDate":null,"endDate":null,"exercises":[]},"diagramType":"ClassDiagram","title":"Exercise 1","maxScore":10,"problemStatement":"","releaseDate":null,"dueDate":null,"assessmentDueDate":null}""")).asJson
+            .body(StringBody("""{"isAtLeastTutor":false,"isAtLeastInstructor":false,"type":"modeling","course":{"id":""" + "${course_id}" + ""","title":"CourseXY","shortName":"TTTXY","studentGroupName":"tumuser","instructorGroupName":"tumuser","onlineCourse":false,"registrationEnabled":false,"startDate":null,"endDate":null,"exercises":[]},"diagramType":"ClassDiagram","title":"Exercise 1","maxScore":10,"problemStatement":"","releaseDate":null,"dueDate":null,"assessmentDueDate":null}""")).asJson
             .check(status.is(201))
             .check(jsonPath("$.id").saveAs("exercise_id"))
             .check(headerRegex("set-cookie", "XSRF-TOKEN=(.*);[\\s]").saveAs("xsrf_token"))).exitHereIfFailed


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Automatic assessment proposals have been activated automatically for UML class and activity diagrams.

### Description
Now, instructors can also choose to deactivate it for those two types. All other types are not supported yet. I also cleaned up some outdated code

### Steps for Testing
1. Create / edit a modeling exercises
2. Try out different diagram types
3. Try out different options for Automatic assessment suggestions enabled
4. Check that these values are saved correctly by choosing edit again
5. Participate in the exercises with 2 student accounts (having similar submissions)
6. Assess the first submission and check whether the 2nd has some automatic suggestions (depending on the exercise configuration)

Legacy exercises have a null value for the attribute assessment_type. If this won't be changed to true/false, the old behavior is preserved (this was already implemented on the server side before this PR)