### PR TITLE
[Exam] Bugfix: Do not switch to next exercise if user wants to hand in early

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -64,18 +64,24 @@ export class ExamNavigationBarComponent implements OnInit {
         this.setExerciseButtonStatus(exerciseIndex);
     }
 
-    saveExercise() {
+    /**
+     * Save the currently active exercise and go to the next exercise.
+     * @param changeExercise whether to go to the next exercise {boolean}
+     */
+    saveExercise(changeExercise = true) {
         const newIndex = this.exerciseIndex + 1;
         const submission = this.getSubmissionForExercise(this.exercises[this.exerciseIndex]);
         // we do not submit programming exercises on a save
         if (submission && this.exercises[this.exerciseIndex].type !== ExerciseType.PROGRAMMING) {
             submission.submitted = true;
         }
-        if (newIndex > this.exercises.length - 1) {
-            // we are in the last exercise, if out of range "change" active exercise to current in order to trigger a save
-            this.changeExercise(this.exerciseIndex, true);
-        } else {
-            this.changeExercise(newIndex, true);
+        if (changeExercise) {
+            if (newIndex > this.exercises.length - 1) {
+                // we are in the last exercise, if out of range "change" active exercise to current in order to trigger a save
+                this.changeExercise(this.exerciseIndex, true);
+            } else {
+                this.changeExercise(newIndex, true);
+            }
         }
     }
 
@@ -136,7 +142,7 @@ export class ExamNavigationBarComponent implements OnInit {
      * Notify parent component when user wants to hand in early
      */
     handInEarly() {
-        this.saveExercise();
+        this.saveExercise(false);
         this.onExamHandInEarly.emit();
     }
 

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -12,19 +12,15 @@ import { Submission } from 'app/entities/submission.model';
     styleUrls: ['./exam-navigation-bar.component.scss'],
 })
 export class ExamNavigationBarComponent implements OnInit {
-    @Input()
-    exercises: Exercise[] = [];
-
-    @Input()
-    endDate: Moment;
+    @Input() exercises: Exercise[] = [];
+    @Input() exerciseIndex = 0;
+    @Input() endDate: Moment;
 
     @Output() onExerciseChanged = new EventEmitter<{ exercise: Exercise; force: boolean }>();
     @Output() examAboutToEnd = new EventEmitter<void>();
     @Output() onExamHandInEarly = new EventEmitter<void>();
 
     static itemsVisiblePerSideDefault = 4;
-
-    exerciseIndex = 0;
     itemsVisiblePerSide = ExamNavigationBarComponent.itemsVisiblePerSideDefault;
 
     criticalTime = moment.duration(5, 'minutes');

--- a/src/main/webapp/app/exam/participate/exam-participation.component.html
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.html
@@ -14,6 +14,7 @@
             <jhi-exam-navigation-bar
                 id="exam-navigation-bar"
                 [exercises]="studentExam.exercises"
+                [exerciseIndex]="exerciseIndex"
                 [endDate]="individualStudentEndDate"
                 (onExerciseChanged)="onExerciseChange($event)"
                 (examAboutToEnd)="examEnded()"

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -65,6 +65,8 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
 
     handInEarly = false;
 
+    exerciseIndex = 0;
+
     isProgrammingExercise() {
         return this.activeExercise.type === ExerciseType.PROGRAMMING;
     }
@@ -289,6 +291,9 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         if (this.handInEarly) {
             // update local studentExam for later sync with server if the student wants to hand in early
             this.updateLocalStudentExam();
+        } else if (this.studentExam?.exercises && this.activeExercise) {
+            const index = this.studentExam.exercises.findIndex((exercise) => exercise.id === this.activeExercise.id);
+            this.exerciseIndex = index ? index : 0;
         }
     }
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
https://github.com/ls1intum/Artemis/issues/1912

### Description
The problem ist that `saveExercise()` is called when the student clicks on *Hand in early*. This method switches to the next exercise and if the user then clicks *Continue* the state of the nav bar is broken. Therefore I've added a flag to `saveExercise()` so that it won't switch to the next exercise.

Additionally, I've ensured that the exercise index will be passed back from the `exam-participation.component` to the `exam-navigation-bar.component` when the students decides to continue.

### Steps for Testing
1. Log in to Artemis
2. Participate in an exam
3. Click on *Hand in early* but to not submit
4. Click on *Continue*
5. Ensure that you are on the same exercise as before