### PR TITLE
Fix Text Exercise Import Button Display for Exercise Groups

### DIFF
--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -39,9 +39,9 @@
                         </button>
                     </div>
                     <div class="btn-group-vertical mr-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
-                        <button *ngIf="course?.isAtLeastInstructor" class="btn btn-info btn-sm mr-1 mb-1" (click)="openImportModal(exerciseGroup, exerciseType.TEXT)">
+                        <button *ngIf="course?.isAtLeastInstructor" (click)="openImportModal(exerciseGroup, exerciseType.TEXT)" class="btn btn-info btn-sm mr-1 mb-1">
                             <fa-icon [icon]="'plus'"></fa-icon>
-                            <span class="hidden-sm-down" jhiTranslate="artemisApp.textExercise.home.importLabel"></span>
+                            <span class="d-none d-md-inline">{{ 'artemisApp.textExercise.home.importLabel' | translate }}</span>
                         </button>
                         <button *ngIf="course?.isAtLeastInstructor" [routerLink]="[exerciseGroup.id, 'text-exercises', 'new']" class="btn btn-info btn-sm mr-1 mb-1">
                             <fa-icon [icon]="'plus'"></fa-icon>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
The button is for some reason coded differently than all the other ones, and the way it has been done causes the button to stay full size all the time; it cannot collapse currently like all the others.

### Description
I copied the code from the other buttons and only adjusted it to the text exercises.

### Steps for Testing
1. Check the code
2. Check that text exercise import in an exam still works (you need to be instructor and have access to an exam and text exercises)
3. Check that the layout problem show in the screenshot below is gone.

### Screenshots

- **Before:**
  ![image](https://user-images.githubusercontent.com/11130248/94511467-b3dd6100-0219-11eb-8078-9a8c76927da8.png)
- **After:**
  ![image](https://user-images.githubusercontent.com/11130248/94511510-d8d1d400-0219-11eb-8853-6623ffe5e04e.png)

