### PR TITLE
[Exam] Add points overview to summary

### DIFF
--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
@@ -7,6 +7,7 @@ import { ExamScoreDTO, ExerciseGroup, StudentResult } from 'app/exam/exam-scores
 import { HttpErrorResponse } from '@angular/common/http';
 import { onError } from 'app/shared/util/global.utils';
 import { AlertService } from 'app/core/alert/alert.service';
+import { round } from 'app/shared/util/utils';
 
 @Component({
     selector: 'jhi-exam-scores',
@@ -38,32 +39,6 @@ export class ExamScoresComponent implements OnInit {
                 (res: HttpErrorResponse) => onError(this.jhiAlertService, res),
             );
         });
-    }
-
-    /**
-     * Helper function to make actually rounding possible
-     * @param value
-     * @param exp
-     */
-    round(value: any, exp: number) {
-        if (typeof exp === 'undefined' || +exp === 0) {
-            return Math.round(value);
-        }
-
-        value = +value;
-        exp = +exp;
-
-        if (isNaN(value) || !(exp % 1 === 0)) {
-            return NaN;
-        }
-
-        // Shift
-        value = value.toString().split('e');
-        value = Math.round(+(value[0] + 'e' + (value[1] ? +value[1] + exp : exp)));
-
-        // Shift back
-        value = value.toString().split('e');
-        return +(value[0] + 'e' + (value[1] ? +value[1] - exp : -exp));
     }
 
     sortRows() {
@@ -114,9 +89,9 @@ export class ExamScoresComponent implements OnInit {
             if (exerciseResult) {
                 csvRow[exerciseGroup.title + 'AssignedExercise'] = exerciseResult.title ? exerciseResult.title : '';
                 csvRow[exerciseGroup.title + 'AchievedPoints'] =
-                    typeof exerciseResult.achievedPoints === 'undefined' || exerciseResult.achievedPoints === null ? '' : this.round(exerciseResult.achievedPoints, 1);
+                    typeof exerciseResult.achievedPoints === 'undefined' || exerciseResult.achievedPoints === null ? '' : round(exerciseResult.achievedPoints, 1);
                 csvRow[exerciseGroup.title + 'AchievedScore(%)'] =
-                    typeof exerciseResult.achievedScore === 'undefined' || exerciseResult.achievedScore === null ? '' : this.round(exerciseResult.achievedScore, 2);
+                    typeof exerciseResult.achievedScore === 'undefined' || exerciseResult.achievedScore === null ? '' : round(exerciseResult.achievedScore, 2);
             } else {
                 csvRow[exerciseGroup.title + 'AssignedExercise'] = '';
                 csvRow[exerciseGroup.title + 'AchievedPoints'] = '';
@@ -125,9 +100,9 @@ export class ExamScoresComponent implements OnInit {
         });
 
         csvRow.overAllPoints =
-            typeof studentResult.overallPointsAchieved === 'undefined' || studentResult.overallPointsAchieved === null ? '' : this.round(studentResult.overallPointsAchieved, 1);
+            typeof studentResult.overallPointsAchieved === 'undefined' || studentResult.overallPointsAchieved === null ? '' : round(studentResult.overallPointsAchieved, 1);
         csvRow.overAllScore =
-            typeof studentResult.overallScoreAchieved === 'undefined' || studentResult.overallScoreAchieved === null ? '' : this.round(studentResult.overallScoreAchieved, 2);
+            typeof studentResult.overallScoreAchieved === 'undefined' || studentResult.overallScoreAchieved === null ? '' : round(studentResult.overallScoreAchieved, 2);
         return csvRow;
     }
 }

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
@@ -76,6 +76,15 @@ export class ExamScoresComponent implements OnInit {
         csvExporter.generateCsv(data);
     }
 
+    /**
+     * Wrapper for round utility function so it can be used in the template.
+     * @param value
+     * @param exp
+     */
+    round(value: any, exp: number) {
+        return round(value, exp);
+    }
+
     private convertToCSVRow(studentResult: StudentResult) {
         const csvRow: any = {
             name: studentResult.name ? studentResult.name : '',

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -29,48 +29,7 @@
                       }
         }}</span>
     </h2>
