### PR TITLE
Provide methods for retrieving student working times and individual exam end dates

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -4,6 +4,7 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -35,4 +36,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
 
     @Query("select max(se.workingTime) from StudentExam se where se.exam.id = :#{#examId}")
     Optional<Integer> findMaxWorkingTimeByExamId(@Param("examId") Long examId);
+
+    @Query("select distinct se.workingTime from StudentExam se where se.exam.id = :#{#examId}")
+    Set<Integer> findAllDistinctWorkingTimesByExamId(@Param("examId") Long examId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -32,4 +32,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
 
     @Query("select distinct se from StudentExam se left join se.exercises e where e.id = :#{#exerciseId} and se.user.id = :#{#userId}")
     Optional<StudentExam> findByExerciseIdAndUserId(@Param("exerciseId") Long exerciseId, @Param("userId") Long userId);
+
+    @Query("select max(se.workingTime) from StudentExam se where se.exam.id = :#{#examId}")
+    Optional<Integer> findMaxWorkingTimeByExamId(@Param("examId") Long examId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -432,4 +432,32 @@ public class ExamService {
         var maxWorkingTime = studentExamRepository.findMaxWorkingTimeByExamId(exam.getId());
         return maxWorkingTime.map(timeInSeconds -> exam.getStartDate().plusSeconds(timeInSeconds)).orElse(exam.getEndDate());
     }
+
+    /**
+     * Returns all individual exam end dates as determined by the working time of the student exams.
+     * <p>
+     * If no student exams are available, an empty set returned.
+     * 
+     * @param examId the id of the exam
+     * @return a set of all end dates. May return an empty set, if the exam has no start/end date or student exams cannot be found.
+     * @throws EntityNotFoundException if no exam with the given examId can be found
+     */
+    public Set<ZonedDateTime> getAllIndiviudalExamEndDates(Long examId) {
+        return getAllIndiviudalExamEndDates(findOne(examId));
+    }
+
+    /**
+     * Returns all individual exam end dates as determined by the working time of the student exams.
+     * <p>
+     * If no student exams are available, an empty set returned.
+     * 
+     * @param exam the exam
+     * @return a set of all end dates. May return an empty set, if the exam has no start/end date or student exams cannot be found.
+     */
+    public Set<ZonedDateTime> getAllIndiviudalExamEndDates(Exam exam) {
+        if (exam.getStartDate() == null)
+            return null;
+        var workingTimes = studentExamRepository.findAllDistinctWorkingTimesByExamId(exam.getId());
+        return workingTimes.stream().map(timeInSeconds -> exam.getStartDate().plusSeconds(timeInSeconds)).collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.service;
 
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -402,5 +403,33 @@ public class ExamService {
         }
 
         return generatedParticipations.size();
+    }
+
+    /**
+     * Returns the latest individual exam end date as determined by the working time of the student exams.
+     * <p>
+     * If no student exams are available, the exam end date is returned.
+     * 
+     * @param examId the id of the exam
+     * @return the latest end date or the exam end date if no student exams are found. May return <code>null</code>, if the exam has no start/end date.
+     * @throws EntityNotFoundException if no exam with the given examId can be found
+     */
+    public ZonedDateTime getLatestIndiviudalExamEndDate(Long examId) {
+        return getLatestIndiviudalExamEndDate(findOne(examId));
+    }
+
+    /**
+     * Returns the latest individual exam end date as determined by the working time of the student exams.
+     * <p>
+     * If no student exams are available, the exam end date is returned.
+     * 
+     * @param exam the exam
+     * @return the latest end date or the exam end date if no student exams are found. May return <code>null</code>, if the exam has no start/end date.
+     */
+    public ZonedDateTime getLatestIndiviudalExamEndDate(Exam exam) {
+        if (exam.getStartDate() == null)
+            return null;
+        var maxWorkingTime = studentExamRepository.findMaxWorkingTimeByExamId(exam.getId());
+        return maxWorkingTime.map(timeInSeconds -> exam.getStartDate().plusSeconds(timeInSeconds)).orElse(exam.getEndDate());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
@@ -112,4 +112,16 @@ public class StudentExamService {
         return studentExamRepository.findByExerciseIdAndUserId(exerciseId, userId)
                 .orElseThrow(() -> new EntityNotFoundException("Student exam for exercise " + exerciseId + " and user " + userId + " does not exist"));
     }
+
+    /**
+     * Get the maximal working time of all student exams for the exam with the given id.
+     *
+     * @param examId the id of the exam
+     * @return the list of all student exams
+     */
+    @NotNull
+    public Integer findOneByExerciseIdAndUserId(Long examId) {
+        log.debug("Request to get the maximum working time of all student exams for Exam : {}", examId);
+        return studentExamRepository.findMaxWorkingTimeByExamId(examId).orElseThrow(() -> new EntityNotFoundException("No student exams found for exam id " + examId));
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
@@ -117,7 +117,8 @@ public class StudentExamService {
      * Get the maximal working time of all student exams for the exam with the given id.
      *
      * @param examId the id of the exam
-     * @return the list of all student exams
+     * @return the maximum of all student exam working times for the given exam
+     * @throws EntityNotFoundException if no student exams could be found
      */
     @NotNull
     public Integer findOneByExerciseIdAndUserId(Long examId) {

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
@@ -122,7 +122,7 @@ public class StudentExamService {
      * @throws EntityNotFoundException if no student exams could be found
      */
     @NotNull
-    public Integer findOneByExerciseIdAndUserId(Long examId) {
+    public Integer findMaxWorkingTimeByExamId(Long examId) {
         log.debug("Request to get the maximum working time of all student exams for Exam : {}", examId);
         return studentExamRepository.findMaxWorkingTimeByExamId(examId).orElseThrow(() -> new EntityNotFoundException("No student exams found for exam id " + examId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.service;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
@@ -124,5 +125,17 @@ public class StudentExamService {
     public Integer findOneByExerciseIdAndUserId(Long examId) {
         log.debug("Request to get the maximum working time of all student exams for Exam : {}", examId);
         return studentExamRepository.findMaxWorkingTimeByExamId(examId).orElseThrow(() -> new EntityNotFoundException("No student exams found for exam id " + examId));
+    }
+
+    /**
+     * Get all distinct student working times of one exam. 
+     *
+     * @param examId the id of the exam
+     * @return a set of all distinct working time values among the student exams of an exam. May be empty if no student exams can be found. 
+     */
+    @NotNull
+    public Set<Integer> findAllDistinctWorkingTimesByExamId(Long examId) {
+        log.debug("Request to find all distinct working times for Exam : {}", examId);
+        return studentExamRepository.findAllDistinctWorkingTimesByExamId(examId);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -22,6 +23,7 @@ import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 import de.tum.in.www1.artemis.domain.quiz.*;
 import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
 
@@ -199,5 +201,61 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
         database.changeUser("instructor1");
         // Make sure delete also works if so many objects have been created before
         request.delete("/api/courses/" + course.getId() + "/exams/" + exam.getId(), HttpStatus.OK);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testGetMaxWorkingTimeNoStudentExams() throws Exception {
+        var examVisibleDate = ZonedDateTime.now().minusMinutes(5);
+        var examStartDate = ZonedDateTime.now().plusMinutes(5);
+        var examEndDate = ZonedDateTime.now().plusMinutes(20);
+
+        Course course = database.addEmptyCourse();
+        Exam exam = database.addExam(course, examVisibleDate, examStartDate, examEndDate);
+        exam = database.addExerciseGroupsAndExercisesToExam(exam, examStartDate, examEndDate);
+
+        // register user
+        exam.setRegisteredUsers(new HashSet<>(users));
+        exam.setNumberOfExercisesInExam(2);
+        exam.setRandomizeExerciseOrder(false);
+        exam = examRepository.save(exam);
+
+        /*
+         * don't generate individual student exams
+         */
+
+        assertThat(studentExamRepository.findMaxWorkingTimeByExamId(exam.getId())).isEmpty();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testGetMaxWorkingTimeDifferent() throws Exception {
+        var examVisibleDate = ZonedDateTime.now().minusMinutes(5);
+        var examStartDate = ZonedDateTime.now().plusMinutes(5);
+        var examEndDate = ZonedDateTime.now().plusMinutes(20);
+
+        Course course = database.addEmptyCourse();
+        Exam exam = database.addExam(course, examVisibleDate, examStartDate, examEndDate);
+        exam = database.addExerciseGroupsAndExercisesToExam(exam, examStartDate, examEndDate);
+
+        // register user
+        exam.setRegisteredUsers(new HashSet<>(users));
+        exam.setNumberOfExercisesInExam(2);
+        exam.setRandomizeExerciseOrder(false);
+        exam = examRepository.save(exam);
+
+        // generate individual student exams
+        List<StudentExam> studentExams = request.postListWithResponseBody("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/generate-student-exams", Optional.empty(),
+                StudentExam.class, HttpStatus.OK);
+
+        int maxWorkingTime = (int) Duration.between(examStartDate, examEndDate).getSeconds();
+        for (var studentExam : studentExams) {
+            maxWorkingTime += 30;
+            studentExam.setWorkingTime(maxWorkingTime);
+            studentExamRepository.save(studentExam);
+        }
+
+        SecurityUtils.setAuthorizationObject(); // TODO why do we get an exception here without that?
+        assertThat(studentExamRepository.findMaxWorkingTimeByExamId(exam.getId())).contains(maxWorkingTime);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Server: I added multiple integration tests (Spring) related to the features
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
This solves the problem that it is currently hard to take student working times into account in different places of Artemis without loading all `StudentExam`s from the database.

### Description
Add methods to the repositories and services surrounding the `StudentExam` to get
- The maximum working time / latest end date of an exam _(determining the "real" exam end)_
- A set of all distinct working times / end dates of an exam _(for scheduling)_

### Steps for Testing
- Review the Code
- Review the JavaDoc
- (Run the tests locally, e.g. `StudentExamIntegrationTest`)
- **Do more methods like that come to your mind that would be generally useful?**