### PR TITLE
Fix non working authentication over LTI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ plugins {
     id "net.ltgt.apt-idea"
     id "net.ltgt.apt"
     //jhipster-needle-gradle-plugins - JHipster will add additional gradle plugins here
-    id "com.diffplug.gradle.spotless" version "4.4.0"
+    id "com.diffplug.gradle.spotless" version "4.5.0"
 }
 
 group = "de.tum.in.www1.artemis"
@@ -189,9 +189,9 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:${fasterxml_version}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${fasterxml_version}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${fasterxml_version}"
-    implementation "com.hazelcast:hazelcast:4.0.1"
+    implementation "com.hazelcast:hazelcast:4.0.2"
     implementation "com.hazelcast:hazelcast-hibernate53:2.0.0"
-    implementation "com.hazelcast:hazelcast-spring:4.0.1"
+    implementation "com.hazelcast:hazelcast-spring:4.0.2"
     implementation "javax.cache:cache-api:1.1.1"
     implementation "org.hibernate:hibernate-core"
     implementation "com.zaxxer:HikariCP:3.4.5"

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -111,10 +111,10 @@ have to configure the file ``application-artemis.yml`` in the folder
            id: artemis_lti
            oauth-key: artemis_lti_key
            oauth-secret: <secret>    # only important for online courses on the edX platform, can typically be ignored
-           user-prefix_edx: edx_
-           user-prefix_u4i: u4i_
-           user-group-name_edx: edx
-           user-group-name_u4i: u4i
+           user-prefix-edx: edx_
+           user-prefix-u4i: u4i_
+           user-group-name-edx: edx
+           user-group-name-u4i: u4i
        git:
            name: Artemis
            email: artemis@in.tum.de
@@ -335,7 +335,7 @@ Other useful commands:
 Text Assessment Clustering Service
 ----------------------------------
 
