### PR TITLE
IP Logging for Exam Sessions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,7 @@ dependencies {
 
     implementation "org.zalando:problem-spring-web:0.25.2"
     implementation "com.ibm.icu:icu4j:67.1"
+    implementation 'com.github.seancfoley:ipaddress:5.3.1'
 
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstruct_version}"
     annotationProcessor "org.hibernate:hibernate-jpamodelgen:${hibernate_version}"

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/ExamSession.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/ExamSession.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import javax.persistence.*;
 
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
@@ -37,6 +39,9 @@ public class ExamSession extends AbstractAuditingEntity implements Serializable 
 
     @Column(name = "instance_id")
     private String instanceId;
+
+    @Column(name = "ip_address")
+    private String ipAddress;
 
     public ExamSession() {
     }
@@ -89,10 +94,20 @@ public class ExamSession extends AbstractAuditingEntity implements Serializable 
         this.instanceId = instanceId;
     }
 
+    public IPAddress getIpAddress() {
+        return ipAddress != null ? new IPAddressString(ipAddress).getAddress() : null;
+    }
+
+    public void setIpAddress(IPAddress ipAddress) {
+        this.ipAddress = ipAddress != null ? ipAddress.toCanonicalString() : null;
+
+    }
+
     public void hideDetails() {
         setUserAgent(null);
         setBrowserFingerprintHash(null);
         setInstanceId(null);
+        setIpAddress(null);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/ExamSession.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/ExamSession.java
@@ -5,13 +5,14 @@ import java.util.Objects;
 
 import javax.persistence.*;
 
-import inet.ipaddr.IPAddress;
-import inet.ipaddr.IPAddressString;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import de.tum.in.www1.artemis.domain.AbstractAuditingEntity;
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
 
 @Entity
 @Table(name = "exam_session")

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamSessionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamSessionService.java
@@ -5,7 +5,6 @@ import java.util.Base64;
 
 import javax.annotation.Nullable;
 
-import inet.ipaddr.IPAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -13,6 +12,7 @@ import org.springframework.stereotype.Service;
 import de.tum.in.www1.artemis.domain.exam.ExamSession;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 import de.tum.in.www1.artemis.repository.ExamSessionRepository;
+import inet.ipaddr.IPAddress;
 
 /**
  * Service Implementation for managing ExamSession.
@@ -35,9 +35,11 @@ public class ExamSessionService {
      * @param fingerprint the browser fingerprint reported by the client, can be null
      * @param userAgent the user agent of the client, can be null
      * @param instanceId the instance id of the client, can be null
+     * @param ipAddress the ip addedd of the client, can be null
      * @return the newly create exam session
      */
-    public ExamSession startExamSession(StudentExam studentExam, @Nullable String fingerprint, @Nullable String userAgent, @Nullable String instanceId, @Nullable IPAddress ipAddress) {
+    public ExamSession startExamSession(StudentExam studentExam, @Nullable String fingerprint, @Nullable String userAgent, @Nullable String instanceId,
+            @Nullable IPAddress ipAddress) {
         String sessionToken = generateSafeToken();
         ExamSession examSession = new ExamSession();
         examSession.setSessionToken(sessionToken);

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamSessionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamSessionService.java
@@ -5,6 +5,7 @@ import java.util.Base64;
 
 import javax.annotation.Nullable;
 
+import inet.ipaddr.IPAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -36,7 +37,7 @@ public class ExamSessionService {
      * @param instanceId the instance id of the client, can be null
      * @return the newly create exam session
      */
-    public ExamSession startExamSession(StudentExam studentExam, @Nullable String fingerprint, @Nullable String userAgent, @Nullable String instanceId) {
+    public ExamSession startExamSession(StudentExam studentExam, @Nullable String fingerprint, @Nullable String userAgent, @Nullable String instanceId, @Nullable IPAddress ipAddress) {
         String sessionToken = generateSafeToken();
         ExamSession examSession = new ExamSession();
         examSession.setSessionToken(sessionToken);
@@ -44,6 +45,7 @@ public class ExamSessionService {
         examSession.setBrowserFingerprintHash(fingerprint);
         examSession.setUserAgent(userAgent);
         examSession.setInstanceId(instanceId);
+        examSession.setIpAddress(ipAddress);
         examSession = examSessionRepository.save(examSession);
         return examSession;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/util/HttpRequestUtils.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/util/HttpRequestUtils.java
@@ -1,26 +1,18 @@
 package de.tum.in.www1.artemis.service.util;
 
-import inet.ipaddr.IPAddress;
-import inet.ipaddr.IPAddressString;
-import org.jetbrains.annotations.NotNull;
-
-import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.jetbrains.annotations.NotNull;
+
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
+
 public class HttpRequestUtils {
-    private static final String[] IP_HEADER_CANDIDATES = {
-        "X-Forwarded-For",
-        "Proxy-Client-IP",
-        "WL-Proxy-Client-IP",
-        "HTTP_X_FORWARDED_FOR",
-        "HTTP_X_FORWARDED",
-        "HTTP_X_CLUSTER_CLIENT_IP",
-        "HTTP_CLIENT_IP",
-        "HTTP_FORWARDED_FOR",
-        "HTTP_FORWARDED",
-        "HTTP_VIA",
-        "REMOTE_ADDR"
-    };
+
+    private static final String[] IP_HEADER_CANDIDATES = { "X-Forwarded-For", "Proxy-Client-IP", "WL-Proxy-Client-IP", "HTTP_X_FORWARDED_FOR", "HTTP_X_FORWARDED",
+            "HTTP_X_CLUSTER_CLIENT_IP", "HTTP_CLIENT_IP", "HTTP_FORWARDED_FOR", "HTTP_FORWARDED", "HTTP_VIA", "REMOTE_ADDR" };
 
     /**
      * Extract Client IP Address from Http Request as String

--- a/src/main/java/de/tum/in/www1/artemis/service/util/HttpRequestUtils.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/util/HttpRequestUtils.java
@@ -1,0 +1,53 @@
+package de.tum.in.www1.artemis.service.util;
+
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
+import org.jetbrains.annotations.NotNull;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+public class HttpRequestUtils {
+    private static final String[] IP_HEADER_CANDIDATES = {
+        "X-Forwarded-For",
+        "Proxy-Client-IP",
+        "WL-Proxy-Client-IP",
+        "HTTP_X_FORWARDED_FOR",
+        "HTTP_X_FORWARDED",
+        "HTTP_X_CLUSTER_CLIENT_IP",
+        "HTTP_CLIENT_IP",
+        "HTTP_FORWARDED_FOR",
+        "HTTP_FORWARDED",
+        "HTTP_VIA",
+        "REMOTE_ADDR"
+    };
+
+    /**
+     * Extract Client IP Address from Http Request as String
+     *
+     * @param request Http Request
+     * @return String representation of IP Address
+     */
+    private static String getIpStringFromRequest(@NotNull HttpServletRequest request) {
+        for (String header : IP_HEADER_CANDIDATES) {
+            String ipList = request.getHeader(header);
+            if (ipList != null && ipList.length() != 0 && !"unknown".equalsIgnoreCase(ipList)) {
+                return ipList.split(",")[0];
+            }
+        }
+
+        return request.getRemoteAddr();
+    }
+
+    /**
+     * Extract Client IP Address from Http Request as IPAddress Object
+     *
+     * @param request Http Request
+     * @return IPAddress Object
+     */
+    public static Optional<IPAddress> getIpAddressFromRequest(@NotNull HttpServletRequest request) {
+        final String ipString = getIpStringFromRequest(request);
+        final IPAddress ipAddress = new IPAddressString(ipString).getAddress();
+        return Optional.ofNullable(ipAddress);
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -124,6 +125,7 @@ public class StudentExamResource {
      *
      * @param courseId  the course to which the student exam belongs to
      * @param examId    the exam to which the student exam belongs to
+     * @param request   the http request, used to extract headers
      * @return the ResponseEntity with status 200 (OK) and with the found student exam as body
      */
     @GetMapping("/courses/{courseId}/exams/{examId}/studentExams/conduction")

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,7 @@ import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.quiz.*;
 import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.service.util.HttpRequestUtils;
 
 /**
  * REST controller for managing ExerciseGroup.
@@ -122,16 +124,11 @@ public class StudentExamResource {
      *
      * @param courseId  the course to which the student exam belongs to
      * @param examId    the exam to which the student exam belongs to
-     * @param browserFingerprint the browser fingerprint reported by the client, can be null
-     * @param userAgent the user agent of the client, can be null
-     * @param instanceId the instance of the client
      * @return the ResponseEntity with status 200 (OK) and with the found student exam as body
      */
     @GetMapping("/courses/{courseId}/exams/{examId}/studentExams/conduction")
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<StudentExam> getStudentExamForConduction(@PathVariable Long courseId, @PathVariable Long examId,
-            @RequestHeader(name = "X-Artemis-Client-Fingerprint", required = false) String browserFingerprint,
-            @RequestHeader(name = "User-Agent", required = false) String userAgent, @RequestHeader(name = "X-Artemis-Client-Instance-ID", required = false) String instanceId) {
+    public ResponseEntity<StudentExam> getStudentExamForConduction(@PathVariable Long courseId, @PathVariable Long examId, HttpServletRequest request) {
         long start = System.currentTimeMillis();
         User currentUser = userService.getUserWithGroupsAndAuthorities();
         log.debug("REST request to get the student exam of user {} for exam {}", currentUser.getLogin(), examId);
@@ -178,7 +175,11 @@ public class StudentExamResource {
             }
         }
 
-        ExamSession examSession = this.examSessionService.startExamSession(studentExam, browserFingerprint, userAgent, instanceId);
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).orElse(null);
+        final String browserFingerprint = request.getHeader("X-Artemis-Client-Fingerprint");
+        final String userAgent = request.getHeader("User-Agent");
+        final String instanceId = request.getHeader("X-Artemis-Client-Instance-ID");
+        ExamSession examSession = this.examSessionService.startExamSession(studentExam, browserFingerprint, userAgent, instanceId, ipAddress);
         examSession.hideDetails();
         studentExam.setExamSessions(Set.of(examSession));
 

--- a/src/main/resources/config/liquibase/changelog/20200703164147_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20200703164147_changelog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+    <changeSet author="jpbernius" id="1593787340249-30">
+        <addColumn tableName="exam_session">
+            <column name="ip_address" type="varchar(48)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -70,4 +70,5 @@
     <include file="classpath:config/liquibase/changelog/20200626022200_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20200629152810_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20200629162710_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20200703164147_changelog.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/test/java/de/tum/in/www1/artemis/ExamSessionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamSessionIntegrationTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import inet.ipaddr.IPAddress;
-import inet.ipaddr.IPAddressString;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +19,7 @@ import de.tum.in.www1.artemis.repository.StudentExamRepository;
 import de.tum.in.www1.artemis.service.ExamSessionService;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
 import de.tum.in.www1.artemis.util.RequestUtilService;
+import inet.ipaddr.IPAddressString;
 
 public class ExamSessionIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
@@ -86,9 +85,8 @@ public class ExamSessionIntegrationTest extends AbstractSpringIntegrationBambooB
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void storeUserAgentOnStartExamSession_asStudent() {
-        final Long id = examSessionService
-                .startExamSession(studentExam1, null, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15", null, null)
-                .getId();
+        final Long id = examSessionService.startExamSession(studentExam1, null,
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15", null, null).getId();
 
         final var examSessionById = examSessionRepository.findById(id);
         assertThat(examSessionById).isPresent();
@@ -100,28 +98,22 @@ public class ExamSessionIntegrationTest extends AbstractSpringIntegrationBambooB
     @WithMockUser(username = "student1", roles = "USER")
     public void storeIPv4OnStartExamSession_asStudent() {
         final var ipAddress = new IPAddressString("192.0.2.235").getAddress();
-        final Long id = examSessionService
-            .startExamSession(studentExam1, null, null, null, ipAddress)
-            .getId();
+        final Long id = examSessionService.startExamSession(studentExam1, null, null, null, ipAddress).getId();
 
         final var examSessionById = examSessionRepository.findById(id);
         assertThat(examSessionById).isPresent();
-        assertThat(examSessionById.get().getIpAddress().toCanonicalString())
-            .isEqualTo("192.0.2.235");
+        assertThat(examSessionById.get().getIpAddress().toCanonicalString()).isEqualTo("192.0.2.235");
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void storeIPv6OnStartExamSession_asStudent() {
         final var ipAddress = new IPAddressString("2001:db8:0:0:0:8a2e:370:7334").getAddress();
-        final Long id = examSessionService
-            .startExamSession(studentExam1, null, null, null, ipAddress)
-            .getId();
+        final Long id = examSessionService.startExamSession(studentExam1, null, null, null, ipAddress).getId();
 
         final var examSessionById = examSessionRepository.findById(id);
         assertThat(examSessionById).isPresent();
-        assertThat(examSessionById.get().getIpAddress().toCanonicalString())
-            .isEqualTo("2001:db8::8a2e:370:7334");
+        assertThat(examSessionById.get().getIpAddress().toCanonicalString()).isEqualTo("2001:db8::8a2e:370:7334");
     }
 
 }

--- a/src/test/java/de/tum/in/www1/artemis/ExamSessionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamSessionIntegrationTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,9 +65,9 @@ public class ExamSessionIntegrationTest extends AbstractSpringIntegrationBambooB
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void testStartExamSession_asStudent() {
-        String newSessionToken = examSessionService.startExamSession(studentExam1, "", "", "").getSessionToken();
-        String newerSessionToken = examSessionService.startExamSession(studentExam1, "", "", "").getSessionToken();
-        String currentSessionToken = examSessionService.startExamSession(studentExam1, "", "", "").getSessionToken();
+        String newSessionToken = examSessionService.startExamSession(studentExam1, null, null, null, null).getSessionToken();
+        String newerSessionToken = examSessionService.startExamSession(studentExam1, null, null, null, null).getSessionToken();
+        String currentSessionToken = examSessionService.startExamSession(studentExam1, null, null, null, null).getSessionToken();
 
         assertThat(currentSessionToken).isNotEqualTo(newSessionToken);
         assertThat(currentSessionToken).isNotEqualTo(newerSessionToken);
@@ -74,7 +76,7 @@ public class ExamSessionIntegrationTest extends AbstractSpringIntegrationBambooB
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void storeFingerprintOnStartExamSession_asStudent() {
-        final Long id = examSessionService.startExamSession(studentExam1, "5b2cc274f6eaf3a71647e1f85358ce32", "", "").getId();
+        final Long id = examSessionService.startExamSession(studentExam1, "5b2cc274f6eaf3a71647e1f85358ce32", null, null, null).getId();
 
         final var examSessionById = examSessionRepository.findById(id);
         assertThat(examSessionById).isPresent();
@@ -85,13 +87,41 @@ public class ExamSessionIntegrationTest extends AbstractSpringIntegrationBambooB
     @WithMockUser(username = "student1", roles = "USER")
     public void storeUserAgentOnStartExamSession_asStudent() {
         final Long id = examSessionService
-                .startExamSession(studentExam1, "", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15", "")
+                .startExamSession(studentExam1, null, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15", null, null)
                 .getId();
 
         final var examSessionById = examSessionRepository.findById(id);
         assertThat(examSessionById).isPresent();
         assertThat(examSessionById.get().getUserAgent())
                 .isEqualTo("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15");
+    }
+
+    @Test
+    @WithMockUser(username = "student1", roles = "USER")
+    public void storeIPv4OnStartExamSession_asStudent() {
+        final var ipAddress = new IPAddressString("192.0.2.235").getAddress();
+        final Long id = examSessionService
+            .startExamSession(studentExam1, null, null, null, ipAddress)
+            .getId();
+
+        final var examSessionById = examSessionRepository.findById(id);
+        assertThat(examSessionById).isPresent();
+        assertThat(examSessionById.get().getIpAddress().toCanonicalString())
+            .isEqualTo("192.0.2.235");
+    }
+
+    @Test
+    @WithMockUser(username = "student1", roles = "USER")
+    public void storeIPv6OnStartExamSession_asStudent() {
+        final var ipAddress = new IPAddressString("2001:db8:0:0:0:8a2e:370:7334").getAddress();
+        final Long id = examSessionService
+            .startExamSession(studentExam1, null, null, null, ipAddress)
+            .getId();
+
+        final var examSessionById = examSessionRepository.findById(id);
+        assertThat(examSessionById).isPresent();
+        assertThat(examSessionById.get().getIpAddress().toCanonicalString())
+            .isEqualTo("2001:db8::8a2e:370:7334");
     }
 
 }

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
-import inet.ipaddr.IPAddressString;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -143,7 +142,7 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
             final HttpHeaders headers = new HttpHeaders();
             headers.set("User-Agent", "foo");
             headers.set("X-Artemis-Client-Fingerprint", "bar");
-            headers.set("X-Forwarded-For", "10.0."+studentExam.getId()+".1");
+            headers.set("X-Forwarded-For", "10.0." + studentExam.getId() + ".1");
             var response = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/studentExams/conduction", HttpStatus.OK, StudentExam.class, headers);
             assertThat(response).isEqualTo(studentExam);
             assertThat(response.getExercises().size()).isEqualTo(2);
@@ -196,7 +195,7 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
             assertThat(examSession.getIpAddress()).isNull();
             assertThat(optionalExamSession.get().getUserAgent()).isEqualTo("foo");
             assertThat(optionalExamSession.get().getBrowserFingerprintHash()).isEqualTo("bar");
-            assertThat(optionalExamSession.get().getIpAddress().toNormalizedString()).isEqualTo("10.0."+studentExam.getId()+".1");
+            assertThat(optionalExamSession.get().getIpAddress().toNormalizedString()).isEqualTo("10.0." + studentExam.getId() + ".1");
 
             // TODO: add other exercises, programming, modeling and file upload
 

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
+import inet.ipaddr.IPAddressString;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -142,6 +143,7 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
             final HttpHeaders headers = new HttpHeaders();
             headers.set("User-Agent", "foo");
             headers.set("X-Artemis-Client-Fingerprint", "bar");
+            headers.set("X-Forwarded-For", "10.0."+studentExam.getId()+".1");
             var response = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/studentExams/conduction", HttpStatus.OK, StudentExam.class, headers);
             assertThat(response).isEqualTo(studentExam);
             assertThat(response.getExercises().size()).isEqualTo(2);
@@ -191,8 +193,10 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
             assertThat(examSession.getSessionToken()).isNotNull();
             assertThat(examSession.getUserAgent()).isNull();
             assertThat(examSession.getBrowserFingerprintHash()).isNull();
+            assertThat(examSession.getIpAddress()).isNull();
             assertThat(optionalExamSession.get().getUserAgent()).isEqualTo("foo");
             assertThat(optionalExamSession.get().getBrowserFingerprintHash()).isEqualTo("bar");
+            assertThat(optionalExamSession.get().getIpAddress().toNormalizedString()).isEqualTo("10.0."+studentExam.getId()+".1");
 
             // TODO: add other exercises, programming, modeling and file upload
 

--- a/src/test/java/de/tum/in/www1/artemis/service/HttpRequestUtilsTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/HttpRequestUtilsTest.java
@@ -1,0 +1,89 @@
+package de.tum.in.www1.artemis.service;
+
+import de.tum.in.www1.artemis.service.util.HttpRequestUtils;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class HttpRequestUtilsTest {
+
+    @Test public void testIPv4String() {
+        HttpServletRequest request = httpRequestMockWithIp("192.0.2.235");
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
+
+        assertThat(ipAddress.toFullString(), is(equalTo("192.000.002.235")));
+    }
+
+    @Test void testIPv6String() {
+        HttpServletRequest request = httpRequestMockWithIp("2001:db8:0:0:0:8a2e:370:7334");
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
+
+        assertThat(ipAddress.toFullString(), is(equalTo("2001:0db8:0000:0000:0000:8a2e:0370:7334")));
+    }
+
+    @Test void testIPv6ShortString() {
+        HttpServletRequest request = httpRequestMockWithIp("2001:db8::8a2e:370:7334");
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
+
+        assertThat(ipAddress.isIPv6(), is(true));
+        assertThat(ipAddress.toFullString(), is(equalTo("2001:0db8:0000:0000:0000:8a2e:0370:7334")));
+    }
+
+    @Test void testIPv4Lopback() {
+        HttpServletRequest request = httpRequestMockWithIp("127.0.0.1");
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
+
+        assertThat(ipAddress.isIPv4(), is(true));
+        assertThat(ipAddress.toFullString(), is(equalTo("127.000.000.001")));
+    }
+
+    @Test void testIPv6Loopback() {
+        HttpServletRequest request = httpRequestMockWithIp("0:0:0:0:0:0:0:1");
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
+
+        assertThat(ipAddress.isIPv6(), is(true));
+        assertThat(ipAddress.toFullString(), is(equalTo("0000:0000:0000:0000:0000:0000:0000:0001")));
+    }
+
+    @Test void testIPv6ShortLoopback() {
+        HttpServletRequest request = httpRequestMockWithIp("::1");
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
+
+        assertThat(ipAddress.isIPv6(), is(true));
+        assertThat(ipAddress.toFullString(), is(equalTo("0000:0000:0000:0000:0000:0000:0000:0001")));
+    }
+
+    @Test() void testInvalidIPv4String() {
+        HttpServletRequest request = httpRequestMockWithIp("192.256.2.235");
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request);
+
+        assertThat(ipAddress.isEmpty(), is(true));
+    }
+
+    @Test void testRandomString() {
+        HttpServletRequest request = httpRequestMockWithIp("foo.example");
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request);
+
+        assertThat(ipAddress.isEmpty(), is(true));
+    }
+
+    @Test void testIpInRemoteAddr() {
+        HttpServletRequest request = httpRequestMockWithIp("REMOTE_ADDR", "224.14.7.42");
+        final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
+
+        assertThat(ipAddress.toFullString(), is(equalTo("224.014.007.042")));
+    }
+
+    private HttpServletRequest httpRequestMockWithIp(String ipAddress) { return httpRequestMockWithIp("X-Forwarded-For", ipAddress); }
+    private HttpServletRequest httpRequestMockWithIp(String headerName, String ipAddress) {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader(anyString())).thenReturn(null);
+        when(request.getHeader(headerName)).thenReturn(ipAddress);
+        return request;
+    }
+
+}

--- a/src/test/java/de/tum/in/www1/artemis/service/HttpRequestUtilsTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/HttpRequestUtilsTest.java
@@ -1,31 +1,35 @@
 package de.tum.in.www1.artemis.service;
 
-import de.tum.in.www1.artemis.service.util.HttpRequestUtils;
-import org.junit.jupiter.api.Test;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import javax.servlet.http.HttpServletRequest;
 
-import static org.mockito.Mockito.*;
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
+import org.junit.jupiter.api.Test;
+
+import de.tum.in.www1.artemis.service.util.HttpRequestUtils;
 
 public class HttpRequestUtilsTest {
 
-    @Test public void testIPv4String() {
+    @Test
+    public void testIPv4String() {
         HttpServletRequest request = httpRequestMockWithIp("192.0.2.235");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
 
         assertThat(ipAddress.toFullString(), is(equalTo("192.000.002.235")));
     }
 
-    @Test void testIPv6String() {
+    @Test
+    void testIPv6String() {
         HttpServletRequest request = httpRequestMockWithIp("2001:db8:0:0:0:8a2e:370:7334");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
 
         assertThat(ipAddress.toFullString(), is(equalTo("2001:0db8:0000:0000:0000:8a2e:0370:7334")));
     }
 
-    @Test void testIPv6ShortString() {
+    @Test
+    void testIPv6ShortString() {
         HttpServletRequest request = httpRequestMockWithIp("2001:db8::8a2e:370:7334");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
 
@@ -33,7 +37,8 @@ public class HttpRequestUtilsTest {
         assertThat(ipAddress.toFullString(), is(equalTo("2001:0db8:0000:0000:0000:8a2e:0370:7334")));
     }
 
-    @Test void testIPv4Lopback() {
+    @Test
+    void testIPv4Lopback() {
         HttpServletRequest request = httpRequestMockWithIp("127.0.0.1");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
 
@@ -41,7 +46,8 @@ public class HttpRequestUtilsTest {
         assertThat(ipAddress.toFullString(), is(equalTo("127.000.000.001")));
     }
 
-    @Test void testIPv6Loopback() {
+    @Test
+    void testIPv6Loopback() {
         HttpServletRequest request = httpRequestMockWithIp("0:0:0:0:0:0:0:1");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
 
@@ -49,7 +55,8 @@ public class HttpRequestUtilsTest {
         assertThat(ipAddress.toFullString(), is(equalTo("0000:0000:0000:0000:0000:0000:0000:0001")));
     }
 
-    @Test void testIPv6ShortLoopback() {
+    @Test
+    void testIPv6ShortLoopback() {
         HttpServletRequest request = httpRequestMockWithIp("::1");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
 
@@ -57,28 +64,34 @@ public class HttpRequestUtilsTest {
         assertThat(ipAddress.toFullString(), is(equalTo("0000:0000:0000:0000:0000:0000:0000:0001")));
     }
 
-    @Test() void testInvalidIPv4String() {
+    @Test()
+    void testInvalidIPv4String() {
         HttpServletRequest request = httpRequestMockWithIp("192.256.2.235");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request);
 
         assertThat(ipAddress.isEmpty(), is(true));
     }
 
-    @Test void testRandomString() {
+    @Test
+    void testRandomString() {
         HttpServletRequest request = httpRequestMockWithIp("foo.example");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request);
 
         assertThat(ipAddress.isEmpty(), is(true));
     }
 
-    @Test void testIpInRemoteAddr() {
+    @Test
+    void testIpInRemoteAddr() {
         HttpServletRequest request = httpRequestMockWithIp("REMOTE_ADDR", "224.14.7.42");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
 
         assertThat(ipAddress.toFullString(), is(equalTo("224.014.007.042")));
     }
 
-    private HttpServletRequest httpRequestMockWithIp(String ipAddress) { return httpRequestMockWithIp("X-Forwarded-For", ipAddress); }
+    private HttpServletRequest httpRequestMockWithIp(String ipAddress) {
+        return httpRequestMockWithIp("X-Forwarded-For", ipAddress);
+    }
+
     private HttpServletRequest httpRequestMockWithIp(String headerName, String ipAddress) {
         final HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getHeader(anyString())).thenReturn(null);


### PR DESCRIPTION
### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Server: I added multiple integration tests (Spring) related to the features
- [X] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [X] Server: I implemented the changes with a good performance and prevented too many database calls
- [X] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
#1566

### Description
When starting an exam session, we persist the User's IP in the Exam Session.

### Steps for Testing

1. Start an Exam Sessions
2. Check your public IP (e.g. [wieistmeineip.de](https://wieistmeineip.de/))
3. Find your IP in the Database (not exposed to the client).
    (Contact me if you need help to check the database!)
