### PR TITLE
Lock student exam repositories upon early submit

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
@@ -207,17 +207,20 @@ public class StudentExamService {
             }
         }
 
-        // use the programming exercises in the DB to lock the repositories (for safety)
-        for (Exercise exercise : existingStudentExam.getExercises()) {
-            if (exercise instanceof ProgrammingExercise) {
-                ProgrammingExercise programmingExercise = (ProgrammingExercise) exercise;
-                ProgrammingExerciseStudentParticipation participation = programmingExerciseParticipationService.findStudentParticipationByExerciseAndStudentId(exercise,
-                        currentUser.getLogin());
-                try {
-                    programmingExerciseParticipationService.lockStudentRepository(programmingExercise, participation);
-                }
-                catch (Exception e) {
-                    log.error("Locking programming exercise " + exercise.getId() + " submitted manually by " + currentUser.getLogin() + " failed", e);
+        // Only lock programming exercises when the student submitted early. Otherwise, the lock operations were already scheduled/executed.
+        if (ZonedDateTime.now().isBefore(examEndDate)) {
+            // Use the programming exercises in the DB to lock the repositories (for safety)
+            for (Exercise exercise : existingStudentExam.getExercises()) {
+                if (exercise instanceof ProgrammingExercise) {
+                    ProgrammingExercise programmingExercise = (ProgrammingExercise) exercise;
+                    ProgrammingExerciseStudentParticipation participation = programmingExerciseParticipationService.findStudentParticipationByExerciseAndStudentId(exercise,
+                            currentUser.getLogin());
+                    try {
+                        programmingExerciseParticipationService.lockStudentRepository(programmingExercise, participation);
+                    }
+                    catch (Exception e) {
+                        log.error("Locking programming exercise " + exercise.getId() + " submitted manually by " + currentUser.getLogin() + " failed", e);
+                    }
                 }
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
@@ -22,10 +22,7 @@ import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.quiz.*;
-import de.tum.in.www1.artemis.repository.ModelingSubmissionRepository;
-import de.tum.in.www1.artemis.repository.QuizSubmissionRepository;
-import de.tum.in.www1.artemis.repository.StudentExamRepository;
-import de.tum.in.www1.artemis.repository.TextSubmissionRepository;
+import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 /**
@@ -211,7 +208,7 @@ public class StudentExamService {
         studentExam.setSubmitted(true);
         studentExam.setSubmissionDate(ZonedDateTime.now());
         studentExamRepository.save(studentExam);
-        
+
         try {
             lockStudentRepositories(currentUser, existingStudentExam, examEndDate);
         }
@@ -230,8 +227,8 @@ public class StudentExamService {
                 if (exercise instanceof ProgrammingExercise) {
                     ProgrammingExercise programmingExercise = (ProgrammingExercise) exercise;
                     try {
-                    ProgrammingExerciseStudentParticipation participation = programmingExerciseParticipationService.findStudentParticipationByExerciseAndStudentId(exercise,
-                            currentUser.getLogin());
+                        ProgrammingExerciseStudentParticipation participation = programmingExerciseParticipationService.findStudentParticipationByExerciseAndStudentId(exercise,
+                                currentUser.getLogin());
                         programmingExerciseParticipationService.lockStudentRepository(programmingExercise, participation);
                     }
                     catch (Exception e) {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseLifecycle;
-import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
@@ -43,6 +42,8 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     private final ProgrammingSubmissionService programmingSubmissionService;
 
+    private final ProgrammingExerciseParticipationService programmingExerciseParticipationService;
+
     private final GroupNotificationService groupNotificationService;
 
     private final Optional<VersionControlService> versionControlService;
@@ -53,7 +54,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     public ProgrammingExerciseScheduleService(ScheduleService scheduleService, ProgrammingExerciseRepository programmingExerciseRepository, Environment env,
             ProgrammingSubmissionService programmingSubmissionService, GroupNotificationService groupNotificationService, Optional<VersionControlService> versionControlService,
-            ParticipationService participationService, ExamService examService) {
+            ParticipationService participationService, ExamService examService, ProgrammingExerciseParticipationService programmingExerciseParticipationService) {
         this.scheduleService = scheduleService;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingSubmissionService = programmingSubmissionService;
@@ -61,6 +62,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
         this.versionControlService = versionControlService;
         this.participationService = participationService;
         this.examService = examService;
+        this.programmingExerciseParticipationService = programmingExerciseParticipationService;
         this.env = env;
     }
 
@@ -237,7 +239,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
                 BiConsumer<ProgrammingExercise, ProgrammingExerciseStudentParticipation> unlockAndCollectOperation = (programmingExercise, participation) -> {
                     var dueDate = participationService.getIndividualDueDate(programmingExercise, participation);
                     individualDueDates.add(new Tuple<>(dueDate, participation));
-                    unlockStudentRepository(programmingExercise, participation);
+                    programmingExerciseParticipationService.unlockStudentRepository(programmingExercise, participation);
                 };
                 List<ProgrammingExerciseStudentParticipation> failedUnlockOperations = invokeOperationOnAllParticipationsThatSatisfy(programmingExerciseId,
                         unlockAndCollectOperation, participation -> true, "add write permissions to all student repositories");
@@ -329,7 +331,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     private List<ProgrammingExerciseStudentParticipation> removeWritePermissionsFromAllStudentRepositories(Long programmingExerciseId,
             Predicate<ProgrammingExerciseStudentParticipation> condition) throws EntityNotFoundException {
-        return invokeOperationOnAllParticipationsThatSatisfy(programmingExerciseId, this::lockStudentRepository, condition,
+        return invokeOperationOnAllParticipationsThatSatisfy(programmingExerciseId, programmingExerciseParticipationService::lockStudentRepository, condition,
                 "remove write permissions from all student repositories");
     }
 
@@ -344,7 +346,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
      * @throws EntityNotFoundException  if the programming exercise can't be found.
      */
     public List<ProgrammingExerciseStudentParticipation> addWritePermissionsToAllStudentRepositories(Long programmingExerciseId) throws EntityNotFoundException {
-        return invokeOperationOnAllParticipationsThatSatisfy(programmingExerciseId, this::unlockStudentRepository, participation -> true,
+        return invokeOperationOnAllParticipationsThatSatisfy(programmingExerciseId, programmingExerciseParticipationService::unlockStudentRepository, participation -> true,
                 "add write permissions to all student repositories");
     }
 
@@ -390,23 +392,5 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
             }
         }
         return failedOperations;
-    }
-
-    private void lockStudentRepository(ProgrammingExercise programmingExercise, ProgrammingExerciseStudentParticipation participation) {
-        if (participation.getInitializationState().hasCompletedState(InitializationState.REPO_CONFIGURED)) {
-            versionControlService.get().setRepositoryPermissionsToReadOnly(participation.getRepositoryUrlAsUrl(), programmingExercise.getProjectKey(), participation.getStudents());
-        }
-        else {
-            log.warn("Cannot lock student repository for participation " + participation.getId() + " because the repository was not copied yet!");
-        }
-    }
-
-    private void unlockStudentRepository(ProgrammingExercise programmingExercise, ProgrammingExerciseStudentParticipation participation) {
-        if (participation.getInitializationState().hasCompletedState(InitializationState.REPO_CONFIGURED)) {
-            versionControlService.get().configureRepository(programmingExercise, participation.getRepositoryUrlAsUrl(), participation.getStudents(), true);
-        }
-        else {
-            log.warn("Cannot unlock student repository for participation " + participation.getId() + " because the repository was not copied yet!");
-        }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -23,7 +23,6 @@ import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.*;
-import de.tum.in.www1.artemis.service.connectors.VersionControlService;
 import de.tum.in.www1.artemis.service.util.Tuple;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import io.github.jhipster.config.JHipsterConstants;
@@ -46,20 +45,17 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     private final GroupNotificationService groupNotificationService;
 
-    private final Optional<VersionControlService> versionControlService;
-
     private final ParticipationService participationService;
 
     private final ExamService examService;
 
     public ProgrammingExerciseScheduleService(ScheduleService scheduleService, ProgrammingExerciseRepository programmingExerciseRepository, Environment env,
-            ProgrammingSubmissionService programmingSubmissionService, GroupNotificationService groupNotificationService, Optional<VersionControlService> versionControlService,
-            ParticipationService participationService, ExamService examService, ProgrammingExerciseParticipationService programmingExerciseParticipationService) {
+            ProgrammingSubmissionService programmingSubmissionService, GroupNotificationService groupNotificationService, ParticipationService participationService,
+            ExamService examService, ProgrammingExerciseParticipationService programmingExerciseParticipationService) {
         this.scheduleService = scheduleService;
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingSubmissionService = programmingSubmissionService;
         this.groupNotificationService = groupNotificationService;
-        this.versionControlService = versionControlService;
         this.participationService = participationService;
         this.examService = examService;
         this.programmingExerciseParticipationService = programmingExerciseParticipationService;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
When a student submits the exam before the (individual) exam end, they most not be able to work on the repository anymore.

### Description
I added a section to the `submitStudentExam` Method in `StudentExamService` that locks the repositories if the exam has not ended.

I also moved the lock and unlock methods from the `ProgrammingExerciseScheduleService` to the `ProgrammingExerciseParticipationService`.

### Steps for Testing
1. Create an exam with student exams and at least one programming in Artemis
2. Take the exam
3. Submit the exam early
4. Check that you don't have write access to the repository anymore
5. Test that this also works with extended working time and early submit after the normal exam end