### PR TITLE
Fix edge cases in programming exercise scheduling

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -149,7 +149,7 @@ public class ProgrammingExerciseService {
         // not yet saved in the database, so we cannot save the submission accordingly (see ProgrammingSubmissionService.notifyPush)
         versionControlService.get().addWebHooksForExercise(programmingExercise);
 
-        instanceMessageSendService.sendProgrammingExerciseSchedule(programmingExercise.getId());
+        scheduleOperations(programmingExercise.getId());
 
         // Notify tutors only if this a course exercise
         if (programmingExercise.hasCourse()) {
@@ -157,6 +157,10 @@ public class ProgrammingExerciseService {
         }
 
         return programmingExercise;
+    }
+
+    public void scheduleOperations(Long programmingExerciseId) {
+        instanceMessageSendService.sendProgrammingExerciseSchedule(programmingExerciseId);
     }
 
     private void setupBuildPlansForNewExercise(ProgrammingExercise programmingExercise, URL exerciseRepoUrl, URL testsRepoUrl, URL solutionRepoUrl) {
@@ -253,8 +257,7 @@ public class ProgrammingExerciseService {
     public ProgrammingExercise updateProgrammingExercise(ProgrammingExercise programmingExercise, @Nullable String notificationText) {
         ProgrammingExercise savedProgrammingExercise = programmingExerciseRepository.save(programmingExercise);
 
-        // TODO: should the call `scheduleExerciseIfRequired` not be moved into the service?
-        instanceMessageSendService.sendProgrammingExerciseSchedule(programmingExercise.getId());
+        scheduleOperations(programmingExercise.getId());
 
         // Only send notification for course exercises
         if (notificationText != null && programmingExercise.hasCourse()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -53,15 +53,18 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     private final ParticipationService participationService;
 
+    private final ExamService examService;
+
     public ProgrammingExerciseScheduleService(ScheduleService scheduleService, ProgrammingExerciseRepository programmingExerciseRepository, Environment env,
             ProgrammingSubmissionService programmingSubmissionService, GroupNotificationService groupNotificationService, Optional<VersionControlService> versionControlService,
-            ParticipationService participationService) {
+            ParticipationService participationService, ExamService examService) {
         this.scheduleService = scheduleService;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingSubmissionService = programmingSubmissionService;
         this.groupNotificationService = groupNotificationService;
         this.versionControlService = versionControlService;
         this.participationService = participationService;
+        this.examService = examService;
         this.env = env;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -120,6 +120,13 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
     }
 
     private void scheduleExamExercise(ProgrammingExercise exercise) {
+        var exam = exercise.getExerciseGroup().getExam();
+        var visibleDate = exam.getVisibleDate();
+        var startDate = exam.getStartDate();
+        if (visibleDate == null || startDate == null) {
+            log.error("Programming exercise {} for exam {} cannot be scheduled properly, visible date is {}, start date is {}", exercise.getId(), exam.getId(), visibleDate,
+                    startDate);
+        }
         var releaseDate = getExamProgrammingExerciseReleaseDate(exercise);
         if (releaseDate.isAfter(ZonedDateTime.now())) {
             // Use the custom date from the exam rather than the of the exercise's lifecycle

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -132,13 +132,13 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
             // Use the custom date from the exam rather than the of the exercise's lifecycle
             scheduleService.scheduleTask(exercise, ExerciseLifecycle.RELEASE, Set.of(new Tuple<>(releaseDate, unlockAllStudentRepositoriesForExam(exercise))));
         }
-        else {
+        else if (examService.getLatestIndiviudalExamEndDate(exam).isBefore(ZonedDateTime.now())) {
             // This is only a backup (e.g. a crash of this node and restart during the exam)
             scheduleService.scheduleTask(exercise, ExerciseLifecycle.RELEASE,
                     Set.of(new Tuple<>(ZonedDateTime.now().plusSeconds(5), unlockAllStudentRepositoriesForExam(exercise))));
         }
 
-        if (exercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null) {
+        if (exercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null && exercise.getBuildAndTestStudentSubmissionsAfterDueDate().isAfter(ZonedDateTime.now())) {
             scheduleService.scheduleTask(exercise, ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE, buildAndTestRunnableForExercise(exercise));
         }
         else {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -25,9 +25,7 @@ import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentPar
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
-import de.tum.in.www1.artemis.service.GroupNotificationService;
-import de.tum.in.www1.artemis.service.ParticipationService;
-import de.tum.in.www1.artemis.service.ProgrammingSubmissionService;
+import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
 import de.tum.in.www1.artemis.service.util.Tuple;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -129,6 +129,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
         if (visibleDate == null || startDate == null) {
             log.error("Programming exercise {} for exam {} cannot be scheduled properly, visible date is {}, start date is {}", exercise.getId(), exam.getId(), visibleDate,
                     startDate);
+            return;
         }
         var releaseDate = getExamProgrammingExerciseReleaseDate(exercise);
         if (releaseDate.isAfter(ZonedDateTime.now())) {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -280,6 +280,9 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
         // using visible date here because unlocking will take some time, see delay below.
         var releaseDate = exercise.getExerciseGroup().getExam().getVisibleDate();
         if (releaseDate == null) {
+            releaseDate = exercise.getExerciseGroup().getExam().getStartDate();
+        }
+        if (releaseDate == null) {
             releaseDate = exercise.getReleaseDate();
         }
         return releaseDate;

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -259,7 +259,8 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     private void scheduleIndividualRepositoryLockTasks(ProgrammingExercise exercise, Set<Tuple<ZonedDateTime, ProgrammingExerciseStudentParticipation>> individualDueDates) {
         // 1. Group all participations by due date (TODO use student exams for safety if some participations are not pre-generated)
-        var participationsGroupedByDueDate = individualDueDates.stream().collect(Collectors.groupingBy(Tuple::getX, Collectors.mapping(Tuple::getY, Collectors.toSet())));
+        var participationsGroupedByDueDate = individualDueDates.stream().filter(tuple -> tuple.getX() != null)
+                .collect(Collectors.groupingBy(Tuple::getX, Collectors.mapping(Tuple::getY, Collectors.toSet())));
         // 2. Transform those groups into lock-repository tasks with times
         var tasks = participationsGroupedByDueDate.entrySet().stream().map(entry -> {
             Predicate<ProgrammingExerciseStudentParticipation> lockingCondition = participation -> entry.getValue().contains(participation);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -137,12 +137,19 @@ public class ExamResource {
 
         // Make sure that the original references are preserved.
         Exam originalExam = examService.findOne(updatedExam.getId());
+
         // NOTE: Make sure that all references are preserved here
         updatedExam.setExerciseGroups(originalExam.getExerciseGroups());
         updatedExam.setStudentExams(originalExam.getStudentExams());
         updatedExam.setRegisteredUsers(originalExam.getRegisteredUsers());
 
         Exam result = examService.save(updatedExam);
+
+        if (!Objects.equals(originalExam.getVisibleDate(), updatedExam.getVisibleDate())) {
+            // TODO: we now have to fetch all programming exercises related to this exam and invoke the following code
+            // instanceMessageSendService.sendProgrammingExerciseSchedule(programmingExerciseId);
+        }
+
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, result.getTitle())).body(result);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -331,7 +331,7 @@ public class ProgrammingExerciseResource {
     @PostMapping(Endpoints.IMPORT)
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
     @FeatureToggle(Feature.PROGRAMMING_EXERCISES)
-    public ResponseEntity<ProgrammingExercise> importExercise(@PathVariable long sourceExerciseId, @RequestBody ProgrammingExercise newExercise) {
+    public ResponseEntity<ProgrammingExercise> importProgrammingExercise(@PathVariable long sourceExerciseId, @RequestBody ProgrammingExercise newExercise) {
         if (sourceExerciseId < 0) {
             return badRequest();
         }
@@ -386,6 +386,8 @@ public class ProgrammingExerciseResource {
         catch (HttpException e) {
             responseHeaders = HeaderUtil.createFailureAlert(applicationName, true, ENTITY_NAME, "importExerciseTriggerPlanFail", "Unable to trigger imported build plans");
         }
+
+        programmingExerciseService.scheduleOperations(importedProgrammingExercise.getId());
 
         // Remove unnecessary fields
         importedProgrammingExercise.setTestCases(null);


### PR DESCRIPTION
### Motivation and Context
Fix some problems concerning programming exercise scheduling

### Description
Reschedule locking/unlocking of the repositories when:
- The exercise has been imported
- The exercise has been updated
- The exam visible/start date has been changed

Fixed
- Participations without student exam causing problems (e.g. of an instructor)


### Steps for Testing
For the exam mode, so you need an exam first (that has a programming exercise). Add some student with student exams generated.

_When testing make sure that the Exam has not started yet._

See if `Scheduled Exam Programming Exercise [...]` appears in the log after
- editing and updating an exam programming exercise
- importing a programming exercise into an exam
- changing the exam start/visible date

See if errors occur if an Instructor without a generated student exam has started the exercise to test it.
You can also try the testing without student exams, too, if you want.

Also look for errors related to `ProgrammingExerciseScheduleService` in the log, if possible.