### PR TITLE
[Exam] Disable hints for exam

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseHintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseHintResource.java
@@ -108,8 +108,7 @@ public class ExerciseHintResource {
         if (exercise.hasExerciseGroup()) {
             return forbidden();
         }
-        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise)
-                || !authCheckService.isAtLeastTeachingAssistantForExercise(hintBeforeSaving.get().getExercise())) {
+        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise) || !authCheckService.isAtLeastTeachingAssistantForExercise(hintBeforeSaving.get().getExercise())) {
             return forbidden();
         }
         ExerciseHint result = exerciseHintService.save(exerciseHint);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseHintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseHintResource.java
@@ -14,14 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import de.tum.in.www1.artemis.domain.Course;
-import de.tum.in.www1.artemis.domain.ExerciseHint;
-import de.tum.in.www1.artemis.domain.ProgrammingExercise;
-import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.service.AuthorizationCheckService;
-import de.tum.in.www1.artemis.service.ExerciseHintService;
-import de.tum.in.www1.artemis.service.ProgrammingExerciseService;
-import de.tum.in.www1.artemis.service.UserService;
+import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.service.*;
 import io.github.jhipster.web.util.HeaderUtil;
 
 /**
@@ -46,12 +40,15 @@ public class ExerciseHintResource {
 
     private final UserService userService;
 
+    private final ExerciseService exerciseService;
+
     public ExerciseHintResource(ExerciseHintService exerciseHintService, AuthorizationCheckService authCheckService, ProgrammingExerciseService programmingExerciseService,
-            UserService userService) {
+            UserService userService, ExerciseService exerciseService) {
         this.exerciseHintService = exerciseHintService;
         this.programmingExerciseService = programmingExerciseService;
         this.authCheckService = authCheckService;
         this.userService = userService;
+        this.exerciseService = exerciseService;
     }
 
     /**
@@ -68,7 +65,14 @@ public class ExerciseHintResource {
         if (exerciseHint.getExercise() == null) {
             return badRequest();
         }
-        Course course = exerciseHint.getExercise().getCourseViaExerciseGroupOrCourseMember();
+        // Reload the exercise from the database as we can't trust data from the client
+        Exercise exercise = exerciseService.findOne(exerciseHint.getExercise().getId());
+
+        // Hints for exam exercises are not supported at the moment
+        if (exercise.hasExerciseGroup()) {
+            return forbidden();
+        }
+        Course course = exercise.getCourseViaExerciseGroupOrCourseMember();
         if (!authCheckService.isAtLeastTeachingAssistantInCourse(course, null)) {
             return forbidden();
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseHintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseHintResource.java
@@ -101,7 +101,14 @@ public class ExerciseHintResource {
         if (!hintBeforeSaving.isPresent()) {
             return notFound();
         }
-        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exerciseHint.getExercise())
+        // Reload the exercise from the database as we can't trust data from the client
+        Exercise exercise = exerciseService.findOne(exerciseHint.getExercise().getId());
+
+        // Hints for exam exercises are not supported at the moment
+        if (exercise.hasExerciseGroup()) {
+            return forbidden();
+        }
+        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise)
                 || !authCheckService.isAtLeastTeachingAssistantForExercise(hintBeforeSaving.get().getExercise())) {
             return forbidden();
         }

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -112,6 +112,8 @@ export class ExamParticipationComponent implements OnInit, OnDestroy {
             this.activeExercise = studentExam.exercises[0];
             // initialize all submissions as synced
             this.studentExam.exercises.forEach((exercise) => {
+                // We do not support hints at the moment. Setting an empty array here disables the hint requests
+                exercise.exerciseHints = [];
                 exercise.studentParticipations.forEach((participation) => {
                     if (participation.submissions && participation.submissions.length > 0) {
                         participation.submissions.forEach((submission) => {

--- a/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.html
@@ -18,7 +18,6 @@
             [participation]="participation"
             [btnSize]="ButtonSize.MEDIUM"
         ></jhi-programming-exercise-student-trigger-build-button>
-        <jhi-exercise-hint-student *ngIf="exercise" [exerciseId]="exercise.id" class="mr-2"></jhi-exercise-hint-student>
         <jhi-code-editor-actions
             [disableActions]="repositoryIsLocked"
             [unsavedFiles]="unsavedFiles"

--- a/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.ts
@@ -60,8 +60,5 @@ export class ExamCodeEditorStudentContainerComponent extends CodeEditorContainer
 
         const participation = { ...this.participation, exercise: this.exercise } as StudentParticipation;
         this.domainService.setDomain([DomainType.PARTICIPATION, participation]);
-
-        // Do not load exercise hints for exam mode. Hint requests won't be send
-        this.exercise.exerciseHints = [];
     }
 }

--- a/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import * as moment from 'moment';
 import { TranslateService } from '@ngx-translate/core';
 import { AlertService } from 'app/core/alert/alert.service';
@@ -21,7 +21,7 @@ import { DomainService } from 'app/exercises/programming/shared/code-editor/serv
     selector: 'jhi-exam-code-editor-student',
     templateUrl: './exam-code-editor-student-container.component.html',
 })
-export class ExamCodeEditorStudentContainerComponent extends CodeEditorContainerComponent implements OnInit, OnDestroy {
+export class ExamCodeEditorStudentContainerComponent extends CodeEditorContainerComponent implements OnInit {
     @ViewChild(CodeEditorFileBrowserComponent, { static: false }) fileBrowser: CodeEditorFileBrowserComponent;
     @ViewChild(CodeEditorActionsComponent, { static: false }) actions: CodeEditorActionsComponent;
     @ViewChild(CodeEditorBuildOutputComponent, { static: false }) buildOutput: CodeEditorBuildOutputComponent;
@@ -60,18 +60,8 @@ export class ExamCodeEditorStudentContainerComponent extends CodeEditorContainer
 
         const participation = { ...this.participation, exercise: this.exercise } as StudentParticipation;
         this.domainService.setDomain([DomainType.PARTICIPATION, participation]);
-    }
 
-    /**
-     * If a subscription exists for paramSub, unsubscribe
-     */
-    ngOnDestroy() {}
-
-    /**
-     * Fetches details for the result (if we received one) and attach them to the result.
-     * Mutates the input parameter result.
-    loadResultDetails(result: Result): Observable<Feedback[] | null> {
-        return this.resultService.getFeedbackDetailsForResult(result.id).pipe(map((res) => res && res.body));
+        // Do not load exercise hints for exam mode. Hint requests won't be send
+        this.exercise.exerciseHints = [];
     }
-     */
 }

