### PR TITLE
Improve configuration of the local development environment

### DIFF
--- a/.idea/runConfigurations/Artemis__Server_.xml
+++ b/.idea/runConfigurations/Artemis__Server_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Artemis (Server)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="Artemis.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
-    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling" />
+    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling,local" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Artemis__Server__Jenkins___Gitlab_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Jenkins___Gitlab_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Artemis (Server, Jenkins &amp; Gitlab)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="Artemis.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
-    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,jenkins,gitlab,artemis,scheduling" />
+    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,jenkins,gitlab,artemis,scheduling,local" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Artemis__Server__Text_Clustering_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Text_Clustering_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Artemis (Server, Text Clustering)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="Artemis.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
-    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,automaticText,scheduling,athene" />
+    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,automaticText,scheduling,athene,local" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.idea/runConfigurations/Artemis__Server___Client_.xml
+++ b/.idea/runConfigurations/Artemis__Server___Client_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Artemis (Server &amp; Client)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <module name="Artemis.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.tum.in.www1.artemis.ArtemisApp" />
-    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling" />
+    <option name="VM_PARAMETERS" value="-Dspring.profiles.active=dev,bamboo,bitbucket,jira,artemis,scheduling,local" />
     <method v="2">
       <option name="Gradle.BeforeRunTask" enabled="true" tasks="webpack" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="" />
       <option name="Make" enabled="true" />

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -148,8 +148,6 @@ information about the setup for programming exercises provided:
    1) Create a file named ``application-local.yml`` under ``src/main/resources/config``.
    2) Copy the contents of ``application-artemis.yml`` into the new file.
    3) Update configuration values in ``application-local.yml``.
-   4) In your local run configuration, add the ``local`` profile to the list of active spring profiles.
-      Make sure it's the last profile in the list so that it overwrites any existing values.
 
    By default, changes to ``application-local.yml`` will be ignored by git so you don't accidentally
    share your credentials or other local configuration options.

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -126,7 +126,7 @@ have to configure the file ``application-artemis.yml`` in the folder
            clustering-url: http://localhost:8002/cluster
            secret: null
 
-Change all entries with ``<...>`` with proper values, e.g. your TUM
+Change all entries with ``<...>`` with proper values, e.g. your TUM
 Online account credentials to connect to the given instances of JIRA,
 Bitbucket and Bamboo. Alternatively, you can connect to your local JIRA,
 Bitbucket and Bamboo instances. It’s not necessary to fill all the
@@ -142,8 +142,17 @@ information about the setup for programming exercises provided:
 
 
 .. note::
-   Be careful that you don’t commit changes in this file.
-   Best practice is to specify that your local git repository ignores this file or assumes that this file is unchanged.
+   Be careful that you don’t commit changes to ``application-artemis.yml``.
+   To avoid this, follow the best practice when configuring your local development environment:
+
+   1) Create a file named ``application-local.yml`` under ``src/main/resources/config``.
+   2) Copy the contents of ``application-artemis.yml`` into the new file.
+   3) Update configuration values in ``application-local.yml``.
+   4) In your local run configuration, add the ``local`` profile to the list of active spring profiles.
+      Make sure it's the last profile in the list so that it overwrites any existing values.
+
+   By default, changes to ``application-local.yml`` will be ignored by git so you don't accidentally
+   share your credentials or other local configuration options.
 
 If you use a password, you need to adapt it in
 ``gradle/liquibase.gradle``.


### PR DESCRIPTION
### Motivation and Context
Because `application-artemis.yml` is tracked by git, making changes to this file to configure your local development environment always ran the risk of accidentally committing your local configuration options (including credentials).

### Description
I updated the development setup guide to include the best practices for configuring your local development environment.

**Update**: As discussed with @krusche, I updated the `.idea/runConfigurations` to include the `local` spring profile by default. This way, developers don't have to manually change their run configurations. Production configurations can't be overwritten by this change because `application-local.yml` is on `.gitignore`.