### PR TITLE
exchange drawing mechanism

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-participation.component.html
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.html
@@ -20,7 +20,7 @@
                     (onExerciseChanged)="onExerciseChange($event)"
                 ></jhi-exam-navigation-bar>
                 <ng-container *ngFor="let exercise of studentExam.exercises; let i = index">
-                    <ng-container *ngIf="submissionComponentVisisted[i]">
+                    <ng-container *ngIf="submissionComponentVisited[i]">
                         <ng-container [ngSwitch]="exercise.type">
                             <div [hidden]="i !== activeExerciseIndex">
                                 <jhi-quiz-submission-exam

--- a/src/main/webapp/app/exam/participate/exam-participation.component.html
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.html
@@ -13,35 +13,39 @@
             <!-- exam nav -->
             <!-- exercises -->
             <ng-container *ngIf="activeExercise.studentParticipations && activeExercise.studentParticipations[0]">
-                <ng-container [ngSwitch]="activeExercise.type">
-                    <jhi-exam-navigation-bar
-                        id="exam-navigation-bar"
-                        [exercises]="studentExam.exercises"
-                        [endDate]="exam.endDate"
-                        (onExerciseChanged)="onExerciseChange($event)"
-                    ></jhi-exam-navigation-bar>
-                    <ng-container *ngIf="_reload">
-                        <jhi-quiz-submission-exam
-                            *ngSwitchCase="QUIZ"
-                            [exercise]="activeExercise"
-                            [studentSubmission]="activeExercise.studentParticipations[0].submissions[0]"
-                        ></jhi-quiz-submission-exam>
-                        <jhi-text-editor-exam
-                            *ngSwitchCase="TEXT"
-                            [exercise]="activeExercise"
-                            [studentSubmission]="activeExercise.studentParticipations[0].submissions[0]"
-                        ></jhi-text-editor-exam>
-                        <jhi-modeling-submission-exam
-                            *ngSwitchCase="MODELING"
-                            [exercise]="activeExercise"
-                            [studentSubmission]="activeExercise.studentParticipations[0].submissions[0]"
-                        ></jhi-modeling-submission-exam>
-                        <jhi-programming-submission-exam
-                            *ngSwitchCase="PROGRAMMING"
-                            [exercise]="activeExercise"
-                            [studentParticipation]="activeExercise.studentParticipations[0]"
-                            [courseId]="courseId"
-                        ></jhi-programming-submission-exam>
+                <jhi-exam-navigation-bar
+                    id="exam-navigation-bar"
+                    [exercises]="studentExam.exercises"
+                    [endDate]="exam.endDate"
+                    (onExerciseChanged)="onExerciseChange($event)"
+                ></jhi-exam-navigation-bar>
+                <ng-container *ngFor="let exercise of studentExam.exercises; let i = index">
+                    <ng-container [ngSwitch]="activeExercise.type">
+                        <ng-container *ngIf="submissionComponentVisisted[i]">
+                            <div [class.collapse]="i !== activeExerciseIndex">
+                                <jhi-quiz-submission-exam
+                                    *ngSwitchCase="QUIZ"
+                                    [exercise]="activeExercise"
+                                    [studentSubmission]="activeExercise.studentParticipations[0].submissions[0]"
+                                ></jhi-quiz-submission-exam>
+                                <jhi-text-editor-exam
+                                    *ngSwitchCase="TEXT"
+                                    [exercise]="activeExercise"
+                                    [studentSubmission]="activeExercise.studentParticipations[0].submissions[0]"
+                                ></jhi-text-editor-exam>
+                                <jhi-modeling-submission-exam
+                                    *ngSwitchCase="MODELING"
+                                    [exercise]="activeExercise"
+                                    [studentSubmission]="activeExercise.studentParticipations[0].submissions[0]"
+                                ></jhi-modeling-submission-exam>
+                                <jhi-programming-submission-exam
+                                    *ngSwitchCase="PROGRAMMING"
+                                    [exercise]="activeExercise"
+                                    [studentParticipation]="activeExercise.studentParticipations[0]"
+                                    [courseId]="courseId"
+                                ></jhi-programming-submission-exam>
+                            </div>
+                        </ng-container>
                     </ng-container>
                 </ng-container>
             </ng-container>

--- a/src/main/webapp/app/exam/participate/exam-participation.component.html
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.html
@@ -20,28 +20,28 @@
                     (onExerciseChanged)="onExerciseChange($event)"
                 ></jhi-exam-navigation-bar>
                 <ng-container *ngFor="let exercise of studentExam.exercises; let i = index">
-                    <ng-container [ngSwitch]="activeExercise.type">
-                        <ng-container *ngIf="submissionComponentVisisted[i]">
-                            <div [class.collapse]="i !== activeExerciseIndex">
+                    <ng-container *ngIf="submissionComponentVisisted[i]">
+                        <ng-container [ngSwitch]="exercise.type">
+                            <div [hidden]="i !== activeExerciseIndex">
                                 <jhi-quiz-submission-exam
                                     *ngSwitchCase="QUIZ"