--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.html
@@ -28,6 +28,7 @@
     <jhi-programming-exercise-instructions
         *ngIf="exercise"
         [exercise]="exercise"
+        [exerciseHints]="exercise.exerciseHints"
         [participation]="studentParticipation"
         [personalParticipation]="true"
     ></jhi-programming-exercise-instructions>

--- a/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-base-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-base-container.component.ts
@@ -21,6 +21,7 @@ import { ProgrammingExerciseStudentParticipation } from 'app/entities/participat
 import { SolutionProgrammingExerciseParticipation } from 'app/entities/participation/solution-programming-exercise-participation.model';
 import { DomainChange, DomainType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
 import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
+import { ExerciseHint } from 'app/entities/exercise-hint.model';
 
 /**
  * Enumeration specifying the repository type
@@ -127,7 +128,10 @@ export abstract class CodeEditorInstructorBaseContainerComponent extends CodeEdi
                     }),
                 )
                 .subscribe(
-                    () => (this.loadingState = LOADING_STATE.CLEAR),
+                    (exerciseHints: ExerciseHint[]) => {
+                        this.exercise.exerciseHints = exerciseHints;
+                        this.loadingState = LOADING_STATE.CLEAR;
+                    },
                     (err) => {
                         this.loadingState = LOADING_STATE.FETCHING_FAILED;
                         this.onError(err);

--- a/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-container.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-container.component.html
@@ -122,7 +122,13 @@
                 [participation]="selectedParticipation"
                 [btnSize]="ButtonSize.MEDIUM"
             ></jhi-programming-exercise-student-trigger-build-button>
-            <jhi-exercise-hint-student *ngIf="exercise && this.selectedRepository === REPOSITORY.ASSIGNMENT" [exerciseId]="exercise.id" class="mr-2"></jhi-exercise-hint-student>
+            <jhi-exercise-hint-student
+                *ngIf="exercise && this.selectedRepository === REPOSITORY.ASSIGNMENT"
+                [exerciseId]="exercise.id"
+                [exerciseHints]="exercise.exerciseHints"
+                class="mr-2"
+            >
+            </jhi-exercise-hint-student>
             <jhi-code-editor-actions
                 [buildable]="selectedRepository !== REPOSITORY.TEST"
                 [unsavedFiles]="unsavedFiles"

--- a/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-container.component.ts
@@ -16,6 +16,7 @@ import { DomainService } from 'app/exercises/programming/shared/code-editor/serv
 import { ProgrammingExerciseParticipationService } from 'app/exercises/programming/manage/services/programming-exercise-participation.service';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
+import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
 
 @Component({
     selector: 'jhi-code-editor-instructor',
@@ -35,6 +36,7 @@ export class CodeEditorInstructorContainerComponent extends CodeEditorInstructor
         courseExerciseService: CourseExerciseService,
         domainService: DomainService,
         programmingExerciseParticipationService: ProgrammingExerciseParticipationService,
+        exerciseHintService: ExerciseHintService,
         participationService: ParticipationService,
         translateService: TranslateService,
         route: ActivatedRoute,
@@ -48,6 +50,7 @@ export class CodeEditorInstructorContainerComponent extends CodeEditorInstructor
             courseExerciseService,
             domainService,
             programmingExerciseParticipationService,
+            exerciseHintService,
             participationService,
             translateService,
             route,

--- a/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-orion-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-orion-container.component.ts
@@ -13,6 +13,7 @@ import { CodeEditorFileService } from 'app/exercises/programming/shared/code-edi
 import { OrionConnectorService } from 'app/shared/orion/orion-connector.service';
 import { OrionBuildAndTestService } from 'app/shared/orion/orion-build-and-test.service';
 import { OrionState } from 'app/shared/orion/orion';
+import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
 
 @Component({
     selector: 'jhi-code-editor-instructor-orion',
@@ -30,6 +31,7 @@ export class CodeEditorInstructorOrionContainerComponent extends CodeEditorInstr
         courseExerciseService: CourseExerciseService,
         domainService: DomainService,
         programmingExerciseParticipationService: ProgrammingExerciseParticipationService,
+        exerciseHintService: ExerciseHintService,
         participationService: ParticipationService,
         translateService: TranslateService,
         route: ActivatedRoute,
@@ -43,6 +45,7 @@ export class CodeEditorInstructorOrionContainerComponent extends CodeEditorInstr
             courseExerciseService,
             domainService,
             programmingExerciseParticipationService,
+            exerciseHintService,
             participationService,
             translateService,
             route,

--- a/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
@@ -34,6 +34,7 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     exerciseValue: ProgrammingExercise;
 
     exerciseTestCases: string[] = [];
+    exerciseHints: ExerciseHint[];
 
     taskCommand = new TaskCommand();
     taskRegex = this.taskCommand.getTagRegex('g');
@@ -67,8 +68,6 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     get participation() {
         return this.participationValue;
     }
-    @Input()
-    exerciseHints: ExerciseHint[];
 
     @Output() participationChange = new EventEmitter<Participation>();
     @Output() hasUnsavedChanges = new EventEmitter<boolean>();
@@ -106,7 +105,8 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     ngOnChanges(changes: SimpleChanges): void {
         if (hasExerciseChanged(changes)) {
             this.setupTestCaseSubscription();
-            if (this.exerciseHints) {
+            if (this.exercise.exerciseHints) {
+                this.exerciseHints = this.exercise.exerciseHints;
                 this.prepareTaskHints();
             } else {
                 if (this.exercise.id) {

--- a/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.ts
@@ -34,7 +34,6 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     exerciseValue: ProgrammingExercise;
 
     exerciseTestCases: string[] = [];
-    exerciseHints: ExerciseHint[];
 
     taskCommand = new TaskCommand();
     taskRegex = this.taskCommand.getTagRegex('g');
@@ -68,6 +67,9 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     get participation() {
         return this.participationValue;
     }
+    @Input()
+    exerciseHints: ExerciseHint[];
+
     @Output() participationChange = new EventEmitter<Participation>();
     @Output() hasUnsavedChanges = new EventEmitter<boolean>();
     @Output() exerciseChange = new EventEmitter<ProgrammingExercise>();
@@ -104,10 +106,14 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
     ngOnChanges(changes: SimpleChanges): void {
         if (hasExerciseChanged(changes)) {
             this.setupTestCaseSubscription();
-            if (this.exercise.id) {
-                this.loadExerciseHints(this.exercise.id);
+            if (this.exerciseHints) {
+                this.prepareTaskHints();
             } else {
-                this.exerciseHints = [];
+                if (this.exercise.id) {
+                    this.loadExerciseHints(this.exercise.id);
+                } else {
+                    this.exerciseHints = [];
+                }
             }
         }
     }
@@ -169,8 +175,15 @@ export class ProgrammingExerciseEditableInstructionComponent implements AfterVie
             .pipe(rxMap(({ body }) => body || []))
             .subscribe((exerciseHints: ExerciseHint[]) => {
                 this.exerciseHints = exerciseHints;
-                this.taskHintCommand.setValues(this.exerciseHints.map(({ id, title }) => ({ id: id.toString(10), value: title })));
+                this.prepareTaskHints();
             });
+    }
+
+    /**
+     * Prepares the task hints using exerciseHints
+     */
+    private prepareTaskHints() {
+        this.taskHintCommand.setValues(this.exerciseHints.map(({ id, title }) => ({ id: id.toString(10), value: title })));
     }
 
     /** Save the problem statement on the server.

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -9,7 +9,7 @@
                 <jhi-external-submission class="mr-1" [exercise]="programmingExercise"></jhi-external-submission>
                 <button
                     type="submit"
-                    *ngIf="programmingExercise.isAtLeastInstructor"
+                    *ngIf="!isExamExercise && programmingExercise.isAtLeastInstructor"
                     [routerLink]="['/course-management', programmingExercise.course?.id, 'exercises', programmingExercise.id, 'hints']"
                     class="btn btn-info btn-sm mr-1"
                 >

--- a/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.html
+++ b/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.html
@@ -32,7 +32,7 @@
             [participation]="participation"
             [btnSize]="ButtonSize.MEDIUM"
         ></jhi-programming-exercise-student-trigger-build-button>
-        <jhi-exercise-hint-student *ngIf="exercise" [exerciseId]="exercise.id" class="mr-2"></jhi-exercise-hint-student>
+        <jhi-exercise-hint-student *ngIf="exercise" [exerciseId]="exercise.id" [exerciseHints]="exercise.exerciseHints" class="mr-2"></jhi-exercise-hint-student>
         <jhi-code-editor-actions
             [disableActions]="repositoryIsLocked"
             [unsavedFiles]="unsavedFiles"

--- a/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { Subscription } from 'rxjs/Subscription';
-import { catchError, flatMap, map, tap } from 'rxjs/operators';
+import { catchError, flatMap, map, switchMap, tap } from 'rxjs/operators';
 import * as moment from 'moment';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
 import { TranslateService } from '@ngx-translate/core';
@@ -27,6 +27,8 @@ import { CodeEditorInstructionsComponent } from 'app/exercises/programming/share
 import { CodeEditorFileBrowserComponent } from 'app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { DomainType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
+import { ExerciseHint } from 'app/entities/exercise-hint.model';
+import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
 
 @Component({
     selector: 'jhi-code-editor-student',
@@ -56,6 +58,7 @@ export class CodeEditorStudentContainerComponent extends CodeEditorContainerComp
         private domainService: DomainService,
         private programmingExerciseParticipationService: ProgrammingExerciseParticipationService,
         private guidedTourService: GuidedTourService,
+        private exerciseHintService: ExerciseHintService,
         participationService: ParticipationService,
         translateService: TranslateService,
         route: ActivatedRoute,
@@ -85,9 +88,13 @@ export class CodeEditorStudentContainerComponent extends CodeEditorContainerComp
                         const dueDateHasPassed = !this.exercise.dueDate || moment(this.exercise.dueDate).isBefore(moment());
                         this.repositoryIsLocked = !!this.exercise.buildAndTestStudentSubmissionsAfterDueDate && !!this.exercise.dueDate && dueDateHasPassed;
                     }),
+                    switchMap(() => {
+                        return this.loadExerciseHints();
+                    }),
                 )
                 .subscribe(
-                    () => {
+                    (exerciseHints: ExerciseHint[]) => {
+                        this.exercise.exerciseHints = exerciseHints;
                         this.loadingParticipation = false;
                         this.guidedTourService.enableTourForExercise(this.exercise, codeEditorTour, true);
                     },
@@ -106,6 +113,16 @@ export class CodeEditorStudentContainerComponent extends CodeEditorContainerComp
         if (this.paramSub) {
             this.paramSub.unsubscribe();
         }
+    }
+
+    /**
+     * Load exercise hints. Take them from the exercise if available.
+     */
+    private loadExerciseHints() {
+        if (!this.exercise.exerciseHints) {
+            return this.exerciseHintService.findByExerciseId(this.exercise.id).pipe(map(({ body }) => body || []));
+        }
+        return of(this.exercise.exerciseHints);
     }
 
     /**

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
@@ -12,6 +12,7 @@
         [exercise]="exercise"
         [participation]="participation"
         [personalParticipation]="true"
+        [exerciseHints]="exerciseHints"
         class="instructions-wrapper__content card-body p-0"
     >
     </jhi-programming-exercise-instructions>
@@ -20,6 +21,7 @@
             [(exercise)]="exercise"
             [(participation)]="participation"
             [templateParticipation]="templateParticipation"
+            [exerciseHints]="exerciseHints"
             [enableResize]="false"
             class="instructions-wrapper__content card-body p-0"
         >

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
@@ -12,7 +12,7 @@
         [exercise]="exercise"
         [participation]="participation"
         [personalParticipation]="true"
-        [exerciseHints]="exerciseHints"
+        [exerciseHints]="exercise.exerciseHints"
         class="instructions-wrapper__content card-body p-0"
     >
     </jhi-programming-exercise-instructions>
@@ -21,7 +21,7 @@
             [(exercise)]="exercise"
             [(participation)]="participation"
             [templateParticipation]="templateParticipation"
-            [exerciseHints]="exerciseHints"
+            [exerciseHints]="exercise.exerciseHints"
             [enableResize]="false"
             class="instructions-wrapper__content card-body p-0"
         >

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
@@ -21,7 +21,6 @@
             [(exercise)]="exercise"
             [(participation)]="participation"
             [templateParticipation]="templateParticipation"
-            [exerciseHints]="exercise.exerciseHints"
             [enableResize]="false"
             class="instructions-wrapper__content card-body p-0"
         >

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.ts
@@ -37,12 +37,7 @@ export class CodeEditorInstructionsComponent implements AfterViewInit, OnDestroy
 
     resizeSubscription: Subscription;
 
-    constructor(
-        private $window: WindowRef,
-        public artemisMarkdown: ArtemisMarkdownService,
-        private codeEditorGridService: CodeEditorGridService,
-        private exerciseHintService: ExerciseHintService,
-    ) {}
+    constructor(private $window: WindowRef, public artemisMarkdown: ArtemisMarkdownService, private codeEditorGridService: CodeEditorGridService) {}
 
     /**
      * After the view was initialized, we create an interact.js resizable object,

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.ts
@@ -1,8 +1,7 @@
-import { OnInit, AfterViewInit, Component, EventEmitter, Input, OnDestroy, Output, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnDestroy, Output, ViewChild } from '@angular/core';
 import { Interactable } from '@interactjs/core/Interactable';
 import interact from 'interactjs';
 import { Subscription } from 'rxjs';
-import { map as rxMap } from 'rxjs/operators';
 import { ArtemisMarkdownService } from 'app/shared/markdown.service';
 import { WindowRef } from 'app/core/websocket/window.service';
 import { Participation } from 'app/entities/participation/participation.model';
@@ -19,7 +18,7 @@ import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/e
     styleUrls: ['./code-editor-instructions.scss'],
     templateUrl: './code-editor-instructions.component.html',
 })
-export class CodeEditorInstructionsComponent implements OnInit, AfterViewInit, OnDestroy {
+export class CodeEditorInstructionsComponent implements AfterViewInit, OnDestroy {
     @ViewChild(ProgrammingExerciseInstructionComponent, { static: false }) readOnlyInstructions: ProgrammingExerciseInstructionComponent;
     @ViewChild(ProgrammingExerciseEditableInstructionComponent, { static: false }) editableInstructions: ProgrammingExerciseEditableInstructionComponent;
 
@@ -29,7 +28,6 @@ export class CodeEditorInstructionsComponent implements OnInit, AfterViewInit, O
     @Input() templateParticipation: Participation;
     @Output()
     onToggleCollapse = new EventEmitter<{ event: any; horizontal: boolean; interactable: Interactable; resizableMinWidth?: number; resizableMinHeight?: number }>();
-    exerciseHints: ExerciseHint[];
 
     /** Resizable constants **/
     initialInstructionsWidth: number;
@@ -45,10 +43,6 @@ export class CodeEditorInstructionsComponent implements OnInit, AfterViewInit, O
         private codeEditorGridService: CodeEditorGridService,
         private exerciseHintService: ExerciseHintService,
     ) {}
