### PR TITLE
[Exam] Delete participations

### DIFF
--- a/src/main/webapp/app/exercises/shared/participation/participation.component.html
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.html
@@ -221,7 +221,7 @@
                     <ng-template ngx-datatable-cell-template let-value="value">
                         <div class="w-100 text-right">
                             <div class="btn-group">
-                                <ng-container *ngIf="exercise?.type === ExerciseType.PROGRAMMING && (exercise.isAtLeastInstructor || exercise.exerciseGroup)">
+                                <ng-container *ngIf="exercise?.type === ExerciseType.PROGRAMMING && exercise.isAtLeastInstructor">
                                     <jhi-programming-exercise-instructor-trigger-build-button
                                         *ngIf="hasLoadedPendingSubmissions; else triggerLoading"
                                         [exercise]="exercise"
@@ -234,7 +234,7 @@
                                     </ng-template>
                                 </ng-container>
                                 <button
-                                    *ngIf="exercise.isAtLeastInstructor || exercise.exerciseGroup"
+                                    *ngIf="exercise.isAtLeastInstructor"
                                     [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                                     [skipFeatureToggle]="exercise.type !== ExerciseType.PROGRAMMING"
                                     jhiDeleteButton
@@ -251,7 +251,7 @@
                                     <fa-icon [icon]="'times'"></fa-icon>
                                 </button>
                                 <button
-                                    *ngIf="exercise?.type === ExerciseType.PROGRAMMING && value.buildPlanId !== null && (exercise.isAtLeastInstructor || exercise.exerciseGroup)"
+                                    *ngIf="exercise?.type === ExerciseType.PROGRAMMING && value.buildPlanId !== null && exercise.isAtLeastInstructor"
                                     [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                                     jhiDeleteButton
                                     [actionType]="ActionType.Cleanup"

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.html
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.html
@@ -221,7 +221,7 @@
                     <ng-template ngx-datatable-cell-template let-value="value">
                         <div class="w-100 text-right">
                             <div class="btn-group">
-                                <ng-container *ngIf="exercise?.type === ExerciseType.PROGRAMMING && exercise.isAtLeastInstructor">
+                                <ng-container *ngIf="exercise?.type === ExerciseType.PROGRAMMING && (exercise.isAtLeastInstructor || exercise.exerciseGroup)">
                                     <jhi-programming-exercise-instructor-trigger-build-button
                                         *ngIf="hasLoadedPendingSubmissions; else triggerLoading"
                                         [exercise]="exercise"
@@ -234,7 +234,7 @@
                                     </ng-template>
                                 </ng-container>
                                 <button
-                                    *ngIf="exercise.isAtLeastInstructor"
+                                    *ngIf="exercise.isAtLeastInstructor || exercise.exerciseGroup"
                                     [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                                     [skipFeatureToggle]="exercise.type !== ExerciseType.PROGRAMMING"
                                     jhiDeleteButton
@@ -251,7 +251,7 @@
                                     <fa-icon [icon]="'times'"></fa-icon>
                                 </button>
                                 <button
-                                    *ngIf="exercise?.type === ExerciseType.PROGRAMMING && value.buildPlanId !== null && exercise.isAtLeastInstructor"
+                                    *ngIf="exercise?.type === ExerciseType.PROGRAMMING && value.buildPlanId !== null && (exercise.isAtLeastInstructor || exercise.exerciseGroup)"
                                     [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
                                     jhiDeleteButton
                                     [actionType]="ActionType.Cleanup"

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.ts
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.ts
@@ -16,6 +16,7 @@ import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service'
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { AlertService } from 'app/core/alert/alert.service';
 import { formatTeamAsSearchResult } from 'app/exercises/shared/team/team.utils';
+import { AccountService } from 'app/core/auth/account.service';
 
 enum FilterProp {
     ALL = 'all',
@@ -63,6 +64,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
         private eventManager: JhiEventManager,
         private exerciseService: ExerciseService,
         private programmingSubmissionService: ProgrammingSubmissionService,
+        private accountService: AccountService,
     ) {
         this.participationCriteria = {
             filterProp: FilterProp.ALL,
@@ -108,8 +110,17 @@ export class ParticipationComponent implements OnInit, OnDestroy {
                 }
                 this.newManualResultAllowed = areManualResultsAllowed(this.exercise);
                 this.presentationScoreEnabled = this.checkPresentationScoreConfig();
+                this.hasAccessRights();
             });
         });
+    }
+
+    hasAccessRights() {
+        if (this.exercise.course) {
+            this.exercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.course);
+        } else if (this.exercise.exerciseGroup) {
+            this.exercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.exerciseGroup.exam?.course!);
+        }
     }
 
     updateParticipationFilter(newValue: FilterProp) {


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
The buttons on the participation page were not shown.

### Steps for Testing
1. Go to exam.
2. Create student exams and participations.#
3. Go to participations on the exam exercises.

###Screenshots
Participations page for FU, Text and Quiz exercises:
![grafik](https://user-images.githubusercontent.com/57408107/86114270-9b4e9500-baca-11ea-8893-2377b04b9197.png)
Participations page for programming exercises:
![grafik](https://user-images.githubusercontent.com/57408107/86114501-e8cb0200-baca-11ea-9ffe-be3441f0caee.png)
