### PR TITLE
[Exam] bugfix: add check if exam is visible

### DIFF
--- a/src/main/webapp/app/overview/courses.component.ts
+++ b/src/main/webapp/app/overview/courses.component.ts
@@ -85,7 +85,9 @@ export class CoursesComponent implements OnInit, OnDestroy {
                         });
                     }
                 });
-                this.nextRelevantExams = this.exams.filter((exam) => moment(exam.endDate!).isAfter(this.serverDateService.now()));
+                this.nextRelevantExams = this.exams.filter(
+                    (exam) => this.serverDateService.now().isBefore(exam.endDate!) && this.serverDateService.now().isAfter(exam.visibleDate!),
+                );
             },
             (response: string) => this.onError(response),
         );


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Exams where visible in the course overview even though their should not have been visible. 


### Description
<!-- Describe your changes in detail -->
- added check for if now is after `visibleDate`

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create an exam with visible date in the future
4. You **should NOT be able** to see the exam in the course overview page until the visible date has passed
5. The exam with the earliest start date should be displayed (of the visible exams)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="566" alt="image" src="https://user-images.githubusercontent.com/41108487/86589335-cbe07400-bf8d-11ea-841f-5c1e67f98e66.png">

![image](https://user-images.githubusercontent.com/41108487/86589326-c551fc80-bf8d-11ea-8d1d-171c9d710773.png)

![image](https://user-images.githubusercontent.com/41108487/86589375-e286cb00-bf8d-11ea-8e4d-7e55e60e11fd.png)

![image](https://user-images.githubusercontent.com/41108487/86589486-1235d300-bf8e-11ea-8141-88cbd95b0ff4.png)

