### PR TITLE
Add Percentages to Exam Scores Page

### DIFF
--- a/src/main/webapp/app/exam/exam-scores/exam-score-dtos.model.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-score-dtos.model.ts
@@ -67,6 +67,7 @@ export class AggregatedExerciseGroupResult {
     public noOfParticipantsWithFilter = 0;
     public totalPoints = 0;
     public averagePoints: number | null = null;
+    public averagePercentage: number | null = null;
     public exerciseResults: AggregatedExerciseResult[] = [];
 
     constructor(exerciseGroupId: number, title: string, maxPoints: number, totalParticipants: number) {
@@ -85,6 +86,7 @@ export class AggregatedExerciseResult {
     public noOfParticipantsWithFilter = 0;
     public totalPoints = 0;
     public averagePoints: number | null = null;
+    public averagePercentage: number | null = null;
 
     constructor(exerciseId: number, title: string, maxPoints: number, totalParticipants: number) {
         this.exerciseId = exerciseId;

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
@@ -136,7 +136,10 @@
                         {{ exerciseGroupResult.title }}
                     </td>
                     <td *ngIf="isFirst" [rowSpan]="exerciseGroupResult.exerciseResults.length">
-                        {{ exerciseGroupResult.noOfParticipantsWithFilter }} / {{ exerciseGroupResult.totalParticipants }}
+                        {{ exerciseGroupResult.noOfParticipantsWithFilter }} / {{ exerciseGroupResult.totalParticipants }} ({{
+                            roundAndPerformLocalConversion((exerciseGroupResult.noOfParticipantsWithFilter / exerciseGroupResult.totalParticipants) * 100, 2, 2)
+                        }}
+                        %)
                     </td>
                     <td *ngIf="isFirst" [rowSpan]="exerciseGroupResult.exerciseResults.length">
                         {{ exerciseGroupResult.averagePoints !== null ? roundAndPerformLocalConversion(exerciseGroupResult.averagePoints, 2, 2) : '-' }} /
@@ -145,6 +148,10 @@
                     </td>
                     <td>{{ exerciseResult.title }}</td>
                     <td>{{ exerciseResult.noOfParticipantsWithFilter }} / {{ exerciseResult.totalParticipants }}</td>
+                    ({{
+                        roundAndPerformLocalConversion((exerciseResult.noOfParticipantsWithFilter / exerciseResult.totalParticipants) * 100, 2, 2)
+                    }}
+                    %)
                     <td>
                         {{ exerciseResult.averagePoints !== null ? roundAndPerformLocalConversion(exerciseResult.averagePoints, 2, 2) : '-' }} /
                         {{ toLocaleString(exerciseResult.maxPoints) }}

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
@@ -147,11 +147,12 @@
                         ({{ exerciseGroupResult.averagePercentage !== null ? roundAndPerformLocalConversion(exerciseGroupResult.averagePercentage, 2, 2) : '-' }} %)
                     </td>
                     <td>{{ exerciseResult.title }}</td>
-                    <td>{{ exerciseResult.noOfParticipantsWithFilter }} / {{ exerciseResult.totalParticipants }}</td>
-                    ({{
-                        roundAndPerformLocalConversion((exerciseResult.noOfParticipantsWithFilter / exerciseResult.totalParticipants) * 100, 2, 2)
-                    }}
-                    %)
+                    <td>
+                        {{ exerciseResult.noOfParticipantsWithFilter }} / {{ exerciseResult.totalParticipants }} ({{
+                            roundAndPerformLocalConversion((exerciseResult.noOfParticipantsWithFilter / exerciseResult.totalParticipants) * 100, 2, 2)
+                        }}
+                        %)
+                    </td>
                     <td>
                         {{ exerciseResult.averagePoints !== null ? roundAndPerformLocalConversion(exerciseResult.averagePoints, 2, 2) : '-' }} /
                         {{ toLocaleString(exerciseResult.maxPoints) }}

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
@@ -141,12 +141,14 @@
                     <td *ngIf="isFirst" [rowSpan]="exerciseGroupResult.exerciseResults.length">
                         {{ exerciseGroupResult.averagePoints !== null ? roundAndPerformLocalConversion(exerciseGroupResult.averagePoints, 2, 2) : '-' }} /
                         {{ toLocaleString(exerciseGroupResult.maxPoints) }}
+                        ({{ exerciseGroupResult.averagePercentage !== null ? roundAndPerformLocalConversion(exerciseGroupResult.averagePercentage, 2, 2) : '-' }} %)
                     </td>
                     <td>{{ exerciseResult.title }}</td>
                     <td>{{ exerciseResult.noOfParticipantsWithFilter }} / {{ exerciseResult.totalParticipants }}</td>
                     <td>
                         {{ exerciseResult.averagePoints !== null ? roundAndPerformLocalConversion(exerciseResult.averagePoints, 2, 2) : '-' }} /
                         {{ toLocaleString(exerciseResult.maxPoints) }}
+                        ({{ exerciseResult.averagePercentage !== null ? roundAndPerformLocalConversion(exerciseResult.averagePercentage, 2, 2) : '-' }} %)
                     </td>
                 </tr>
             </tbody>

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
@@ -219,11 +219,13 @@ export class ExamScoresComponent implements OnInit, OnDestroy {
             // For average points for exercise groups
             if (groupResult.noOfParticipantsWithFilter) {
                 groupResult.averagePoints = groupResult.totalPoints / groupResult.noOfParticipantsWithFilter;
+                groupResult.averagePercentage = (groupResult.averagePoints / groupResult.maxPoints) * 100;
             }
             // Calculate average points for exercises
             groupResult.exerciseResults.forEach((exResult) => {
                 if (exResult.noOfParticipantsWithFilter) {
                     exResult.averagePoints = exResult.totalPoints / exResult.noOfParticipantsWithFilter;
+                    exResult.averagePercentage = (exResult.averagePoints / exResult.maxPoints) * 100;
                 }
             });
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Requested by @krusche 

### Description
<!-- Describe your changes in detail -->

- Added average display as percentage for exercises and exercise groups
- Added participation as percentage for exercises and exercise groups 


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Look at the the exam results of some exams and see if the percentages are displayed correctly

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/29718932/90310898-29a19d80-def6-11ea-91aa-f168e605255a.png)

