### PR TITLE
[Exam] Show points next to exercise and show exam title in summary

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
@@ -1,9 +1,11 @@
 <div class="row justify-content-between align-items-start exam-navigation sticky-top pt-2">
     <div class="col-auto d-none d-md-block h3 m-0 text-overflow" *ngIf="exercises && exercises.length > 0">
         {{ 'artemisApp.examParticipation.progress' | translate: { current: exerciseIndex + 1, all: exercises.length } }}
+        <span class="text-muted">[{{ exercises[exerciseIndex].maxScore }} {{ 'artemisApp.examParticipation.points' | translate }}]</span>
     </div>
     <div class="col-auto d-block d-md-none h3 m-0 text-overflow" *ngIf="exercises && exercises.length > 0">
         {{ 'artemisApp.examParticipation.progressSmall' | translate: { current: exerciseIndex + 1, all: exercises.length } }}
+        <span class="text-muted">[{{ exercises[exerciseIndex].maxScore }} {{ 'artemisApp.examParticipation.points' | translate }}]</span>
     </div>
     <div class="col">
         <div class="d-flex justify-content-center">

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
@@ -1,11 +1,9 @@
 <div class="row justify-content-between align-items-start exam-navigation sticky-top pt-2">
     <div class="col-auto d-none d-md-block h3 m-0 text-overflow" *ngIf="exercises && exercises.length > 0">
         {{ 'artemisApp.examParticipation.progress' | translate: { current: exerciseIndex + 1, all: exercises.length } }}
-        <span class="text-muted">[{{ exercises[exerciseIndex].maxScore }} {{ 'artemisApp.examParticipation.points' | translate }}]</span>
     </div>
     <div class="col-auto d-block d-md-none h3 m-0 text-overflow" *ngIf="exercises && exercises.length > 0">
         {{ 'artemisApp.examParticipation.progressSmall' | translate: { current: exerciseIndex + 1, all: exercises.length } }}
-        <span class="text-muted">[{{ exercises[exerciseIndex].maxScore }} {{ 'artemisApp.examParticipation.points' | translate }}]</span>
     </div>
     <div class="col">
         <div class="d-flex justify-content-center">

--- a/src/main/webapp/app/exam/participate/exercises/modeling/modeling-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/modeling/modeling-exam-submission.component.html
@@ -1,6 +1,7 @@
 <jhi-resizeable-container class="col-12" *ngIf="exercise">
     <!--region Left Panel-->
     <span left-header *ngIf="exercise.title">{{ exercise.title }}</span>
+    <span class="text-muted">[{{ exercise.maxScore }} {{ 'artemisApp.examParticipation.points' | translate }}]</span>
     <div left-body class="submission-container d-flex flex-column pl-2 mt-3 w-100">
         <jhi-fullscreen>
             <div class="row flex-grow-1">

--- a/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.html
@@ -1,6 +1,6 @@
 <h4>Online Code Editor</h4>
 <jhi-alert></jhi-alert>
-<jhi-code-editor-grid #grid [exerciseTitle]="exercise?.title">
+<jhi-code-editor-grid #grid [exerciseTitle]="exercise?.title" [exerciseMaxScore]="exercise?.maxScore">
     <div class="d-flex align-items-center ml-auto" editorNavbar>
         <jhi-updating-result
             *ngIf="participation"

--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
@@ -10,6 +10,10 @@
 </div>
 <!-- ngIf Offline IDE clone button start -->
 <div *ngIf="!exercise.allowOnlineEditor && exercise.allowOfflineIde">
+    <div class="mb-1">
+        <span class="editor-statusbar__title">{{ exercise.title }}</span>
+        <span class="text-muted">[{{ exercise.maxScore }} {{ 'artemisApp.examParticipation.points' | translate }}]</span>
+    </div>
     <jhi-exercise-details-student-actions jhiOrionFilter [showInOrionWindow]="false" [exercise]="exercise" [courseId]="courseId" [showResult]="true">
     </jhi-exercise-details-student-actions>
     <div style="display: flex; justify-content: flex-end;">

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
@@ -1,6 +1,7 @@
 <div class="quiz-content container" *ngIf="exercise">
     <h2>
         {{ exercise.title }}
+        <span class="text-muted">[{{ exercise.maxScore }} {{ 'artemisApp.examParticipation.points' | translate }}]</span>
     </h2>
     <div *ngFor="let question of exercise.quizQuestions; let i = index">
         <jhi-multiple-choice-question

--- a/src/main/webapp/app/exam/participate/exercises/text/text-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/text/text-exam-submission.component.html
@@ -2,6 +2,7 @@
 <jhi-resizeable-container class="col-12" *ngIf="exercise">
     <!--region Left Panel-->
     <span left-header *ngIf="exercise.title">{{ exercise.title }}</span>
+    <span class="text-muted">[{{ exercise.maxScore }} {{ 'artemisApp.examParticipation.points' | translate }}]</span>
     <div left-body class="text-editor-grid mt-4 pl-2 pb-2 w-100">
         <div class="grid-area-main">
             <div>

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -1,6 +1,7 @@
 <div>
     <h2>
         <span jhiTranslate="artemisApp.exam.examSummary.summaryCapital">SUMMARY</span>
