### PR TITLE
Fix evaluating quiz exams, generating missing exams and (un)locking repos with large participations 

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -43,9 +43,8 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @Query("select distinct exam from Exam exam left join fetch exam.studentExams studentExams left join fetch exam.exerciseGroups exerciseGroups left join fetch exerciseGroups.exercises where (exam.id = :#{#examId})")
     Exam findOneWithEagerExercisesGroupsAndStudentExams(@Param("examId") long examId);
 
-    // TODO: for exams with many users, this DB query crashes the server due to memory issues
-    @EntityGraph(type = LOAD, attributePaths = { "exerciseGroups", "exerciseGroups.exercises", "registeredUsers", "studentExams" })
-    Optional<Exam> findWithExercisesRegisteredUsersStudentExamsById(Long examId);
+    // IMPORTANT: NEVER use the following EntityGraph because it will lead to crashes for exams with many users
+    // @EntityGraph(type = LOAD, attributePaths = { "exerciseGroups", "exerciseGroups.exercises", "registeredUsers", "studentExams" })
 
     /**
      * Checks if the user is registered for the exam.

--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -43,6 +43,7 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @Query("select distinct exam from Exam exam left join fetch exam.studentExams studentExams left join fetch exam.exerciseGroups exerciseGroups left join fetch exerciseGroups.exercises where (exam.id = :#{#examId})")
     Exam findOneWithEagerExercisesGroupsAndStudentExams(@Param("examId") long examId);
 
+    // TODO: for exams with many users, this DB query crashes the server due to memory issues
     @EntityGraph(type = LOAD, attributePaths = { "exerciseGroups", "exerciseGroups.exercises", "registeredUsers", "studentExams" })
     Optional<Exam> findWithExercisesRegisteredUsersStudentExamsById(Long examId);
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/QuizExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/QuizExerciseRepository.java
@@ -26,10 +26,6 @@ public interface QuizExerciseRepository extends JpaRepository<QuizExercise, Long
     @EntityGraph(type = LOAD, attributePaths = { "quizQuestions", "quizPointStatistic", "quizQuestions.quizQuestionStatistic", "categories" })
     Optional<QuizExercise> findWithEagerQuestionsAndStatisticsById(Long quizExerciseId);
 
-    @EntityGraph(type = LOAD, attributePaths = { "quizQuestions", "quizPointStatistic", "quizQuestions.quizQuestionStatistic", "categories", "studentParticipations",
-            "studentParticipations.submissions", "studentParticipations.results" })
-    Optional<QuizExercise> findWithEagerQuestionsAndStatisticsAndParticipationsById(Long quizExerciseId);
-
     @EntityGraph(type = LOAD, attributePaths = { "quizQuestions" })
     Optional<QuizExercise> findWithEagerQuestionsById(Long quizExerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 
 /**
@@ -38,4 +39,7 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
 
     @Query("select distinct se.workingTime from StudentExam se where se.exam.id = :#{#examId}")
     Set<Integer> findAllDistinctWorkingTimesByExamId(@Param("examId") Long examId);
+
+    @Query("select u from StudentExam se left join se.user u where se.exam.id = :#{#examId}")
+    Set<User> findUsersWithStudentExamsForExam(@Param("examId") Long examId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
@@ -127,6 +127,9 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
     @EntityGraph(type = LOAD, attributePaths = { "submissions", "submissions.result", "submissions.result.assessor" })
     List<StudentParticipation> findAllWithEagerSubmissionsAndEagerResultsAndEagerAssessorByExerciseId(long exerciseId);
 
+    @EntityGraph(type = LOAD, attributePaths = { "submissions", "submissions.result", "results" })
+    List<StudentParticipation> findAllWithEagerSubmissionsAndEagerResultsByExerciseId(long exerciseId);
+
     @Query("SELECT DISTINCT participation FROM StudentParticipation participation LEFT JOIN FETCH participation.exercise e LEFT JOIN FETCH e.course WHERE participation.id = :#{#participationId}")
     StudentParticipation findOneByIdWithEagerExerciseAndEagerCourse(@Param("participationId") Long participationId);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamQuizService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamQuizService.java
@@ -48,14 +48,14 @@ public class ExamQuizService {
     /**
      * Evaluate the given quiz exercise by evaluate the submission for each participation (there is only one for each participation in exams)
      * and update the statistics with the generated results.
-     * @param quizExercise the QuizExercise that should be evaluated
+     * @param quizExerciseId the id of the QuizExercise that should be evaluated
      */