-    <div class="mt-3 mb-4 text-center">
-        <div class="mb-2">
-            <span class="mx-2" *ngIf="exam.startDate">
-                <strong class="font-weight-bold">{{ 'artemisApp.exam.date' | translate }}:</strong>
-                {{ exam.startDate | artemisDate: 'long-date' }}
-            </span>
-            <span class="mx-2">
-                <strong class="font-weight-bold">{{ 'artemisApp.exam.time' | translate }}:</strong>
-                {{ exam.startDate | artemisDate: 'time' }}
-                -
-                {{ endTime() | artemisDate: 'time' }}
-            </span>
-            <span class="mx-2" *ngIf="studentExam && studentExam.workingTime">
-                <strong class="font-weight-bold">{{ 'artemisApp.exam.durationWithFormat' | translate }}:</strong>
-                {{ studentExam.workingTime | artemisDurationFromSeconds }}
-            </span>
-        </div>
-        <div class="mb-2" *ngIf="exam.examiner || exam.moduleNumber || exam.courseName">
-            <span class="mx-2" *ngIf="exam.examiner">
-                <strong class="font-weight-bold">{{ 'artemisApp.examManagement.examiner' | translate }}:</strong>
-                {{ exam.examiner }}
-            </span>
-            <span class="mx-2" *ngIf="exam.moduleNumber">
-                <strong class="font-weight-bold">{{ 'artemisApp.examManagement.moduleNumber' | translate }}:</strong>
-                {{ exam.moduleNumber }}
-            </span>
-            <span class="mx-2" *ngIf="exam.courseName">
-                <strong class="font-weight-bold">{{ 'artemisApp.exam.course' | translate }}:</strong>
-                {{ exam.courseName }}
-            </span>
-        </div>
-        <div>
-            <span class="mx-2">
-                <strong class="font-weight-bold">{{ 'artemisApp.exam.exercises' | translate }}:</strong>
-                {{ exam.numberOfExercisesInExam }}
-            </span>
-            <span class="mx-2">
-                <strong class="font-weight-bold">{{ 'artemisApp.exam.points' | translate }}:</strong>
-                {{ exam.maxPoints }}
-            </span>
-        </div>
-    </div>
+    <jhi-exam-information [exam]="exam" [studentExam]="studentExam"></jhi-exam-information>
     <div><span style="display: table; margin-left: auto; margin-right: auto;" [innerHTML]="formattedGeneralInformation"></span></div>
     <div class="d-flex justify-content-center">
         <input

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
@@ -203,14 +203,4 @@ export class ExamParticipationCoverComponent implements OnInit, OnDestroy {
     get inserted(): boolean {
         return this.enteredName.trim() !== '';
     }
-
-    /**
-     * Calculates the end time depending on the individual working time
-     */
-    endTime(): moment.Moment {
-        if (this.studentExam && this.studentExam.workingTime && this.exam.startDate) {
-            return moment(this.exam.startDate).add(this.studentExam.workingTime, 'seconds');
-        }
-        return this.exam.endDate!;
-    }
 }

--- a/src/main/webapp/app/exam/participate/exam-participation.module.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.module.ts
@@ -27,7 +27,6 @@ import { ArtemisCoursesModule } from 'app/overview/courses.module';
 import { OrionModule } from 'app/shared/orion/orion.module';
 import { ArtemisParticipationSummaryModule } from 'app/exam/participate/summary/exam-participation-summary.module';
 import { ExamTimerComponent } from './timer/exam-timer.component';
-import { ExamInformationComponent } from 'app/exam/participate/information/exam-information.component';
 
 const ENTITY_STATES = [...examParticipationState];
 
@@ -61,7 +60,6 @@ const ENTITY_STATES = [...examParticipationState];
         ExamNavigationBarComponent,
         ExamCodeEditorStudentContainerComponent,
         ExamTimerComponent,
-        ExamInformationComponent,
     ],
 })
 export class ArtemisExamParticipationModule {}

--- a/src/main/webapp/app/exam/participate/exam-participation.module.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.module.ts
@@ -27,6 +27,7 @@ import { ArtemisCoursesModule } from 'app/overview/courses.module';
 import { OrionModule } from 'app/shared/orion/orion.module';
 import { ArtemisParticipationSummaryModule } from 'app/exam/participate/summary/exam-participation-summary.module';
 import { ExamTimerComponent } from './timer/exam-timer.component';
+import { ExamInformationComponent } from 'app/exam/participate/information/exam-information.component';
 
 const ENTITY_STATES = [...examParticipationState];
 