+        {{ studentExam.exam.title }}
         <button class="btn btn-primary float-right" (click)="printPDF()">
             <fa-icon [icon]="'print'"></fa-icon>
             <span jhiTranslate="artemisApp.exam.examSummary.exportPDF">Export PDF</span>

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -1,7 +1,6 @@
 <div>
     <h2>
-        <span jhiTranslate="artemisApp.exam.examSummary.summaryCapital">SUMMARY</span>
-        {{ studentExam.exam.title }}
+        {{ 'artemisApp.exam.examSummary.yourSubmissionTo' | translate: { examTitle: studentExam.exam.title, studentName: studentExam.user.name } }}
         <button class="btn btn-primary float-right" (click)="printPDF()">
             <fa-icon [icon]="'print'"></fa-icon>
             <span jhiTranslate="artemisApp.exam.examSummary.exportPDF">Export PDF</span>

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/layout/code-editor-grid.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/layout/code-editor-grid.component.html
@@ -3,6 +3,7 @@
     <nav class="editor-statusbar">
         <!-- Exercise title -->
         <span class="editor-statusbar__title">{{ exerciseTitle }}</span>
+        <span class="text-muted" *ngIf="exerciseMaxScore"> [{{ exerciseMaxScore }} {{ 'artemisApp.examParticipation.points' | translate }}] </span>
         <ng-content select="[editorNavbar]"> </ng-content>
     </nav>
 

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/layout/code-editor-grid.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/layout/code-editor-grid.component.html
@@ -3,7 +3,7 @@
     <nav class="editor-statusbar">
         <!-- Exercise title -->
         <span class="editor-statusbar__title">{{ exerciseTitle }}</span>
-        <span class="text-muted" *ngIf="exerciseMaxScore"> [{{ exerciseMaxScore }} {{ 'artemisApp.examParticipation.points' | translate }}] </span>
+        <span class="text-muted" *ngIf="exerciseMaxScore">[{{ exerciseMaxScore }} {{ 'artemisApp.examParticipation.points' | translate }}]</span>
         <ng-content select="[editorNavbar]"> </ng-content>
     </nav>
 

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/layout/code-editor-grid.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/layout/code-editor-grid.component.ts
@@ -21,6 +21,8 @@ export class CodeEditorGridComponent implements AfterViewInit {
 
     @Input()
     exerciseTitle: string;
+    @Input()
+    exerciseMaxScore: number;
 
     interactResizableMain: Interactable;
     resizableMinHeightMain = 480;

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -7,7 +7,7 @@
                 "maxPoints": "max. Punkte: {{points}}"
             },
             "examSummary": {
-                "summaryCapital": "ZUSAMMENFASSUNG",
+                "yourSubmissionTo": "Deine Abgabe für {{examTitle}} ({{studentName}})",
                 "exportPDF": "Als PDF exportieren"
             },
             "title": "Klausur",

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -48,7 +48,8 @@
             "submitProgrammingExercise": "Weiter",
             "submitOtherExercise": "Speichern & Weiter",
             "submitLastExercise": "Speichern",
-            "greeting": "Hallo {{ fullName }}, willkommen zu \"{{ title }}\""
+            "greeting": "Hallo {{ fullName }}, willkommen zu \"{{ title }}\"",
+            "points": "Punkte"
         },
         "exerciseGroup": {
             "created": "Neue Aufgabengruppe erstellt",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -48,7 +48,8 @@
             "submitProgrammingExercise": "Continue",
             "submitOtherExercise": "Save & continue",
             "submitLastExercise": "Save",
-            "greeting": "Hello {{ fullName }}, welcome to \"{{ title }}\""
+            "greeting": "Hello {{ fullName }}, welcome to \"{{ title }}\"",
+            "points": "points"
         },
         "exerciseGroup": {
             "created": "New exercise group created",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -7,7 +7,7 @@
                 "maxPoints": "max. Points: {{points}}"
             },
             "examSummary": {
-                "summaryCapital": "SUMMARY",
+                "yourSubmissionTo": "Your submission to {{examTitle}} ({{studentName}})",
                 "exportPDF": "Export PDF"
             },
             "title": "Exam",


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Description
- [x] I've added the points next to the exercise title
- [x] I've added the exam title and the student to the summary page

### Steps for Testing
1. Log in to Artemis
2. Participate in an exam (you can set the endDate of an existing exam to the future)
3. Check that the points for the exercise are shown next to the exercise title (check it for all supported exercise types: programming, modeling, text and quiz exercises)
4. After the exam has finished: Check that the title of the exam and the exam is shown in the summary (and the print version)

### Screenshots
![image](https://user-images.githubusercontent.com/15168372/86169047-500fa300-bb19-11ea-8637-b3bfc2610276.png)
![image](https://user-images.githubusercontent.com/15168372/86165991-61a27c00-bb14-11ea-822c-064d8924ac81.png)