### PR TITLE
[Exam][Code-Editor] Minor bugfixes

### DIFF
--- a/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.html
@@ -1,4 +1,3 @@
-<jhi-alert></jhi-alert>
 <jhi-code-editor-grid #grid [exerciseTitle]="exercise?.title" [exerciseMaxScore]="exercise?.maxScore">
     <div class="d-flex align-items-center ml-auto" editorNavbar>
         <jhi-updating-result

--- a/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.ts
@@ -81,4 +81,12 @@ export class ExamCodeEditorStudentContainerComponent extends CodeEditorContainer
         super.onFileChange($event);
         this.participation.submissions[0].isSynced = false;
     }
+
+    /**
+     * When the content of a file changes, set the submission status to unsynchronised.
+     */
+    onFileContentChange($event: { file: string; fileContent: string }) {
+        super.onFileContentChange($event);
+        this.participation.submissions[0].isSynced = false;
+    }
 }

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -108,6 +108,13 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
 
     executeRefresh() {
         this.editorState = EditorState.REFRESHING;
+        setTimeout(() => {
+            if (this.editorState === EditorState.REFRESHING) {
+                this.editorState = EditorState.UNSAVED_CHANGES;
+                const error = new Error('connectionTimeoutRefresh');
+                this.onError.emit(error.message);
+            }
+        }, 8000);
         this.repositoryService.pull().subscribe(() => {
             this.unsavedFiles = {};
             this.editorState = EditorState.CLEAN;
@@ -129,7 +136,7 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
             setTimeout(() => {
                 if (this.editorState === EditorState.SAVING) {
                     this.editorState = EditorState.UNSAVED_CHANGES;
-                    const error = new Error('connectionTimeout');
+                    const error = new Error('connectionTimeoutSave');
                     this.onError.emit(error.message);
                 }
             }, 8000);

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -116,12 +116,7 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
 
     onSave() {
         this.saveChangedFiles()
-            .pipe(
-                catchError((err) => {
-                    this.editorState = EditorState.UNSAVED_CHANGES;
-                    return of(err);
-                }),
-            )
+            .pipe(catchError(() => of()))
             .subscribe();
     }
 

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -126,6 +126,12 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
      */
     saveChangedFiles(): Observable<any> {
         if (!_isEmpty(this.unsavedFiles)) {
+            setTimeout(() => {
+                if (this.editorState === EditorState.SAVING) {
+                    this.editorState = EditorState.UNSAVED_CHANGES;
+                    return throwError('saving failed');
+                }
+            }, 4000);
             this.editorState = EditorState.SAVING;
             const unsavedFiles = Object.entries(this.unsavedFiles).map(([fileName, fileContent]) => ({ fileName, fileContent }));
             return this.repositoryFileService.updateFiles(unsavedFiles).pipe(

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -131,7 +131,7 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
                     this.editorState = EditorState.UNSAVED_CHANGES;
                     return throwError('saving failed');
                 }
-            }, 4000);
+            }, 8000);
             this.editorState = EditorState.SAVING;
             const unsavedFiles = Object.entries(this.unsavedFiles).map(([fileName, fileContent]) => ({ fileName, fileContent }));
             return this.repositoryFileService.updateFiles(unsavedFiles).pipe(

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -116,7 +116,12 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
 
     onSave() {
         this.saveChangedFiles()
-            .pipe(catchError(() => of()))
+            .pipe(
+                catchError((err) => {
+                    this.editorState = EditorState.UNSAVED_CHANGES;
+                    return of(err);
+                }),
+            )
             .subscribe();
     }
 

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -130,6 +130,7 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
                 if (this.editorState === EditorState.SAVING) {
                     this.editorState = EditorState.UNSAVED_CHANGES;
                     const error = new Error('Connection timeout. Saving Failed.');
+                    error.name = 'timeout';
                     this.onError.emit(error.message);
                 }
             }, 8000);

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -129,7 +129,8 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
             setTimeout(() => {
                 if (this.editorState === EditorState.SAVING) {
                     this.editorState = EditorState.UNSAVED_CHANGES;
-                    return throwError('saving failed');
+                    const error = new Error('Connection timeout. Saving Failed.');
+                    this.onError.emit(error.message);
                 }
             }, 8000);
             this.editorState = EditorState.SAVING;

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -129,8 +129,7 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
             setTimeout(() => {
                 if (this.editorState === EditorState.SAVING) {
                     this.editorState = EditorState.UNSAVED_CHANGES;
-                    const error = new Error('Connection timeout. Saving Failed.');
-                    error.name = 'timeout';
+                    const error = new Error('connectionTimeout');
                     this.onError.emit(error.message);
                 }
             }, 8000);

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
@@ -195,17 +195,12 @@ export class CodeEditorRepositoryFileService extends DomainDependentEndpointServ
                         // Checkout conflict handling.
                         if (checkIfSubmissionIsError(fileSubmission) && fileSubmission.error === RepositoryError.CHECKOUT_CONFLICT) {
                             this.conflictService.notifyConflictState(GitConflictState.CHECKOUT_CONFLICT);
-                        } else if (checkIfSubmissionIsError(fileSubmission)) {
-                            console.log('Error');
-                            throw new Error('saving failed');
-                            // throwError('saving failed');
                         }
                         return;
                     }
                     this.fileUpdateSubject.next(fileSubmission);
                 }),
                 catchError((err) => {
-                    console.log('catching errors');
                     return throwError(err);
                 }),
             )

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
@@ -200,7 +200,7 @@ export class CodeEditorRepositoryFileService extends DomainDependentEndpointServ
                     }
                     this.fileUpdateSubject.next(fileSubmission);
                 }),
