### PR TITLE
Add validation for exam publish and review dates if they are set

### DIFF
--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.html
@@ -75,6 +75,7 @@
                     <jhi-date-time-picker
                         labelName="{{ 'artemisApp.examManagement.publishResultsDate' | translate }}"
                         [(ngModel)]="exam.publishResultsDate"
+                        [error]="!isValidPublishResultsDate"
                         name="publishResultsDate"
                         id="publishResultsDate"
                     ></jhi-date-time-picker>
@@ -83,6 +84,7 @@
                     <jhi-date-time-picker
                         labelName="{{ 'artemisApp.examManagement.examStudentReviewStart' | translate }}"
                         [(ngModel)]="exam.examStudentReviewStart"
+                        [error]="!isValidExamStudentReviewStart"
                         name="examStudentReviewStart"
                         id="examStudentReviewStart"
                     ></jhi-date-time-picker>
@@ -91,6 +93,7 @@
                     <jhi-date-time-picker
                         labelName="{{ 'artemisApp.examManagement.examStudentReviewEnd' | translate }}"
                         [(ngModel)]="exam.examStudentReviewEnd"
+                        [error]="!isValidExamStudentReviewEnd"
                         name="examStudentReviewEnd"
                         id="examStudentReviewEnd"
                     ></jhi-date-time-picker>
@@ -140,7 +143,7 @@
                 <button type="button" class="btn btn-secondary" (click)="previousState()">
                     <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel"> Cancel</span>
                 </button>
-                <button type="submit" [disabled]="editForm.form.invalid || !isValidEndDate || isSaving" class="btn btn-primary">
+                <button type="submit" [disabled]="editForm.form.invalid || !isValidConfiguration || isSaving" class="btn btn-primary">
                     <fa-icon [icon]="'save'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
                 </button>
             </div>

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
@@ -75,6 +75,12 @@ export class ExamUpdateComponent implements OnInit {
         this.jhiAlertService.error(error.message);
     }
 
