### PR TITLE
[Exam] Due date instead of duration for quiz detail and small UI adjustments

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
@@ -188,7 +188,7 @@
         <div class="edit-quiz-footer">
             <div class="container">
                 <div class="edit-quiz-footer-content">
-                    <div class="form-group">
+                    <div class="form-group" *ngIf="!isExamMode">
                         <span jhiTranslate="artemisApp.quizExercise.status" class="colon-suffix"></span>
                         <select
                             *ngIf="showDropdown === 'isOpenForPractice'"

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
@@ -42,32 +42,55 @@
             </div>
             <div class="col-12 col-md-6">
                 <div class="form-group-narrow">
-                    <label jhiTranslate="artemisApp.quizExercise.duration">Duration</label>
-                    <div class="d-flex align-items-center">
-                        <input
-                            id="quiz-duration-minutes"
-                            style="width: 70px;"
-                            class="form-control mb-2 mr-2"
-                            title="Duration"
-                            type="number"
-                            min="0"
-                            max="600"
-                            [(ngModel)]="duration.minutes"
-                            (ngModelChange)="onDurationChange()"
-                        />
-                        <span jhiTranslate="artemisApp.quizExercise.minutes"></span>
-                        <input
-                            id="quiz-duration-seconds"
-                            style="width: 70px;"
-                            class="form-control mb-2 mr-2 ml-2"
-                            title="Duration"
-                            type="number"
-                            max="60"
-                            min="-1"
-                            [(ngModel)]="duration.seconds"
-                            (ngModelChange)="onDurationChange()"
-                        />
-                        <span jhiTranslate="artemisApp.quizExercise.seconds"></span>
+                    <ng-container *ngIf="!isExamMode">
+                        <label jhiTranslate="artemisApp.quizExercise.duration">Duration</label>
+                        <div class="d-flex align-items-center">
+                            <input
+                                id="quiz-duration-minutes"
+                                style="width: 70px;"
+                                class="form-control mb-2 mr-2"
+                                title="Duration"
+                                type="number"
+                                min="0"
+                                max="600"
+                                [(ngModel)]="duration.minutes"
+                                (ngModelChange)="onDurationChange()"
+                            />
+                            <span jhiTranslate="artemisApp.quizExercise.minutes"></span>
+                            <input
+                                id="quiz-duration-seconds"
+                                style="width: 70px;"
+                                class="form-control mb-2 mr-2 ml-2"
+                                title="Duration"
+                                type="number"
+                                max="60"
+                                min="-1"
+                                [(ngModel)]="duration.seconds"
+                                (ngModelChange)="onDurationChange()"
+                            />
+                            <span jhiTranslate="artemisApp.quizExercise.seconds"></span>
+                        </div>
+                    </ng-container>
+                    <div *ngIf="isExamMode" class="d-flex">
+                        <div class="form-group flex-grow-1">
+                            <jhi-date-time-picker
+                                labelName="{{ 'artemisApp.exercise.releaseDate' | translate }}"
+                                [(ngModel)]="quizExercise.releaseDate"
+                                (ngModelChange)="cacheValidation()"
+                                [error]="false"
+                                name="releaseDate"
+                            ></jhi-date-time-picker>
+                        </div>
+                        <div class="form-group flex-grow-1 ml-3">
+                            <jhi-date-time-picker
+                                name="dueDate"
+                                [error]="quizExercise.dueDateError"
+                                labelName="{{ 'artemisApp.exercise.dueDate' | translate }}"
+                                (ngModelChange)="cacheValidation()"
+                                [(ngModel)]="quizExercise.dueDate"
+                            ></jhi-date-time-picker>
+                            <span *ngIf="quizExercise.dueDateError" class="invalid-feedback">{{ 'artemisApp.exercise.dueDateError' | translate }}</span>
+                        </div>
                     </div>
                     <div class="form-group-narrow">
                         <label jhiTranslate="artemisApp.quizExercise.options">Options</label>
@@ -81,26 +104,28 @@
                             />
                             <label class="form-check-label custom-control-label" for="cbRandomizeOrder" jhiTranslate="artemisApp.quizExercise.randomizeQuestionOrder"> </label>
                         </div>
-                        <div class="form-check custom-control custom-checkbox">
-                            <input
-                                type="checkbox"
-                                id="cbPlannedToStart"
-                                class="form-check-input custom-control-input"
-                                [(ngModel)]="quizExercise.isPlannedToStart"
-                                (ngModelChange)="cacheValidation()"
-                            />
-                            <label class="form-check-label custom-control-label" for="cbPlannedToStart" jhiTranslate="artemisApp.quizExercise.startTime"> </label>
-                        </div>
-                        <div class="mt-1 d-flex align-items-center" *ngIf="quizExercise.isPlannedToStart">
-                            <div class="flex-grow-1">
-                                <jhi-date-time-picker
-                                    [disabled]="!quizExercise.isPlannedToStart"
-                                    [(ngModel)]="quizExercise.releaseDate"
+                        <ng-container *ngIf="!isExamMode">
+                            <div class="form-check custom-control custom-checkbox">
+                                <input
+                                    type="checkbox"
+                                    id="cbPlannedToStart"
+                                    class="form-check-input custom-control-input"
+                                    [(ngModel)]="quizExercise.isPlannedToStart"
                                     (ngModelChange)="cacheValidation()"
