### PR TITLE
Expression has changed after it was checked, exam navigation bar timer

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
@@ -50,7 +50,7 @@
                 </ng-template>
             </div>
             <div class="col-auto h5 m-0 text-overflow px-3 py-2 remaining-time" [class.critical]="criticalTime">
-                {{ remainingTime }}
+                {{ displayTime$ | async }}
             </div>
         </div>
     </div>

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -26,7 +26,7 @@ export class ExamNavigationBarComponent implements OnInit {
     exerciseIndex = 0;
     itemsVisiblePerSide = ExamNavigationBarComponent.itemsVisiblePerSideDefault;
 
-    displayTime$ = timer(0, 500).pipe(
+    displayTime$ = timer(0, 100).pipe(
         map(() => this.updateDisplayTime()),
         distinctUntilChanged(),
     );

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -4,6 +4,8 @@ import { LayoutService } from 'app/shared/breakpoints/layout.service';
 import { CustomBreakpointNames } from 'app/shared/breakpoints/breakpoints.service';
 import * as moment from 'moment';
 import { Moment } from 'moment';
+import { timer } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 
 @Component({
     selector: 'jhi-exam-navigation-bar',
@@ -23,6 +25,11 @@ export class ExamNavigationBarComponent implements OnInit {
 
     exerciseIndex = 0;
     itemsVisiblePerSide = ExamNavigationBarComponent.itemsVisiblePerSideDefault;
+
+    displayTime$ = timer(0, 500).pipe(
+        map(() => this.updateDisplayTime()),
+        distinctUntilChanged(),
+    );
 
     criticalTime = false;
     icon: string;
@@ -64,7 +71,7 @@ export class ExamNavigationBarComponent implements OnInit {
         }
     }
 
-    get remainingTime(): string {
+    updateDisplayTime() {
         const timeDiff = moment.duration(this.endDate.diff(moment()));
         if (!this.criticalTime && timeDiff.asMinutes() < 5) {
             this.criticalTime = true;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) **locally**

### Description
<!-- Describe your changes in detail -->
Instead of using a binding to time change, use an Obervable which emits a changed time every 100ms (only if changed), thereby making the time less accurate (worst case the timer is 99ms off). This fixes the issue with angular that the timer value updated before the view could be rendered

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Start an exam, which takes some time to finish
2. Check browser console for Expression has changed after it was checked error (in regard to timer, there sometimes happens the same error when changing exercises)
3. It should not occur anymore
