### PR TITLE
[Exam] Adapt Edit/Re-evaluate button for quizzes to exam lifecycle 

### DIFF
--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -139,7 +139,7 @@
                         <td class="d-flex justify-content-end">
                             <jhi-exam-exercise-row-buttons
                                 [course]="course"
-                                [examId]="exam.id"
+                                [exam]="exam"
                                 [exercise]="exercise"
                                 [exerciseGroupId]="exerciseGroup.id"
                                 [latestIndividualEndDate]="latestIndividualEndDate"

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -97,20 +97,35 @@
         <span class="d-none d-md-inline" jhiTranslate="artemisApp.quizExercise.solution">Solution</span>
     </button>
 
-    <button
-        *ngIf="course.isAtLeastInstructor && isExamOver() && exercise.type === exerciseType.QUIZ"
-        type="submit"
-        [routerLink]="['/course-management', course.id, 'quiz-exercises', exercise.id, 're-evaluate']"
-        class="btn btn-primary btn-sm mr-1"
-    >
-        <fa-icon [icon]="'pencil-alt'"></fa-icon>
-        <span class="d-none d-md-inline" jhiTranslate="entity.action.re-evaluate">Re-evaluate</span>
-    </button>
+    <!-- Edit or re-evaluate for quizzes -->
+    <ng-container *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.QUIZ">
+        <!-- Only show the re-evaluate button after the exam has ended -->
+        <button
+            *ngIf="isExamOver()"
+            type="submit"
+            [routerLink]="['/course-management', course.id, 'quiz-exercises', exercise.id, 're-evaluate']"
+            class="btn btn-primary btn-sm mr-1"
+        >
+            <fa-icon [icon]="'pencil-alt'"></fa-icon>
+            <span class="d-none d-md-inline" jhiTranslate="entity.action.re-evaluate">Re-evaluate</span>
+        </button>
+        <!-- Only show the the edit button if the exam has not ended. Disable the button if the exam is running -->
+        <button
+            *ngIf="!isExamOver()"
+            [disabled]="hasExamStarted()"
+            type="submit"
+            [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, exercise.type + '-exercises', exercise.id, 'edit']"
+            class="btn btn-primary btn-sm mr-1"
+        >
+            <fa-icon [icon]="'pencil-alt'"></fa-icon>
+            <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
+        </button>
+    </ng-container>
 
     <button
-        *ngIf="course.isAtLeastInstructor"
+        *ngIf="course.isAtLeastInstructor && exercise.type !== exerciseType.QUIZ"
         type="submit"
-        [routerLink]="['/course-management', course.id, 'exams', examId, 'exercise-groups', exerciseGroupId, exercise.type + '-exercises', exercise.id, 'edit']"
+        [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, exercise.type + '-exercises', exercise.id, 'edit']"
         class="btn btn-primary btn-sm mr-1"
     >
         <fa-icon [icon]="'pencil-alt'"></fa-icon>

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.ts
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.ts
@@ -9,7 +9,7 @@ import { QuizExerciseService } from 'app/exercises/quiz/manage/quiz-exercise.ser
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
 import { ModelingExerciseService } from 'app/exercises/modeling/manage/modeling-exercise.service';
 import { Course } from 'app/entities/course.model';
-
+import { Exam } from 'app/entities/exam.model';
 import * as moment from 'moment';
 
 @Component({
@@ -19,7 +19,7 @@ import * as moment from 'moment';
 export class ExamExerciseRowButtonsComponent {
     @Input() course: Course;
     @Input() exercise: Exercise;
-    @Input() examId: number;
+    @Input() exam: Exam;
     @Input() exerciseGroupId: number;
     @Input() latestIndividualEndDate: moment.Moment | null;
     @Output() onDeleteExercise = new EventEmitter<void>();
@@ -41,6 +41,13 @@ export class ExamExerciseRowButtonsComponent {
      */
     isExamOver() {
         return this.latestIndividualEndDate ? this.latestIndividualEndDate.isBefore(moment()) : false;
+    }
+
+    /**
+     * Checks whether the exam has started
+     */
+    hasExamStarted() {
+        return this.exam.startDate ? this.exam.startDate.isBefore(moment()) : false;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
Edit/Re-evaluate for quizzes is mutual exclusive. The buttons shown for this functionality in the exercise group view must follow the exam lifecycle.

### Description
Adapt Edit/Re-evaluate buttons for quizzes
1. **Exam has not started yet**: Edit is shown and activated; Re-evaluate is not shown
2. **Exam is running**: Edit is shown and disabled; Re-evaluate is not shown
3. **Exam has ended (latest individual end date passed)**: Edit is not shown; Re-evaluate is shown and activated

### Steps for Testing
1. Create a new exam with quizzes and at least another exercise type
2. Check the buttons of the exercise group view during the lifecycle of the exam
--> Edit/Re-evaluate buttons work as described for quizzes while the buttons for the other exercise types are unaffected.