### PR TITLE
Do not allow tutors to override their own assessments if there is a complaint

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -107,6 +107,10 @@ public final class Constants {
 
     public static final String DELETE_EXAM = "DELETE_EXAM";
 
+    public static final String ADD_USER_TO_EXAM = "ADD_USER_TO_EXAM";
+
+    public static final String REMOVE_USER_FROM_EXAM = "REMOVE_USER_FROM_EXAM";
+
     public static final String DELETE_PARTICIPATION = "DELETE_PARTICIPATION";
 
     public static final String DELETE_TEAM = "DELETE_TEAM";

--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -53,8 +53,6 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
     @EntityGraph(type = LOAD, attributePaths = "feedbacks")
     Optional<Result> findDistinctWithFeedbackBySubmissionId(Long submissionId);
 
-    List<Result> findAllByParticipationExerciseIdAndAssessorIdAndHasComplaintFalse(Long exerciseId, Long assessorId);
-
     @Query("select r from Result r left join fetch r.feedbacks where r.id = :resultId")
     Optional<Result> findByIdWithEagerFeedbacks(@Param("resultId") Long id);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -53,7 +53,7 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
     @EntityGraph(type = LOAD, attributePaths = "feedbacks")
     Optional<Result> findDistinctWithFeedbackBySubmissionId(Long submissionId);
 
-    List<Result> findAllByParticipationExerciseIdAndAssessorId(Long exerciseId, Long assessorId);
+    List<Result> findAllByParticipationExerciseIdAndAssessorIdAndHasComplaintFalse(Long exerciseId, Long assessorId);
 
     @Query("select r from Result r left join fetch r.feedbacks where r.id = :resultId")
     Optional<Result> findByIdWithEagerFeedbacks(@Param("resultId") Long id);

--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import de.tum.in.www1.artemis.domain.Submission;
+import de.tum.in.www1.artemis.domain.User;
 
 /**
  * Spring Data repository for the Submission entity.
@@ -90,5 +91,13 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      */
     @Query("SELECT COUNT (DISTINCT submission) FROM Submission submission WHERE submission.participation.exercise.id = :#{#exerciseId} AND submission.submitted = TRUE AND submission.participation.exercise.dueDate IS NOT NULL AND submission.submissionDate > submission.participation.exercise.dueDate")
     long countByExerciseIdSubmittedAfterDueDate(@Param("exerciseId") long exerciseId);
+
+    /**
+     *
+     * @param exerciseId the exercise id we are interested in
+     * @param assessor the assessor we are interested in
+     * @return the submissions belonging to the exercise id, which have been assessed by the given assessor
+     */
+    List<Submission> findAllByParticipationExerciseIdAndResultAssessor(@Param("exerciseId") Long exerciseId, @Param("assessor") User assessor);
 
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -103,16 +103,14 @@ public class FileUploadSubmissionService extends SubmissionService {
 
     /**
      * Given an exercise id and a tutor id, it returns all the file upload submissions where the tutor has a result associated.
-     * Submissions which contain results with a complaint are filtered out.
      *
      * @param exerciseId - the id of the exercise we are looking for
      * @param tutor - the tutor we are interested in
      * @return a list of file upload Submissions
      */
-    public List<FileUploadSubmission> getAllFileUploadSubmissionsAssessedByTutorWithNoComplaintsForExercise(Long exerciseId, User tutor) {
-        // Retrieve all submissions assessed by the tutor and filter out ones which contain complaints
+    public List<FileUploadSubmission> getAllFileUploadSubmissionsAssessedByTutorForExercise(Long exerciseId, User tutor) {
         List<Submission> submissions = this.submissionRepository.findAllByParticipationExerciseIdAndResultAssessor(exerciseId, tutor);
-        return submissions.stream().filter(submission -> !Boolean.TRUE.equals(submission.getResult().hasComplaint())).map(submission -> {
+        return submissions.stream().map(submission -> {
             submission.getResult().setSubmission(null);
             return (FileUploadSubmission) submission;
         }).collect(Collectors.toList());

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -103,30 +103,18 @@ public class FileUploadSubmissionService extends SubmissionService {
 
     /**
      * Given an exercise id and a tutor id, it returns all the file upload submissions where the tutor has a result associated.
-     * Results with a complaint
+     * Submissions which contain results with a complaint are filtered out.
      *
      * @param exerciseId - the id of the exercise we are looking for
-     * @param tutorId    - the id of the tutor we are interested in
+     * @param tutor - the tutor we are interested in
      * @return a list of file upload Submissions
      */
-    @Transactional(readOnly = true)
-    public List<FileUploadSubmission> getAllFileUploadSubmissionsByTutorForExercise(Long exerciseId, Long tutorId) {
-        // We take all the results in this exercise associated to the tutor, and from there we retrieve the submissions
-        List<Result> results = this.resultRepository.findAllByParticipationExerciseIdAndAssessorIdAndHasComplaintFalse(exerciseId, tutorId);
-
-        // TODO: properly load the submissions with all required data from the database without using @Transactional
-        return results.stream().map(result -> {
-            Submission submission = result.getSubmission();
-            FileUploadSubmission fileUploadSubmission = new FileUploadSubmission();
-
-            result.setSubmission(null);
-            fileUploadSubmission.setLanguage(submission.getLanguage());
-            fileUploadSubmission.setResult(result);
-            fileUploadSubmission.setParticipation(submission.getParticipation());
-            fileUploadSubmission.setId(submission.getId());
-            fileUploadSubmission.setSubmissionDate(submission.getSubmissionDate());
-
-            return fileUploadSubmission;
+    public List<FileUploadSubmission> getAllFileUploadSubmissionsAssessedByTutorWithNoComplaintsForExercise(Long exerciseId, User tutor) {
+        // Retrieve all submissions assessed by the tutor and filter out ones which contain complaints
+        List<Submission> submissions = this.submissionRepository.findAllByParticipationExerciseIdAndResultAssessor(exerciseId, tutor);
+        return submissions.stream().filter(submission -> !Boolean.TRUE.equals(submission.getResult().hasComplaint())).map(submission -> {
+            submission.getResult().setSubmission(null);
+            return (FileUploadSubmission) submission;
         }).collect(Collectors.toList());
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -102,7 +102,8 @@ public class FileUploadSubmissionService extends SubmissionService {
     }
 
     /**
-     * Given an exercise id and a tutor id, it returns all the file upload submissions where the tutor has a result associated
+     * Given an exercise id and a tutor id, it returns all the file upload submissions where the tutor has a result associated.
+     * Results with a complaint
      *
      * @param exerciseId - the id of the exercise we are looking for
      * @param tutorId    - the id of the tutor we are interested in
@@ -111,7 +112,7 @@ public class FileUploadSubmissionService extends SubmissionService {
     @Transactional(readOnly = true)
     public List<FileUploadSubmission> getAllFileUploadSubmissionsByTutorForExercise(Long exerciseId, Long tutorId) {
         // We take all the results in this exercise associated to the tutor, and from there we retrieve the submissions
-        List<Result> results = this.resultRepository.findAllByParticipationExerciseIdAndAssessorId(exerciseId, tutorId);
+        List<Result> results = this.resultRepository.findAllByParticipationExerciseIdAndAssessorIdAndHasComplaintFalse(exerciseId, tutorId);
 
         // TODO: properly load the submissions with all required data from the database without using @Transactional
         return results.stream().map(result -> {

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -160,16 +160,14 @@ public class ModelingSubmissionService extends SubmissionService {
 
     /**
      * Given an exercise id and a tutor id, it returns all the modeling submissions where the tutor has a result associated.
-     * Submissions which contain results with a complaint are filtered out.
      *
      * @param exerciseId - the id of the exercise we are looking for
      * @param tutor - the tutor we are interested in
      * @return a list of modeling submissions
      */
-    public List<ModelingSubmission> getAllModelingSubmissionsAssessedByTutorWithNoComplaintsForExercise(Long exerciseId, User tutor) {
-        // Retrieve all submissions assessed by the tutor and filter out ones which contain complaints
+    public List<ModelingSubmission> getAllModelingSubmissionsAssessedByTutorForExercise(Long exerciseId, User tutor) {
         List<Submission> submissions = this.submissionRepository.findAllByParticipationExerciseIdAndResultAssessor(exerciseId, tutor);
-        return submissions.stream().filter(submission -> !Boolean.TRUE.equals(submission.getResult().hasComplaint())).map(submission -> {
+        return submissions.stream().map(submission -> {
             submission.getResult().setSubmission(null);
             return (ModelingSubmission) submission;
         }).collect(Collectors.toList());

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -168,7 +168,7 @@ public class ModelingSubmissionService extends SubmissionService {
     @Transactional(readOnly = true)
     public List<ModelingSubmission> getAllModelingSubmissionsByTutorForExercise(Long exerciseId, Long tutorId) {
         // We take all the results in this exercise associated to the tutor, and from there we retrieve the submissions
-        List<Result> results = this.resultRepository.findAllByParticipationExerciseIdAndAssessorId(exerciseId, tutorId);
+        List<Result> results = this.resultRepository.findAllByParticipationExerciseIdAndAssessorIdAndHasComplaintFalse(exerciseId, tutorId);
 
         // TODO: properly load the submissions with all required data from the database without using @Transactional
         return results.stream().map(result -> {

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -569,10 +569,10 @@ public class ProgrammingSubmissionService extends SubmissionService {
      * @param tutorId    - the id of the tutor we are interested in
      * @return a list of programming submissions
      */
-    public List<ProgrammingSubmission> getAllProgrammingSubmissionsAssessedByTutorWithNoComplaintsForExercise(long exerciseId, long tutorId) {
+    public List<ProgrammingSubmission> getAllProgrammingSubmissionsAssessedByTutorForExercise(long exerciseId, long tutorId) {
         List<StudentParticipation> participations = this.studentParticipationRepository.findWithLatestSubmissionByExerciseAndAssessor(exerciseId, tutorId);
         return participations.stream().map(Participation::findLatestSubmission).filter(Optional::isPresent).map(submission -> (ProgrammingSubmission) submission.get())
-                .filter(submission -> !Boolean.TRUE.equals(submission.getResult().hasComplaint())).collect(Collectors.toList());
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -569,10 +569,10 @@ public class ProgrammingSubmissionService extends SubmissionService {
      * @param tutorId    - the id of the tutor we are interested in
      * @return a list of programming submissions
      */
-    public List<ProgrammingSubmission> getAllProgrammingSubmissionsByTutorForExercise(long exerciseId, long tutorId) {
+    public List<ProgrammingSubmission> getAllProgrammingSubmissionsAssessedByTutorWithNoComplaintsForExercise(long exerciseId, long tutorId) {
         List<StudentParticipation> participations = this.studentParticipationRepository.findWithLatestSubmissionByExerciseAndAssessor(exerciseId, tutorId);
         return participations.stream().map(Participation::findLatestSubmission).filter(Optional::isPresent).map(submission -> (ProgrammingSubmission) submission.get())
-                .collect(Collectors.toList());
+                .filter(submission -> !Boolean.TRUE.equals(submission.getResult().hasComplaint())).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -232,16 +232,15 @@ public class TextSubmissionService extends SubmissionService {
 
     /**
      * Given an exercise id and a tutor id, it returns all the text submissions where the tutor has a result associated
-     * Submissions which contain results with a complaint are filtered out.
      *
      * @param exerciseId - the id of the exercise we are looking for
      * @param tutor - the tutor we are interested in
      * @return a list of text Submissions
      */
-    public List<TextSubmission> getAllTextSubmissionsAssessedByTutorWithNoComplaintsForExercise(Long exerciseId, User tutor) {
+    public List<TextSubmission> getAllTextSubmissionsAssessedByTutorWithForExercise(Long exerciseId, User tutor) {
         // Retrieve all submissions assessed by the tutor and filter out ones which contain complaints
         List<Submission> submissions = this.submissionRepository.findAllByParticipationExerciseIdAndResultAssessor(exerciseId, tutor);
-        return submissions.stream().filter(submission -> !Boolean.TRUE.equals(submission.getResult().hasComplaint())).map(submission -> {
+        return submissions.stream().map(submission -> {
             submission.getResult().setSubmission(null);
             return (TextSubmission) submission;
         }).collect(Collectors.toList());

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -244,7 +244,7 @@ public class TextSubmissionService extends SubmissionService {
     @Transactional(readOnly = true)
     public List<TextSubmission> getAllTextSubmissionsByTutorForExercise(Long exerciseId, Long tutorId) {
         // We take all the results in this exercise associated to the tutor, and from there we retrieve the submissions
-        List<Result> results = this.resultRepository.findAllByParticipationExerciseIdAndAssessorId(exerciseId, tutorId);
+        List<Result> results = this.resultRepository.findAllByParticipationExerciseIdAndAssessorIdAndHasComplaintFalse(exerciseId, tutorId);
 
         // TODO: properly load the submissions with all required data from the database without using @Transactional
         return results.stream().map(result -> {

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,12 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import de.tum.in.www1.artemis.domain.Result;
-import de.tum.in.www1.artemis.domain.Submission;
-import de.tum.in.www1.artemis.domain.TextBlock;
-import de.tum.in.www1.artemis.domain.TextCluster;
-import de.tum.in.www1.artemis.domain.TextExercise;
-import de.tum.in.www1.artemis.domain.TextSubmission;
+import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
@@ -236,30 +232,20 @@ public class TextSubmissionService extends SubmissionService {
 
     /**
      * Given an exercise id and a tutor id, it returns all the text submissions where the tutor has a result associated
+     * Submissions which contain results with a complaint are filtered out.
      *
      * @param exerciseId - the id of the exercise we are looking for
-     * @param tutorId    - the id of the tutor we are interested in
+     * @param tutor - the tutor we are interested in
      * @return a list of text Submissions
      */
     @Transactional(readOnly = true)
-    public List<TextSubmission> getAllTextSubmissionsByTutorForExercise(Long exerciseId, Long tutorId) {
-        // We take all the results in this exercise associated to the tutor, and from there we retrieve the submissions
-        List<Result> results = this.resultRepository.findAllByParticipationExerciseIdAndAssessorIdAndHasComplaintFalse(exerciseId, tutorId);
-
-        // TODO: properly load the submissions with all required data from the database without using @Transactional
-        return results.stream().map(result -> {
-            Submission submission = result.getSubmission();
-            TextSubmission textSubmission = new TextSubmission();
-
-            result.setSubmission(null);
-            textSubmission.setLanguage(submission.getLanguage());
-            textSubmission.setResult(result);
-            textSubmission.setParticipation(submission.getParticipation());
-            textSubmission.setId(submission.getId());
-            textSubmission.setSubmissionDate(submission.getSubmissionDate());
-
-            return textSubmission;
-        }).collect(toList());
+    public List<TextSubmission> getAllTextSubmissionsAssessedByTutorWithNoComplaintsForExercise(Long exerciseId, User tutor) {
+        // Retrieve all submissions assessed by the tutor and filter out ones which contain complaints
+        List<Submission> submissions = this.submissionRepository.findAllByParticipationExerciseIdAndResultAssessor(exerciseId, tutor);
+        return submissions.stream().filter(submission -> !Boolean.TRUE.equals(submission.getResult().hasComplaint())).map(submission -> {
+            submission.getResult().setSubmission(null);
+            return (TextSubmission) submission;
+        }).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -238,7 +238,6 @@ public class TextSubmissionService extends SubmissionService {
      * @param tutor - the tutor we are interested in
      * @return a list of text Submissions
      */
-    @Transactional(readOnly = true)
     public List<TextSubmission> getAllTextSubmissionsAssessedByTutorWithNoComplaintsForExercise(Long exerciseId, User tutor) {
         // Retrieve all submissions assessed by the tutor and filter out ones which contain complaints
         List<Submission> submissions = this.submissionRepository.findAllByParticipationExerciseIdAndResultAssessor(exerciseId, tutor);

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -238,7 +238,6 @@ public class TextSubmissionService extends SubmissionService {
      * @return a list of text Submissions
      */
     public List<TextSubmission> getAllTextSubmissionsAssessedByTutorWithForExercise(Long exerciseId, User tutor) {
-        // Retrieve all submissions assessed by the tutor and filter out ones which contain complaints
         List<Submission> submissions = this.submissionRepository.findAllByParticipationExerciseIdAndResultAssessor(exerciseId, tutor);
         return submissions.stream().map(submission -> {
             submission.getResult().setSubmission(null);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -375,6 +375,12 @@ public class ExamResource {
             userService.addUserToGroup(student.get(), course.getStudentGroupName());
         }
         examRepository.save(exam);
+
+        User currentUser = userService.getUserWithGroupsAndAuthorities();
+        AuditEvent auditEvent = new AuditEvent(currentUser.getLogin(), Constants.ADD_USER_TO_EXAM, "exam=" + exam.getTitle(), "user=" + studentLogin);
+        auditEventRepository.add(auditEvent);
+        log.info("User " + currentUser.getLogin() + " has added user " + studentLogin + " to the exam " + exam.getTitle() + " with id " + exam.getId());
+
         return ResponseEntity.ok().body(null);
     }
 
@@ -618,6 +624,13 @@ public class ExamResource {
             // Delete the student exam
             studentExamService.deleteStudentExam(studentExam.getId());
         }
+
+        User currentUser = userService.getUserWithGroupsAndAuthorities();
+        AuditEvent auditEvent = new AuditEvent(currentUser.getLogin(), Constants.REMOVE_USER_FROM_EXAM, "exam=" + exam.getTitle(), "user=" + studentLogin);
+        auditEventRepository.add(auditEvent);
+        log.info("User " + currentUser.getLogin() + " has removed user " + studentLogin + " from the exam " + exam.getTitle() + " with id " + exam.getId()
+                + ". This also deleted a potentially existing student exam with all its participations and submissions.");
+
         return ResponseEntity.ok().body(null);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
@@ -209,7 +209,7 @@ public class FileUploadSubmissionResource {
 
         final List<FileUploadSubmission> fileUploadSubmissions;
         if (assessedByTutor) {
-            fileUploadSubmissions = fileUploadSubmissionService.getAllFileUploadSubmissionsAssessedByTutorWithNoComplaintsForExercise(exerciseId, user);
+            fileUploadSubmissions = fileUploadSubmissionService.getAllFileUploadSubmissionsAssessedByTutorForExercise(exerciseId, user);
         }
         else {
             fileUploadSubmissions = fileUploadSubmissionService.getFileUploadSubmissions(exerciseId, submittedOnly);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
@@ -209,7 +209,7 @@ public class FileUploadSubmissionResource {
 
         final List<FileUploadSubmission> fileUploadSubmissions;
         if (assessedByTutor) {
-            fileUploadSubmissions = fileUploadSubmissionService.getAllFileUploadSubmissionsByTutorForExercise(exerciseId, user.getId());
+            fileUploadSubmissions = fileUploadSubmissionService.getAllFileUploadSubmissionsAssessedByTutorWithNoComplaintsForExercise(exerciseId, user);
         }
         else {
             fileUploadSubmissions = fileUploadSubmissionService.getFileUploadSubmissions(exerciseId, submittedOnly);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -207,7 +207,7 @@ public class ModelingSubmissionResource {
 
         final List<ModelingSubmission> modelingSubmissions;
         if (assessedByTutor) {
-            modelingSubmissions = modelingSubmissionService.getAllModelingSubmissionsByTutorForExercise(exerciseId, user.getId());
+            modelingSubmissions = modelingSubmissionService.getAllModelingSubmissionsAssessedByTutorWithNoComplaintsForExercise(exerciseId, user);
         }
         else {
             modelingSubmissions = modelingSubmissionService.getModelingSubmissions(exerciseId, submittedOnly);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -207,7 +207,7 @@ public class ModelingSubmissionResource {
 
         final List<ModelingSubmission> modelingSubmissions;
         if (assessedByTutor) {
-            modelingSubmissions = modelingSubmissionService.getAllModelingSubmissionsAssessedByTutorWithNoComplaintsForExercise(exerciseId, user);
+            modelingSubmissions = modelingSubmissionService.getAllModelingSubmissionsAssessedByTutorForExercise(exerciseId, user);
         }
         else {
             modelingSubmissions = modelingSubmissionService.getModelingSubmissions(exerciseId, submittedOnly);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
@@ -358,7 +358,7 @@ public class ProgrammingSubmissionResource {
         List<ProgrammingSubmission> programmingSubmissions;
         if (assessedByTutor) {
             User user = userService.getUserWithGroupsAndAuthorities();
-            programmingSubmissions = programmingSubmissionService.getAllProgrammingSubmissionsAssessedByTutorWithNoComplaintsForExercise(exerciseId, user.getId());
+            programmingSubmissions = programmingSubmissionService.getAllProgrammingSubmissionsAssessedByTutorForExercise(exerciseId, user.getId());
         }
         else {
             programmingSubmissions = programmingSubmissionService.getProgrammingSubmissions(exerciseId, submittedOnly);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
@@ -358,7 +358,7 @@ public class ProgrammingSubmissionResource {
         List<ProgrammingSubmission> programmingSubmissions;
         if (assessedByTutor) {
             User user = userService.getUserWithGroupsAndAuthorities();
-            programmingSubmissions = programmingSubmissionService.getAllProgrammingSubmissionsByTutorForExercise(exerciseId, user.getId());
+            programmingSubmissions = programmingSubmissionService.getAllProgrammingSubmissionsAssessedByTutorWithNoComplaintsForExercise(exerciseId, user.getId());
         }
         else {
             programmingSubmissions = programmingSubmissionService.getProgrammingSubmissions(exerciseId, submittedOnly);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -218,7 +218,7 @@ public class TextSubmissionResource {
 
         final List<TextSubmission> textSubmissions;
         if (assessedByTutor) {
-            textSubmissions = textSubmissionService.getAllTextSubmissionsByTutorForExercise(exerciseId, user.getId());
+            textSubmissions = textSubmissionService.getAllTextSubmissionsAssessedByTutorWithNoComplaintsForExercise(exerciseId, user);
         }
         else {
             textSubmissions = textSubmissionService.getTextSubmissionsByExerciseId(exerciseId, submittedOnly);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -218,7 +218,7 @@ public class TextSubmissionResource {
 
         final List<TextSubmission> textSubmissions;
         if (assessedByTutor) {
-            textSubmissions = textSubmissionService.getAllTextSubmissionsAssessedByTutorWithNoComplaintsForExercise(exerciseId, user);
+            textSubmissions = textSubmissionService.getAllTextSubmissionsAssessedByTutorWithForExercise(exerciseId, user);
         }
         else {
             textSubmissions = textSubmissionService.getTextSubmissionsByExerciseId(exerciseId, submittedOnly);

--- a/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
+++ b/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
@@ -19,13 +19,13 @@
                 step="0.5"
                 [(ngModel)]="assessment.credits"
                 (ngModelChange)="emitChanges()"
-                [readOnly]="disabled || disableEditScore"
+                [readOnly]="disabled || disableEditScore || readOnly"
                 [disabled]="disabled"
             />
         </div>
         <div class="form-group row">
             <label class="col-3 assessment-label" jhiTranslate="artemisApp.assessment.detail.feedback"></label>
-            <textarea class="col form-control" rows="2" [(ngModel)]="assessment.detailText" (ngModelChange)="emitChanges()" [readOnly]="disabled" [disabled]="disabled"></textarea>
+            <textarea class="col form-control" rows="2" [(ngModel)]="assessment.detailText" (ngModelChange)="emitChanges()" [readOnly]="readOnly" [disabled]="disabled"></textarea>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.ts
+++ b/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.ts
@@ -17,6 +17,7 @@ export class AssessmentDetailComponent implements AfterViewInit {
     @Input() public highlightColor: HighlightColors.Color;
     @Output() public deleteAssessment = new EventEmitter<Feedback>();
     @Input() public disabled = false;
+    @Input() public readOnly: boolean;
     disableEditScore = false;
 
     public FeedbackType_AUTOMATIC = FeedbackType.AUTOMATIC;

--- a/src/main/webapp/app/assessment/assessment-general-feedback/assessment-general-feedback.component.html
+++ b/src/main/webapp/app/assessment/assessment-general-feedback/assessment-general-feedback.component.html
@@ -1,6 +1,6 @@
 <div class="row mt-2">
     <h4 class="col-12" jhiTranslate="artemisApp.assessment.generalFeedback">General Feedback</h4>
     <div class="col-12 col-lg-8 col-xl-6">
-        <textarea ondrop="return false;" class="form-control" rows="2" maxlength="5000" [ngModel]="text" (ngModelChange)="onTextChange($event)"></textarea>
+        <textarea ondrop="return false;" class="form-control" rows="2" maxlength="5000" [ngModel]="text" [readOnly]="readOnly" (ngModelChange)="onTextChange($event)"></textarea>
     </div>
 </div>

--- a/src/main/webapp/app/assessment/assessment-general-feedback/assessment-general-feedback.component.ts
+++ b/src/main/webapp/app/assessment/assessment-general-feedback/assessment-general-feedback.component.ts
@@ -10,6 +10,7 @@ export class AssessmentGeneralFeedbackComponent {
     private feedbackClone: Feedback;
     public text: string;
 
+    @Input() readOnly: boolean;
     @Input() set feedback(feedback: Feedback) {
         this.feedbackClone = Object.assign({}, feedback);
         this.text = feedback.detailText || '';

--- a/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
+++ b/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
@@ -16,6 +16,9 @@
         >
             Assessment locked by: otherUser
         </span>
+        <span id="assessmentReadOnly" *ngIf="isAssessor && isComplaint" class="ml-3" style="font-size: 65%;" jhiTranslate="artemisApp.assessment.assessmentReadOnly">
+            There is a complaint for this assessment. Another tutor must respond
+        </span>
         <span
             *ngIf="!isAssessor && isComplaint"
             class="ml-3"
@@ -25,7 +28,13 @@
         >
             Original Assessor: otherUser
         </span>
-        <span id="assessmentLockedCurrentUser" *ngIf="isAssessor" class="text-danger ml-3" style="font-size: 65%;" jhiTranslate="artemisApp.assessment.assessmentLockedCurrentUser">
+        <span
+            id="assessmentLockedCurrentUser"
+            *ngIf="isAssessor && !isComplaint"
+            class="text-danger ml-3"
+            style="font-size: 65%;"
+            jhiTranslate="artemisApp.assessment.assessmentLockedCurrentUser"
+        >
             You have the lock for this assessment
         </span>
         <ng-container *ngIf="!result?.completionDate">

--- a/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
+++ b/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
@@ -45,7 +45,7 @@
         </span>
         <span
             id="assessmentLockedCurrentUser"
-            *ngIf="(isAssessor && !hasComplaint) || (isAssessor && isAtLeastInstructor)"
+            *ngIf="isAssessor && (!hasComplaint || isAtLeastInstructor)"
             class="text-danger ml-3"
             style="font-size: 65%;"
             jhiTranslate="artemisApp.assessment.assessmentLockedCurrentUser"

--- a/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
+++ b/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
@@ -8,7 +8,7 @@
     <div class="row-container" *ngIf="!isLoading">
         <span
             id="assessmentLocked"
-            *ngIf="!isAssessor && !isComplaint"
+            *ngIf="!isAssessor && !hasComplaint"
             class="text-danger ml-3"
             style="font-size: 65%;"
             jhiTranslate="artemisApp.assessment.assessmentLocked"
@@ -17,16 +17,25 @@
             Assessment locked by: otherUser
         </span>
         <span
-            id="assessmentReadOnly"
-            *ngIf="isAssessor && !isAtLeastInstructor && isComplaint"
+            id="assessmentReadOnlyUnhandledComplaint"
+            *ngIf="isAssessor && !isAtLeastInstructor && hasComplaint && !complaintHandled"
             class="ml-3"
             style="font-size: 65%;"
-            jhiTranslate="artemisApp.assessment.assessmentReadOnly"
+            jhiTranslate="artemisApp.assessment.assessmentReadOnlyUnhandledComplaint"
         >
-            There is a complaint for this assessment. Another tutor must respond
+            There is a complaint for this assessment. Another tutor must respond.
         </span>
         <span
-            *ngIf="!isAssessor && isComplaint"
+            id="assessmentReadOnlyhandled"
+            *ngIf="isAssessor && !isAtLeastInstructor && hasComplaint && complaintHandled"
+            class="ml-3"
+            style="font-size: 65%;"
+            jhiTranslate="artemisApp.assessment.assessmentReadOnlyHandledComplaint"
+        >
+            The complaint about your assessment has been resolved.
+        </span>
+        <span
+            *ngIf="!isAssessor && hasComplaint"
             class="ml-3"
             style="font-size: 65%;"
             jhiTranslate="artemisApp.assessment.assessmentLockedComplaintView"
@@ -36,7 +45,7 @@
         </span>
         <span
             id="assessmentLockedCurrentUser"
-            *ngIf="(isAssessor && !isComplaint) || (isAssessor && isAtLeastInstructor)"
+            *ngIf="(isAssessor && !hasComplaint) || (isAssessor && isAtLeastInstructor)"
             class="text-danger ml-3"
             style="font-size: 65%;"
             jhiTranslate="artemisApp.assessment.assessmentLockedCurrentUser"

--- a/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
+++ b/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
@@ -16,7 +16,13 @@
         >
             Assessment locked by: otherUser
         </span>
-        <span id="assessmentReadOnly" *ngIf="isAssessor && isComplaint" class="ml-3" style="font-size: 65%;" jhiTranslate="artemisApp.assessment.assessmentReadOnly">
+        <span
+            id="assessmentReadOnly"
+            *ngIf="isAssessor && !isAtLeastInstructor && isComplaint"
+            class="ml-3"
+            style="font-size: 65%;"
+            jhiTranslate="artemisApp.assessment.assessmentReadOnly"
+        >
             There is a complaint for this assessment. Another tutor must respond
         </span>
         <span
@@ -30,7 +36,7 @@
         </span>
         <span
             id="assessmentLockedCurrentUser"
-            *ngIf="isAssessor && !isComplaint"
+            *ngIf="(isAssessor && !isComplaint) || (isAssessor && isAtLeastInstructor)"
             class="text-danger ml-3"
             style="font-size: 65%;"
             jhiTranslate="artemisApp.assessment.assessmentLockedCurrentUser"

--- a/src/main/webapp/app/assessment/assessment-header/assessment-header.component.ts
+++ b/src/main/webapp/app/assessment/assessment-header/assessment-header.component.ts
@@ -14,7 +14,6 @@ import { Result } from 'app/entities/result.model';
 })
 export class AssessmentHeaderComponent {
     @Input() hideBackButton: boolean;
-    @Input() isComplaint: boolean;
     @Output() navigateBack = new EventEmitter<void>();
 
     @Input() isLoading: boolean;
@@ -31,6 +30,7 @@ export class AssessmentHeaderComponent {
     @Input() result: Result | null;
     @Input() hasConflict = false;
     @Input() hasComplaint = false;
+    @Input() complaintHandled = false;
     @Input() assessmentsAreValid: boolean;
 
     @Output() save = new EventEmitter<void>();

--- a/src/main/webapp/app/assessment/assessment-layout/assessment-layout.component.html
+++ b/src/main/webapp/app/assessment/assessment-layout/assessment-layout.component.html
@@ -1,5 +1,4 @@
 <jhi-assessment-header
-    [isComplaint]="complaint"
     [hideBackButton]="hideBackButton"
     (navigateBack)="navigateBack.emit()"
     [isLoading]="isLoading"
@@ -20,6 +19,7 @@
     [hasConflict]="conflicts && conflicts.length >= 0"
     (resolveConflict)="resolveConflict.emit()"
     [hasComplaint]="!!complaint"
+    [complaintHandled]="!!complaint ? complaint.accepted !== undefined : false"
 ></jhi-assessment-header>
 
 <jhi-assessment-complaint-alert [complaint]="complaint"></jhi-assessment-complaint-alert>

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.html
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.html
@@ -30,7 +30,9 @@
                             {{ attachmentExtension(submission.filePath!) | uppercase }}
                         </span>
                     </div>
-                    <button class="btn btn-success mt-4" (click)="addReferencedFeedback()">{{ 'artemisApp.fileUploadAssessment.addFeedback' | translate }}</button>
+                    <button class="btn btn-success mt-4" (click)="addReferencedFeedback()" [disabled]="!canOverride">
+                        {{ 'artemisApp.fileUploadAssessment.addFeedback' | translate }}
+                    </button>
                     <ng-container *ngIf="!busy && !notFound">
                         <div class="row mt-4">
                             <h4 class="col-12" jhiTranslate="artemisApp.assessment.detail.feedback">Feedback</h4>
@@ -45,10 +47,15 @@
                                     [(assessment)]="referencedFeedback[i]"
                                     (assessmentChange)="updateAssessment()"
                                     (deleteAssessment)="deleteAssessment($event)"
+                                    [readOnly]="!canOverride"
                                 ></jhi-assessment-detail>
                             </div>
                         </div>
-                        <jhi-assessment-general-feedback [(feedback)]="generalFeedback" (feedbackChange)="validateAssessment()"></jhi-assessment-general-feedback>
+                        <jhi-assessment-general-feedback
+                            [(feedback)]="generalFeedback"
+                            (feedbackChange)="validateAssessment()"
+                            [readOnly]="!canOverride"
+                        ></jhi-assessment-general-feedback>
                     </ng-container>
                 </div>
             </div>

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.html
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.html
@@ -30,7 +30,7 @@
                             {{ attachmentExtension(submission.filePath!) | uppercase }}
                         </span>
                     </div>
-                    <button class="btn btn-success mt-4" (click)="addReferencedFeedback()" [disabled]="!canOverride">
+                    <button class="btn btn-success mt-4" (click)="addReferencedFeedback()" [disabled]="readOnly">
                         {{ 'artemisApp.fileUploadAssessment.addFeedback' | translate }}
                     </button>
                     <ng-container *ngIf="!busy && !notFound">
@@ -47,14 +47,14 @@
                                     [(assessment)]="referencedFeedback[i]"
                                     (assessmentChange)="updateAssessment()"
                                     (deleteAssessment)="deleteAssessment($event)"
-                                    [readOnly]="!canOverride"
+                                    [readOnly]="readOnly"
                                 ></jhi-assessment-detail>
                             </div>
                         </div>
                         <jhi-assessment-general-feedback
                             [(feedback)]="generalFeedback"
                             (feedbackChange)="validateAssessment()"
-                            [readOnly]="!canOverride"
+                            [readOnly]="readOnly"
                         ></jhi-assessment-general-feedback>
                     </ng-container>
                 </div>

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.ts
@@ -520,7 +520,7 @@ export class FileUploadAssessmentComponent implements OnInit, AfterViewInit, OnD
     }
 
     get readOnly(): boolean {
-        return !!this.complaint && this.isAssessor;
+        return !this.isAtLeastInstructor && !!this.complaint && this.isAssessor;
     }
 
     private onError(error: string) {

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.component.ts
@@ -429,8 +429,6 @@ export class FileUploadAssessmentComponent implements OnInit, AfterViewInit, OnD
         this.isAssessor = this.result && this.result.assessor && this.result.assessor.id === this.userId;
         if (this.exercise) {
             this.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.course || this.exercise.exerciseGroup!.exam!.course);
-        } else {
-            this.isAtLeastInstructor = this.accountService.hasAnyAuthorityDirect(['ROLE_INSTRUCTOR', 'ROLE_ADMIN']);
         }
     }
 

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.html
@@ -30,6 +30,7 @@
             [maxScore]="modelingExercise?.maxScore"
             [totalScore]="totalScore"
             [model]="model"
+            [readOnly]="!canOverride"
             [feedbacks]="result?.feedbacks"
             [highlightedElements]="highlightedElements"
             (feedbackChanged)="onFeedbackChanged($event)"
@@ -44,8 +45,8 @@
 
     <div class="row mt-3">
         <div class="col-md-6">
-            <jhi-unreferenced-feedback [(feedbacks)]="unreferencedFeedback" (feedbacksChange)="validateFeedback()"></jhi-unreferenced-feedback>
-            <jhi-assessment-general-feedback [(feedback)]="generalFeedback" (feedbackChange)="validateFeedback()"></jhi-assessment-general-feedback>
+            <jhi-unreferenced-feedback [(feedbacks)]="unreferencedFeedback" (feedbacksChange)="validateFeedback()" [readOnly]="!canOverride"></jhi-unreferenced-feedback>
+            <jhi-assessment-general-feedback [(feedback)]="generalFeedback" (feedbackChange)="validateFeedback()" [readOnly]="!canOverride"></jhi-assessment-general-feedback>
         </div>
         <div class="col-md-6" *ngIf="(hasAutomaticFeedback || highlightMissingFeedback) && !result?.completionDate">
             <h4 jhiTranslate="modelingAssessmentEditor.highlightingColors.title">Highlighting Color(s)</h4>

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.html
@@ -30,7 +30,7 @@
             [maxScore]="modelingExercise?.maxScore"
             [totalScore]="totalScore"
             [model]="model"
-            [readOnly]="!canOverride"
+            [readOnly]="readOnly"
             [feedbacks]="result?.feedbacks"
             [highlightedElements]="highlightedElements"
             (feedbackChanged)="onFeedbackChanged($event)"
@@ -45,8 +45,8 @@
 
     <div class="row mt-3">
         <div class="col-md-6">
-            <jhi-unreferenced-feedback [(feedbacks)]="unreferencedFeedback" (feedbacksChange)="validateFeedback()" [readOnly]="!canOverride"></jhi-unreferenced-feedback>
-            <jhi-assessment-general-feedback [(feedback)]="generalFeedback" (feedbackChange)="validateFeedback()" [readOnly]="!canOverride"></jhi-assessment-general-feedback>
+            <jhi-unreferenced-feedback [(feedbacks)]="unreferencedFeedback" (feedbacksChange)="validateFeedback()" [readOnly]="readOnly"></jhi-unreferenced-feedback>
+            <jhi-assessment-general-feedback [(feedback)]="generalFeedback" (feedbackChange)="validateFeedback()" [readOnly]="readOnly"></jhi-assessment-general-feedback>
         </div>
         <div class="col-md-6" *ngIf="(hasAutomaticFeedback || highlightMissingFeedback) && !result?.completionDate">
             <h4 jhiTranslate="modelingAssessmentEditor.highlightingColors.title">Highlighting Color(s)</h4>

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -256,7 +256,7 @@ export class ModelingAssessmentEditorComponent implements OnInit {
     }
 
     get readOnly(): boolean {
-        return !!this.complaint && this.isAssessor;
+        return !this.isAtLeastInstructor && !!this.complaint && this.isAssessor;
     }
 
     onError(): void {

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -222,8 +222,6 @@ export class ModelingAssessmentEditorComponent implements OnInit {
         this.isAssessor = this.result != null && this.result.assessor && this.result.assessor.id === this.userId;
         if (this.modelingExercise) {
             this.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.modelingExercise.course || this.modelingExercise.exerciseGroup!.exam!.course);
-        } else {
-            this.isAtLeastInstructor = this.accountService.hasAnyAuthorityDirect(['ROLE_INSTRUCTOR', 'ROLE_ADMIN']);
         }
     }
 

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/tutor-exercise-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/tutor-exercise-dashboard.component.ts
@@ -201,7 +201,7 @@ export class TutorExerciseDashboardComponent implements OnInit, AfterViewInit {
                     this.exam = this.exercise?.exerciseGroup?.exam;
                 }
 
-                this.getSubmissions();
+                this.getTutorAssessedSubmissions();
 
                 // 1. We don't want to assess submissions before the exercise due date
                 // 2. The assessment for team exercises is not started from the tutor exercise dashboard but from the team pages
@@ -265,7 +265,7 @@ export class TutorExerciseDashboardComponent implements OnInit, AfterViewInit {
      * Get all the submissions from the server for which the current user is the assessor, which is the case for started or completed assessments. All these submissions get listed
      * in the exercise dashboard.
      */
-    private getSubmissions(): void {
+    private getTutorAssessedSubmissions(): void {
         let submissionsObservable: Observable<HttpResponse<Submission[]>> = of();
         // TODO: This could be one generic endpoint.
         switch (this.exercise.type) {

--- a/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.html
+++ b/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.html
@@ -1,4 +1,4 @@
-<button class="btn btn-success mt-4" (click)="addReferencedFeedback()">{{ 'artemisApp.fileUploadAssessment.addFeedback' | translate }}</button>
+<button class="btn btn-success mt-4" (click)="addReferencedFeedback()" [disabled]="readOnly">{{ 'artemisApp.fileUploadAssessment.addFeedback' | translate }}</button>
 <ng-container *ngIf="!busy">
     <div class="row mt-4">
         <h4 class="col-12" jhiTranslate="artemisApp.assessment.detail.feedback">Feedback</h4>
@@ -13,6 +13,7 @@
                 [(assessment)]="unreferencedFeedback[i]"
                 (assessmentChange)="updateAssessment(assessment)"
                 (deleteAssessment)="deleteAssessment($event)"
+                [readOnly]="readOnly"
             ></jhi-assessment-detail>
         </div>
     </div>

--- a/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.ts
+++ b/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.ts
@@ -10,6 +10,7 @@ export class UnreferencedFeedbackComponent {
     unreferencedFeedback: Feedback[] = [];
     assessmentsAreValid: boolean;
     @Input() busy: boolean;
+    @Input() readOnly: boolean;
     @Output() feedbacksChange = new EventEmitter<Feedback[]>();
 
     @Input() set feedbacks(feedbacks: Feedback[]) {

--- a/src/main/webapp/app/exercises/text/assess-new/manual-textblock-selection/manual-textblock-selection.component.html
+++ b/src/main/webapp/app/exercises/text/assess-new/manual-textblock-selection/manual-textblock-selection.component.html
@@ -5,6 +5,7 @@
         [selected]="selectedRef === group.singleRef"
         (didSelect)="selectedRef = $event; selectedRefChange.emit($event)"
         (didChange)="textBlockRefsChangeEmit()"
+        [readOnly]="readOnly"
     ></jhi-textblock-assessment-card>
     <ng-template #selectionInterface>
         <!-- DO NOT ADD LINEBREAKS INSIDE <jhi-manual-text-selection> -->

--- a/src/main/webapp/app/exercises/text/assess-new/manual-textblock-selection/manual-textblock-selection.component.ts
+++ b/src/main/webapp/app/exercises/text/assess-new/manual-textblock-selection/manual-textblock-selection.component.ts
@@ -18,6 +18,7 @@ export class ManualTextblockSelectionComponent {
     @Output() textBlockRefsChange = new EventEmitter<TextBlockRef[]>();
     @Output() textBlockRefAdded = new EventEmitter<TextBlockRef>();
     @Input() selectedRef: TextBlockRef | null = null;
+    @Input() readOnly: boolean;
     @Output() selectedRefChange = new EventEmitter<TextBlockRef | null>();
     @Input() submission: TextSubmission;
     textBlockRefGroups: TextBlockRefGroup[];

--- a/src/main/webapp/app/exercises/text/assess-new/text-assessment-area/text-assessment-area.component.html
+++ b/src/main/webapp/app/exercises/text/assess-new/text-assessment-area/text-assessment-area.component.html
@@ -3,6 +3,7 @@
         *ngFor="let ref of textBlockRefs"
         [textBlockRef]="ref"
         [selected]="selectedRef === ref"
+        [readOnly]="readOnly"
         (didSelect)="selectedRef = $event"
         (didChange)="textBlockRefsChangeEmit()"
         (didDelete)="removeTextBlockRef($event)"
@@ -12,6 +13,7 @@
     <jhi-manual-textblock-selection
         [(textBlockRefs)]="textBlockRefs"
         [(selectedRef)]="selectedRef"
+        [readOnly]="readOnly"
         (textBlockRefAdded)="addTextBlockRef($event)"
         [submission]="submission"
     ></jhi-manual-textblock-selection>

--- a/src/main/webapp/app/exercises/text/assess-new/text-assessment-area/text-assessment-area.component.ts
+++ b/src/main/webapp/app/exercises/text/assess-new/text-assessment-area/text-assessment-area.component.ts
@@ -17,6 +17,7 @@ import { StringCountService } from 'app/exercises/text/participate/string-count.
 export class TextAssessmentAreaComponent implements OnChanges {
     @Input() submission: TextSubmission;
     @Input() textBlockRefs: TextBlockRef[];
+    @Input() readonly: boolean;
     @Output() textBlockRefsChange = new EventEmitter<TextBlockRef[]>();
     @Output() textBlockRefsAddedRemoved = new EventEmitter<void>();
     autoTextBlockAssessment = true;

--- a/src/main/webapp/app/exercises/text/assess-new/text-assessment-area/text-assessment-area.component.ts
+++ b/src/main/webapp/app/exercises/text/assess-new/text-assessment-area/text-assessment-area.component.ts
@@ -17,7 +17,7 @@ import { StringCountService } from 'app/exercises/text/participate/string-count.
 export class TextAssessmentAreaComponent implements OnChanges {
     @Input() submission: TextSubmission;
     @Input() textBlockRefs: TextBlockRef[];
-    @Input() readonly: boolean;
+    @Input() readOnly: boolean;
     @Output() textBlockRefsChange = new EventEmitter<TextBlockRef[]>();
     @Output() textBlockRefsAddedRemoved = new EventEmitter<void>();
     autoTextBlockAssessment = true;

--- a/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.html
+++ b/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.html
@@ -30,6 +30,7 @@
                 left-body
                 [submission]="submission"
                 [(textBlockRefs)]="textBlockRefs"
+                [readOnly]="!canOverride"
                 (textBlockRefsChange)="validateFeedback()"
                 (textBlockRefsAddedRemoved)="recalculateTextBlockRefs()"
             ></jhi-text-assessment-area>
@@ -46,8 +47,8 @@
 
     <div class="row mt-3">
         <div class="col-md-6">
-            <jhi-unreferenced-feedback [(feedbacks)]="unreferencedFeedback" (feedbacksChange)="validateFeedback()"></jhi-unreferenced-feedback>
-            <jhi-assessment-general-feedback [(feedback)]="generalFeedback" (feedbackChange)="validateFeedback()"></jhi-assessment-general-feedback>
+            <jhi-unreferenced-feedback [(feedbacks)]="unreferencedFeedback" (feedbacksChange)="validateFeedback()" [readOnly]="!canOverride"></jhi-unreferenced-feedback>
+            <jhi-assessment-general-feedback [(feedback)]="generalFeedback" (feedbackChange)="validateFeedback()" [readOnly]="!canOverride"></jhi-assessment-general-feedback>
         </div>
     </div>
 </ng-template>

--- a/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.html
+++ b/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.html
@@ -30,7 +30,7 @@
                 left-body
                 [submission]="submission"
                 [(textBlockRefs)]="textBlockRefs"
-                [readOnly]="!canOverride"
+                [readOnly]="readOnly"
                 (textBlockRefsChange)="validateFeedback()"
                 (textBlockRefsAddedRemoved)="recalculateTextBlockRefs()"
             ></jhi-text-assessment-area>
@@ -47,8 +47,8 @@
 
     <div class="row mt-3">
         <div class="col-md-6">
-            <jhi-unreferenced-feedback [(feedbacks)]="unreferencedFeedback" (feedbacksChange)="validateFeedback()" [readOnly]="!canOverride"></jhi-unreferenced-feedback>
-            <jhi-assessment-general-feedback [(feedback)]="generalFeedback" (feedbackChange)="validateFeedback()" [readOnly]="!canOverride"></jhi-assessment-general-feedback>
+            <jhi-unreferenced-feedback [(feedbacks)]="unreferencedFeedback" (feedbacksChange)="validateFeedback()" [readOnly]="readOnly"></jhi-unreferenced-feedback>
+            <jhi-assessment-general-feedback [(feedback)]="generalFeedback" (feedbackChange)="validateFeedback()" [readOnly]="readOnly"></jhi-assessment-general-feedback>
         </div>
     </div>
 </ng-template>

--- a/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/exercises/text/assess-new/text-submission-assessment.component.ts
@@ -450,7 +450,7 @@ export class TextSubmissionAssessmentComponent implements OnInit {
     }
 
     get readOnly(): boolean {
-        return !!this.complaint && this.isAssessor;
+        return !this.isAtLeastInstructor && !!this.complaint && this.isAssessor;
     }
 
     private checkPermissions(): void {

--- a/src/main/webapp/app/exercises/text/assess-new/textblock-assessment-card/textblock-assessment-card.component.html
+++ b/src/main/webapp/app/exercises/text/assess-new/textblock-assessment-card/textblock-assessment-card.component.html
@@ -22,4 +22,5 @@
     (close)="unselect()"
     (feedbackChange)="feedbackDidChange()"
     [disableEditScore]="disableEditScore"
+    [readOnly]="readOnly"
 ></jhi-textblock-feedback-editor>

--- a/src/main/webapp/app/exercises/text/assess-new/textblock-assessment-card/textblock-assessment-card.component.ts
+++ b/src/main/webapp/app/exercises/text/assess-new/textblock-assessment-card/textblock-assessment-card.component.ts
@@ -14,6 +14,7 @@ type OptionalTextBlockRef = TextBlockRef | null;
 export class TextblockAssessmentCardComponent {
     @Input() textBlockRef: TextBlockRef;
     @Input() selected = false;
+    @Input() readOnly: boolean;
     @Output() didSelect = new EventEmitter<OptionalTextBlockRef>();
     @Output() didChange = new EventEmitter<TextBlockRef>();
     @Output() didDelete = new EventEmitter<TextBlockRef>();

--- a/src/main/webapp/app/exercises/text/assess-new/textblock-feedback-editor/textblock-feedback-editor.component.html
+++ b/src/main/webapp/app/exercises/text/assess-new/textblock-feedback-editor/textblock-feedback-editor.component.html
@@ -16,6 +16,7 @@
             (keyup)="textareaAutogrow()"
             (keydown.escape)="escKeyup()"
             (focus)="inFocus()"
+            [readOnly]="readonly"
             (ngModelChange)="didChange()"
         ></textarea>
     </div>
@@ -31,7 +32,7 @@
             (click)="onScoreClick($event)"
             (focus)="inFocus()"
             (ngModelChange)="didChange()"
-            [readOnly]="disableEditScore"
+            [readOnly]="disableEditScore || readonly"
         />
     </div>
 </div>

--- a/src/main/webapp/app/exercises/text/assess-new/textblock-feedback-editor/textblock-feedback-editor.component.html
+++ b/src/main/webapp/app/exercises/text/assess-new/textblock-feedback-editor/textblock-feedback-editor.component.html
@@ -16,7 +16,7 @@
             (keyup)="textareaAutogrow()"
             (keydown.escape)="escKeyup()"
             (focus)="inFocus()"
-            [readOnly]="readonly"
+            [readOnly]="readOnly"
             (ngModelChange)="didChange()"
         ></textarea>
     </div>
@@ -32,7 +32,7 @@
             (click)="onScoreClick($event)"
             (focus)="inFocus()"
             (ngModelChange)="didChange()"
-            [readOnly]="disableEditScore || readonly"
+            [readOnly]="disableEditScore || readOnly"
         />
     </div>
 </div>

--- a/src/main/webapp/app/exercises/text/assess-new/textblock-feedback-editor/textblock-feedback-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/assess-new/textblock-feedback-editor/textblock-feedback-editor.component.ts
@@ -20,6 +20,7 @@ export class TextblockFeedbackEditorComponent implements AfterViewInit {
     @ViewChild('detailText') textareaRef: ElementRef;
     @ViewChild(ConfirmIconComponent) confirmIconComponent: ConfirmIconComponent;
     @Input() disableEditScore = false;
+    @Input() readonly: boolean;
     private textareaElement: HTMLTextAreaElement;
 
     @HostBinding('class.alert') @HostBinding('class.alert-dismissible') readonly classes = true;

--- a/src/main/webapp/app/exercises/text/assess-new/textblock-feedback-editor/textblock-feedback-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/assess-new/textblock-feedback-editor/textblock-feedback-editor.component.ts
@@ -20,7 +20,7 @@ export class TextblockFeedbackEditorComponent implements AfterViewInit {
     @ViewChild('detailText') textareaRef: ElementRef;
     @ViewChild(ConfirmIconComponent) confirmIconComponent: ConfirmIconComponent;
     @Input() disableEditScore = false;
-    @Input() readonly: boolean;
+    @Input() readOnly: boolean;
     private textareaElement: HTMLTextAreaElement;
 
     @HostBinding('class.alert') @HostBinding('class.alert-dismissible') readonly classes = true;

--- a/src/main/webapp/i18n/de/assessment.json
+++ b/src/main/webapp/i18n/de/assessment.json
@@ -12,6 +12,7 @@
             "assessmentLocked": "Bewertung gesperrt von: {{otherUser}}",
             "assessmentLockedComplaintView": "Ursprünglicher Tutor: {{otherUser}}",
             "assessmentLockedCurrentUser": "Diese Bewertung ist von dir gesperrt",
+            "assessmentReadOnly": "Es gibt eine Beschwerde für diese Bewertung. Ein anderer Tutor muss antworten.",
             "button": {
                 "overrideAssessment": "Bewertung überschreiben",
                 "nextSubmission": "Nächste Abgabe bewerten",

--- a/src/main/webapp/i18n/de/assessment.json
+++ b/src/main/webapp/i18n/de/assessment.json
@@ -12,7 +12,8 @@
             "assessmentLocked": "Bewertung gesperrt von: {{otherUser}}",
             "assessmentLockedComplaintView": "Ursprünglicher Tutor: {{otherUser}}",
             "assessmentLockedCurrentUser": "Diese Bewertung ist von dir gesperrt",
-            "assessmentReadOnly": "Es gibt eine Beschwerde für diese Bewertung. Ein anderer Tutor muss antworten.",
+            "assessmentReadOnlyUnhandledComplaint": "Es gibt eine Beschwerde für diese Bewertung. Ein anderer Tutor muss antworten.",
+            "assessmentReadOnlyHandledComplaint": "Die Beschwerde über deine Bewertung wurde bearbeitet.",
             "button": {
                 "overrideAssessment": "Bewertung überschreiben",
                 "nextSubmission": "Nächste Abgabe bewerten",

--- a/src/main/webapp/i18n/en/assessment.json
+++ b/src/main/webapp/i18n/en/assessment.json
@@ -12,7 +12,8 @@
             "assessmentLocked": "Assessment locked by: {{otherUser}}",
             "assessmentLockedComplaintView": "Original Assessor: {{otherUser}}",
             "assessmentLockedCurrentUser": "You have the lock for this assessment",
-            "assessmentReadOnly": "There is a complaint for this assessment. Another tutor must respond.",
+            "assessmentReadOnlyUnhandledComplaint": "There is a complaint for this assessment. Another tutor must respond.",
+            "assessmentReadOnlyHandledComplaint": "The complaint about your assessment has been resolved.",
             "button": {
                 "overrideAssessment": "Override Assessment",
                 "nextSubmission": "Assess Next Submission",

--- a/src/main/webapp/i18n/en/assessment.json
+++ b/src/main/webapp/i18n/en/assessment.json
@@ -12,6 +12,7 @@
             "assessmentLocked": "Assessment locked by: {{otherUser}}",
             "assessmentLockedComplaintView": "Original Assessor: {{otherUser}}",
             "assessmentLockedCurrentUser": "You have the lock for this assessment",
+            "assessmentReadOnly": "There is a complaint for this assessment. Another tutor must respond.",
             "button": {
                 "overrideAssessment": "Override Assessment",
                 "nextSubmission": "Assess Next Submission",


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I implemented the changes with good performance and prevented too many database calls
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Fixes #1922
**Edit:** We want to allow the tutor to still see the complaint. However, he/she should not obtain the lock or be able to override the result.

### Description
- [x] Remove transactional & refactor getAllModelingSubmissionsByTutorForExercise
- [x] Remove transactional & refactor getAllTextSubmissionsByTutorForExercise
- [x] Remove transactional & refactor getAllFileUploadSubmissionsByTutorForExercise
- [x] Delete obsolete DB call from ResultRepository and move to SubmissionRepository
- [x] Add a text which lets the tutor know why he cannot override the assessment.
- [x] Make all input elements readOnly, if the tutors assessment has a complaint

### Steps for Testing
1. Create an exam
2. participate and submit it as a student
3. Assess an exercise as a tutor
4. Make a complaint about the assessment as a student
5. As the tutor navigate back to tutor dashboard: You should still see the submission on under your assessed submissions. But you should not be able to obtain the lock and override the assessment. Furthermore, all input fields should be read-only. **Caution: Instructors are always allowed to override**
6. Log in as a different tutor, you should see the submission in your complaints table of the tutor exercise dashboard. You should be able to handle the complaint. The submissions stays in the complaints table also after the complaint has been handled.

### Screenshots
![image](https://user-images.githubusercontent.com/15110960/88105577-6f43a280-cba4-11ea-92af-fc65c2c358e5.png)

