### PR TITLE
[exam mode] make format of numbers in exam scores dependent on locale setting

### DIFF
--- a/src/main/webapp/app/course/course-scores/course-scores.component.html
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.html
@@ -53,32 +53,66 @@
                 <tr>
                     <th><span jhiTranslate="instructorDashboard.average">Average</span></th>
                     <th></th>
-                    <th>{{ toLocaleString(averageNumberOfParticipatedExercises) }} ({{ toLocaleString((averageNumberOfParticipatedExercises / exercises.length) * 100) }}%)</th>
-                    <th>{{ toLocaleString(averageNumberOfSuccessfulExercises) }} ({{ toLocaleString((averageNumberOfSuccessfulExercises / exercises.length) * 100) }}%)</th>
+                    <th>
+                        {{ getLocaleConversionService().toLocaleString(averageNumberOfParticipatedExercises) }} ({{
+                            getLocaleConversionService().toLocaleString((averageNumberOfParticipatedExercises / exercises.length) * 100)
+                        }}
+                        %)
+                    </th>
+                    <th>
+                        {{ getLocaleConversionService().toLocaleString(averageNumberOfSuccessfulExercises) }} ({{
+                            getLocaleConversionService().toLocaleString((averageNumberOfSuccessfulExercises / exercises.length) * 100)
+                        }}
+                        %)
+                    </th>
                     <ng-container *ngFor="let exerciseType of exerciseTypes">
                         <th *ngIf="maxNumberOfPointsPerExerciseType.get(exerciseType)! > 0">
