### PR TITLE
[Exam] Fix missing exercises for exercise groups

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/ExerciseGroup.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/ExerciseGroup.java
@@ -19,6 +19,7 @@ import javax.persistence.Table;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.tum.in.www1.artemis.domain.Exercise;
 
@@ -48,6 +49,7 @@ public class ExerciseGroup implements Serializable {
 
     @OneToMany(mappedBy = "exerciseGroup", fetch = FetchType.LAZY)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @JsonIgnoreProperties("exerciseGroup")
     private Set<Exercise> exercises = new HashSet<>();
 
     public Long getId() {

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -24,11 +24,14 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @EntityGraph(type = LOAD, attributePaths = { "exerciseGroups" })
     Optional<Exam> findWithExerciseGroupsById(Long id);
 
+    @EntityGraph(type = LOAD, attributePaths = { "exerciseGroups", "exerciseGroups.exercises" })
+    Optional<Exam> findWithExerciseGroupsAndExercisesById(Long id);
+
     @EntityGraph(type = LOAD, attributePaths = { "registeredUsers" })
     Optional<Exam> findWithRegisteredUsersById(Long id);
 
-    @EntityGraph(type = LOAD, attributePaths = { "registeredUsers", "exerciseGroups" })
-    Optional<Exam> findWithRegisteredUsersAndExerciseGroupsById(Long id);
+    @EntityGraph(type = LOAD, attributePaths = { "registeredUsers", "exerciseGroups", "exerciseGroups.exercises" })
+    Optional<Exam> findWithRegisteredUsersAndExerciseGroupsAndExercisesById(Long id);
 
     @EntityGraph(type = LOAD, attributePaths = { "studentExams" })
     Optional<Exam> findWithStudentExamsById(Long id);

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -94,6 +94,19 @@ public class ExamService {
     }
 
     /**
+     * Get one exam by id with exercise groups and exercises.
+     *
+     * @param examId the id of the entity
+     * @return the exam with exercise groups
+     */
+    @NotNull
+    public Exam findOneWithExerciseGroupsAndExercises(Long examId) {
+        log.debug("Request to get exam with exercise groups : {}", examId);
+        Exam exam = examRepository.findWithExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
+        return breakSerializationCycleExercises(exam);
+    }
+
+    /**
      * Get one exam by id with registered users.
      *
      * @param examId the id of the entity
@@ -112,10 +125,11 @@ public class ExamService {
      * @return the exam with registered users and exercise groups
      */
     @NotNull
-    public Exam findOneWithRegisteredUsersAndExerciseGroups(Long examId) {
+    public Exam findOneWithRegisteredUsersAndExerciseGroupsAndExercises(Long examId) {
         log.debug("Request to get exam with registered users and registered students : {}", examId);
-        return examRepository.findWithRegisteredUsersAndExerciseGroupsById(examId)
+        Exam exam = examRepository.findWithRegisteredUsersAndExerciseGroupsAndExercisesById(examId)
                 .orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
+        return breakSerializationCycleExercises(exam);
     }
 
     /**
@@ -368,5 +382,14 @@ public class ExamService {
         }
 
         return generatedParticipations;
+    }
+
+    private Exam breakSerializationCycleExercises(Exam exam) {
+        for (ExerciseGroup exerciseGroup : exam.getExerciseGroups()) {
+            for (Exercise exercise : exerciseGroup.getExercises()) {
+                exercise.setExerciseGroup(null);
+            }
+        }
+        return exam;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -102,8 +102,7 @@ public class ExamService {
     @NotNull
     public Exam findOneWithExerciseGroupsAndExercises(Long examId) {
         log.debug("Request to get exam with exercise groups : {}", examId);
-        Exam exam = examRepository.findWithExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
-        return breakSerializationCycleExercises(exam);
+        return examRepository.findWithExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
     }
 
     /**
@@ -127,9 +126,8 @@ public class ExamService {
     @NotNull
     public Exam findOneWithRegisteredUsersAndExerciseGroupsAndExercises(Long examId) {
         log.debug("Request to get exam with registered users and registered students : {}", examId);
-        Exam exam = examRepository.findWithRegisteredUsersAndExerciseGroupsAndExercisesById(examId)
+        return examRepository.findWithRegisteredUsersAndExerciseGroupsAndExercisesById(examId)
                 .orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
-        return breakSerializationCycleExercises(exam);
     }
 
     /**
@@ -382,14 +380,5 @@ public class ExamService {
         }
 
         return generatedParticipations;
-    }
-
-    private Exam breakSerializationCycleExercises(Exam exam) {
-        for (ExerciseGroup exerciseGroup : exam.getExerciseGroups()) {
-            for (Exercise exercise : exerciseGroup.getExercises()) {
-                exercise.setExerciseGroup(null);
-            }
-        }
-        return exam;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -172,6 +172,7 @@ public class ExamResource {
             return ResponseEntity.ok(examService.findOneWithRegisteredUsersAndExerciseGroupsAndExercises(examId));
         }
         if (withExerciseGroups) {
+            var tmp = examService.findOneWithExerciseGroupsAndExercises(examId);
             return ResponseEntity.ok(examService.findOneWithExerciseGroupsAndExercises(examId));
         }
         Exam exam = examService.findOneWithRegisteredUsers(examId);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -172,7 +172,6 @@ public class ExamResource {
             return ResponseEntity.ok(examService.findOneWithRegisteredUsersAndExerciseGroupsAndExercises(examId));
         }
         if (withExerciseGroups) {
-            var tmp = examService.findOneWithExerciseGroupsAndExercises(examId);
             return ResponseEntity.ok(examService.findOneWithExerciseGroupsAndExercises(examId));
         }
         Exam exam = examService.findOneWithRegisteredUsers(examId);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -169,10 +169,10 @@ public class ExamResource {
             return ResponseEntity.ok(examService.findOne(examId));
         }
         if (withStudents && withExerciseGroups) {
-            return ResponseEntity.ok(examService.findOneWithRegisteredUsersAndExerciseGroups(examId));
+            return ResponseEntity.ok(examService.findOneWithRegisteredUsersAndExerciseGroupsAndExercises(examId));
         }
         if (withExerciseGroups) {
-            return ResponseEntity.ok(examService.findOneWithExerciseGroups(examId));
+            return ResponseEntity.ok(examService.findOneWithExerciseGroupsAndExercises(examId));
         }
         Exam exam = examService.findOneWithRegisteredUsers(examId);
         exam.getRegisteredUsers().forEach(user -> user.setVisibleRegistrationNumber(user.getRegistrationNumber()));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseImportService.java
@@ -67,7 +67,7 @@ public class TextExerciseImportService {
     private TextExercise copyTextExerciseBasis(TextExercise importedExercise) {
         log.debug("Copying the exercise basis from {}", importedExercise);
         TextExercise newExercise = new TextExercise();
-        if (importedExercise.getCourseViaExerciseGroupOrCourseMember() != null) {
+        if (importedExercise.hasCourse()) {
             newExercise.setCourse(importedExercise.getCourseViaExerciseGroupOrCourseMember());
         }
         else {

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.ts
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.ts
@@ -99,16 +99,7 @@ export class ExerciseGroupsComponent implements OnInit {
      * @param exerciseType The exercise type you want to import
      */
     openImportModal(exerciseGroup: ExerciseGroup, exerciseType: ExerciseType) {
-        const importBaseRoute = [
-            '/course-management',
-            exerciseGroup.exam?.course?.id,
-            'exams',
-            exerciseGroup.exam?.id,
-            'exercise-groups',
-            exerciseGroup.id,
-            `${exerciseType}-exercises`,
-            'import',
-        ];
+        const importBaseRoute = ['/course-management', this.courseId, 'exams', this.examId, 'exercise-groups', exerciseGroup.id, `${exerciseType}-exercises`, 'import'];
 
         switch (exerciseType) {
             case ExerciseType.PROGRAMMING:

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
@@ -129,9 +129,6 @@ export class TextExerciseUpdateComponent implements OnInit {
             .subscribe();
         this.isSaving = false;
         this.notificationText = null;
-        console.log('Is is in Import Mode:' + this.isImport);
-        console.log('Is In Exam Mode:' + this.isExamMode);
-        console.log('Is Exam Exercise:' + !!this.textExercise.exerciseGroup);
 
         // Set submit button text depending on component state
         if (this.isImport) {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
1. After merging https://github.com/ls1intum/Artemis/pull/1698 exercise groups are not loaded with exercises. This also caused the import feature to break as they rely on the exercise fields to find the correct route. 
2.  After a refactoring regarding the access rights for exams and courses, the import service for text exercises defaulted to always creating a normal exercise for the course or exam's course. 

### Description
- [x] The exercise groups will now be loaded with the exercises
- [x] To prevent a cyclic error on serialization we've ensured that the exerciseGroup -> exercise -> exerciseGroup is set to null in `ExamService`
- [x] Instead of getting the course id, exam id from the exercise we use the route parameters.
- [x] We replaced the refactored getCourseViaExerciseGroupOrCourseMember with hasCourse.

### Steps for Testing
1. Log in to Artemis
2. Go to the exercise groups of an exam
3. Add some exercises to some exercise groups and check that the are loaded without any errors
4. Import an exercise to an exercise group and ensure that no error appears