### PR TITLE
Fix the Quiz Exercise Re-evaluate Integration Test

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/AbstractAuditingEntity.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/AbstractAuditingEntity.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.Instant;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -19,14 +17,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class AbstractAuditingEntity implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public abstract class AbstractAuditingEntity extends DomainObject {
 
     @CreatedBy
     @Column(name = "created_by", nullable = false, length = 50, updatable = false)
@@ -47,14 +38,6 @@ public abstract class AbstractAuditingEntity implements Serializable {
     @Column(name = "last_modified_date")
     @JsonIgnore
     private Instant lastModifiedDate = Instant.now();
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getCreatedBy() {
         return createdBy;
@@ -86,25 +69,5 @@ public abstract class AbstractAuditingEntity implements Serializable {
 
     public void setLastModifiedDate(Instant lastModifiedDate) {
         this.lastModifiedDate = lastModifiedDate;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        AbstractAuditingEntity entity = (AbstractAuditingEntity) o;
-        if (entity.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), entity.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/AbstractAuditingEntity.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/AbstractAuditingEntity.java
@@ -2,10 +2,9 @@ package de.tum.in.www1.artemis.domain;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Objects;
 
-import javax.persistence.Column;
-import javax.persistence.EntityListeners;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -23,6 +22,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public abstract class AbstractAuditingEntity implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @CreatedBy
     @Column(name = "created_by", nullable = false, length = 50, updatable = false)
@@ -43,6 +47,14 @@ public abstract class AbstractAuditingEntity implements Serializable {
     @Column(name = "last_modified_date")
     @JsonIgnore
     private Instant lastModifiedDate = Instant.now();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
 
     public String getCreatedBy() {
         return createdBy;
@@ -74,5 +86,25 @@ public abstract class AbstractAuditingEntity implements Serializable {
 
     public void setLastModifiedDate(Instant lastModifiedDate) {
         this.lastModifiedDate = lastModifiedDate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AbstractAuditingEntity entity = (AbstractAuditingEntity) o;
+        if (entity.getId() == null || getId() == null) {
+            return false;
+        }
+        return Objects.equals(getId(), entity.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
@@ -2,7 +2,6 @@ package de.tum.in.www1.artemis.domain;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -24,19 +23,13 @@ import de.tum.in.www1.artemis.service.FileService;
 @Table(name = "attachment")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class Attachment implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class Attachment extends DomainObject implements Serializable {
 
     @Transient
     private transient FileService fileService = new FileService();
 
     @Transient
     private String prevLink;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @Column(name = "name")
     private String name;
@@ -128,14 +121,6 @@ public class Attachment implements Serializable {
             // delete old file if necessary
             fileService.manageFilesForUpdatedFilePath(prevLink, null, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(), true);
         }
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getName() {
@@ -240,27 +225,6 @@ public class Attachment implements Serializable {
 
     public void setLecture(Lecture lecture) {
         this.lecture = lecture;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Attachment attachment = (Attachment) o;
-        if (attachment.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), attachment.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/Authority.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Authority.java
@@ -21,7 +21,6 @@ import de.tum.in.www1.artemis.security.AuthoritiesConstants;
 @Entity
 @Table(name = "jhi_authority")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-
 public class Authority implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/de/tum/in/www1/artemis/domain/BuildLogEntry.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/BuildLogEntry.java
@@ -67,4 +67,9 @@ public class BuildLogEntry extends DomainObject {
     public void setProgrammingSubmission(ProgrammingSubmission programmingSubmission) {
         this.programmingSubmission = programmingSubmission;
     }
+
+    @Override
+    public String toString() {
+        return "BuildLogEntry{" + "time=" + time + ", log='" + log + '\'' + '}';
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/BuildLogEntry.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/BuildLogEntry.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -18,11 +17,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @Table(name = "build_log_entry")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class BuildLogEntry {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class BuildLogEntry extends DomainObject {
 
     @Column(name = "time")
     private ZonedDateTime time;
@@ -49,14 +44,6 @@ public class BuildLogEntry {
         this.programmingSubmission = programmingSubmission;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public ZonedDateTime getTime() {
         return time;
     }
@@ -79,33 +66,5 @@ public class BuildLogEntry {
 
     public void setProgrammingSubmission(ProgrammingSubmission programmingSubmission) {
         this.programmingSubmission = programmingSubmission;
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-        if (object == null || getClass() != object.getClass()) {
-            return false;
-        }
-        BuildLogEntry that = (BuildLogEntry) object;
-        if (id != null && that.id != null) {
-            return Objects.equals(id, that.id);
-        }
-        else if (time != null && that.time != null) {
-            return Objects.equals(time.toInstant(), that.time.toInstant()) && Objects.equals(log, that.log);
-        }
-        else if (time == null && that.time == null) {
-            return Objects.equals(log, that.log);
-        }
-        else {
-            return false;
-        }
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/BuildLogEntry.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/BuildLogEntry.java
@@ -106,6 +106,6 @@ public class BuildLogEntry {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, time, log);
+        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/Complaint.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Complaint.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 import java.util.Optional;
 
 import javax.persistence.*;
@@ -24,13 +22,7 @@ import de.tum.in.www1.artemis.domain.participation.Participant;
 @Table(name = "complaint")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class Complaint implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Complaint extends DomainObject {
 
     @Column(name = "complaint_text")
     @Size(max = 2000)
@@ -59,15 +51,6 @@ public class Complaint implements Serializable {
 
     @ManyToOne
     private Team team;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getComplaintText() {
         return complaintText;
@@ -192,26 +175,6 @@ public class Complaint implements Serializable {
      */
     public void filterSensitiveInformation() {
         setParticipant(null);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Complaint complaint = (Complaint) o;
-        if (complaint.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), complaint.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/ComplaintResponse.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ComplaintResponse.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
@@ -19,13 +17,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @Table(name = "complaint_response")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ComplaintResponse implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class ComplaintResponse extends DomainObject {
 
     @Column(name = "response_text")
     @Size(max = 2000)
@@ -40,15 +32,6 @@ public class ComplaintResponse implements Serializable {
 
     @ManyToOne
     private User reviewer;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getResponseText() {
         return responseText;
@@ -100,27 +83,6 @@ public class ComplaintResponse implements Serializable {
 
     public void setReviewer(User user) {
         this.reviewer = user;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ComplaintResponse complaintResponse = (ComplaintResponse) o;
-        if (complaintResponse.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), complaintResponse.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/Course.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Course.java
@@ -2,10 +2,8 @@ package de.tum.in.www1.artemis.domain;
 
 import static de.tum.in.www1.artemis.config.Constants.ARTEMIS_GROUP_DEFAULT_PREFIX;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -31,20 +29,13 @@ import de.tum.in.www1.artemis.service.FileService;
 @Table(name = "course")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class Course implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class Course extends DomainObject {
 
     @Transient
     private transient FileService fileService = new FileService();
 
     @Transient
     private String prevCourseIcon;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
 
     @Column(name = "title")
     @JsonView(QuizView.Before.class)
@@ -139,15 +130,6 @@ public class Course implements Serializable {
 
     @Transient
     private Long numberOfStudentsTransient;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -534,26 +516,6 @@ public class Course implements Serializable {
     public void onDelete() {
         // delete old file if necessary
         fileService.manageFilesForUpdatedFilePath(prevCourseIcon, null, FilePathService.getCourseIconFilepath(), getId());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Course course = (Course) o;
-        if (course.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), course.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/DomainObject.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/DomainObject.java
@@ -1,0 +1,57 @@
+package de.tum.in.www1.artemis.domain;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.persistence.*;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import de.tum.in.www1.artemis.domain.view.QuizView;
+
+/**
+ * Base abstract class for entities which have an id that is generated automatically (basically all domain objects).
+ */
+@MappedSuperclass
+public abstract class DomainObject implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @JsonView(QuizView.Before.class)
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * this methods checks for database equality based on the id
+     * @param o another object
+     * @return whether this and the other object are equal based on the database id
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DomainObject domainObject = (DomainObject) o;
+        if (domainObject.getId() == null || getId() == null) {
+            return false;
+        }
+        return Objects.equals(getId(), domainObject.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/domain/ExampleSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ExampleSubmission.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -19,13 +17,7 @@ import de.tum.in.www1.artemis.domain.participation.TutorParticipation;
 @Entity
 @Table(name = "example_submission")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class ExampleSubmission implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class ExampleSubmission extends DomainObject {
 
     @Column(name = "used_for_tutorial")
     private Boolean usedForTutorial;
@@ -44,15 +36,6 @@ public class ExampleSubmission implements Serializable {
 
     @Column(name = "assessment_explanation")
     private String assessmentExplanation;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Boolean isUsedForTutorial() {
         return usedForTutorial;
@@ -129,28 +112,6 @@ public class ExampleSubmission implements Serializable {
 
     public void setAssessmentExplanation(String assessmentExplanation) {
         this.assessmentExplanation = assessmentExplanation;
-    }
-
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ExampleSubmission exampleSubmission = (ExampleSubmission) o;
-        if (exampleSubmission.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), exampleSubmission.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -44,14 +43,7 @@ import de.tum.in.www1.artemis.web.rest.dto.DueDateStat;
         @JsonSubTypes.Type(value = QuizExercise.class, name = "quiz"), @JsonSubTypes.Type(value = TextExercise.class, name = "text"),
         @JsonSubTypes.Type(value = FileUploadExercise.class, name = "file-upload"), })
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public abstract class Exercise implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public abstract class Exercise extends DomainObject {
 
     @Column(name = "title")
     @JsonView(QuizView.Before.class)
@@ -186,15 +178,6 @@ public abstract class Exercise implements Serializable {
 
     @Transient
     private boolean studentAssignedTeamIdComputedTransient = false; // set to true if studentAssignedTeamIdTransient was computed for the exercise
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -764,26 +747,6 @@ public abstract class Exercise implements Serializable {
             }
         }
         return null;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Exercise exercise = (Exercise) o;
-        if (exercise.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), exercise.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/ExerciseHint.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ExerciseHint.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -16,13 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Entity
 @Table(name = "exercise_hint")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class ExerciseHint implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class ExerciseHint extends DomainObject {
 
     @Column(name = "title")
     private String title;
@@ -33,15 +24,6 @@ public class ExerciseHint implements Serializable {
     @ManyToOne
     @JsonIgnoreProperties("exerciseHints")
     private Exercise exercise;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -80,23 +62,6 @@ public class ExerciseHint implements Serializable {
 
     public void setExercise(Exercise exercise) {
         this.exercise = exercise;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof ExerciseHint)) {
-            return false;
-        }
-        return id != null && id.equals(((ExerciseHint) o).id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/Feedback.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Feedback.java
@@ -1,9 +1,7 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.persistence.*;
 import javax.validation.constraints.Size;
@@ -23,17 +21,11 @@ import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
 @Table(name = "feedback")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class Feedback implements Serializable {
+public class Feedback extends DomainObject {
 
     public static final int MAX_REFERENCE_LENGTH = 2000;
 
-    private static final long serialVersionUID = 1L;
-
     public static final String STATIC_CODE_ANALYSIS_FEEDBACK_IDENTIFIER = "SCAFeedbackIdentifier:";
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @Size(max = 500)
     @Column(name = "text")
@@ -76,15 +68,6 @@ public class Feedback implements Serializable {
 
     @OneToMany(mappedBy = "secondFeedback", orphanRemoval = true)
     private List<FeedbackConflict> secondConflicts = new ArrayList<>();
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getText() {
         return text;
@@ -243,28 +226,8 @@ public class Feedback implements Serializable {
         return this.text != null && this.text.startsWith(STATIC_CODE_ANALYSIS_FEEDBACK_IDENTIFIER) && this.type == FeedbackType.AUTOMATIC;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Feedback feedback = (Feedback) o;
-        if (feedback.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), feedback.getId());
-    }
-
     public boolean referenceEquals(Feedback otherFeedback) {
         return reference.equals(otherFeedback.reference);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/FeedbackConflict.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FeedbackConflict.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 
 import javax.persistence.*;
@@ -12,13 +11,7 @@ import de.tum.in.www1.artemis.domain.enumeration.FeedbackConflictType;
  */
 @Entity
 @Table(name = "feedback_conflict")
-public class FeedbackConflict implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class FeedbackConflict extends DomainObject {
 
     @Column(name = "conflict", nullable = false)
     private Boolean conflict;
@@ -40,14 +33,6 @@ public class FeedbackConflict implements Serializable {
     @ManyToOne(optional = false)
     @JoinColumn(name = "second_feedback_id", referencedColumnName = "id")
     private Feedback secondFeedback;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Boolean getConflict() {
         return conflict;

--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadExercise.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
@@ -11,7 +10,6 @@ import javax.persistence.Lob;
 /**
  * A FileUploadExercise.
  */
-
 @Entity
 @DiscriminatorValue(value = "F")
 public class FileUploadExercise extends Exercise implements Serializable {
@@ -22,8 +20,6 @@ public class FileUploadExercise extends Exercise implements Serializable {
 
     @Column(name = "filePattern")
     private String filePattern;
-
-    // jhipster-needle-entity-add-field - Jhipster will add fields here, do not remove
 
     public String getFilePattern() {
         return filePattern;
@@ -49,26 +45,6 @@ public class FileUploadExercise extends Exercise implements Serializable {
 
     public void setSampleSolution(String sampleSolution) {
         this.sampleSolution = sampleSolution;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        FileUploadExercise fileUploadExercise = (FileUploadExercise) o;
-        if (fileUploadExercise.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), fileUploadExercise.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadExercise.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -12,7 +10,7 @@ import javax.persistence.Lob;
  */
 @Entity
 @DiscriminatorValue(value = "F")
-public class FileUploadExercise extends Exercise implements Serializable {
+public class FileUploadExercise extends Exercise {
 
     @Column(name = "sample_solution")
     @Lob

--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-
 import javax.persistence.*;
 
 import org.apache.commons.lang3.math.NumberUtils;
@@ -15,9 +13,7 @@ import de.tum.in.www1.artemis.service.FileService;
  */
 @Entity
 @DiscriminatorValue(value = "F")
-public class FileUploadSubmission extends Submission implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class FileUploadSubmission extends Submission {
 
     @Transient
     private transient FileService fileService = new FileService();

--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -25,8 +24,6 @@ public class FileUploadSubmission extends Submission implements Serializable {
 
     @Column(name = "file_path")
     private String filePath;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
 
     /**
      * Deletes solution file for this submission
@@ -66,27 +63,6 @@ public class FileUploadSubmission extends Submission implements Serializable {
 
     public void setFilePath(String filePath) {
         this.filePath = filePath;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        FileUploadSubmission fileUploadSubmission = (FileUploadSubmission) o;
-        if (fileUploadSubmission.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), fileUploadSubmission.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/GradingCriterion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/GradingCriterion.java
@@ -1,9 +1,7 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -18,11 +16,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Entity
 @Table(name = "grading_criterion")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class GradingCriterion implements Serializable {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class GradingCriterion extends DomainObject {
 
     @OneToMany(mappedBy = "gradingCriterion", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JsonIgnoreProperties(value = "gradingCriterion", allowSetters = true)
@@ -34,15 +28,6 @@ public class GradingCriterion implements Serializable {
 
     @Column(name = "title")
     private String title;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -101,26 +86,6 @@ public class GradingCriterion implements Serializable {
 
     public void setExercise(Exercise exercise) {
         this.exercise = exercise;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        GradingCriterion gradingCriterion = (GradingCriterion) o;
-        if (gradingCriterion.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), gradingCriterion.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/GradingInstruction.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/GradingInstruction.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -18,11 +16,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Entity
 @Table(name = "grading_instruction")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class GradingInstruction implements Serializable {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class GradingInstruction extends DomainObject {
 
     // the score students get if this grading instruction is applicable
     @Column(name = "credits")
@@ -52,15 +46,6 @@ public class GradingInstruction implements Serializable {
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties(value = "gradingInstruction", allowSetters = true)
     private Set<Feedback> feedbacks = new HashSet<>();
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public double getCredits() {
         return credits;
@@ -162,28 +147,6 @@ public class GradingInstruction implements Serializable {
 
     public void setFeedbacks(Set<Feedback> feedbacks) {
         this.feedbacks = feedbacks;
-    }
-
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        GradingInstruction gradingInstruction = (GradingInstruction) o;
-        if (gradingInstruction.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), gradingInstruction.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/GuidedTourSetting.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/GuidedTourSetting.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -14,17 +12,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @Table(name = "guided_tour_setting")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class GuidedTourSetting implements Serializable {
+public class GuidedTourSetting extends DomainObject {
 
     public enum Status {
         STARTED, FINISHED
     }
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @Column(name = "guided_tour_key")
     private String guidedTourKey;
@@ -38,14 +30,6 @@ public class GuidedTourSetting implements Serializable {
     @ManyToOne
     @JsonIgnore
     private User user;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getGuidedTourKey() {
         return guidedTourKey;
@@ -91,7 +75,7 @@ public class GuidedTourSetting implements Serializable {
 
     @Override
     public String toString() {
-        return "GuidedTourSetting{" + "id=" + id + ", guidedTourKey='" + guidedTourKey + '\'' + ", guidedTourStep=" + guidedTourStep + ", guidedTourState=" + guidedTourState
+        return "GuidedTourSetting{" + "id=" + getId() + ", guidedTourKey='" + guidedTourKey + '\'' + ", guidedTourStep=" + guidedTourStep + ", guidedTourState=" + guidedTourState
                 + ", user=" + user + '}';
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/Lecture.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Lecture.java
@@ -1,9 +1,7 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -21,13 +19,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @Table(name = "lecture")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class Lecture implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Lecture extends DomainObject {
 
     @Column(name = "title")
     private String title;
@@ -54,15 +46,6 @@ public class Lecture implements Serializable {
     @ManyToOne
     @JsonIgnoreProperties("lectures")
     private Course course;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -177,27 +160,6 @@ public class Lecture implements Serializable {
 
     public void setCourse(Course course) {
         this.course = course;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Lecture lecture = (Lecture) o;
-        if (lecture.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), lecture.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/LtiOutcomeUrl.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/LtiOutcomeUrl.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -14,13 +11,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @Entity
 @Table(name = "lti_outcome_url")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class LtiOutcomeUrl implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class LtiOutcomeUrl extends DomainObject {
 
     @Column(name = "url")
     private String url;
@@ -33,14 +24,6 @@ public class LtiOutcomeUrl implements Serializable {
 
     @ManyToOne
     private Exercise exercise;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getUrl() {
         return url;
@@ -75,27 +58,7 @@ public class LtiOutcomeUrl implements Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        LtiOutcomeUrl ltiOutcomeUrl = (LtiOutcomeUrl) o;
-        if (ltiOutcomeUrl.id == null || id == null) {
-            return false;
-        }
-        return Objects.equals(id, ltiOutcomeUrl.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(id);
-    }
-
-    @Override
     public String toString() {
-        return "LtiOutcomeUrl{" + "id=" + id + ", url='" + url + "'" + ", sourcedId='" + sourcedId + "'" + '}';
+        return "LtiOutcomeUrl{" + "id=" + getId() + ", url='" + url + "'" + ", sourcedId='" + sourcedId + "'" + '}';
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/LtiUserId.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/LtiUserId.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -14,13 +11,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 @Entity
 @Table(name = "lti_user_id")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class LtiUserId implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class LtiUserId extends DomainObject {
 
     @Column(name = "lti_user_id")
     private String ltiUserId;
@@ -28,15 +19,6 @@ public class LtiUserId implements Serializable {
     @OneToOne
     @JoinColumn(unique = true)
     private User user;
-
-    // jhipster-needle-entity-add-field - Jhipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getLtiUserId() {
         return ltiUserId;
@@ -62,27 +44,6 @@ public class LtiUserId implements Serializable {
 
     public void setUser(User user) {
         this.user = user;
-    }
-    // jhipster-needle-entity-add-getters-setters - Jhipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        LtiUserId ltiUserId = (LtiUserId) o;
-        if (ltiUserId.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), ltiUserId.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/PersistentAuditEvent.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/PersistentAuditEvent.java
@@ -1,10 +1,8 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -16,14 +14,7 @@ import javax.validation.constraints.NotNull;
  */
 @Entity
 @Table(name = "jhi_persistent_audit_event")
-public class PersistentAuditEvent implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "event_id")
-    private Long id;
+public class PersistentAuditEvent extends DomainObject {
 
     @NotNull
     @Column(nullable = false)
@@ -40,14 +31,6 @@ public class PersistentAuditEvent implements Serializable {
     @Column(name = "value")
     @CollectionTable(name = "jhi_persistent_audit_evt_data", joinColumns = @JoinColumn(name = "event_id"))
     private Map<String, String> data = new HashMap<>();
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getPrincipal() {
         return principal;
@@ -79,24 +62,6 @@ public class PersistentAuditEvent implements Serializable {
 
     public void setData(Map<String, String> data) {
         this.data = data;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        PersistentAuditEvent persistentAuditEvent = (PersistentAuditEvent) o;
-        return !(persistentAuditEvent.getId() == null || getId() == null) && Objects.equals(getId(), persistentAuditEvent.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
@@ -5,7 +5,6 @@ import java.net.URL;
 import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -518,26 +517,6 @@ public class ProgrammingExercise extends Exercise {
         // Only allow manual results for programming exercises if option was enabled and due dates have passed;
         final var relevantDueDate = getBuildAndTestStudentSubmissionsAfterDueDate() != null ? getBuildAndTestStudentSubmissionsAfterDueDate() : getDueDate();
         return getAssessmentType() == AssessmentType.SEMI_AUTOMATIC && (relevantDueDate == null || relevantDueDate.isBefore(ZonedDateTime.now()));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ProgrammingExercise programmingExercise = (ProgrammingExercise) o;
-        if (programmingExercise.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), programmingExercise.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
@@ -37,8 +37,6 @@ public class ProgrammingExercise extends Exercise {
 
     private static final Logger log = LoggerFactory.getLogger(ProgrammingExercise.class);
 
-    private static final long serialVersionUID = 1L;
-
     @Column(name = "test_repository_url")
     private String testRepositoryUrl;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.annotation.Nonnull;
 import javax.persistence.*;
 
@@ -17,13 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @Entity
 @Table(name = "programming_exercise_test_case")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class ProgrammingExerciseTestCase implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class ProgrammingExerciseTestCase extends DomainObject {
 
     @Column(name = "test_name")
     private String testName;
@@ -47,16 +38,8 @@ public class ProgrammingExerciseTestCase implements Serializable {
     @JsonIgnoreProperties("programmingExerciseTestCase")
     private ProgrammingExercise exercise;
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public ProgrammingExerciseTestCase id(Long id) {
-        this.id = id;
+        setId(id);
         return this;
     }
 
@@ -169,26 +152,6 @@ public class ProgrammingExerciseTestCase implements Serializable {
     }
 
     /**
-     * this methods checks for database equality based on the id
-     * @param o another object
-     * @return whether this and the other object are equal based on the database id
-     */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ProgrammingExerciseTestCase testCase = (ProgrammingExerciseTestCase) o;
-        if (testCase.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), exercise.getId());
-    }
-
-    /**
      * this methods checks for logical equality based on the name and the exercise
      * @param testCase another test case which should be checked for being the same
      * @return whether this and the other test case are the same based on name and exercise
@@ -198,13 +161,8 @@ public class ProgrammingExerciseTestCase implements Serializable {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
-    }
-
-    @Override
     public String toString() {
-        return "ProgrammingExerciseTestCase{" + "id=" + id + ", testName='" + testName + '\'' + ", weight=" + weight + ", active=" + active + ", afterDueDate=" + afterDueDate
+        return "ProgrammingExerciseTestCase{" + "id=" + getId() + ", testName='" + testName + '\'' + ", weight=" + weight + ", active=" + active + ", afterDueDate=" + afterDueDate
                 + ", bonusMultiplier=" + bonusMultiplier + ", bonusPoints=" + bonusPoints + '}';
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
@@ -191,7 +191,7 @@ public class ProgrammingExerciseTestCase implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(testName) + Objects.hashCode(getExercise().getId());
+        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
@@ -179,14 +179,11 @@ public class ProgrammingExerciseTestCase implements Serializable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ProgrammingExerciseTestCase programmingExerciseTestCase = (ProgrammingExerciseTestCase) o;
-        if (programmingExerciseTestCase.getTestName().equals(this.getTestName()) && this.getExercise().getId().equals(programmingExerciseTestCase.getExercise().getId())) {
-            return true;
-        }
-        if (getId() == null && programmingExerciseTestCase.getId() == null) {
+        ProgrammingExerciseTestCase testCase = (ProgrammingExerciseTestCase) o;
+        if (testCase.getId() == null || getId() == null) {
             return false;
         }
-        return Objects.equals(getId(), programmingExerciseTestCase.getId());
+        return Objects.equals(getId(), exercise.getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
@@ -47,7 +47,6 @@ public class ProgrammingExerciseTestCase implements Serializable {
     @JsonIgnoreProperties("programmingExerciseTestCase")
     private ProgrammingExercise exercise;
 
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
     public Long getId() {
         return id;
     }
@@ -157,8 +156,6 @@ public class ProgrammingExerciseTestCase implements Serializable {
         return this;
     }
 
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
     /**
      * This method needs to be checked and updated if there is a new class attribute. Creates a clone with all attributes set to the value of the object, including the id.
      *
@@ -171,6 +168,11 @@ public class ProgrammingExerciseTestCase implements Serializable {
         return clone;
     }
 
+    /**
+     * this methods checks for database equality based on the id
+     * @param o another object
+     * @return whether this and the other object are equal based on the database id
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -184,6 +186,15 @@ public class ProgrammingExerciseTestCase implements Serializable {
             return false;
         }
         return Objects.equals(getId(), exercise.getId());
+    }
+
+    /**
+     * this methods checks for logical equality based on the name and the exercise
+     * @param testCase another test case which should be checked for being the same
+     * @return whether this and the other test case are the same based on name and exercise
+     */
+    public boolean isSameTestCase(ProgrammingExerciseTestCase testCase) {
+        return testCase.getTestName().equals(this.getTestName()) && this.getExercise().getId().equals(testCase.getExercise().getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis.domain;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -37,8 +36,6 @@ public class ProgrammingSubmission extends Submission implements Serializable {
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<BuildLogEntry> buildLogEntries = new ArrayList<>();
 
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-
     public String getCommitHash() {
         return commitHash;
     }
@@ -51,7 +48,6 @@ public class ProgrammingSubmission extends Submission implements Serializable {
     public void setCommitHash(String commitHash) {
         this.commitHash = commitHash;
     }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
 
     public boolean isBuildFailed() {
         return buildFailed;
@@ -75,23 +71,6 @@ public class ProgrammingSubmission extends Submission implements Serializable {
 
     public void setBuildLogEntries(List<BuildLogEntry> buildLogEntries) {
         this.buildLogEntries = buildLogEntries;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (!(o instanceof ProgrammingSubmission))
-            return false;
-        if (!super.equals(o))
-            return false;
-        ProgrammingSubmission that = (ProgrammingSubmission) o;
-        return buildFailed == that.buildFailed && buildArtifact == that.buildArtifact && Objects.equals(commitHash, that.commitHash);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,9 +15,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @Entity
 @DiscriminatorValue(value = "P")
-public class ProgrammingSubmission extends Submission implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class ProgrammingSubmission extends Submission {
 
     @Column(name = "commit_hash")
     private String commitHash;

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
@@ -91,7 +91,7 @@ public class ProgrammingSubmission extends Submission implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), commitHash, buildFailed, buildArtifact);
+        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/Rating.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Rating.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -14,11 +11,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 @Entity
 @Table(name = "result_rating")
 @JsonInclude(Include.NON_EMPTY)
-public class Rating implements Serializable {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Rating extends DomainObject {
 
     @Column(name = "rating")
     private Integer rating;
@@ -26,14 +19,6 @@ public class Rating implements Serializable {
     @OneToOne
     @JoinColumn(name = "result_id")
     private Result result;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Integer getRating() {
         return rating;
@@ -49,11 +34,6 @@ public class Rating implements Serializable {
 
     public void setResult(Result result) {
         this.result = result;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/Result.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Result.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -35,14 +34,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Table(name = "result")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class Result implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public class Result extends DomainObject {
 
     @Column(name = "result_string")
     @JsonView(QuizView.After.class)
@@ -114,15 +106,6 @@ public class Result implements Serializable {
 
     @Column(name = "example_result")
     private Boolean exampleResult;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getResultString() {
         return resultString;
@@ -486,28 +469,8 @@ public class Result implements Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Result result = (Result) o;
-        if (result.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), result.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
-    }
-
-    @Override
     public String toString() {
-        return "Result{" + "id=" + id + ", resultString='" + resultString + '\'' + ", completionDate=" + completionDate + ", successful=" + successful + ", score=" + score
+        return "Result{" + "id=" + getId() + ", resultString='" + resultString + '\'' + ", completionDate=" + completionDate + ", successful=" + successful + ", score=" + score
                 + ", rated=" + rated + ", hasFeedback=" + hasFeedback + ", assessmentType=" + assessmentType + ", hasComplaint=" + hasComplaint + '}';
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/StaticCodeAnalysisCategory.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/StaticCodeAnalysisCategory.java
@@ -1,16 +1,10 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
@@ -28,13 +22,7 @@ import de.tum.in.www1.artemis.domain.enumeration.CategoryState;
 @Table(name = "static_code_analysis_category")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class StaticCodeAnalysisCategory implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class StaticCodeAnalysisCategory extends DomainObject {
 
     @Column(name = "name")
     private String name;
@@ -52,14 +40,6 @@ public class StaticCodeAnalysisCategory implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnoreProperties("staticCodeAnalysisCategories")
     private ProgrammingExercise exercise;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getName() {
         return name;
@@ -102,24 +82,7 @@ public class StaticCodeAnalysisCategory implements Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        StaticCodeAnalysisCategory that = (StaticCodeAnalysisCategory) o;
-        return Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id);
-    }
-
-    @Override
     public String toString() {
-        return "StaticCodeAnalysisCategory{" + "id=" + id + ", name='" + name + '\'' + ", penalty=" + penalty + ", maxPenalty=" + maxPenalty + ", state=" + state + '}';
+        return "StaticCodeAnalysisCategory{" + "id=" + getId() + ", name='" + name + '\'' + ", penalty=" + penalty + ", maxPenalty=" + maxPenalty + ", state=" + state + '}';
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/StudentQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/StudentQuestion.java
@@ -1,9 +1,7 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -22,13 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @Table(name = "student_question")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class StudentQuestion implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class StudentQuestion extends DomainObject {
 
     @Size(max = 1000)
     @Column(name = "question_text")
@@ -57,15 +49,6 @@ public class StudentQuestion implements Serializable {
     @ManyToOne
     @JsonIgnoreProperties("studentQuestions")
     private Lecture lecture;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getQuestionText() {
         return questionText;
@@ -196,26 +179,6 @@ public class StudentQuestion implements Serializable {
             return getExercise().getCourseViaExerciseGroupOrCourseMember();
         }
         return null;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        StudentQuestion studentQuestion = (StudentQuestion) o;
-        if (studentQuestion.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), studentQuestion.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/StudentQuestionAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/StudentQuestionAnswer.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -19,13 +17,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @Table(name = "student_question_answer")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class StudentQuestionAnswer implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class StudentQuestionAnswer extends DomainObject {
 
     @Lob
     @Column(name = "answer_text")
@@ -47,15 +39,6 @@ public class StudentQuestionAnswer implements Serializable {
     @ManyToOne
     @JsonIgnoreProperties("answers")
     private StudentQuestion question;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getAnswerText() {
         return answerText;
@@ -133,27 +116,6 @@ public class StudentQuestionAnswer implements Serializable {
 
     public void setQuestion(StudentQuestion studentQuestion) {
         this.question = studentQuestion;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        StudentQuestionAnswer studentQuestionAnswer = (StudentQuestionAnswer) o;
-        if (studentQuestionAnswer.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), studentQuestionAnswer.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
@@ -1,11 +1,9 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -39,14 +37,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
         @JsonSubTypes.Type(value = QuizSubmission.class, name = "quiz"), @JsonSubTypes.Type(value = TextSubmission.class, name = "text"),
         @JsonSubTypes.Type(value = FileUploadSubmission.class, name = "file-upload"), })
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public abstract class Submission implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public abstract class Submission extends DomainObject {
 
     @Column(name = "submitted")
     @JsonView(QuizView.Before.class)
@@ -133,14 +124,6 @@ public abstract class Submission implements Serializable {
         this.submissionDate = submissionDate;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public Boolean isSubmitted() {
         return submitted != null ? submitted : false;
     }
@@ -191,26 +174,6 @@ public abstract class Submission implements Serializable {
 
     public void setExampleSubmission(Boolean exampleSubmission) {
         this.exampleSubmission = exampleSubmission;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Submission submission = (Submission) o;
-        if (submission.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), submission.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/SubmissionVersion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/SubmissionVersion.java
@@ -14,11 +14,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "submission_version")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @EntityListeners(AuditingEntityListener.class)
-public class SubmissionVersion {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class SubmissionVersion extends DomainObject {
 
     @ManyToOne
     private Submission submission;
@@ -38,19 +34,6 @@ public class SubmissionVersion {
     @LastModifiedDate
     @Column(name = "last_modified_date")
     private Instant lastModifiedDate = Instant.now();
-
-    public Long getId() {
-        return id;
-    }
-
-    public SubmissionVersion id(Long id) {
-        this.id = id;
-        return this;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Submission getSubmission() {
         return submission;

--- a/src/main/java/de/tum/in/www1/artemis/domain/Team.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Team.java
@@ -1,9 +1,7 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -24,13 +22,7 @@ import de.tum.in.www1.artemis.domain.participation.Participant;
 @Table(name = "team", uniqueConstraints = { @UniqueConstraint(columnNames = { "exercise_id", "short_name" }) })
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class Team extends AbstractAuditingEntity implements Serializable, Participant {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Team extends AbstractAuditingEntity implements Participant {
 
     @Column(name = "name")
     private String name;
@@ -74,18 +66,9 @@ public class Team extends AbstractAuditingEntity implements Serializable, Partic
         this.owner = team.owner;
     }
 
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
     public Team id(Long id) {
-        this.id = id;
+        this.setId(id);
         return this;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getName() {
@@ -221,26 +204,6 @@ public class Team extends AbstractAuditingEntity implements Serializable, Partic
             student.setLangKey(null);
             student.setLastNotificationRead(null);
         });
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Team team = (Team) o;
-        if (team.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), team.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/TeamAssignmentConfig.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TeamAssignmentConfig.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -18,13 +15,7 @@ import de.tum.in.www1.artemis.validation.constraints.TeamAssignmentConfigConstra
 @Table(name = "team_assignment_config")
 @TeamAssignmentConfigConstraints
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class TeamAssignmentConfig implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class TeamAssignmentConfig extends DomainObject {
 
     @OneToOne(mappedBy = "teamAssignmentConfig", fetch = FetchType.LAZY, optional = false)
     @JsonIgnoreProperties("teamAssignmentConfig")
@@ -38,14 +29,6 @@ public class TeamAssignmentConfig implements Serializable {
     @Min(1)
     @Column(name = "max_team_size")
     private Integer maxTeamSize;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Exercise getExercise() {
         return exercise;
@@ -84,26 +67,6 @@ public class TeamAssignmentConfig implements Serializable {
 
     public void setMaxTeamSize(Integer maxTeamSize) {
         this.maxTeamSize = maxTeamSize;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        TeamAssignmentConfig team = (TeamAssignmentConfig) o;
-        if (team.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), team.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/TempIdObject.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TempIdObject.java
@@ -1,0 +1,43 @@
+package de.tum.in.www1.artemis.domain;
+
+import java.util.Objects;
+
+import javax.persistence.Transient;
+
+public abstract class TempIdObject extends DomainObject {
+
+    /**
+     * tempID is needed to refer to objects that have not been persisted yet (so user can create and connect those in the UI before saving them)
+     */
+    @Transient
+    // variable name must be different from Getter name, so that Jackson ignores the @Transient annotation, but Hibernate still respects it
+    private Long tempIDTransient;
+
+    public Long getTempID() {
+        return tempIDTransient;
+    }
+
+    public void setTempID(Long tempID) {
+        this.tempIDTransient = tempID;
+    }
+
+    /**
+     * checks the tempId first and then the database id
+     * @param o another object
+     * @return true when the tempIds are equal or the ids are equal
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TempIdObject tempIdObject = (TempIdObject) o;
+        if (tempIdObject.getTempID() != null && getTempID() != null && Objects.equals(getTempID(), tempIdObject.getTempID())) {
+            return true;
+        }
+        return super.equals(o);
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/domain/TextCluster.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TextCluster.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis.domain;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -15,13 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @Entity
 @Table(name = "text_cluster")
-public class TextCluster implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class TextCluster extends DomainObject {
 
     @Lob
     @Column(name = "probabilities")
@@ -39,15 +32,6 @@ public class TextCluster implements Serializable {
     @ManyToOne
     @JsonIgnore
     private TextExercise exercise;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public double[] getProbabilities() {
         return castFromBinary(probabilities);
@@ -153,22 +137,6 @@ public class TextCluster implements Serializable {
         for (int i = 0; i < size(); i++) {
             blocks.get(i).setPositionInCluster(i);
         }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof TextCluster)) {
-            return false;
-        }
-        return id != null && id.equals(((TextCluster) o).id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/TextExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TextExercise.java
@@ -2,7 +2,6 @@ package de.tum.in.www1.artemis.domain;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -48,26 +47,6 @@ public class TextExercise extends Exercise implements Serializable {
     public void filterSensitiveInformation() {
         setSampleSolution(null);
         super.filterSensitiveInformation();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        TextExercise textExercise = (TextExercise) o;
-        if (textExercise.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), textExercise.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/TextExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TextExercise.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.util.List;
 
 import javax.persistence.*;
@@ -13,7 +12,7 @@ import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
  */
 @Entity
 @DiscriminatorValue(value = "T")
-public class TextExercise extends Exercise implements Serializable {
+public class TextExercise extends Exercise {
 
     @Column(name = "sample_solution")
     @Lob

--- a/src/main/java/de/tum/in/www1/artemis/domain/TextSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TextSubmission.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,9 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @Entity
 @DiscriminatorValue(value = "T")
-public class TextSubmission extends Submission implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class TextSubmission extends Submission {
 
     private static final int MAX_EXCERPT_LENGTH = 100;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/TextSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TextSubmission.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis.domain;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -28,8 +27,6 @@ public class TextSubmission extends Submission implements Serializable {
     @OneToMany(mappedBy = "submission", cascade = CascadeType.REMOVE)
     @JsonIgnoreProperties("submission")
     private List<TextBlock> blocks = new ArrayList<>();
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
 
     public TextSubmission() {
     }
@@ -92,30 +89,9 @@ public class TextSubmission extends Submission implements Serializable {
     public void setBlocks(List<TextBlock> textBlocks) {
         this.blocks = textBlocks;
     }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
 
     public boolean isEmpty() {
         return text == null || text.isEmpty();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        TextSubmission textSubmission = (TextSubmission) o;
-        if (textSubmission.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), textSubmission.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/TutorGroup.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TutorGroup.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -23,13 +21,7 @@ import de.tum.in.www1.artemis.domain.enumeration.Weekday;
 @Table(name = "tutor_group")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class TutorGroup implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class TutorGroup extends DomainObject {
 
     @Column(name = "name")
     private String name;
@@ -63,15 +55,6 @@ public class TutorGroup implements Serializable {
     @ManyToOne
     @JsonIgnoreProperties("tutorGroups")
     private Course course;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getName() {
         return name;
@@ -198,27 +181,6 @@ public class TutorGroup implements Serializable {
 
     public void setCourse(Course course) {
         this.course = course;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        TutorGroup tutorGroup = (TutorGroup) o;
-        if (tutorGroup.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), tutorGroup.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/User.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/User.java
@@ -1,11 +1,9 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -32,13 +30,7 @@ import de.tum.in.www1.artemis.domain.participation.Participant;
 @Table(name = "jhi_user")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class User extends AbstractAuditingEntity implements Serializable, Participant {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class User extends AbstractAuditingEntity implements Participant {
 
     @NotNull
     @Pattern(regexp = Constants.LOGIN_REGEX)
@@ -119,14 +111,6 @@ public class User extends AbstractAuditingEntity implements Serializable, Partic
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @BatchSize(size = 20)
     private Set<Authority> authorities = new HashSet<>();
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getLogin() {
         return login;
@@ -289,24 +273,6 @@ public class User extends AbstractAuditingEntity implements Serializable, Partic
 
     public void setGuidedTourSettings(Set<GuidedTourSetting> guidedTourSettings) {
         this.guidedTourSettings = guidedTourSettings;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        User user = (User) o;
-        return !(user.getId() == null || getId() == null) && Objects.equals(getId(), user.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.exam;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.*;
 
@@ -13,18 +12,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.in.www1.artemis.domain.Course;
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.User;
 
 @Entity
 @Table(name = "exam")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class Exam implements Serializable {
-
-    @Id
-    @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Exam extends DomainObject {
 
     @Column(name = "title", nullable = false)
     private String title;
@@ -123,14 +118,6 @@ public class Exam implements Serializable {
 
     @Transient
     private Long numberOfRegisteredUsersTransient;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -348,21 +335,6 @@ public class Exam implements Serializable {
 
     public void setNumberOfRegisteredUsers(Long numberOfRegisteredUsers) {
         this.numberOfRegisteredUsersTransient = numberOfRegisteredUsers;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        Exam exam = (Exam) o;
-        return Objects.equals(getId(), exam.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/ExamSession.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/ExamSession.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.exam;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -18,12 +15,7 @@ import inet.ipaddr.IPAddressString;
 @Table(name = "exam_session")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ExamSession extends AbstractAuditingEntity implements Serializable {
-
-    @Id
-    @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class ExamSession extends AbstractAuditingEntity {
 
     @ManyToOne
     @JoinColumn(name = "student_exam_id")
@@ -45,14 +37,6 @@ public class ExamSession extends AbstractAuditingEntity implements Serializable 
     private String ipAddress;
 
     public ExamSession() {
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public StudentExam getStudentExam() {
@@ -110,20 +94,4 @@ public class ExamSession extends AbstractAuditingEntity implements Serializable 
         setInstanceId(null);
         setIpAddress(null);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        ExamSession that = (ExamSession) o;
-        return Objects.equals(getId(), that.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
-    }
-
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/ExerciseGroup.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/ExerciseGroup.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain.exam;
 
-import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -12,18 +10,15 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.Exercise;
 
 @Entity
 @Table(name = "exercise_group")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ExerciseGroup implements Serializable {
-
-    @Id
-    @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class ExerciseGroup extends DomainObject {
 
     @Column(name = "title")
     private String title;
@@ -42,14 +37,6 @@ public class ExerciseGroup implements Serializable {
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties(value = "exerciseGroup", allowSetters = true)
     private Set<Exercise> exercises = new HashSet<>();
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -92,20 +79,4 @@ public class ExerciseGroup implements Serializable {
         this.exercises.remove(exercise);
         return this;
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        ExerciseGroup that = (ExerciseGroup) o;
-        return Objects.equals(getId(), that.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
-    }
-
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/StudentExam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/StudentExam.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.exam;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.*;
 
@@ -21,12 +20,7 @@ import de.tum.in.www1.artemis.domain.User;
 @Table(name = "student_exam")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class StudentExam extends AbstractAuditingEntity implements Serializable {
-
-    @Id
-    @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class StudentExam extends AbstractAuditingEntity {
 
     @Column(name = "submitted")
     private Boolean submitted;
@@ -67,14 +61,6 @@ public class StudentExam extends AbstractAuditingEntity implements Serializable 
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonIgnoreProperties("studentExam")
     private Set<ExamSession> examSessions = new HashSet<>();
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Boolean isSubmitted() {
         return submitted;
@@ -219,20 +205,5 @@ public class StudentExam extends AbstractAuditingEntity implements Serializable 
     @JsonIgnore
     public boolean areResultsPublishedYet() {
         return exam.resultsPublished();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        StudentExam that = (StudentExam) o;
-        return Objects.equals(getId(), that.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/modeling/ApollonDiagram.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/modeling/ApollonDiagram.java
@@ -1,14 +1,13 @@
 package de.tum.in.www1.artemis.domain.modeling;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.enumeration.DiagramType;
 
 /**
@@ -18,13 +17,7 @@ import de.tum.in.www1.artemis.domain.enumeration.DiagramType;
 @Table(name = "apollon_diagram")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ApollonDiagram implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class ApollonDiagram extends DomainObject {
 
     @Column(name = "title")
     private String title;
@@ -39,15 +32,6 @@ public class ApollonDiagram implements Serializable {
 
     @Column(name = "course_id")
     private Long courseId;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -95,26 +79,6 @@ public class ApollonDiagram implements Serializable {
 
     public void setCourseId(Long courseId) {
         this.courseId = courseId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ApollonDiagram apollonDiagram = (ApollonDiagram) o;
-        if (apollonDiagram.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), apollonDiagram.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/modeling/ModelingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/modeling/ModelingExercise.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.domain.modeling;
 
-import java.io.Serializable;
-
 import javax.persistence.*;
 
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -12,9 +10,7 @@ import de.tum.in.www1.artemis.domain.enumeration.DiagramType;
  */
 @Entity
 @DiscriminatorValue(value = "M")
-public class ModelingExercise extends Exercise implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class ModelingExercise extends Exercise {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "diagram_type")

--- a/src/main/java/de/tum/in/www1/artemis/domain/modeling/ModelingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/modeling/ModelingExercise.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.domain.modeling;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -28,8 +27,6 @@ public class ModelingExercise extends Exercise implements Serializable {
     @Column(name = "sample_solution_explanation")
     @Lob
     private String sampleSolutionExplanation;
-
-    // jhipster-needle-entity-add-field - Jhipster will add fields here, do not remove
 
     public DiagramType getDiagramType() {
         return diagramType;
@@ -70,8 +67,6 @@ public class ModelingExercise extends Exercise implements Serializable {
         this.sampleSolutionExplanation = sampleSolutionExplanation;
     }
 
-    // jhipster-needle-entity-add-getters-setters - Jhipster will add getters and setters here, do not remove
-
     /**
      * set all sensitive information to null, so no info with respect to the solution gets leaked to students through json
      */
@@ -80,26 +75,6 @@ public class ModelingExercise extends Exercise implements Serializable {
         setSampleSolutionModel(null);
         setSampleSolutionExplanation(null);
         super.filterSensitiveInformation();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ModelingExercise modelingExercise = (ModelingExercise) o;
-        if (modelingExercise.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), modelingExercise.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/modeling/ModelingSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/modeling/ModelingSubmission.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.domain.modeling;
 
-import java.io.Serializable;
-
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -16,9 +14,7 @@ import de.tum.in.www1.artemis.domain.Submission;
  */
 @Entity
 @DiscriminatorValue(value = "M")
-public class ModelingSubmission extends Submission implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class ModelingSubmission extends Submission {
 
     @Column(name = "model")
     @Lob

--- a/src/main/java/de/tum/in/www1/artemis/domain/modeling/ModelingSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/modeling/ModelingSubmission.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.domain.modeling;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
@@ -55,28 +54,6 @@ public class ModelingSubmission extends Submission implements Serializable {
 
     public void setExplanationText(String explanationText) {
         this.explanationText = explanationText;
-    }
-
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ModelingSubmission modelingSubmission = (ModelingSubmission) o;
-        if (modelingSubmission.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), modelingSubmission.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotification.java
@@ -2,7 +2,6 @@ package de.tum.in.www1.artemis.domain.notification;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -67,22 +66,6 @@ public class GroupNotification extends Notification implements Serializable {
 
     public void setCourse(Course course) {
         this.course = course;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        GroupNotification groupNotification = (GroupNotification) o;
-        if (groupNotification.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), groupNotification.getId());
     }
 
     public String getExerciseCreatedTarget(Exercise exercise) {
@@ -166,11 +149,6 @@ public class GroupNotification extends Notification implements Serializable {
 
     public String getTopic() {
         return "/topic/course/" + getCourse().getId() + "/" + getType();
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotification.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.notification;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 
 import javax.persistence.*;
@@ -16,9 +15,7 @@ import de.tum.in.www1.artemis.domain.enumeration.GroupNotificationType;
  */
 @Entity
 @DiscriminatorValue(value = "G")
-public class GroupNotification extends Notification implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class GroupNotification extends Notification {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "jhi_type")

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/Notification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/Notification.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain.notification;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -14,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.NotificationPriority;
 
@@ -33,13 +32,7 @@ import de.tum.in.www1.artemis.domain.enumeration.NotificationPriority;
 @JsonSubTypes({ @JsonSubTypes.Type(value = GroupNotification.class, name = "group"), @JsonSubTypes.Type(value = SingleUserNotification.class, name = "single"),
         @JsonSubTypes.Type(value = SystemNotification.class, name = "system") })
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public abstract class Notification implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public abstract class Notification extends DomainObject {
 
     @Column(name = "title")
     private String title;
@@ -63,14 +56,6 @@ public abstract class Notification implements Serializable {
 
     @ManyToOne
     private User author;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -164,28 +149,8 @@ public abstract class Notification implements Serializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Notification notification = (Notification) o;
-        if (notification.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), notification.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
-    }
-
-    @Override
     public String toString() {
-        return "Notification{" + "id=" + id + ", title='" + title + '\'' + ", text='" + text + '\'' + ", notificationDate=" + notificationDate + ", target='" + target + '\''
+        return "Notification{" + "id=" + getId() + ", title='" + title + '\'' + ", text='" + text + '\'' + ", notificationDate=" + notificationDate + ", target='" + target + '\''
                 + ", priority=" + priority + ", outdated=" + outdated + ", author=" + author + '}';
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/Notification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/Notification.java
@@ -64,7 +64,6 @@ public abstract class Notification implements Serializable {
     @ManyToOne
     private User author;
 
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
     public Long getId() {
         return id;
     }
@@ -163,7 +162,6 @@ public abstract class Notification implements Serializable {
     public void setAuthor(User user) {
         this.author = user;
     }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/SingleUserNotification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/SingleUserNotification.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.notification;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 
 import javax.persistence.DiscriminatorValue;
@@ -17,9 +16,7 @@ import de.tum.in.www1.artemis.domain.User;
  */
 @Entity
 @DiscriminatorValue(value = "U")
-public class SingleUserNotification extends Notification implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class SingleUserNotification extends Notification {
 
     @ManyToOne
     private User recipient;

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/SingleUserNotification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/SingleUserNotification.java
@@ -2,7 +2,6 @@ package de.tum.in.www1.artemis.domain.notification;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -25,7 +24,6 @@ public class SingleUserNotification extends Notification implements Serializable
     @ManyToOne
     private User recipient;
 
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
     public User getRecipient() {
         return recipient;
     }
@@ -38,7 +36,6 @@ public class SingleUserNotification extends Notification implements Serializable
     public void setRecipient(User user) {
         this.recipient = user;
     }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
 
     public String getTopic() {
         return "/topic/user/" + getRecipient().getId() + "/notifications";
@@ -85,26 +82,6 @@ public class SingleUserNotification extends Notification implements Serializable
         target.addProperty("course", studentQuestionAnswer.getQuestion().getLecture().getCourse().getId());
         target.addProperty("mainPage", "courses");
         return target.toString();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        SingleUserNotification singleUserNotification = (SingleUserNotification) o;
-        if (singleUserNotification.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), singleUserNotification.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/SystemNotification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/SystemNotification.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.notification;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 
 import javax.persistence.*;
@@ -12,9 +11,7 @@ import de.tum.in.www1.artemis.domain.enumeration.SystemNotificationType;
  */
 @Entity
 @DiscriminatorValue(value = "S")
-public class SystemNotification extends Notification implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class SystemNotification extends Notification {
 
     @Column(name = "expire_date")
     private ZonedDateTime expireDate;

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/SystemNotification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/SystemNotification.java
@@ -2,7 +2,6 @@ package de.tum.in.www1.artemis.domain.notification;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -24,7 +23,6 @@ public class SystemNotification extends Notification implements Serializable {
     @Column(name = "jhi_type")
     private SystemNotificationType type;
 
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
     public ZonedDateTime getExpireDate() {
         return expireDate;
     }
@@ -49,27 +47,6 @@ public class SystemNotification extends Notification implements Serializable {
 
     public void setType(SystemNotificationType type) {
         this.type = type;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        SystemNotification systemNotification = (SystemNotification) o;
-        if (systemNotification.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), systemNotification.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/Participation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/Participation.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.participation;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.*;
 
@@ -12,6 +11,7 @@ import org.hibernate.annotations.DiscriminatorOptions;
 
 import com.fasterxml.jackson.annotation.*;
 
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.Submission;
@@ -37,14 +37,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
         @JsonSubTypes.Type(value = TemplateProgrammingExerciseParticipation.class, name = "template"),
         @JsonSubTypes.Type(value = SolutionProgrammingExerciseParticipation.class, name = "solution"), })
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public abstract class Participation implements Serializable, ParticipationInterface {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public abstract class Participation extends DomainObject implements ParticipationInterface {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "initialization_state")
@@ -102,15 +95,6 @@ public abstract class Participation implements Serializable, ParticipationInterf
 
     public void setSubmissionCount(Integer submissionCount) {
         this.submissionCount = submissionCount;
-    }
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public InitializationState getInitializationState() {
@@ -243,28 +227,8 @@ public abstract class Participation implements Serializable, ParticipationInterf
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Participation participation = (Participation) o;
-        if (participation.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), participation.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
-    }
-
-    @Override
     public String toString() {
-        return "Participation{" + "id=" + id + ", initializationState=" + initializationState + ", initializationDate=" + initializationDate + ", results=" + results
+        return "Participation{" + "id=" + getId() + ", initializationState=" + initializationState + ", initializationDate=" + initializationDate + ", results=" + results
                 + ", submissions=" + submissions + ", submissionCount=" + submissionCount + "}";
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/ProgrammingExerciseStudentParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/ProgrammingExerciseStudentParticipation.java
@@ -18,8 +18,6 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @DiscriminatorValue(value = "PESP")
 public class ProgrammingExerciseStudentParticipation extends StudentParticipation implements ProgrammingExerciseParticipation {
 
-    private static final long serialVersionUID = 1L;
-
     @Column(name = "repository_url")
     @JsonView(QuizView.Before.class)
     private String repositoryUrl;

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/StudentParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/StudentParticipation.java
@@ -19,8 +19,6 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @DiscriminatorValue(value = "SP")
 public class StudentParticipation extends Participation {
 
-    private static final long serialVersionUID = 1L;
-
     @Column(name = "presentation_score")
     private Integer presentationScore;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/TutorParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/TutorParticipation.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.domain.participation;
 
-import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -13,6 +11,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.ExampleSubmission;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.User;
@@ -25,13 +24,7 @@ import de.tum.in.www1.artemis.domain.enumeration.TutorParticipationStatus;
 @Table(name = "tutor_participation")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class TutorParticipation implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class TutorParticipation extends DomainObject {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
@@ -49,14 +42,6 @@ public class TutorParticipation implements Serializable {
     @JsonIgnoreProperties({ "tutorParticipations" })
     private Set<ExampleSubmission> trainedExampleSubmissions = new HashSet<>();
     // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public TutorParticipationStatus getStatus() {
         return status;
@@ -122,26 +107,6 @@ public class TutorParticipation implements Serializable {
         this.trainedExampleSubmissions = exampleSubmissions;
     }
     // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        TutorParticipation tutorParticipation = (TutorParticipation) o;
-        if (tutorParticipation.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), tutorParticipation.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
-    }
 
     @Override
     public String toString() {

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerCounter.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerCounter.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-
 import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -11,9 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 @Entity
 @DiscriminatorValue(value = "AC")
-public class AnswerCounter extends QuizStatisticCounter implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class AnswerCounter extends QuizStatisticCounter {
 
     @ManyToOne
     @JsonIgnore

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -11,6 +8,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -20,14 +19,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Table(name = "answer_option")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class AnswerOption implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public class AnswerOption extends DomainObject {
 
     @Column(name = "text")
     @JsonView(QuizView.Before.class)
@@ -52,14 +44,6 @@ public class AnswerOption implements Serializable {
     @ManyToOne
     @JsonIgnore
     private MultipleChoiceQuestion question;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getText() {
         return text;
@@ -127,26 +111,6 @@ public class AnswerOption implements Serializable {
 
     public void setQuestion(MultipleChoiceQuestion multipleChoiceQuestion) {
         this.question = multipleChoiceQuestion;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        AnswerOption answerOption = (AnswerOption) o;
-        if (answerOption.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), answerOption.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropMapping.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropMapping.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -11,6 +8,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -20,14 +19,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Table(name = "drag_and_drop_mapping")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class DragAndDropMapping implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public class DragAndDropMapping extends DomainObject {
 
     @Column(name = "drag_item_index")
     @JsonView(QuizView.Before.class)
@@ -56,15 +48,6 @@ public class DragAndDropMapping implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private DragAndDropQuestion question;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Integer getDragItemIndex() {
         return dragItemIndex;
@@ -130,26 +113,6 @@ public class DragAndDropMapping implements Serializable {
 
     public void setQuestion(DragAndDropQuestion dragAndDropQuestion) {
         this.question = dragAndDropQuestion;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        DragAndDropMapping dragAndDropMapping = (DragAndDropMapping) o;
-        if (dragAndDropMapping.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), dragAndDropMapping.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -25,9 +24,7 @@ import de.tum.in.www1.artemis.service.FileService;
 @Entity
 @DiscriminatorValue(value = "DD")
 @JsonTypeName("drag-and-drop")
-public class DragAndDropQuestion extends QuizQuestion implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class DragAndDropQuestion extends QuizQuestion {
 
     @Transient
     private transient FileService fileService = new FileService();

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestionStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestionStatistic.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,9 +16,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @Entity
 @DiscriminatorValue(value = "DD")
 @JsonTypeName("drag-and-drop")
-public class DragAndDropQuestionStatistic extends QuizQuestionStatistic implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class DragAndDropQuestionStatistic extends QuizQuestionStatistic {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "dragAndDropQuestionStatistic")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropSubmittedAnswer.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -19,9 +18,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Entity
 @DiscriminatorValue(value = "DD")
 @JsonTypeName("drag-and-drop")
-public class DragAndDropSubmittedAnswer extends SubmittedAnswer implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class DragAndDropSubmittedAnswer extends SubmittedAnswer {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "submitted_answer_id")

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import de.tum.in.www1.artemis.config.Constants;
-import de.tum.in.www1.artemis.domain.DomainObject;
+import de.tum.in.www1.artemis.domain.TempIdObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
@@ -24,7 +23,7 @@ import de.tum.in.www1.artemis.service.FileService;
 @Entity
 @Table(name = "drag_item")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class DragItem extends DomainObject {
+public class DragItem extends TempIdObject {
 
     @Transient
     private transient FileService fileService = new FileService();
@@ -52,24 +51,6 @@ public class DragItem extends DomainObject {
     @JsonIgnore
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<DragAndDropMapping> mappings = new HashSet<>();
-
-    /**
-     * tempID is needed to refer to drag items that have not been persisted yet in the correctMappings of a question (so user can create mappings in the UI before saving new drag
-     * items)
-     */
-    @Transient
-    // variable name must be different from Getter name,
-    // so that Jackson ignores the @Transient annotation,
-    // but Hibernate still respects it
-    private Long tempIDTransient;
-
-    public Long getTempID() {
-        return tempIDTransient;
-    }
-
-    public void setTempID(Long tempID) {
-        this.tempIDTransient = tempID;
-    }
 
     public String getPictureFilePath() {
         return pictureFilePath;
@@ -172,21 +153,6 @@ public class DragItem extends DomainObject {
     public void onDelete() {
         // delete old file if necessary
         fileService.manageFilesForUpdatedFilePath(prevPictureFilePath, null, FilePathService.getDragItemFilepath(), getId());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        DragItem dragItem = (DragItem) o;
-        if (dragItem.getTempID() != null && getTempID() != null && Objects.equals(getTempID(), dragItem.getTempID())) {
-            return true;
-        }
-        return super.equals(o);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragItem.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -14,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 
 import de.tum.in.www1.artemis.config.Constants;
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
@@ -24,20 +24,13 @@ import de.tum.in.www1.artemis.service.FileService;
 @Entity
 @Table(name = "drag_item")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class DragItem implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class DragItem extends DomainObject {
 
     @Transient
     private transient FileService fileService = new FileService();
 
     @Transient
     private String prevPictureFilePath;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
 
     @Column(name = "picture_file_path")
     @JsonView(QuizView.Before.class)
@@ -76,14 +69,6 @@ public class DragItem implements Serializable {
 
     public void setTempID(Long tempID) {
         this.tempIDTransient = tempID;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getPictureFilePath() {
@@ -201,15 +186,7 @@ public class DragItem implements Serializable {
         if (dragItem.getTempID() != null && getTempID() != null && Objects.equals(getTempID(), dragItem.getTempID())) {
             return true;
         }
-        if (dragItem.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), dragItem.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
+        return super.equals(o);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -12,7 +11,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
 
-import de.tum.in.www1.artemis.domain.DomainObject;
+import de.tum.in.www1.artemis.domain.TempIdObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -21,7 +20,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Entity
 @Table(name = "drop_location")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class DropLocation extends DomainObject {
+public class DropLocation extends TempIdObject {
 
     @Column(name = "pos_x")
     @JsonView(QuizView.Before.class)
@@ -51,24 +50,6 @@ public class DropLocation extends DomainObject {
     @JsonIgnore
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<DragAndDropMapping> mappings = new HashSet<>();
-
-    /**
-     * tempID is needed to refer to drop locations that have not been persisted yet in the correctMappings of a question (so user can create mappings in the UI before saving new
-     * drop locations)
-     */
-    @Transient
-    // variable name must be different from Getter name,
-    // so that Jackson ignores the @Transient annotation,
-    // but Hibernate still respects it
-    private Long tempIDTransient;
-
-    public Long getTempID() {
-        return tempIDTransient;
-    }
-
-    public void setTempID(Long tempID) {
-        this.tempIDTransient = tempID;
-    }
 
     public Double getPosX() {
         return posX;
@@ -169,21 +150,6 @@ public class DropLocation extends DomainObject {
         // this drop location was meant to stay empty and user didn't drag anything onto it
         // OR the user dragged one of the correct drag items onto this drop location
         // => this is correct => Return true;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        DropLocation dropLocation = (DropLocation) o;
-        if (dropLocation.getTempID() != null && getTempID() != null && Objects.equals(getTempID(), dropLocation.getTempID())) {
-            return true;
-        }
-        return super.equals(o);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocation.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -12,6 +11,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -20,14 +21,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Entity
 @Table(name = "drop_location")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class DropLocation implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public class DropLocation extends DomainObject {
 
     @Column(name = "pos_x")
     @JsonView(QuizView.Before.class)
@@ -74,14 +68,6 @@ public class DropLocation implements Serializable {
 
     public void setTempID(Long tempID) {
         this.tempIDTransient = tempID;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public Double getPosX() {
@@ -197,15 +183,7 @@ public class DropLocation implements Serializable {
         if (dropLocation.getTempID() != null && getTempID() != null && Objects.equals(getTempID(), dropLocation.getTempID())) {
             return true;
         }
-        if (dropLocation.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), dropLocation.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
+        return super.equals(o);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocationCounter.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DropLocationCounter.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -12,9 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 @Entity
 @DiscriminatorValue(value = "DD")
-public class DropLocationCounter extends QuizStatisticCounter implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class DropLocationCounter extends QuizStatisticCounter {
 
     @ManyToOne
     @JsonIgnore
@@ -38,26 +33,6 @@ public class DropLocationCounter extends QuizStatisticCounter implements Seriali
 
     public void setDropLocation(DropLocation dropLocation) {
         this.dropLocation = dropLocation;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        DropLocationCounter dropLocationCounter = (DropLocationCounter) o;
-        if (dropLocationCounter.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), dropLocationCounter.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestion.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -21,9 +20,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Entity
 @DiscriminatorValue(value = "MC")
 @JsonTypeName("multiple-choice")
-public class MultipleChoiceQuestion extends QuizQuestion implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class MultipleChoiceQuestion extends QuizQuestion {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn
@@ -31,8 +28,6 @@ public class MultipleChoiceQuestion extends QuizQuestion implements Serializable
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     @JsonView(QuizView.Before.class)
     private List<AnswerOption> answerOptions = new ArrayList<>();
-
-    // jhipster-needle-entity-add-field - Jhipster will add fields here, do not remove
 
     public List<AnswerOption> getAnswerOptions() {
         return answerOptions;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestionStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestionStatistic.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,9 +16,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @Entity
 @DiscriminatorValue(value = "MC")
 @JsonTypeName("multiple-choice")
-public class MultipleChoiceQuestionStatistic extends QuizQuestionStatistic implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class MultipleChoiceQuestionStatistic extends QuizQuestionStatistic {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "multipleChoiceQuestionStatistic")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceSubmittedAnswer.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.domain.quiz;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -56,7 +57,7 @@ public class MultipleChoiceSubmittedAnswer extends SubmittedAnswer implements Se
     public boolean isSelected(AnswerOption answerOption) {
         // search for this answer option in the selected answer options
         for (AnswerOption selectedOption : getSelectedOptions()) {
-            if (selectedOption.getId().longValue() == answerOption.getId().longValue()) {
+            if (Objects.equals(selectedOption.getId(), answerOption.getId())) {
                 // this answer option is selected => we can stop searching
                 return true;
             }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceSubmittedAnswer.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -20,9 +19,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Entity
 @DiscriminatorValue(value = "MC")
 @JsonTypeName("multiple-choice")
-public class MultipleChoiceSubmittedAnswer extends SubmittedAnswer implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class MultipleChoiceSubmittedAnswer extends SubmittedAnswer {
 
     @ManyToMany(fetch = FetchType.EAGER)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/PointCounter.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/PointCounter.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -14,9 +12,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 @Entity
 @DiscriminatorValue(value = "PC")
-public class PointCounter extends QuizStatisticCounter implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class PointCounter extends QuizStatisticCounter {
 
     @Column(name = "points")
     private Double points;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
@@ -339,7 +339,7 @@ public class QuizExercise extends Exercise implements Serializable {
      */
     public Long getScoreForSubmission(QuizSubmission quizSubmission) {
         double score = getScoreInPointsForSubmission(quizSubmission);
-        int maxScore = getMaxTotalScore();
+        double maxScore = getMaxTotalScore();
         // map the resulting score to the 0 to 100 scale
         return Math.round(100.0 * score / maxScore);
     }
@@ -525,8 +525,8 @@ public class QuizExercise extends Exercise implements Serializable {
      * @return the sum of all the quizQuestions' maximum scores
      */
     @JsonIgnore
-    public Integer getMaxTotalScore() {
-        int maxScore = 0;
+    public Double getMaxTotalScore() {
+        double maxScore = 0.0;
         // iterate through all quizQuestions of this quiz and add up the score
         if (quizQuestions != null && Hibernate.isInitialized(quizQuestions)) {
             for (QuizQuestion quizQuestion : getQuizQuestions()) {
@@ -544,7 +544,7 @@ public class QuizExercise extends Exercise implements Serializable {
             return score;
         }
         else if (quizQuestions != null && Hibernate.isInitialized(quizQuestions)) {
-            return getMaxTotalScore().doubleValue();
+            return getMaxTotalScore();
         }
         return null;
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -30,9 +29,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
  */
 @Entity
 @DiscriminatorValue(value = "Q")
-public class QuizExercise extends Exercise implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class QuizExercise extends Exercise {
 
     @Column(name = "randomize_question_order")
     @JsonView(QuizView.Before.class)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
@@ -549,21 +549,6 @@ public class QuizExercise extends Exercise implements Serializable {
         return null;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        QuizExercise quizExercise = (QuizExercise) o;
-        if (quizExercise.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), quizExercise.getId());
-    }
-
     /**
      * correct the associated quizPointStatistic
      * 1. add new PointCounters for new Scores
@@ -692,11 +677,6 @@ public class QuizExercise extends Exercise implements Serializable {
                 pointCounter.setQuizPointStatistic(getQuizPointStatistic());
             }
         }
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizPointStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizPointStatistic.java
@@ -90,7 +90,10 @@ public class QuizPointStatistic extends QuizStatistic implements Serializable {
      *              quizExercise)
      */
     public void addResult(Long score, Boolean rated) {
-        changeStatisticBasedOnResult(score, rated, 1);
+        if (score == null) {
+            return;
+        }
+        changeStatisticBasedOnResult(score.doubleValue(), rated, 1);
     }
 
     /**
@@ -101,7 +104,10 @@ public class QuizPointStatistic extends QuizStatistic implements Serializable {
      *              quizExercise)
      */
     public void removeOldResult(Long score, Boolean rated) {
-        changeStatisticBasedOnResult(score, rated, -1);
+        if (score == null) {
+            return;
+        }
+        changeStatisticBasedOnResult(score.doubleValue(), rated, -1);
     }
 
     /**
@@ -110,35 +116,31 @@ public class QuizPointStatistic extends QuizStatistic implements Serializable {
      * @param score  whose PointCounter decreases
      * @param rated  specify if the Result was rated ( participated during the releaseDate and the dueDate of the quizExercise) or unrated ( participated after the dueDate of the
      *               quizExercise)
-     * @param change the int-value, which will be added to the Counter and participants
+     * @param countChange the int-value, which will be added to the Counter and participants
      */
-    private void changeStatisticBasedOnResult(Long score, Boolean rated, int change) {
+    private void changeStatisticBasedOnResult(double score, Boolean rated, int countChange) {
 
-        if (score == null) {
-            return;
-        }
-
-        Double points = (double) Math.round(((double) quiz.getMaxTotalScore()) * ((double) score / 100));
+        Double points = (double) Math.round(quiz.getMaxTotalScore() * (score / 100));
 
         if (Boolean.TRUE.equals(rated)) {
             // change rated participants
-            setParticipantsRated(getParticipantsRated() + change);
+            setParticipantsRated(getParticipantsRated() + countChange);
 
             // find associated rated pointCounter and change it
             for (PointCounter pointCounter : pointCounters) {
                 if (points.equals(pointCounter.getPoints())) {
-                    pointCounter.setRatedCounter(pointCounter.getRatedCounter() + change);
+                    pointCounter.setRatedCounter(pointCounter.getRatedCounter() + countChange);
                 }
             }
         }
         else {
             // change unrated participants
-            setParticipantsUnrated(getParticipantsUnrated() + change);
+            setParticipantsUnrated(getParticipantsUnrated() + countChange);
 
             // find associated unrated pointCounter and change it
             for (PointCounter pointCounter : pointCounters) {
                 if (points.equals(pointCounter.getPoints())) {
-                    pointCounter.setUnRatedCounter(pointCounter.getUnRatedCounter() + change);
+                    pointCounter.setUnRatedCounter(pointCounter.getUnRatedCounter() + countChange);
                 }
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizPointStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizPointStatistic.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -16,9 +15,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 @Entity
 @DiscriminatorValue(value = "QP")
-public class QuizPointStatistic extends QuizStatistic implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class QuizPointStatistic extends QuizStatistic {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "quizPointStatistic")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizQuestion.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -11,6 +8,7 @@ import org.hibernate.annotations.DiscriminatorOptions;
 
 import com.fasterxml.jackson.annotation.*;
 
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.enumeration.ScoringType;
 import de.tum.in.www1.artemis.domain.quiz.scoring.ScoringStrategyFactory;
 import de.tum.in.www1.artemis.domain.view.QuizView;
@@ -29,14 +27,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonSubTypes({ @JsonSubTypes.Type(value = MultipleChoiceQuestion.class, name = "multiple-choice"), @JsonSubTypes.Type(value = DragAndDropQuestion.class, name = "drag-and-drop"),
         @JsonSubTypes.Type(value = ShortAnswerQuestion.class, name = "short-answer") })
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public abstract class QuizQuestion implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public abstract class QuizQuestion extends DomainObject {
 
     @Column(name = "title")
     @JsonView(QuizView.Before.class)
@@ -78,14 +69,6 @@ public abstract class QuizQuestion implements Serializable {
     @ManyToOne
     @JsonIgnore
     private QuizExercise exercise;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getTitle() {
         return title;
@@ -226,26 +209,6 @@ public abstract class QuizQuestion implements Serializable {
     public Boolean isValid() {
         // check title and score
         return getTitle() != null && !getTitle().equals("") && getScore() >= 0;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        QuizQuestion quizQuestion = (QuizQuestion) o;
-        if (quizQuestion.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), quizQuestion.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizQuestionStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizQuestionStatistic.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -20,9 +18,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({ @JsonSubTypes.Type(value = MultipleChoiceQuestionStatistic.class, name = "multiple-choice"),
         @JsonSubTypes.Type(value = DragAndDropQuestionStatistic.class, name = "drag-and-drop"),
         @JsonSubTypes.Type(value = ShortAnswerQuestionStatistic.class, name = "short-answer") })
-public abstract class QuizQuestionStatistic extends QuizStatistic implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public abstract class QuizQuestionStatistic extends QuizStatistic {
 
     @Column(name = "rated_correct_counter")
     private Integer ratedCorrectCounter = 0;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizStatistic.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -10,6 +7,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.DiscriminatorOptions;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import de.tum.in.www1.artemis.domain.DomainObject;
 
 /**
  * A QuizStatistic.
@@ -22,27 +20,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @DiscriminatorOptions(force = true)
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public abstract class QuizStatistic implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public abstract class QuizStatistic extends DomainObject {
 
     @Column(name = "participants_rated")
     private Integer participantsRated = 0;
 
     @Column(name = "participants_unrated")
     private Integer participantsUnrated = 0;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Integer getParticipantsRated() {
         return participantsRated;
@@ -58,25 +42,5 @@ public abstract class QuizStatistic implements Serializable {
 
     public void setParticipantsUnrated(Integer participantsUnrated) {
         this.participantsUnrated = participantsUnrated;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        QuizStatistic quizStatistic = (QuizStatistic) o;
-        if (quizStatistic.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), quizStatistic.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizStatisticCounter.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizStatisticCounter.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -10,6 +7,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.DiscriminatorOptions;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import de.tum.in.www1.artemis.domain.DomainObject;
 
 /**
  * A QuizStatisticCounter.
@@ -22,27 +20,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @DiscriminatorOptions(force = true)
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public abstract class QuizStatisticCounter implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public abstract class QuizStatisticCounter extends DomainObject {
 
     @Column(name = "rated_counter")
     private Integer ratedCounter = 0;
 
     @Column(name = "un_rated_counter")
     private Integer unRatedCounter = 0;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Integer getRatedCounter() {
         return ratedCounter;
@@ -58,25 +42,5 @@ public abstract class QuizStatisticCounter implements Serializable {
 
     public void setUnRatedCounter(Integer unRatedCounter) {
         this.unRatedCounter = unRatedCounter;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        QuizStatisticCounter quizStatisticCounter = (QuizStatisticCounter) o;
-        if (quizStatisticCounter.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), quizStatisticCounter.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizSubmission.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -20,9 +19,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
  */
 @Entity
 @DiscriminatorValue(value = "Q")
-public class QuizSubmission extends Submission implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class QuizSubmission extends Submission {
 
     @Column(name = "score_in_points")
     @JsonView(QuizView.After.class)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizSubmission.java
@@ -2,7 +2,6 @@ package de.tum.in.www1.artemis.domain.quiz;
 
 import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -117,28 +116,7 @@ public class QuizSubmission extends Submission implements Serializable {
             }
         }
         // set total score
-
         setScoreInPoints(quizExercise.getScoreInPointsForSubmission(this));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        QuizSubmission quizSubmission = (QuizSubmission) o;
-        if (quizSubmission.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), quizSubmission.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerMapping.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerMapping.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -11,6 +8,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -20,14 +19,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Table(name = "short_answer_mapping")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ShortAnswerMapping implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public class ShortAnswerMapping extends DomainObject {
 
     @Column(name = "short_answer_spot_index")
     @JsonView(QuizView.Before.class)
@@ -52,15 +44,6 @@ public class ShortAnswerMapping implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private ShortAnswerQuestion question;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Integer getShortAnswerSpotIndex() {
         return shortAnswerSpotIndex;
@@ -118,27 +101,6 @@ public class ShortAnswerMapping implements Serializable {
 
     public void setQuestion(ShortAnswerQuestion shortAnswerQuestion) {
         this.question = shortAnswerQuestion;
-    }
-    // jhipster-needle-entity-add-getters-setters - JHipster will add getters and setters here, do not remove
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ShortAnswerMapping shortAnswerMapping = (ShortAnswerMapping) o;
-        if (shortAnswerMapping.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), shortAnswerMapping.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -21,9 +20,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Entity
 @DiscriminatorValue(value = "SA")
 @JsonTypeName("short-answer")
-public class ShortAnswerQuestion extends QuizQuestion implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class ShortAnswerQuestion extends QuizQuestion {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @OrderColumn

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestionStatistic.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestionStatistic.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,9 +16,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @Entity
 @DiscriminatorValue(value = "SA")
 @JsonTypeName("short-answer")
-public class ShortAnswerQuestionStatistic extends QuizQuestionStatistic implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class ShortAnswerQuestionStatistic extends QuizQuestionStatistic {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true, mappedBy = "shortAnswerQuestionStatistic")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -13,6 +12,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -22,14 +23,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Table(name = "short_answer_solution")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ShortAnswerSolution implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public class ShortAnswerSolution extends DomainObject {
 
     @Column(name = "text")
     @JsonView(QuizView.Before.class)
@@ -65,15 +59,6 @@ public class ShortAnswerSolution implements Serializable {
 
     public void setTempID(Long tempID) {
         this.tempIDTransient = tempID;
-    }
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public String getText() {
@@ -133,15 +118,7 @@ public class ShortAnswerSolution implements Serializable {
         if (shortAnswerSolution.getTempID() != null && getTempID() != null && Objects.equals(getTempID(), shortAnswerSolution.getTempID())) {
             return true;
         }
-        if (shortAnswerSolution.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), shortAnswerSolution.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
+        return super.equals(o);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSolution.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
 
-import de.tum.in.www1.artemis.domain.DomainObject;
+import de.tum.in.www1.artemis.domain.TempIdObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -23,7 +22,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Table(name = "short_answer_solution")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ShortAnswerSolution extends DomainObject {
+public class ShortAnswerSolution extends TempIdObject {
 
     @Column(name = "text")
     @JsonView(QuizView.Before.class)
@@ -42,24 +41,6 @@ public class ShortAnswerSolution extends DomainObject {
     @JsonIgnore
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<ShortAnswerMapping> mappings = new HashSet<>();
-
-    /**
-     * tempID is needed to refer to solutions that have not been persisted yet in the correctMappings of a question (so user can create mappings in the UI before saving new
-     * solutions)
-     */
-    @Transient
-    // variable name must be different from Getter name,
-    // so that Jackson ignores the @Transient annotation,
-    // but Hibernate still respects it
-    private Long tempIDTransient;
-
-    public Long getTempID() {
-        return tempIDTransient;
-    }
-
-    public void setTempID(Long tempID) {
-        this.tempIDTransient = tempID;
-    }
 
     public String getText() {
         return text;
@@ -104,21 +85,6 @@ public class ShortAnswerSolution extends DomainObject {
         this.mappings.remove(mapping);
         mapping.setSolution(null);
         return this;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ShortAnswerSolution shortAnswerSolution = (ShortAnswerSolution) o;
-        if (shortAnswerSolution.getTempID() != null && getTempID() != null && Objects.equals(getTempID(), shortAnswerSolution.getTempID())) {
-            return true;
-        }
-        return super.equals(o);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
 
-import de.tum.in.www1.artemis.domain.DomainObject;
+import de.tum.in.www1.artemis.domain.TempIdObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -23,7 +22,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Table(name = "short_answer_spot")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ShortAnswerSpot extends DomainObject {
+public class ShortAnswerSpot extends TempIdObject {
 
     @Column(name = "spotNr")
     @JsonView(QuizView.Before.class)
@@ -45,23 +44,6 @@ public class ShortAnswerSpot extends DomainObject {
     @JsonIgnore
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private Set<ShortAnswerMapping> mappings = new HashSet<>();
-
-    /**
-     * tempID is needed to refer to spots that have not been persisted yet in the correctMappings of a question (so user can create mappings in the UI before saving new spots)
-     */
-    @Transient
-    // variable name must be different from Getter name,
-    // so that Jackson ignores the @Transient annotation,
-    // but Hibernate still respects it
-    private Long tempIDTransient;
-
-    public Long getTempID() {
-        return tempIDTransient;
-    }
-
-    public void setTempID(Long tempID) {
-        this.tempIDTransient = tempID;
-    }
 
     public Integer getSpotNr() {
         return spotNr;
@@ -119,21 +101,6 @@ public class ShortAnswerSpot extends DomainObject {
         this.mappings.remove(mapping);
         mapping.setSpot(null);
         return this;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ShortAnswerSpot shortAnswerSpot = (ShortAnswerSpot) o;
-        if (shortAnswerSpot.getTempID() != null && getTempID() != null && Objects.equals(getTempID(), shortAnswerSpot.getTempID())) {
-            return true;
-        }
-        return super.equals(o);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpot.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -13,6 +12,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonView;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -22,14 +23,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Table(name = "short_answer_spot")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ShortAnswerSpot implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public class ShortAnswerSpot extends DomainObject {
 
     @Column(name = "spotNr")
     @JsonView(QuizView.Before.class)
@@ -67,15 +61,6 @@ public class ShortAnswerSpot implements Serializable {
 
     public void setTempID(Long tempID) {
         this.tempIDTransient = tempID;
-    }
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
     }
 
     public Integer getSpotNr() {
@@ -148,16 +133,7 @@ public class ShortAnswerSpot implements Serializable {
         if (shortAnswerSpot.getTempID() != null && getTempID() != null && Objects.equals(getTempID(), shortAnswerSpot.getTempID())) {
             return true;
         }
-        if (shortAnswerSpot.getId() == null || getId() == null) {
-            return false;
-        }
-
-        return Objects.equals(getId(), shortAnswerSpot.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
+        return super.equals(o);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpotCounter.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSpotCounter.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-
 import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -11,9 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 @Entity
 @DiscriminatorValue(value = "SA")
-public class ShortAnswerSpotCounter extends QuizStatisticCounter implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class ShortAnswerSpotCounter extends QuizStatisticCounter {
 
     @ManyToOne
     @JsonIgnore

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedAnswer.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -19,9 +18,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Entity
 @DiscriminatorValue(value = "SA")
 @JsonTypeName("short-answer")
-public class ShortAnswerSubmittedAnswer extends SubmittedAnswer implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+public class ShortAnswerSubmittedAnswer extends SubmittedAnswer {
 
     @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @JoinColumn(name = "submitted_answer_id")

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedText.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerSubmittedText.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import me.xdrop.fuzzywuzzy.FuzzySearch;
@@ -12,6 +9,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -20,14 +19,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @Entity
 @Table(name = "short_answer_submitted_text")
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-public class ShortAnswerSubmittedText implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public class ShortAnswerSubmittedText extends DomainObject {
 
     @Column(name = "text")
     @JsonView(QuizView.Before.class)
@@ -45,15 +37,6 @@ public class ShortAnswerSubmittedText implements Serializable {
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonIgnore
     private ShortAnswerSubmittedAnswer submittedAnswer;
-
-    // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getText() {
         return text;
@@ -96,26 +79,6 @@ public class ShortAnswerSubmittedText implements Serializable {
      */
     public boolean isSubmittedTextCorrect(String submittedText, String solution) {
         return FuzzySearch.ratio(submittedText.toLowerCase(), solution.toLowerCase()) > 85;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ShortAnswerSubmittedText shortAnswerSubmittedText = (ShortAnswerSubmittedText) o;
-        if (shortAnswerSubmittedText.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), shortAnswerSubmittedText.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/SubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/SubmittedAnswer.java
@@ -116,7 +116,7 @@ public abstract class SubmittedAnswer implements Serializable {
             question.filterForStudentsDuringQuiz();
         }
         this.setScoreInPoints(null);
-    };
+    }
 
     /**
      * Delete all references to quizQuestion and quizQuestion-elements if the quiz was changed

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/SubmittedAnswer.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/SubmittedAnswer.java
@@ -1,8 +1,5 @@
 package de.tum.in.www1.artemis.domain.quiz;
 
-import java.io.Serializable;
-import java.util.Objects;
-
 import javax.persistence.*;
 
 import org.hibernate.annotations.Cache;
@@ -10,6 +7,8 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.DiscriminatorOptions;
 
 import com.fasterxml.jackson.annotation.*;
+
+import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.view.QuizView;
 
 /**
@@ -31,14 +30,7 @@ import de.tum.in.www1.artemis.domain.view.QuizView;
 @JsonSubTypes({ @JsonSubTypes.Type(value = MultipleChoiceSubmittedAnswer.class, name = "multiple-choice"),
         @JsonSubTypes.Type(value = DragAndDropSubmittedAnswer.class, name = "drag-and-drop"), @JsonSubTypes.Type(value = ShortAnswerSubmittedAnswer.class, name = "short-answer") })
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public abstract class SubmittedAnswer implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @JsonView(QuizView.Before.class)
-    private Long id;
+public abstract class SubmittedAnswer extends DomainObject {
 
     @Column(name = "score_in_points")
     @JsonView(QuizView.After.class)
@@ -52,14 +44,6 @@ public abstract class SubmittedAnswer implements Serializable {
     @ManyToOne
     @JsonIgnore
     private QuizSubmission submission;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public Double getScoreInPoints() {
         return scoreInPoints;
@@ -83,26 +67,6 @@ public abstract class SubmittedAnswer implements Serializable {
 
     public void setSubmission(QuizSubmission quizSubmission) {
         this.submission = quizSubmission;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        SubmittedAnswer submittedAnswer = (SubmittedAnswer) o;
-        if (submittedAnswer.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), submittedAnswer.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(getId());
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseTestCaseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseTestCaseService.java
@@ -117,11 +117,11 @@ public class ProgrammingExerciseTestCaseService {
                 .map(feedback -> new ProgrammingExerciseTestCase().testName(feedback.getText()).weight(1.0).bonusMultiplier(1.0).bonusPoints(0.0).exercise(exercise).active(true))
                 .collect(Collectors.toSet());
         // Get test cases that are not already in database - those will be added as new entries.
-        Set<ProgrammingExerciseTestCase> newTestCases = testCasesFromFeedbacks.stream().filter(testCase -> existingTestCases.stream().noneMatch(testCase::equals))
+        Set<ProgrammingExerciseTestCase> newTestCases = testCasesFromFeedbacks.stream().filter(testCase -> existingTestCases.stream().noneMatch(testCase::isSameTestCase))
                 .collect(Collectors.toSet());
         // Get test cases which activate state flag changed.
         Set<ProgrammingExerciseTestCase> testCasesWithUpdatedActivation = existingTestCases.stream().filter(existing -> {
-            Optional<ProgrammingExerciseTestCase> matchingText = testCasesFromFeedbacks.stream().filter(existing::equals).findFirst();
+            Optional<ProgrammingExerciseTestCase> matchingText = testCasesFromFeedbacks.stream().filter(existing::isSameTestCase).findFirst();
             // Either the test case was active and is not part of the feedback anymore OR was not active before and is now part of the feedback again.
             return matchingText.isEmpty() && existing.isActive() || matchingText.isPresent() && matchingText.get().isActive() && !existing.isActive();
         }).map(existing -> existing.clone().active(!existing.isActive())).collect(Collectors.toSet());

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseTestCaseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseTestCaseService.java
@@ -21,34 +21,31 @@ public class ProgrammingExerciseTestCaseService {
 
     private final ProgrammingSubmissionService programmingSubmissionService;
 
-    private final ParticipationService participationService;
-
     public ProgrammingExerciseTestCaseService(ProgrammingExerciseTestCaseRepository testCaseRepository, ProgrammingExerciseService programmingExerciseService,
-            ProgrammingSubmissionService programmingSubmissionService, ParticipationService participationService) {
+            ProgrammingSubmissionService programmingSubmissionService) {
         this.testCaseRepository = testCaseRepository;
         this.programmingExerciseService = programmingExerciseService;
         this.programmingSubmissionService = programmingSubmissionService;
-        this.participationService = participationService;
     }
 
     /**
      * Returns all test cases for a programming exercise.
      *
-     * @param id of a programming exercise.
+     * @param exerciseId of a programming exercise.
      * @return test cases of a programming exercise.
      */
-    public Set<ProgrammingExerciseTestCase> findByExerciseId(Long id) {
-        return this.testCaseRepository.findByExerciseId(id);
+    public Set<ProgrammingExerciseTestCase> findByExerciseId(Long exerciseId) {
+        return this.testCaseRepository.findByExerciseId(exerciseId);
     }
 
     /**
      * Returns all active test cases for a programming exercise. Only active test cases are evaluated on build runs.
      *
-     * @param id of a programming exercise.
+     * @param exerciseId of a programming exercise.
      * @return active test cases of a programming exercise.
      */
-    public Set<ProgrammingExerciseTestCase> findActiveByExerciseId(Long id) {
-        return this.testCaseRepository.findByExerciseIdAndActive(id, true);
+    public Set<ProgrammingExerciseTestCase> findActiveByExerciseId(Long exerciseId) {
+        return this.testCaseRepository.findByExerciseIdAndActive(exerciseId, true);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
@@ -81,7 +81,7 @@ public class QuizExerciseService {
     }
 
     /**
-     * Save the given quizExercise to the database and make sure that objects with references to one another are saved in the correct order to avoid PersistencyExceptions
+     * Save the given quizExercise to the database and make sure that objects with references to one another are saved in the correct order to avoid PersistenceExceptions
      *
      * @param quizExercise the quiz exercise to save
      * @return the saved quiz exercise
@@ -349,7 +349,7 @@ public class QuizExerciseService {
     public void sendQuizExerciseToSubscribedClients(QuizExercise quizExercise, String quizChange) {
         try {
             long start = System.currentTimeMillis();
-            Class view = viewForStudentsInQuizExercise(quizExercise);
+            Class<?> view = viewForStudentsInQuizExercise(quizExercise);
             byte[] payload = objectMapper.writerWithView(view).writeValueAsBytes(quizExercise);
             // For each change we send the same message. The client needs to decide how to handle the date based on the quiz status
             if (quizExercise.isVisibleToStudents() && quizExercise.hasCourse()) {
@@ -381,7 +381,7 @@ public class QuizExerciseService {
      * @param quizExercise the quiz to get the view for
      * @return the view depending on the current state of the quiz
      */
-    public Class viewForStudentsInQuizExercise(QuizExercise quizExercise) {
+    public Class<?> viewForStudentsInQuizExercise(QuizExercise quizExercise) {
         if (!quizExercise.isStarted()) {
             return QuizView.Before.class;
         }
@@ -561,7 +561,7 @@ public class QuizExerciseService {
      * @param exerciseId Id of the exercise to reset
      */
     public void resetExercise(Long exerciseId) {
-        // refetch exercise to make sure we have an updated version
+        // fetch exercise again to make sure we have an updated version
         QuizExercise quizExercise = findOneWithQuestionsAndStatistics(exerciseId);
 
         // for quizzes we need to delete the statistics and we need to reset the quiz to its original state

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizStatisticService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizStatisticService.java
@@ -170,7 +170,7 @@ public class QuizStatisticService {
 
         // update QuizPointStatistic with the result
         if (result != null) {
-            // check if result contains a quizSubmission if true -> a it's not necessary to fetch it from the database
+            // check if result contains a quizSubmission if true -> it's not necessary to fetch it from the database
             QuizSubmission quizSubmission = (QuizSubmission) result.getSubmission();
             quizExercise.getQuizPointStatistic().addResult(result.getScore(), result.isRated());
             for (QuizQuestion quizQuestion : quizExercise.getQuizQuestions()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/assessment/Context.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/assessment/Context.java
@@ -1,5 +1,6 @@
 package de.tum.in.www1.artemis.service.compass.assessment;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -42,6 +43,6 @@ public class Context {
 
     @Override
     public int hashCode() {
-        return contextElementIDs.hashCode();
+        return Objects.hashCode(getContextElementIDs());
     }
 }

--- a/src/main/webapp/app/overview/course-registration-selector/course-registration-selector.component.ts
+++ b/src/main/webapp/app/overview/course-registration-selector/course-registration-selector.component.ts
@@ -3,7 +3,7 @@ import { AlertService } from 'app/core/alert/alert.service';
 import { TUM_USERNAME_REGEX } from 'app/app.constants';
 import { AccountService } from 'app/core/auth/account.service';
 import { Course } from 'app/entities/course.model';
-import { CourseManagementService } from '../../course/manage/course-management.service';
+import { CourseManagementService } from 'app/course/manage/course-management.service';
 
 @Component({
     selector: 'jhi-course-registration-selector',

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -486,8 +486,11 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         exam.setTitle("Over 9000!");
         long examCountBefore = examRepository.count();
         Exam createdExam = request.putWithResponseBody("/api/courses/" + course1.getId() + "/exams", exam, Exam.class, HttpStatus.CREATED);
-        createdExam.setId(null);
-        assertEquals(exam, createdExam);
+        assertThat(exam.getEndDate()).isEqualTo(createdExam.getEndDate());
+        assertThat(exam.getStartDate()).isEqualTo(createdExam.getStartDate());
+        assertThat(exam.getVisibleDate()).isEqualTo(createdExam.getVisibleDate());
+        // Note: ZonedDateTime has problems with comparison due to time zone differences for values saved in the database and values not saved in the database
+        assertThat(exam).usingRecursiveComparison().ignoringFields("id", "course", "endDate", "startDate", "visibleDate").isEqualTo(createdExam);
         assertThat(examCountBefore + 1).isEqualTo(examRepository.count());
         // No course is set -> conflict
         exam = ModelFactory.generateExam(course1);

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -745,7 +744,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         }
     }
 
-    @RepeatedTest(100)
+    @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testReevaluateStatistics() throws Exception {
         quizExercise = createQuizOnServer(ZonedDateTime.now().plusSeconds(5), null);

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.byLessThan;
 
-import java.awt.*;
 import java.security.Principal;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -12,6 +11,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -22,10 +22,7 @@ import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.DifficultyLevel;
 import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.quiz.*;
-import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
-import de.tum.in.www1.artemis.repository.QuizSubmissionRepository;
-import de.tum.in.www1.artemis.repository.ResultRepository;
-import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
+import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.QuizExerciseService;
 import de.tum.in.www1.artemis.service.scheduled.quiz.QuizScheduleService;
 import de.tum.in.www1.artemis.util.DatabaseUtilService;
@@ -61,6 +58,9 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
     @Autowired
     QuizSubmissionRepository quizSubmissionRepository;
+
+    @Autowired
+    SubmittedAnswerRepository submittedAnswerRepository;
 
     private QuizExercise quizExercise;
 
@@ -547,7 +547,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         final var username = "student1";
         final Principal principal = () -> username;
-        QuizSubmission quizSubmission = database.generateSubmission(quizExercise, 1, true, null);
+        QuizSubmission quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, 1, true, null);
         quizSubmissionWebsocketService.saveSubmission(quizExercise.getId(), quizSubmission, principal);
 
         // Quiz submissions are not yet in database
@@ -683,7 +683,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         int numberOfParticipants = 10;
 
         for (int i = 1; i <= numberOfParticipants; i++) {
-            QuizSubmission quizSubmission = database.generateSubmission(quizExercise, i, true, now.minusHours(3));
+            QuizSubmission quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, i, true, now.minusHours(3));
             database.addSubmission(quizExercise, quizSubmission, "student" + i);
             database.addResultToSubmission(quizSubmission, AssessmentType.AUTOMATIC, null, quizExercise.getScoreForSubmission(quizSubmission), true);
         }
@@ -696,13 +696,13 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         assertThat(quizExerciseWithRecalculatedStatistics.getQuizPointStatistic().getParticipantsRated()).isEqualTo(numberOfParticipants);
 
         for (PointCounter pointCounter : quizExerciseWithRecalculatedStatistics.getQuizPointStatistic().getPointCounters()) {
-            if (pointCounter.getPoints() == 0.0) {
+            if (pointCounter.getPoints().equals(0.0)) {
                 assertThat(pointCounter.getRatedCounter()).isEqualTo(3);
             }
-            else if (pointCounter.getPoints() == 3.0 || pointCounter.getPoints() == 4.0 || pointCounter.getPoints() == 6.0) {
+            else if (pointCounter.getPoints().equals(3.0) || pointCounter.getPoints().equals(4.0) || pointCounter.getPoints().equals(6.0)) {
                 assertThat(pointCounter.getRatedCounter()).isEqualTo(2);
             }
-            else if (pointCounter.getPoints() == 7.0) {
+            else if (pointCounter.getPoints().equals(7.0)) {
                 assertThat(pointCounter.getRatedCounter()).isEqualTo(1);
             }
             else {
@@ -712,7 +712,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         // add more submissions and recalculate
         for (int i = numberOfParticipants; i <= 14; i++) {
-            QuizSubmission quizSubmission = database.generateSubmission(quizExercise, i, true, now.minusHours(3));
+            QuizSubmission quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, i, true, now.minusHours(3));
             database.addSubmission(quizExercise, quizSubmission, "student" + i);
             database.addResultToSubmission(quizSubmission, AssessmentType.AUTOMATIC, null, quizExercise.getScoreForSubmission(quizSubmission), true);
         }
@@ -724,19 +724,19 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         assertThat(quizExerciseWithRecalculatedStatistics.getQuizPointStatistic().getParticipantsRated()).isEqualTo(numberOfParticipants + 4);
 
         for (PointCounter pointCounter : quizExerciseWithRecalculatedStatistics.getQuizPointStatistic().getPointCounters()) {
-            if (pointCounter.getPoints() == 0.0) {
+            if (pointCounter.getPoints().equals(0.0)) {
                 assertThat(pointCounter.getRatedCounter()).isEqualTo(5);
             }
-            else if (pointCounter.getPoints() == 4.0) {
+            else if (pointCounter.getPoints().equals(4.0)) {
                 assertThat(pointCounter.getRatedCounter()).isEqualTo(3);
             }
-            else if (pointCounter.getPoints() == 3.0 || pointCounter.getPoints() == 6.0) {
+            else if (pointCounter.getPoints().equals(3.0) || pointCounter.getPoints().equals(6.0)) {
                 assertThat(pointCounter.getRatedCounter()).isEqualTo(2);
             }
-            else if (pointCounter.getPoints() == 7.0) {
+            else if (pointCounter.getPoints().equals(7.0)) {
                 assertThat(pointCounter.getRatedCounter()).isEqualTo(1);
             }
-            else if (pointCounter.getPoints() == 9.0) {
+            else if (pointCounter.getPoints().equals(9.0)) {
                 assertThat(pointCounter.getRatedCounter()).isEqualTo(1);
             }
             else {
@@ -745,7 +745,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         }
     }
 
-    @Test
+    @RepeatedTest(100)
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testReevaluateStatistics() throws Exception {
         quizExercise = createQuizOnServer(ZonedDateTime.now().plusSeconds(5), null);
@@ -762,11 +762,13 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         for (int i = 1; i <= numberOfParticipants; i++) {
             if (i != 1 && i != 5) {
-                QuizSubmission quizSubmission = database.generateSubmission(quizExercise, i, true, ZonedDateTime.now().minusHours(1));
+                QuizSubmission quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, i, true, ZonedDateTime.now().minusHours(1));
                 database.addSubmission(quizExercise, quizSubmission, "student" + i);
                 database.addResultToSubmission(quizSubmission, AssessmentType.AUTOMATIC, null, quizExercise.getScoreForSubmission(quizSubmission), true);
             }
         }
+
+        assertThat(submittedAnswerRepository.findAll().size()).isEqualTo((numberOfParticipants - 2) * 3);
 
         // submission with everything selected
         QuizSubmission quizSubmission = database.generateSpecialSubmissionWithResult(quizExercise, true, ZonedDateTime.now().minusHours(1), true);
@@ -778,16 +780,22 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         database.addSubmission(quizExercise, quizSubmission, "student5");
         database.addResultToSubmission(quizSubmission, AssessmentType.AUTOMATIC, null, quizExercise.getScoreForSubmission(quizSubmission), true);
 
-        assertThat(studentParticipationRepository.findAll().size()).isEqualTo(10);
-        assertThat(resultRepository.findAll().size()).isEqualTo(10);
+        assertThat(studentParticipationRepository.findAll().size()).isEqualTo(numberOfParticipants);
+        assertThat(resultRepository.findAll().size()).isEqualTo(numberOfParticipants);
+        assertThat(quizSubmissionRepository.findAll().size()).isEqualTo(numberOfParticipants);
+        assertThat(submittedAnswerRepository.findAll().size()).isEqualTo(numberOfParticipants * 3);
 
         // calculate statistics
         quizExercise = request.get("/api/quiz-exercises/" + quizExercise.getId() + "/recalculate-statistics", HttpStatus.OK, QuizExercise.class);
 
-        // reevaluate without changing anything and check if statistics are still correct
+        System.out.println("QuizPointStatistic before re-evaluate: " + quizExercise.getQuizPointStatistic());
+
+        // reevaluate without changing anything and check if statistics are still correct (i.e. unchanged)
         QuizExercise quizExerciseWithReevaluatedStatistics = request.putWithResponseBody("/api/quiz-exercises/" + quizExercise.getId() + "/re-evaluate/", quizExercise,
                 QuizExercise.class, HttpStatus.OK);
         checkStatistics(quizExercise, quizExerciseWithReevaluatedStatistics);
+
+        System.out.println("QuizPointStatistic after re-evaluate (without changes): " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
 
         // remove wrong answer option and reevaluate
         var multipleChoiceQuestion = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
@@ -802,11 +810,12 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         assertThat(multipleChoiceQuestionAfterReevaluate.getAnswerOptions()).hasSize(1);
 
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic()).isEqualTo(quizExercise.getQuizPointStatistic());
-        System.out.println(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().hashCode());
+        System.out.println("QuizPointStatistic.hashCode:" + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().hashCode());
 
         // one student should get a higher score
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters().size())
                 .isEqualTo(quizExercise.getQuizPointStatistic().getPointCounters().size());
+        System.out.println("QuizPointStatistic after 1st re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
         // TODO: sometimes 0.0 is flaky and will be pc30 instead of pc20
         // TODO: sometimes 4.0 is flaky and will be pc20 instead of pc30
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(0.0, pc20, 3.0, pc20, 4.0, pc30, 6.0, pc20, 7.0, pc10));
@@ -825,6 +834,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         // several students should get a higher score
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters().size())
                 .isEqualTo(quizExercise.getQuizPointStatistic().getPointCounters().size());
+        System.out.println("QuizPointStatistic after 2nd re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(2.0, pc20, 5.0, pc20, 6.0, pc50, 9.0, pc10));
 
         // delete a question and reevaluate
@@ -839,6 +849,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         // max score should be less
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters().size())
                 .isEqualTo(quizExercise.getQuizPointStatistic().getPointCounters().size() - 3);
+        System.out.println("QuizPointStatistic after 3rd re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(2.0, pc40, 6.0, pc60));
     }
 
@@ -862,7 +873,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         for (int i = 1; i <= numberOfParticipants; i++) {
             if (i != 1 && i != 5) {
-                QuizSubmission quizSubmissionPractice = database.generateSubmission(quizExercise, i, true, ZonedDateTime.now());
+                QuizSubmission quizSubmissionPractice = database.generateSubmissionForThreeQuestions(quizExercise, i, true, ZonedDateTime.now());
                 database.addSubmission(quizExercise, quizSubmissionPractice, "student" + i);
                 database.addResultToSubmission(quizSubmissionPractice, AssessmentType.AUTOMATIC, null, quizExercise.getScoreForSubmission(quizSubmissionPractice), false);
             }
@@ -1036,24 +1047,24 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 var mcStatistic = (MultipleChoiceQuestionStatistic) statistic;
                 assertThat(mcStatistic.getAnswerCounters()).isNotEmpty();
                 for (var counter : mcStatistic.getAnswerCounters()) {
-                    System.out.println(counter.toString());
-                    System.out.println(counter.getMultipleChoiceQuestionStatistic());
+                    System.out.println("AnswerCounters: " + counter.toString());
+                    System.out.println("MultipleChoiceQuestionStatistic: " + counter.getMultipleChoiceQuestionStatistic());
                 }
             }
             if (statistic instanceof DragAndDropQuestionStatistic) {
                 var dndStatistic = (DragAndDropQuestionStatistic) statistic;
                 assertThat(dndStatistic.getDropLocationCounters()).isNotEmpty();
                 for (var counter : dndStatistic.getDropLocationCounters()) {
-                    System.out.println(counter.toString());
-                    System.out.println(counter.getDragAndDropQuestionStatistic());
+                    System.out.println("DropLocationCounters: " + counter.toString());
+                    System.out.println("DragAndDropQuestionStatistic: " + counter.getDragAndDropQuestionStatistic());
                 }
             }
             if (statistic instanceof ShortAnswerQuestionStatistic) {
                 var saStatistic = (ShortAnswerQuestionStatistic) statistic;
                 assertThat(saStatistic.getShortAnswerSpotCounters()).isNotEmpty();
                 for (var counter : saStatistic.getShortAnswerSpotCounters()) {
-                    System.out.println(counter.toString());
-                    System.out.println(counter.getShortAnswerQuestionStatistic());
+                    System.out.println("ShortAnswerSpotCounters: " + counter.toString());
+                    System.out.println("ShortAnswerQuestionStatistic: " + counter.getShortAnswerQuestionStatistic());
                 }
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -819,8 +819,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         assertThat(quizExerciseWithReevaluatedStatistics.getQuizPointStatistic().getPointCounters().size())
                 .isEqualTo(quizExercise.getQuizPointStatistic().getPointCounters().size());
         System.out.println("QuizPointStatistic after 1st re-evaluate: " + quizExerciseWithReevaluatedStatistics.getQuizPointStatistic());
-        // TODO: sometimes 0.0 is flaky and will be pc30 instead of pc20
-        // TODO: sometimes 4.0 is flaky and will be pc20 instead of pc30
+
         assertQuizPointStatisticsPointCounters(quizExerciseWithReevaluatedStatistics, Map.of(0.0, pc20, 3.0, pc20, 4.0, pc30, 6.0, pc20, 7.0, pc10));
 
         // set a question invalid and reevaluate

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -790,6 +790,9 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         System.out.println("QuizPointStatistic before re-evaluate: " + quizExercise.getQuizPointStatistic());
 
+        // check that the statistic is correct before any re-evaluate
+        assertQuizPointStatisticsPointCounters(quizExercise, Map.of(0.0, pc30, 3.0, pc20, 4.0, pc20, 6.0, pc20, 7.0, pc10));
+
         // reevaluate without changing anything and check if statistics are still correct (i.e. unchanged)
         QuizExercise quizExerciseWithReevaluatedStatistics = request.putWithResponseBody("/api/quiz-exercises/" + quizExercise.getId() + "/re-evaluate/", quizExercise,
                 QuizExercise.class, HttpStatus.OK);

--- a/src/test/java/de/tum/in/www1/artemis/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizSubmissionIntegrationTest.java
@@ -99,7 +99,7 @@ public class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         QuizSubmission quizSubmission;
 
         for (int i = 1; i <= numberOfParticipants; i++) {
-            quizSubmission = database.generateSubmission(quizExercise, i, false, null);
+            quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, i, false, null);
             final var username = "student" + i;
             final Principal principal = () -> username;
             // save
@@ -110,7 +110,7 @@ public class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
 
         // only half of the students submit manually
         for (int i = 1; i <= numberOfParticipants / 2; i++) {
-            quizSubmission = database.generateSubmission(quizExercise, i, true, null);
+            quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, i, true, null);
             final var username = "student" + i;
             final Principal principal = () -> username;
             // submit
@@ -204,7 +204,7 @@ public class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
 
         // submit 10 times for 10 different students
         for (int i = 1; i <= numberOfParticipants; i++) {
-            QuizSubmission quizSubmission = database.generateSubmission(quizExercise, i, true, null);
+            QuizSubmission quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, i, true, null);
             database.changeUser("student" + i);
             Result receivedResult = request.postWithResponseBody("/api/exercises/" + quizExercise.getId() + "/submissions/practice", quizSubmission, Result.class, HttpStatus.OK);
             assertThat(((QuizSubmission) receivedResult.getSubmission()).getSubmittedAnswers().size()).isEqualTo(quizSubmission.getSubmittedAnswers().size());
@@ -457,7 +457,7 @@ public class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         verify(messagingTemplate, never()).send(eq(publishQuizPath), any());
 
         // check that submission fails
-        QuizSubmission quizSubmission = database.generateSubmission(quizExercise, 1, true, null);
+        QuizSubmission quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, 1, true, null);
         quizSubmissionWebsocketService.saveSubmission(quizExercise.getId(), quizSubmission, () -> "student1");
 
         quizScheduleService.processCachedQuizSubmissions();
@@ -476,7 +476,7 @@ public class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         // save submissions
         int numberOfParticipants = 10;
         for (int i = 1; i <= numberOfParticipants; i++) {
-            quizSubmission = database.generateSubmission(quizExercise, i, false, null);
+            quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, i, false, null);
             final var username = "student" + i;
             final Principal principal = () -> username;
             // save

--- a/src/test/java/de/tum/in/www1/artemis/RepositoryProgrammingExerciseParticipationResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/RepositoryProgrammingExerciseParticipationResourceIntegrationTest.java
@@ -386,7 +386,9 @@ public class RepositoryProgrammingExerciseParticipationResourceIntegrationTest e
         var receivedLogs = request.getList(studentRepoBaseUrl + participation.getId() + "/buildlogs", HttpStatus.OK, BuildLogEntry.class);
         assertThat(receivedLogs).isNotNull();
         assertThat(receivedLogs).hasSize(1);
-        assertThat(receivedLogs).isEqualTo(logs);
+        assertThat(receivedLogs.get(0).getTime()).isEqualTo(logs.get(0).getTime());
+        // due to timezone assertThat isEqualTo issues, we compare those directly first and ignore them afterwards
+        assertThat(receivedLogs).usingElementComparatorIgnoringFields("time", "id").isEqualTo(logs);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
@@ -159,7 +159,7 @@ public class ResultServiceIntegrationTest extends AbstractSpringIntegrationBambo
         final var optionalResult = gradingService.processNewProgrammingExerciseResult(solutionParticipation, resultNotification);
 
         Set<ProgrammingExerciseTestCase> testCases = programmingExerciseTestCaseService.findByExerciseId(programmingExercise.getId());
-        assertThat(testCases).isEqualTo(expectedTestCases);
+        assertThat(testCases).usingElementComparatorIgnoringFields("exercise", "id").isEqualTo(expectedTestCases);
         assertThat(optionalResult).isPresent();
         assertThat(optionalResult.get().getScore()).isEqualTo(100L);
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -960,7 +960,7 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         final var testsInDB = programmingExerciseTestCaseRepository.findByExerciseId(programmingExercise.getId());
         returnedTests.forEach(testCase -> testCase.setExercise(programmingExercise));
 
-        assertThat(new HashSet<>(returnedTests)).isEqualTo(testsInDB);
+        assertThat(new HashSet<>(returnedTests)).usingElementComparatorIgnoringFields("exercise").isEqualTo(testsInDB);
     }
 
     @Test
@@ -1002,7 +1002,7 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         testCasesResponse.forEach(testCase -> testCase.setExercise(programmingExercise));
         final var testCasesInDB = programmingExerciseTestCaseRepository.findByExerciseId(programmingExercise.getId());
 
-        assertThat(new HashSet<>(testCasesResponse)).isEqualTo(testCasesInDB);
+        assertThat(new HashSet<>(testCasesResponse)).usingElementComparatorIgnoringFields("exercise").isEqualTo(testCasesInDB);
         assertThat(testCasesResponse).allSatisfy(testCase -> {
             assertThat(testCase.isAfterDueDate()).isTrue();
             assertThat(testCase.getWeight()).isEqualTo(testCase.getId() + 42);
@@ -1047,7 +1047,7 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         testCasesResponse.forEach(testCase -> testCase.setExercise(programmingExercise));
         final var testsInDB = programmingExerciseTestCaseRepository.findByExerciseId(programmingExercise.getId());
 
-        assertThat(new HashSet<>(testCasesResponse)).isEqualTo(testsInDB);
+        assertThat(new HashSet<>(testCasesResponse)).usingElementComparatorIgnoringFields("exercise").isEqualTo(testsInDB);
         assertThat(testsInDB).allSatisfy(test -> assertThat(test.getWeight()).isEqualTo(1));
         assertThat(testsInDB).allSatisfy(test -> assertThat(test.getBonusMultiplier()).isEqualTo(1.0));
         assertThat(testsInDB).allSatisfy(test -> assertThat(test.getBonusPoints()).isEqualTo(0.0));

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -1047,7 +1047,7 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         testCasesResponse.forEach(testCase -> testCase.setExercise(programmingExercise));
         final var testsInDB = programmingExerciseTestCaseRepository.findByExerciseId(programmingExercise.getId());
 
-        assertThat(new HashSet<>(testCasesResponse)).usingElementComparatorIgnoringFields("exercise").isEqualTo(testsInDB);
+        assertThat(testCasesResponse).containsExactlyInAnyOrderElementsOf(testsInDB);
         assertThat(testsInDB).allSatisfy(test -> assertThat(test.getWeight()).isEqualTo(1));
         assertThat(testsInDB).allSatisfy(test -> assertThat(test.getBonusMultiplier()).isEqualTo(1.0));
         assertThat(testsInDB).allSatisfy(test -> assertThat(test.getBonusPoints()).isEqualTo(0.0));

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -14,6 +14,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -956,11 +957,10 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
     @WithMockUser(username = "tutor1", roles = "TA")
     public void getTestCases_asTutor() throws Exception {
         final var endpoint = ProgrammingExerciseTestCaseResource.Endpoints.TEST_CASES.replace("{exerciseId}", programmingExercise.getId() + "");
-        final var returnedTests = request.getList(ROOT + endpoint, HttpStatus.OK, ProgrammingExerciseTestCase.class);
-        final var testsInDB = programmingExerciseTestCaseRepository.findByExerciseId(programmingExercise.getId());
+        final List<ProgrammingExerciseTestCase> returnedTests = request.getList(ROOT + endpoint, HttpStatus.OK, ProgrammingExerciseTestCase.class);
+        final List<ProgrammingExerciseTestCase> testsInDB = new ArrayList<>(programmingExerciseTestCaseRepository.findByExerciseId(programmingExercise.getId()));
         returnedTests.forEach(testCase -> testCase.setExercise(programmingExercise));
-
-        assertThat(new HashSet<>(returnedTests)).usingElementComparatorIgnoringFields("exercise").isEqualTo(testsInDB);
+        assertThat(returnedTests).containsExactlyInAnyOrderElementsOf(testsInDB);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/service/ExamQuizServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExamQuizServiceTest.java
@@ -153,7 +153,7 @@ public class ExamQuizServiceTest extends AbstractSpringIntegrationBambooBitbucke
 
         for (int i = 0; i < numberOfParticipants; i++) {
             database.changeUser("student" + (i + 1));
-            QuizSubmission quizSubmission = database.generateSubmission(quizExercise, i + 1, true, ZonedDateTime.now());
+            QuizSubmission quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, i + 1, true, ZonedDateTime.now());
             request.put("/api/exercises/" + quizExercise.getId() + "/submissions/exam", quizSubmission, HttpStatus.OK);
         }
 
@@ -196,7 +196,7 @@ public class ExamQuizServiceTest extends AbstractSpringIntegrationBambooBitbucke
 
         for (int i = 0; i < numberOfParticipants; i++) {
             database.changeUser("student" + (i + 1));
-            QuizSubmission quizSubmission = database.generateSubmission(quizExercise, i + 1, true, ZonedDateTime.now());
+            QuizSubmission quizSubmission = database.generateSubmissionForThreeQuestions(quizExercise, i + 1, true, ZonedDateTime.now());
             request.put("/api/exercises/" + quizExercise.getId() + "/submissions/exam", quizSubmission, HttpStatus.OK);
         }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2029,8 +2029,8 @@ public class DatabaseUtilService {
         sa.setExplanation("Explanation");
         sa.setRandomizeOrder(true);
         // invoke some util methods
-        System.out.println(sa.toString());
-        System.out.println(sa.hashCode());
+        System.out.println("ShortAnswer: " + sa.toString());
+        System.out.println("ShortAnswer.hashCode: " + sa.hashCode());
         sa.copyQuestionId();
         return sa;
     }
@@ -2075,8 +2075,8 @@ public class DatabaseUtilService {
         dnd.addCorrectMapping(mapping2);
         dnd.setExplanation("Explanation");
         // invoke some util methods
-        System.out.println(dnd.toString());
-        System.out.println(dnd.hashCode());
+        System.out.println("DnD: " + dnd.toString());
+        System.out.println("DnD.hashCode: " + dnd.hashCode());
         dnd.copyQuestionId();
         return dnd;
     }
@@ -2093,8 +2093,8 @@ public class DatabaseUtilService {
         mc.getAnswerOptions().add(new AnswerOption().text("B").hint("H2").explanation("E2").isCorrect(false));
         mc.setExplanation("Explanation");
         // invoke some util methods
-        System.out.println(mc.toString());
-        System.out.println(mc.hashCode());
+        System.out.println("MC: " + mc.toString());
+        System.out.println("MC.hashCode: " + mc.hashCode());
         mc.copyQuestionId();
         return mc;
     }
@@ -2106,7 +2106,7 @@ public class DatabaseUtilService {
      * @param submitted Boolean if it is submitted or not
      * @param submissionDate Submission date
      */
-    public QuizSubmission generateSubmission(QuizExercise quizExercise, int studentID, boolean submitted, ZonedDateTime submissionDate) {
+    public QuizSubmission generateSubmissionForThreeQuestions(QuizExercise quizExercise, int studentID, boolean submitted, ZonedDateTime submissionDate) {
         QuizSubmission quizSubmission = new QuizSubmission();
         QuizQuestion quizQuestion1 = quizExercise.getQuizQuestions().get(0);
         QuizQuestion quizQuestion2 = quizExercise.getQuizQuestions().get(1);

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2145,8 +2145,6 @@ public class DatabaseUtilService {
             else {
                 quizSubmission.addSubmittedAnswers(generateSubmittedAnswerFor(question, false));
             }
-            quizSubmission.addSubmittedAnswers(generateSubmittedAnswerFor(question, false));
-            quizSubmission.addSubmittedAnswers(generateSubmittedAnswerFor(question, false));
         }
         quizSubmission.submitted(submitted);
         quizSubmission.submissionDate(submissionDate);

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -1458,9 +1458,10 @@ public class DatabaseUtilService {
 
     public List<FileUploadExercise> createFileUploadExercisesWithCourse() {
         Course course = ModelFactory.generateCourse(null, pastTimestamp, futureFutureTimestamp, new HashSet<>(), "tumuser", "tutor", "instructor");
+        int courseSizeBefore = courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now()).size();
         courseRepo.save(course);
         List<Course> courseRepoContent = courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now());
-        assertThat(courseRepoContent.size()).as("a course got stored").isEqualTo(1);
+        assertThat(courseRepoContent.size()).as("a course got stored").isEqualTo(courseSizeBefore + 1);
 
         FileUploadExercise releasedFileUploadExercise = ModelFactory.generateFileUploadExercise(pastTimestamp, futureTimestamp, futureFutureTimestamp, "png,pdf", course);
         releasedFileUploadExercise.setTitle("released");


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I made sure the tests still work and are not flaky any more by executing them 100 times in a row.

### Motivation and Context
The test `de.tum.in.www1.artemis.QuizExerciseIntegrationTest.testReevaluateStatistics()` failed every 8th execution for no apparent reason.

### Description
Removed two calls that added two extra `SubmittedAswers` for no reason.

@krusche also improve the code quality and removed lots of duplicated code in this PR by moving the id attribute to a new abstract super class called `DomainObject`. This allowed to unify almost all `equals(...)` and `hashCode()` methods and led to the deletion of more than 2100 lines of code. There is also another new abstract super class `TempIdObject` for some quiz objects.

### Steps for Testing
1. Check the code
2. Run the tests
