### PR TITLE
Trim solutions and answers when correcting a Short Answer Quiz

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedText.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedText.java
@@ -95,7 +95,7 @@ public class ShortAnswerSubmittedText implements Serializable {
      * @return boolean true if submittedText fits the restrictions above, false when not
      */
     public boolean isSubmittedTextCorrect(String submittedText, String solution) {
-        return FuzzySearch.ratio(submittedText.toLowerCase(), solution.toLowerCase()) > 85;
+        return FuzzySearch.ratio(submittedText.toLowerCase().trim(), solution.toLowerCase().trim()) > 85;
     }
 
     @Override

--- a/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.ts
@@ -142,10 +142,11 @@ export class ShortAnswerQuestionComponent {
      * @param spotTag Spot tag for which to return the input field's background color
      */
     getBackgroundColourForInputField(spotTag: string): string {
-        if (this.getSubmittedTextForSpot(spotTag) === undefined) {
+        const submittedTextForSpot = this.getSubmittedTextForSpot(spotTag);
+        if (submittedTextForSpot === undefined) {
             return 'red';
         }
-        return this.getSubmittedTextForSpot(spotTag).isCorrect ? (this.isSubmittedTextCompletelyCorrect(spotTag) ? 'lightgreen' : 'yellow') : 'red';
+        return submittedTextForSpot.isCorrect ? (this.isSubmittedTextCompletelyCorrect(spotTag) ? 'lightgreen' : 'yellow') : 'red';
     }
 
     /**
@@ -158,7 +159,7 @@ export class ShortAnswerQuestionComponent {
             this.question.correctMappings,
             this.shortAnswerQuestionUtil.getSpot(this.shortAnswerQuestionUtil.getSpotNr(spotTag), this.question),
         );
-        const solutions = solutionsForSpot?.filter((solution) => solution.text === this.getSubmittedTextForSpot(spotTag)?.text);
+        const solutions = solutionsForSpot?.filter((solution) => solution.text?.trim() === this.getSubmittedTextForSpot(spotTag)?.text?.trim());
         if (solutions && solutions.length > 0) {
             isTextCorrect = true;
         }

--- a/src/test/java/de/tum/in/www1/artemis/domain/ShortAnswerQuestionTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/domain/ShortAnswerQuestionTest.java
@@ -1,0 +1,19 @@
+package de.tum.in.www1.artemis.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import de.tum.in.www1.artemis.domain.quiz.ShortAnswerSubmittedText;
+
+public class ShortAnswerQuestionTest {
+
+    @Test
+    public void checkSolutionsAreTrimmed() {
+        var shortAnswerQuestion = new ShortAnswerSubmittedText();
+        assertThat(shortAnswerQuestion.isSubmittedTextCorrect("  submitted untrimmed \n", "submitted untrimmed")).isTrue();
+        assertThat(shortAnswerQuestion.isSubmittedTextCorrect("solution untrimmed", "  solution untrimmed \n")).isTrue();
+        assertThat(shortAnswerQuestion.isSubmittedTextCorrect("both untrimmed  ", "  both untrimmed\n")).isTrue();
+        assertThat(shortAnswerQuestion.isSubmittedTextCorrect("  wrong but untrimmed", "different  ")).isFalse();
+    }
+}

--- a/src/test/javascript/spec/component/short-answer-quiz/short-answer-question.component.spec.ts
+++ b/src/test/javascript/spec/component/short-answer-quiz/short-answer-question.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShortAnswerQuestionComponent } from 'app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component';
+import { ShortAnswerSpot } from 'app/entities/quiz/short-answer-spot.model';
+import { ShortAnswerQuestion } from 'app/entities/quiz/short-answer-question.model';
+import { ScoringType } from 'app/entities/quiz/quiz-question.model';
+import { ShortAnswerSolution } from 'app/entities/quiz/short-answer-solution.model';
+import { ShortAnswerMapping } from 'app/entities/quiz/short-answer-mapping.model';
+import { ShortAnswerSubmittedText } from 'app/entities/quiz/short-answer-submitted-text.model';
+
+describe('ShortAnswerQuestion Component', () => {
+    let comp: ShortAnswerQuestionComponent;
+    let fixture: ComponentFixture<ShortAnswerQuestionComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [ShortAnswerQuestionComponent],
+        })
+            .overrideTemplate(ShortAnswerQuestionComponent, '')
+            .compileComponents();
+
+        fixture = TestBed.createComponent(ShortAnswerQuestionComponent);
+        comp = fixture.componentInstance;
+
+        const shortAnswerQuestion = new ShortAnswerQuestion();
+        shortAnswerQuestion.title = '';
+        shortAnswerQuestion.text = '[-spot 1] and [-spot 2] and [-spot 3]\n[-option 1] a\n[-option 2] b\n[-option 3] c';
+        shortAnswerQuestion.scoringType = ScoringType.ALL_OR_NOTHING;
+        shortAnswerQuestion.randomizeOrder = true;
+        shortAnswerQuestion.score = 1;
+        const shortAnswerSpot1 = new ShortAnswerSpot();
+        shortAnswerSpot1.spotNr = 1;
+        const shortAnswerSpot2 = new ShortAnswerSpot();
+        shortAnswerSpot2.spotNr = 2;
+        const shortAnswerSpot3 = new ShortAnswerSpot();
+        shortAnswerSpot3.spotNr = 3;
+        shortAnswerQuestion.spots = [shortAnswerSpot1, shortAnswerSpot2, shortAnswerSpot3];
+        const shortAnswerSolution1 = new ShortAnswerSolution();
+        shortAnswerSolution1.text = 'a';
+        const shortAnswerSolution2 = new ShortAnswerSolution();
+        shortAnswerSolution2.text = 'b';
+        const shortAnswerSolution3 = new ShortAnswerSolution();
+        shortAnswerSolution3.text = 'c';
+        shortAnswerQuestion.solutions = [shortAnswerSolution1, shortAnswerSolution2, shortAnswerSolution3];
+        const shortAnswerMapping1 = new ShortAnswerMapping(shortAnswerSpot1, shortAnswerSolution1);
+        const shortAnswerMapping2 = new ShortAnswerMapping(shortAnswerSpot2, shortAnswerSolution2);
+        const shortAnswerMapping3 = new ShortAnswerMapping(shortAnswerSpot3, shortAnswerSolution3);
+        shortAnswerQuestion.correctMappings = [shortAnswerMapping1, shortAnswerMapping2, shortAnswerMapping3];
+        comp.question = shortAnswerQuestion;
+
+        const submittedText1 = new ShortAnswerSubmittedText();
+        submittedText1.spot = shortAnswerSpot1;
+        submittedText1.isCorrect = true;
+        submittedText1.text = ' a ';
+        const submittedText2 = new ShortAnswerSubmittedText();
+        submittedText2.spot = shortAnswerSpot2;
+        submittedText2.isCorrect = true;
+        submittedText2.text = 'b\n';
+        const submittedText3 = new ShortAnswerSubmittedText();
+        submittedText3.spot = shortAnswerSpot3;
+        submittedText3.isCorrect = false;
+        submittedText3.text = 'not c\n';
+        comp.submittedTexts = [submittedText1, submittedText2, submittedText3];
+    });
+
+    it('Should trim submitted answers', () => {
+        expect(comp.isSubmittedTextCompletelyCorrect('[-spot 1]')).toEqual(true);
+        expect(comp.isSubmittedTextCompletelyCorrect('[-spot 2]')).toEqual(true);
+        expect(comp.isSubmittedTextCompletelyCorrect('[-spot 3]')).toEqual(false);
+    });
+
+    it('Display correct background colors', () => {
+        expect(comp.getBackgroundColourForInputField('[-spot 1]')).toEqual('lightgreen');
+        expect(comp.getBackgroundColourForInputField('[-spot 2]')).toEqual('lightgreen');
+        expect(comp.getBackgroundColourForInputField('[-spot 3]')).toEqual('red');
+    });
+});


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

I did not check the first box since I did not test on https://artemistest.ase.in.tum.de (frankly, I do not know how to get my code there for testing), but I did test locally. That is also the reason I submitted this as draft; otherwise the PR is complete. (See 'Description' for another thought of what can be done here.)

### Motivation and Context
Closes #2082.

### Description
Strings are now trimmed before being compared for correctness. This results in the following:
![grafik](https://user-images.githubusercontent.com/7704140/92125642-89a5a880-edff-11ea-9f61-c665fe8e46b9.png)
("in " is entered and thus marked yellow.)
The answer is marked yellow since it is not "completely correct". I'm not sure if that should be changed. It could be changed to trim the user input directly. (And then only display a trimmed submission; just "in" instead of "in " in this case. That however is changing the answers of students, so I'm unsure about it.)

### Steps for Testing
1. Create a new Quiz using the Course Administration
2. Add a Short Answer Question (you can use the default template)
3. Open/Start the quiz and enter it from the student view
4. Enter a correct answer but put spaces in front and/or behind
5. Submit and view your corrected submission after the timer ran out

### Test Coverage
I actually don't know where to find the test coverage for the changed file. Neither `.\gradlew.bat executeTests` nor `.\gradlew.bat executeTests jacocoTestReport -x yarn_install -x webpack` reported any coverage, but the same tests pass that pass on `develop`, so this should be fine.

### Screenshots
When submitting "in " untrimmed:
![grafik](https://user-images.githubusercontent.com/7704140/92125642-89a5a880-edff-11ea-9f61-c665fe8e46b9.png)
Submitting just "in" without extra spaces:
![grafik](https://user-images.githubusercontent.com/7704140/92136587-7b11be00-ee0c-11ea-9d77-281ae7e8a824.png)
