### PR TITLE
Improve logging for already submitted student exam

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
@@ -117,6 +117,7 @@ public class StudentExamService {
         // checks if student exam is already marked as submitted
         StudentExam existingStudentExam = findOneWithExercises(studentExam.getId());
         if (Boolean.TRUE.equals(studentExam.isSubmitted()) || Boolean.TRUE.equals(existingStudentExam.isSubmitted())) {
+            log.error("Student exam with id {} for user {} is already submitted.", studentExam.getId(), currentUser.getLogin());
             return conflict(ENTITY_NAME, "alreadySubmitted", "You have already submitted.");
         }
 


### PR DESCRIPTION
### Motivation and Context
When working through the logs of the EIST GOE, I noticed a few log entries about student exams being already submitted. However, it does not contain details on which user is affected.

### Description
This PR improves the logging in this case by adding the student exam Id and also the user's login.