### PR TITLE
Fix target for notifications for programming exercises in exams.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotification.java
@@ -9,10 +9,7 @@ import javax.persistence.*;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.gson.JsonObject;
 
-import de.tum.in.www1.artemis.domain.Course;
-import de.tum.in.www1.artemis.domain.Exercise;
-import de.tum.in.www1.artemis.domain.Lecture;
-import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType;
 
 /**
@@ -114,6 +111,23 @@ public class GroupNotification extends Notification implements Serializable {
 
     public String getAttachmentUpdated(Lecture lecture) {
         return getLectureTarget(lecture, "attachmentUpdated");
+    }
+
+    /**
+     * Create JSON representation for a GroupNotification for an ProgrammingExercise in an Exam.
+     *
+     * @param programmingExercise for which to create the notification.
+     * @param message to use for the notification.
+     * @return the stringified JSON of the target.
+     */
+    public String getExamProgrammingExerciseTarget(ProgrammingExercise programmingExercise, String message) {
+        JsonObject target = new JsonObject();
+        target.addProperty("message", message);
+        target.addProperty("id", programmingExercise.getId());
+        target.addProperty("entity", "programming-exercises");
+        target.addProperty("course", programmingExercise.getCourseViaExerciseGroupOrCourseMember().getId());
+        target.addProperty("mainPage", "course-management");
+        return target.toString();
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotificationFactory.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotificationFactory.java
@@ -85,8 +85,8 @@ public class GroupNotificationFactory {
                 notification.setTarget(notification.getExamProgrammingExerciseTarget((ProgrammingExercise) exercise, "exerciseUpdated"));
             }
 
-            // Exercises for courses (not for exams)
         }
+        // Exercises for courses (not for exams)
         else if (notificationType == NotificationType.EXERCISE_CREATED) {
             notification.setTarget(notification.getExerciseCreatedTarget(exercise));
         }

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotificationFactory.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotificationFactory.java
@@ -79,7 +79,15 @@ public class GroupNotificationFactory {
 
         GroupNotification notification = new GroupNotification(exercise.getCourseViaExerciseGroupOrCourseMember(), title, text, author, groupNotificationType);
 
-        if (notificationType == NotificationType.EXERCISE_CREATED) {
+        // Exercises for exams
+        if (exercise.hasExerciseGroup()) {
+            if (exercise instanceof ProgrammingExercise) {
+                notification.setTarget(notification.getExamProgrammingExerciseTarget((ProgrammingExercise) exercise, "exerciseUpdated"));
+            }
+
+            // Exercises for courses (not for exams)
+        }
+        else if (notificationType == NotificationType.EXERCISE_CREATED) {
             notification.setTarget(notification.getExerciseCreatedTarget(exercise));
         }
         else {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://vmbruegge60.in.tum.de.
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
Notifications that are sent to instructors when updates for programming exercises in exams are performed lead to a wrong page (the course page, not the exam page) and can thus not be shown.

### Description
Use the correct navigation target when clicking on a programming exercise in an exam.

### Steps for Testing
1. Create an exam with a programming exercise
2. Add at least one student, generate the student exams and prepare the exercises
3. Lock/Unlock the repositories
4. A notification should appear, once you click on it you should be sent to the view-page of the programming-exercise within the exam.

**NOTE**: This does only affect new notification, not old ones!

### Screenshots
![Peek 2020-08-04 12-20](https://user-images.githubusercontent.com/5084100/89283156-f553f480-d64c-11ea-9037-3b319e929c0b.gif)

