### PR TITLE
[Bugfix] Handle importing quizzes with invalid flags

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-confirm-import-invalid-questions-modal.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-confirm-import-invalid-questions-modal.component.html
@@ -1,0 +1,25 @@
+<form class="conflict-modal" #confirmForm="ngForm" name="confirmForm" (ngSubmit)="importQuestions()">
+    <div class="conflict-modal__header">
+        <h4 jhiTranslate="artemisApp.quizExercise.importWarningShort"></h4>
+    </div>
+    <div class="conflict-modal__body">
+        <jhi-alert-error></jhi-alert-error>
+        <span class="conflict-modal__body__warning">
+            <fa-icon [icon]="'exclamation-triangle'"></fa-icon>
+            <div jhiTranslate="artemisApp.quizExercise.importWarningLong"></div>
+            <p></p>
+            <div *ngFor="let reason of invalidFlaggedQuestions">
+                <p *ngIf="(reason.translateValues | json) != '{}'" jhiTranslate="{{ reason.translateKey }}" [translateValues]="{ index: reason.translateValues.index }"></p>
+                <p *ngIf="(reason.translateValues | json) == '{}'" jhiTranslate="{{ reason.translateKey }}"></p>
+            </div>
+        </span>
+    </div>
+    <div class="conflict-modal__footer">
+        <button class="conflict-modal__footer__cancel" type="button" data-dismiss="modal" (click)="closeModal()">
+            <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
+        </button>
+        <button type="submit" class="conflict-modal__footer__submit" [disabled]="!confirmForm.valid">
+            <fa-icon [icon]="'times'"></fa-icon><span jhiTranslate="artemisApp.quizExercise.confirmImport">Continue</span>
+        </button>
+    </div>
+</form>

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-confirm-import-invalid-questions-modal.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-confirm-import-invalid-questions-modal.component.ts
@@ -1,0 +1,29 @@
+import { Component, EventEmitter } from '@angular/core';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { Reason } from 'app/exercises/quiz/manage/quiz-exercise-detail.component';
+
+@Component({
+    selector: 'jhi-quiz-confirm-import-invalid-questions-modal',
+    templateUrl: './quiz-confirm-import-invalid-questions-modal.component.html',
+    styleUrls: ['./quiz-confirm-import-invalid-questions-modal.scss'],
+})
+export class QuizConfirmImportInvalidQuestionsModalComponent {
+    constructor(public activeModal: NgbActiveModal) {}
+
+    invalidFlaggedQuestions: Reason[];
+    shouldImport: EventEmitter<void> = new EventEmitter<void>();
+
+    /**
+     * Reset the git repository.
+     *
+     * @function resetRepository
+     */
+    importQuestions() {
+        this.activeModal.close();
+        this.shouldImport.emit();
+    }
+
+    closeModal() {
+        this.activeModal.dismiss('cancel');
+    }
+}

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-confirm-import-invalid-questions-modal.scss
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-confirm-import-invalid-questions-modal.scss
@@ -1,0 +1,35 @@
+@import 'src/main/webapp/content/scss/bootstrap-variables';
+
+@import 'node_modules/bootstrap/scss/variables';
+@import 'node_modules/bootstrap/scss/buttons';
+@import 'node_modules/bootstrap/scss/modal';
+
+.conflict-modal__header {
+    @extend .modal-header;
+}
+
+.conflict-modal {
+    &__body {
+        @extend .modal-body;
+        &__warning > fa-icon {
+            @extend .text-warning;
+        }
+    }
+    &__footer {
+        @extend .modal-footer;
+        &__cancel {
+            @extend .btn;
+            @extend .btn-secondary;
+            > *:not(:first-child) {
+                @extend .ml-2;
+            }
+        }
+        &__submit {
+            @extend .btn;
+            @extend .btn-danger;
+            > *:not(:first-child) {
+                @extend .ml-2;
+            }
+        }
+    }
+}

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -670,12 +670,12 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
         if (questions.length === 0) {
             questions = this.quizExercise.quizQuestions;
         }