-                                    [exercise]="activeExercise"
-                                    [studentSubmission]="activeExercise.studentParticipations[0].submissions[0]"
+                                    [exercise]="exercise"
+                                    [studentSubmission]="exercise.studentParticipations[0].submissions[0]"
                                 ></jhi-quiz-submission-exam>
                                 <jhi-text-editor-exam
                                     *ngSwitchCase="TEXT"
-                                    [exercise]="activeExercise"
-                                    [studentSubmission]="activeExercise.studentParticipations[0].submissions[0]"
+                                    [exercise]="exercise"
+                                    [studentSubmission]="exercise.studentParticipations[0].submissions[0]"
                                 ></jhi-text-editor-exam>
                                 <jhi-modeling-submission-exam
                                     *ngSwitchCase="MODELING"
-                                    [exercise]="activeExercise"
-                                    [studentSubmission]="activeExercise.studentParticipations[0].submissions[0]"
+                                    [exercise]="exercise"
+                                    [studentSubmission]="exercise.studentParticipations[0].submissions[0]"
                                 ></jhi-modeling-submission-exam>
                                 <jhi-programming-submission-exam
                                     *ngSwitchCase="PROGRAMMING"
-                                    [exercise]="activeExercise"
-                                    [studentParticipation]="activeExercise.studentParticipations[0]"
+                                    [exercise]="exercise"
+                                    [studentParticipation]="exercise.studentParticipations[0]"
                                     [courseId]="courseId"
                                 ></jhi-programming-submission-exam>
                             </div>

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -72,8 +72,6 @@ export class ExamParticipationComponent implements OnInit, OnDestroy {
     autoSaveTimer = 0;
     autoSaveInterval: number;
 
-    _reload = true;
-
     constructor(
         private courseCalculationService: CourseScoreCalculationService,
         private jhiWebsocketService: JhiWebsocketService,
@@ -110,6 +108,10 @@ export class ExamParticipationComponent implements OnInit, OnDestroy {
             return 0;
         }
         return this.studentExam.exercises.findIndex((examExercise) => examExercise.id === this.activeExercise.id);
+    }
+
+    get activeSubmissionComponent(): ExamSubmissionComponent | undefined {
+        return this.currentSubmissionComponents.find((submissionComponent, index) => index === this.activeExerciseIndex);
     }
 
     /**
@@ -155,6 +157,9 @@ export class ExamParticipationComponent implements OnInit, OnDestroy {
                     }
                 });
             });
+            if (this.activeSubmissionComponent) {
+                this.activeSubmissionComponent.onActivate();
+            }
         }
         this.examConfirmed = true;
         this.startAutoSaveTimer();
@@ -231,6 +236,9 @@ export class ExamParticipationComponent implements OnInit, OnDestroy {
         this.triggerSave(false);
         this.activeExercise = exercise;
         this.submissionComponentVisisted[this.activeExerciseIndex] = true;
+        if (this.activeSubmissionComponent) {
+            this.activeSubmissionComponent.onActivate();
+        }
     }
 
     /**
@@ -247,12 +255,8 @@ export class ExamParticipationComponent implements OnInit, OnDestroy {
         // right after the response - in case it was successful - we mark the submission as isSynced = false
         this.autoSaveTimer = 0;
 
-        const activeSubmissionComponent: ExamSubmissionComponent | undefined = this.currentSubmissionComponents.find(
-            (submissionComponent, index) => index === this.activeExerciseIndex,
-        );
-
-        if (activeSubmissionComponent?.hasUnsavedChanges()) {
-            activeSubmissionComponent.updateSubmissionFromView(intervalSave);
+        if (this.activeSubmissionComponent?.hasUnsavedChanges()) {
+            this.activeSubmissionComponent.updateSubmissionFromView(intervalSave);
         }
 
         // goes through all exercises and checks if there are unsynched submissions

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -38,7 +38,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy {
     examId: number;
 
     // determines if component was once drawn visited
-    submissionComponentVisisted: boolean[];
+    submissionComponentVisited: boolean[];
 
     // needed, because studentExam is downloaded only when exam is started
     exam: Exam;
@@ -123,8 +123,8 @@ export class ExamParticipationComponent implements OnInit, OnDestroy {
             this.studentExam = studentExam;
             this.activeExercise = studentExam.exercises[0];
             // initializes array which manages submission component initialization
-            this.submissionComponentVisisted = new Array(studentExam.exercises.length).fill(false);
-            this.submissionComponentVisisted[0] = true;
+            this.submissionComponentVisited = new Array(studentExam.exercises.length).fill(false);
+            this.submissionComponentVisited[0] = true;
             // initialize all submissions as synced
             this.studentExam.exercises.forEach((exercise) => {
                 exercise.studentParticipations.forEach((participation) => {
@@ -235,7 +235,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy {
     onExerciseChange(exercise: Exercise): void {
         this.triggerSave(false);
         this.activeExercise = exercise;
-        this.submissionComponentVisisted[this.activeExerciseIndex] = true;
+        this.submissionComponentVisited[this.activeExerciseIndex] = true;
         if (this.activeSubmissionComponent) {
             this.activeSubmissionComponent.onActivate();
         }

--- a/src/main/webapp/app/exam/participate/exercises/exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/exam-submission.component.ts
@@ -1,4 +1,9 @@
 export abstract class ExamSubmissionComponent {
     abstract hasUnsavedChanges(): boolean;
     abstract updateSubmissionFromView(intervalSave: boolean): void;
+
+    /**
+     * is called when the component becomes active / visible
+     */
+    abstract onActivate(): void;
 }

