### PR TITLE
Fix missing scheduling for manually assessed programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -97,7 +97,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @param dateTime ZonedDateTime object.
      * @return List<ProgrammingExercise> (can be empty)
      */
-    @Query("select pe from ProgrammingExercise pe where pe.assessmentType <> 'AUTOMATIC' pe.dueDate > :#{#dateTime}")
+    @Query("select pe from ProgrammingExercise pe where pe.assessmentType <> 'AUTOMATIC' and pe.dueDate > :#{#dateTime}")
     List<ProgrammingExercise> findAllByManualAssessmentAndDueDateAfterDate(@Param("dateTime") ZonedDateTime dateTime);
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -92,6 +92,15 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
     List<ProgrammingExercise> findAllByBuildAndTestStudentSubmissionsAfterDueDateAfterDate(@Param("dateTime") ZonedDateTime dateTime);
 
     /**
+     * Returns the programming exercises that have manual assessment enabled and a due date higher than the provided date.
+     *
+     * @param dateTime ZonedDateTime object.
+     * @return List<ProgrammingExercise> (can be empty)
+     */
+    @Query("select pe from ProgrammingExercise pe where pe.assessmentType <> 'AUTOMATIC' pe.dueDate > :#{#dateTime}")
+    List<ProgrammingExercise> findAllByManualAssessmentAndDueDateAfterDate(@Param("dateTime") ZonedDateTime dateTime);
+
+    /**
      * Returns the programming exercises that are part of an exam with an end date after than the provided date.
      * This method also fetches the exercise group and exam.
      *

--- a/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageReceiveService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageReceiveService.java
@@ -71,7 +71,7 @@ public class InstanceMessageReceiveService {
     public void processScheduleProgrammingExercise(Long exerciseId) {
         log.info("Received schedule update for programming exercise " + exerciseId);
         ProgrammingExercise programmingExercise = programmingExerciseService.findWithTemplateParticipationAndSolutionParticipationById(exerciseId);
-        programmingExerciseScheduleService.scheduleExerciseIfRequired(programmingExercise);
+        programmingExerciseScheduleService.updateScheduling(programmingExercise);
     }
 
     public void processScheduleTextExercise(Long exerciseId) {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/IExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/IExerciseScheduleService.java
@@ -20,5 +20,5 @@ public interface IExerciseScheduleService<T extends Exercise> {
      *
      * @param exercise Exercise
      */
-    void scheduleExerciseIfRequired(T exercise);
+    void updateScheduling(T exercise);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -76,7 +76,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
                 return;
             }
             SecurityUtils.setAuthorizationObject();
-            // TODO: also take exercises with manual assessments into account here
+
             List<ProgrammingExercise> programmingExercisesWithBuildAfterDueDate = programmingExerciseRepository
                     .findAllByBuildAndTestStudentSubmissionsAfterDueDateAfterDate(ZonedDateTime.now());
             programmingExercisesWithBuildAfterDueDate.forEach(this::scheduleExercise);
