### PR TITLE
fix fullscreen on safari

### DIFF
--- a/src/main/webapp/app/shared/fullscreen/fullscreen.scss
+++ b/src/main/webapp/app/shared/fullscreen/fullscreen.scss
@@ -2,6 +2,7 @@
     display: flex;
     position: relative;
     background-color: white;
+    width: 100%;
 }
 
 .absolute {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) locally
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Modeling Editor in Safari is not displayed as expected. Only the side bar is shown

### Description
<!-- Describe your changes in detail -->
Added css to fullscreen component - width: 100% which fixes the error

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Choose browser safari
2. Participate in a modeling exercise
3. Click on fullscreen
4. Fullscreen should be displayed on whole screen and work as outside of fullscreen
