### PR TITLE
Make uploads directory configurable.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.config;
 
-import java.io.File;
 import java.util.regex.Pattern;
 
 /**
@@ -16,19 +15,6 @@ public final class Constants {
     public static final String DEFAULT_LANGUAGE = "en";
 
     public static final int QUIZ_GRACE_PERIOD_IN_SECONDS = 5;
-
-    public static final String TEMP_FILEPATH = "uploads" + File.separator + "images" + File.separator + "temp" + File.separator;
-
-    public static final String DRAG_AND_DROP_BACKGROUND_FILEPATH = "uploads" + File.separator + "images" + File.separator + "drag-and-drop" + File.separator + "backgrounds"
-            + File.separator;
-
-    public static final String DRAG_ITEM_FILEPATH = "uploads" + File.separator + "images" + File.separator + "drag-and-drop" + File.separator + "drag-items" + File.separator;
-
-    public static final String COURSE_ICON_FILEPATH = "uploads" + File.separator + "images" + File.separator + "course" + File.separator + "icons" + File.separator;
-
-    public static final String LECTURE_ATTACHMENT_FILEPATH = "uploads" + File.separator + "attachments" + File.separator + "lecture" + File.separator;
-
-    public static final String FILE_UPLOAD_EXERCISES_FILEPATH = "uploads" + File.separator + "file-upload-exercises" + File.separator;
 
     public static final String FILEPATH_ID_PLACHEOLDER = "PLACEHOLDER_FOR_ID";
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.enumeration.AttachmentType;
+import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 
 /**
@@ -28,7 +29,10 @@ public class Attachment implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Transient
-    private transient FileService fileService = new FileService();
+    private transient FileService fileService = new FileService(filePathService);
+
+    @Transient
+    private transient FilePathService filePathService = new FilePathService();
 
     @Transient
     private String prevLink;
@@ -91,7 +95,8 @@ public class Attachment implements Serializable {
     public void beforeCreate() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // move file if necessary (id at this point will be null, so placeholder will be inserted)
-            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, Constants.LECTURE_ATTACHMENT_FILEPATH + getLecture().getId() + '/', getLecture().getId(), true);
+            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, filePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(),
+                    true);
         }
     }
 
@@ -107,7 +112,8 @@ public class Attachment implements Serializable {
     public void onUpdate() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // move file and delete old file if necessary
-            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, Constants.LECTURE_ATTACHMENT_FILEPATH + getLecture().getId() + '/', getLecture().getId(), true);
+            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, filePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(),
+                    true);
         }
     }
 
@@ -115,7 +121,7 @@ public class Attachment implements Serializable {
     public void onDelete() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // delete old file if necessary
-            fileService.manageFilesForUpdatedFilePath(prevLink, null, Constants.LECTURE_ATTACHMENT_FILEPATH + getLecture().getId() + '/', getLecture().getId(), true);
+            fileService.manageFilesForUpdatedFilePath(prevLink, null, filePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(), true);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
@@ -29,10 +29,7 @@ public class Attachment implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Transient
-    private transient FileService fileService = new FileService(filePathService);
-
-    @Transient
-    private transient FilePathService filePathService = new FilePathService();
+    private transient FileService fileService = new FileService();
 
     @Transient
     private String prevLink;
@@ -95,7 +92,7 @@ public class Attachment implements Serializable {
     public void beforeCreate() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // move file if necessary (id at this point will be null, so placeholder will be inserted)
-            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, filePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(),
+            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(),
                     true);
         }
     }
@@ -112,7 +109,7 @@ public class Attachment implements Serializable {
     public void onUpdate() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // move file and delete old file if necessary
-            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, filePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(),
+            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(),
                     true);
         }
     }
@@ -121,7 +118,7 @@ public class Attachment implements Serializable {
     public void onDelete() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // delete old file if necessary
-            fileService.manageFilesForUpdatedFilePath(prevLink, null, filePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(), true);
+            fileService.manageFilesForUpdatedFilePath(prevLink, null, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(), true);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
@@ -88,6 +88,10 @@ public class Attachment implements Serializable {
         prevLink = link; // save current path as old path (needed to know old path in onUpdate() and onDelete())
     }
 
+    /**
+     * Will be called before the entity is persisted (saved).
+     * Manages files by taking care of file system changes for this entity.
+     */
     @PrePersist
     public void beforeCreate() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
@@ -105,6 +109,10 @@ public class Attachment implements Serializable {
         }
     }
 
