### PR TITLE
Allow students to see the quiz exercise results for exam review

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -752,4 +752,25 @@ public class ExamService {
         var workingTimes = studentExamRepository.findAllDistinctWorkingTimesByExamId(exam.getId());
         return workingTimes.stream().map(timeInSeconds -> exam.getStartDate().plusSeconds(timeInSeconds)).collect(Collectors.toSet());
     }
+
+    /**
+     * Returns <code>true</code> if the current user is registered for the exam
+     *
+     * @param examId the id of the exam
+     * @return <code>true</code> if the user if registered for the exam, false if this is not the case or the exam does not exist
+     */
+    public boolean isCurrentUserRegisteredForExam(Long examId) {
+        return isUserRegisteredForExam(examId, userService.getUser().getId());
+    }
+
+    /**
+     * Returns <code>true</code> if the user with the given id is registered for the exam
+     *
+     * @param examId the id of the exam
+     * @param userId the id of the user to check
+     * @return <code>true</code> if the user if registered for the exam, false if this is not the case or the exam does not exist
+     */
+    public boolean isUserRegisteredForExam(Long examId, Long userId) {
+        return examRepository.isUserRegisteredForExam(examId, userId);
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -19,9 +19,7 @@ import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
-import de.tum.in.www1.artemis.domain.quiz.QuizQuestion;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.scheduled.quiz.QuizScheduleService;
@@ -223,30 +221,16 @@ public class QuizExerciseResource {
 
         if (quizExercise.hasExerciseGroup()) {
             // Get the course over the exercise group
-            Exam exam = quizExercise.getExerciseGroup().getExam();
-            Course course = exam.getCourse();
+            Course course = quizExercise.getExerciseGroup().getExam().getCourse();
 
             if (!authCheckService.isAtLeastInstructorInCourse(course, null)) {
-                // only allow registered students to see the quiz results after the results are published
-                if (exam.resultsPublished() && examService.isCurrentUserRegisteredForExam(exam.getId())) {
-                    filterForExamReview(quizExercise);
-                }
-                else {
-                    return forbidden();
-                }
+                return forbidden();
             }
         }
         else if (!authCheckService.isAllowedToSeeExercise(quizExercise, null)) {
             return forbidden();
         }
         return ResponseUtil.wrapOrNotFound(Optional.ofNullable(quizExercise));
-    }
-
-    private static void filterForExamReview(QuizExercise quizExercise) {
-        quizExercise.setQuizPointStatistic(null);
-        for (QuizQuestion question : quizExercise.getQuizQuestions()) {
-            question.setQuizQuestionStatistic(null);
-        }
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -19,7 +19,9 @@ import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
+import de.tum.in.www1.artemis.domain.quiz.QuizQuestion;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.scheduled.quiz.QuizScheduleService;
@@ -221,16 +223,30 @@ public class QuizExerciseResource {
 
         if (quizExercise.hasExerciseGroup()) {
             // Get the course over the exercise group
-            Course course = quizExercise.getExerciseGroup().getExam().getCourse();
+            Exam exam = quizExercise.getExerciseGroup().getExam();
+            Course course = exam.getCourse();
 
             if (!authCheckService.isAtLeastInstructorInCourse(course, null)) {
-                return forbidden();
+                // only allow registered students to see the quiz results after the results are published
+                if (exam.resultsPublished() && examService.isCurrentUserRegisteredForExam(exam.getId())) {
+                    filterForExamReview(quizExercise);
+                }
+                else {
+                    return forbidden();
+                }
             }
         }
         else if (!authCheckService.isAllowedToSeeExercise(quizExercise, null)) {
             return forbidden();
         }
         return ResponseUtil.wrapOrNotFound(Optional.ofNullable(quizExercise));
+    }
+
+    private static void filterForExamReview(QuizExercise quizExercise) {
+        quizExercise.setQuizPointStatistic(null);
+        for (QuizQuestion question : quizExercise.getQuizQuestions()) {
+            question.setQuizQuestionStatistic(null);
+        }
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -301,7 +301,10 @@ public class StudentExamResource {
             if (exercise instanceof QuizExercise) {
                 // reload and replace the quiz exercise
                 var quizExercise = quizExerciseService.findOneWithQuestions(exercise.getId());
-                quizExercise.filterForStudentsDuringQuiz();
+                // filter quiz solutions when the publish result date is not set (or when set before the publish result date)
+                if (studentExam.getExam().getPublishResultsDate() == null || ZonedDateTime.now().isBefore(studentExam.getExam().getPublishResultsDate())) {
+                    quizExercise.filterForStudentsDuringQuiz();
+                }
                 studentExam.getExercises().set(i, quizExercise);
             }
         }

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
@@ -1,8 +1,8 @@
-<div class="quiz-content container" *ngIf="quizQuestions && quizQuestions.length > 0">
+<div class="quiz-content container" *ngIf="exercise.quizQuestions && exercise.quizQuestions.length > 0">
     <div class="alert alert-info mb-2" *ngIf="showMissingResultsNotice">
         {{ 'artemisApp.exam.examSummary.missingResultNotice' | translate }}
     </div>
-    <div *ngFor="let question of quizQuestions; let i = index">
+    <div *ngFor="let question of exercise.quizQuestions; let i = index">
         <jhi-multiple-choice-question
             id="question{{ i }}"
             *ngIf="question.type === MULTIPLE_CHOICE"

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
@@ -26,7 +26,6 @@ export class QuizExamSummaryComponent implements OnInit {
     selectedAnswerOptions = new Map<number, AnswerOption[]>();
     dragAndDropMappings = new Map<number, DragAndDropMapping[]>();
     shortAnswerSubmittedTexts = new Map<number, ShortAnswerSubmittedText[]>();
-    exerciseWithSolution: QuizExercise;
 
     @Input()
     exercise: QuizExercise;
@@ -44,16 +43,6 @@ export class QuizExamSummaryComponent implements OnInit {
 
     ngOnInit(): void {
         this.updateViewFromSubmission();
-        // get quiz-exercise with solution after result is published
-        if (this.resultsPublished && this.exercise) {
-            this.exerciseService.find(this.exercise.id).subscribe((response) => {
-                this.exerciseWithSolution = response.body!;
-            });
-        }
-    }
-
-    get quizQuestions() {
-        return this.resultsPublished && this.exerciseWithSolution ? this.exerciseWithSolution.quizQuestions : this.exercise.quizQuestions;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
Fix #1980.

### Description
- Don't return forbidden if the user is registered for the exam and the results are published.
- Remove the statistics from the sent quiz exercise.

### Steps for Testing
Make sure that the steps for reproducing #1980 don't work and the students see right and wrong answers in the exam review phase for quiz exercises. Again, make sure to test this as a student.

What you can test in addition to that is that the requests when loading the summary page (the call is `api/quiz-exercises/<id>`) don't send other sensitive information like the statistics.

### Screenshots
![image](https://user-images.githubusercontent.com/11130248/88713699-00be9180-d11c-11ea-8fe3-121765fad20b.png)
