### PR TITLE
Add version to Spring Devtools dependency

### DIFF
--- a/gradle/profile_dev.gradle
+++ b/gradle/profile_dev.gradle
@@ -6,7 +6,7 @@ configurations {
 }
 
 dependencies {
-    developmentOnly "org.springframework.boot:spring-boot-devtools"
+    developmentOnly "org.springframework.boot:spring-boot-devtools:${spring_boot_version}"
 }
 
 def profiles = 'dev'


### PR DESCRIPTION
Adds version via variable
Fixes #2057

### Description
In order to leave out the version on spring tools you need to have a specific plugin. Since this project misses this plugin the version must be specified. Further details in issue.