-
-    ngOnInit() {
-        this.loadExerciseHints();
-    }
 
     /**
      * After the view was initialized, we create an interact.js resizable object,
@@ -73,24 +67,6 @@ export class CodeEditorInstructionsComponent implements OnInit, AfterViewInit, O
     ngOnDestroy(): void {
         if (this.resizeSubscription) {
             this.resizeSubscription.unsubscribe();
-        }
-    }
-
-    /**
-     * Load exercise hints. Take them from the exercise if possible.
-     */
-    private loadExerciseHints() {
-        if (this.exercise) {
-            if (this.exercise.exerciseHints) {
-                this.exerciseHints = this.exercise.exerciseHints;
-            } else {
-                this.exerciseHintService
-                    .findByExerciseId(this.exercise.id)
-                    .pipe(rxMap(({ body }) => body || []))
-                    .subscribe((exerciseHints: ExerciseHint[]) => {
-                        this.exerciseHints = exerciseHints;
-                    });
-            }
         }
     }
 

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.ts
@@ -10,8 +10,6 @@ import { ProgrammingExerciseInstructionComponent } from 'app/exercises/programmi
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { ProgrammingExerciseEditableInstructionComponent } from 'app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component';
 import { ResizeType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
-import { ExerciseHint } from 'app/entities/exercise-hint.model';
-import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
 
 @Component({
     selector: 'jhi-code-editor-instructions',

--- a/src/main/webapp/app/exercises/shared/exercise-hint/participate/exercise-hint-student-dialog.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/participate/exercise-hint-student-dialog.component.ts
@@ -47,7 +47,7 @@ export class ExerciseHintStudentDialogComponent {
 })
 export class ExerciseHintStudentComponent implements OnInit, OnDestroy {
     @Input() exerciseId: number;
-    exerciseHints: ExerciseHint[] | null;
+    @Input() exerciseHints: ExerciseHint[] | null;
     protected ngbModalRef: NgbModalRef | null;
 
     constructor(protected exerciseHintService: ExerciseHintService, protected activatedRoute: ActivatedRoute, protected router: Router, protected modalService: NgbModal) {}
@@ -56,14 +56,16 @@ export class ExerciseHintStudentComponent implements OnInit, OnDestroy {
      * Fetches all exercise hints for an exercise from the server
      */
     ngOnInit() {
-        this.exerciseHintService
-            .findByExerciseId(this.exerciseId)
-            .pipe(
-                map(({ body }) => body),
-                tap((hints: ExerciseHint[]) => (this.exerciseHints = hints)),
-                catchError(() => of()),
-            )
-            .subscribe();
+        if (!this.exerciseHints) {
+            this.exerciseHintService
+                .findByExerciseId(this.exerciseId)
+                .pipe(
+                    map(({ body }) => body),
+                    tap((hints: ExerciseHint[]) => (this.exerciseHints = hints)),
+                    catchError(() => of()),
+                )
+                .subscribe();
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
Code editor issues multiple requests to fetch hints. Also hints are currently not used so they can be deactivated for exam exercises.

### Description

- [x] Disable creation of hints for exam exercises on server side
- [x] Disable attaching hints to exam exercises in the PUT request
- [x] Hide the "Manage Hints" button in the programming exercise details page for exam exercises
- [x] Refactor code editor to issue only one request for hints
- [x] Disable fetching of hints for exam mode code editor

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

_Button disabled_
1. Create an exam programming exercise
2. Navigate to the details page of this exercise
--> Manage hints button should not be displayed

_Hints load once for normal programming exercises_
1. Create a normal programming exercise with code editor enabled
2. Create hints for it
3. Open the online code editor and open the network dev tool
--> Hints should be loaded correctly but only once

_Hints are not fetched for exam exercises_
1. Create a exam programming exercise with code editor enabled
2. Participate in the exam and open the network dev tool
--> No hint request should be issued