### PR TITLE
[Bugfix]Fix the different rounding in student exam -> view and the summery

### DIFF
--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
@@ -110,7 +110,7 @@
                         </td>
                         <td class="align-middle">
                             <ng-container *ngIf="!!(exercise?.studentParticipations)[0].results">
-                                {{ rounding((((exercise?.studentParticipations)[0]?.results)[0]?.score * exercise?.maxScore) / 100 )}}
+                                {{ rounding((((exercise?.studentParticipations)[0]?.results)[0]?.score * exercise?.maxScore) / 100) }}
                             </ng-container>
                         </td>
                         <td class="align-middle">

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
@@ -86,10 +86,10 @@
                             <span jhiTranslate="artemisApp.studentExamDetail.title">Title</span>
                         </th>
                         <th>
-                            <span jhiTranslate="artemisApp.studentExamDetail.result">Result</span>
+                            <span jhiTranslate="artemisApp.studentExamDetail.result">Your points</span>
                         </th>
                         <th>
-                            <span jhiTranslate="artemisApp.exercise.maxScore">Max Score</span>
+                            <span jhiTranslate="artemisApp.exercise.maxScore">Max. points</span>
                         </th>
 
                         <th>
@@ -110,7 +110,7 @@
                         </td>
                         <td class="align-middle">
                             <ng-container *ngIf="!!(exercise?.studentParticipations)[0].results">
-                                {{ (((exercise?.studentParticipations)[0]?.results)[0]?.score * exercise?.maxScore) / 100 }}
+                                {{ rounding((((exercise?.studentParticipations)[0]?.results)[0]?.score * exercise?.maxScore) / 100 )}}
                             </ng-container>
                         </td>
                         <td class="align-middle">

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
@@ -89,7 +89,7 @@
                             <span jhiTranslate="artemisApp.studentExamDetail.result">Your points</span>
                         </th>
                         <th>
-                            <span jhiTranslate="artemisApp.exercise.maxScore">Max. points</span>
+                            <span jhiTranslate="artemisApp.exam.examSummary.points.maxPoints">Max. points</span>
                         </th>
 
                         <th>

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
@@ -9,6 +9,7 @@ import { User } from 'app/core/user/user.model';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { ArtemisDurationFromSecondsPipe } from 'app/shared/pipes/artemis-duration-from-seconds.pipe';
 import { AlertService } from 'app/core/alert/alert.service';
+import { round } from 'app/shared/util/utils';
 import * as moment from 'moment';
 
 @Component({
@@ -105,6 +106,7 @@ export class StudentExamDetailComponent implements OnInit {
             this.maxTotalScore += exercise.maxScore;
             if (!!exercise.studentParticipations[0].results && exercise.studentParticipations[0].results.length >= 1) {
                 this.achievedTotalScore += (exercise.studentParticipations[0].results[0].score * exercise.maxScore) / 100;
+                this.achievedTotalScore = this.rounding(this.achievedTotalScore);
             }
         });
     }
@@ -138,5 +140,8 @@ export class StudentExamDetailComponent implements OnInit {
         return this.examIsVisible()
             ? 'You cannot change the individual working time after the exam has become visible.'
             : 'You can change the individual working time of the student here.';
+    }
+    rounding(number: number) {
+        return round(number, 1);
     }
 }

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -272,7 +272,7 @@
             "id": "ID",
             "type": "Type",
             "title": "Title",
-            "result": "Result",
+            "result": "Your points",
             "reviewer": "Reviewer",
             "openSubmission": "Open Submission",
             "openAssessment": " Open Assessment",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
the rounding for points and the naming are different in the summery and instructor view (student exam -> View) which should be consistent

### Description
<!-- Describe your changes in detail -->
Change the rounding methods
Change the exam.json file for the naming of points (Result -> Your Points)
Using naming from another .json file (Max Score -> Max. Points)
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Finish and submit a exam from one course (here as student)
3. Navigate to Course Administration
4. Open Tutor Dashboard
5. Assess one exercise from the submission with a decimal grade
6. Go back to main page 
7. Click on the exam and see the summery of Submission in point 2
8. Go back to Course Administration
9. Go to Exam -> Student Exam -> View to view the detail of submission in point 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![Screenshot 2020-09-08 at 14 40 13](https://user-images.githubusercontent.com/48210790/92483780-876d9080-f1e9-11ea-998a-3fb31b9fe0a3.png)
![Screenshot 2020-09-08 at 14 40 47](https://user-images.githubusercontent.com/48210790/92483790-89375400-f1e9-11ea-8235-fb8286717276.png)
![Screenshot 2020-09-08 at 15 28 44](https://user-images.githubusercontent.com/48210790/92483794-8a688100-f1e9-11ea-87b9-336747c07912.png)
