### PR TITLE
Update file content via REST instead of WebSocket.

### DIFF
--- a/src/test/k6/requests/endpoints.js
+++ b/src/test/k6/requests/endpoints.js
@@ -13,6 +13,7 @@ export const EXERCISES = (courseId) => `${COURSE(courseId)}/exercises`;
 export const EXERCISE = (courseId, exerciseId) => `${EXERCISES(courseId)}/${exerciseId}`;
 export const PARTICIPATION = (exerciseId) => `/exercises/${exerciseId}/participation`;
 export const PARTICIPATIONS = (courseId, exerciseId) => `${EXERCISE(courseId, exerciseId)}/participations`;
+export const FILES = (participationId) => `/repository/${participationId}/files`;
 export const COMMIT = (participationId) => `/repository/${participationId}/commit`;
 export const NEW_FILE = (participationId) => `/repository/${participationId}/file`;
 export const PARTICIPATION_WITH_RESULT = (participationId) => `/participations/${participationId}/withLatestResult`;

--- a/src/test/k6/requests/programmingExercise.js
+++ b/src/test/k6/requests/programmingExercise.js
@@ -1,5 +1,5 @@
 import { nextAlphanumeric, nextWSSubscriptionId, extractDestination } from '../util/utils.js';
-import { COMMIT, NEW_FILE, PARTICIPATION_WITH_RESULT, PARTICIPATIONS, PROGRAMMING_EXERCISE, PROGRAMMING_EXERCISES_SETUP } from './endpoints.js';
+import { COMMIT, NEW_FILE, PARTICIPATION_WITH_RESULT, PARTICIPATIONS, PROGRAMMING_EXERCISE, PROGRAMMING_EXERCISES_SETUP, FILES } from './endpoints.js';
 import { fail, sleep } from 'k6';
 import { programmingExerciseProblemStatementJava } from '../resource/constants_java.js';
 import { programmingExerciseProblemStatementPython } from '../resource/constants_python.js';
@@ -151,12 +151,20 @@ export function createNewFile(artemis, participationId, filename) {
     }
 }
 
+export function updateFileContent(artemis, participationId, content) {
+    const res = artemis.put(FILES(participationId), content);
+
+    if (res[0].status !== 200) {
+        fail('ERROR: Unable to update file content for participation' + participationId);
+    }
+}
+
 export function simulateSubmission(artemis, participationSimulation, expectedResult, resultString) {
     // First, we have to create all new files
     participationSimulation.newFiles.forEach((file) => createNewFile(artemis, participationSimulation.participationId, file));
 
     artemis.websocket(function (socket) {
-        // Send changes via websocket
+        // Send changes via websocket - DEPRECATED AS OF 2020-07-13, now REST is used (see commit e6038467a8cc5ea29cb0b50b0bb2d2c51c94d348)
         function submitChange(content) {
             const contentString = JSON.stringify(content);
             const changeMessage =
@@ -187,7 +195,8 @@ export function simulateSubmission(artemis, participationSimulation, expectedRes
         }, 5 * 1000);
 
         socket.setTimeout(function () {
-            submitChange(participationSimulation.content);
+            // submitChange(participationSimulation.content);
+            updateFileContent(artemis, participationSimulation.participationId, participationSimulation.content);
             console.log('SEND file data for test user ' + __VU);
         }, 10 * 1000);
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
In #1864, the save-method for files was changed from WebSockets to REST, but the changes were not reflected to the K6 tests.
This PR updates the K6 tests.

### Steps for Testing
Verify that the tests pass:
https://bamboo.ase.in.tum.de/browse/ARTEMIS-SATJG3
