### PR TITLE
Execute "prepare exercise start" in fork join pool with exactly 10 threads

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -581,16 +581,9 @@ public class ExamService {
 
     private static void executeInParallel(Runnable task) {
         final int numberOfParallelThreads = 10;
-        ForkJoinPool forkJoinPool = null;
-        try {
-            forkJoinPool = new ForkJoinPool(numberOfParallelThreads);
-            forkJoinPool.submit(task);
-        }
-        finally {
-            if (forkJoinPool != null) {
-                forkJoinPool.shutdown();
-            }
-        }
+        ForkJoinPool forkJoinPool = new ForkJoinPool(numberOfParallelThreads);
+        forkJoinPool.submit(task);
+        forkJoinPool.shutdown();
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -585,7 +585,6 @@ public class ExamService {
         final int numberOfParallelThreads = 10;
         ForkJoinPool forkJoinPool = new ForkJoinPool(numberOfParallelThreads);
         Future<?> future = forkJoinPool.submit(task);
-        forkJoinPool.shutdown();
         // Wait for the operation to complete
         try {
             future.get();
@@ -595,6 +594,9 @@ public class ExamService {
         }
         catch (ExecutionException e) {
             log.error("Execute in parallel failed, an exception was thrown", e.getCause());
+        }
+        finally {
+            forkJoinPool.shutdown();
         }
     }
 


### PR DESCRIPTION
This makes the previously introduced parallelism more deterministic. At the moment, it depends which VM is used (4 CPUs --> 3 Threads in parallel, 12 CPUs --> 11 Threads in parallel). Some instructors might be out of luck and need to wait longer.
With this change, it should be independent which VM is chosen in production.

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

1. Create an exam with at least 1 programming exercise and at least 20 participants
2. Generate the individual student exams and click on "prepare exercise start"
3. This should be blazingly fast (10x faster than some days ago), because the server runs this task in 10 threads in parallel
4. Navigate to the participations page of the programming exercise(s) and check that all are created with state active