### PR TITLE
[Bugfix] Fix Flaky Integration Test

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -238,7 +238,7 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
             final HttpHeaders headers = new HttpHeaders();
             headers.set("User-Agent", "foo");
             headers.set("X-Artemis-Client-Fingerprint", "bar");
-            headers.set("X-Forwarded-For", "10.0." + studentExam.getId() + ".1");
+            headers.set("X-Forwarded-For", "10.0.28.1");
             var response = request.get("/api/courses/" + course2.getId() + "/exams/" + exam2.getId() + "/studentExams/conduction", HttpStatus.OK, StudentExam.class, headers);
             assertThat(response).isEqualTo(studentExam);
             assertThat(response.isStarted()).isTrue();
@@ -294,7 +294,7 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
             assertThat(examSession.getIpAddress()).isNull();
             assertThat(optionalExamSession.get().getUserAgent()).isEqualTo("foo");
             assertThat(optionalExamSession.get().getBrowserFingerprintHash()).isEqualTo("bar");
-            assertThat(optionalExamSession.get().getIpAddress().toNormalizedString()).isEqualTo("10.0." + studentExam.getId() + ".1");
+            assertThat(optionalExamSession.get().getIpAddress().toNormalizedString()).isEqualTo("10.0.28.1");
         }
 
         // change back to instructor user


### PR DESCRIPTION
### Flaky Integration Test Fix
The integration test `testGetStudentExamForConduction()` had flaky behaviour. 

In most first time runs, the test failed due to a `NullPointerException`, specifically the `ipAdress` of the `examSession` was null.
This was due to how the IP address was set in the test. It used the studentExamID as part of its body. 
When running all tests, however, the studentExamId would be >255 resulting in an invalid IP adress. This was translated to null which led to the NullPointerException.

### Screenshots
![image](https://user-images.githubusercontent.com/15110960/89562646-917f2680-d81a-11ea-9299-3b799c2d7bf4.png)
