### PR TITLE
[Exam] Submission allowance checks for programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryProgrammingExerciseParticipationResource.java
@@ -67,9 +67,7 @@ public class RepositoryProgrammingExerciseParticipationResource extends Reposito
             throw new IllegalAccessException();
         }
         // Error case 4: The user is not (any longer) allowed to submit to the exam/exercise
-        // TODO: user should be cached but we might want to combine it with canAccessParticipation()
         User user = userService.getUserWithGroupsAndAuthorities();
-        // TODO: we might want to prevent this check for getFiles(), getFile() and pullChanges()
         if (!examSubmissionService.isAllowedToSubmit(participation.getExercise(), user)) {
             throw new IllegalAccessException();
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryProgrammingExerciseParticipationResource.java
@@ -39,12 +39,15 @@ public class RepositoryProgrammingExerciseParticipationResource extends Reposito
 
     private final ProgrammingExerciseService programmingExerciseService;
 
+    private final ExamSubmissionService examSubmissionService;
+
     public RepositoryProgrammingExerciseParticipationResource(UserService userService, AuthorizationCheckService authCheckService, GitService gitService,
             Optional<ContinuousIntegrationService> continuousIntegrationService, RepositoryService repositoryService, ProgrammingExerciseParticipationService participationService,
-            ProgrammingExerciseService programmingExerciseService) {
+            ProgrammingExerciseService programmingExerciseService, ExamSubmissionService examSubmissionService) {
         super(userService, authCheckService, gitService, continuousIntegrationService, repositoryService);
         this.participationService = participationService;
         this.programmingExerciseService = programmingExerciseService;
+        this.examSubmissionService = examSubmissionService;
     }
 
     @Override
@@ -61,6 +64,13 @@ public class RepositoryProgrammingExerciseParticipationResource extends Reposito
         }
         // Error case 3: The user's participation repository is locked.
         if (repositoryAction == RepositoryActionType.WRITE && programmingExerciseService.isParticipationRepositoryLocked((ProgrammingExerciseParticipation) participation)) {
+            throw new IllegalAccessException();
+        }
+        // Error case 4: The user is not (any longer) allowed to submit to the exam/exercise
+        // TODO: user should be cached but we might want to combine it with canAccessParticipation()
+        User user = userService.getUserWithGroupsAndAuthorities();
+        // TODO: we might want to prevent this check for getFiles(), getFile() and pullChanges()
+        if (!examSubmissionService.isAllowedToSubmit(participation.getExercise(), user)) {
             throw new IllegalAccessException();
         }
         URL repositoryUrl = ((ProgrammingExerciseParticipation) participation).getRepositoryUrlAsUrl();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryProgrammingExerciseParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryProgrammingExerciseParticipationResource.java
@@ -66,9 +66,9 @@ public class RepositoryProgrammingExerciseParticipationResource extends Reposito
         if (repositoryAction == RepositoryActionType.WRITE && programmingExerciseService.isParticipationRepositoryLocked((ProgrammingExerciseParticipation) participation)) {
             throw new IllegalAccessException();
         }
-        // Error case 4: The user is not (any longer) allowed to submit to the exam/exercise
+        // Error case 4: The user is not (any longer) allowed to submit to the exam/exercise. This check is only relevant for students.
         User user = userService.getUserWithGroupsAndAuthorities();
