### PR TITLE
Team complaints logic for programming exercises + indicator icon on team page

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
@@ -177,10 +177,15 @@ public class ComplaintResource {
             return forbidden();
         }
         var isAtLeastInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
+        var isTeamParticipation = participation.getParticipant() instanceof Team;
+        var isTutorOfTeam = user.equals(participation.getTeam().map(Team::getOwner).orElse(null));
 
         if (!isAtLeastInstructor) {
             complaint.getResult().setAssessor(null);
-            complaint.filterSensitiveInformation();
+
+            if (!isTeamParticipation || !isTutorOfTeam) {
+                complaint.filterSensitiveInformation();
+            }
         }
         // hide participation + exercise + course which might include sensitive information
         complaint.getResult().setParticipation(null);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
@@ -178,7 +178,7 @@ public class ComplaintResource {
         }
         var isAtLeastInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
         var isTeamParticipation = participation.getParticipant() instanceof Team;
-        var isTutorOfTeam = user.equals(participation.getTeam().map(Team::getOwner).orElse(null));
+        var isTutorOfTeam = user.getLogin().equals(participation.getTeam().map(team -> team.getOwner().getLogin()).orElse(null));
 
         if (!isAtLeastInstructor) {
             complaint.getResult().setAssessor(null);

--- a/src/main/webapp/app/exercises/programming/assess/manual-result/programming-assessment-manual-result-dialog.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/manual-result/programming-assessment-manual-result-dialog.component.html
@@ -1,19 +1,18 @@
 <form name="editForm" role="form" novalidate (ngSubmit)="save()" #editForm="ngForm" *ngIf="!isLoading; else loadingContainer">
     <div class="modal-header">
         <h4 class="modal-title">
-            <span *ngIf="!result?.id; else dialogTitleWithResult" jhiTranslate="artemisApp.result.createManual">Create manual result </span>
+            <span *ngIf="!result?.id; else dialogTitleWithResult" jhiTranslate="artemisApp.result.createManual">Create manual result</span>
             <ng-template #dialogTitleWithResult>
                 <span *ngIf="!complaint" jhiTranslate="artemisApp.result.updateManual">Update manual result</span>
                 <span
-                    *ngIf="complaint && ((complaint.complaintType === ComplaintType.COMPLAINT && isAssessor) || complaint.accepted !== undefined)"
-                    jhiTranslate="artemisApp.result.viewManual"
-                    >View manual result</span
-                >
-                <span
-                    *ngIf="complaint && (complaint.complaintType !== ComplaintType.MORE_FEEDBACK || !isAssessor) && complaint.accepted === undefined"
+                    *ngIf="complaint && complaint.complaintType === ComplaintType.COMPLAINT && isAllowedToRespond && complaint.accepted === undefined; else viewManualResult"
                     jhiTranslate="artemisApp.tutorExerciseDashboard.evaluateComplaint"
-                    >Evaluate complaint
+                >
+                    Evaluate complaint
                 </span>
+                <ng-template #viewManualResult>
+                    <span jhiTranslate="artemisApp.result.viewManual">View manual result</span>
+                </ng-template>
             </ng-template>
             ({{ exercise.title }})
         </h4>
@@ -134,7 +133,7 @@
         <div class="mt-3" *ngIf="complaint">
             <jhi-complaints-for-tutor-form
                 [complaint]="complaint"
-                [isAllowedToRespond]="complaint.complaintType === ComplaintType.COMPLAINT ? !isAssessor : isAssessor"
+                [isAllowedToRespond]="isAllowedToRespond"
                 (updateAssessmentAfterComplaint)="onUpdateAssessmentAfterComplaint($event)"
             >
             </jhi-complaints-for-tutor-form>

--- a/src/main/webapp/app/exercises/programming/assess/manual-result/programming-assessment-manual-result-dialog.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/manual-result/programming-assessment-manual-result-dialog.component.ts
@@ -245,6 +245,18 @@ export class ProgrammingAssessmentManualResultDialogComponent implements OnInit 
     }
 
     /**
+     * For team exercises, the team tutor is the assessor and handles both complaints and feedback requests himself
+     * For individual exercises, complaints are handled by a secondary reviewer and feedback requests by the assessor himself
+     */
+    get isAllowedToRespond(): boolean {
+        if (this.complaint.team) {
+            return this.isAssessor;
+        } else {
+            return this.complaint.complaintType === ComplaintType.COMPLAINT ? !this.isAssessor : this.isAssessor;
+        }
+    }
+
+    /**
      * Sends the current (updated) assessment to the server to update the original assessment after a complaint was accepted.
      * The corresponding complaint response is sent along with the updated assessment to prevent additional requests.
      *

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
@@ -185,14 +185,22 @@
                 </ng-template>
                 <ng-template ngx-datatable-cell-template let-value="row">
                     <ng-container *ngIf="value.type !== ExerciseType.PROGRAMMING; else programmingAssessment">
-                        <button
-                            [disabled]="assessmentButtonDisabled(value, value.submission)"
-                            (click)="openAssessmentEditor(value, value.submission)"
-                            class="btn btn-warning btn-sm"
-                        >
-                            <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
-                            <span [jhiTranslate]="'artemisApp.tutorExerciseDashboard.' + assessmentAction(value.submission) + 'Assessment'"></span>
-                        </button>
+                        <div class="d-flex justify-content-start align-items-center">
+                            <button
+                                [disabled]="assessmentButtonDisabled(value, value.submission)"
+                                (click)="openAssessmentEditor(value, value.submission)"
+                                class="btn btn-warning btn-sm"
+                            >
+                                <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
+                                <span [jhiTranslate]="'artemisApp.tutorExerciseDashboard.' + assessmentAction(value.submission) + 'Assessment'"></span>
+                            </button>
+                            <fa-icon
+                                class="mx-3"
+                                *ngIf="value.submission.result.hasComplaint"
+                                [icon]="'flag'"
+                                ngbTooltip="{{ 'artemisApp.team.detail.participationsTable.complaintOrMoreFeedbackRequest' | translate }}"
+                            ></fa-icon>
+                        </div>
                     </ng-container>
                     <ng-template #programmingAssessment>
                         <jhi-programming-assessment-manual-result

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
@@ -196,7 +196,7 @@
                             </button>
                             <fa-icon
                                 class="mx-3"
-                                *ngIf="value.submission.result.hasComplaint"
+                                *ngIf="value.submission?.result?.hasComplaint"
                                 [icon]="'flag'"
                                 ngbTooltip="{{ 'artemisApp.team.detail.participationsTable.complaintOrMoreFeedbackRequest' | translate }}"
                             ></fa-icon>

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
@@ -184,8 +184,8 @@
                     </span>
                 </ng-template>
                 <ng-template ngx-datatable-cell-template let-value="row">
-                    <ng-container *ngIf="value.type !== ExerciseType.PROGRAMMING; else programmingAssessment">
-                        <div class="d-flex justify-content-start align-items-center">
+                    <div class="d-flex justify-content-start align-items-center">
+                        <ng-container *ngIf="value.type !== ExerciseType.PROGRAMMING; else programmingAssessment">
                             <button
                                 [disabled]="assessmentButtonDisabled(value, value.submission)"
                                 (click)="openAssessmentEditor(value, value.submission)"
@@ -194,23 +194,23 @@
                                 <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                 <span [jhiTranslate]="'artemisApp.tutorExerciseDashboard.' + assessmentAction(value.submission) + 'Assessment'"></span>
                             </button>
-                            <fa-icon
-                                class="mx-3"
-                                *ngIf="value.submission?.result?.hasComplaint"
-                                [icon]="'flag'"
-                                ngbTooltip="{{ 'artemisApp.team.detail.participationsTable.complaintOrMoreFeedbackRequest' | translate }}"
-                            ></fa-icon>
-                        </div>
-                    </ng-container>
-                    <ng-template #programmingAssessment>
-                        <jhi-programming-assessment-manual-result
-                            *ngIf="value.participation"
-                            [participationId]="value.participation?.id"
-                            [latestResult]="value.submission?.result"
-                            [exercise]="value"
-                            (onResultModified)="loadAll()"
-                        ></jhi-programming-assessment-manual-result>
-                    </ng-template>
+                        </ng-container>
+                        <ng-template #programmingAssessment>
+                            <jhi-programming-assessment-manual-result
+                                *ngIf="value.participation"
+                                [participationId]="value.participation?.id"
+                                [latestResult]="value.submission?.result"
+                                [exercise]="value"
+                                (onResultModified)="loadAll()"
+                            ></jhi-programming-assessment-manual-result>
+                        </ng-template>
+                        <fa-icon
+                            class="mx-3"
+                            *ngIf="value.submission?.result?.hasComplaint"
+                            [icon]="'flag'"
+                            ngbTooltip="{{ 'artemisApp.team.detail.participationsTable.complaintOrMoreFeedbackRequest' | translate }}"
+                        ></fa-icon>
+                    </div>
                 </ng-template>
             </ngx-datatable-column>
         </ngx-datatable>

--- a/src/main/webapp/i18n/de/team.json
+++ b/src/main/webapp/i18n/de/team.json
@@ -25,7 +25,8 @@
                     "title": "Teilnahmen in \"{{ courseTitle }}\" für",
                     "columns": {
                         "assessment": "Bewertung"
-                    }
+                    },
+                    "complaintOrMoreFeedbackRequest": "Beschwerde oder weitere Feedback-Anfrage"
                 }
             },
             "team": "Team",

--- a/src/main/webapp/i18n/en/team.json
+++ b/src/main/webapp/i18n/en/team.json
@@ -25,7 +25,8 @@
                     "title": "Participations in \"{{ courseTitle }}\" for",
                     "columns": {
                         "assessment": "Assessment"
-                    }
+                    },
+                    "complaintOrMoreFeedbackRequest": "Complaint or More Feedback Request"
                 }
             },
             "team": "Team",


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
This PR addresses issue https://github.com/ls1intum/Artemis/issues/1834.

### Description
- Consider team exercise assessor logic in programming exercise manual result dialog
- Add flag to team participation table to indicate the existence of a complaint or more feedback request

### Steps for Testing
1. Log in to Artemis as a Tutor
2. Assess a team programming exercise
3. Log in as a Student and hand in a complaint or more feedback request
4. With the tutor, go the the team page and check that the complaint/request is indicated with an icon
5. Check that you can respond to the complaint/request as the team tutor

### Screenshots
![OnPaste 20200719-164607](https://user-images.githubusercontent.com/7109225/87877561-62298680-c9df-11ea-8ed3-5e14c7342f9e.png)
![OnPaste 20200719-164620](https://user-images.githubusercontent.com/7109225/87877564-62c21d00-c9df-11ea-8be2-c55720efbc56.png)
![OnPaste 20200719-182713](https://user-images.githubusercontent.com/7109225/87879867-812f1500-c9ed-11ea-9226-f2627e7a2858.png)
