### PR TITLE
Lock code editor after due date for manually assessed programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -750,7 +750,8 @@ public class ProgrammingExerciseService {
 
     /**
      * Check if the repository of the given participation is locked.
-     * This is the case when the participation is a ProgrammingExerciseStudentParticipation, the buildAndTestAfterDueDate of the exercise is set and the due date has passed.
+     * This is the case when the participation is a ProgrammingExerciseStudentParticipation, the buildAndTestAfterDueDate of the exercise is set and the due date has passed, 
+     * or if manual correction is involved and the due date has passed.
      *
      * Locked means that the student can't make any changes to their repository anymore. While we can control this easily in the remote VCS, we need to check this manually for the local repository on the Artemis server.
      *
@@ -760,8 +761,10 @@ public class ProgrammingExerciseService {
     public boolean isParticipationRepositoryLocked(ProgrammingExerciseParticipation participation) {
         if (participation instanceof ProgrammingExerciseStudentParticipation) {
             ProgrammingExercise programmingExercise = participation.getProgrammingExercise();
-            return programmingExercise.getDueDate() != null && programmingExercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null
-                    && programmingExercise.getDueDate().isBefore(ZonedDateTime.now());
+            // Editing is allowed if build and test after due date is not set and no manual correction is involved
+            boolean isEditingAfterDueAllowed = programmingExercise.getBuildAndTestStudentSubmissionsAfterDueDate() == null
+                    && programmingExercise.getAssessmentType() == AssessmentType.AUTOMATIC;
+            return programmingExercise.getDueDate() != null && programmingExercise.getDueDate().isBefore(ZonedDateTime.now()) && !isEditingAfterDueAllowed;
         }
         return false;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -762,6 +762,7 @@ public class ProgrammingExerciseService {
         if (participation instanceof ProgrammingExerciseStudentParticipation) {
             ProgrammingExercise programmingExercise = participation.getProgrammingExercise();
             // Editing is allowed if build and test after due date is not set and no manual correction is involved
+            // (this should match CodeEditorStudentContainerComponent.repositoryIsLocked on the client-side)
             boolean isEditingAfterDueAllowed = programmingExercise.getBuildAndTestStudentSubmissionsAfterDueDate() == null
                     && programmingExercise.getAssessmentType() == AssessmentType.AUTOMATIC;
             return programmingExercise.getDueDate() != null && programmingExercise.getDueDate().isBefore(ZonedDateTime.now()) && !isEditingAfterDueAllowed;

--- a/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
@@ -86,6 +86,7 @@ export class CodeEditorStudentContainerComponent extends CodeEditorContainerComp
                         this.participation = participationWithResults!;
                         this.exercise = this.participation.exercise as ProgrammingExercise;
                         // We lock the repository when the buildAndTestAfterDueDate is set and the due date has passed or if they require manual assessment.
+                        // (this should match ProgrammingExerciseService.isParticipationRepositoryLocked on the server-side)
                         const dueDateHasPassed = !this.exercise.dueDate || moment(this.exercise.dueDate).isBefore(moment());
                         const isEditingAfterDueAllowed = !this.exercise.buildAndTestStudentSubmissionsAfterDueDate && this.exercise.assessmentType === AssessmentType.AUTOMATIC;
                         this.repositoryIsLocked = !isEditingAfterDueAllowed && !!this.exercise.dueDate && dueDateHasPassed;

--- a/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
@@ -19,6 +19,7 @@ import { CodeEditorFileService } from 'app/exercises/programming/shared/code-edi
 import { CodeEditorActionsComponent } from 'app/exercises/programming/shared/code-editor/actions/code-editor-actions.component';
 import { CodeEditorAceComponent } from 'app/exercises/programming/shared/code-editor/ace/code-editor-ace.component';
 import { ExerciseType } from 'app/entities/exercise.model';
+import { AssessmentType } from 'app/entities/assessment-type.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { Result } from 'app/entities/result.model';
 import { CodeEditorContainerComponent } from 'app/exercises/programming/shared/code-editor/code-editor-mode-container.component';
@@ -84,9 +85,10 @@ export class CodeEditorStudentContainerComponent extends CodeEditorContainerComp
                         this.domainService.setDomain([DomainType.PARTICIPATION, participationWithResults!]);
                         this.participation = participationWithResults!;
                         this.exercise = this.participation.exercise as ProgrammingExercise;
-                        // We lock the repository when the buildAndTestAfterDueDate is set and the due date has passed.
+                        // We lock the repository when the buildAndTestAfterDueDate is set and the due date has passed or if they require manual assessment.
                         const dueDateHasPassed = !this.exercise.dueDate || moment(this.exercise.dueDate).isBefore(moment());
-                        this.repositoryIsLocked = !!this.exercise.buildAndTestStudentSubmissionsAfterDueDate && !!this.exercise.dueDate && dueDateHasPassed;
+                        const isEditingAfterDueAllowed = !this.exercise.buildAndTestStudentSubmissionsAfterDueDate && this.exercise.assessmentType === AssessmentType.AUTOMATIC;
+                        this.repositoryIsLocked = !isEditingAfterDueAllowed && !!this.exercise.dueDate && dueDateHasPassed;
                     }),
                     switchMap(() => {
                         return this.loadExerciseHints();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I added multiple integration tests (Spring) related to the features
- [x] Server: I documented the Java code using JavaDoc and comments.
- [x] Client: I documented the TypeScript code using regular comments.

### Motivation and Context
This is the fix for the code editor analogue of #1936 and #1937.

### Description
- Lock repository client side if the exercise involves manual assessment
- Check on the server-side if manual assessment is involved and disallow code editor commits if this is the case.

### Steps for Testing
1. Create a programming exercise with manual assessment (and/or build after due date or none of both)
2. Start the exercise and let the due date pass.
3. Check that if the student opens the repository if the code editor, it is displayed as locked and submit is not possible anymore. (if neither build and test after due date nor manual assessment is set, editing should still be allowed)

What is expected:
- `Run Tests once after Due Date` is set ---> repository should be locked after due date
- `Manual Review` is set ---> repository should be locked after due date
- `otherwise` ---> students can still make changes