--- a/src/main/webapp/app/exam/participate/exercises/modeling/modeling-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/modeling/modeling-exam-submission.component.ts
@@ -30,6 +30,8 @@ export class ModelingExamSubmissionComponent extends ExamSubmissionComponent imp
         this.updateViewFromSubmission();
     }
 
+    onActivate(): void {}
+
     updateViewFromSubmission(): void {
         if (this.studentSubmission.model) {
             // Updates the Apollon editor model state (view) with the latest modeling submission

--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, ViewChild } from '@angular/core';
 import { ExamSubmissionComponent } from 'app/exam/participate/exercises/exam-submission.component';
 import { ProgrammingExerciseStudentParticipation } from 'app/entities/participation/programming-exercise-student-participation.model';
 import { ButtonSize, ButtonType } from 'app/shared/components/button.component';
@@ -12,7 +12,7 @@ import { EditorState } from 'app/exercises/programming/shared/code-editor/model/
     providers: [{ provide: ExamSubmissionComponent, useExisting: ProgrammingExamSubmissionComponent }],
     styleUrls: ['./programming-exam-submission.component.scss'],
 })
-export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent implements OnInit {
+export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent {
     // IMPORTANT: this reference must be activeExercise.studentParticipation[0] otherwise the parent component will not be able to react to change
     @Input()
     studentParticipation: ProgrammingExerciseStudentParticipation;
@@ -34,8 +34,6 @@ export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent 
         }
         return this.codeEditorComponent.editorState === EditorState.UNSAVED_CHANGES;
     }
-
-    ngOnInit(): void {}
 
     onActivate(): void {
         if (this.codeEditorComponent) {

--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { ExamSubmissionComponent } from 'app/exam/participate/exercises/exam-submission.component';
 import { ProgrammingExerciseStudentParticipation } from 'app/entities/participation/programming-exercise-student-participation.model';
 import { ButtonSize, ButtonType } from 'app/shared/components/button.component';
@@ -12,7 +12,7 @@ import { EditorState } from 'app/exercises/programming/shared/code-editor/model/
     providers: [{ provide: ExamSubmissionComponent, useExisting: ProgrammingExamSubmissionComponent }],
     styleUrls: ['./programming-exam-submission.component.scss'],
 })
-export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent implements OnInit, OnChanges {
+export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent implements OnInit {
     // IMPORTANT: this reference must be activeExercise.studentParticipation[0] otherwise the parent component will not be able to react to change
     @Input()
     studentParticipation: ProgrammingExerciseStudentParticipation;
@@ -35,14 +35,13 @@ export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent 
         return this.codeEditorComponent.editorState === EditorState.UNSAVED_CHANGES;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    ngOnChanges(changes: SimpleChanges): void {
-        if (this.exercise.allowOnlineEditor) {
-            // show submission answers in UI
+    ngOnInit(): void {}
+
+    onActivate(): void {
+        if (this.codeEditorComponent) {
+            this.codeEditorComponent.ngOnInit();
         }
     }
-
-    ngOnInit(): void {}
 
     updateSubmissionFromView(intervalSave: boolean): void {
         if (this.exercise.allowOnlineEditor) {

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.ts
@@ -59,6 +59,8 @@ export class QuizExamSubmissionComponent extends ExamSubmissionComponent impleme
         this.updateViewFromSubmission();
     }
 
+    onActivate(): void {}
+
     /**
      * Initialize the selections / mappings for each question with an empty array
      */

--- a/src/main/webapp/app/exam/participate/exercises/text/text-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/text/text-exam-submission.component.ts
@@ -41,6 +41,8 @@ export class TextExamSubmissionComponent extends ExamSubmissionComponent impleme
         this.updateViewFromSubmission();
     }
 
+    onActivate(): void {}
+
     updateViewFromSubmission(): void {
         if (this.studentSubmission.text) {
             this.answer = this.studentSubmission.text;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) **locally** and on test server 2

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In the current implementation, the exercise components are recreated when changing the exercise. That causes the components to be reinitialized every time we change the exercise. Now we initialize them only once and hide them if they are not active. This reduces amount of server calls e.g. for programming exercises and makes the current state available (if we switch from programming exercise with opened file test.txt to another exercise and then back the test.txt file is still opened)

### Description
<!-- Describe your changes in detail -->
Hide exercises if they are not displayed anymore, don't destroy them.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create an exam with exercises of type programming exercise, text exercise, quiz exercise 
2. Generate StudentExams
3. Generate Participations
4. Participate in Exam, see if you encounter any weird behavior in regard to synchronization or changing between exercises. Especially check the online editor for programming exercises
