### PR TITLE
[Exam] Bugfixes: Exam and Quiz navigation

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
@@ -40,7 +40,7 @@
     </div>
     <div class="col-auto">
         <div class="row justify-content-end align-items-start pr-2">
-            <div class="col-auto">
+            <div class="col">
                 <button *ngIf="isProgrammingExercise(); else notAProgrammingExercise" class="btn btn-primary px-3 mb-2" (click)="saveExercise()">
                     {{ 'artemisApp.examParticipation.' + (exerciseIndex >= exercises.length - 1 ? 'submitLastExercise' : 'submitOtherExercise') | translate }}
                     <!-- TODO: do not show a "Save" button for offline only programming exercises, show continue -->
@@ -52,7 +52,7 @@
                 </ng-template>
             </div>
             <div class="col-auto h3 timer px-1" jhiTranslate="artemisApp.examParticipation.timer">Time Left:</div>
-            <div class="col-auto h3 m-0 text-overflow remaining-time mb-2 px-1" [class.critical]="criticalTime">
+            <div class="col-auto h3 m-0 text-overflow remaining-time mb-2 px-0" [class.critical]="criticalTime">
                 {{ displayTime$ | async }}
             </div>
         </div>

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.scss
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.scss
@@ -4,6 +4,7 @@
     z-index: 50;
 
     .remaining-time {
+        min-width: 160px;
         background: white;
         text-align: center;
     }

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -96,6 +96,7 @@ export class ExamNavigationBarComponent implements OnInit {
         }
         if (this.exercises[i].studentParticipations[0].submissions[0].isSynced) {
             // make button blue
+            this.icon = 'check';
             status = 'synced';
             if (i === this.exerciseIndex) {
                 status = status + ' active';

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
@@ -19,8 +19,8 @@
                         [ngbTooltip]="selectedAnswerOptions[question.id]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
                         [ngClass]="{ 'changed-question': selectedAnswerOptions[question.id]?.length }"
                     >
-                    <b class="fa">MC</b>
-                </span>
+                        <b class="fa">MC</b>
+                    </span>
                     <span
                         *ngIf="question.type === SHORT_ANSWER"
                         class="btn btn-light btn-circle stepbutton stepwizardquiz-circle shortanswercolor-question"
@@ -28,8 +28,8 @@
                         [ngbTooltip]="shortAnswerSubmittedTexts[question.id]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
                         [ngClass]="{ 'changed-question': shortAnswerSubmittedTexts[question.id]?.length }"
                     >
-                    <b class="fa">SA</b>
-                </span>
+                        <b class="fa">SA</b>
+                    </span>
                     <ng-template #tooltipExplanationTranslate>{{ 'artemisApp.quizExercise.explanationAnswered' | translate }}</ng-template>
                     <ng-template #tooltipNotExplanationTranslate>{{ 'artemisApp.quizExercise.explanationNotAnswered' | translate }}</ng-template>
                 </div>
@@ -66,5 +66,3 @@
         </div>
     </div>
 </div>
-
-

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
@@ -1,66 +1,70 @@
-<div class="quiz-content container" *ngIf="exercise">
-    <h2>
-        {{ exercise.title }}
-    </h2>
-    <div *ngFor="let question of exercise.quizQuestions; let i = index">
-        <jhi-multiple-choice-question
-            id="question{{ i }}"
-            *ngIf="question.type === MULTIPLE_CHOICE"
-            [question]="question"
-            [(selectedAnswerOptions)]="selectedAnswerOptions[question.id]"
-            [submittedQuizExercise]="exercise"
-            [questionIndex]="i + 1"
-        ></jhi-multiple-choice-question>
-        <jhi-drag-and-drop-question
-            id="question{{ i }}"
-            *ngIf="question.type === DRAG_AND_DROP"
-            [question]="question"
-            [(mappings)]="dragAndDropMappings[question.id]"
-            [questionIndex]="i + 1"
-        ></jhi-drag-and-drop-question>
-        <jhi-short-answer-question
-            id="question{{ i }}"
-            *ngIf="question.type === SHORT_ANSWER"
-            [question]="question"
-            [(submittedTexts)]="shortAnswerSubmittedTexts[question.id]"
-            [questionIndex]="i + 1"
-        ></jhi-short-answer-question>
-    </div>
-</div>
-<div class="quiz-navigation" *ngIf="exercise">
-    <div class="quiz-navigation-content">
-        <div class="stepwizardquiz">
-            <div *ngFor="let question of exercise.quizQuestions; let i = index" class="stepwizardquiz__step">
-                <div
-                    *ngIf="question.type === DRAG_AND_DROP"
-                    class="btn btn-light btn-circle stepbutton stepwizardquiz-circle draganddropcolor-question"
-                    (click)="navigateToQuestion(i)"
-                    [ngbTooltip]="dragAndDropMappings[question.id]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
-                    [ngClass]="{ 'changed-question': dragAndDropMappings[question.id]?.length }"
-                >
-                    <b class="fa">DD</b>
-                </div>
-                <span
-                    *ngIf="question.type === MULTIPLE_CHOICE"
-                    class="btn btn-light btn-circle stepbutton stepwizardquiz-circle multiplechoicecolor-question"
-                    (click)="navigateToQuestion(i)"
-                    [ngbTooltip]="selectedAnswerOptions[question.id]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
-                    [ngClass]="{ 'changed-question': selectedAnswerOptions[question.id]?.length }"
-                >
+<div class="row">
+    <div class="quiz-navigation sticky-top" *ngIf="exercise">
+        <div class="quiz-navigation-content">
+            <div class="stepwizardquiz">
+                <div *ngFor="let question of exercise.quizQuestions; let i = index" class="stepwizardquiz__step">
+                    <div
+                        *ngIf="question.type === DRAG_AND_DROP"
+                        class="btn btn-light btn-circle stepbutton stepwizardquiz-circle draganddropcolor-question"
+                        (click)="navigateToQuestion(i)"
+                        [ngbTooltip]="dragAndDropMappings[question.id]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
+                        [ngClass]="{ 'changed-question': dragAndDropMappings[question.id]?.length }"
+                    >
+                        <b class="fa">DD</b>
+                    </div>
+                    <span
+                        *ngIf="question.type === MULTIPLE_CHOICE"
+                        class="btn btn-light btn-circle stepbutton stepwizardquiz-circle multiplechoicecolor-question"
+                        (click)="navigateToQuestion(i)"
+                        [ngbTooltip]="selectedAnswerOptions[question.id]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
+                        [ngClass]="{ 'changed-question': selectedAnswerOptions[question.id]?.length }"
+                    >
                     <b class="fa">MC</b>
                 </span>
-                <span
-                    *ngIf="question.type === SHORT_ANSWER"
-                    class="btn btn-light btn-circle stepbutton stepwizardquiz-circle shortanswercolor-question"
-                    (click)="navigateToQuestion(i)"
-                    [ngbTooltip]="shortAnswerSubmittedTexts[question.id]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
-                    [ngClass]="{ 'changed-question': shortAnswerSubmittedTexts[question.id]?.length }"
-                >
+                    <span
+                        *ngIf="question.type === SHORT_ANSWER"
+                        class="btn btn-light btn-circle stepbutton stepwizardquiz-circle shortanswercolor-question"
+                        (click)="navigateToQuestion(i)"
+                        [ngbTooltip]="shortAnswerSubmittedTexts[question.id]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
+                        [ngClass]="{ 'changed-question': shortAnswerSubmittedTexts[question.id]?.length }"
+                    >
                     <b class="fa">SA</b>
                 </span>
-                <ng-template #tooltipExplanationTranslate>{{ 'artemisApp.quizExercise.explanationAnswered' | translate }}</ng-template>
-                <ng-template #tooltipNotExplanationTranslate>{{ 'artemisApp.quizExercise.explanationNotAnswered' | translate }}</ng-template>
+                    <ng-template #tooltipExplanationTranslate>{{ 'artemisApp.quizExercise.explanationAnswered' | translate }}</ng-template>
+                    <ng-template #tooltipNotExplanationTranslate>{{ 'artemisApp.quizExercise.explanationNotAnswered' | translate }}</ng-template>
+                </div>
             </div>
         </div>
     </div>
+    <div class="quiz-content container" *ngIf="exercise">
+        <h2>
+            {{ exercise.title }}
+        </h2>
+        <div *ngFor="let question of exercise.quizQuestions; let i = index">
+            <jhi-multiple-choice-question
+                id="question{{ i }}"
+                *ngIf="question.type === MULTIPLE_CHOICE"
+                [question]="question"
+                [(selectedAnswerOptions)]="selectedAnswerOptions[question.id]"
+                [submittedQuizExercise]="exercise"
+                [questionIndex]="i + 1"
+            ></jhi-multiple-choice-question>
+            <jhi-drag-and-drop-question
+                id="question{{ i }}"
+                *ngIf="question.type === DRAG_AND_DROP"
+                [question]="question"
+                [(mappings)]="dragAndDropMappings[question.id]"
+                [questionIndex]="i + 1"
+            ></jhi-drag-and-drop-question>
+            <jhi-short-answer-question
+                id="question{{ i }}"
+                *ngIf="question.type === SHORT_ANSWER"
+                [question]="question"
+                [(submittedTexts)]="shortAnswerSubmittedTexts[question.id]"
+                [questionIndex]="i + 1"
+            ></jhi-short-answer-question>
+        </div>
+    </div>
 </div>
+
+

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.scss
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.scss
@@ -10,7 +10,7 @@
 }
 
 .quiz-navigation {
-    width: 60px;
+    width: 45px;
     height: 100%;
     position: absolute;
     padding: 0 10px;
@@ -107,6 +107,8 @@
     flex-wrap: wrap;
     overflow: hidden;
     position: fixed;
+    height: 90vh;
+    top: 30%;
 
     &__step {
         display: inline-block;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Faulty quiz navigation display.
Remaining time _jumping_ when displaying seconds.
Checkmark icon not being shown causes confusion.

### Description
<!-- Describe your changes in detail -->
Adjusted the quiz navigation bar
Added min-width to remaining time, so it doesn't _jump_ when displaying seconds.
Checkmark icon is displayed when exercises are synced (so when the students navigates to another exercise)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create an exam with multiple quiz questions in one quiz
3. Make sure all are displayed correctly in the view
4. Make sure the _checkmark_ icon is displayed when the exercise is synced
5. Make sure the remaining time doesn't _jump_ when displaying seconds (<10min)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="364" alt="Bildschirmfoto 2020-06-30 um 15 09 36" src="https://user-images.githubusercontent.com/51987021/86132390-19209980-bae7-11ea-9c33-142b94c56b8b.png">
<img width="219" alt="Bildschirmfoto 2020-06-30 um 15 09 45" src="https://user-images.githubusercontent.com/51987021/86132398-1c1b8a00-bae7-11ea-9ac3-302bf3caf54e.png">
<img width="1434" alt="Bildschirmfoto 2020-06-30 um 15 10 26" src="https://user-images.githubusercontent.com/51987021/86132403-1de54d80-bae7-11ea-8ffb-7e7c494d289c.png">
