### PR TITLE
[Exam] Ability to take exercise dates from exam

### DIFF
--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -33,6 +33,10 @@
             </div>
         </div>
         <jhi-team-config-form-group [exercise]="textExercise"></jhi-team-config-form-group>
+        <hr />
+        <div *ngIf="isExamMode" class="mt-1 mb-1">
+            <button type="button" class="btn btn-outline-primary" (click)="setDatesFromExam()" jhiTranslate="artemisApp.exercise.setDatesFromExam">Get Dates From Exam</button>
+        </div>
         <div class="d-flex">
             <div class="form-group flex-grow-1">
                 <jhi-date-time-picker
@@ -64,6 +68,7 @@
             ></jhi-date-time-picker>
             <span *ngIf="textExercise.assessmentDueDateError" class="invalid-feedback">{{ 'artemisApp.exercise.assessmentDueDateError' | translate }}</span>
         </div>
+        <hr />
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="artemisApp.exercise.maxScore" for="field_maxScore">Max Score</label>
             <input

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
@@ -210,10 +210,20 @@ export class TextExerciseUpdateComponent implements OnInit {
     private onError(error: HttpErrorResponse) {
         this.jhiAlertService.error(error.message);
     }
+
     /**
      * gets the flag of the structured grading instructions slide toggle
      */
     getCheckedFlag(event: boolean) {
         this.checkedFlag = event;
+    }
+
+    setDatesFromExam() {
+        if (this.isExamMode) {
+            const exam = this.textExercise.exerciseGroup?.exam!;
+            this.textExercise.releaseDate = exam.startDate;
+            this.textExercise.dueDate = exam.endDate;
+            this.textExercise.assessmentDueDate = exam.examStudentReviewStart;
+        }
     }
 }

--- a/src/main/webapp/i18n/de/exercise.json
+++ b/src/main/webapp/i18n/de/exercise.json
@@ -143,7 +143,7 @@
                 }
             },
             "exam": "Klausur",
-            "setDatesFromExam": "Set Dates From Exam"
+            "setDatesFromExam": "Datumsfelder der Klausur übernehmen"
         },
         "exerciseLtiConfiguration": {
             "lti": "LTI",

--- a/src/main/webapp/i18n/de/exercise.json
+++ b/src/main/webapp/i18n/de/exercise.json
@@ -142,7 +142,8 @@
                     "pattern": "Die maximale Punktzahl muss zwischen 1 und 9999 liegen!"
                 }
             },
-            "exam": "Klausur"
+            "exam": "Klausur",
+            "setDatesFromExam": "Set Dates From Exam"
         },
         "exerciseLtiConfiguration": {
             "lti": "LTI",

--- a/src/main/webapp/i18n/en/exercise.json
+++ b/src/main/webapp/i18n/en/exercise.json
@@ -142,7 +142,8 @@
                     "pattern": "The maximum score must be between 1 and 9999!"
                 }
             },
-            "exam": "Exam"
+            "exam": "Exam",
+            "setDatesFromExam": "Set Dates From Exam"
         },
         "exerciseLtiConfiguration": {
             "lti": "LTI",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Server: I added multiple integration tests (Spring) related to the features
- [ ] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] Server: I documented the Java code using JavaDoc style.
- [ ] Client: I added multiple integration tests (Jest) related to the features
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [ ] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This simplifies creating exercises for exams, because instructors can just copy the necessary dates from the exam with the click of a button

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/29718932/87097959-91edc700-c246-11ea-8251-a9ec0def87f3.png)