@@ -97,7 +97,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
     }
 
     /**
-     * Will cancel a scheduled task if the buildAndTestAfterDueDate is null or has passed already.
+     * Will cancel or reschedule tasks for updated programming exercises
      *
      * @param exercise ProgrammingExercise
      */

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -111,11 +111,13 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     private static boolean needsToBeScheduled(ProgrammingExercise exercise) {
         // Exam exercises need to be scheduled
-        if (isExamExercise(exercise))
+        if (isExamExercise(exercise)) {
             return true;
+        }
         // Manual assessed programming exercises as well
-        if (exercise.getAssessmentType() != AssessmentType.AUTOMATIC)
+        if (exercise.getAssessmentType() != AssessmentType.AUTOMATIC) {
             return true;
+        }
         // If tests are run after due date and that due date lies in the future, we need to schedule that as well
         return exercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null && ZonedDateTime.now().isBefore(exercise.getBuildAndTestStudentSubmissionsAfterDueDate());
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseLifecycle;
 import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
@@ -79,6 +80,11 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
             List<ProgrammingExercise> programmingExercisesWithBuildAfterDueDate = programmingExerciseRepository
                     .findAllByBuildAndTestStudentSubmissionsAfterDueDateAfterDate(ZonedDateTime.now());
             programmingExercisesWithBuildAfterDueDate.forEach(this::scheduleExercise);
+
+            List<ProgrammingExercise> programmingExercisesWithFutureManualAssessment = programmingExerciseRepository
+                    .findAllByManualAssessmentAndDueDateAfterDate(ZonedDateTime.now());
+            programmingExercisesWithFutureManualAssessment.forEach(this::scheduleExercise);
+
             // for exams (TODO take info account that the individual due dates can be after the exam end date)
             List<ProgrammingExercise> programmingExercisesWithExam = programmingExerciseRepository.findAllWithEagerExamAllByExamEndDateAfterDate(ZonedDateTime.now());
             programmingExercisesWithExam.forEach(this::scheduleExamExercise);
@@ -93,21 +99,34 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
     /**
      * Will cancel a scheduled task if the buildAndTestAfterDueDate is null or has passed already.
      *
-     * // TODO: the method name and logic is really hard to understand, we should improve this
      * @param exercise ProgrammingExercise
      */
     @Override
-    public void scheduleExerciseIfRequired(ProgrammingExercise exercise) {
-        // TODO: also take exercises with manual assessments into account here and deal better with exams
-        if (!isExamExercise(exercise)
-                && (exercise.getBuildAndTestStudentSubmissionsAfterDueDate() == null || exercise.getBuildAndTestStudentSubmissionsAfterDueDate().isBefore(ZonedDateTime.now()))) {
-            // this only cancels a schedule, but does not schedule one
-            scheduleService.cancelScheduledTaskForLifecycle(exercise, ExerciseLifecycle.DUE);
-            scheduleService.cancelScheduledTaskForLifecycle(exercise, ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE);
+    public void updateScheduling(ProgrammingExercise exercise) {
+        if (!needsToBeScheduled(exercise)) {
+            // If a programming exercise got changed so that any scheduling becomes unnecessary, we need to cancel all scheduled tasks
+            cancelAllScheduledTasks(exercise);
             return;
         }
-        // exam exercises are always scheduled, course exercises are only scheduled if buildAndTestStudentSubmissionsAfterDueDate is set and in the future
         scheduleExercise(exercise);
+    }
+
+    private static boolean needsToBeScheduled(ProgrammingExercise exercise) {
+        // Exam exercises need to be scheduled
+        if (isExamExercise(exercise))
+            return true;
+        // Manual assessed programming exercises as well
+        if (exercise.getAssessmentType() != AssessmentType.AUTOMATIC)
+            return true;
+        // If tests are run after due date and that due date lies in the future, we need to schedule that as well
+        return exercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null && ZonedDateTime.now().isBefore(exercise.getBuildAndTestStudentSubmissionsAfterDueDate());
+    }
+
+    private void cancelAllScheduledTasks(ProgrammingExercise exercise) {
+        scheduleService.cancelScheduledTaskForLifecycle(exercise, ExerciseLifecycle.RELEASE);
+        scheduleService.cancelScheduledTaskForLifecycle(exercise, ExerciseLifecycle.DUE);
+        scheduleService.cancelScheduledTaskForLifecycle(exercise, ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE);
+        scheduleService.cancelScheduledTaskForLifecycle(exercise, ExerciseLifecycle.ASSESSMENT_DUE);
     }
 
     private void scheduleExercise(ProgrammingExercise exercise) {
@@ -125,11 +144,24 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
     }
 
     private void scheduleCourseExercise(ProgrammingExercise exercise) {
-        // TODO: there is small logic error here. When build and run test date is after the due date, the lock operation might be executed even if it is not necessary.
-        scheduleService.scheduleTask(exercise, ExerciseLifecycle.DUE, lockAllStudentRepositories(exercise));
-        scheduleService.scheduleTask(exercise, ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE, buildAndTestRunnableForExercise(exercise));
-        log.debug("Scheduled build and test for student submissions after due date for Programming Exercise \"" + exercise.getTitle() + "\" (#" + exercise.getId() + ") for "
-                + exercise.getBuildAndTestStudentSubmissionsAfterDueDate() + ".");
+        // For exercises with buildAndTestAfterDueDate or manual assessment
+        if (exercise.getDueDate() != null && ZonedDateTime.now().isBefore(exercise.getDueDate())) {
+            scheduleService.scheduleTask(exercise, ExerciseLifecycle.DUE, lockAllStudentRepositories(exercise));
+            log.debug("Scheduled lock student repositories after due date for Programming Exercise \"" + exercise.getTitle() + "\" (#" + exercise.getId() + ") for "
+                    + exercise.getDueDate() + ".");
+        }
+        else {
+            scheduleService.cancelScheduledTaskForLifecycle(exercise, ExerciseLifecycle.DUE);
+        }
+        // For exercises with buildAndTestAfterDueDate
+        if (exercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null) {
+            scheduleService.scheduleTask(exercise, ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE, buildAndTestRunnableForExercise(exercise));
+            log.debug("Scheduled build and test for student submissions after due date for Programming Exercise \"" + exercise.getTitle() + "\" (#" + exercise.getId() + ") for "
+                    + exercise.getBuildAndTestStudentSubmissionsAfterDueDate() + ".");
+        }
+        else {
+            scheduleService.cancelScheduledTaskForLifecycle(exercise, ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE);
+        }
     }
 
     private void scheduleExamExercise(ProgrammingExercise exercise) {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -144,7 +144,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
     }
 
     private void scheduleCourseExercise(ProgrammingExercise exercise) {
-        // For exercises with buildAndTestAfterDueDate or manual assessment
+        // For any course exercise that needsToBeScheduled (buildAndTestAfterDueDate and/or manual assessment)
         if (exercise.getDueDate() != null && ZonedDateTime.now().isBefore(exercise.getDueDate())) {
             scheduleService.scheduleTask(exercise, ExerciseLifecycle.DUE, lockAllStudentRepositories(exercise));
             log.debug("Scheduled lock student repositories after due date for Programming Exercise \"" + exercise.getTitle() + "\" (#" + exercise.getId() + ") for "


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I added multiple integration tests (Spring) related to the features
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.


### Motivation and Context
Fix #1936 and refactor and fix some other problems that are mentioned in the TODOs.

### Description
- Rename `scheduleExerciseIfRequired` into `updateScheduling`
- Add database call for programming exercises with manual assessment and due date that lies in the future
- Schedule programming exercises with manual assessment on startup
- Schedule programming exercises with manual assessment when updated
- Fix `TODO: there is small logic error here. [...]`
- Break up code into smaller functions to improve level of abstraction consistency of the methods.
- Add comments to explain the intent behind what is scheduled how and what is not

### Steps for Testing
0. _Best would be to repeat that process with different exercise settings (automatic only, build after due date, manual review, exam)_
1. Create programming exercise
2. Participate (maybe change something)
3. Check that the repository gets locked properly (e.g. over BitBucket) and that tests are run, if that was selected. _(In case the exercise was automatic only, editing and submitting should still be possible)_

What is expected:
- `Run Tests once after Due Date` is set ---> repository should be locked after due date
- `Manual Review` is set ---> repository should be locked after due date
- `otherwise` ---> students can still make changes