### PR TITLE
[Exam] Prevent NPE in quiz exam summary and complaint interactions component

### DIFF
--- a/src/main/webapp/app/complaints/complaint-interactions.component.ts
+++ b/src/main/webapp/app/complaints/complaint-interactions.component.ts
@@ -96,7 +96,7 @@ export class ComplaintInteractionsComponent implements OnInit {
      */
     get isTimeOfComplaintValid(): boolean {
         if (this.isExamMode) {
-            return this.isWithinStudentReviewPeriod && !!this.result.completionDate;
+            return this.isWithinStudentReviewPeriod && !!this.result && !!this.result.completionDate;
         } else if (this.result && this.result.completionDate) {
             const resultCompletionDate = moment(this.result.completionDate!);
             if (!this.exercise.assessmentDueDate || resultCompletionDate.isAfter(this.exercise.assessmentDueDate)) {

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
@@ -1,4 +1,4 @@
-<div class="quiz-content container">
+<div class="quiz-content container" *ngIf="quizQuestions && quizQuestions.length > 0">
     <div class="alert alert-info mb-2" *ngIf="showMissingResultsNotice()">
         {{ 'artemisApp.exam.examSummary.missingResultNotice' | translate }}
     </div>

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
@@ -11,7 +11,9 @@
             [clickDisabled]="true"
             [showResult]="resultsPublished && !showMissingResultsNotice"
             [submittedQuizExercise]="exercise"
-            [submittedResult]="exercise.studentParticipations[0].results[0]"
+            [submittedResult]="
+                exercise.studentParticipations[0]?.results && exercise.studentParticipations[0]?.results.length > 0 ? exercise.studentParticipations[0].results[0] : null
+            "
             [forceSampleSolution]="false"
             [questionIndex]="i + 1"
             [score]="getScoreForQuizQuestion(question.id)"

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
@@ -1,5 +1,5 @@
 <div class="quiz-content container">
-    <div class="alert alert-info mb-2" *ngIf="showMissingResultsNotice">
+    <div class="alert alert-info mb-2" *ngIf="showMissingResultsNotice()">
         {{ 'artemisApp.exam.examSummary.missingResultNotice' | translate }}
     </div>
     <div *ngFor="let question of quizQuestions; let i = index">

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import * as moment from 'moment';
 import { QuizQuestionType } from 'app/entities/quiz/quiz-question.model';
 import { QuizSubmission } from 'app/entities/quiz/quiz-submission.model';
 import { AnswerOption } from 'app/entities/quiz/answer-option.model';
@@ -121,7 +122,14 @@ export class QuizExamSummaryComponent implements OnInit {
      * We only show the notice when there is a publishResultsDate that has already passed by now and the result is missing
      */
     showMissingResultsNotice(): boolean {
-        if (this.exam && this.exam.publishResultsDate && this.exercise && this.exercise.studentParticipations && this.exercise.studentParticipations.length > 0) {
+        if (
+            this.exam &&
+            this.exam.publishResultsDate &&
+            moment.isMoment(this.exam.publishResultsDate) &&
+            this.exercise &&
+            this.exercise.studentParticipations &&
+            this.exercise.studentParticipations.length > 0
+        ) {
             return (
                 this.exam.publishResultsDate.isBefore(this.serverDateService.now()) &&
                 (!this.exercise.studentParticipations[0].results || this.exercise.studentParticipations[0].results.length <= 0)

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
@@ -129,16 +129,9 @@ export class QuizExamSummaryComponent implements OnInit {
      * We only show the notice when there is a publishResultsDate that has already passed by now and the result is missing
      */
     showMissingResultsNotice(): boolean {
-        if (
-            this.exam &&
-            this.exam.publishResultsDate &&
-            moment.isMoment(this.exam.publishResultsDate) &&
-            this.exercise &&
-            this.exercise.studentParticipations &&
-            this.exercise.studentParticipations.length > 0
-        ) {
+        if (this.exam && this.exam.publishResultsDate && this.exercise && this.exercise.studentParticipations && this.exercise.studentParticipations.length > 0) {
             return (
-                this.exam.publishResultsDate.isBefore(this.serverDateService.now()) &&
+                moment(this.exam.publishResultsDate).isBefore(this.serverDateService.now()) &&
                 (!this.exercise.studentParticipations[0].results || this.exercise.studentParticipations[0].results.length <= 0)
             );
         }

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
@@ -113,7 +113,7 @@ export class QuizExamSummaryComponent implements OnInit {
         }
     }
 
-    getScoreForQuizQuestion(quizQuestionId: number): number {
+    getScoreForQuizQuestion(quizQuestionId: number): number | undefined {
         if (this.submission && this.submission.submittedAnswers && this.submission.submittedAnswers.length > 0) {
             const submittedAnswer = this.submission.submittedAnswers.find((answer) => {
                 return answer && answer.quizQuestion ? answer.quizQuestion.id === quizQuestionId : false;
@@ -122,7 +122,6 @@ export class QuizExamSummaryComponent implements OnInit {
                 return Math.round(submittedAnswer.scoreInPoints * 100) / 100;
             }
         }
-        return 0;
     }
 
     /**

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
@@ -113,9 +113,12 @@ export class QuizExamSummaryComponent implements OnInit {
         }
     }
 
-    getScoreForQuizQuestion(quizQuestionId: number) {
-        const submittedAnswer = this.submission.submittedAnswers.find((answer) => answer.quizQuestion.id === quizQuestionId);
-        return Math.round(submittedAnswer!.scoreInPoints * 100) / 100;
+    getScoreForQuizQuestion(quizQuestionId: number): number {
+        if (this.submission && this.submission.submittedAnswers && this.submission.submittedAnswers.length > 0) {
+            const submittedAnswer = this.submission.submittedAnswers.find((answer) => answer.quizQuestion?.id === quizQuestionId);
+            return Math.round(submittedAnswer!.scoreInPoints * 100) / 100;
+        }
+        return 0;
     }
 
     /**

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
@@ -45,7 +45,7 @@ export class QuizExamSummaryComponent implements OnInit {
     ngOnInit(): void {
         this.updateViewFromSubmission();
         // get quiz-exercise with solution after result is published
-        if (this.resultsPublished) {
+        if (this.resultsPublished && this.exercise) {
             this.exerciseService.find(this.exercise.id).subscribe((response) => {
                 this.exerciseWithSolution = response.body!;
             });
@@ -69,7 +69,7 @@ export class QuizExamSummaryComponent implements OnInit {
         this.dragAndDropMappings = new Map<number, DragAndDropMapping[]>();
         this.shortAnswerSubmittedTexts = new Map<number, ShortAnswerSubmittedText[]>();
 
-        if (this.exercise.quizQuestions && this.submission) {
+        if (this.exercise && this.exercise.quizQuestions && this.submission) {
             // iterate through all questions of this quiz
             this.exercise.quizQuestions.forEach((question) => {
                 // find the submitted answer that belongs to this question, only when submitted answers already exist
@@ -115,8 +115,12 @@ export class QuizExamSummaryComponent implements OnInit {
 
     getScoreForQuizQuestion(quizQuestionId: number): number {
         if (this.submission && this.submission.submittedAnswers && this.submission.submittedAnswers.length > 0) {
-            const submittedAnswer = this.submission.submittedAnswers.find((answer) => answer.quizQuestion?.id === quizQuestionId);
-            return Math.round(submittedAnswer!.scoreInPoints * 100) / 100;
+            const submittedAnswer = this.submission.submittedAnswers.find((answer) => {
+                return answer && answer.quizQuestion ? answer.quizQuestion.id === quizQuestionId : false;
+            });
+            if (submittedAnswer && submittedAnswer.scoreInPoints) {
+                return Math.round(submittedAnswer.scoreInPoints * 100) / 100;
+            }
         }
         return 0;
     }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
(1)
![image](https://user-images.githubusercontent.com/15168372/87813615-8ad84180-c862-11ea-9cad-df78ca7bca11.png)

(2)
![image](https://user-images.githubusercontent.com/15168372/87822483-d514ef00-c871-11ea-8f11-9b760447f245.png)

### Description
- [x] I've ensured that there is no chance of a null pointer / index out of bound exception in the `quiz-exam-summary.component`
- [x] I've ensured that there won't be a null pointer exception if `this.result` is not set in `isTimeOfComplaintValid()` in the `complaint-interactions.component` 