### PR TITLE
Add scheduling profile to run configurations.

### DIFF
--- a/.idea/runConfigurations/Artemis__Server_.xml
+++ b/.idea/runConfigurations/Artemis__Server_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Artemis (Server)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="Artemis.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
-    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis" />
+    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Artemis__Server__Jenkins___Gitlab_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Jenkins___Gitlab_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Artemis (Server, Jenkins &amp; Gitlab)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="Artemis.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
-    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,jenkins,gitlab,artemis" />
+    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,jenkins,gitlab,artemis,scheduling" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Artemis__Server__Text_Clustering_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Text_Clustering_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Artemis (Server, Text Clustering)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="Artemis.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
-    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,automaticText" />
+    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,automaticText,scheduling" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Artemis__Server___Client_.xml
+++ b/.idea/runConfigurations/Artemis__Server___Client_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Artemis (Server &amp; Client)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="Artemis.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
-    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis" />
+    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling" />
     <method v="2">
       <option name="Gradle.BeforeRunTask" enabled="true" tasks="webpack" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="" />
       <option name="Make" enabled="true" />


### PR DESCRIPTION
### Motivation and Context
In https://github.com/ls1intum/Artemis/pull/1691, a new `scheduling` profile was added that enables scheduling on that particular instance of Artemis.
The profile is not activated in the IntelliJ Idea run configurations.

### Description
I've added the `scheduling` profile to the existing run configurations.

### Steps for Testing

1. Start Artemis locally in IntelliJ Idea using the provided run configurations
2. Verify that the scheduling profile is active, e.g. by checking if the `Process cached quiz submissions` message is shown.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/5084100/86097936-b9f66100-bab5-11ea-8348-d5aa1a356970.png)
