### PR TITLE
Fix Assessment of modeling exercises without any submission

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -33,7 +33,11 @@
         </div>
         <div class="card-body question-card-body" [ngbCollapse]="isCollapsed(exercise.id)">
             <div *ngIf="exercise.type !== QUIZ && exercise.type !== PROGRAMMING && resultsPublished">
-                <button class="btn btn-primary float-right" [routerLink]="generateLink(exercise)">
+                <button
+                    *ngIf="exercise.studentParticipations && exercise.studentParticipations.length > 0"
+                    class="btn btn-primary float-right"
+                    [routerLink]="generateLink(exercise)"
+                >
                     <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon><span jhiTranslate="artemisApp.exam.examSummary.viewResult">&nbsp;View Result</span>
                 </button>
             </div>

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
@@ -62,7 +62,9 @@ export class ExamParticipationSummaryComponent implements OnInit {
     }
 
     public generateLink(exercise: Exercise) {
-        return ['/courses', this.courseId, `${exercise.type}-exercises`, exercise.id, 'participate', exercise.studentParticipations[0].id];
+        if (exercise && exercise.studentParticipations && exercise.studentParticipations.length > 0) {
+            return ['/courses', this.courseId, `${exercise.type}-exercises`, exercise.id, 'participate', exercise.studentParticipations[0].id];
+        }
     }
 
     /**

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -266,7 +266,7 @@ export class ModelingAssessmentEditorComponent implements OnInit {
     }
 
     onSubmitAssessment() {
-        if (this.referencedFeedback.length < this.model!.elements.length || !this.assessmentsAreValid) {
+        if ((this.model && this.referencedFeedback.length < this.model.elements.length) || !this.assessmentsAreValid) {
             const confirmationMessage = this.translateService.instant('modelingAssessmentEditor.messages.confirmSubmission');
 
             // if the assessment is before the assessment due date, don't show the confirm submission button

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment.component.ts
@@ -245,7 +245,7 @@ export class ModelingAssessmentComponent implements AfterViewInit, OnDestroy, On
      * @param feedbacks the feedback list to convert and pass on to Apollon
      */
     private updateApollonAssessments(feedbacks: Feedback[]) {
-        if (!feedbacks) {
+        if (!feedbacks || !this.model) {
             return;
         }
         this.model.assessments = feedbacks.map<Assessment>((feedback) => ({


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) locally
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Assessment of empty UML-Models should work

### Description
<!-- Describe your changes in detail -->
Checked the places in the modeling-assessment component where it is assumed that there must be a model from apollon. In those places I added checks to prevent errors

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create an exam with at least 2 modeling exercises
2. Generate Student Exams and participate
3. Exercise 1: **do not** submit any solution for the exercise
4. Exercise 2: submit a model, then delete every element and submit again (empty submission should be counted) 
5. After the exam has ended, switch to tutor account and go to the assessment of the modeling exercise
6. do an assessment with open browser console -> no error should be displayed (The error you can see in the screenshot is happening, because there isn't any other submission for this exercise which can be assessed )

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/22955066/87836443-5d09f180-c890-11ea-843a-3fa42c9ff096.png)
