### PR TITLE
[Bugfix] Fix sticky navbar in safari

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ springBoot {
 }
 
 tasks.withType(JavaCompile).each {
-//    it.options.compilerArgs.add('--enable-preview')
+    it.options.compilerArgs.add('--enable-preview')
 }
 
 // Execute the test cases: ./gradlew executeTests

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ springBoot {
 }
 
 tasks.withType(JavaCompile).each {
-    it.options.compilerArgs.add('--enable-preview')
+//    it.options.compilerArgs.add('--enable-preview')
 }
 
 // Execute the test cases: ./gradlew executeTests

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
@@ -1,4 +1,4 @@
-<div class="row justify-content-between align-items-start exam-navigation sticky-top pt-2">
+<div class="row justify-content-between align-items-start exam-navigation pt-2">
     <div class="col d-none d-lg-block h3 m-0 text-overflow" *ngIf="exercises && exercises.length > 0">
         {{ 'artemisApp.examParticipation.progress' | translate: { current: exerciseIndex + 1, all: exercises.length } }}
     </div>

--- a/src/main/webapp/app/exam/participate/exam-participation.component.html
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.html
@@ -13,6 +13,7 @@
             <!-- exam nav -->
             <jhi-exam-navigation-bar
                 id="exam-navigation-bar"
+                class="sticky-top"
                 [exercises]="studentExam.exercises"
                 [exerciseIndex]="exerciseIndex"
                 [endDate]="individualStudentEndDate"

--- a/src/main/webapp/app/exam/participate/exam-participation.component.html
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.html
@@ -13,7 +13,7 @@
             <!-- exam nav -->
             <jhi-exam-navigation-bar
                 id="exam-navigation-bar"
-                class="sticky-top"
+                class="sticky-top d-block"
                 [exercises]="studentExam.exercises"
                 [exerciseIndex]="exerciseIndex"
                 [endDate]="individualStudentEndDate"

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.ts
@@ -103,9 +103,18 @@ export class QuizExamSubmissionComponent extends ExamSubmissionComponent impleme
      * @param questionId
      */
     navigateToQuestion(questionId: number): void {
-        document.getElementById('question' + questionId)!.scrollIntoView({
-            behavior: 'smooth',
-        });
+        let yOffset = 0;
+        const examNavigationBar = document.getElementById('exam-navigation-bar');
+        if (examNavigationBar) {
+            yOffset = examNavigationBar.clientHeight;
+        }
+        // get html element for question
+        const element = document.getElementById('question' + questionId);
+        if (element) {
+            // scroll to correct y
+            const y = element.getBoundingClientRect().top + window.pageYOffset - yOffset;
+            window.scrollTo({ top: y, behavior: 'smooth' });
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fix sticky navbar for safari
Fix scrolling to quiz questions in all browsers

### Description
<!-- Describe your changes in detail -->

Move sticky class to component. 
Take exam navigation bar  into account when calculating scroll position for quiz questions.
Tested on Safari, Firefox and Chrome.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Participate in Exam with quiz exercise with many questions
3. Scroll down
4. Use the bar on the left to navigate to quiz questions. Expected outcome: question is on the top of the page when using bar to navigate to quiz questions

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<img width="1440" alt="Bildschirmfoto 2020-09-22 um 17 16 32" src="https://user-images.githubusercontent.com/13920539/93901991-5f0c8880-fcf7-11ea-8ab2-02c3f8ae547e.png">
