### PR TITLE
Update setup documentation (scheduling profile)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     image: openjdk:14-jdk-alpine
     environment:
       - SPRING_DATASOURCE_URL=jdbc:mysql://artemis-mysql:3306/Artemis?createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true&useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC
-      - SPRING_PROFILES_ACTIVE=dev,bamboo,bitbucket,jira,artemis
+      - SPRING_PROFILES_ACTIVE=dev,bamboo,bitbucket,jira,artemis,scheduling
     networks:
       - artemis
     ports:

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -197,7 +197,7 @@ The Artemis server should startup by running the main class
 
 ::
 
-   --spring.profiles.active=dev,bamboo,bitbucket,jira,artemis
+   --spring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling
 
 If you use IntelliJ (Community or Ultimate) you can set the active
 profiles by
@@ -205,7 +205,7 @@ profiles by
 * Choosing ``Run | Edit Configurations...``
 * Going to the ``Configuration Tab``
 * Expanding the ``Environment`` section to reveal ``VM Options`` and setting them to
-``-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis``
+``-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling``
 
 Set Spring profiles with IntelliJ Ultimate
 """"""""""""""""""""""""""""""""""""""""""
@@ -216,7 +216,7 @@ configuration:
 
 ::
 
-   dev,bamboo,bitbucket,jira,artemis
+   dev,bamboo,bitbucket,jira,artemis,scheduling
 
 Run the server with the command line (Gradle wrapper)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -226,14 +226,14 @@ sure to pass the active profiles to the ``gradlew`` command like this:
 
 ::
 
-   ./gradlew bootRun --args='--spring.profiles.active=dev,bamboo,bitbucket,jira,artemis'
+   ./gradlew bootRun --args='--spring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling'
 
 As an alternative, you might want to use Jenkins and Gitlab with an
 internal user management in Artemis, then you would use the profiles:
 
 ::
 
-   dev,jenkins,gitlab,artemis
+   dev,jenkins,gitlab,artemis,scheduling
 
 Client Setup
 ------------
@@ -343,7 +343,7 @@ Enable the ``automaticText`` Spring profile:
 
 ::
 
-   --spring.profiles.active=dev,bamboo,bitbucket,jira,artemis,automaticText
+   --spring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling,automaticText
 
 Configure API Endpoints:
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Mention usage of scheduling profile (e.g. to allow automatic text-assessments)
- Update setup documentation
- Update docker-compose
