### PR TITLE
[Exam] Show error in client if submitting exam failed. Update Exam Page if student failed to submit on time

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -16,7 +16,7 @@
     </h2>
     <jhi-exam-timer class="col-md-3 justify-content-end" [isEndView]="!startView" [endDate]="graceEndDate" [criticalTime]="criticalTime"></jhi-exam-timer>
 </div>
-<div class="w-100 d-flex" *ngIf="!startView && !studentFailedToSubmit()">
+<div class="w-100 d-flex" *ngIf="!startView && !studentFailedToSubmit">
     <div class="col-md-3"></div>
     <p class="col-md-6 font-weight-bold" style="text-align: center;">
         <span jhiTranslate="artemisApp.examParticipation.submitFinalExam"></span>
@@ -37,10 +37,10 @@
     </h2>
     <jhi-exam-information [exam]="exam" [studentExam]="studentExam"></jhi-exam-information>
     <div><span style="display: table; margin-left: auto; margin-right: auto;" [innerHTML]="formattedGeneralInformation"></span></div>
-    <div *ngIf="studentFailedToSubmit()" class="mb-2 font-weight-bold text-danger">
+    <div *ngIf="studentFailedToSubmit" class="mb-2 font-weight-bold text-danger">
         {{ 'studentExam.submissionNotInTime' | translate }}
     </div>
-    <ng-container *ngIf="!studentFailedToSubmit()">
+    <ng-container *ngIf="!studentFailedToSubmit">
         <div class="d-flex justify-content-center">
             <input
                 [(ngModel)]="confirmed"

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -16,7 +16,7 @@
     </h2>
     <jhi-exam-timer class="col-md-3 justify-content-end" [isEndView]="!startView" [endDate]="graceEndDate" [criticalTime]="criticalTime"></jhi-exam-timer>
 </div>
-<div class="w-100 d-flex" *ngIf="!startView">
+<div class="w-100 d-flex" *ngIf="!startView && !studentFailedToSubmit()">
     <div class="col-md-3"></div>
     <p class="col-md-6 font-weight-bold" style="text-align: center;">
         <span jhiTranslate="artemisApp.examParticipation.submitFinalExam"></span>
@@ -37,83 +37,92 @@
     </h2>
     <jhi-exam-information [exam]="exam" [studentExam]="studentExam"></jhi-exam-information>
     <div><span style="display: table; margin-left: auto; margin-right: auto;" [innerHTML]="formattedGeneralInformation"></span></div>
-    <div class="d-flex justify-content-center">
-        <input
-            [(ngModel)]="confirmed"
-            type="checkbox"
-            id="confirmBox"
-            (click)="updateConfirmation()"
-            style="place-self: flex-start;"
-            class="mt-1"
-            [required]="inserted"
-            [disabled]="startView ? waitingForExamStart : false"
-        />
-        <span id="formatted-confirmation-text" class="d-inline-block ml-2" [innerHTML]="formattedConfirmationText"></span>
+    <div *ngIf="studentFailedToSubmit()" class="mb-2 font-weight-bold text-danger">
+        {{ 'studentExam.submissionNotInTime' | translate }}
     </div>
-    <div style="text-align: center;">
-        <div class="login-form">
-            <div class="row justify-content-center">
-                <div class="col-md-6">
-                    <label class="font-weight-bold" for="fullname" jhiTranslate="{{ startView ? 'artemisApp.exam.startConsentText' : 'artemisApp.exam.endConsentText' }}"></label>
-                </div>
-            </div>
-            <div class="row justify-content-center">
-                <div class="form-group">
-                    <input
-                        size="50"
-                        type="text"
-                        class="form-control"
-                        name="fullname"
-                        id="fullname"
-                        [placeholder]="'artemisApp.examParticipation.namePlaceholder' | translate"
-                        [(ngModel)]="enteredName"
-                        [ngModelOptions]="{ updateOn: 'change' }"
-                        [disabled]="startView ? waitingForExamStart : false"
-                    />
-                </div>
-            </div>
-            <div class="row justify-content-center">
-                <div class="form-group">
-                    <div class="alert alert-danger mt-1" *ngIf="!!!confirmed && inserted">
-                        <span [innerHTML]="'artemisApp.exam.notConfirmed' | translate"></span>
-                    </div>
-                    <div class="alert alert-danger mt-1" *ngIf="!nameIsCorrect && inserted">
-                        <span [innerHTML]="'artemisApp.exam.falseName' | translate"></span>
+    <ng-container *ngIf="!studentFailedToSubmit()">
+        <div class="d-flex justify-content-center">
+            <input
+                [(ngModel)]="confirmed"
+                type="checkbox"
+                id="confirmBox"
+                (click)="updateConfirmation()"
+                style="place-self: flex-start;"
+                class="mt-1"
+                [required]="inserted"
+                [disabled]="startView ? waitingForExamStart : false"
+            />
+            <span id="formatted-confirmation-text" class="d-inline-block ml-2" [innerHTML]="formattedConfirmationText"></span>
+        </div>
+        <div style="text-align: center;">
+            <div class="login-form">
+                <div class="row justify-content-center">
+                    <div class="col-md-6">
+                        <label
+                            class="font-weight-bold"
+                            for="fullname"
+                            jhiTranslate="{{ startView ? 'artemisApp.exam.startConsentText' : 'artemisApp.exam.endConsentText' }}"
+                        ></label>
                     </div>
                 </div>
