### PR TITLE
Prevent changing the working time of student exams after the exam is visible

### DIFF
--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
@@ -36,16 +36,16 @@
     </div>
 
     <div class="mb-3">
-        <h5><span jhiTranslate="artemisApp.studentExams.workingTime">Working time</span></h5>
+        <h5><span jhiTranslate="artemisApp.studentExams.workingTime" [ngbTooltip]="getWorkingTimeToolTip()">Working time</span></h5>
         <form class="d-flex" [formGroup]="workingTimeForm" (ngSubmit)="saveWorkingTime()">
-            <div class="mr-2">
+            <div class="mr-2" [ngbTooltip]="getWorkingTimeToolTip()">
                 <input formControlName="minutes" type="number" style="width: 60px; height: 35px;" class="text-center" min="0" step="1" required />
                 :
                 <input formControlName="seconds" type="number" style="width: 60px; height: 35px;" class="text-center" min="0" max="59" step="1" required />
             </div>
-            <button type="submit" class="btn btn-primary" [disabled]="workingTimeForm.invalid || isSavingWorkingTime">
-                <fa-icon [icon]="'save'"></fa-icon>
-                <span jhiTranslate="entity.action.save">Save</span>
+            <button type="submit" class="btn btn-primary" [disabled]="workingTimeForm.invalid || isSavingWorkingTime || examIsVisible()">
+                <fa-icon [icon]="'save'" [ngbTooltip]="getWorkingTimeToolTip()"></fa-icon>
+                <span jhiTranslate="entity.action.save" [ngbTooltip]="getWorkingTimeToolTip()">Save</span>
             </button>
         </form>
     </div>

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
@@ -124,7 +124,7 @@ export class StudentExamDetailComponent implements OnInit {
         if (this.studentExam.exam) {
             return moment(this.studentExam.exam.visibleDate).isBefore(moment());
         }
-        // if the exam is not visible, we rather disable the form
+        // if the exam is not visible to students yet, we disable the form to edit the working time
         return true;
     }
 

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
@@ -122,9 +122,10 @@ export class StudentExamDetailComponent implements OnInit {
 
     examIsVisible(): boolean {
         if (this.studentExam.exam) {
+            // Disable the form to edit the working time if the exam is already visible
             return moment(this.studentExam.exam.visibleDate).isBefore(moment());
         }
-        // if the exam is not visible to students yet, we disable the form to edit the working time
+        // if exam is undefined, the form to edit the working time is disabled
         return true;
     }
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Changing the working time after the exam is visible, leads to issues with lock and unlock programming exercise operations. This can also be confusing during testing

### Description
Instructors can now only change the working time of an individual student before the exam is visible

### Steps for Testing
1. Generate student exams
2. Change the working time of one student **before** the exam is visible --> should work
3. Try to change the working time of one student **after** the exam is visible --> should **not** work
