### PR TITLE
Add error message for missing exam start confirmation

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -80,6 +80,7 @@
             (click)="updateConfirmation()"
             style="place-self: flex-start;"
             class="mt-1"
+            [required]="inserted"
             [disabled]="startView ? waitingForExamStart : false"
         />
         <span id="formatted-confirmation-text" class="d-inline-block ml-2" [innerHTML]="formattedConfirmationText"></span>
@@ -107,6 +108,9 @@
             </div>
             <div class="row justify-content-center">
                 <div class="form-group">
+                    <div class="alert alert-danger mt-1" *ngIf="!!!confirmed && inserted">
+                        <span [innerHTML]="'artemisApp.exam.notConfirmed' | translate"></span>
+                    </div>
                     <div class="alert alert-danger mt-1" *ngIf="!nameIsCorrect && inserted">
                         <span [innerHTML]="'artemisApp.exam.falseName' | translate"></span>
                     </div>

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -38,6 +38,7 @@
             "exercise": "Aufgabe {{nr}}",
             "startConsentText": "Hiermit bestätige ich mit meinem vollen Namen stellvertretend für meine Unterschrift, dass ich die Teilnahmebedingungen gelesen habe und diese für die Dauer der Klausur einhalten werde.",
             "endConsentText": "Hiermit bestätige ich mit meinem vollen Namen stellvertretend für meine Unterschrift, dass ich die Klausur eigenständig und nur mithilfe der angegebene Hilfsmittel bearbeitet habe.",
+            "notConfirmed": "Bitte setze einen Haken in das Kästchen um fortzufahren.",
             "falseName": "Der angegebene Name ist nicht korrekt. Bitte versuche es erneut!",
             "validation": {
                 "startAndEndMustBeSet": "Start- und Enddatum der Klausur müssen festgelegt werden.",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -38,6 +38,7 @@
             "exercise": "Exercise {{nr}}",
             "startConsentText": "I hereby confirm with my full name, representing my signature, that I have read the conditions of participation and will adhere to them for the duration of the exam.",
             "endConsentText": "I hereby confirm with my full name, representing my signature, that this exam is my own work and I have only used the indicated aids.",
+            "notConfirmed": "Please tick the checkbox to continue.",
             "falseName": "Entered name is incorrect. Please try again!",
             "validation": {
                 "startAndEndMustBeSet": "The start and end date must be set for the exam",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
Students complain that they cannot start the exam, and it turned out some just missed the confirmation checkbox.
While this is technically their fault, it causes more unnecessary communication and complaints during the exam. This PR aims to eliminate one potential problem source when students report "I cannot start the exam".

### Description
We ...
- show an error message above the button and 
- mark the checkbox as required
  (highlighted red if it is not checked; seems to work in Firefox but not Chromium)

if ...
- the student didn't tick the checkbox but
- started/completed entering their name

This behavior should avoid that students miss the checkbox and enter the name correctly and get confused why the start button is still disabled. The changes of this PR don't affect the scenario that the checkbox is ticked before entering the name.

### Steps for Testing
1. Create a new exam in Artemis with at least one student exam and enough time between visible and exam start
2. Go to the exam start page and try out different combinations of confirmation and username
3. See if it works for the other language as well.

### Screenshots
![prExamConfirm](https://user-images.githubusercontent.com/11130248/87700604-e3420d00-c796-11ea-969a-e3dfd770d199.gif)