+    get isValidConfiguration(): boolean {
+        const examConductionDatesValid = this.isValidVisibleDate && this.isValidStartDate && this.isValidEndDate;
+        const examReviewDatesValid = this.isValidPublishResultsDate && this.isValidExamStudentReviewStart && this.isValidExamStudentReviewEnd;
+        return examConductionDatesValid && examReviewDatesValid;
+    }
+
     get isValidVisibleDate(): boolean {
         // note: != includes a check for undefined
         return this.exam.visibleDate != null;
@@ -88,5 +94,26 @@ export class ExamUpdateComponent implements OnInit {
     get isValidEndDate(): boolean {
         // note: != includes a check for undefined
         return this.exam.endDate != null && moment(this.exam.endDate).isAfter(this.exam.startDate);
+    }
+
+    get isValidPublishResultsDate(): boolean {
+        // allow instructors to set publishResultsDate later
+        if(!this.exam.publishResultsDate)
+            return true;
+        return moment(this.exam.publishResultsDate).isAfter(this.exam.endDate);
+    }
+
+    get isValidExamStudentReviewStart(): boolean {
+        // allow instructors to set examStudentReviewStart later
+        if(!this.exam.examStudentReviewStart)
+            return true;
+        return moment(this.exam.examStudentReviewStart).isAfter(this.exam.publishResultsDate);
+    }
+
+    get isValidExamStudentReviewEnd(): boolean {
+        // allow instructors to set examStudentReviewEnd later
+        if(!this.exam.examStudentReviewEnd)
+            return true;
+        return moment(this.exam.examStudentReviewEnd).isAfter(this.exam.examStudentReviewStart);
     }
 }

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
@@ -98,22 +98,25 @@ export class ExamUpdateComponent implements OnInit {
 
     get isValidPublishResultsDate(): boolean {
         // allow instructors to set publishResultsDate later
-        if(!this.exam.publishResultsDate)
+        if (!this.exam.publishResultsDate) {
             return true;
+        }
         return moment(this.exam.publishResultsDate).isAfter(this.exam.endDate);
     }
 
     get isValidExamStudentReviewStart(): boolean {
         // allow instructors to set examStudentReviewStart later
-        if(!this.exam.examStudentReviewStart)
+        if (!this.exam.examStudentReviewStart) {
             return true;
+        }
         return moment(this.exam.examStudentReviewStart).isAfter(this.exam.publishResultsDate);
     }
 
     get isValidExamStudentReviewEnd(): boolean {
         // allow instructors to set examStudentReviewEnd later
-        if(!this.exam.examStudentReviewEnd)
+        if (!this.exam.examStudentReviewEnd) {
             return true;
+        }
         return moment(this.exam.examStudentReviewEnd).isAfter(this.exam.examStudentReviewStart);
     }
 }

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
@@ -101,7 +101,8 @@ export class ExamUpdateComponent implements OnInit {
         if (!this.exam.publishResultsDate) {
             return true;
         }
-        return moment(this.exam.publishResultsDate).isAfter(this.exam.endDate);
+        // check for undefined because undefined is otherwise treated as the now moment by moment.js
+        return this.exam.endDate !== undefined && moment(this.exam.publishResultsDate).isAfter(this.exam.endDate);
     }
 
     get isValidExamStudentReviewStart(): boolean {
@@ -109,7 +110,8 @@ export class ExamUpdateComponent implements OnInit {
         if (!this.exam.examStudentReviewStart) {
             return true;
         }
-        return moment(this.exam.examStudentReviewStart).isAfter(this.exam.publishResultsDate);
+        // check for undefined because undefined is otherwise treated as the now moment by moment.js
+        return this.exam.publishResultsDate !== undefined && moment(this.exam.examStudentReviewStart).isAfter(this.exam.publishResultsDate);
     }
 
     get isValidExamStudentReviewEnd(): boolean {
@@ -117,6 +119,7 @@ export class ExamUpdateComponent implements OnInit {
         if (!this.exam.examStudentReviewEnd) {
             return true;
         }
-        return moment(this.exam.examStudentReviewEnd).isAfter(this.exam.examStudentReviewStart);
+        // check for undefined because undefined is otherwise treated as the now moment by moment.js
+        return this.exam.examStudentReviewStart !== undefined && moment(this.exam.examStudentReviewEnd).isAfter(this.exam.examStudentReviewStart);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshotsof my UI changes

### Motivation and Context
Fix #1907. The dates can currently be set incorrectly, e.g. the review end date before the review start date or the review start date before the publish results date. The latter problem can cause the students being able to complain without seeing any results.

### Description
Add checks that the dates have to be in order, meaning
- Exam End before Result Release
- Result Release before Review Start
- Review Start before Review End

Since most of the time those dates are unknown when the exam is created and taken, they can still be left empty and changed later. For one date to be valid, the previous date needs to be set properly.

#### Known issues:
- After setting a date, unsetting/deleting the date is not possible, the input field will retain the value and the following date may remain invalid. This seems to be an issue with the JHipster date time picker. This is also the case for already existing date input fields in Artemis.

#### For consideration:
- Add server-side validation as well. The editing is only available for instructors, however.

### Steps for Testing
1. Open the "Create a new exam"-page and play around with the different dates, especially the lower three.
2. See if the input field get marked red and the "Save" button gets disabled.

### Screenshots
- #### Correct dates
   ![image](https://user-images.githubusercontent.com/11130248/87802960-3331da00-c852-11ea-87da-e46c93791eb9.png)
- #### Only release date of the results set
   ![image](https://user-images.githubusercontent.com/11130248/87803135-64aaa580-c852-11ea-9a22-a8fa1405a39b.png)
- #### Wrong dates
   ![image](https://user-images.githubusercontent.com/11130248/87803194-73915800-c852-11ea-8201-70df5737d8ad.png)


