### PR TITLE
Detect changes of the quiz randomize question order option

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -531,7 +531,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
         if (!this.quizExercise || !this.savedEntity) {
             return false;
         }
-        const keysToCompare = ['title', 'difficulty', 'duration', 'isPlannedToStart', 'isVisibleBeforeStart', 'isOpenForPractice'];
+        const keysToCompare = ['title', 'difficulty', 'duration', 'isPlannedToStart', 'isVisibleBeforeStart', 'isOpenForPractice', 'randomizeQuestionOrder'];
 
         // Unsaved changes if any of the stated object key values are not equal or the questions/release dates differ
         return (


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
The "Present Questions in Random Order" option is not used for calculating pending changes currently. This PR fixes the issue and resolves #1801.

### Description
Add the `randomizeQuestionOrder` attribute to the key list that is used for calculating `pendingChanges`.

### Steps for Testing
_A course needs to be created, possibly with an exam._
1. Create a quiz and save it.
2. Change only "Present Questions in Random Order"
3. You should be able to save.
4. Save and reload and check that the change was applied and saved.
5. Maybe also try this using the exam management view / course management view.

### Screenshots
![prQuizRandSave](https://user-images.githubusercontent.com/11130248/86487656-f698b580-bd5e-11ea-9c6d-11cdabe0759a.gif)

