### PR TITLE
[Bug] Fix broken back button in example submission for modeling exercises #2039

### DIFF
--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
@@ -87,7 +87,7 @@ export class ExampleModelingSubmissionComponent implements OnInit {
     private loadAll(): void {
         this.exerciseService.find(this.exerciseId).subscribe((exerciseResponse: HttpResponse<ModelingExercise>) => {
             this.exercise = exerciseResponse.body!;
-            this.isExamMode = this.exercise.exerciseGroup !== null && this.exercise.exerciseGroup !== undefined ? true : false;
+            this.isExamMode = this.exercise.exerciseGroup != null;
             this.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.course || this.exercise.exerciseGroup!.exam!.course);
         });
 

--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
@@ -87,9 +87,7 @@ export class ExampleModelingSubmissionComponent implements OnInit {
     private loadAll(): void {
         this.exerciseService.find(this.exerciseId).subscribe((exerciseResponse: HttpResponse<ModelingExercise>) => {
             this.exercise = exerciseResponse.body!;
-            if (this.exercise.exerciseGroup !== null) {
-                this.isExamMode = true;
-            }
+            this.isExamMode = this.exercise.exerciseGroup !== null && this.exercise.exerciseGroup !== undefined ? true : false;
             this.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.course || this.exercise.exerciseGroup!.exam!.course);
         });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is a bug fix for issue #2039 

### Description
<!-- Describe your changes in detail -->
An access to an undefined object property "exam" caused the bug. The undefined variable "exerciseGroup" of exercise was only checked of being null instead of also being tested being undefined.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Follow the steps of Issue #2039 
2. The back button doesn't throw an error anymore and goes back to the previous page.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
