### PR TITLE
Fix split.js linting issue

### DIFF
--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/plagiarism-split-view.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/plagiarism-split-view.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, Directive, ElementRef, Input, OnChanges, OnInit, QueryList, SimpleChanges, ViewChildren } from '@angular/core';
 // @ts-ignore
-import { Split } from 'split.js';
+import Split from 'split.js';
 import { Observable } from 'rxjs';
 import { ModelingSubmissionComparisonDTO } from 'app/exercises/modeling/manage/modeling-exercise.service';
 import { ModelingSubmissionService } from 'app/exercises/modeling/participate/modeling-submission.service';
@@ -27,7 +27,7 @@ export class PlagiarismSplitViewComponent implements AfterViewInit, OnChanges, O
 
     @ViewChildren(SplitPaneDirective) panes!: QueryList<SplitPaneDirective>;
 
-    private split: Split;
+    private split: Split.Instance;
 
     constructor(private submissionService: ModelingSubmissionService) {}
 


### PR DESCRIPTION
This PR fixes a webpack and linting issue related to the import of the `Split.js` module:

![image](https://user-images.githubusercontent.com/21973908/95000268-9284c800-05bf-11eb-9619-268acd0388bb.png)

and

`Cannot use namespace ‘Split’ as a type`