### PR TITLE
Fix generate StudentExams with existing ExamSessiosn

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -36,6 +36,9 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @EntityGraph(type = LOAD, attributePaths = { "studentExams" })
     Optional<Exam> findWithStudentExamsById(Long examId);
 
+    @EntityGraph(type = LOAD, attributePaths = { "studentExams", "studentExams.examSessions" })
+    Optional<Exam> findWithStudentExamsAndExamSessionsById(Long examId);
+
     @EntityGraph(type = LOAD, attributePaths = { "studentExams", "studentExams.exercises", "studentExams.exercises.studentParticipations",
             "studentExams.exercises.studentParticipations.submissions" })
     Optional<Exam> findWithStudentExamsExercisesParticipationsSubmissionsById(Long id);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) locally

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Generating StudentExams which already have an ExamSession fails, due to db constraing of ExamSessions (FK)

### Description
<!-- Describe your changes in detail -->
Before generating the exams, delete all existing ExamSessions for the existing StudentExams

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create an exam and generate StudentExams and prepare exercises
2. Participate in Exam
3. Change Exam Dates
4. Generate StudentExams again
5. Should work