### PR TITLE
[Bugfix] Refresh files visual bug

### DIFF
--- a/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/programming/code-editor/exam-code-editor-student-container.component.html
@@ -22,6 +22,7 @@
             [(editorState)]="editorState"
             [(commitState)]="commitState"
             (onSavedFiles)="onSavedFiles($event)"
+            (onRefreshFiles)="onRefreshFiles()"
             (onError)="onError($event)"
             (commitStateChange)="onCommitStateChange($event)"
         ></jhi-code-editor-actions>

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -43,6 +43,8 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
     @Output()
     onSavedFiles = new EventEmitter<{ [fileName: string]: string | null }>();
     @Output()
+    onRefreshFiles = new EventEmitter();
+    @Output()
     onError = new EventEmitter<string>();
 
     isBuilding: boolean;
@@ -110,7 +112,7 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy {
         this.editorState = EditorState.REFRESHING;
         this.repositoryService.pull().subscribe(
             () => {
-                this.unsavedFiles = {};
+                this.onRefreshFiles.emit();
                 this.editorState = EditorState.CLEAN;
             },
             (error: Error) => {

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/code-editor-mode-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/code-editor-mode-container.component.ts
@@ -136,6 +136,13 @@ export abstract class CodeEditorContainerComponent implements ComponentCanDeacti
     }
 
     /**
+     * On successful pull, we remove all unsaved Files.
+     */
+    onRefreshFiles() {
+        this.unsavedFiles = {};
+    }
+
+    /**
      * When the content of a file changes, set it as unsaved.
      */
     onFileContentChange({ file, fileContent }: { file: string; fileContent: string }) {

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/code-editor-mode-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/code-editor-mode-container.component.ts
@@ -136,7 +136,7 @@ export abstract class CodeEditorContainerComponent implements ComponentCanDeacti
     }
 
     /**
-     * On successful pull, we remove all unsaved Files.
+     * On successful pull during a refresh operation, we remove all unsaved files.
      */
     onRefreshFiles() {
         this.unsavedFiles = {};


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
If you made changes on two or more files and pressed refresh, after making another change the "yellow circle" indicating **unsaved changes** would appear for all originally changed files again. 

### Description
The issue was that the unsaved files reset was not propagated to the parent component which the file browser was using as an input. Because of this, the file browser still thought that there are unsaved changes.

**Fix:** Emit an _onRefreshFiles_ event on successful pull and reset the unsavedFiles in the parent component. All child components will then receive the correct status as an input

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Create an exam with a programming exercise + code editor
4. Make changes in two files
5. Hit refresh files before the autosave kicks in 
6. Now make changes in one of those files, or another file
**Result:** The yellow circle should only appear on the file you last made changes on.