### PR TITLE
fix printing of exam in firefox

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
@@ -33,7 +33,9 @@ export class ExamParticipationSummaryComponent {
      * called for exportPDF Button
      */
     printPDF() {
-        window.print();
+        // expand all exercises before printing
+        this.collapsedSubmissionIds = [];
+        setTimeout(() => window.print());
     }
 
     /**

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -738,8 +738,7 @@ ngb-tooltip-window {
 }
 
 @media print {
-    body,
-    div {
-        display: block !important;
+    .container {
+        min-width: 0 !important;
     }
 }

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -736,3 +736,10 @@ ngb-tooltip-window {
         margin-right: 2px;
     }
 }
+
+@media print {
+    body,
+    div {
+        display: block !important;
+    }
+}

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -741,4 +741,7 @@ ngb-tooltip-window {
     .container {
         min-width: 0 !important;
     }
+    .card {
+        display: block !important;
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) **locally**
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
When printing longer exams, firefox would only print the first page. This is because of flex layout according to firefox support: https://support.mozilla.org/en-US/questions/1227484
It also fixes the layouting issues with MC quizzes in print view
It also adds the functionality that all exercises are expanded before printing to get a full print

In the attachments you can find the prints of a test exam which i did locally. For me it looks good (development banner on the top left corner will not be there on production)
The issue in DnD is unrelated to this PR (wrong drop location)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Use firefox
2. Create an exam with various exercise types
3. participate and go to summary page
4. print exam
5. exam should be printed in a readable manner (there are some layouting issues due to changing the layout, but everything should be readable)

6. if you have additional browsers installed, please quickly test printing there and report any issue you find

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/22955066/86145765-a0760900-baf7-11ea-9cce-b8dab901caf4.png)

### Attachements
[firefox.pdf](https://github.com/ls1intum/Artemis/files/4857810/firefox.pdf)
[chrome.pdf](https://github.com/ls1intum/Artemis/files/4857811/chrome.pdf)



