### PR TITLE
GH Actions: Skip Codacy on Forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: build/reports/jacoco/test/jacocoTestReport.xml
-      if: github.repository == 'ls1intum/Artemis' && (success() || failure())
+      if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
     - name: Java Code Style
       run: ./gradlew spotlessCheck
       if: success() || failure()
@@ -142,7 +142,7 @@ jobs:
       with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/lcov.info
-      if: github.repository == 'ls1intum/Artemis' && (success() || failure())
+      if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
     - name: TypeScript Formatting
       run: yarn prettier:check
       if: success() || failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: build/reports/jacoco/test/jacocoTestReport.xml
-      if: success() || failure()
+      if: github.repository == 'ls1intum/Artemis' && (success() || failure())
     - name: Java Code Style
       run: ./gradlew spotlessCheck
       if: success() || failure()
@@ -142,7 +142,7 @@ jobs:
       with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/lcov.info
-      if: success() || failure()
+      if: github.repository == 'ls1intum/Artemis' && (success() || failure())
     - name: TypeScript Formatting
       run: yarn prettier:check
       if: success() || failure()

--- a/.github/workflows/pullrequest-labeler.yml
+++ b/.github/workflows/pullrequest-labeler.yml
@@ -1,5 +1,5 @@
 name: Pull Request Labeler
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   label:

--- a/.github/workflows/pullrequest-opened.yml
+++ b/.github/workflows/pullrequest-opened.yml
@@ -13,6 +13,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   addToProject:
+    if: github.repository == 'ls1intum/Artemis'
     runs-on: ubuntu-latest
     steps:
       - name: Add Pull Request to Project
@@ -21,7 +22,6 @@ jobs:
           project: Artemis Development
           column: In progress
           repo-token: ${{ secrets.GH_TOKEN_ADD_TO_PROJECT }}
-        if: github.repository == 'ls1intum/Artemis'
 
   commentOnNonDraft:
     runs-on: ubuntu-latest

--- a/.github/workflows/pullrequest-opened.yml
+++ b/.github/workflows/pullrequest-opened.yml
@@ -21,6 +21,7 @@ jobs:
           project: Artemis Development
           column: In progress
           repo-token: ${{ secrets.GH_TOKEN_ADD_TO_PROJECT }}
+        if: github.repository == 'ls1intum/Artemis'
 
   commentOnNonDraft:
     runs-on: ubuntu-latest

--- a/.github/workflows/pullrequest-opened.yml
+++ b/.github/workflows/pullrequest-opened.yml
@@ -1,6 +1,6 @@
 name: Pull Request Opened
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
@@ -13,7 +13,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   addToProject:
-    if: github.repository == 'ls1intum/Artemis'
     runs-on: ubuntu-latest
     steps:
       - name: Add Pull Request to Project

--- a/.github/workflows/pullrequest-readyforreview.yml
+++ b/.github/workflows/pullrequest-readyforreview.yml
@@ -1,6 +1,6 @@
 name: Pull Request Ready for Review
 on:
-  pull_request:
+  pull_request_target:
     types: [ready_for_review]
 
 jobs:

--- a/.github/workflows/pullrequest-reopened.yml
+++ b/.github/workflows/pullrequest-reopened.yml
@@ -1,6 +1,6 @@
 name: Pull Request Converted to draft
 on:
-  pull_request:
+  pull_request_target:
     types: [assigned, unassigned, labeled, unlabeled, opened, edited, closed, reopened, synchronize, locked, unlocked]
 
 jobs:


### PR DESCRIPTION
### Motivation and Context
Cannot report Coverage to Codacy for forks, as they do not have access to the token.

### Description
Skip these steps if not running in the `ls1intum/Artemis` repo.