### PR TITLE
Disable Copy Paste to Clipboard in Modeling Exercises

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@fortawesome/fontawesome-svg-core": "1.2.29",
         "@fortawesome/free-regular-svg-icons": "5.13.1",
         "@fortawesome/free-solid-svg-icons": "5.13.1",
-        "@ls1intum/apollon": "2.1.7",
+        "@ls1intum/apollon": "2.1.8",
         "@ng-bootstrap/ng-bootstrap": "7.0.0",
         "@ngx-translate/core": "13.0.0",
         "@ngx-translate/http-loader": "6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,10 +1290,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@ls1intum/apollon@2.1.7":
-  version "2.1.7"
-  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.1.7.tgz#a55895d0b3f319bd89da31ab4c5a97badf853cc4"
-  integrity sha512-VfneSrPKAVKu5aUE/rbhio4mdSXPZoCNMJiw4KJ7+UanBHSFqeybHSDP0N233QiHpi+Z3aTx73EEuRvfe+E5IQ==
+"@ls1intum/apollon@2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.1.8.tgz#1ee335809a26ed19292a616da7d2a52907e5318f"
+  integrity sha512-ysDpDsbntaHjdhafy5jN9EAi6IklF+bxaSchLHHOB02ETL3dzSVmg2Whb2PKgzgaKanNZVmMjtYZst4FkP4noQ==
   dependencies:
     pepjs "0.5.2"
     react "16.13.1"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) **locally**

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Disable copying from one modeling exercise to another -> prevents cheating

### Description
<!-- Describe your changes in detail -->
Changes in Apollon:
- ApollonOptions support a new flag -> copyPasteToClipboard which enables/disables copy-paste to clipboard. Default: disable copy-paste to clipboard

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

#### Copy paste across modeling exercises
1. Open two modeling exercises in exam mode or default course exercises
2. try copy pasting from one modeling editor to another
3. Copy paste should not work

#### Copy paste within one modeling exercise
1. Copy elements within one modeling exercise
2. Paste them inside the same modeling editor (try single elements and elements with children)
3. Expected behavior:
- Pasting the same elements several times will create several copies. All of them are transferred by a few pixels
- Selected elements should be copied 
- The newly created copies should be selected
- If editing elements or children (changing attributes, moving around, deleting, adding new elements to containers) -> should work as expected - actions are applied on copies alone, not on the original element

