### PR TITLE
Use exerciseId instead of participationId to identify tasks in programming exercises

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/extensions/programming-exercise-task.extension.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/extensions/programming-exercise-task.extension.ts
@@ -8,16 +8,16 @@ import { escapeStringForUseInRegex } from 'app/shared/util/global.utils';
 import { ProgrammingExerciseInstructionService } from 'app/exercises/programming/shared/instructions-render/service/programming-exercise-instruction.service';
 import { ArtemisShowdownExtensionWrapper } from 'app/shared/markdown-editor/extensions/artemis-showdown-extension-wrapper';
 import { ExerciseHint } from 'app/entities/exercise-hint.model';
-import { TaskArray, TaskArrayWithParticipation } from 'app/exercises/programming/shared/instructions-render/task/programming-exercise-task.model';
-import { Participation } from 'app/entities/participation/participation.model';
+import { TaskArray, TaskArrayWithExercise } from 'app/exercises/programming/shared/instructions-render/task/programming-exercise-task.model';
+import { Exercise } from 'app/entities/exercise.model';
 
 @Injectable({ providedIn: 'root' })
 export class ProgrammingExerciseTaskExtensionWrapper implements ArtemisShowdownExtensionWrapper {
     public exerciseHints: ExerciseHint[] = [];
     private latestResult: Result | null = null;
-    private participation: Participation;
+    private exercise: Exercise;
 
-    private testsForTaskSubject = new Subject<TaskArrayWithParticipation>();
+    private testsForTaskSubject = new Subject<TaskArrayWithExercise>();
     private injectableElementsFoundSubject = new Subject<() => void>();
 
     // unique index, even if multiple tasks are shown from different problem statements on the same page (in different tabs)
@@ -39,12 +39,12 @@ export class ProgrammingExerciseTaskExtensionWrapper implements ArtemisShowdownE
     }
 
     /**
-     * Sets the participation. This is needed as multiple instructions components reuse this service and we have to
-     * associate tasks with a participation.
-     * @param participation - participation.
+     * Sets the exercise. This is needed as multiple instructions components use this service in parallel and we have to
+     * associate tasks with an exercise to identify tasks properly
+     * @param exercise - the current exercise.
      */
-    public setParticipation(participation: Participation) {
-        this.participation = participation;
+    public setExercise(exercise: Exercise) {
+        this.exercise = exercise;
     }
 
     /**
@@ -118,8 +118,8 @@ export class ProgrammingExerciseTaskExtensionWrapper implements ArtemisShowdownE
                             hints: testMatch[4] ? testMatch[4].split(',').map((s) => s.trim()) : [],
                         };
                     });
-                const tasksWithParticipationId: TaskArrayWithParticipation = {
-                    participationId: this.participation.id,
+                const tasksWithParticipationId: TaskArrayWithExercise = {
+                    exerciseId: this.exercise.id,
                     tasks: testsForTask,
                 };
                 this.testsForTaskSubject.next(tasksWithParticipationId);

--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -10,7 +10,7 @@ import { ArtemisMarkdownService } from 'app/shared/markdown.service';
 import { ProgrammingExerciseTaskExtensionWrapper } from './extensions/programming-exercise-task.extension';
 import { ProgrammingExercisePlantUmlExtensionWrapper } from 'app/exercises/programming/shared/instructions-render/extensions/programming-exercise-plant-uml.extension';
 import { ProgrammingExerciseInstructionService } from 'app/exercises/programming/shared/instructions-render/service/programming-exercise-instruction.service';
-import { TaskArray, TaskArrayWithParticipation } from 'app/exercises/programming/shared/instructions-render/task/programming-exercise-task.model';
+import { TaskArray, TaskArrayWithExercise } from 'app/exercises/programming/shared/instructions-render/task/programming-exercise-task.model';
 import { ExerciseHint } from 'app/entities/exercise-hint.model';
 import { Participation } from 'app/entities/participation/participation.model';
 import { Feedback } from 'app/entities/feedback.model';
@@ -50,7 +50,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
 
     set latestResult(result: Result | null) {
         this.latestResultValue = result;
-        this.programmingExerciseTaskWrapper.setParticipation(this.participation);
+        this.programmingExerciseTaskWrapper.setExercise(this.exercise);
         this.programmingExerciseTaskWrapper.setLatestResult(this.latestResult);
         this.programmingExercisePlantUmlWrapper.setLatestResult(this.latestResult);
     }
@@ -176,9 +176,9 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
         if (this.tasksSubscription) {
             this.tasksSubscription.unsubscribe();
         }
-        this.tasksSubscription = this.programmingExerciseTaskWrapper.subscribeForFoundTestsInTasks().subscribe((tasks: TaskArrayWithParticipation) => {
-            // Multiple instances of the code editor use the TaskWrapperService. We have to check, that the returned tasks belong to this participation
-            if (tasks.participationId === this.participation.id) {
+        this.tasksSubscription = this.programmingExerciseTaskWrapper.subscribeForFoundTestsInTasks().subscribe((tasks: TaskArrayWithExercise) => {
+            // Multiple instances of the code editor use the TaskWrapperService. We have to check, that the returned tasks belong to this exercise
+            if (tasks.exerciseId === this.exercise.id) {
                 this.tasks = tasks.tasks;
             }
         });

--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/task/programming-exercise-task.model.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/task/programming-exercise-task.model.ts
@@ -1,6 +1,6 @@
 export type Task = { id: number; completeString: string; taskName: string; tests: string[]; hints: string[] };
 export type TaskArray = Array<Task>;
-export type TaskArrayWithParticipation = {
-    participationId: number;
+export type TaskArrayWithExercise = {
+    exerciseId: number;
     tasks: Array<Task>;
 };

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
@@ -288,12 +288,10 @@ describe('ProgrammingExerciseInstructionComponent', () => {
             feedbacks: [{ text: 'testMergeSort', detail_text: 'lorem ipsum', positive: true }],
         } as any;
         const exercise = { id: 3, course: { id: 4 }, problemStatement } as ProgrammingExercise;
-        const participation = { id: 42 } as Participation;
 
         openModalStub.returns({ componentInstance: {} });
         comp.problemStatement = exercise.problemStatement;
         comp.exercise = exercise;
-        comp.participation = participation;
         comp.latestResult = result;
         // @ts-ignore
         comp.setupMarkdownSubscriptions();
@@ -340,11 +338,9 @@ describe('ProgrammingExerciseInstructionComponent', () => {
             feedbacks: [{ text: 'testBubbleSort', detail_text: 'lorem ipsum' }],
         } as any;
         const exercise = { id: 3, course: { id: 4 }, problemStatement } as ProgrammingExercise;
-        const participation = { id: 42 } as Participation;
         openModalStub.returns({ componentInstance: {} });
         comp.problemStatement = exercise.problemStatement;
         comp.exercise = exercise;
-        comp.participation = participation;
         comp.latestResult = result;
         // @ts-ignore
         comp.setupMarkdownSubscriptions();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Bugfix

### Description
Use exercise to identify tasks instead of participation. Participation is not always available in other parts of the application using this component.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

_Test instructions in exam_
1. Try out an exam with multiple programming exercises but different tasks
2. Navigate between those
--> Tasks in the instructions and in the task step bar should refresh correctly

_Test instructions in course exercise_
1. Create a course programming exercise
2. Switch user to a tutor who doesn't have a participation in the exercise
3. View the exercise over course-management--> exercises --> click on name of the exercise
--> No console errors should be shown