-        let invalidQuestions: {
+        const invalidQuestions: {
             [questionId: number]: (AnswerOption | ShortAnswerSolution | ShortAnswerMapping | ShortAnswerSpot | DropLocation | DragItem | DragAndDropMapping)[] | null;
         } = {};
         questions.forEach(function (question) {
             const invalidQuestion = question.invalid;
-            let invalidElements: (AnswerOption | ShortAnswerSolution | ShortAnswerMapping | ShortAnswerSpot | DropLocation | DragItem | DragAndDropMapping)[] = [];
+            const invalidElements: (AnswerOption | ShortAnswerSolution | ShortAnswerMapping | ShortAnswerSpot | DropLocation | DragItem | DragAndDropMapping)[] = [];
             if (question.type === QuizQuestionType.MULTIPLE_CHOICE && (<MultipleChoiceQuestion>question).answerOptions !== undefined) {
                 (<MultipleChoiceQuestion>question).answerOptions!.forEach(function (option) {
                     if (option.invalid) {
@@ -739,7 +739,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
      * @returns {Array} array of objects with fields 'translateKey' and 'translateValues'
      */
     computeInvalidWarnings(): Warning[] {
-        let invalidWarnings = !this.quizExercise
+        const invalidWarnings = !this.quizExercise
             ? []
             : this.quizExercise.quizQuestions
                   .map((question, index) => {

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -497,7 +497,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
                 questions.push(question);
             }
         }
-        this.verifyImportedQuestions(questions);
+        this.verifyAndImportQuestions(questions);
         this.showExistingQuestions = !this.showExistingQuestions;
         this.selectedCourseId = null;
         this.allExistingQuestions = this.existingQuestions = [];
@@ -513,7 +513,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
         this.warningQuizCache = this.computeInvalidWarnings().length > 0;
         this.quizIsValid = this.validQuiz();
         this.pendingChangesCache = this.pendingChanges();
-        this.checkInvalidFlaggedQuestions();
+        this.checkForInvalidFlaggedQuestions();
         this.computeInvalidReasons();
         this.computeInvalidWarnings();
         this.changeDetector.detectChanges();
@@ -658,7 +658,12 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
         return isGenerallyValid && areAllQuestionsValid && this.isEmpty(this.invalidFlaggedQuestions);
     }
 
-    checkInvalidFlaggedQuestions(questions: QuizQuestion[] = []) {
+    /**
+     * Iterates through the questions is search for invalid flags. Updates {@link invalidFlaggedQuestions} accordingly.
+     * Check the invalid flag of the question as well as all elements which can be set as invalid, for each quiz exercise type.
+     * @param questions optional parameter, if it is not set, it iterates over the exercise questions.
+     */
+    checkForInvalidFlaggedQuestions(questions: QuizQuestion[] = []) {
         if (!this.quizExercise) {
             return;
         }
@@ -951,7 +956,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
             try {
                 // Read the file and get list of questions from the file
                 const questions = JSON.parse(fileReader.result as string) as QuizQuestion[];
-                this.verifyImportedQuestions(questions);
+                this.verifyAndImportQuestions(questions);
                 // Clearing html elements,
                 this.importFile = null;
                 this.importFileName = '';
@@ -966,13 +971,13 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
     }
 
     /**
-     * Calls {@link checkInvalidFlaggedQuestions} to verify whether any question or its elements have the invalid flag set.
+     * Calls {@link checkForInvalidFlaggedQuestions} to verify whether any question or its elements have the invalid flag set.
      * If this is the case, the user is notified using the {@link QuizConfirmImportInvalidQuestionsModalComponent} modal.
      * If the user accepts importing the questions with invalid flags, all these flags are reset. See {@link addQuestions}.
      * @param questions the question which are being imported.
      */
-    verifyImportedQuestions(questions: QuizQuestion[]) {
-        this.checkInvalidFlaggedQuestions(questions);
+    verifyAndImportQuestions(questions: QuizQuestion[]) {
+        this.checkForInvalidFlaggedQuestions(questions);
         if (!this.isEmpty(this.invalidFlaggedQuestions)) {
             const modal = this.modalService.open(QuizConfirmImportInvalidQuestionsModalComponent, { keyboard: true, size: 'lg' });
             modal.componentInstance.invalidFlaggedQuestions = questions

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-management.module.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-management.module.ts
@@ -25,6 +25,7 @@ import { QuizReEvaluateWarningComponent } from 'app/exercises/quiz/manage/re-eva
 import { QuizExerciseExportComponent } from 'app/exercises/quiz/manage/quiz-exercise-export.component';
 import { ArtemisQuizQuestionTypesModule } from 'app/exercises/quiz/shared/questions/artemis-quiz-question-types.module';
 import { ArtemisQuizParticipationModule } from 'app/exercises/quiz/participate/quiz-participation.module';
+import { QuizConfirmImportInvalidQuestionsModalComponent } from 'app/exercises/quiz/manage/quiz-confirm-import-invalid-questions-modal.component';
 
 const ENTITY_STATES = [...quizManagementRoute];
 
@@ -46,6 +47,7 @@ const ENTITY_STATES = [...quizManagementRoute];
     ],
     declarations: [
         QuizExerciseComponent,
+        QuizConfirmImportInvalidQuestionsModalComponent,
         QuizExerciseDetailComponent,
         MultipleChoiceQuestionEditComponent,
         DragAndDropQuestionEditComponent,

--- a/src/main/webapp/i18n/de/quizExercise.json
+++ b/src/main/webapp/i18n/de/quizExercise.json
@@ -168,7 +168,8 @@
                 "shortAnswerQuestionDuplicateMapping": "Frage {{index}}: Es gibt mindestens ein Mapping das doppelt ist.",
                 "questionTitleLength": "Frage {{index}}: Die Frage ist länger als 250 Zeichen. Bitte kürzen!",
                 "quizTitleLength": "Quiz: Der Titel ist länger als 250 Zeichen. Bitte kürzen!",
-                "explanationIsMissing": "Frage {{index}}: Nicht jede Antwortmöglichkeit enthält eine Erklärung."
+                "explanationIsMissing": "Frage {{index}}: Nicht jede Antwortmöglichkeit enthält eine Erklärung.",
+                "questionHasInvalidFlaggedElements": "<strong>Frage {{index}} </strong>: Diese Frage wurde zuvor als ungültig markiert oder enthält ungültige Elemente. Diese werden nach dem Speichern zurückgesetzt."
             },
             "scoringType": {
                 "all_or_nothing": "Alles-oder-Nichts",
@@ -180,6 +181,9 @@
                 "proportional_with_penalty": "Jede richtige Antwort führt zu einem Bruchteil der Gesamtpunktzahl. Um Rätselraten zu vermeiden, wird für jeden Fehler der gleiche Anteil von den erreichten Punkten abgezogen. Beispiel: Wenn die gesamt Punktzahl der Frage 3 ist und es 5 Optionen gibt, ergibt jede richtige Antwortmöglichkeit 0,6 Punkte. Jede falsche Antwortmöglichkeit zieht 0,6 Punkte ab. Ein Student mit 4 richtigen und 1 falschen Auswahlmöglichkeit erhält dann 1,8 Punkte."
             },
             "importJSON": "Fragen importieren (JSON)",
+            "importWarningShort": "Ungültige Fragen gefunden",
+            "importWarningLong": "Bei den folgenden Fragen ist ein ungültiges Flag gesetzt. Bist du sicher, dass du fortfahren möchtest? <strong>In diesem Fall werden die ungültigen Flags zurückgesetzt</ strong>.",
+            "confirmImport": "Weiter",
             "explanationText": {
                 "point": "Punkt",
                 "points": "Punkte",

--- a/src/main/webapp/i18n/en/quizExercise.json
+++ b/src/main/webapp/i18n/en/quizExercise.json
@@ -168,7 +168,8 @@
                 "shortAnswerQuestionDuplicateMapping": "Question {{index}}: At least one mapping ist duplicated.",
                 "questionTitleLength": "Question {{index}}: Please shorten your question title. Currently it contains more than 250 signs.",
                 "quizTitleLength": "Quiz: The title is too long. Currently it contains more than 250 signs.",
-                "explanationIsMissing": "Question {{index}}: Not every answer option contains an explanation. Please add an explanation!"
+                "explanationIsMissing": "Question {{index}}: Not every answer option contains an explanation. Please add an explanation!",
+                "questionHasInvalidFlaggedElements": "<strong>Question {{index}} </strong>: This question has been marked previously as invalid or contains invalid elements."
             },
             "scoringType": {
                 "all_or_nothing": "All or Nothing",
@@ -180,6 +181,9 @@
                 "proportional_with_penalty": "Each correct answer results in a fraction of the total score. To avoid guesswork, the same fraction is subtracted from the achieved points for each mistake. Example: if the score of the question is 3 and there are 5 options. Each correct answer option results in 0.6 points. Each wrong answer option subtracts 0.6 points. A student with 4 correct and 1 wrong choice would then receive 1.8 points."
             },
             "importJSON": "Import Question(s) in JSON Format",
+            "importWarningShort": "Invalid questions found",
+            "importWarningLong": "The following questions have an invalid flag set. Are you sure you want to continue? <strong>If so, the invalid flags will be reset</strong>.",
+            "confirmImport": "Continue",
             "explanationText": {
                 "point": "point",
                 "points": "points",


### PR DESCRIPTION
#1384 # Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
Resolves #1911 

### Description
- [x] Before adding existing questions or importing them as a .json file, check the questions and its elements for invalid flags
- [x] If an invalid flag is set, open a modal and notify the user
- [x] If the user accepts, all invalid flags are reset

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Create a quiz exercise, start it and set some elements as invalid (in re-evaluate)
4. Create a new quiz and add the existing questions from the previous exercise
5. The modal should appear and list the questions which have an invalid flag set
6. If you cancel, the questions are not added. If you continue, the invalid flags are reset and everything continues as normally
7. Export the exercise from 3. and repeat 4-6 by importing the quiz exercise.


### Screenshots
![image](https://user-images.githubusercontent.com/15110960/88328362-9aef9580-cd28-11ea-88d8-a4cefdf5fde1.png)