-                catchError((err) => of(err)),
+                catchError(() => of()),
             )
             .subscribe();
         this.jhiWebsocketService.send(`${this.websocketResourceUrlSend}/files`, fileUpdates);

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
@@ -200,9 +200,7 @@ export class CodeEditorRepositoryFileService extends DomainDependentEndpointServ
                     }
                     this.fileUpdateSubject.next(fileSubmission);
                 }),
-                catchError((err) => {
-                    return throwError(err);
-                }),
+                catchError(() => of()),
             )
             .subscribe();
         this.jhiWebsocketService.send(`${this.websocketResourceUrlSend}/files`, fileUpdates);

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
@@ -195,12 +195,17 @@ export class CodeEditorRepositoryFileService extends DomainDependentEndpointServ
                         // Checkout conflict handling.
                         if (checkIfSubmissionIsError(fileSubmission) && fileSubmission.error === RepositoryError.CHECKOUT_CONFLICT) {
                             this.conflictService.notifyConflictState(GitConflictState.CHECKOUT_CONFLICT);
+                        } else if (checkIfSubmissionIsError(fileSubmission)) {
+                            console.log('Error');
+                            throw new Error('saving failed');
+                            // throwError('saving failed');
                         }
                         return;
                     }
                     this.fileUpdateSubject.next(fileSubmission);
                 }),
                 catchError((err) => {
+                    console.log('catching errors');
                     return throwError(err);
                 }),
             )

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
@@ -200,7 +200,7 @@ export class CodeEditorRepositoryFileService extends DomainDependentEndpointServ
                     }
                     this.fileUpdateSubject.next(fileSubmission);
                 }),
-                catchError(() => of()),
+                catchError((err) => of(err)),
             )
             .subscribe();
         this.jhiWebsocketService.send(`${this.websocketResourceUrlSend}/files`, fileUpdates);

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
@@ -200,7 +200,9 @@ export class CodeEditorRepositoryFileService extends DomainDependentEndpointServ
                     }
                     this.fileUpdateSubject.next(fileSubmission);
                 }),
-                catchError(() => of()),
+                catchError((err) => {
+                    return throwError(err);
+                }),
             )
             .subscribe();
         this.jhiWebsocketService.send(`${this.websocketResourceUrlSend}/files`, fileUpdates);

--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -86,7 +86,8 @@
                 "failedToLoadBuildLogs": "Die Build Logs konnten nicht geladen werden.",
                 "repositoryInConflict": "Dein Repository befindet sich in einem Konfliktzustand.",
                 "notAllowedExam": "Du kannst (nicht mehr) abgeben",
