### PR TITLE
[Bugfix] Course exercise dashboard crashes when programming exercise has no result 

### DIFF
--- a/src/main/webapp/app/shared/util/utils.ts
+++ b/src/main/webapp/app/shared/util/utils.ts
@@ -81,5 +81,5 @@ export const round = (value: any, exp: number) => {
  * @param results
  */
 export const findLatestResult = (results?: Result[]) => {
-    return results?.reduce((current, result) => (current.id! > result.id! ? current : result));
+    return results?.length ? results.reduce((current, result) => (current.id! > result.id! ? current : result)) : undefined;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Fixes https://github.com/ls1intum/Artemis/issues/2146

### Description
Only attempt to call `reduce` when the result array has at least one entry.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a programming exercise with due date
2. Participate in the exercise.
3. Submit a result after the due date
4. Open the course exercise dashboard
--> Dashboard should not crash