+    /**
+     * Will be called before the entity is flushed.
+     * Manages files by taking care of file system changes for this entity.
+     */
     @PreUpdate
     public void onUpdate() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {

--- a/src/main/java/de/tum/in/www1/artemis/domain/Course.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Course.java
@@ -54,9 +54,6 @@ public class Course implements Serializable {
     private transient FileService fileService = new FileService();
 
     @Transient
-    private transient FilePathService filePathService = new FilePathService();
-
-    @Transient
     private String prevCourseIcon;
 
     @Id
@@ -531,7 +528,7 @@ public class Course implements Serializable {
     @PrePersist
     public void beforeCreate() {
         // move file if necessary (id at this point will be null, so placeholder will be inserted)
-        courseIcon = fileService.manageFilesForUpdatedFilePath(prevCourseIcon, courseIcon, filePathService.getCourseIconFilepath(), getId());
+        courseIcon = fileService.manageFilesForUpdatedFilePath(prevCourseIcon, courseIcon, FilePathService.getCourseIconFilepath(), getId());
     }
 
     @PostPersist
@@ -545,13 +542,13 @@ public class Course implements Serializable {
     @PreUpdate
     public void onUpdate() {
         // move file and delete old file if necessary
-        courseIcon = fileService.manageFilesForUpdatedFilePath(prevCourseIcon, courseIcon, filePathService.getCourseIconFilepath(), getId());
+        courseIcon = fileService.manageFilesForUpdatedFilePath(prevCourseIcon, courseIcon, FilePathService.getCourseIconFilepath(), getId());
     }
 
     @PostRemove
     public void onDelete() {
         // delete old file if necessary
-        fileService.manageFilesForUpdatedFilePath(prevCourseIcon, null, filePathService.getCourseIconFilepath(), getId());
+        fileService.manageFilesForUpdatedFilePath(prevCourseIcon, null, FilePathService.getCourseIconFilepath(), getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/Course.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Course.java
@@ -36,6 +36,7 @@ import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.view.QuizView;
+import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 
 /**
@@ -51,6 +52,9 @@ public class Course implements Serializable {
 
     @Transient
     private transient FileService fileService = new FileService();
+
+    @Transient
+    private transient FilePathService filePathService = new FilePathService();
 
     @Transient
     private String prevCourseIcon;
@@ -527,7 +531,7 @@ public class Course implements Serializable {
     @PrePersist
     public void beforeCreate() {
         // move file if necessary (id at this point will be null, so placeholder will be inserted)
-        courseIcon = fileService.manageFilesForUpdatedFilePath(prevCourseIcon, courseIcon, Constants.COURSE_ICON_FILEPATH, getId());
+        courseIcon = fileService.manageFilesForUpdatedFilePath(prevCourseIcon, courseIcon, filePathService.getCourseIconFilepath(), getId());
     }
 
     @PostPersist
@@ -541,13 +545,13 @@ public class Course implements Serializable {
     @PreUpdate
     public void onUpdate() {
         // move file and delete old file if necessary
-        courseIcon = fileService.manageFilesForUpdatedFilePath(prevCourseIcon, courseIcon, Constants.COURSE_ICON_FILEPATH, getId());
+        courseIcon = fileService.manageFilesForUpdatedFilePath(prevCourseIcon, courseIcon, filePathService.getCourseIconFilepath(), getId());
     }
 
     @PostRemove
     public void onDelete() {
         // delete old file if necessary
-        fileService.manageFilesForUpdatedFilePath(prevCourseIcon, null, Constants.COURSE_ICON_FILEPATH, getId());
+        fileService.manageFilesForUpdatedFilePath(prevCourseIcon, null, filePathService.getCourseIconFilepath(), getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
@@ -7,8 +7,8 @@ import javax.persistence.*;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
-import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.exception.FilePathParsingException;
+import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 
 /**
@@ -21,7 +21,7 @@ public class FileUploadSubmission extends Submission implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Transient
-    private transient FileService fileService = new FileService(filePathService);
+    private transient FileService fileService = new FileService();
 
     @Column(name = "file_path")
     private String filePath;
@@ -61,7 +61,7 @@ public class FileUploadSubmission extends Submission implements Serializable {
      * @return path where submission for file upload exercise is stored
      */
     public static String buildFilePath(Long exerciseId, Long submissionId) {
-        return Constants.FILE_UPLOAD_EXERCISES_FILEPATH + exerciseId + File.separator + submissionId + File.separator;
+        return FilePathService.getFileUploadExercisesFilepath() + exerciseId + File.separator + submissionId + File.separator;
     }
 
     public void setFilePath(String filePath) {

--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
@@ -21,7 +21,7 @@ public class FileUploadSubmission extends Submission implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Transient
-    private transient FileService fileService = new FileService();
+    private transient FileService fileService = new FileService(filePathService);
 
     @Column(name = "file_path")
     private String filePath;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -26,7 +26,7 @@ public class DragAndDropQuestion extends QuizQuestion implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Transient
-    private transient FileService fileService = new FileService();
+    private transient FileService fileService = new FileService(filePathService);
 
     @Transient
     private String prevBackgroundFilePath;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.view.QuizView;
+import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 
 /**
@@ -26,7 +27,7 @@ public class DragAndDropQuestion extends QuizQuestion implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Transient
-    private transient FileService fileService = new FileService(filePathService);
+    private transient FileService fileService = new FileService();
 
     @Transient
     private String prevBackgroundFilePath;
@@ -173,7 +174,7 @@ public class DragAndDropQuestion extends QuizQuestion implements Serializable {
     @PrePersist
     public void beforeCreate() {
         // move file if necessary (id at this point will be null, so placeholder will be inserted)
-        backgroundFilePath = fileService.manageFilesForUpdatedFilePath(prevBackgroundFilePath, backgroundFilePath, Constants.DRAG_AND_DROP_BACKGROUND_FILEPATH, getId());
+        backgroundFilePath = fileService.manageFilesForUpdatedFilePath(prevBackgroundFilePath, backgroundFilePath, FilePathService.getDragAndDropBackgroundFilepath(), getId());
     }
 
     @PostPersist
@@ -187,13 +188,13 @@ public class DragAndDropQuestion extends QuizQuestion implements Serializable {
     @PreUpdate
     public void onUpdate() {
         // move file and delete old file if necessary
-        backgroundFilePath = fileService.manageFilesForUpdatedFilePath(prevBackgroundFilePath, backgroundFilePath, Constants.DRAG_AND_DROP_BACKGROUND_FILEPATH, getId());
+        backgroundFilePath = fileService.manageFilesForUpdatedFilePath(prevBackgroundFilePath, backgroundFilePath, FilePathService.getDragAndDropBackgroundFilepath(), getId());
     }
 
     @PostRemove
     public void onDelete() {
         // delete old file if necessary
-        fileService.manageFilesForUpdatedFilePath(prevBackgroundFilePath, null, Constants.DRAG_AND_DROP_BACKGROUND_FILEPATH, getId());
+        fileService.manageFilesForUpdatedFilePath(prevBackgroundFilePath, null, FilePathService.getDragAndDropBackgroundFilepath(), getId());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.view.QuizView;
+import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 
 /**
@@ -28,7 +29,7 @@ public class DragItem implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Transient
-    private transient FileService fileService = new FileService(filePathService);
+    private transient FileService fileService = new FileService();
 
     @Transient
     private String prevPictureFilePath;
@@ -185,7 +186,7 @@ public class DragItem implements Serializable {
     @PrePersist
     public void beforeCreate() {
         // move file if necessary (id at this point will be null, so placeholder will be inserted)
-        pictureFilePath = fileService.manageFilesForUpdatedFilePath(prevPictureFilePath, pictureFilePath, Constants.DRAG_ITEM_FILEPATH, getId());
+        pictureFilePath = fileService.manageFilesForUpdatedFilePath(prevPictureFilePath, pictureFilePath, FilePathService.getDragItemFilepath(), getId());
     }
 
     @PostPersist
@@ -199,13 +200,13 @@ public class DragItem implements Serializable {
     @PreUpdate
     public void onUpdate() {
         // move file and delete old file if necessary
-        pictureFilePath = fileService.manageFilesForUpdatedFilePath(prevPictureFilePath, pictureFilePath, Constants.DRAG_ITEM_FILEPATH, getId());
+        pictureFilePath = fileService.manageFilesForUpdatedFilePath(prevPictureFilePath, pictureFilePath, FilePathService.getDragItemFilepath(), getId());
     }
 
     @PostRemove
     public void onDelete() {
         // delete old file if necessary
-        fileService.manageFilesForUpdatedFilePath(prevPictureFilePath, null, Constants.DRAG_ITEM_FILEPATH, getId());
+        fileService.manageFilesForUpdatedFilePath(prevPictureFilePath, null, FilePathService.getDragItemFilepath(), getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
@@ -28,7 +28,7 @@ public class DragItem implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Transient
-    private transient FileService fileService = new FileService();
+    private transient FileService fileService = new FileService(filePathService);
 
     @Transient
     private String prevPictureFilePath;

--- a/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
@@ -1,0 +1,37 @@
+package de.tum.in.www1.artemis.service;
+
+import java.io.File;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FilePathService {
+
+    @Value("${artemis.file-upload-path}")
+    private String fileUploadPath;
+
+    public String getTempFilepath() {
+        return fileUploadPath + File.separator + "images" + File.separator + "temp" + File.separator;
+    }
+
+    public String getDragAndDropBackgroundFilepath() {
+        return fileUploadPath + File.separator + "images" + File.separator + "drag-and-drop" + File.separator + "backgrounds" + File.separator;
+    }
+
+    public String getDragItemFilepath() {
+        return fileUploadPath + File.separator + "images" + File.separator + "drag-and-drop" + File.separator + "drag-items" + File.separator;
+    }
+
+    public String getCourseIconFilepath() {
+        return fileUploadPath + File.separator + "images" + File.separator + "course" + File.separator + "icons" + File.separator;
+    }
+
+    public String getLectureAttachmentFilepath() {
+        return fileUploadPath + File.separator + "attachments" + File.separator + "lecture" + File.separator;
+    }
+
+    public String getFileUploadExercisesFilepath() {
+        return fileUploadPath + File.separator + "file-upload-exercises" + File.separator;
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
@@ -8,30 +8,42 @@ import org.springframework.stereotype.Service;
 @Service
 public class FilePathService {
 
+    // Note: We use this static field as a kind of constant. In Spring, we cannot inject a value into a constant field, so we have to use this work-around.
+    // This is also documented here: https://www.baeldung.com/spring-inject-static-field
+    // We can not use a normal service here, as some classes (in the domain package) require this service (or depend on another service that depend on this service), were we cannot
+    // use auto-injection
+    // TODO: Rework this behaviour be removing the dependencies to services (like FileService) from the domain package
+    private static String FILE_UPLOAD_PATH;
+
     @Value("${artemis.file-upload-path}")
     private String fileUploadPath;
 
-    public String getTempFilepath() {
-        return fileUploadPath + File.separator + "images" + File.separator + "temp" + File.separator;
+    @Value("${artemis.file-upload-path}")
+    public void setFileUploadPathStatic(String fileUploadPath) {
+        FilePathService.FILE_UPLOAD_PATH = fileUploadPath;
     }
 
-    public String getDragAndDropBackgroundFilepath() {
-        return fileUploadPath + File.separator + "images" + File.separator + "drag-and-drop" + File.separator + "backgrounds" + File.separator;
+    public static String getTempFilepath() {
+        return FILE_UPLOAD_PATH + File.separator + "images" + File.separator + "temp" + File.separator;
     }
 
-    public String getDragItemFilepath() {
-        return fileUploadPath + File.separator + "images" + File.separator + "drag-and-drop" + File.separator + "drag-items" + File.separator;
+    public static String getDragAndDropBackgroundFilepath() {
+        return FILE_UPLOAD_PATH + File.separator + "images" + File.separator + "drag-and-drop" + File.separator + "backgrounds" + File.separator;
     }
 
-    public String getCourseIconFilepath() {
-        return fileUploadPath + File.separator + "images" + File.separator + "course" + File.separator + "icons" + File.separator;
+    public static String getDragItemFilepath() {
+        return FILE_UPLOAD_PATH + File.separator + "images" + File.separator + "drag-and-drop" + File.separator + "drag-items" + File.separator;
     }
 
-    public String getLectureAttachmentFilepath() {
-        return fileUploadPath + File.separator + "attachments" + File.separator + "lecture" + File.separator;
+    public static String getCourseIconFilepath() {
+        return FILE_UPLOAD_PATH + File.separator + "images" + File.separator + "course" + File.separator + "icons" + File.separator;
     }
 
-    public String getFileUploadExercisesFilepath() {
-        return fileUploadPath + File.separator + "file-upload-exercises" + File.separator;
+    public static String getLectureAttachmentFilepath() {
+        return FILE_UPLOAD_PATH + File.separator + "attachments" + File.separator + "lecture" + File.separator;
+    }
+
+    public static String getFileUploadExercisesFilepath() {
+        return FILE_UPLOAD_PATH + File.separator + "file-upload-exercises" + File.separator;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -41,6 +41,12 @@ public class FileService {
 
     private final Logger log = LoggerFactory.getLogger(FileService.class);
 
+    private final FilePathService filePathService;
+
+    public FileService(FilePathService filePathService) {
+        this.filePathService = filePathService;
+    }
+
     /**
      * Get the file for the given path as a byte[]
      *
@@ -138,20 +144,20 @@ public class FileService {
 
         // check for known path to convert
         if (publicPath.contains("files/temp")) {
-            return Constants.TEMP_FILEPATH + filename;
+            return filePathService.getTempFilepath() + filename;
         }
         if (publicPath.contains("files/drag-and-drop/backgrounds")) {
-            return Constants.DRAG_AND_DROP_BACKGROUND_FILEPATH + filename;
+            return filePathService.getDragAndDropBackgroundFilepath() + filename;
         }
         if (publicPath.contains("files/drag-and-drop/drag-items")) {
-            return Constants.DRAG_ITEM_FILEPATH + filename;
+            return filePathService.getDragItemFilepath() + filename;
         }
         if (publicPath.contains("files/course/icons")) {
-            return Constants.COURSE_ICON_FILEPATH + filename;
+            return filePathService.getCourseIconFilepath() + filename;
         }
         if (publicPath.contains("files/attachments/lecture")) {
             String lectureId = publicPath.replace(filename, "").replace("/api/files/attachments/lecture/", "");
-            return Constants.LECTURE_ATTACHMENT_FILEPATH + lectureId + filename;
+            return filePathService.getLectureAttachmentFilepath() + lectureId + filename;
         }
         if (publicPath.contains("files/file-upload-exercises")) {
             final var uploadSubpath = publicPath.replace(filename, "").replace("/api/files/file-upload-exercises/", "").split("/");
@@ -184,22 +190,22 @@ public class FileService {
         String id = entityId == null ? Constants.FILEPATH_ID_PLACHEOLDER : entityId.toString();
 
         // check for known path to convert
-        if (actualPath.contains(Constants.TEMP_FILEPATH)) {
+        if (actualPath.contains(filePathService.getTempFilepath())) {
             return "/api/files/temp/" + filename;
         }
-        if (actualPath.contains(Constants.DRAG_AND_DROP_BACKGROUND_FILEPATH)) {
+        if (actualPath.contains(filePathService.getDragAndDropBackgroundFilepath())) {
             return "/api/files/drag-and-drop/backgrounds/" + id + "/" + filename;
         }
-        if (actualPath.contains(Constants.DRAG_ITEM_FILEPATH)) {
+        if (actualPath.contains(filePathService.getDragItemFilepath())) {
             return "/api/files/drag-and-drop/drag-items/" + id + "/" + filename;
         }
-        if (actualPath.contains(Constants.COURSE_ICON_FILEPATH)) {
+        if (actualPath.contains(filePathService.getCourseIconFilepath())) {
             return "/api/files/course/icons/" + id + "/" + filename;
         }
-        if (actualPath.contains(Constants.LECTURE_ATTACHMENT_FILEPATH)) {
+        if (actualPath.contains(filePathService.getLectureAttachmentFilepath())) {
             return "/api/files/attachments/lecture/" + id + "/" + filename;
         }
-        if (actualPath.contains(Constants.FILE_UPLOAD_EXERCISES_FILEPATH)) {
+        if (actualPath.contains(filePathService.getFileUploadExercisesFilepath())) {
             final var path = Paths.get(actualPath);
             final long exerciseId;
             try {
@@ -227,16 +233,16 @@ public class FileService {
     private File generateTargetFile(String originalFilename, String targetFolder, Boolean keepFileName) throws IOException {
         // determine the base for the filename
         String filenameBase = "Unspecified_";
-        if (targetFolder.equals(Constants.DRAG_AND_DROP_BACKGROUND_FILEPATH)) {
+        if (targetFolder.equals(filePathService.getDragAndDropBackgroundFilepath())) {
             filenameBase = "DragAndDropBackground_";
         }
-        if (targetFolder.equals(Constants.DRAG_ITEM_FILEPATH)) {
+        if (targetFolder.equals(filePathService.getDragItemFilepath())) {
             filenameBase = "DragItem_";
         }
-        if (targetFolder.equals(Constants.COURSE_ICON_FILEPATH)) {
+        if (targetFolder.equals(filePathService.getCourseIconFilepath())) {
             filenameBase = "CourseIcon_";
         }
-        if (targetFolder.contains(Constants.LECTURE_ATTACHMENT_FILEPATH)) {
+        if (targetFolder.contains(filePathService.getLectureAttachmentFilepath())) {
             filenameBase = "LectureAttachment_";
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -203,7 +203,8 @@ public class FileService {
             final var path = Paths.get(actualPath);
             final long exerciseId;
             try {
-                final var shouldBeExerciseId = path.getName(2).toString();
+                // The last name is the file name, the one one before that is the submissionId and the one before that is the exerciseId, in which we are interested
+                final var shouldBeExerciseId = path.getName(path.getNameCount() - 3).toString();
                 exerciseId = Long.parseLong(shouldBeExerciseId);
             }
             catch (IllegalArgumentException e) {

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -41,12 +41,6 @@ public class FileService {
 
     private final Logger log = LoggerFactory.getLogger(FileService.class);
 
-    private final FilePathService filePathService;
-
-    public FileService(FilePathService filePathService) {
-        this.filePathService = filePathService;
-    }
-
     /**
      * Get the file for the given path as a byte[]
      *
@@ -144,20 +138,20 @@ public class FileService {
 
         // check for known path to convert
         if (publicPath.contains("files/temp")) {
-            return filePathService.getTempFilepath() + filename;
+            return FilePathService.getTempFilepath() + filename;
         }
         if (publicPath.contains("files/drag-and-drop/backgrounds")) {
-            return filePathService.getDragAndDropBackgroundFilepath() + filename;
+            return FilePathService.getDragAndDropBackgroundFilepath() + filename;
         }
         if (publicPath.contains("files/drag-and-drop/drag-items")) {
-            return filePathService.getDragItemFilepath() + filename;
+            return FilePathService.getDragItemFilepath() + filename;
         }
         if (publicPath.contains("files/course/icons")) {
-            return filePathService.getCourseIconFilepath() + filename;
+            return FilePathService.getCourseIconFilepath() + filename;
         }
         if (publicPath.contains("files/attachments/lecture")) {
             String lectureId = publicPath.replace(filename, "").replace("/api/files/attachments/lecture/", "");
-            return filePathService.getLectureAttachmentFilepath() + lectureId + filename;
+            return FilePathService.getLectureAttachmentFilepath() + lectureId + filename;
         }
         if (publicPath.contains("files/file-upload-exercises")) {
             final var uploadSubpath = publicPath.replace(filename, "").replace("/api/files/file-upload-exercises/", "").split("/");
@@ -190,22 +184,22 @@ public class FileService {
         String id = entityId == null ? Constants.FILEPATH_ID_PLACHEOLDER : entityId.toString();
 
         // check for known path to convert
-        if (actualPath.contains(filePathService.getTempFilepath())) {
+        if (actualPath.contains(FilePathService.getTempFilepath())) {
             return "/api/files/temp/" + filename;
         }
-        if (actualPath.contains(filePathService.getDragAndDropBackgroundFilepath())) {
+        if (actualPath.contains(FilePathService.getDragAndDropBackgroundFilepath())) {
             return "/api/files/drag-and-drop/backgrounds/" + id + "/" + filename;
         }
-        if (actualPath.contains(filePathService.getDragItemFilepath())) {
+        if (actualPath.contains(FilePathService.getDragItemFilepath())) {
             return "/api/files/drag-and-drop/drag-items/" + id + "/" + filename;
         }
-        if (actualPath.contains(filePathService.getCourseIconFilepath())) {
+        if (actualPath.contains(FilePathService.getCourseIconFilepath())) {
             return "/api/files/course/icons/" + id + "/" + filename;
         }
-        if (actualPath.contains(filePathService.getLectureAttachmentFilepath())) {
+        if (actualPath.contains(FilePathService.getLectureAttachmentFilepath())) {
             return "/api/files/attachments/lecture/" + id + "/" + filename;
         }
-        if (actualPath.contains(filePathService.getFileUploadExercisesFilepath())) {
+        if (actualPath.contains(FilePathService.getFileUploadExercisesFilepath())) {
             final var path = Paths.get(actualPath);
             final long exerciseId;
             try {
@@ -233,16 +227,16 @@ public class FileService {
     private File generateTargetFile(String originalFilename, String targetFolder, Boolean keepFileName) throws IOException {
         // determine the base for the filename
         String filenameBase = "Unspecified_";
-        if (targetFolder.equals(filePathService.getDragAndDropBackgroundFilepath())) {
+        if (targetFolder.equals(FilePathService.getDragAndDropBackgroundFilepath())) {
             filenameBase = "DragAndDropBackground_";
         }
-        if (targetFolder.equals(filePathService.getDragItemFilepath())) {
+        if (targetFolder.equals(FilePathService.getDragItemFilepath())) {
             filenameBase = "DragItem_";
         }
-        if (targetFolder.equals(filePathService.getCourseIconFilepath())) {
+        if (targetFolder.equals(FilePathService.getCourseIconFilepath())) {
             filenameBase = "CourseIcon_";
         }
-        if (targetFolder.contains(filePathService.getLectureAttachmentFilepath())) {
+        if (targetFolder.contains(FilePathService.getLectureAttachmentFilepath())) {
             filenameBase = "LectureAttachment_";
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
@@ -213,6 +213,7 @@ public class SubmissionService {
      * @return The filtered list of submissions
      */
     protected <T extends Submission> List<T> selectOnlySubmissionsBeforeDueDateOrAll(List<T> submissions, ZonedDateTime dueDate) {
+
         boolean hasInTimeSubmissions = submissions.stream().anyMatch(s -> s.getSubmissionDate().isBefore(dueDate));
         if (hasInTimeSubmissions) {
             return submissions.stream().filter(s -> s.getSubmissionDate().isBefore(dueDate)).collect(Collectors.toList());

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -27,7 +27,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.FileUploadExercise;
 import de.tum.in.www1.artemis.domain.FileUploadSubmission;
 import de.tum.in.www1.artemis.domain.Lecture;
@@ -36,6 +35,7 @@ import de.tum.in.www1.artemis.repository.FileUploadExerciseRepository;
 import de.tum.in.www1.artemis.repository.FileUploadSubmissionRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.security.jwt.TokenProvider;
+import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 
 /**
@@ -104,10 +104,10 @@ public class FileResource {
 
         try {
             // create folder if necessary
-            File folder = new File(Constants.TEMP_FILEPATH);
+            File folder = new File(FilePathService.getTempFilepath());
             if (!folder.exists()) {
                 if (!folder.mkdirs()) {
-                    log.error("Could not create directory: {}", Constants.TEMP_FILEPATH);
+                    log.error("Could not create directory: {}", FilePathService.getTempFilepath());
                     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
                 }
             }
@@ -124,7 +124,7 @@ public class FileResource {
                     filename = "Temp_" + ZonedDateTime.now().toString().substring(0, 23).replaceAll(":|\\.", "-") + "_" + UUID.randomUUID().toString().substring(0, 8) + "."
                             + fileExtension;
                 }
-                String path = Constants.TEMP_FILEPATH + filename;
+                String path = FilePathService.getTempFilepath() + filename;
 
                 newFile = new File(path);
                 if (keepFileName && newFile.exists()) {
@@ -158,7 +158,7 @@ public class FileResource {
     @PreAuthorize("hasAnyRole('ADMIN', 'INSTRUCTOR', 'TA')")
     public ResponseEntity<byte[]> getTempFile(@PathVariable String filename) {
         log.debug("REST request to get file : {}", filename);
-        return responseEntityForFilePath(Constants.TEMP_FILEPATH + filename);
+        return responseEntityForFilePath(FilePathService.getTempFilepath() + filename);
     }
 
     /**
@@ -198,7 +198,7 @@ public class FileResource {
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<byte[]> getDragAndDropBackgroundFile(@PathVariable Long questionId, @PathVariable String filename) {
         log.debug("REST request to get file : {}", filename);
-        return responseEntityForFilePath(Constants.DRAG_AND_DROP_BACKGROUND_FILEPATH + filename);
+        return responseEntityForFilePath(FilePathService.getDragAndDropBackgroundFilepath() + filename);
     }
 
     /**
@@ -212,7 +212,7 @@ public class FileResource {
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<byte[]> getDragItemFile(@PathVariable Long dragItemId, @PathVariable String filename) {
         log.debug("REST request to get file : {}", filename);
-        return responseEntityForFilePath(Constants.DRAG_ITEM_FILEPATH + filename);
+        return responseEntityForFilePath(FilePathService.getDragItemFilepath() + filename);
     }
 
     /**
@@ -253,7 +253,7 @@ public class FileResource {
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<byte[]> getCourseIcon(@PathVariable Long courseId, @PathVariable String filename) {
         log.debug("REST request to get file : {}", filename);
-        return responseEntityForFilePath(Constants.COURSE_ICON_FILEPATH + filename);
+        return responseEntityForFilePath(FilePathService.getCourseIconFilepath() + filename);
     }
 
     /**
@@ -294,7 +294,7 @@ public class FileResource {
             String errorMessage = "You don't have the access rights for this file! Please login to Artemis and download the attachment in the corresponding lecture";
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorMessage.getBytes());
         }
-        return buildFileResponse(Constants.LECTURE_ATTACHMENT_FILEPATH + optionalLecture.get().getId(), filename);
+        return buildFileResponse(FilePathService.getLectureAttachmentFilepath() + optionalLecture.get().getId(), filename);
     }
 
     /**

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -23,6 +23,7 @@ logging:
 
 artemis:
     version: #project.version#
+    file-upload-path: uploads
 
 management:
     endpoints:

--- a/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
@@ -14,12 +14,12 @@ import org.springframework.security.test.context.support.WithMockUser;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.quiz.DragAndDropQuestion;
 import de.tum.in.www1.artemis.domain.quiz.DragItem;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
@@ -103,7 +103,7 @@ public class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         MockMultipartFile file = new MockMultipartFile("file", "icon.png", "application/json", "some data".getBytes());
         JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=false", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.CREATED);
         String responsePath = response.get("path").asText();
-        String iconPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, Constants.COURSE_ICON_FILEPATH, course.getId());
+        String iconPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, FilePathService.getCourseIconFilepath(), course.getId());
 
         course.setCourseIcon(iconPath);
         courseRepo.save(course);
@@ -123,7 +123,7 @@ public class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         MockMultipartFile file = new MockMultipartFile("file", "background.png", "application/json", "some data".getBytes());
         JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=false", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.CREATED);
         String responsePath = response.get("path").asText();
-        String backgroundPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, Constants.DRAG_AND_DROP_BACKGROUND_FILEPATH, dragAndDropQuestion.getId());
+        String backgroundPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, FilePathService.getDragAndDropBackgroundFilepath(), dragAndDropQuestion.getId());
 
         dragAndDropQuestion.setBackgroundFilePath(backgroundPath);
         courseRepo.save(course);
@@ -145,7 +145,7 @@ public class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         MockMultipartFile file = new MockMultipartFile("file", "background.png", "application/json", "some data".getBytes());
         JsonNode response = request.postWithMultipartFile("/api/fileUpload?keepFileName=false", file.getOriginalFilename(), "file", file, JsonNode.class, HttpStatus.CREATED);
         String responsePath = response.get("path").asText();
-        String dragItemPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, Constants.DRAG_ITEM_FILEPATH, dragItem.getId());
+        String dragItemPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, FilePathService.getDragItemFilepath(), dragItem.getId());
 
         dragItem.setPictureFilePath(dragItemPath);
         courseRepo.save(course);
@@ -232,7 +232,8 @@ public class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         }
         String responsePath = response.get("path").asText();
         // move file from temp folder to correct folder
-        String attachmentPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, Constants.LECTURE_ATTACHMENT_FILEPATH + lecture.getId() + '/', lecture.getId(), true);
+        String attachmentPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, FilePathService.getLectureAttachmentFilepath() + lecture.getId() + '/',
+                lecture.getId(), true);
 
         attachment.setLink(attachmentPath);
         lecture.addAttachments(attachment);

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -6,6 +6,7 @@ logging:
 
 artemis:
     version: 1.3.3-beta7
+    file-upload-path: uploads
 
 spring:
     application:


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
In a distributed setup, we want to configure the path where file uploads are stored, so that they can be made accessible from several (virtual) machines.

### Description
I've added a FilePathService that provides values for file paths there were previously constants where the path can be configured using `artemis.file-upload-path`.
As we cannot inject values into static fields, we have to use a workaround: Create an instance of the service that sets the static values.
We cannot use a non-static method as we use the file path in some of the domain classes, which should not have dependencies to services. In the future, we should probably redesign the classes in the domain package, to not depend on services. 

### Steps for Testing
1. Start Artemis without any config changes, upload e.g. a course icon and verify that it is saved in the `uploads` directory.
2. Change the value `artemis.file-upload-path` to a different folder and restart Artemis.
3. Upload a new file (e.g. again a course icon) and verify that it is stored in the newly configured folder.