-                "connectionTimeout": "Speichern ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal."
+                "connectionTimeoutSave": "Speichern ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
+                "connectionTimeoutRefresh": "Aktualisieren ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal."
             },
             "testStatusLabels": {
                 "noResult": "Keine Ergebnisse",

--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -86,7 +86,7 @@
                 "failedToLoadBuildLogs": "Die Build Logs konnten nicht geladen werden.",
                 "repositoryInConflict": "Dein Repository befindet sich in einem Konfliktzustand.",
                 "notAllowedExam": "Du kannst (nicht mehr) abgeben",
-                "connectionTimeout": "Zeitlimit überschritten. Speichern ist fehlgeschlagen."
+                "connectionTimeout": "Speichern ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal."
             },
             "testStatusLabels": {
                 "noResult": "Keine Ergebnisse",

--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -85,7 +85,8 @@
                 "problemStatementCouldNotBeUpdated": "Die Aufgabenstellung der Übung konnte nicht aktualisiert werden.",
                 "failedToLoadBuildLogs": "Die Build Logs konnten nicht geladen werden.",
                 "repositoryInConflict": "Dein Repository befindet sich in einem Konfliktzustand.",
-                "notAllowedExam": "Du kannst (nicht mehr) abgeben"
+                "notAllowedExam": "Du kannst (nicht mehr) abgeben",
+                "connectionTimeout": "Zeitlimit überschritten. Speichern ist fehlgeschlagen."
             },
             "testStatusLabels": {
                 "noResult": "Keine Ergebnisse",

--- a/src/main/webapp/i18n/en/editor.json
+++ b/src/main/webapp/i18n/en/editor.json
@@ -90,7 +90,8 @@
                 "failedToLoadBuildLogs": "The build logs could not be retrieved.",
                 "repositoryInConflict": "Your repository has entered a conflict state.",
                 "notAllowedExam": "You must not submit (anymore)",
-                "connectionTimeout": ".Saving failed. Please make sure you have a stable internet connection and try again."
+                "connectionTimeoutSave": "Saving failed. Please make sure you have a stable internet connection and try again.",
+                "connectionTimeoutRefresh": "Refreshing failed. Please make sure you have a stable internet connection and try again."
             },
             "testStatusLabels": {
                 "noResult": "No results",

--- a/src/main/webapp/i18n/en/editor.json
+++ b/src/main/webapp/i18n/en/editor.json
@@ -89,7 +89,8 @@
                 "problemStatementCouldNotBeUpdated": "The problem statement of this exercise could not be updated.",
                 "failedToLoadBuildLogs": "The build logs could not be retrieved.",
                 "repositoryInConflict": "Your repository has entered a conflict state.",
-                "notAllowedExam": "You must not submit (anymore)"
+                "notAllowedExam": "You must not submit (anymore)",
+                "connectionTimeout": "Connection timeout. Saving failed."
             },
             "testStatusLabels": {
                 "noResult": "No results",

--- a/src/main/webapp/i18n/en/editor.json
+++ b/src/main/webapp/i18n/en/editor.json
@@ -90,7 +90,7 @@
                 "failedToLoadBuildLogs": "The build logs could not be retrieved.",
                 "repositoryInConflict": "Your repository has entered a conflict state.",
                 "notAllowedExam": "You must not submit (anymore)",
-                "connectionTimeout": "Connection timeout. Saving failed."
+                "connectionTimeout": ".Saving failed. Please make sure you have a stable internet connection and try again."
             },
             "testStatusLabels": {
                 "noResult": "No results",


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
- **Save, Submit, Refresh files not available in exam mode after being offline:**
See #1797
- **Programming Excercise topbar indicator misbehaviour**
See #1819 

### Description
When the client is disconnected from the internet before or during saving, no error is thrown and the action buttons remain locked. In order to not lock the student action buttons in case the save operation does not return, we set a timeout of 8 seconds. If the timeout is reached and the editor is still in 'saving' mode, we set the mode to unsaved changes.

The topbar was only updated on file creation/deletion but not on file content changes. To fix this we handle the file content changes and update the topbar accordingly. 

### Steps for Testing
- **Save, Submit, Refresh files not available in exam mode after being offline:**

1. Create an exam with one programming exercise (make sure the code editor is enabled) and one other exercise
2. Participate in the exam and navigate to the programming exercise
3. Disconnect and wait until Artemis says you are disconnected
4. Make some changes, e.g. type some text into a file
5. Hit save or wait for the automatic save to trigger, this will lock the Save, Submit and Refresh files buttons
6. It should unlock once 8 seconds have passed

- **Programming Excercise topbar indicator misbehaviour**

1. Start an exam with a programming exercise
2. Navigate to the programming exercise
3. Change something in the online editor (no save or submission)
4. See that the top bar indicator updates
