### PR TITLE
Tutor Dashboard show "Start new assessment" as is finds a semi_automatic result

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
@@ -105,7 +105,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
      * @param exerciseId the exercise id the participations should belong to
      * @return a list of participations including their submitted submissions that do not have a manual result
      */
-    @Query("select distinct participation from Participation participation left join fetch participation.submissions submission left join fetch submission.result result where participation.exercise.id = :#{#exerciseId} and not exists (select prs from participation.results prs where prs.assessmentType = 'MANUAL') and submission.submitted = true and submission.id = (select max(id) from participation.submissions)")
+    @Query("select distinct participation from Participation participation left join fetch participation.submissions submission left join fetch submission.result result where participation.exercise.id = :#{#exerciseId} and not exists (select prs from participation.results prs where prs.assessmentType IN ('MANUAL', 'SEMI_AUTOMATIC')) and submission.submitted = true and submission.id = (select max(id) from participation.submissions)")
     List<StudentParticipation> findByExerciseIdWithLatestSubmissionWithoutManualResults(@Param("exerciseId") Long exerciseId);
 
     @Query("select distinct participation from StudentParticipation participation left join fetch participation.results where participation.id = :#{#participationId}")


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
The Tutor Course Dashboard can show the "Start new assessment" button if all exercises are locked, but some have a semi_automatic result.

The Endpoint `/text-submission-without-assessment?head=true` returns a submission that, in fact, already has an assessment:
```
    "result": {
        "id": 1602424,
        "resultString": "4 of 4 points",
        "completionDate": "2020-08-06T18:59:12+02:00",
        "successful": true,
        "score": 100,
        "rated": true,
        "hasFeedback": false,
        "assessmentType": "SEMI_AUTOMATIC"
    },
```

In the query, SEMI_AUTOMATIC and MANUAL should be treated the same.

### Steps for Testing

Prepare a text exercise where all submissions are locked and most are assessed. (Some should be locked (saved) but not submitted).
At least one assessed submission is of type `SEMI_AUTOMATIC ` (has at least one automatic/adapted automatic feedback element).

1. Open Tutor Exercise Dashboard
2. Do not find "Start new assessment" button.