-        if (!examSubmissionService.isAllowedToSubmit(participation.getExercise(), user)) {
+        if (!authCheckService.isAtLeastTeachingAssistantForExercise(participation.getExercise()) && !examSubmissionService.isAllowedToSubmit(participation.getExercise(), user)) {
             throw new IllegalAccessException();
         }
         URL repositoryUrl = ((ProgrammingExerciseParticipation) participation).getRepositoryUrlAsUrl();

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
@@ -134,6 +134,8 @@ public class RepositoryWebsocketResource {
 
         // Apply checks for exam (submission is in time & user's student exam has the exercise)
         // TODO: user should be cached but we might want to combine it with canAccessParticipation()
+        // TODO: We might need to extend the ExamSubmissionService to support team exercises. Nevertheless this is not
+        // relevant at the moment as we don't support teams in the exam mode.
         User user = userService.getUserWithGroupsAndAuthorities(principal.getName());
         if (!examSubmissionService.isAllowedToSubmit(programmingExerciseParticipation.getProgrammingExercise(), user)) {
             FileSubmissionError error = new FileSubmissionError(participationId, "notAllowedExam");

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
@@ -133,9 +133,6 @@ public class RepositoryWebsocketResource {
         }
 
         // Apply checks for exam (submission is in time & user's student exam has the exercise)
-        // TODO: user should be cached but we might want to combine it with canAccessParticipation()
-        // TODO: We might need to extend the ExamSubmissionService to support team exercises. Nevertheless this is not
-        // relevant at the moment as we don't support teams in the exam mode.
         User user = userService.getUserWithGroupsAndAuthorities(principal.getName());
         if (!examSubmissionService.isAllowedToSubmit(programmingExerciseParticipation.getProgrammingExercise(), user)) {
             FileSubmissionError error = new FileSubmissionError(participationId, "notAllowedExam");

--- a/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/websocket/repository/RepositoryWebsocketResource.java
@@ -155,20 +155,18 @@ public class RepositoryWebsocketResource {
     @FeatureToggle(Feature.PROGRAMMING_EXERCISES)
     // TODO: this should rather be a REST call so that security checks are easier to implement
     public void updateTestFiles(@DestinationVariable Long exerciseId, @Payload List<FileSubmission> submissions, Principal principal) {
-        String principalName = principal.getName();
-
-        // Without this, custom jpa repository methods don't work in websocket channel.
-        SecurityUtils.setAuthorizationObject();
-
-        // Check that principal has permission to change the test repository
         String topic = "/topic/test-repository/" + exerciseId + "/files";
-        User user = userService.getUserByLogin(principalName).get();
+
+        User user = userService.getUserByLogin(principal.getName()).get();
         Exercise exercise = exerciseService.findOne(exerciseId);
         if (!authCheckService.isAtLeastInstructorForExercise(exercise, user)) {
             FileSubmissionError error = new FileSubmissionError(exerciseId, "noPermissions");
             messagingTemplate.convertAndSendToUser(principal.getName(), topic, error);
             return;
         }
+
+        // Without this, custom jpa repository methods don't work in websocket channel.
+        SecurityUtils.setAuthorizationObject();
 
         ProgrammingExercise programmingExercise = (ProgrammingExercise) exerciseService.findOneWithAdditionalElements(exerciseId);
         String testRepoName = programmingExercise.getProjectKey().toLowerCase() + "-" + RepositoryType.TESTS.getName();

--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -76,7 +76,8 @@
                 "couldNotBeRetrieved": "Der Repository Status konnte nicht überprüft werden.",
                 "problemStatementCouldNotBeUpdated": "Die Aufgabenstellung der Übung konnte nicht aktualisiert werden.",
                 "failedToLoadBuildLogs": "Die Build Logs konnten nicht geladen werden.",
-                "repositoryInConflict": "Dein Repository befindet sich in einem Konfliktzustand."
+                "repositoryInConflict": "Dein Repository befindet sich in einem Konfliktzustand.",
+                "notAllowedExam": "Du kannst (nicht mehr) abgeben"
             },
             "testStatusLabels": {
                 "noResult": "Keine Ergebnisse",

--- a/src/main/webapp/i18n/en/editor.json
+++ b/src/main/webapp/i18n/en/editor.json
@@ -80,7 +80,8 @@
                 "couldNotBeRetrieved": "The repository status could not be retrieved.",
                 "problemStatementCouldNotBeUpdated": "The problem statement of this exercise could not be updated.",
                 "failedToLoadBuildLogs": "The build logs could not be retrieved.",
-                "repositoryInConflict": "Your repository has entered a conflict state."
+                "repositoryInConflict": "Your repository has entered a conflict state.",
+                "notAllowedExam": "You must not submit (anymore)"
             },
             "testStatusLabels": {
                 "noResult": "No results",

--- a/src/test/java/de/tum/in/www1/artemis/service/ExamSubmissionServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExamSubmissionServiceTest.java
@@ -83,6 +83,8 @@ public class ExamSubmissionServiceTest extends AbstractSpringIntegrationBambooBi
         Exercise nonExamExercise = ModelFactory.generateTextExercise(ZonedDateTime.now(), ZonedDateTime.now(), ZonedDateTime.now(), tmpCourse);
         Optional<ResponseEntity<Submission>> result = examSubmissionService.checkSubmissionAllowance(nonExamExercise, user);
         assertThat(result.isEmpty()).isTrue();
+        boolean result2 = examSubmissionService.isAllowedToSubmit(nonExamExercise, user);
+        assertThat(result2).isTrue();
     }
 
     @Test
@@ -94,17 +96,23 @@ public class ExamSubmissionServiceTest extends AbstractSpringIntegrationBambooBi
         Optional<ResponseEntity<Submission>> result = examSubmissionService.checkSubmissionAllowance(exercise, user);
         assertThat(result.isPresent()).isTrue();
         assertThat(result.get()).isEqualTo(forbidden());
+        boolean result2 = examSubmissionService.isAllowedToSubmit(exercise, user);
+        assertThat(result2).isFalse();
         // Should fail when submission is made after (start date + working time)
         exam.setStartDate(ZonedDateTime.now().minusMinutes(130));
         examService.save(exam);
         result = examSubmissionService.checkSubmissionAllowance(exercise, user);
         assertThat(result.isPresent()).isTrue();
         assertThat(result.get()).isEqualTo(forbidden());
+        result2 = examSubmissionService.isAllowedToSubmit(exercise, user);
+        assertThat(result2).isFalse();
         // Should pass if submission is made in time
         exam.setStartDate(ZonedDateTime.now().minusMinutes(90));
         examService.save(exam);
         result = examSubmissionService.checkSubmissionAllowance(exercise, user);
         assertThat(result.isEmpty()).isTrue();
+        result2 = examSubmissionService.isAllowedToSubmit(exercise, user);
+        assertThat(result2).isTrue();
         // Should fail when submission is made after end date (if no working time is set)
         studentExam.setWorkingTime(0);
         studentExamRepository.save(studentExam);
@@ -114,6 +122,8 @@ public class ExamSubmissionServiceTest extends AbstractSpringIntegrationBambooBi
         result = examSubmissionService.checkSubmissionAllowance(exercise, user);
         assertThat(result.isPresent()).isTrue();
         assertThat(result.get()).isEqualTo(forbidden());
+        result2 = examSubmissionService.isAllowedToSubmit(exercise, user);
+        assertThat(result2).isFalse();
     }
 
     @Test
@@ -127,6 +137,9 @@ public class ExamSubmissionServiceTest extends AbstractSpringIntegrationBambooBi
         assertThrows(EntityNotFoundException.class, () -> {
             examSubmissionService.checkSubmissionAllowance(exercise, user);
         });
+        assertThrows(EntityNotFoundException.class, () -> {
+            examSubmissionService.isAllowedToSubmit(exercise, user);
+        });
         // Should fail if the user's student exam does not have the exercise
         studentExam.setUser(user);
         studentExam.removeExercise(exercise);
@@ -134,6 +147,8 @@ public class ExamSubmissionServiceTest extends AbstractSpringIntegrationBambooBi
         Optional<ResponseEntity<Submission>> result = examSubmissionService.checkSubmissionAllowance(exercise, user);
         assertThat(result.isPresent()).isTrue();
         assertThat(result.get()).isEqualTo(forbidden());
+        boolean result2 = examSubmissionService.isAllowedToSubmit(exercise, user);
+        assertThat(result2).isFalse();
     }
 
     @Test


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I added multiple integration tests (Spring) related to the features
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
We have some checks in `ExamSubmissionService` that were already added to quiz, modeling, text and file upload exercises (https://github.com/ls1intum/Artemis/pull/1723). At least the checks that check that the submission is in time and that the user's student exam has the exercise to which a submission should be saved should be added to programming exercises.

### Description
- [x] I've added `isAllowedToSubmit()` to `ExamSubmissionService` and extended the tests in `ExamSubmissionServiceTest`
- [x] I've added the checks to `RepositoryWebsocketResource`
- [x] I've added the checks to `RepositoryProgrammingExerciseParticipationResource`
- [ ] I've extended the existing test cases for `RepositoryWebsocketResource` and `RepositoryProgrammingExerciseParticipationResource`

**To be discussed:**
- [x] Do we need to apply the checks in `@MessageMapping("/topic/test-repository/{exerciseId}/files")` in `RepositoryWebsocketResource`? --> No
- [x] In `RepositoryWebsocketResource` we get the `principal` from the socket message. Is the principal *safe* or is it possible to fake it? (e.g. `public void updateParticipationFiles(@DestinationVariable Long participationId, @Payload List<FileSubmission> submissions, Principal principal)`) --> Yes
- [x] The current implementation of `RepositoryProgrammingExerciseParticipationResource::getRepository()` made it easier to apply the checks to all actions. Should I remove the checks from `getFiles()`, `getFile()` and `pullChanges()`?
- [x] The current user is needed for the checks. `participationService.canAccessParticipation()` is executed before in some places and does also query for the current user. Should I trust the cache or should I manually ensure that the user is not fetched from the database twice?

### Steps for Testing
1. Participate in a programming exercise of an exam
2. Make some submits to the programming exercise (via websocket) & refresh the page multiple times (via REST)
3. Everything should work (you cannot test the submission allowance checks via the UI)

**Test that tutors (and higher) are still able to access the student's participation for assessment**
This can be tested outside of the exam mode.

1. Create a submission to a programming exercise
3. Check that the submission is accessible for assessment

**Test repository changes**
This can be tested outside of the exam mode.
1. Go to a course in the course management that has at least one programming exercise
2. Click on exercises
3. Click on *Edit in editor* next to the programming exercise
4. Add e.g. a comment in any of the files
5. Submit the changes. This should still work