### PR TITLE
[Enhancement] Update Readme of Setup Programming Exercises

### DIFF
--- a/docs/dev/setup/bamboo-bitbucket-jira.rst
+++ b/docs/dev/setup/bamboo-bitbucket-jira.rst
@@ -70,10 +70,15 @@ under ``localhost:7990``.
 
 3. Enable the created `application
    links <https://confluence.atlassian.com/doc/linking-to-another-application-360677690.html>`__
-   between all 3 application (OAuth Impersonate). **You manually have to
-   adjust the Display URL for the Bamboo → Bitbucket AND
-   Bitbucket → Bamboo URl to** ``http://localhost:7990`` **and**
-   ``http://localhost:8085`` **.**
+   between all 3 application (OAuth Impersonate). The links should open automatically after the shell script 
+   has finished. If not open them manually: 
+ - Bitbucket: http://localhost:7990/plugins/servlet/applinks/listApplicationLinks
+ - Bamboo: http://localhost:8085/plugins/servlet/applinks/listApplicationLinks
+ - Jira: http://localhost:8081/plugins/servlet/applinks/listApplicationLinks
+   
+ **You manually have to adjust the Display URL for the Bamboo → Bitbucket AND
+ Bitbucket → Bamboo URl to** ``http://localhost:7990`` **and**
+ ``http://localhost:8085`` **.**
 
     **Bamboo:**
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
While setting up bamboo, bitbucket and jira for the programming exercises on macOS, the atlassian-setup.sh script doesn't open the application links automatically. 

The last lines of the script won't get executed:
- xdg-open $jira_application_links_url
- xdg-open $bamboo_application_links_url
- xdg-open $bitbucket_application_links_url 

This update of the Readme shall simplify the walkthrough if that happens on a machine.
<!-- If it fixes an open issue, please link to the issue here. -->