-                                    name="releaseDate"
-                                ></jhi-date-time-picker>
+                                />
+                                <label class="form-check-label custom-control-label" for="cbPlannedToStart" jhiTranslate="artemisApp.quizExercise.startTime"> </label>
                             </div>
-                        </div>
+                            <div class="mt-1 d-flex align-items-center" *ngIf="quizExercise.isPlannedToStart">
+                                <div class="flex-grow-1">
+                                    <jhi-date-time-picker
+                                        [disabled]="!quizExercise.isPlannedToStart"
+                                        [(ngModel)]="quizExercise.releaseDate"
+                                        (ngModelChange)="cacheValidation()"
+                                        name="releaseDate"
+                                    ></jhi-date-time-picker>
+                                </div>
+                            </div>
+                        </ng-container>
                     </div>
                 </div>
             </div>
@@ -220,7 +245,7 @@
                             </option>
                         </select>
                     </div>
-                    <div class="form-group flex-fill ml-5">
+                    <div class="form-group flex-fill ml-5" *ngIf="!isExamMode">
                         <div class="form-group flex-fill" *ngIf="quizExercise.id">
                             <input
                                 minlength="3"

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
@@ -76,7 +76,7 @@
                             <jhi-date-time-picker
                                 labelName="{{ 'artemisApp.exercise.releaseDate' | translate }}"
                                 [(ngModel)]="quizExercise.releaseDate"
-                                (ngModelChange)="cacheValidation()"
+                                (ngModelChange)="onDurationChange()"
                                 [error]="false"
                                 name="releaseDate"
                             ></jhi-date-time-picker>
@@ -86,7 +86,7 @@
                                 name="dueDate"
                                 [error]="quizExercise.dueDateError"
                                 labelName="{{ 'artemisApp.exercise.dueDate' | translate }}"
-                                (ngModelChange)="cacheValidation()"
+                                (ngModelChange)="onDurationChange()"
                                 [(ngModel)]="quizExercise.dueDate"
                             ></jhi-date-time-picker>
                             <span *ngIf="quizExercise.dueDateError" class="invalid-feedback">{{ 'artemisApp.exercise.dueDateError' | translate }}</span>

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -1041,16 +1041,24 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
         quizExercise.releaseDate = quizExercise.releaseDate ? moment(quizExercise.releaseDate) : moment();
         quizExercise.duration = Number(quizExercise.duration);
         quizExercise.duration = isNaN(quizExercise.duration) ? 10 : quizExercise.duration;
+        quizExercise.dueDate = quizExercise.dueDate ? moment(quizExercise.releaseDate) : quizExercise.releaseDate.add(quizExercise.duration, 's');
     }
 
     /**
      * Reach to changes of duration inputs by updating model and ui
      */
     onDurationChange(): void {
-        const duration = moment.duration(this.duration);
-        this.quizExercise.duration = Math.min(Math.max(duration.asSeconds(), 0), 10 * 60 * 60);
-        this.updateDuration();
-        this.cacheValidation();
+        if (!this.isExamMode) {
+            const duration = moment.duration(this.duration);
+            this.quizExercise.duration = Math.min(Math.max(duration.asSeconds(), 0), 10 * 60 * 60);
+            this.updateDuration();
+            this.cacheValidation();
+        } else if (this.quizExercise.releaseDate && this.quizExercise.dueDate) {
+            const duration = moment(this.quizExercise.dueDate).diff(this.quizExercise.releaseDate, 's');
+            this.quizExercise.duration = Math.round(duration);
+            this.updateDuration();
+            this.cacheValidation();
+        }
     }
 
     /**

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -1038,10 +1038,13 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
      * @param quizExercise {QuizExercise} exercise which will be prepared
      */
     prepareEntity(quizExercise: QuizExercise): void {
-        quizExercise.releaseDate = quizExercise.releaseDate ? moment(quizExercise.releaseDate) : moment();
-        quizExercise.duration = Number(quizExercise.duration);
-        quizExercise.duration = isNaN(quizExercise.duration) ? 10 : quizExercise.duration;
-        quizExercise.dueDate = quizExercise.dueDate ? moment(quizExercise.releaseDate) : quizExercise.releaseDate.add(quizExercise.duration, 's');
+        if (this.isExamMode) {
+            quizExercise.releaseDate = moment(quizExercise.releaseDate);
+        } else {
+            quizExercise.releaseDate = quizExercise.releaseDate ? moment(quizExercise.releaseDate) : moment();
+            quizExercise.duration = Number(quizExercise.duration);
+            quizExercise.duration = isNaN(quizExercise.duration) ? 10 : quizExercise.duration;
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When creating a quiz for exercises the duration field and visible status is not needed. Instead the due date should be configurable.

### Description
<!-- Describe your changes in detail -->
Removed the footer bar fields not necessary for exams.
Added the start and due date to creating an exercise for exams instead of duration.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

**Test locally until builds work again**

1. Log in to Artemis
2. Navigate to Exam Management
3. Add a new quiz exercise to an exercise group
4. Check that the new fields are there
5. Check that the new fields work as expected
6. Check that nothing changed when creating / editing regular quizzes

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1409" alt="Bildschirmfoto 2020-06-29 um 23 13 26" src="https://user-images.githubusercontent.com/51987021/86056742-2fcede00-ba5e-11ea-812b-acc40038bfd6.png">