+                <div class="row justify-content-center">
+                    <div class="form-group">
+                        <input
+                            size="50"
+                            type="text"
+                            class="form-control"
+                            name="fullname"
+                            id="fullname"
+                            [placeholder]="'artemisApp.examParticipation.namePlaceholder' | translate"
+                            [(ngModel)]="enteredName"
+                            [ngModelOptions]="{ updateOn: 'change' }"
+                            [disabled]="startView ? waitingForExamStart : false"
+                        />
+                    </div>
+                </div>
+                <div class="row justify-content-center">
+                    <div class="form-group">
+                        <div class="alert alert-danger mt-1" *ngIf="!!!confirmed && inserted">
+                            <span [innerHTML]="'artemisApp.exam.notConfirmed' | translate"></span>
+                        </div>
+                        <div class="alert alert-danger mt-1" *ngIf="!nameIsCorrect && inserted">
+                            <span [innerHTML]="'artemisApp.exam.falseName' | translate"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <ng-container #startButton *ngIf="startView; else endButton">
+                <button [disabled]="!startButtonEnabled || waitingForExamStart" type="submit" (click)="startExam()" class="btn btn-primary">
+                    <span jhiTranslate="artemisApp.exam.startExam">Start Exam</span>
+                </button>
+            </ng-container>
+            <ng-template #endButton>
+                <div *ngIf="handInEarly" class="mb-2 font-weight-bold text-danger">
+                    {{ 'artemisApp.examParticipation.handInEarlyNotice' | translate }}
+                </div>
+                <button [disabled]="!endButtonEnabled" type="submit" (click)="submitExam()" class="btn btn-primary">
+                    <span jhiTranslate="artemisApp.exam.endExam">Finish</span>
+                </button>
+            </ng-template>
+            <div *ngIf="handInEarly" class="mt-5">
+                <div class="mb-2 font-weight-bold">
+                    {{ 'artemisApp.examParticipation.continueAfterHandInEarlyDescription' | translate }}
+                </div>
+                <button class="btn btn-secondary mt-2" (click)="continueAfterHandInEarly()">
+                    <fa-icon [icon]="'arrow-left'"></fa-icon>
+                    {{ 'artemisApp.examParticipation.continueAfterHandInEarly' | translate }}
+                </button>
             </div>
         </div>
-        <ng-container #startButton *ngIf="startView; else endButton">
-            <button [disabled]="!startButtonEnabled || waitingForExamStart" type="submit" (click)="startExam()" class="btn btn-primary">
-                <span jhiTranslate="artemisApp.exam.startExam">Start Exam</span>
-            </button>
-        </ng-container>
-        <ng-template #endButton>
-            <div *ngIf="handInEarly" class="mb-2 font-weight-bold text-danger">
-                {{ 'artemisApp.examParticipation.handInEarlyNotice' | translate }}
+        <div class="exam-waiting-for-start-overlay alert alert-info" *ngIf="waitingForExamStart">
+            <span>{{ 'artemisApp.examParticipation.waitForStart' | translate: { title: exam.title } }}</span>
+            <div *ngIf="exam.startDate">
+                <hr />
+                <span jhiTranslate="artemisApp.examParticipation.timeUntilPlannedStart"></span>
+                <span class="text-bold">{{ timeUntilStart }}</span>
+                <br />
+                <span>({{ formattedStartDate }})</span>
             </div>