-    public void evaluateQuizAndUpdateStatistics(@NotNull QuizExercise quizExercise) {
+    public void evaluateQuizAndUpdateStatistics(@NotNull Long quizExerciseId) {
         long start = System.nanoTime();
-        log.info("Starting quiz evaluation for quiz " + quizExercise.getId());
+        log.info("Starting quiz evaluation for quiz " + quizExerciseId);
         // We have to load the questions and statistics so that we can evaluate and update and we also need the participations and submissions that exist for this exercise so that
         // they can be evaluated
-        quizExercise = quizExerciseService.findOneWithQuestionsAndStatisticsAndParticipations(quizExercise.getId());
+        var quizExercise = quizExerciseService.findOneWithQuestionsAndStatistics(quizExerciseId);
         Set<Result> createdResults = evaluateSubmissions(quizExercise);
         log.info("Quiz evaluation for quiz {} finished after {} with {} created results", quizExercise.getId(), TimeLogUtil.formatDurationFrom(start), createdResults.size());
         quizStatisticService.updateStatistics(createdResults, quizExercise);
@@ -74,12 +74,12 @@ public class ExamQuizService {
      *
      * After processing all participations, the created results will be returned for further processing
      * // @formatter:on
-     * @param quizExercise the QuizExercise that should be evaluated
+     * @param quizExercise the id of the QuizExercise that should be evaluated
      * @return the newly generated results
      */
     private Set<Result> evaluateSubmissions(@NotNull QuizExercise quizExercise) {
         Set<Result> createdResults = new HashSet<>();
-        Set<StudentParticipation> studentParticipations = quizExercise.getStudentParticipations();
+        List<StudentParticipation> studentParticipations = studentParticipationRepository.findAllWithEagerSubmissionsAndEagerResultsByExerciseId(quizExercise.getId());
 
         for (var participation : studentParticipations) {
             try {
@@ -131,7 +131,7 @@ public class ExamQuizService {
                 participation = studentParticipationRepository.save(participation);
                 quizSubmissionRepository.save(quizSubmission);
                 result = resultRepository.save(result);
-                result = resultRepository.findWithEagerSubmissionAndFeedbackById(result.getId()).orElse(null);
+                // result = resultRepository.findWithEagerSubmissionAndFeedbackById(result.getId()).orElse(null);
 
                 // Add result so that it can be returned (and processed later)
                 if (!resultExisting) {

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamQuizService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamQuizService.java
@@ -83,6 +83,8 @@ public class ExamQuizService {
 
         for (var participation : studentParticipations) {
             try {
+                // reconnect so that the quiz questions are available later on (otherwise there will be a org.hibernate.LazyInitializationException)
+                participation.setExercise(quizExercise);
                 Set<Submission> submissions = participation.getSubmissions();
                 QuizSubmission quizSubmission;
                 if (submissions.size() == 0) {

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -326,7 +326,7 @@ public class ExamService {
      * @return the list of student exams with their corresponding users
      */
     public List<StudentExam> generateMissingStudentExams(Long examId) {
-        Exam exam = examRepository.findWithExercisesRegisteredUsersStudentExamsById(examId).get();
+        Exam exam = examRepository.findWithRegisteredUsersAndExerciseGroupsAndExercisesById(examId).get();
 
         // TODO: the validation checks should happen in the resource, before this method is even being called!
         if (exam.getNumberOfExercisesInExam() == null) {
@@ -339,14 +339,14 @@ public class ExamService {
         validateStudentExamGeneration(exam, numberOfOptionalExercises);
 
         // Get all users who already have an individual exam
-        Set<User> usersWithExam = exam.getStudentExams().stream().map(StudentExam::getUser).collect(Collectors.toSet());
+        Set<User> usersWithStudentExam = studentExamRepository.findUsersWithStudentExamsForExam(examId);
 
         // Get all registered users
         Set<User> allRegisteredUsers = exam.getRegisteredUsers();
 
         // Get all students who don't have an exam yet
         Set<User> missingUsers = new HashSet<>(allRegisteredUsers);
-        missingUsers.removeAll(usersWithExam);
+        missingUsers.removeAll(usersWithStudentExam);
 
         // StudentExams are saved in the called method
         List<StudentExam> missingStudentExams = createRandomStudentExams(exam, missingUsers, numberOfOptionalExercises);

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -586,8 +586,7 @@ public class ExamService {
      * @return number of evaluated exercises
      */
     public Integer evaluateQuizExercises(Long examId) {
-        var exam = examRepository.findWithExercisesRegisteredUsersStudentExamsById(examId)
-                .orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
+        var exam = examRepository.findWithExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
 
         // Collect all quiz exercises for the given exam
         Set<QuizExercise> quizExercises = new HashSet<>();
@@ -602,7 +601,9 @@ public class ExamService {
         long start = System.nanoTime();
         log.info("Evaluating {} quiz exercies in exam {}", quizExercises.size(), examId);
         // Evaluate all quizzes for that exercise
-        quizExercises.forEach(examQuizService::evaluateQuizAndUpdateStatistics);
+        quizExercises.forEach(quiz -> {
+            examQuizService.evaluateQuizAndUpdateStatistics(quiz.getId());
+        });
         log.info("Evaluated {} quiz exercies in exam {} in {}", quizExercises.size(), examId, TimeLogUtil.formatDurationFrom(start));
 
         return quizExercises.size();

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -624,8 +624,7 @@ public class ExamService {
      * @return number of exercises for which the repositories are unlocked
      */
     public Integer unlockAllRepositories(Long examId) {
-        var exam = examRepository.findWithExercisesRegisteredUsersStudentExamsById(examId)
-                .orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
+        var exam = examRepository.findWithExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
 
         // Collect all programming exercises for the given exam
         Set<ProgrammingExercise> programmingExercises = new HashSet<>();
@@ -652,8 +651,7 @@ public class ExamService {
      * @return number of exercises for which the repositories are locked
      */
     public Integer lockAllRepositories(Long examId) {
-        var exam = examRepository.findWithExercisesRegisteredUsersStudentExamsById(examId)
-                .orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
+        var exam = examRepository.findWithExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
 
         // Collect all programming exercises for the given exam
         Set<ProgrammingExercise> programmingExercises = new HashSet<>();

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -304,7 +304,7 @@ public class ExamService {
         studentExamRepository.deleteInBatch(examWithExistingStudentExams.getStudentExams());
 
         // now fetch the exam with additional information
-        Exam exam = examRepository.findWithExercisesRegisteredUsersStudentExamsById(examId).get();
+        Exam exam = examRepository.findWithRegisteredUsersAndExerciseGroupsAndExercisesById(examId).get();
 
         List<ExerciseGroup> exerciseGroups = exam.getExerciseGroups();
         long numberOfOptionalExercises = exam.getNumberOfExercisesInExam() - exerciseGroups.stream().filter(ExerciseGroup::getIsMandatory).count();

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
@@ -273,18 +273,6 @@ public class QuizExerciseService {
     }
 
     /**
-     * Get one quiz exercise by id and eagerly load questions, statistics and submissions
-     *
-     * @param quizExerciseId the id of the entity
-     * @return the quiz exercise entity
-     */
-    public QuizExercise findOneWithQuestionsAndStatisticsAndParticipations(Long quizExerciseId) {
-        log.debug("Find quiz exercise {} with questions and statistics and participations", quizExerciseId);
-        Optional<QuizExercise> optionalQuizExercise = quizExerciseRepository.findWithEagerQuestionsAndStatisticsAndParticipationsById(quizExerciseId);
-        return optionalQuizExercise.orElse(null);
-    }
-
-    /**
      * Get all quiz exercises for the given course.
      *
      * @param courseId the id of the course

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -713,7 +713,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         assertThat(savedExerciseGroups.get(2).getTitle()).isEqualTo("first");
 
         // Exercises should be preserved
-        Exam savedExam = examRepository.findWithExercisesRegisteredUsersStudentExamsById(exam.getId()).get();
+        Exam savedExam = examRepository.findWithExerciseGroupsAndExercisesById(exam.getId()).get();
         ExerciseGroup savedExerciseGroup1 = savedExam.getExerciseGroups().get(2);
         ExerciseGroup savedExerciseGroup2 = savedExam.getExerciseGroups().get(0);
         ExerciseGroup savedExerciseGroup3 = savedExam.getExerciseGroups().get(1);


### PR DESCRIPTION
Evaluating quiz exams, generating individual exams and (un)locking with a large number of participants can crash the server. The DB query had too many elements and Hibernate then cannot load the whole Entity Graph. I split the DB queries into multiple ones, which should still be quite performant and should prevent the issues with the current implementation

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

**Round 1**
1. Create an exam with a quiz
2. Participate in the quiz and wait for the exam end
3. Go to Student Exam Screen and click on Evaluate Quiz
4. Check in the quiz scores page and statistic, that the quiz has been evaluated (i.e. graded) and all results exist

**Round 2**
1. Create an exam
2. Generate the student exams
3. Re-generate the student exams
4. Add a student to the exam and generate the missing exam
5. All calls should be fast (<5s) and should also work if several hundred students are registered