### PR TITLE
Exam Summary: White Space in Text Submissions

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/exercises/text-exam-summary/text-exam-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exercises/text-exam-summary/text-exam-summary.component.html
@@ -1,1 +1,0 @@
-<div class="editor-outline-background">{{ submission.text }}</div>

--- a/src/main/webapp/app/exam/participate/summary/exercises/text-exam-summary/text-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/text-exam-summary/text-exam-summary.component.ts
@@ -3,12 +3,17 @@ import { TextSubmission } from 'app/entities/text-submission.model';
 
 @Component({
     selector: 'jhi-text-exam-summary',
-    templateUrl: './text-exam-summary.component.html',
-    styles: [],
+    template: '{{ submission.text }}',
+    styles: [
+        `
+            :host {
+                white-space: pre-wrap;
+                display: block;
+                background-color: #f8f9fa;
+            }
+        `,
+    ],
 })
 export class TextExamSummaryComponent {
-    @Input()
-    submission: TextSubmission;
-
-    constructor() {}
+    @Input() submission: TextSubmission;
 }


### PR DESCRIPTION
### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
White Space in text submissions is not displayed in HTML (see e.g. #1744), but important for some exercises (see #1720).
White space is not properly displayed on the exam summary page.

### Description
Add needed css `white-space: pre-wrap;` to overwrite default HTML behavior.
Also, clean up HTML a bit by removing unneeded tags.

### Steps for Testing
1. Participate in Exam with Text Exercise
2. Indent lines with spaces (see example in #1720) 
3. Find properly indented submission in summary.

### Screenshots
<img width="1761" alt="image" src="https://user-images.githubusercontent.com/6382716/86258932-ad5c3080-bbbb-11ea-8f89-71a2d6451d61.png">
