### PR TITLE
[Bugfix] Fix programming exercise test case import

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
@@ -193,6 +193,7 @@ public class ProgrammingExerciseTestCase implements Serializable {
 
     @Override
     public String toString() {
-        return "ProgrammingExerciseTestCase{" + "id=" + getId() + ", testName='" + getTestName() + "'" + ", weight=" + getWeight() + ", active='" + isActive() + "'" + "}";
+        return "ProgrammingExerciseTestCase{" + "id=" + id + ", testName='" + testName + '\'' + ", weight=" + weight + ", active=" + active + ", afterDueDate=" + afterDueDate
+                + ", bonusMultiplier=" + bonusMultiplier + ", bonusPoints=" + bonusPoints + '}';
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseImportService.java
@@ -202,6 +202,8 @@ public class ProgrammingExerciseImportService {
             copy.setAfterDueDate(testCase.isAfterDueDate());
             copy.setTestName(testCase.getTestName());
             copy.setWeight(testCase.getWeight());
+            copy.setBonusMultiplier(testCase.getBonusMultiplier());
+            copy.setBonusPoints(testCase.getBonusPoints());
             copy.setExercise(targetExercise);
             programmingExerciseTestCaseRepository.save(copy);
             return copy;

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseServiceIntegrationTest.java
@@ -114,6 +114,7 @@ public class ProgrammingExerciseServiceIntegrationTest extends AbstractSpringInt
         final var newTestCaseIDs = newlyImported.getTestCases().stream().map(ProgrammingExerciseTestCase::getId).collect(Collectors.toSet());
         assertThat(newlyImported.getTestCases().size()).isEqualTo(programmingExercise.getTestCases().size());
         assertThat(programmingExercise.getTestCases()).noneMatch(testCase -> newTestCaseIDs.contains(testCase.getId()));
+        assertThat(programmingExercise.getTestCases()).usingElementComparatorIgnoringFields("id", "exercise").containsExactlyInAnyOrderElementsOf(newlyImported.getTestCases());
         final var newHintIDs = newlyImported.getExerciseHints().stream().map(ExerciseHint::getId).collect(Collectors.toSet());
         assertThat(newlyImported.getExerciseHints().size()).isEqualTo(programmingExercise.getExerciseHints().size());
         assertThat(programmingExercise.getExerciseHints()).noneMatch(hint -> newHintIDs.contains(hint.getId()));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Two attributes were added to the test case table namely `bonusMultiplier` and `bonusPoints` but not added to the copy of test case entities on import of programming exercises. This leads to a nullpointer exception when the score is calculated (at least one test case passed). 

### Description

- [x] Copy `bonusMultiplier` and `bonusPoints` on import
- [x] Enhance integration test to check for this error

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Import a programming exercise
2. Participate in the programming exercise
3. Submit a solution which passes a test case
--> Correct score should be displayed
