### PR TITLE
Add exercise release and due date to exam exercise groups overview

### DIFF
--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -117,6 +117,12 @@
                         <th>
                             <span>{{ 'artemisApp.examManagement.exerciseGroup.maxPoints' | translate }}</span>
                         </th>
+                        <th>
+                            <span>{{ 'artemisApp.exercise.releaseDate' | translate }}</span>
+                        </th>
+                        <th>
+                            <span>{{ 'artemisApp.exercise.dueDate' | translate }}</span>
+                        </th>
                         <th></th>
                     </tr>
                 </thead>
@@ -133,6 +139,12 @@
                         </td>
                         <td class="align-middle">
                             {{ exercise.maxScore }}
+                        </td>
+                        <td class="align-middle">
+                            {{ exercise.releaseDate | artemisDate }}
+                        </td>
+                        <td class="align-middle">
+                            {{ exercise.dueDate | artemisDate }}
                         </td>
                         <td class="d-flex justify-content-end">
                             <jhi-exercise-row-buttons


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://vmbruegge60.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English _(reused translations)_

### Motivation and Context
Show the exercise release and due dates in the "Exercise Groups" view so instructors can directly see the dates of each exercise in the overview to make sure everything is properly configured.

### Description
Add two columns for the release and due date.

### Steps for Testing
_You need a course with at least one exam._
- Create exercise groups in the exam
- Create different exercises in the different groups, some with release/due date set and some not.
- See if the exercise release and due dates are properly displayed for each exercise. _(In DE and EN)_

### Screenshots
![image](https://user-images.githubusercontent.com/11130248/86482137-a1a27280-bd51-11ea-93ae-1b19b6e0fa8d.png)

