### PR TITLE
Bugfix: Refresh quiz after 5 secs when no update from websocket

### DIFF
--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts
@@ -94,6 +94,7 @@ export class QuizParticipationComponent implements OnInit, OnDestroy {
     quizId: number;
     courseId: number;
     interval: any;
+    quizStarted = false;
 
     /**
      * Websocket channels
@@ -402,6 +403,17 @@ export class QuizParticipationComponent implements OnInit, OnDestroy {
                 this.timeUntilStart = this.relativeTimeText(this.quizExercise.adjustedReleaseDate.diff(moment(), 'seconds'));
             } else {
                 this.timeUntilStart = this.translateService.instant(translationBasePath + 'now');
+                // Check if websocket has updated the quiz exercise and check that following block is only executed once
+                if (!this.quizExercise.started && !this.quizStarted) {
+                    this.quizStarted = true;
+                    // Refresh quiz after 5 seconds when client did not receive websocket message to start the quiz
+                    setTimeout(() => {
+                        // Check again if websocket has updated the quiz exercise within the 5 seconds
+                        if (!this.quizExercise.started) {
+                            this.refreshQuiz(true);
+                        }
+                    }, 5000);
+                }
             }
         } else {
             this.timeUntilStart = '';


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #1894 

### Description
<!-- Describe your changes in detail -->
Added check when the countdown runs down if the quiz exercise was updated (from websocket) and executes a refresh when it was not updated.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create a quiz with a `Start Time` in the future and make it visible to students
3. Go to the course and enter the quiz (a countdown when the quiz starts is displayed)
4. Go offline before the quiz is supposed to start and open network tab
5. Wait until the countdown runs down and check that after 5 seconds the `for-student` call is executed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/41108487/88022375-6cf33100-cb2f-11ea-8b07-9ff62d181c1f.png">

After 5 seconds the `for-student` should be executed:
<img width="1042" alt="image" src="https://user-images.githubusercontent.com/41108487/88022977-86e14380-cb30-11ea-8eb2-8b752a7c0382.png">