@@ -60,6 +61,7 @@ const ENTITY_STATES = [...examParticipationState];
         ExamNavigationBarComponent,
         ExamCodeEditorStudentContainerComponent,
         ExamTimerComponent,
+        ExamInformationComponent,
     ],
 })
 export class ArtemisExamParticipationModule {}

--- a/src/main/webapp/app/exam/participate/information/exam-information.component.html
+++ b/src/main/webapp/app/exam/participate/information/exam-information.component.html
@@ -1,0 +1,42 @@
+<div class="mt-3 mb-4 text-center">
+    <div class="mb-2">
+        <span class="mx-2" *ngIf="exam.startDate">
+            <strong class="font-weight-bold">{{ 'artemisApp.exam.date' | translate }}:</strong>
+            {{ exam.startDate | artemisDate: 'long-date' }}
+        </span>
+        <span class="mx-2">
+            <strong class="font-weight-bold">{{ 'artemisApp.exam.time' | translate }}:</strong>
+            {{ exam.startDate | artemisDate: 'time' }}
+            -
+            {{ endTime() | artemisDate: 'time' }}
+        </span>
+        <span class="mx-2" *ngIf="studentExam && studentExam.workingTime">
+            <strong class="font-weight-bold">{{ 'artemisApp.exam.durationWithFormat' | translate }}:</strong>
+            {{ studentExam.workingTime | artemisDurationFromSeconds }}
+        </span>
+    </div>
+    <div class="mb-2" *ngIf="exam.examiner || exam.moduleNumber || exam.courseName">
+        <span class="mx-2" *ngIf="exam.examiner">
+            <strong class="font-weight-bold">{{ 'artemisApp.examManagement.examiner' | translate }}:</strong>
+            {{ exam.examiner }}
+        </span>
+        <span class="mx-2" *ngIf="exam.moduleNumber">
+            <strong class="font-weight-bold">{{ 'artemisApp.examManagement.moduleNumber' | translate }}:</strong>
+            {{ exam.moduleNumber }}
+        </span>
+        <span class="mx-2" *ngIf="exam.courseName">
+            <strong class="font-weight-bold">{{ 'artemisApp.exam.course' | translate }}:</strong>
+            {{ exam.courseName }}
+        </span>
+    </div>
+    <div>
+        <span class="mx-2">
+            <strong class="font-weight-bold">{{ 'artemisApp.exam.exercises' | translate }}:</strong>
+            {{ exam.numberOfExercisesInExam }}
+        </span>
+        <span class="mx-2">
+            <strong class="font-weight-bold">{{ 'artemisApp.exam.points' | translate }}:</strong>
+            {{ exam.maxPoints }}
+        </span>
+    </div>
+</div>

--- a/src/main/webapp/app/exam/participate/information/exam-information.component.html
+++ b/src/main/webapp/app/exam/participate/information/exam-information.component.html
@@ -1,10 +1,10 @@
 <div class="mt-3 mb-4 text-center">
     <div class="mb-2">
-        <span class="mx-2" *ngIf="exam.startDate">
+        <span class="mx-2" *ngIf="exam && exam.startDate">
             <strong class="font-weight-bold">{{ 'artemisApp.exam.date' | translate }}:</strong>
             {{ exam.startDate | artemisDate: 'long-date' }}
         </span>
-        <span class="mx-2">
+        <span class="mx-2" *ngIf="exam">
             <strong class="font-weight-bold">{{ 'artemisApp.exam.time' | translate }}:</strong>
             {{ exam.startDate | artemisDate: 'time' }}
             -
@@ -15,7 +15,7 @@
             {{ studentExam.workingTime | artemisDurationFromSeconds }}
         </span>
     </div>
-    <div class="mb-2" *ngIf="exam.examiner || exam.moduleNumber || exam.courseName">
+    <div class="mb-2" *ngIf="exam && (exam.examiner || exam.moduleNumber || exam.courseName)">
         <span class="mx-2" *ngIf="exam.examiner">
             <strong class="font-weight-bold">{{ 'artemisApp.examManagement.examiner' | translate }}:</strong>
             {{ exam.examiner }}
@@ -29,12 +29,12 @@
             {{ exam.courseName }}
         </span>
     </div>