-            <button [disabled]="!endButtonEnabled" type="submit" (click)="submitExam()" class="btn btn-primary">
-                <span jhiTranslate="artemisApp.exam.endExam">Finish</span>
-            </button>
-        </ng-template>
-        <div *ngIf="handInEarly" class="mt-5">
-            <div class="mb-2 font-weight-bold">
-                {{ 'artemisApp.examParticipation.continueAfterHandInEarlyDescription' | translate }}
-            </div>
-            <button class="btn btn-secondary mt-2" (click)="continueAfterHandInEarly()">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>
-                {{ 'artemisApp.examParticipation.continueAfterHandInEarly' | translate }}
-            </button>
         </div>
-    </div>
-    <div class="exam-waiting-for-start-overlay alert alert-info" *ngIf="waitingForExamStart">
-        <span>{{ 'artemisApp.examParticipation.waitForStart' | translate: { title: exam.title } }}</span>
-        <div *ngIf="exam.startDate">
-            <hr />
-            <span jhiTranslate="artemisApp.examParticipation.timeUntilPlannedStart"></span>
-            <span class="text-bold">{{ timeUntilStart }}</span>
-            <br />
-            <span>({{ formattedStartDate }})</span>
-        </div>
-    </div>
+    </ng-container>
 </div>

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
@@ -178,7 +178,7 @@ export class ExamParticipationCoverComponent implements OnInit, OnDestroy {
         //         // error message
         //     }
         // });
-        this.handInPossible = false;
+        // temporary lock the submit button in order to protect against spam
         this.onExamEnded.emit();
     }
 
