### PR TITLE
[Exam] Add submitted flag to scores CSV

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -201,7 +201,7 @@ public class ExamService {
      * @return return ExamScoresDTO with students, scores and exerciseGroups for exam
      */
     public ExamScoresDTO getExamScore(Long examId) {
-        Exam exam = examRepository.findOneWithEagerExercisesGroupsAndStudentExams(examId);
+        Exam exam = examRepository.findWithExerciseGroupsAndExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
 
         List<StudentParticipation> studentParticipations = participationService.findByExamIdWithRelevantResult(examId);
 
@@ -226,7 +226,8 @@ public class ExamService {
         }
 
         // Adding registered student information to DTO
-        for (StudentExam studentExam : exam.getStudentExams()) {
+        List<StudentExam> studentExams = studentExamRepository.findByExamId(examId);
+        for (StudentExam studentExam : studentExams) {
             User user = studentExam.getUser();
             scores.studentResults
                     .add(new ExamScoresDTO.StudentResult(user.getId(), user.getName(), user.getEmail(), user.getLogin(), user.getRegistrationNumber(), studentExam.isSubmitted()));

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -201,8 +201,7 @@ public class ExamService {
      * @return return ExamScoresDTO with students, scores and exerciseGroups for exam
      */
     public ExamScoresDTO getExamScore(Long examId) {
-        Exam exam = examRepository.findWithRegisteredUsersAndExerciseGroupsAndExercisesById(examId)
-                .orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
+        Exam exam = examRepository.findOneWithEagerExercisesGroupsAndStudentExams(examId);
 
         List<StudentParticipation> studentParticipations = participationService.findByExamIdWithRelevantResult(examId);
 
@@ -227,8 +226,10 @@ public class ExamService {
         }
 
         // Adding registered student information to DTO
-        for (User user : exam.getRegisteredUsers()) {
-            scores.studentResults.add(new ExamScoresDTO.StudentResult(user.getId(), user.getName(), user.getEmail(), user.getLogin(), user.getRegistrationNumber()));
+        for (StudentExam studentExam : exam.getStudentExams()) {
+            User user = studentExam.getUser();
+            scores.studentResults
+                    .add(new ExamScoresDTO.StudentResult(user.getId(), user.getName(), user.getEmail(), user.getLogin(), user.getRegistrationNumber(), studentExam.isSubmitted()));
         }
 
         // Adding student results information to DTO

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamScoresDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamScoresDTO.java
@@ -76,18 +76,21 @@ public class ExamScoresDTO {
 
         public Double overallScoreAchieved = null;
 
+        public Boolean submitted = false;
+
         public Map<Long, ExerciseResult> exerciseGroupIdToExerciseResult = new HashMap<>();
 
         public StudentResult() {
             // default constructor for our beloved Jackson :-*
         }
 
-        public StudentResult(Long id, String name, String eMail, String login, String registrationNumber) {
+        public StudentResult(Long id, String name, String eMail, String login, String registrationNumber, Boolean submitted) {
             this.id = id;
             this.eMail = eMail;
             this.name = name;
             this.login = login;
             this.registrationNumber = registrationNumber;
+            this.submitted = submitted;
         }
     }
 

--- a/src/main/webapp/app/exam/exam-scores/exam-score-dtos.model.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-score-dtos.model.ts
@@ -22,6 +22,7 @@ export class StudentResult {
         public registrationNumber: string,
         public overallPointsAchieved: number,
         public overallScoreAchieved: number,
+        public submitted: boolean,
         public exerciseGroupIdToExerciseResult: MapToExerciseResult,
     ) {}
 }

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
@@ -54,6 +54,7 @@ export class ExamScoresComponent implements OnInit {
         });
         headers.push('Overall Points');
         headers.push('Overall Score (%)');
+        headers.push('Submitted');
 
         const data = this.studentResults.map((studentResult) => {
             return this.convertToCSVRow(studentResult);
@@ -112,6 +113,7 @@ export class ExamScoresComponent implements OnInit {
             typeof studentResult.overallPointsAchieved === 'undefined' || studentResult.overallPointsAchieved === null ? '' : round(studentResult.overallPointsAchieved, 1);
         csvRow.overAllScore =
             typeof studentResult.overallScoreAchieved === 'undefined' || studentResult.overallScoreAchieved === null ? '' : round(studentResult.overallScoreAchieved, 2);
+        csvRow.submitted = studentResult.submitted ? 'yes' : 'no';
         return csvRow;
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I implemented the changes with a good performance and prevented too many database calls

### Description
- [x] Server: I've added the `submitted` flag from  the `studentExam` to the `ExamScoresDTO`
- [x] Client: I've ensured that the `submitted` flag will be part of the export CSV file

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to Exams -> Scores of an exam that has assessed results
4. Click "Export to CSV"
5. Ensure that the `submitted` flag is part of the exported CSV and that everything else is still exported correctly

### Example CSV export
```
Name,Login,E-Mail,Matriculation Number,Text exercise 1 Assigned Exercise,Text exercise 1 Achieved Points,Text exercise 1 Achieved Score (%),Text exercise 2 Assigned Exercise,Text exercise 2 Achieved Points,Text exercise 2 Achieved Score (%),Text exercise 3 Assigned Exercise,Text exercise 3 Achieved Points,Text exercise 3 Achieved Score (%),Text exercise 4 Assigned Exercise,Text exercise 4 Achieved Points,Text exercise 4 Achieved Score (%),Text exercise 5 Assigned Exercise,Text exercise 5 Achieved Points,Text exercise 5 Achieved Score (%),Text exercise 6 Assigned Exercise,Text exercise 6 Achieved Points,Text exercise 6 Achieved Score (%),Text exercise 7 Assigned Exercise,Text exercise 7 Achieved Points,Text exercise 7 Achieved Score (%),Overall Points,Overall Score (%),Submitted
"Sascha Beele","ga83wuv","sascha.beele@tum.de","","Text exercise 1",4.4,88,"Text exercise 2",1.5,21,"Text exercise 3",1,33,"Text exercise 4",3,50,"Text exercise 5",1.4,28,"Text exercise 6",0.3,15,"Text exercise 7",4.3,61,15.9,45.43,"yes"
```