-    <div>
-        <span class="mx-2">
+    <div *ngIf="exam && (exam.numberOfExercisesInExam || exam.maxPoints)">
+        <span class="mx-2" *ngIf="exam.numberOfExercisesInExam">
             <strong class="font-weight-bold">{{ 'artemisApp.exam.exercises' | translate }}:</strong>
             {{ exam.numberOfExercisesInExam }}
         </span>
-        <span class="mx-2">
+        <span class="mx-2" *ngIf="exam.maxPoints">
             <strong class="font-weight-bold">{{ 'artemisApp.exam.points' | translate }}:</strong>
             {{ exam.maxPoints }}
         </span>

--- a/src/main/webapp/app/exam/participate/information/exam-information.component.ts
+++ b/src/main/webapp/app/exam/participate/information/exam-information.component.ts
@@ -14,10 +14,13 @@ export class ExamInformationComponent {
     /**
      * Calculates the end time depending on the individual working time.
      */
-    endTime(): moment.Moment {
+    endTime(): moment.Moment | null {
+        if (!this.exam || !this.exam.endDate) {
+            return null;
+        }
         if (this.studentExam && this.studentExam.workingTime && this.exam.startDate) {
             return moment(this.exam.startDate).add(this.studentExam.workingTime, 'seconds');
         }
-        return this.exam.endDate!;
+        return this.exam.endDate;
     }
 }

--- a/src/main/webapp/app/exam/participate/information/exam-information.component.ts
+++ b/src/main/webapp/app/exam/participate/information/exam-information.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input } from '@angular/core';
+import * as moment from 'moment';
+import { StudentExam } from 'app/entities/student-exam.model';
+import { Exam } from 'app/entities/exam.model';
+
+@Component({
+    selector: 'jhi-exam-information',
+    templateUrl: './exam-information.component.html',
+})
+export class ExamInformationComponent {
+    @Input() exam: Exam;
+    @Input() studentExam: StudentExam;
+
+    /**
+     * Calculates the end time depending on the individual working time.
+     */
+    endTime(): moment.Moment {
+        if (this.studentExam && this.studentExam.workingTime && this.exam.startDate) {
+            return moment(this.exam.startDate).add(this.studentExam.workingTime, 'seconds');
+        }
+        return this.exam.endDate!;
+    }
+}

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -13,8 +13,8 @@
     </h2>
 </div>
 <jhi-exam-information [exam]="studentExam.exam" [studentExam]="studentExam"></jhi-exam-information>
-<div class="mb-5" *ngIf="studentExam && studentExam.exercises">
-    <jhi-exam-points-summary [exercises]="studentExam.exercises"></jhi-exam-points-summary>
+<div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam">
+    <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam"></jhi-exam-points-summary>
 </div>
 <h4 class="mb-0">{{ 'artemisApp.exam.exercises' | translate }}</h4>
 <div *ngFor="let exercise of studentExam.exercises; let i = index">

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -13,6 +13,10 @@
     </h2>
 </div>
 <jhi-exam-information [exam]="studentExam.exam" [studentExam]="studentExam"></jhi-exam-information>
+<div class="mb-5" *ngIf="studentExam && studentExam.exercises">
+    <jhi-exam-points-summary [exercises]="studentExam.exercises"></jhi-exam-points-summary>
+</div>
+<h4 class="mb-0">{{ 'artemisApp.exam.exercises' | translate }}</h4>
 <div *ngFor="let exercise of studentExam.exercises; let i = index">
     <div class="question card">
         <div class="question-options card-header question-card-header">

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -12,6 +12,7 @@
         </button>
     </h2>
 </div>
+<jhi-exam-information [exam]="studentExam.exam" [studentExam]="studentExam"></jhi-exam-information>
 <div *ngFor="let exercise of studentExam.exercises; let i = index">
     <div class="question card">
         <div class="question-options card-header question-card-header">

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.module.ts
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.module.ts
@@ -14,6 +14,7 @@ import { ArtemisFullscreenModule } from 'app/shared/fullscreen/fullscreen.module
 import { ArtemisResultModule } from 'app/exercises/shared/result/result.module';
 import { ArtemisCoursesModule } from 'app/overview/courses.module';
 import { ArtemisComplaintsModule } from 'app/complaints/complaints.module';