@@ -195,7 +195,7 @@ export class ExamParticipationCoverComponent implements OnInit, OnDestroy {
 
     get endButtonEnabled(): boolean {
         // TODO: add logic when confirm can be clicked
-        return !!(this.nameIsCorrect && this.confirmed && this.exam && this.handInPossible);
+        return this.nameIsCorrect && this.confirmed && this.exam && this.handInPossible;
     }
 
     get nameIsCorrect(): boolean {

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
@@ -205,7 +205,10 @@ export class ExamParticipationCoverComponent implements OnInit, OnDestroy {
         return this.enteredName.trim() !== '';
     }
 
-    studentFailedToSubmit() {
+    /**
+     * Returns whether the student failed to submit on time. In this case the end page is adapted.
+     */
+    get studentFailedToSubmit(): boolean {
         const individualStudentEndDate = moment(this.exam.startDate).add(this.studentExam.workingTime, 'seconds');
         return individualStudentEndDate.add(this.exam.gracePeriod, 'seconds').isBefore(this.serverDateService.now()) && !this.studentExam.submitted;
     }

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
@@ -177,8 +177,7 @@ export class ExamParticipationCoverComponent implements OnInit, OnDestroy {
         //         console.log('Something went wrong');
         //         // error message
         //     }
-        // });
-        // temporary lock the submit button in order to protect against spam
+        // })
         this.onExamEnded.emit();
     }
 
@@ -204,5 +203,10 @@ export class ExamParticipationCoverComponent implements OnInit, OnDestroy {
 
     get inserted(): boolean {
         return this.enteredName.trim() !== '';
+    }
+
+    studentFailedToSubmit() {
+        const individualStudentEndDate = moment(this.exam.startDate).add(this.studentExam.workingTime, 'seconds');
+        return individualStudentEndDate.add(this.exam.gracePeriod, 'seconds').isBefore(this.serverDateService.now()) && !this.studentExam.submitted;
     }
 }

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.ts
@@ -27,6 +27,7 @@ export class ExamParticipationCoverComponent implements OnInit, OnDestroy {
     @Input() exam: Exam;
     @Input() studentExam: StudentExam;
     @Input() handInEarly = false;
+    @Input() handInPossible = true;
     @Output() onExamStarted: EventEmitter<StudentExam> = new EventEmitter<StudentExam>();
     @Output() onExamEnded: EventEmitter<StudentExam> = new EventEmitter<StudentExam>();
     @Output() onExamContinueAfterHandInEarly = new EventEmitter<void>();
@@ -177,6 +178,7 @@ export class ExamParticipationCoverComponent implements OnInit, OnDestroy {
         //         // error message
         //     }
         // });
+        this.handInPossible = false;
         this.onExamEnded.emit();
     }
 
@@ -193,7 +195,7 @@ export class ExamParticipationCoverComponent implements OnInit, OnDestroy {
 
     get endButtonEnabled(): boolean {
         // TODO: add logic when confirm can be clicked
-        return !!(this.nameIsCorrect && this.confirmed && this.exam);
+        return !!(this.nameIsCorrect && this.confirmed && this.exam && this.handInPossible);
     }
 
     get nameIsCorrect(): boolean {

--- a/src/main/webapp/app/exam/participate/exam-participation.component.html
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.html
@@ -114,6 +114,7 @@
             [exam]="exam"
             [studentExam]="studentExam"
             [handInEarly]="handInEarly"
+            [handInPossible]="handInPossible"
             (onExamEnded)="onExamEndConfirmed()"
             (onExamContinueAfterHandInEarly)="toggleHandInEarly()"
         ></jhi-exam-participation-cover>

--- a/src/main/webapp/app/exam/participate/exam-participation.component.html
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.html
@@ -121,7 +121,7 @@
         <jhi-exam-participation-summary *ngIf="isOver() && studentExam.submitted" [studentExam]="studentExam"></jhi-exam-participation-summary>
     </ng-container>
     <ng-template #alert>
-        <div class="d-flex my-2">
+        <div class="d-flex justify-content-center mt-2 mb-4">
             <jhi-alert></jhi-alert>
         </div>
     </ng-template>

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -64,6 +64,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
     disconnected = false;
 
     handInEarly = false;
+    handInPossible = true;
 
     exerciseIndex = 0;
 
@@ -269,7 +270,19 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         if (this.autoSaveInterval) {
             window.clearInterval(this.autoSaveInterval);
         }
-        this.examParticipationService.submitStudentExam(this.courseId, this.examId, this.studentExam).subscribe((studentExam) => (this.studentExam = studentExam));
+        this.examParticipationService.submitStudentExam(this.courseId, this.examId, this.studentExam).subscribe(
+            (studentExam) => (this.studentExam = studentExam),
+            (error) => {
+                // Explicitly check whether the error was caused because the submission was not in-time
+                if (error.status === 403 && error.errorKey === 'submissionNotInTime') {
+                    this.alertService.error(error.errorKey);
+                    this.handInPossible = false;
+                } else {
+                    this.alertService.error('handInFailed');
+                    this.handInPossible = true;
+                }
+            },
+        );
     }
 
     /**

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -29,7 +29,6 @@ import * as moment from 'moment';
 import { Moment } from 'moment';
 import { ProgrammingSubmission } from 'app/entities/programming-submission.model';
 import { cloneDeep } from 'lodash';
-import { HttpErrorResponse } from '@angular/common/http';
 
 type GenerateParticipationStatus = 'generating' | 'failed' | 'success';
 
@@ -268,16 +267,17 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
      * triggered after student accepted exam end terms, will make final call to update submission on server
      */
     onExamEndConfirmed() {
+        // temporary lock the submit button in order to protect against spam
         this.handInPossible = false;
         if (this.autoSaveInterval) {
             window.clearInterval(this.autoSaveInterval);
         }
         this.examParticipationService.submitStudentExam(this.courseId, this.examId, this.studentExam).subscribe(
             (studentExam) => (this.studentExam = studentExam),
-            (error) => {
-                this.alertService.error(error);
+            (error: Error) => {
+                this.alertService.error(error.message);
                 // Explicitly check whether the error was caused because the submission was not in-time, in this case, set hand in not possible
-                this.handInPossible = error !== 'studentExam.submissionNotInTime';
+                this.handInPossible = error.message !== 'studentExam.submissionNotInTime';
             },
         );
     }

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { SERVER_API_URL } from 'app/app.constants';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, throwError } from 'rxjs';
 import { StudentExam } from 'app/entities/student-exam.model';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { QuizSubmission } from 'app/entities/quiz/quiz-submission.model';
 import { catchError, map } from 'rxjs/operators';
@@ -68,9 +68,16 @@ export class ExamParticipationService {
      */
     public submitStudentExam(courseId: number, examId: number, studentExam: StudentExam): Observable<StudentExam> {
         const url = this.getResourceURL(courseId, examId) + '/studentExams/submit';
-        return this.httpClient.post<StudentExam>(url, studentExam).pipe(
-            map((submittedStudentExam: StudentExam) => {
-                return this.convertStudentExamFromServer(submittedStudentExam);
+        return this.httpClient.post<HttpResponse<StudentExam>>(url, studentExam).pipe(
+            map((res: HttpResponse<StudentExam>) => {
+                return this.convertStudentExamFromServer(res.body!);
+            }),
+            catchError((error: HttpErrorResponse) => {
+                if (error.status === 403 && error.headers.get('x-null-error') === 'error.submissionNotInTime') {
+                    return throwError('studentExam.submissionNotInTime');
+                } else {
+                    return throwError('studentExam.handInFailed');
+                }
             }),
         );
     }

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { SERVER_API_URL } from 'app/app.constants';
 import { Observable, Subject, throwError } from 'rxjs';
 import { StudentExam } from 'app/entities/student-exam.model';
-import { HttpClient, HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { QuizSubmission } from 'app/entities/quiz/quiz-submission.model';
 import { catchError, map } from 'rxjs/operators';

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -74,9 +74,9 @@ export class ExamParticipationService {
             }),
             catchError((error: HttpErrorResponse) => {
                 if (error.status === 403 && error.headers.get('x-null-error') === 'error.submissionNotInTime') {
-                    return throwError('studentExam.submissionNotInTime');
+                    return throwError(new Error('studentExam.submissionNotInTime'));
                 } else {
-                    return throwError('studentExam.handInFailed');
+                    return throwError(new Error('studentExam.handInFailed'));
                 }
             }),
         );

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -68,9 +68,9 @@ export class ExamParticipationService {
      */
     public submitStudentExam(courseId: number, examId: number, studentExam: StudentExam): Observable<StudentExam> {
         const url = this.getResourceURL(courseId, examId) + '/studentExams/submit';
-        return this.httpClient.post<HttpResponse<StudentExam>>(url, studentExam).pipe(
-            map((res: HttpResponse<StudentExam>) => {
-                return this.convertStudentExamFromServer(res.body!);
+        return this.httpClient.post<StudentExam>(url, studentExam).pipe(
+            map((studentExam: StudentExam) => {
+                return this.convertStudentExamFromServer(studentExam);
             }),
             catchError((error: HttpErrorResponse) => {
                 if (error.status === 403 && error.headers.get('x-null-error') === 'error.submissionNotInTime') {

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -69,8 +69,8 @@ export class ExamParticipationService {
     public submitStudentExam(courseId: number, examId: number, studentExam: StudentExam): Observable<StudentExam> {
         const url = this.getResourceURL(courseId, examId) + '/studentExams/submit';
         return this.httpClient.post<StudentExam>(url, studentExam).pipe(
-            map((studentExam: StudentExam) => {
-                return this.convertStudentExamFromServer(studentExam);
+            map((submittedStudentExam: StudentExam) => {
+                return this.convertStudentExamFromServer(submittedStudentExam);
             }),
             catchError((error: HttpErrorResponse) => {
                 if (error.status === 403 && error.headers.get('x-null-error') === 'error.submissionNotInTime') {

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -268,6 +268,7 @@
     },
     "studentExam": {
         "alreadySubmitted": "Du hast bereits abgegeben.",
-        "submissionNotInTime": "Du kannst nur zwischen Start und Ende der Klausur abgeben."
+        "submissionNotInTime": "Du hast die Klausur nicht rechtzeitig abgegeben. Sie wird nicht bewertet!",
+        "handInFailed": "Die Abgabe der Klausur ist fehlgeschlagen. Bitte versuchen Sie es erneut!"
     }
 }

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -268,6 +268,7 @@
     },
     "studentExam": {
         "alreadySubmitted": "You have already submitted.",
-        "submissionNotInTime": "You can only submit between start and end of the exam."
+        "submissionNotInTime": "You have not submitted your exam on time. It will not be graded!",
+        "handInFailed": "Submission of your exam failed. Please try again!"
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
Fixes #1941

### Description
- [x] Handle the 403 error thrown if not within the defined exam end time
- [x] Lock the submit button to protect against spamming
- [x] Hide all exam page elements in case the student fails to hand in on time and the exam will not be graded. 

### Steps for Testing
1. Participate in an exam
2. Press hand in early
3. Go offline, and confirm
4. You should be reported that submitting failed and that you should try again. The button should be unlocked as soon as you receive the error message. 
5. Go online
6. Wait for the grace period to pass
7. The exam end interactions should disappear and you should be informed that your exam will not be graded. 

### Screenshots
![image](https://user-images.githubusercontent.com/15110960/87956485-61602580-caaf-11ea-8072-92bd7ceb841a.png)