### PR TITLE
Update jenkins-gitlab.rst

### DIFF
--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -199,7 +199,7 @@ Gitlab Access Token
 
        artemis:
            version-control:
-               token: your.generated.api.token
+               secret: your.generated.api.token
 
 12. (Optional) Allow outbound requests to local network
 


### PR DESCRIPTION
token property does not exist the property is called secrete instead