+import { ExamInformationComponent } from 'app/exam/participate/information/exam-information.component';
 
 @NgModule({
     imports: [
@@ -34,7 +35,8 @@ import { ArtemisComplaintsModule } from 'app/complaints/complaints.module';
         FileUploadExamSummaryComponent,
         TextExamSummaryComponent,
         QuizExamSummaryComponent,
+        ExamInformationComponent,
     ],
-    exports: [ExamParticipationSummaryComponent],
+    exports: [ExamParticipationSummaryComponent, ExamInformationComponent],
 })
 export class ArtemisParticipationSummaryModule {}

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.module.ts
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.module.ts
@@ -15,6 +15,7 @@ import { ArtemisResultModule } from 'app/exercises/shared/result/result.module';
 import { ArtemisCoursesModule } from 'app/overview/courses.module';
 import { ArtemisComplaintsModule } from 'app/complaints/complaints.module';
 import { ExamInformationComponent } from 'app/exam/participate/information/exam-information.component';
+import { ExamPointsSummaryComponent } from 'app/exam/participate/summary/points-summary/exam-points-summary.component';
 
 @NgModule({
     imports: [
@@ -36,6 +37,7 @@ import { ExamInformationComponent } from 'app/exam/participate/information/exam-
         TextExamSummaryComponent,
         QuizExamSummaryComponent,
         ExamInformationComponent,
+        ExamPointsSummaryComponent,
     ],
     exports: [ExamParticipationSummaryComponent, ExamInformationComponent],
 })

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
@@ -1,0 +1,26 @@
+<div *ngIf="hasResults()">
+    <h4>{{ 'artemisApp.exam.examSummary.points.yourPoints' | translate }}</h4>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th scope="col">#</th>
+                <th scope="col">{{ 'artemisApp.exam.examSummary.points.exercise' | translate }}</th>
+                <th scope="col">{{ 'artemisApp.exam.examSummary.points.yourPoints' | translate }}</th>
+                <th scope="col">{{ 'artemisApp.exam.examSummary.points.maxPoints' | translate }}</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr *ngFor="let exercise of exercises; let i = index">
+                <th scope="row">{{ i }}</th>
+                <td></td>
+                <td></td>
+                <td></td>
+            </tr>
+            <tr>
+                <th colspan="2" class="text-right">{{ 'artemisApp.exam.examSummary.points.sum' | translate }}</th>
+                <td></td>
+                <td></td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
@@ -11,7 +11,7 @@
         </thead>
         <tbody>
             <tr *ngFor="let exercise of exercises; let i = index">
-                <th scope="row">{{ i }}</th>
+                <th scope="row">{{ i + 1 }}</th>
                 <td>
                     <span *ngIf="exercise.title">{{ exercise.title }}</span>
                 </td>

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="hasResults()">
+<div *ngIf="show()" style="max-width: 980px;">
     <h4>{{ 'artemisApp.exam.examSummary.points.yourPoints' | translate }}</h4>
     <table class="table table-striped">
         <thead>
@@ -12,14 +12,20 @@
         <tbody>
             <tr *ngFor="let exercise of exercises; let i = index">
                 <th scope="row">{{ i }}</th>
-                <td></td>
-                <td></td>
-                <td></td>
+                <td>
+                    <span *ngIf="exercise.title">{{ exercise.title }}</span>
+                </td>
+                <td>
+                    {{ calculateAchievedPointsForExercise(exercise) }}
+                </td>
+                <td>
+                    <span *ngIf="exercise.maxScore">{{ exercise.maxScore }}</span>
+                </td>
             </tr>
             <tr>
                 <th colspan="2" class="text-right">{{ 'artemisApp.exam.examSummary.points.sum' | translate }}</th>
-                <td></td>
-                <td></td>
+                <td>{{ calculatePointsSum() }}</td>
+                <td>{{ calculateMaxPointsSum() }}</td>
             </tr>
         </tbody>
     </table>

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="show()" style="max-width: 980px;">
-    <h4>{{ 'artemisApp.exam.examSummary.points.yourPoints' | translate }}</h4>
+    <h4>{{ 'artemisApp.exam.examSummary.points.overview' | translate }}</h4>
     <table class="table table-striped">
         <thead>
             <tr>

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
@@ -16,7 +16,7 @@
                     <span *ngIf="exercise.title">{{ exercise.title }}</span>
                 </td>
                 <td>
-                    {{ calculateAchievedPointsForExercise(exercise) }}
+                    {{ calculateAchievedPoints(exercise) }}
                 </td>
                 <td>
                     <span *ngIf="exercise.maxScore">{{ exercise.maxScore }}</span>

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -3,6 +3,7 @@ import * as moment from 'moment';
 import { Exercise } from 'app/entities/exercise.model';
 import { ArtemisServerDateService } from 'app/shared/server-date.service';
 import { Exam } from 'app/entities/exam.model';
