### PR TITLE
Set AuthorizationObject when schedule task is received from remote node.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageReceiveService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageReceiveService.java
@@ -11,6 +11,7 @@ import com.hazelcast.core.HazelcastInstance;
 
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.TextExercise;
+import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ProgrammingExerciseService;
 import de.tum.in.www1.artemis.service.TextExerciseService;
 import de.tum.in.www1.artemis.service.scheduled.ProgrammingExerciseScheduleService;
@@ -50,23 +51,27 @@ public class InstanceMessageReceiveService {
 
     public void processScheduleProgrammingExercise(Long exerciseId) {
         log.info("Received schedule update for programming exercise " + exerciseId);
+        SecurityUtils.setAuthorizationObject();
         ProgrammingExercise programmingExercise = programmingExerciseService.findWithTemplateParticipationAndSolutionParticipationById(exerciseId);
         programmingExerciseScheduleService.scheduleExerciseIfRequired(programmingExercise);
     }
 
     public void processScheduleTextExercise(Long exerciseId) {
         log.info("Received schedule update for text exercise " + exerciseId);
+        SecurityUtils.setAuthorizationObject();
         TextExercise textExercise = textExerciseService.findOne(exerciseId);
         textClusteringScheduleService.ifPresent(service -> service.scheduleExerciseForClusteringIfRequired(textExercise));
     }
 
     public void processTextExerciseScheduleCancel(Long exerciseId) {
         log.info("Received schedule cancel for text exercise " + exerciseId);
+        SecurityUtils.setAuthorizationObject();
         textClusteringScheduleService.ifPresent(service -> service.cancelScheduledClustering(exerciseId));
     }
 
     public void processTextExerciseInstantClustering(Long exerciseId) {
         log.info("Received schedule instant clustering for text exercise " + exerciseId);
+        SecurityUtils.setAuthorizationObject();
         TextExercise textExercise = textExerciseService.findOne(exerciseId);
         textClusteringScheduleService.ifPresent(service -> service.scheduleExerciseForInstantClustering(textExercise));
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageReceiveService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageReceiveService.java
@@ -42,36 +42,43 @@ public class InstanceMessageReceiveService {
         this.textExerciseService = textExerciseService;
         this.textClusteringScheduleService = textClusteringScheduleService;
 
-        hazelcastInstance.<Long>getTopic("programming-exercise-schedule").addMessageListener(message -> processScheduleProgrammingExercise((message.getMessageObject())));
-        hazelcastInstance.<Long>getTopic("text-exercise-schedule").addMessageListener(message -> processScheduleTextExercise((message.getMessageObject())));
-        hazelcastInstance.<Long>getTopic("text-exercise-schedule-cancel").addMessageListener(message -> processTextExerciseScheduleCancel((message.getMessageObject())));
-        hazelcastInstance.<Long>getTopic("text-exercise-schedule-instant-clustering")
-                .addMessageListener(message -> processTextExerciseInstantClustering((message.getMessageObject())));
+        hazelcastInstance.<Long>getTopic("programming-exercise-schedule").addMessageListener(message -> {
+            SecurityUtils.setAuthorizationObject();
+            processScheduleProgrammingExercise((message.getMessageObject()));
+        });
+        hazelcastInstance.<Long>getTopic("text-exercise-schedule").addMessageListener(message -> {
+            SecurityUtils.setAuthorizationObject();
+            processScheduleTextExercise((message.getMessageObject()));
+        });
+        hazelcastInstance.<Long>getTopic("text-exercise-schedule-cancel").addMessageListener(message -> {
+            SecurityUtils.setAuthorizationObject();
+            processTextExerciseScheduleCancel((message.getMessageObject()));
+        });
+        hazelcastInstance.<Long>getTopic("text-exercise-schedule-instant-clustering").addMessageListener(message -> {
+            SecurityUtils.setAuthorizationObject();
+            processTextExerciseInstantClustering((message.getMessageObject()));
+        });
     }
 
     public void processScheduleProgrammingExercise(Long exerciseId) {
         log.info("Received schedule update for programming exercise " + exerciseId);
-        SecurityUtils.setAuthorizationObject();
         ProgrammingExercise programmingExercise = programmingExerciseService.findWithTemplateParticipationAndSolutionParticipationById(exerciseId);
         programmingExerciseScheduleService.scheduleExerciseIfRequired(programmingExercise);
     }
 
     public void processScheduleTextExercise(Long exerciseId) {
         log.info("Received schedule update for text exercise " + exerciseId);
-        SecurityUtils.setAuthorizationObject();
         TextExercise textExercise = textExerciseService.findOne(exerciseId);
         textClusteringScheduleService.ifPresent(service -> service.scheduleExerciseForClusteringIfRequired(textExercise));
     }
 
     public void processTextExerciseScheduleCancel(Long exerciseId) {
         log.info("Received schedule cancel for text exercise " + exerciseId);
-        SecurityUtils.setAuthorizationObject();
         textClusteringScheduleService.ifPresent(service -> service.cancelScheduledClustering(exerciseId));
     }
 
     public void processTextExerciseInstantClustering(Long exerciseId) {
         log.info("Received schedule instant clustering for text exercise " + exerciseId);
-        SecurityUtils.setAuthorizationObject();
         TextExercise textExercise = textExerciseService.findOne(exerciseId);
         textClusteringScheduleService.ifPresent(service -> service.scheduleExerciseForInstantClustering(textExercise));
     }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
For certain operations, an `AuthorizationObject` must be available.
In normal scenarios, this is set by Spring, but if an task is executed on another node (e.g. due to the `scheduling` profile), this is not set and will throw an error.

### Description
Set the AuthorizationObject when an operation is performed that is received by another node.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. ...
