### PR TITLE
[Bugfix] Fix CodeEditor vertical resizing

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/layout/code-editor-grid.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/layout/code-editor-grid.component.html
@@ -26,7 +26,7 @@
         </div>
 
         <!-- Required for resizing; don't remove empty span -->
-        <!--<fa-icon [icon]="'grip-lines'" class="rg-main-bottom text-lightgrey"><span></span></fa-icon> -->
+        <fa-icon [icon]="'grip-lines'" class="rg-main-bottom text-lightgrey"><span></span></fa-icon>
     </div>
     <div *ngIf="isTutorAssessment">
         <ng-content select="[editorBottom]"></ng-content>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The code editor could not be resized vertically anymore.

### Description
<!-- Describe your changes in detail -->

The resize icon was commented out. It isn't anymore.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Open the Code Editor
3. Resize vertically.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<img width="1433" alt="Bildschirmfoto 2020-09-25 um 17 40 34" src="https://user-images.githubusercontent.com/13920539/94287237-536acd00-ff56-11ea-9ce3-e0460443b69a.png">