+import { round } from 'app/shared/util/utils';
 
 @Component({
     selector: 'jhi-exam-points-summary',
@@ -28,11 +29,11 @@ export class ExamPointsSummaryComponent {
      * Calculate the achieved points of an exercise.
      * @param exercise
      */
-    calculateAchievedPointsForExercise(exercise: Exercise): number | '-' {
+    calculateAchievedPoints(exercise: Exercise): number {
         if (ExamPointsSummaryComponent.hasResultScore(exercise)) {
-            return ExamPointsSummaryComponent.getResultPoints(exercise);
+            return round(exercise.maxScore * (exercise.studentParticipations[0].results[0].score / 100), 1);
         }
-        return '-';
+        return 0;
     }
 
     /**
@@ -40,7 +41,7 @@ export class ExamPointsSummaryComponent {
      */
     calculatePointsSum(): number {
         if (this.exercises) {
-            return this.exercises.reduce((sum: number, nextExercise: Exercise) => sum + ExamPointsSummaryComponent.getResultPoints(nextExercise), 0);
+            return this.exercises.reduce((sum: number, nextExercise: Exercise) => sum + this.calculateAchievedPoints(nextExercise), 0);
         }
         return 0;
     }
@@ -79,13 +80,6 @@ export class ExamPointsSummaryComponent {
             exercise.studentParticipations[0].results.length > 0 &&
             exercise.studentParticipations[0].results[0].score
         );
-    }
-
-    private static getResultPoints(exercise: Exercise): number {
-        if (ExamPointsSummaryComponent.hasResultScore(exercise)) {
-            return round(exercise.maxScore * (exercise.studentParticipations[0].results[0].score / 100), 1);
-        }
-        return 0;
     }
 
     private static getMaxScore(exercise: Exercise): number {

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { Exercise } from 'app/entities/exercise.model';
+import { ArtemisServerDateService } from 'app/shared/server-date.service';
+import { Exam } from 'app/entities/exam.model';
 
 @Component({
     selector: 'jhi-exam-points-summary',
@@ -7,11 +9,88 @@ import { Exercise } from 'app/entities/exercise.model';
 })
 export class ExamPointsSummaryComponent {
     @Input() exercises: Exercise[];
+    @Input() exam: Exam;
+
+    constructor(private serverDateService: ArtemisServerDateService) {}
 
     /**
-     * Checks if results are part of the received exercises array.
+     * The points summary table will only be shown if:
+     * - exam.publishResultsDate is set
+     * - we are after the exam.publishResultsDate
+     * - at least one exercise has a result
      */
-    hasResults(): boolean {
-        return true;
+    show() {
+        return !!(this.exam && this.exam.publishResultsDate && this.exam.publishResultsDate.isBefore(this.serverDateService.now()) && this.hasAtLeastOneResult());
+    }
+
+    /**
+     * Calculate the achieved points of an exercise.
+     * @param exercise
+     */
+    calculateAchievedPointsForExercise(exercise: Exercise): number | '-' {
+        if (ExamPointsSummaryComponent.hasResultScore(exercise)) {
+            return ExamPointsSummaryComponent.getResultPoints(exercise);
+        }
+        return '-';
+    }
+
+    /**
+     * Calculate the sum of points the student achieved.
+     */
+    calculatePointsSum(): number {
+        if (this.exercises) {
+            return this.exercises.reduce((sum: number, nextExercise: Exercise) => sum + ExamPointsSummaryComponent.getResultPoints(nextExercise), 0);
+        }
+        return 0;
+    }
+
+    /**
+     * Calculate the max. achievable points.
+     */
+    calculateMaxPointsSum(): number {
+        if (this.exercises) {
+            return this.exercises.reduce((sum: number, nextExercise: Exercise) => sum + ExamPointsSummaryComponent.getMaxScore(nextExercise), 0);
+        }
+        return 0;
+    }
+
+    private hasAtLeastOneResult(): boolean {
+        if (this.exercises && this.exercises.length > 0) {
+            return this.exercises.some((exercise) => {
+                return (
+                    exercise.studentParticipations &&
+                    exercise.studentParticipations.length > 0 &&
+                    exercise.studentParticipations[0].results &&
+                    exercise.studentParticipations[0].results.length > 0
+                );
+            });
+        }
+        return false;
+    }
+
+    private static hasResultScore(exercise: Exercise): boolean {
+        return !!(
+            exercise &&
+            exercise.maxScore &&
+            exercise.studentParticipations &&
+            exercise.studentParticipations.length > 0 &&
+            exercise.studentParticipations[0].results &&
+            exercise.studentParticipations[0].results.length > 0 &&
+            exercise.studentParticipations[0].results[0].score
+        );
+    }
+
+    private static getResultPoints(exercise: Exercise): number {
+        if (ExamPointsSummaryComponent.hasResultScore(exercise)) {
+            return exercise.maxScore * (exercise.studentParticipations[0].results[0].score / 100);
+        }
+        return 0;
+    }
+
+    private static getMaxScore(exercise: Exercise): number {
+        if (exercise && exercise.maxScore) {
+            return exercise.maxScore;
+        }
+        return 0;
     }
 }

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -83,7 +83,7 @@ export class ExamPointsSummaryComponent {
 
     private static getResultPoints(exercise: Exercise): number {
         if (ExamPointsSummaryComponent.hasResultScore(exercise)) {
-            return Math.round(exercise.maxScore * (exercise.studentParticipations[0].results[0].score / 100) * 100) / 100;
+            return round(exercise.maxScore * (exercise.studentParticipations[0].results[0].score / 100), 1);
         }
         return 0;
     }

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -83,7 +83,7 @@ export class ExamPointsSummaryComponent {
 
     private static getResultPoints(exercise: Exercise): number {
         if (ExamPointsSummaryComponent.hasResultScore(exercise)) {
-            return exercise.maxScore * (exercise.studentParticipations[0].results[0].score / 100);
+            return Math.round(exercise.maxScore * (exercise.studentParticipations[0].results[0].score / 100) * 100) / 100;
         }
         return 0;
     }

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -41,7 +41,10 @@ export class ExamPointsSummaryComponent {
      */
     calculatePointsSum(): number {
         if (this.exercises) {
-            return this.exercises.reduce((sum: number, nextExercise: Exercise) => sum + this.calculateAchievedPoints(nextExercise), 0);
+            return round(
+                this.exercises.reduce((sum: number, nextExercise: Exercise) => sum + this.calculateAchievedPoints(nextExercise), 0),
+                1,
+            );
         }
         return 0;
     }
@@ -51,7 +54,10 @@ export class ExamPointsSummaryComponent {
      */
     calculateMaxPointsSum(): number {
         if (this.exercises) {
-            return this.exercises.reduce((sum: number, nextExercise: Exercise) => sum + ExamPointsSummaryComponent.getMaxScore(nextExercise), 0);
+            return round(
+                this.exercises.reduce((sum: number, nextExercise: Exercise) => sum + ExamPointsSummaryComponent.getMaxScore(nextExercise), 0),
+                1,
+            );
         }
         return 0;
     }

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import * as moment from 'moment';
 import { Exercise } from 'app/entities/exercise.model';
 import { ArtemisServerDateService } from 'app/shared/server-date.service';
 import { Exam } from 'app/entities/exam.model';
@@ -19,8 +20,8 @@ export class ExamPointsSummaryComponent {
      * - we are after the exam.publishResultsDate
      * - at least one exercise has a result
      */
-    show() {
-        return !!(this.exam && this.exam.publishResultsDate && this.exam.publishResultsDate.isBefore(this.serverDateService.now()) && this.hasAtLeastOneResult());
+    show(): boolean {
+        return !!(this.exam && this.exam.publishResultsDate && moment(this.exam.publishResultsDate).isBefore(this.serverDateService.now()) && this.hasAtLeastOneResult());
     }
 
     /**

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input } from '@angular/core';
+import { Exercise } from 'app/entities/exercise.model';
+
+@Component({
+    selector: 'jhi-exam-points-summary',
+    templateUrl: './exam-points-summary.component.html',
+})
+export class ExamPointsSummaryComponent {
+    @Input() exercises: Exercise[];
+
+    /**
+     * Checks if results are part of the received exercises array.
+     */
+    hasResults(): boolean {
+        return true;
+    }
+}

--- a/src/main/webapp/app/shared/util/utils.ts
+++ b/src/main/webapp/app/shared/util/utils.ts
@@ -48,3 +48,29 @@ export const stringifyCircular = (val: any): string => {
 export const stringifyIgnoringFields = (val: any, ...ignoredFields: string[]): string => {
     return JSON.stringify(omit(val, ignoredFields));
 };
+
+/**
+ * Helper function to make actually rounding possible
+ * @param value
+ * @param exp
+ */
+export const round = (value: any, exp: number) => {
+    if (typeof exp === 'undefined' || +exp === 0) {
+        return Math.round(value);
+    }
+
+    value = +value;
+    exp = +exp;
+
+    if (isNaN(value) || !(exp % 1 === 0)) {
+        return NaN;
+    }
+
+    // Shift
+    value = value.toString().split('e');
+    value = Math.round(+(value[0] + 'e' + (value[1] ? +value[1] + exp : exp)));
+
+    // Shift back
+    value = value.toString().split('e');
+    return +(value[0] + 'e' + (value[1] ? +value[1] - exp : -exp));
+};

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -17,6 +17,7 @@
                 "missingResultNotice": "Es gibt derzeit kein Ergebnis für diese Quiz Aufgabe, obwohl die Ergebnisse schon veröffentlicht wurden. Bitte informiere deinen Instruktor.",
                 "points": {
                     "exercise": "Aufgabe",
+                    "overview": "Übersicht",
                     "yourPoints": "Deine Punkte",
                     "maxPoints": "Max. Punkte",
                     "sum": "Summe"

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -14,7 +14,13 @@
                 "noCommitHash": "Kein Commit wurde gemacht",
                 "studentSubmissionTo": "{{studentName}}s Abgabe für {{examTitle}}",
                 "viewResult": " Ergebnis ansehen",
-                "missingResultNotice": "Es gibt derzeit kein Ergebnis für diese Quiz Aufgabe, obwohl die Ergebnisse schon veröffentlicht wurden. Bitte informiere deinen Instruktor."
+                "missingResultNotice": "Es gibt derzeit kein Ergebnis für diese Quiz Aufgabe, obwohl die Ergebnisse schon veröffentlicht wurden. Bitte informiere deinen Instruktor.",
+                "points": {
+                    "exercise": "Aufgabe",
+                    "yourPoints": "Deine Punkte",
+                    "maxPoints": "Max. Punkte",
+                    "sum": "Summe"
+                }
             },
             "title": "Klausur",
             "startExam": "Starten",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -17,6 +17,7 @@
                 "missingResultNotice": "There is currently no result for this quiz exercise, although the results have already been published. Please inform your instructor.",
                 "points": {
                     "exercise": "Exercise",
+                    "overview": "Overview",
                     "yourPoints": "Your points",
                     "maxPoints": "Max. points",
                     "sum": "Sum"

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -14,7 +14,13 @@
                 "noCommitHash": "No commit was made",
                 "studentSubmissionTo": "{{studentName}}'s submission to {{examTitle}}",
                 "viewResult": " View Result",
-                "missingResultNotice": "There is currently no result for this quiz exercise, although the results have already been published. Please inform your instructor."
+                "missingResultNotice": "There is currently no result for this quiz exercise, although the results have already been published. Please inform your instructor.",
+                "points": {
+                    "exercise": "Exercise",
+                    "yourPoints": "Your points",
+                    "maxPoints": "Max. points",
+                    "sum": "Sum"
+                }
             },
             "title": "Exam",
             "startExam": "Start",


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
We want to provide an overview of the achieved / achievable points in the exam summary.

### Description
I've implemented an overview table with the achieved / achievable points that is shown in the exam summary for the student and the instructor in the exam management. "-" is shown if no result for that exercise is available.

### Steps for Testing
The following should be checked for the exam summary for students (participation) and the exam summary in the student exams management for instructors.

1. Log in to Artemis
2. Participate in an exam with multiple exercises
3. Check that the table is not shown if the `publishResultsDate` is not set
4. Check that the table is not shown if the `publishResultsDate` is in the future
5. Check that the points in the table are calculated correctly (for each exercise and the sums)

**NOTE:** if you get a null pointer exception in `quiz-exam-summary.component` you could possibly ignore it as that will be fixed here: https://github.com/ls1intum/Artemis/pull/1914

### Screenshots
![image](https://user-images.githubusercontent.com/15168372/87824266-3be7d780-c875-11ea-9644-04c8e2ac9f12.png)