### PR TITLE
[Exam] Fix rounding on exam scores page

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -278,7 +278,7 @@ public class ExamService {
         }
 
         // Updating exam information in DTO
-        Double sumOverallPoints = scores.studentResults.stream().map(studentResult -> studentResult.overallPointsAchieved).reduce(0.0, Double::sum);
+        Double sumOverallPoints = scores.studentResults.stream().mapToDouble(studentResult -> studentResult.overallPointsAchieved).sum();
 
         int numberOfStudentResults = scores.studentResults.size();
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -246,7 +246,7 @@ public class ExamService {
                 if (studentParticipation.getResults() != null && !studentParticipation.getResults().isEmpty()) {
                     Result relevantResult = studentParticipation.getResults().iterator().next();
                     double achievedPoints = relevantResult.getScore() / 100.0 * exercise.getMaxScore();
-                    studentResult.overallPointsAchieved += achievedPoints;
+                    studentResult.overallPointsAchieved += Math.round(achievedPoints * 10) / 10.0;
                     studentResult.exerciseGroupIdToExerciseResult.put(exercise.getExerciseGroup().getId(),
                             new ExamScoresDTO.ExerciseResult(exercise.getId(), exercise.getTitle(), exercise.getMaxScore(), relevantResult.getScore(), achievedPoints));
 

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -1024,7 +1024,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
 
             // Calculate overall points achieved
             var calculatedOverallPoints = studentExamOfUser.getExercises().stream().map(exercise -> exercise.getMaxScore()).reduce(0.0,
-                    (total, maxScore) -> total + maxScore * resultScore / 100);
+                    (total, maxScore) -> (Math.round((total + maxScore * resultScore / 100) * 10) / 10.0));
             assertEquals(studentResult.overallPointsAchieved, calculatedOverallPoints, EPSILON);
 
             // Calculate overall score achieved

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -975,7 +975,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         double calculatedAverageScore = 0.0;
         for (var exerciseGroup : exam.getExerciseGroups()) {
             var exercise = exerciseGroup.getExercises().stream().findAny().get();
-            calculatedAverageScore += exercise.getMaxScore() * resultScore / 100.00;
+            calculatedAverageScore += Math.round(exercise.getMaxScore() * resultScore / 100.00 * 10) / 10.0;
         }
         // TODO: the rest of the test is flaky and does not pass. We should investigate and fix this!!
 

--- a/src/test/javascript/jest.config.js
+++ b/src/test/javascript/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
         '<rootDir>/src/test/javascript/spec/integration/**/*.ts',
         '<rootDir>/src/test/javascript/spec/pipe/**/*.ts',
         '<rootDir>/src/test/javascript/spec/service/**/*.ts',
+        '<rootDir>/src/test/javascript/spec/util/**/*.ts',
     ],
     moduleNameMapper: {
         '^app/(.*)': '<rootDir>/src/main/webapp/app/$1',

--- a/src/test/javascript/spec/util/shared/utils.spec.ts
+++ b/src/test/javascript/spec/util/shared/utils.spec.ts
@@ -1,0 +1,36 @@
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import { round } from 'app/shared/util/utils';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('Utilities', () => {
+    describe('Round', () => {
+        it('Decimal length', () => {
+            expect(round(14.821354, 4)).to.be.equal(14.8214);
+            expect(round(14.821354, 3)).to.be.equal(14.821);
+            expect(round(14.821354, 2)).to.be.equal(14.82);
+            expect(round(14.821354, 1)).to.be.equal(14.8);
+            expect(round(14.821354, 0)).to.be.equal(15);
+        });
+
+        it('Turning points', () => {
+            expect(round(2.4999999, 0)).to.be.equal(2);
+            expect(round(2.5, 0)).to.be.equal(3);
+            expect(round(2.55, 1)).to.be.equal(2.6);
+            expect(round(2.555, 2)).to.be.equal(2.56);
+            expect(round(2.5555, 3)).to.be.equal(2.556);
+            expect(round(2.55555, 4)).to.be.equal(2.5556);
+        });
+
+        it('Other', () => {
+            expect(round(9.99999999, 0)).to.be.equal(10);
+            expect(round(9.99999999, 1)).to.be.equal(10);
+            expect(round(5.55555555, 0)).to.be.equal(6);
+            expect(round(5.55555555, 1)).to.be.equal(5.6);
+            expect(round(1.00000001, 0)).to.be.equal(1);
+            expect(round(1.00000001, 1)).to.be.equal(1.0);
+        });
+    });
+});


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Client: I added multiple integration tests (Jest) related to the features

### Motivation and Context
In some cases the *Sum of your points* in the participation summary and the *Overall points* in the exam scores page are not rounded equally.

### Description
- [x] I've ensured that the achieved points are rounded before added to `overallPointsAchieved` in the `ExamService`
- [x] I've added Jest tests for the generic `round()` utility function

### Steps for Testing
1. Log in to Artemis
2. Participate in exam with at least 3 exercises
3. Assess your participation (**important:** the sum of the achieved points should have at least one decimal place e.g. `14.9`)
4. Go to the *participation summary* and the *exam scores page* in the exam management
5. Check that the *sum of your points* and *Overall points* are equally rounded