### PR TITLE
[Bugfix] [Exam] Refreshing files in the code-editor if offline

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
@@ -118,7 +118,10 @@ export class CodeEditorAceComponent implements AfterViewInit, OnChanges, OnDestr
                 this.fileSession = { ...this.fileSession, [this.fileChange.fileName]: { code: '', cursor: { row: 0, column: 0 } } };
                 this.initEditorAfterFileChange();
             }
-        } else if ((changes.selectedFile && this.selectedFile) || (changes.editorState && changes.editorState.previousValue === EditorState.REFRESHING)) {
+        } else if (
+            (changes.selectedFile && this.selectedFile) ||
+            (changes.editorState && changes.editorState.previousValue === EditorState.REFRESHING && this.editorState === EditorState.CLEAN)
+        ) {
             // Current file has changed
             // Only load the file from server if there is nothing stored in the editorFileSessions
             if (this.selectedFile && !this.fileSession[this.selectedFile]) {

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
@@ -103,7 +103,7 @@ export class CodeEditorAceComponent implements AfterViewInit, OnChanges, OnDestr
     ngOnChanges(changes: SimpleChanges): void {
         if (
             (changes.commitState && changes.commitState.previousValue !== CommitState.UNDEFINED && this.commitState === CommitState.UNDEFINED) ||
-            (changes.editorState && changes.editorState.previousValue === EditorState.REFRESHING && this.editorState !== EditorState.REFRESHING)
+            (changes.editorState && changes.editorState.previousValue === EditorState.REFRESHING && this.editorState === EditorState.CLEAN)
         ) {
             this.fileSession = {};
             if (this.annotationChange) {

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -115,10 +115,16 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
                 this.onError.emit(error.message);
             }
         }, 8000);
-        this.repositoryService.pull().subscribe(() => {
-            this.unsavedFiles = {};
-            this.editorState = EditorState.CLEAN;
-        });
+        this.repositoryService.pull().subscribe(
+            () => {
+                this.unsavedFiles = {};
+                this.editorState = EditorState.CLEAN;
+            },
+            (error: Error) => {
+                this.onError.error(error.message);
+                this.editorState = EditorState.UNSAVED_CHANGES;
+            },
+        );
     }
 
     onSave() {

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -7,7 +7,7 @@ import { CodeEditorSubmissionService } from 'app/exercises/programming/shared/co
 import { CodeEditorConflictStateService } from 'app/exercises/programming/shared/code-editor/service/code-editor-conflict-state.service';
 import { CodeEditorResolveConflictModalComponent } from 'app/exercises/programming/shared/code-editor/actions/code-editor-resolve-conflict-modal.component';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
-import { CodeEditorRepositoryFileService, CodeEditorRepositoryService } from 'app/exercises/programming/shared/code-editor/service/code-editor-repository.service';
+import { CodeEditorRepositoryFileService, CodeEditorRepositoryService, ConnectionError } from 'app/exercises/programming/shared/code-editor/service/code-editor-repository.service';
 import { CommitState, EditorState, FileSubmission, GitConflictState } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
 import { CodeEditorConfirmRefreshModalComponent } from './code-editor-confirm-refresh-modal.component';
 
@@ -108,27 +108,24 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
 
     executeRefresh() {
         this.editorState = EditorState.REFRESHING;
-        setTimeout(() => {
-            if (this.editorState === EditorState.REFRESHING) {
-                this.editorState = EditorState.UNSAVED_CHANGES;
-                const error = new Error('connectionTimeoutRefresh');
-                this.onError.emit(error.message);
-            }
-        }, 8000);
         this.repositoryService.pull().subscribe(
             () => {
                 this.unsavedFiles = {};
                 this.editorState = EditorState.CLEAN;
             },
             (error: Error) => {
-                this.onError.error(error.message);
                 this.editorState = EditorState.UNSAVED_CHANGES;
+                if (error.message === ConnectionError.message) {
+                    this.onError.emit('refreshFailed' + error.message);
+                } else {
+                    this.onError.emit('refreshFailed');
+                }
             },
         );
     }
 
     onSave() {
-        this.saveChangedFilesWithTimeout()
+        this.saveChangedFiles()
             .pipe(catchError(() => of()))
             .subscribe();
     }
@@ -137,32 +134,25 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
      * @function saveFiles
      * @desc Saves all files that have unsaved changes in the editor.
      */
-    saveChangedFilesWithTimeout(): Observable<any> {
+    saveChangedFiles(): Observable<any> {
         if (!_isEmpty(this.unsavedFiles)) {
-            setTimeout(() => {
-                if (this.editorState === EditorState.SAVING) {
-                    this.editorState = EditorState.UNSAVED_CHANGES;
-                    const error = new Error('connectionTimeoutSave');
-                    this.onError.emit(error.message);
-                }
-            }, 8000);
             this.editorState = EditorState.SAVING;
             const unsavedFiles = Object.entries(this.unsavedFiles).map(([fileName, fileContent]) => ({ fileName, fileContent }));
-            this.saveFiles(unsavedFiles);
+            this.repositoryFileService.updateFiles(unsavedFiles).subscribe(
+                (fileSubmission: FileSubmission) => {
+                    this.onSavedFiles.emit(fileSubmission);
+                },
+                (error) => {
+                    this.editorState = EditorState.UNSAVED_CHANGES;
+                    if (error.message === ConnectionError.message) {
+                        this.onError.emit('saveFailed' + error.message);
+                    } else {
+                        this.onError.emit('saveFailed');
+                    }
+                },
+            );
         }
         return Observable.of(null);
-    }
-
-    private saveFiles(fileUpdates: Array<{ fileName: string; fileContent: string }>) {
-        this.repositoryFileService.updateFiles(fileUpdates).subscribe(
-            (fileSubmission: FileSubmission) => {
-                this.onSavedFiles.emit(fileSubmission);
-            },
-            (err) => {
-                this.onError.emit(err.error);
-                this.editorState = EditorState.UNSAVED_CHANGES;
-            },
-        );
     }
 
     /**
@@ -178,7 +168,7 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
         // If there are unsaved changes, save them before trying to commit again.
         Observable.of(null)
             .pipe(
-                switchMap(() => (this.editorState === EditorState.UNSAVED_CHANGES ? this.saveChangedFilesWithTimeout() : Observable.of(null))),
+                switchMap(() => (this.editorState === EditorState.UNSAVED_CHANGES ? this.saveChangedFiles() : Observable.of(null))),
                 tap(() => (this.commitState = CommitState.COMMITTING)),
                 switchMap(() => this.repositoryService.commit()),
                 tap(() => {
@@ -192,9 +182,13 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
             )
             .subscribe(
                 () => {},
-                () => {
+                (error) => {
                     this.commitState = CommitState.UNCOMMITTED_CHANGES;
-                    this.onError.emit('commitFailed');
+                    if (error.message === ConnectionError.message) {
+                        this.onError.emit('commitFailed' + error.message);
+                    } else {
+                        this.onError.emit('commitFailed');
+                    }
                 },
             );
     }

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/code-editor-mode-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/code-editor-mode-container.component.ts
@@ -35,7 +35,7 @@ export abstract class CodeEditorContainerComponent implements ComponentCanDeacti
     editorState: EditorState;
     commitState: CommitState;
 
-    constructor(
+    protected constructor(
         protected participationService: ParticipationService | null,
         private translateService: TranslateService,
         protected route: ActivatedRoute | null,

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
@@ -147,7 +147,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
     ngOnChanges(changes: SimpleChanges): void {
         if (
             (changes.commitState && changes.commitState.previousValue !== CommitState.UNDEFINED && this.commitState === CommitState.UNDEFINED) ||
-            (changes.editorState && changes.editorState.previousValue === EditorState.REFRESHING && this.editorState !== EditorState.REFRESHING)
+            (changes.editorState && changes.editorState.previousValue === EditorState.REFRESHING && this.editorState === EditorState.CLEAN)
         ) {
             this.initializeComponent();
         } else if (changes.selectedFile && changes.selectedFile.currentValue) {

--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -74,6 +74,7 @@
                 "exerciseNotFound": "Die Übung konnte nicht gefunden werden.",
                 "saveFailed": "Eine oder mehrere Dateien konnte nicht gespeichert werden.",
                 "commitFailed": "Eine oder mehrere Dateien konnte nicht commited werden.",
+                "refreshFailed": "Der Stand konnte nicht von der Repository bezogen werden",
                 "noPermissions": "Du verfügst nicht über die notwendigen Berechtigungen.",
                 "checkoutFailed": "Dein git repository konnte nicht ausgecheckt werden.",
                 "fileExists": "Datei/Verzeichnis Name existiert bereits. Bitte wähle einen anderen Namen.",
@@ -86,10 +87,10 @@
                 "failedToLoadBuildLogs": "Die Build Logs konnten nicht geladen werden.",
                 "repositoryInConflict": "Dein Repository befindet sich in einem Konfliktzustand.",
                 "notAllowedExam": "Du kannst (nicht mehr) abgeben",
-                "connectionTimeoutSave": "Speichern ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
-                "undefined": "Vorgang ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
-                "connectionTimeoutRefresh": "Aktualisieren ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
-                "resetFailed": "Dein Repository konnte nicht zurückgesetzt werden."
+                "saveFailedInternetDisconnected": "Speichern ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
+                "commitFailedInternetDisconnected": "Commit ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
+                "refreshFailedInternetDisconnected": "Aktualisieren ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
+                "resetFailed": "Deine Repository konnte nicht zurückgesetzt werden."
             },
             "testStatusLabels": {
                 "noResult": "Keine Ergebnisse",

--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -74,7 +74,7 @@
                 "exerciseNotFound": "Die Übung konnte nicht gefunden werden.",
                 "saveFailed": "Eine oder mehrere Dateien konnte nicht gespeichert werden.",
                 "commitFailed": "Eine oder mehrere Dateien konnte nicht commited werden.",
-                "refreshFailed": "Der Stand konnte nicht von der Repository bezogen werden",
+                "refreshFailed": "Die Aktualisierung ist fehlgeschlagen",
                 "noPermissions": "Du verfügst nicht über die notwendigen Berechtigungen.",
                 "checkoutFailed": "Dein git repository konnte nicht ausgecheckt werden.",
                 "fileExists": "Datei/Verzeichnis Name existiert bereits. Bitte wähle einen anderen Namen.",

--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -90,7 +90,7 @@
                 "saveFailedInternetDisconnected": "Speichern ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
                 "commitFailedInternetDisconnected": "Commit ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
                 "refreshFailedInternetDisconnected": "Aktualisieren ist fehlgeschlagen. Bitte stelle eine gute Internetverbindung sicher und versuche es nochmal.",
-                "resetFailed": "Deine Repository konnte nicht zurückgesetzt werden."
+                "resetFailed": "Dein Repository konnte nicht zurückgesetzt werden."
             },
             "testStatusLabels": {
                 "noResult": "Keine Ergebnisse",

--- a/src/main/webapp/i18n/en/editor.json
+++ b/src/main/webapp/i18n/en/editor.json
@@ -78,6 +78,7 @@
                 "exerciseNotFound": "The exercise could not be found.",
                 "saveFailed": "One or more files could not be updated.",
                 "commitFailed": "One or more files could not be commited.",
+                "refreshFailed": "Could not pull from repository",
                 "noPermissions": "You don't have the necessary permissions.",
                 "checkoutFailed": "The checkout of your git repository failed.",
                 "fileExists": "File/Directory name already exists. Please choose a different name.",
@@ -90,9 +91,9 @@
                 "failedToLoadBuildLogs": "The build logs could not be retrieved.",
                 "repositoryInConflict": "Your repository has entered a conflict state.",
                 "notAllowedExam": "You must not submit (anymore)",
-                "connectionTimeoutSave": "Saving failed. Please make sure you have a stable internet connection and try again.",
-                "undefined": "Action failed. Please make sure you have a stable internet connection and try again.",
-                "connectionTimeoutRefresh": "Refreshing failed. Please make sure you have a stable internet connection and try again.",
+                "saveFailedInternetDisconnected": "Saving failed. Please make sure you have a stable internet connection and try again.",
+                "commitFailedInternetDisconnected": "Commit failed. Please make sure you have a stable internet connection and try again.",
+                "refreshFailedInternetDisconnected": "Refresh failed. Please make sure you have a stable internet connection and try again.",
                 "resetFailed": "Your repository could not be reset."
             },
             "testStatusLabels": {

--- a/src/main/webapp/i18n/en/editor.json
+++ b/src/main/webapp/i18n/en/editor.json
@@ -78,7 +78,7 @@
                 "exerciseNotFound": "The exercise could not be found.",
                 "saveFailed": "One or more files could not be updated.",
                 "commitFailed": "One or more files could not be commited.",
-                "refreshFailed": "Could not pull from repository",
+                "refreshFailed": "Refresh has failed",
                 "noPermissions": "You don't have the necessary permissions.",
                 "checkoutFailed": "The checkout of your git repository failed.",
                 "fileExists": "File/Directory name already exists. Please choose a different name.",

--- a/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
@@ -198,7 +198,7 @@ describe('CodeEditorActionsComponent', () => {
 
         // receive error for save
         saveObservable.error(errorResponse);
-        expect(onErrorSpy).to.have.been.calledOnceWith(errorResponse.error);
+        expect(onErrorSpy).to.have.been.calledOnceWith('saveFailed');
         expect(comp.editorState).to.be.equal(EditorState.UNSAVED_CHANGES);
         fixture.detectChanges();
         expect(saveButton.nativeElement.disabled).to.be.false;
@@ -272,13 +272,13 @@ describe('CodeEditorActionsComponent', () => {
         const unsavedFiles = { fileName: 'lorem ipsum fileContent lorem ipsum' };
         const commitObservable = new Subject<null>();
         const saveObservable = new Subject<null>();
-        const saveChangedFilesStub = stub(comp, 'saveChangedFilesWithTimeout');
+        const saveChangedFilesStub = stub(comp, 'saveChangedFiles');
         comp.commitState = CommitState.UNCOMMITTED_CHANGES;
         comp.editorState = EditorState.UNSAVED_CHANGES;
         comp.isBuilding = false;
 
         comp.unsavedFiles = unsavedFiles;
-        comp.saveChangedFilesWithTimeout = saveChangedFilesStub;
+        comp.saveChangedFiles = saveChangedFilesStub;
         fixture.detectChanges();
 
         commitStub.returns(commitObservable);

--- a/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
@@ -401,7 +401,7 @@ describe('CodeEditorStudentIntegration', () => {
         containerFixture.detectChanges();
 
         // init saving
-        container.actions.saveChangedFilesWithTimeout().subscribe();
+        container.actions.saveChangedFiles().subscribe();
         expect(container.commitState).to.equal(CommitState.CLEAN);
         expect(container.editorState).to.equal(EditorState.SAVING);
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
In the testing session today, we found a bug which happened when the user was offline. 
If the user made changes and then pressed on refresh while being offline all the file representations stored in the local storage would be deleted. 

### Description
This behaviour was happening because, after switching away from a refreshing state, we would fetch the files again from the server. This, of course, was not possible when you are offline. 
**Fix:** Only reload the files from the server if the state switches from refreshing to clean. 

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Create an exam with a programming exercise with the code editor
4. Go offline and make some changes. 
5. Press on refresh
6. An error message should be displayed, but the local files should not be changed. 
7. The editor state should be unsaved changes. 
