### PR TITLE
Fix display duration over 59minutes

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { Exercise, ExerciseType, ParticipationStatus } from 'app/entities/exercise.model';
+import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { LayoutService } from 'app/shared/breakpoints/layout.service';
 import { CustomBreakpointNames } from 'app/shared/breakpoints/breakpoints.service';
 import * as moment from 'moment';
@@ -77,8 +77,8 @@ export class ExamNavigationBarComponent implements OnInit {
             this.criticalTime = true;
         }
         return timeDiff.asMinutes() > 10
-            ? Math.round(timeDiff.minutes()) + ' min'
-            : timeDiff.minutes().toString().padStart(2, '0') + ' : ' + timeDiff.seconds().toString().padStart(2, '0');
+            ? Math.round(timeDiff.asMinutes()) + ' min'
+            : timeDiff.minutes().toString().padStart(2, '0') + ' : ' + timeDiff.seconds().toString().padStart(2, '0') + ' min';
     }
 
     isProgrammingExercise() {
@@ -86,7 +86,7 @@ export class ExamNavigationBarComponent implements OnInit {
     }
 
     setExerciseButtonStatus(i: number): string {
-        let status = '';
+        let status: string;
         this.icon = 'edit';
         if (this.exercises[i].studentParticipations[0].submissions[0].isSynced) {
             // make button blue


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) **locally**

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Display remaining time over 59 minutes correctly 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create exam with duration > 59 minutes
2. Check if time is correctly displayed
3. Time < 10min has min label 

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/22955066/85957762-6e966280-b990-11ea-9479-b42b4d5e8ebf.png)
![image](https://user-images.githubusercontent.com/22955066/85957774-8bcb3100-b990-11ea-8690-96f5d96f5ad9.png)

