### PR TITLE
[Bugfix] Fix DragnDrop Style Warning in Build

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.scss
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.scss
@@ -161,7 +161,7 @@
                 display: flex;
                 flex-direction: row;
                 flex-wrap: wrap;
-                justify-content: start;
+                justify-content: flex-start;
                 align-items: center;
                 margin-left: auto;
                 margin-right: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The develop webpack build has the following warning:
`(1:4704) start value has mixed support, consider using flex-start instead
 @ ./src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.scss 2:21-278`

### Description
<!-- Describe your changes in detail -->

Using `flex-start` instead of `flex`.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. No warning in the build output.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
