### PR TITLE
Fix import of team programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseImportService.java
@@ -224,6 +224,10 @@ public class ProgrammingExerciseImportService {
         newExercise.setExampleSubmissions(null);
         newExercise.setStudentQuestions(null);
         newExercise.setStudentParticipations(null);
+
+        if (newExercise.isTeamMode()) {
+            newExercise.getTeamAssignmentConfig().setId(null);
+        }
     }
 
     /**


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
An import of a team-based programming exercise fails right now due to an error with the persistence of the team assignment config. The id of the team assignment config of the cloned source exercise needs to be set to null so that a the imported exercise gets its own new team assignment config entity.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Management
3. Click on Exercises for a Course
4. Click on "Import new Programming Exercise"
5. Select a team programming exercise for the import
6. Fill out the form and click on "Import"

### Screenshots
![OnPaste 20200620-173811](https://user-images.githubusercontent.com/7109225/85205632-d3ace100-b31c-11ea-9b9a-af092d5915e1.png)
(no UI changes, just for reference)
