### PR TITLE
Show number of registered users per exam

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
@@ -98,6 +98,9 @@ public class Exam implements Serializable {
     @JoinTable(name = "exam_user", joinColumns = @JoinColumn(name = "exam_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "student_id", referencedColumnName = "id"))
     private Set<User> registeredUsers = new HashSet<>();
 
+    @Transient
+    private long numberOfRegisteredUsersTransient;
+
     public Long getId() {
         return id;
     }
@@ -258,6 +261,14 @@ public class Exam implements Serializable {
     public Exam removeUser(User user) {
         this.registeredUsers.remove(user);
         return this;
+    }
+
+    public long getNumberOfRegisteredUsers() {
+        return this.numberOfRegisteredUsersTransient;
+    }
+
+    public void setNumberOfRegisteredUsers(long numberOfRegisteredUsers) {
+        this.numberOfRegisteredUsersTransient = numberOfRegisteredUsers;
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -45,4 +45,8 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
      */
     @Query("SELECT CASE WHEN COUNT(exam) > 0 THEN true ELSE false END FROM Exam exam LEFT JOIN exam.registeredUsers registeredUsers WHERE exam.id = :#{#examId} AND registeredUsers.id = :#{#userId}")
     boolean isUserRegisteredForExam(@Param("examId") long examId, @Param("userId") long userId);
+
+    @Query("select exam.id, count(registeredUsers) from Exam exam left join exam.registeredUsers registeredUsers where exam.id in :#{#examIds} group by exam.id")
+    List<long[]> countRegisteredUsersByExamIds(@Param("examIds") List<Long> examIds);
+
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -302,7 +302,7 @@ public class ExamService {
      */
     private Map<Long, Integer> convertListOfCountsIntoMap(List<long[]> examIdAndRegisteredUsersCountPairs) {
         return examIdAndRegisteredUsersCountPairs.stream().collect(Collectors.toMap(examIdAndRegisteredUsersCountPair -> examIdAndRegisteredUsersCountPair[0], // examId
-            examIdAndRegisteredUsersCountPair -> Math.toIntExact(examIdAndRegisteredUsersCountPair[1]) // registeredUsersCount
+                examIdAndRegisteredUsersCountPair -> Math.toIntExact(examIdAndRegisteredUsersCountPair[1]) // registeredUsersCount
         ));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -282,6 +282,30 @@ public class ExamService {
         return notFoundStudentsDtos;
     }
 
+    /**
+     * Sets the transient attribute numberOfRegisteredUsers for all given exams
+     *
+     * @param exams Exams for which to compute and set the number of registered users
+     */
+    public void setNumberOfRegisteredUsersForExams(List<Exam> exams) {
+        List<Long> examIds = exams.stream().map(Exam::getId).collect(Collectors.toList());
+        List<long[]> examIdAndRegisteredUsersCountPairs = examRepository.countRegisteredUsersByExamIds(examIds);
+        Map<Long, Integer> registeredUsersCountMap = convertListOfCountsIntoMap(examIdAndRegisteredUsersCountPairs);
+        exams.forEach(exam -> exam.setNumberOfRegisteredUsers(registeredUsersCountMap.get(exam.getId())));
+    }
+
+    /**
+     * Converts List<[examId, registeredUsersCount]> into Map<examId -> registeredUsersCount>
+     *
+     * @param examIdAndRegisteredUsersCountPairs list of pairs (examId, registeredUsersCount)
+     * @return map of exam id to registered users count
+     */
+    private Map<Long, Integer> convertListOfCountsIntoMap(List<long[]> examIdAndRegisteredUsersCountPairs) {
+        return examIdAndRegisteredUsersCountPairs.stream().collect(Collectors.toMap(examIdAndRegisteredUsersCountPair -> examIdAndRegisteredUsersCountPair[0], // examId
+            examIdAndRegisteredUsersCountPair -> Math.toIntExact(examIdAndRegisteredUsersCountPair[1]) // registeredUsersCount
+        ));
+    }
+
     private List<Integer> assembleIndicesListWithRandomSelection(List<Integer> mandatoryIndices, List<Integer> optionalIndices, Long numberOfOptionalExercises) {
         // Add all mandatory indices
         List<Integer> indices = new ArrayList<>(mandatoryIndices);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -182,7 +182,11 @@ public class ExamResource {
     public ResponseEntity<List<Exam>> getExamsForCourse(@PathVariable Long courseId) {
         log.debug("REST request to get all exams for Course : {}", courseId);
         Optional<ResponseEntity<List<Exam>>> courseAccessFailure = examAccessService.checkCourseAccess(courseId);
-        return courseAccessFailure.orElseGet(() -> ResponseEntity.ok(examService.findAllByCourseId(courseId)));
+        return courseAccessFailure.orElseGet(() -> {
+            List<Exam> exams = examService.findAllByCourseId(courseId);
+            examService.setNumberOfRegisteredUsersForExams(exams);
+            return ResponseEntity.ok(exams);
+        });
     }
 
     /**

--- a/src/main/webapp/app/entities/exam.model.ts
+++ b/src/main/webapp/app/entities/exam.model.ts
@@ -22,4 +22,5 @@ export class Exam implements BaseEntity {
     public exerciseGroups: ExerciseGroup[] | null;
     public studentExams: StudentExam[] | null;
     public registeredUsers: User[] | null;
+    public numberOfRegisteredUsers?: number; // transient
 }

--- a/src/main/webapp/app/exam/manage/exam-management.component.html
+++ b/src/main/webapp/app/exam/manage/exam-management.component.html
@@ -41,7 +41,7 @@
                     <th>
                         <span>{{ 'artemisApp.exam.duration' | translate }}</span>
                     </th>
-                    <th jhiSortBy="registeredUsers">
+                    <th jhiSortBy="numberOfRegisteredUsers">
                         <span>{{ 'artemisApp.exam.nrOfStudents' | translate }}</span>
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
@@ -63,7 +63,7 @@
                     <td>{{ exam.startDate | artemisDate }}</td>
                     <td>{{ exam.endDate | artemisDate }}</td>
                     <td>{{ exam.startDate | durationTo: exam.endDate }}</td>
-                    <td>{{ exam.registeredUsers || 0 }}</td>
+                    <td>{{ exam.numberOfRegisteredUsers }}</td>
                     <td class="text-right">
                         <div class="btn-group flex-btn-group-container">
                             <div class="btn-group-vertical mr-1 mb-1">


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
The number of registered users for the exams in a course is not displayed at the moment. This PR adds this functionality.

### Description
- add `numberOfRegisteredUsersTransient` to Exam
- add service method to compute the number of registered users for a list of exams
- apply this method when all exams for a course are requested
- use new transient attribute client-side

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Management
3. Click on Exams for a Course
4. Create an Exam and register students for it
5. Go to the exams overview for the course
6. Check that the number of registered users is shown correctly

### Mockup
![image](https://user-images.githubusercontent.com/7109225/85419793-c852f300-b572-11ea-937b-7d1b9223b144.png)

### Screenshots
![OnPaste 20200623-170311](https://user-images.githubusercontent.com/7109225/85420408-72327f80-b573-11ea-81e0-dc754e6dd36e.png)