-The semi-automatic text assessment relies on the Athene_ service.  
+The semi-automatic text assessment relies on the Athene_ service.
 To enable automatic text assessments, special configuration is required:
 
 Enable the ``automaticText`` Spring profile:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sat Jan 25 14:25:36 CET 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -54,11 +54,11 @@ public class BitbucketService extends AbstractVersionControlService {
     @Value("${artemis.version-control.password}")
     private String BITBUCKET_PASSWORD;
 
-    @Value("${artemis.lti.user-prefix-edx}")
-    private String USER_PREFIX_EDX = "edx";
+    @Value("${artemis.lti.user-prefix-edx:#{null}}")
+    private Optional<String> USER_PREFIX_EDX;
 
-    @Value("${artemis.lti.user-prefix-u4i}")
-    private String USER_PREFIX_U4I = "u4i";
+    @Value("${artemis.lti.user-prefix-u4i:#{null}}")
+    private Optional<String> USER_PREFIX_U4I;
 
     @Value("${artemis.git.name}")
     private String ARTEMIS_GIT_NAME;
@@ -77,7 +77,7 @@ public class BitbucketService extends AbstractVersionControlService {
         for (User user : users) {
             String username = user.getLogin();
 
-            if (username.startsWith(USER_PREFIX_EDX) || username.startsWith((USER_PREFIX_U4I))) {
+            if ((USER_PREFIX_EDX.isPresent() && username.startsWith(USER_PREFIX_EDX.get())) || (USER_PREFIX_U4I.isPresent() && username.startsWith((USER_PREFIX_U4I.get())))) {
                 // It is an automatically created user
 
                 if (!userExists(username)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketService.java
@@ -55,10 +55,10 @@ public class BitbucketService extends AbstractVersionControlService {
     private String BITBUCKET_PASSWORD;
 
     @Value("${artemis.lti.user-prefix-edx}")
-    private String USER_PREFIX_EDX = "";
+    private String USER_PREFIX_EDX = "edx";
 
     @Value("${artemis.lti.user-prefix-u4i}")
-    private String USER_PREFIX_U4I = "";
+    private String USER_PREFIX_U4I = "u4i";
 
     @Value("${artemis.git.name}")
     private String ARTEMIS_GIT_NAME;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/LtiService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/LtiService.java
@@ -374,7 +374,7 @@ public class LtiService {
         LtiVerifier ltiVerifier = new LtiOauthVerifier();
         if (this.OAUTH_SECRET.isEmpty()) {
             // this means Artemis does not support this
-            String message = "verifyRequest for LTI is not supported on this Artemis instance, not artemis.lti.oauth-secret was specified in the yml configuration";
+            String message = "verifyRequest for LTI is not supported on this Artemis instance, artemis.lti.oauth-secret was not specified in the yml configuration";
             log.warn(message);
             return message;
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
@@ -49,10 +49,10 @@ public class GitLabService extends AbstractVersionControlService {
     private URL GITLAB_SERVER_URL;
 
     @Value("${artemis.lti.user-prefix-edx}")
-    private String USER_PREFIX_EDX = "";
+    private String USER_PREFIX_EDX = "edx";
 
     @Value("${artemis.lti.user-prefix-u4i}")
-    private String USER_PREFIX_U4I = "";
+    private String USER_PREFIX_U4I = "u4i";
 
     @Value("${artemis.version-control.ci-token}")
     private String CI_TOKEN;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
@@ -48,11 +48,11 @@ public class GitLabService extends AbstractVersionControlService {
     @Value("${artemis.version-control.url}")
     private URL GITLAB_SERVER_URL;
 
-    @Value("${artemis.lti.user-prefix-edx}")
-    private String USER_PREFIX_EDX = "edx";
+    @Value("${artemis.lti.user-prefix-edx:#{null}}")
+    private Optional<String> USER_PREFIX_EDX;
 
-    @Value("${artemis.lti.user-prefix-u4i}")
-    private String USER_PREFIX_U4I = "u4i";
+    @Value("${artemis.lti.user-prefix-u4i:#{null}}")
+    private Optional<String> USER_PREFIX_U4I;
 
     @Value("${artemis.version-control.ci-token}")
     private String CI_TOKEN;
@@ -86,7 +86,7 @@ public class GitLabService extends AbstractVersionControlService {
             String username = user.getLogin();
 
             // Automatically created users
-            if (username.startsWith(USER_PREFIX_EDX) || username.startsWith(USER_PREFIX_U4I)) {
+            if ((USER_PREFIX_EDX.isPresent() && username.startsWith(USER_PREFIX_EDX.get())) || (USER_PREFIX_U4I.isPresent() && username.startsWith((USER_PREFIX_U4I.get())))) {
                 if (!userExists(username)) {
                     gitLabUserManagementService.importUser(user);
                 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LtiResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LtiResource.java
@@ -86,7 +86,7 @@ public class LtiResource {
 
         if (this.LTI_OAUTH_SECRET.isEmpty() || this.LTI_ID.isEmpty() || this.LTI_OAUTH_KEY.isEmpty()) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN,
-                    "LTI not configure on this Artemis server. Cannot launch exercise " + exerciseId + ". " + "Please contact an admin or try again.");
+                    "LTI not configured on this Artemis server. Cannot launch exercise " + exerciseId + ". " + "Please contact an admin or try again.");
         }
 
         if (!request.getRequestURL().toString().startsWith("https")) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/LtiLaunchRequestDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/LtiLaunchRequestDTO.java
@@ -230,7 +230,7 @@ public class LtiLaunchRequestDTO {
 
     @Override
     public String toString() {
-        return "LtiLaunchRequestDTO{" + "lis_person_sourcedid='" + lis_person_sourcedid + '\'' + ", lis_person_contact_email_primary='" + lis_person_contact_email_primary + '\''
+        return "LtiLaunchRequest{" + "lis_person_sourcedid='" + lis_person_sourcedid + '\'' + ", lis_person_contact_email_primary='" + lis_person_contact_email_primary + '\''
                 + ", lis_outcome_service_url='" + lis_outcome_service_url + '\'' + ", lti_message_type='" + lti_message_type + '\'' + ", lti_version='" + lti_version + '\''
                 + ", context_id='" + context_id + '\'' + ", context_label='" + context_label + '\'' + ", oauth_version='" + oauth_version + '\'' + ", oauth_signature_method='"
                 + oauth_signature_method + '\'' + ", oauth_timestamp=" + oauth_timestamp + ", roles='" + roles + '\'' + ", launch_presentation_locale='"

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -59,14 +59,14 @@ artemis:
         # Bamboo: The token value you use for the Server Notification Plugin
         # Jenkins: The token value you use for the Server Notification Plugin and is stored under the notification-token credential above
         artemis-authentication-token-value: <token>
-    lti:
+    lti: # only important for online courses that use LTI, can typically be ignored
         id: artemis_lti
         oauth-key: artemis_lti_key
-        oauth-secret: <secret>    # only important for online courses on the edX platform, can typically be ignored
-        user-prefix_edx: edx_
-        user-prefix_u4i: u4i_
-        user-group-name_edx: edx
-        user-group-name_u4i: u4i
+        oauth-secret: nychpC7yWsXH7aZqLcAdNX
+        user-prefix-edx: edx_
+        user-prefix-u4i: u4i_
+        user-group-name-edx: edx
+        user-group-name-u4i: u4i
     git:
         name: Artemis
         email: artemis@in.tum.de

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -62,7 +62,7 @@ artemis:
     lti: # only important for online courses that use LTI, can typically be ignored
         id: artemis_lti
         oauth-key: artemis_lti_key
-        oauth-secret: nychpC7yWsXH7aZqLcAdNX
+        oauth-secret: <secret>
         user-prefix-edx: edx_
         user-prefix-u4i: u4i_
         user-group-name-edx: edx

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -149,6 +149,7 @@ server:
             cookie:
                 http-only: true
     shutdown: graceful
+    forward-headers-strategy: native
 
 # Properties to be exposed on the /info management endpoint
 info:

--- a/src/test/java/de/tum/in/www1/artemis/LtiIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiIntegrationTest.java
@@ -62,7 +62,7 @@ public class LtiIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
     @BeforeEach
     void init() {
         /* We mock the following methods because we don't have the OAuth secret for edx */
-        doReturn(true).when(ltiService).verifyRequest(any());
+        doReturn(null).when(ltiService).verifyRequest(any());
         doNothing().when(ltiService).handleLaunchRequest(any(), any());
 
         database.addUsers(1, 1, 0);
@@ -108,7 +108,7 @@ public class LtiIntegrationTest extends AbstractSpringIntegrationBambooBitbucket
         doThrow(ArtemisAuthenticationException.class).when(ltiService).handleLaunchRequest(any(), any());
         request.postWithoutLocation("/api/lti/launch/" + programmingExercise.getId(), requestBody, HttpStatus.INTERNAL_SERVER_ERROR, new HttpHeaders());
 
-        doReturn(false).when(ltiService).verifyRequest(any());
+        doReturn("error").when(ltiService).verifyRequest(any());
         request.postWithoutLocation("/api/lti/launch/" + programmingExercise.getId(), requestBody, HttpStatus.UNAUTHORIZED, new HttpHeaders());
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -93,7 +93,7 @@ public class InternalAuthenticationIntegrationTest extends AbstractSpringIntegra
         course = database.addCourseWithOneProgrammingExercise();
         programmingExercise = programmingExerciseRepository.findAllWithEagerParticipations().get(0);
         ltiLaunchRequest = AuthenticationIntegrationTestHelper.setupDefaultLtiLaunchRequest();
-        doReturn(true).when(ltiService).verifyRequest(any());
+        doReturn(null).when(ltiService).verifyRequest(any());
 
         final var userAuthority = new Authority(AuthoritiesConstants.USER);
         final var instructorAuthority = new Authority(AuthoritiesConstants.INSTRUCTOR);

--- a/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegationTest.java
@@ -99,7 +99,7 @@ public class JiraAuthenticationIntegationTest extends AbstractSpringIntegrationB
         course = database.addCourseWithOneProgrammingExercise();
         programmingExercise = programmingExerciseRepository.findAllWithEagerParticipations().get(0);
         ltiLaunchRequest = AuthenticationIntegrationTestHelper.setupDefaultLtiLaunchRequest();
-        doReturn(true).when(ltiService).verifyRequest(any());
+        doReturn(null).when(ltiService).verifyRequest(any());
 
         final var userAuthority = new Authority(AuthoritiesConstants.USER);
         final var instructorAuthority = new Authority(AuthoritiesConstants.INSTRUCTOR);

--- a/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
@@ -63,10 +63,17 @@ public class RequestUtilService {
     }
 
     public URI post(String path, Object body, HttpStatus expectedStatus, MediaType contentType, boolean withLocation) throws Exception {
+        return post(path, body, expectedStatus, contentType, withLocation, null);
+    }
+
+    public URI post(String path, Object body, HttpStatus expectedStatus, MediaType contentType, boolean withLocation, @Nullable HttpHeaders httpHeaders) throws Exception {
         String jsonBody = body != null ? mapper.writeValueAsString(body) : null;
         var requestBuilder = MockMvcRequestBuilders.post(new URI(path)).contentType(contentType);
         if (jsonBody != null) {
             requestBuilder = requestBuilder.content(jsonBody);
+        }
+        if (httpHeaders != null) {
+            requestBuilder = requestBuilder.headers(httpHeaders);
         }
         MvcResult res = mvc.perform(requestBuilder.with(csrf())).andExpect(status().is(expectedStatus.value())).andReturn();
         if (withLocation && !expectedStatus.is2xxSuccessful()) {

--- a/src/test/resources/config/application-artemis.yml
+++ b/src/test/resources/config/application-artemis.yml
@@ -54,14 +54,14 @@ artemis:
         # Bamboo: The token value you use for the Server Notification Plugin
         # Jenkins: The token value you use for the Server Notification Plugin and is stored under the notification-token credential above
         artemis-authentication-token-value: secrettokenvalue
-    lti:
+    lti: # only important for online courses on the edX platform, can typically be ignored
         id: artemis_lti
         oauth-key: artemis_lti_key
-        oauth-secret: <secret>    # only important for online courses on the edX platform, can typically be ignored
-        user-prefix_edx: edx_
-        user-prefix_u4i: u4i_
-        user-group-name_edx: edx
-        user-group-name_u4i: u4i
+        oauth-secret: <secret>
+        user-prefix-edx: edx_
+        user-prefix-u4i: u4i_
+        user-group-name-edx: edx
+        user-group-name-u4i: u4i
     git:
         name: Artemis
         email: artemis@in.tum.de

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -97,6 +97,7 @@ spring:
 server:
     port: 8080
     url: https://artemislocal.ase.in.tum.de
+    forward-headers-strategy: native
 
 management:
     endpoints:


### PR DESCRIPTION
This should fix an issue with the authentication over LTI
We currently assume that the forwarding of the full URL is not working correctly and therefore the request cannot be verified.
It seems that Spring does not check the header value 'X-Forwarded-Proto' set by nginx.

### Motivation and Context
Users of online courses cannot participate in exercises over LTI

### Description
Additionally, I made the whole LTI config optional, so that administrators of other Artemis instances can also deactivate it.

### Steps for Testing
0. Make sure you are logged out on Artemis
1. Create an account on edx (do not use your TUM Email) and register for the software engineering essentials course
2. Participate in one programming exercises (use OOP1 because this is synced with TS1) over LTI
3. You should automatically get a new Artemis account (starting with 'edx_') when you first try this. There should be no issue with unauthorized errors