-                            {{ toLocaleString(averageNumberOfPointsPerExerciseTypes.get(exerciseType)!) }} ({{
-                                toLocaleString((averageNumberOfPointsPerExerciseTypes.get(exerciseType)! / maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100)
+                            {{ getLocaleConversionService().toLocaleString(averageNumberOfPointsPerExerciseTypes.get(exerciseType)!) }}
+                            ({{
+                                getLocaleConversionService().toLocaleString(
+                                    (averageNumberOfPointsPerExerciseTypes.get(exerciseType)! / maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100
+                                )
                             }}%)
                         </th>
                     </ng-container>
-                    <th>{{ toLocaleString(averageNumberOfOverallPoints) }} ({{ toLocaleString((averageNumberOfOverallPoints / maxNumberOfOverallPoints) * 100) }}%)</th>
+                    <th>
+                        {{ getLocaleConversionService().toLocaleString(averageNumberOfOverallPoints) }} ({{
+                            getLocaleConversionService().toLocaleString((averageNumberOfOverallPoints / maxNumberOfOverallPoints) * 100)
+                        }}
+                        %)
+                    </th>
                 </tr>
             </thead>
             <tbody>
                 <tr *ngFor="let student of students">
                     <td>{{ student.user.name }}</td>
                     <td>{{ student.user.login }}</td>
-                    <td>{{ student.numberOfParticipatedExercises }} ({{ toLocaleString((student.numberOfParticipatedExercises / exercises.length) * 100) }}%)</td>
-                    <td>{{ student.numberOfSuccessfulExercises }} ({{ toLocaleString((student.numberOfSuccessfulExercises / exercises.length) * 100) }}%)</td>
+                    <td>
+                        {{ student.numberOfParticipatedExercises }} ({{
+                            getLocaleConversionService().toLocaleString((student.numberOfParticipatedExercises / exercises.length) * 100)
+                        }}
+                        %)
+                    </td>
+                    <td>
+                        {{ student.numberOfSuccessfulExercises }} ({{ getLocaleConversionService().toLocaleString((student.numberOfSuccessfulExercises / exercises.length) * 100) }}
+                        %)
+                    </td>
                     <ng-container *ngFor="let exerciseType of exerciseTypes">
                         <td *ngIf="maxNumberOfPointsPerExerciseType.get(exerciseType)! > 0">
-                            {{ toLocaleString(student.sumPointsPerExerciseType.get(exerciseType)!) }} ({{
-                                toLocaleString((student.sumPointsPerExerciseType.get(exerciseType)! / maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100)
+                            {{ getLocaleConversionService().toLocaleString(student.sumPointsPerExerciseType.get(exerciseType)!) }}
+                            ({{
+                                getLocaleConversionService().toLocaleString(
+                                    (student.sumPointsPerExerciseType.get(exerciseType)! / maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100
+                                )
                             }}%)
                         </td>
                     </ng-container>
-                    <td>{{ toLocaleString(student.overallPoints) }} ({{ toLocaleString((student.overallPoints / maxNumberOfOverallPoints) * 100) }}%)</td>
+                    <td>
+                        {{ getLocaleConversionService().toLocaleString(student.overallPoints) }} ({{
+                            getLocaleConversionService().toLocaleString((student.overallPoints / maxNumberOfOverallPoints) * 100)
+                        }}
+                        %)
+                    </td>
                 </tr>
             </tbody>
         </table>

--- a/src/main/webapp/app/course/course-scores/course-scores.component.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.ts
@@ -1,4 +1,3 @@
-import { JhiLanguageService } from 'ng-jhipster';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 import { ActivatedRoute } from '@angular/router';
@@ -6,11 +5,11 @@ import { User } from 'app/core/user/user.model';
 import * as moment from 'moment';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { ExportToCsv } from 'export-to-csv';
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { Course } from 'app/entities/course.model';
 import { CourseManagementService } from '../manage/course-management.service';
 import { SortService } from 'app/shared/service/sort.service';
+import { LocaleConversionService } from 'app/shared/service/locale-conversion.service';
 
 const PRESENTATION_SCORE_KEY = 'Presentation Score';
 const NAME_KEY = 'Name';
@@ -59,22 +58,14 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
     averageNumberOfPointsPerExerciseTypes = new Map<ExerciseType, number>();
     averageNumberOfOverallPoints = 0;
 
-    options: Intl.NumberFormatOptions = { maximumFractionDigits: 1 }; // TODO: allow user to customize
-    locale = getLang(); // default value, will be overridden by the current language of Artemis
-
     constructor(
         private route: ActivatedRoute,
         private courseService: CourseManagementService,
-        private languageHelper: JhiLanguageHelper,
-        private languageService: JhiLanguageService,
         private sortService: SortService,
+        private localeConversionService: LocaleConversionService,
     ) {
         this.reverse = false;
         this.predicate = 'id';
-        this.locale = this.languageService.currentLang;
-        this.languageHelper.language.subscribe((languageKey: string) => {
-            this.locale = languageKey;
-        });
     }
 
     /**
@@ -287,18 +278,18 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
                         const exerciseTitleKeys = this.exerciseTitlesPerType.get(exerciseType)!;
                         const exercisePointValues = student.pointsPerExerciseType.get(exerciseType)!;
                         exerciseTitleKeys.forEach((title, index) => {
-                            rowData[title] = this.toLocaleString(exercisePointValues[index]);
+                            rowData[title] = this.localeConversionService.toLocaleString(exercisePointValues[index]);
                         });
-                        rowData[exerciseTypeName + ' ' + POINTS_KEY] = this.toLocaleString(exercisePointsPerType);
-                        rowData[exerciseTypeName + ' ' + SCORE_KEY] = this.toLocalePercentageString(exerciseScoresPerType);
+                        rowData[exerciseTypeName + ' ' + POINTS_KEY] = this.localeConversionService.toLocaleString(exercisePointsPerType);
+                        rowData[exerciseTypeName + ' ' + SCORE_KEY] = this.localeConversionService.toLocalePercentageString(exerciseScoresPerType);
                     }
                 }
 
                 const overallScore = (student.overallPoints / this.maxNumberOfOverallPoints) * 100;
-                rowData[TOTAL_COURSE_POINTS_KEY] = this.toLocaleString(student.overallPoints);
-                rowData[TOTAL_COURSE_SCORE_KEY] = this.toLocalePercentageString(overallScore);
+                rowData[TOTAL_COURSE_POINTS_KEY] = this.localeConversionService.toLocaleString(student.overallPoints);
+                rowData[TOTAL_COURSE_SCORE_KEY] = this.localeConversionService.toLocalePercentageString(overallScore);
                 if (this.course.presentationScore) {
-                    rowData[PRESENTATION_SCORE_KEY] = this.toLocaleString(student.presentationScore);
+                    rowData[PRESENTATION_SCORE_KEY] = this.localeConversionService.toLocaleString(student.presentationScore);
                 }
                 rows.push(rowData);
             }
@@ -314,14 +305,14 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
                     const exerciseTitleKeys = this.exerciseTitlesPerType.get(exerciseType)!;
                     const exerciseMaxPoints = this.exerciseMaxPointsPerType.get(exerciseType)!;
                     exerciseTitleKeys.forEach((title, index) => {
-                        rowDataMax[title] = this.toLocaleString(exerciseMaxPoints[index]);
+                        rowDataMax[title] = this.localeConversionService.toLocaleString(exerciseMaxPoints[index]);
                     });
-                    rowDataMax[exerciseTypeName + ' ' + POINTS_KEY] = this.toLocaleString(this.maxNumberOfPointsPerExerciseType.get(exerciseType)!);
-                    rowDataMax[exerciseTypeName + ' ' + SCORE_KEY] = this.toLocalePercentageString(100);
+                    rowDataMax[exerciseTypeName + ' ' + POINTS_KEY] = this.localeConversionService.toLocaleString(this.maxNumberOfPointsPerExerciseType.get(exerciseType)!);
+                    rowDataMax[exerciseTypeName + ' ' + SCORE_KEY] = this.localeConversionService.toLocalePercentageString(100);
                 }
             }
-            rowDataMax[TOTAL_COURSE_POINTS_KEY] = this.toLocaleString(this.maxNumberOfOverallPoints);
-            rowDataMax[TOTAL_COURSE_SCORE_KEY] = this.toLocalePercentageString(100);
+            rowDataMax[TOTAL_COURSE_POINTS_KEY] = this.localeConversionService.toLocaleString(this.maxNumberOfOverallPoints);
+            rowDataMax[TOTAL_COURSE_SCORE_KEY] = this.localeConversionService.toLocalePercentageString(100);
             if (this.course.presentationScore) {
                 rowDataMax[PRESENTATION_SCORE_KEY] = '';
             }
@@ -336,19 +327,21 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
                     const exerciseTitleKeys = this.exerciseTitlesPerType.get(exerciseType)!;
                     const exerciseAveragePoints = this.exerciseAveragePointsPerType.get(exerciseType)!;
                     exerciseTitleKeys.forEach((title, index) => {
-                        rowDataAverage[title] = this.toLocaleString(exerciseAveragePoints[index]);
+                        rowDataAverage[title] = this.localeConversionService.toLocaleString(exerciseAveragePoints[index]);
                     });
 
                     const averageScore = (this.averageNumberOfPointsPerExerciseTypes.get(exerciseType)! / this.maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100;
 
-                    rowDataAverage[exerciseTypeName + ' ' + POINTS_KEY] = this.toLocaleString(this.averageNumberOfPointsPerExerciseTypes.get(exerciseType)!);
-                    rowDataAverage[exerciseTypeName + ' ' + SCORE_KEY] = this.toLocalePercentageString(averageScore);
+                    rowDataAverage[exerciseTypeName + ' ' + POINTS_KEY] = this.localeConversionService.toLocaleString(
+                        this.averageNumberOfPointsPerExerciseTypes.get(exerciseType)!,
+                    );
+                    rowDataAverage[exerciseTypeName + ' ' + SCORE_KEY] = this.localeConversionService.toLocalePercentageString(averageScore);
                 }
             }
 
             const averageOverallScore = (this.averageNumberOfOverallPoints / this.maxNumberOfOverallPoints) * 100;
-            rowDataAverage[TOTAL_COURSE_POINTS_KEY] = this.toLocaleString(this.averageNumberOfOverallPoints);
-            rowDataAverage[TOTAL_COURSE_SCORE_KEY] = this.toLocalePercentageString(averageOverallScore);
+            rowDataAverage[TOTAL_COURSE_POINTS_KEY] = this.localeConversionService.toLocaleString(this.averageNumberOfOverallPoints);
+            rowDataAverage[TOTAL_COURSE_SCORE_KEY] = this.localeConversionService.toLocalePercentageString(averageOverallScore);
             if (this.course.presentationScore) {
                 rowDataAverage[PRESENTATION_SCORE_KEY] = '';
             }
@@ -363,7 +356,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
                     const exerciseTitleKeys = this.exerciseTitlesPerType.get(exerciseType)!;
                     const exerciseParticipations = this.exerciseParticipationsPerType.get(exerciseType)!;
                     exerciseTitleKeys.forEach((title, index) => {
-                        rowDataParticipation[title] = this.toLocaleString(exerciseParticipations[index]);
+                        rowDataParticipation[title] = this.localeConversionService.toLocaleString(exerciseParticipations[index]);
                     });
                     rowDataParticipation[exerciseTypeName + ' ' + POINTS_KEY] = '';
                     rowDataParticipation[exerciseTypeName + ' ' + SCORE_KEY] = '';
@@ -380,7 +373,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
                     const exerciseTitleKeys = this.exerciseTitlesPerType.get(exerciseType)!;
                     const exerciseParticipationsSuccessful = this.exerciseSuccessfulPerType.get(exerciseType)!;
                     exerciseTitleKeys.forEach((title, index) => {
-                        rowDataParticipationSuccuessful[title] = this.toLocaleString(exerciseParticipationsSuccessful[index]);
+                        rowDataParticipationSuccuessful[title] = this.localeConversionService.toLocaleString(exerciseParticipationsSuccessful[index]);
                     });
                     rowDataParticipationSuccuessful[exerciseTypeName + ' ' + POINTS_KEY] = '';
                     rowDataParticipationSuccuessful[exerciseTypeName + ' ' + SCORE_KEY] = '';
@@ -442,35 +435,15 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
         this.sortService.sortByProperty(this.students, this.predicate, this.reverse);
     }
 
+    getLocaleConversionService() {
+        return this.localeConversionService;
+    }
+
     /**
      * On destroy unsubscribe.
      */
     ngOnDestroy() {
         this.paramSub.unsubscribe();
-    }
-
-    /**
-     * Convert a number value to a locale string.
-     * @param value
-     */
-    toLocaleString(value: number) {
-        if (isNaN(value)) {
-            return '-';
-        } else {
-            return value.toLocaleString(this.locale, this.options);
-        }
-    }
-
-    /**
-     * Convert a number value to a locale string with a % added at the end.
-     * @param value
-     */
-    toLocalePercentageString(value: number) {
-        if (isNaN(value)) {
-            return '-';
-        } else {
-            return value.toLocaleString(this.locale, this.options) + '%';
-        }
     }
 }
 
@@ -503,15 +476,4 @@ class Student {
  */
 function capitalizeFirstLetter(string: String) {
     return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
-/**
- * Get the language set by the user.
- */
-function getLang() {
-    if (navigator.languages !== undefined) {
-        return navigator.languages[0];
-    } else {
-        return navigator.language;
-    }
 }

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
@@ -11,7 +11,7 @@
             {{ examScoreDTO.title }}
         </h3>
         <h4 *ngIf="examScoreDTO.maxPoints" jhiTranslate="artemisApp.examScores.pointsAchievable" [translateValues]="{ maxPoints: examScoreDTO.maxPoints }">
-            {{ examScoreDTO.maxPoints }} Points achievable
+            {{ getLocaleConversionService().toLocaleString(examScoreDTO.maxPoints) }} Points achievable
         </h4>
         <h4 *ngIf="exerciseGroups && studentResults">
             <small jhiTranslate="artemisApp.examScores.examResultSummary" [translateValues]="{ exercisesLength: exerciseGroups.length, studentsLength: studentResults.length }">
@@ -52,8 +52,10 @@
                                 </li>
                             </ul>
                         </td>
-                        <td>{{ exerciseGroup.averagePointsAchieved == null ? '-' : round(exerciseGroup.averagePointsAchieved, 2) }}</td>
-                        <td>{{ exerciseGroup.maxPoints == null ? '-' : exerciseGroup.maxPoints }}</td>
+                        <td>
+                            {{ exerciseGroup.averagePointsAchieved == null ? '-' : getLocaleConversionService().toLocaleString(round(exerciseGroup.averagePointsAchieved, 2), 2) }}
+                        </td>
+                        <td>{{ exerciseGroup.maxPoints == null ? '-' : getLocaleConversionService().toLocaleString(exerciseGroup.maxPoints) }}</td>
                     </tr>
                 </tbody>
             </table>
@@ -107,9 +109,10 @@
                             <td *ngIf="studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id]; else empty">
                                 {{ studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id].title }}
                                 :
-                                {{ round(studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id].achievedPoints, 1) }}
+                                {{ getLocaleConversionService().toLocaleString(round(studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id].achievedPoints, 1)) }}
 
-                                ({{ round(studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id].achievedScore, 2) }}
+                                (
+                                {{ getLocaleConversionService().toLocaleString(round(studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id].achievedScore, 2), 2) }}
                                 %)
                             </td>
                             <ng-template #empty>
@@ -118,8 +121,8 @@
                                 </td>
                             </ng-template>
                         </ng-container>
-                        <td>{{ round(studentResult.overallPointsAchieved, 1) }}</td>
-                        <td>{{ round(studentResult.overallScoreAchieved, 2) }}</td>
+                        <td>{{ getLocaleConversionService().toLocaleString(round(studentResult.overallPointsAchieved, 1)) }}</td>
+                        <td>{{ getLocaleConversionService().toLocaleString(round(studentResult.overallScoreAchieved, 2), 2) }}</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
@@ -8,6 +8,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { onError } from 'app/shared/util/global.utils';
 import { AlertService } from 'app/core/alert/alert.service';
 import { round } from 'app/shared/util/utils';
+import { LocaleConversionService } from 'app/shared/service/locale-conversion.service';
 
 @Component({
     selector: 'jhi-exam-scores',
@@ -23,7 +24,13 @@ export class ExamScoresComponent implements OnInit {
     public reverse = false;
     public isLoading = true;
 
-    constructor(private route: ActivatedRoute, private examService: ExamManagementService, private sortService: SortService, private jhiAlertService: AlertService) {}
+    constructor(
+        private route: ActivatedRoute,
+        private examService: ExamManagementService,
+        private sortService: SortService,
+        private jhiAlertService: AlertService,
+        private localeConversionService: LocaleConversionService,
+    ) {}
 
     ngOnInit() {
         this.route.params.subscribe((params) => {
@@ -61,9 +68,9 @@ export class ExamScoresComponent implements OnInit {
         });
 
         const options = {
-            fieldSeparator: ',',
+            fieldSeparator: ';',
             quoteStrings: '"',
-            decimalSeparator: '.',
+            decimalSeparator: 'locale',
             showLabels: true,
             title: this.examScoreDTO.title,
             filename: this.examScoreDTO.title + 'Results',
@@ -99,9 +106,13 @@ export class ExamScoresComponent implements OnInit {
             if (exerciseResult) {
                 csvRow[exerciseGroup.title + 'AssignedExercise'] = exerciseResult.title ? exerciseResult.title : '';
                 csvRow[exerciseGroup.title + 'AchievedPoints'] =
-                    typeof exerciseResult.achievedPoints === 'undefined' || exerciseResult.achievedPoints === null ? '' : round(exerciseResult.achievedPoints, 1);
+                    typeof exerciseResult.achievedPoints === 'undefined' || exerciseResult.achievedPoints === null
+                        ? ''
+                        : this.localeConversionService.toLocaleString(round(exerciseResult.achievedPoints, 1));
                 csvRow[exerciseGroup.title + 'AchievedScore(%)'] =
-                    typeof exerciseResult.achievedScore === 'undefined' || exerciseResult.achievedScore === null ? '' : round(exerciseResult.achievedScore, 2);
+                    typeof exerciseResult.achievedScore === 'undefined' || exerciseResult.achievedScore === null
+                        ? ''
+                        : this.localeConversionService.toLocaleString(round(exerciseResult.achievedScore, 2), 2);
             } else {
                 csvRow[exerciseGroup.title + 'AssignedExercise'] = '';
                 csvRow[exerciseGroup.title + 'AchievedPoints'] = '';
@@ -110,10 +121,18 @@ export class ExamScoresComponent implements OnInit {
         });
 
         csvRow.overAllPoints =
-            typeof studentResult.overallPointsAchieved === 'undefined' || studentResult.overallPointsAchieved === null ? '' : round(studentResult.overallPointsAchieved, 1);
+            typeof studentResult.overallPointsAchieved === 'undefined' || studentResult.overallPointsAchieved === null
+                ? ''
+                : this.localeConversionService.toLocaleString(round(studentResult.overallPointsAchieved, 1));
         csvRow.overAllScore =
-            typeof studentResult.overallScoreAchieved === 'undefined' || studentResult.overallScoreAchieved === null ? '' : round(studentResult.overallScoreAchieved, 2);
+            typeof studentResult.overallScoreAchieved === 'undefined' || studentResult.overallScoreAchieved === null
+                ? ''
+                : this.localeConversionService.toLocaleString(round(studentResult.overallScoreAchieved, 2), 2);
         csvRow.submitted = studentResult.submitted ? 'yes' : 'no';
         return csvRow;
+    }
+
+    getLocaleConversionService() {
+        return this.localeConversionService;
     }
 }

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -19,6 +19,7 @@ import { Router, NavigationEnd, ActivatedRoute, RouterEvent } from '@angular/rou
 import { ExamParticipationService } from 'app/exam/participate/exam-participation.service';
 import { Exam } from 'app/entities/exam.model';
 import { ArtemisServerDateService } from 'app/shared/server-date.service';
+import { LocaleConversionService } from 'app/shared/service/locale-conversion.service';
 
 @Component({
     selector: 'jhi-navbar',
@@ -45,6 +46,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
         private loginService: LoginService,
         private languageService: JhiLanguageService,
         private languageHelper: JhiLanguageHelper,
+        private localeConversionService: LocaleConversionService,
         private sessionStorage: SessionStorageService,
         private accountService: AccountService,
         private profileService: ProfileService,
@@ -106,6 +108,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
         this.sessionStorage.store('locale', languageKey);
         this.languageService.changeLanguage(languageKey);
         moment.locale(languageKey);
+        this.localeConversionService.locale = languageKey;
     }
 
     collapseNavbar() {

--- a/src/main/webapp/app/shared/service/locale-conversion.service.ts
+++ b/src/main/webapp/app/shared/service/locale-conversion.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@angular/core';
+import { JhiLanguageService } from 'ng-jhipster';
+
+@Injectable({
+    providedIn: 'root',
+})
+export class LocaleConversionService {
+    locale = this.getLang(); // default value, will be overridden by the current language of Artemis
+
+    constructor(private languageService: JhiLanguageService) {
+        this.locale = this.languageService.getCurrentLanguage();
+    }
+
+    /**
+     * Convert a number value to a locale string.
+     * @param value
+     * @param maximumFractionDigits
+     */
+    toLocaleString(value: number, maximumFractionDigits = 1) {
+        const options: Intl.NumberFormatOptions = {
+            maximumFractionDigits,
+        };
+
+        if (isNaN(value)) {
+            return '-';
+        } else {
+            return value.toLocaleString(this.locale, options);
+        }
+    }
+
+    /**
+     * Convert a number value to a locale string with a % added at the end.
+     * @param value
+     * @param maximumFractionDigits
+     */
+    toLocalePercentageString(value: number, maximumFractionDigits = 1) {
+        const options: Intl.NumberFormatOptions = {
+            maximumFractionDigits,
+        };
+
+        if (isNaN(value)) {
+            return '-';
+        } else {
+            return value.toLocaleString(this.locale, options) + '%';
+        }
+    }
+
+    /**
+     * Get the language set by the user.
+     */
+    private getLang() {
+        if (navigator.languages !== undefined) {
+            return navigator.languages[0];
+        } else {
+            return navigator.language;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
Currently the Course Scores Page changes the number format depending on the language setting of the user ( english will use "." as a fraction separator and german will use ","). This includes the table and the csv export. The goal of this pr was to include this feature in the Exam Scores Page and associated csv export.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

**Testing that Course Scores + CSV Export still behaves as expected**
1. Log in to Artemis
2. Navigate to a Course Scores Page. 
3. Is the correct fraction separator ("." or ",") used for your artemis language setting? Is it correct in the csv export?
4. Change the language of artemis 
5. Is the correct fraction separator ("." or ",") used for your artemis language setting? Is it correct in the csv export?

**Testing that Exam Scores + CSV Export**
1. Log in to Artemis
2. Navigate to a Exam Scores Page. 
3. Is the correct fraction separator ("." or ",") used for your artemis language setting? Is it correct in the csv export?
4. Change the language of artemis 
5. Is the correct fraction separator ("." or ",") used for your artemis language setting? Is it correct in the csv export?


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-
ffmpeg-and-docker/ -->

**Look at the number 13.33 or 13,33**
![image](https://user-images.githubusercontent.com/29718932/88807416-fc44b800-d1b1-11ea-9ec9-a183c43172dd.png)
![image](https://user-images.githubusercontent.com/29718932/88807439-023a9900-d1b2-11ea-8182-af8390f0a49a.png)
