### PR TITLE
[Feature] Use JPlag for text exercises plagiarism detection

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionExportService.java
@@ -34,6 +34,14 @@ public class TextSubmissionExportService extends SubmissionExportService {
         }
     }
 
+    /**
+     * Save the content of the given TextSubmission to a file.
+     *
+     * @param exercise the submission belongs to
+     * @param submission that will be saved to a file
+     * @param submissionsFolderName base folder name to save the file to
+     * @throws IOException
+     */
     public void saveSubmissionToFile(TextExercise exercise, TextSubmission submission, String submissionsFolderName) throws IOException {
         String submissionFileName = String.format("%s-Submission-%s%s", exercise.getTitle(), submission.getId(), this.getFileEndingForSubmission(submission));
 

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionExportService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Submission;
+import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.domain.TextSubmission;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 
@@ -31,6 +32,20 @@ public class TextSubmissionExportService extends SubmissionExportService {
             writer.write(((TextSubmission) submission).getText());
             writer.close();
         }
+    }
+
+    public void saveSubmissionToFile(TextExercise exercise, TextSubmission submission, String submissionsFolderName) throws IOException {
+        String submissionFileName = String.format("%s-Submission-%s%s", exercise.getTitle(), submission.getId(), this.getFileEndingForSubmission(submission));
+
+        File submissionExportFile = new File(submissionsFolderName, submissionFileName);
+
+        if (!submissionExportFile.exists()) {
+            submissionExportFile.createNewFile();
+        }
+
+        BufferedWriter writer = new BufferedWriter(new FileWriter(submissionExportFile));
+        writer.write(submission.getText());
+        writer.close();
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import jplag.ExitException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -563,14 +565,12 @@ public class TextExerciseResource {
      */
     @GetMapping("/text-exercises/{exerciseId}/check-plagiarism")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
-    public ResponseEntity<Stream<SubmissionComparisonDTO>> checkPlagiarism(@PathVariable long exerciseId, @RequestParam(required = false) String strategy) {
+    public ResponseEntity<Stream<SubmissionComparisonDTO>> checkPlagiarism(@PathVariable long exerciseId) {
         Optional<TextExercise> optionalTextExercise = textExerciseService.findOneWithParticipationsAndSubmissions(exerciseId);
 
         if (optionalTextExercise.isEmpty()) {
             return notFound();
         }
-
-        log.info("TEXT PLAGIARISM STRATEGY: " + strategy);
 
         TextExercise textExercise = optionalTextExercise.get();
 
@@ -587,15 +587,29 @@ public class TextExerciseResource {
 
         log.info("Found " + textSubmissions.size() + " non empty text submissions to compare");
 
-        // TODO: allow one more alternative using JPlag with text compare, see ProgrammingExerciseResource:961 --> checkPlagiarism()
-        // TODO: let the user specify the minimum similarity in the client
-        return ResponseEntity.ok(Stream
+        Stream<SubmissionComparisonDTO> submissionComparisonDTOStream = Stream
                 .of(new Tuple<>(normalizedLevenshtein(), "normalizedLevenshtein"), new Tuple<>(metricLongestCommonSubsequence(), "metricLongestCommonSubsequence"),
                         new Tuple<>(nGram(), "nGram"), new Tuple<>(cosine(), "cosine"))
                 .parallel()
-                .flatMap(strat -> textPlagiarismDetectionService.compareSubmissionsForExerciseWithStrategy(textSubmissions, strat.getX(), strat.getY(), 0.8).entrySet().stream()
-                        .map(entry -> new SubmissionComparisonDTO().addAllSubmissions(entry.getKey()).putMetric(strat.getY(), entry.getValue())))
-                .collect(toMap(dto -> dto.submissions, dto -> dto, SubmissionComparisonDTO::merge)).values().stream().sorted());
+                .flatMap(comparisonStrategy -> textPlagiarismDetectionService
+                        .compareSubmissionsForExerciseWithStrategy(textSubmissions, comparisonStrategy.getX(), comparisonStrategy.getY(), 0.8).entrySet().stream()
+                        .map(entry -> new SubmissionComparisonDTO().addAllSubmissions(entry.getKey()).putMetric(comparisonStrategy.getY(), entry.getValue())))
+                .collect(toMap(dto -> dto.submissions, dto -> dto, SubmissionComparisonDTO::merge)).values().stream().sorted();
+
+        // TODO: Let the user specify the minimum similarity in the client
+        return ResponseEntity.ok(submissionComparisonDTOStream);
+    }
+
+    /**
+     * GET /check-plagiarism : Use JPlag to detect plagiarism in text exercises
+     *
+     * @param exerciseId for which all submission should be checked
+     * @return the JPlag result directory as zip file
+     */
+    @GetMapping(value = "/text-exercises/{exerciseId}/check-plagiarism", params = { "strategy=JPlag" })
+    @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
+    public ResponseEntity<String> checkPlagiarismJPlag(@PathVariable long exerciseId) throws ExitException, IOException {
+        return ResponseEntity.ok("Works");
     }
 
 }

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.html
@@ -34,6 +34,7 @@
                 <div ngbDropdownMenu aria-labelledby="check-plagiarism-download">
                     <button type="button" (click)="checkPlagiarismJson()" ngbDropdownItem>JSON</button>
                     <button type="button" (click)="checkPlagiarismCsv()" ngbDropdownItem>CSV</button>
+                    <button type="button" (click)="checkPlagiarismJPlag()" ngbDropdownItem>JPLAG</button>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
@@ -120,6 +120,8 @@ export class TextExerciseDetailComponent implements OnInit, OnDestroy {
         });
     }
 
+    checkPlagiarismJPlag() {}
+
     checkPlagiarismCsv() {
         this.checkPlagiarism((data) => {
             if (data.length > 0) {

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
@@ -9,7 +9,7 @@ import { TextExercise } from 'app/entities/text-exercise.model';
 import { SubmissionComparisonDTO, TextExerciseService } from './text-exercise.service';
 import { ArtemisMarkdownService } from 'app/shared/markdown.service';
 import { AssessmentType } from 'app/entities/assessment-type.model';
-import { downloadFile } from 'app/shared/util/download.util';
+import { downloadFile, downloadZipFileFromResponse } from 'app/shared/util/download.util';
 import { ExportToCsv } from 'export-to-csv';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { User } from 'app/core/user/user.model';
@@ -120,7 +120,16 @@ export class TextExerciseDetailComponent implements OnInit, OnDestroy {
         });
     }
 
-    checkPlagiarismJPlag() {}
+    checkPlagiarismJPlag() {
+        this.checkPlagiarismInProgress = true;
+        this.textExerciseService.checkPlagiarismJPlag(this.textExercise.id!).subscribe(
+            (response: HttpResponse<Blob>) => {
+                this.checkPlagiarismInProgress = false;
+                downloadZipFileFromResponse(response);
+            },
+            () => (this.checkPlagiarismInProgress = false),
+        );
+    }
 
     checkPlagiarismCsv() {
         this.checkPlagiarism((data) => {

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.service.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.service.ts
@@ -90,9 +90,25 @@ export class TextExerciseService {
 
     /**
      * Check for plagiarism
+     *
      * @param exerciseId of the text exercise
      */
     checkPlagiarism(exerciseId: number): Observable<HttpResponse<Array<SubmissionComparisonDTO>>> {
         return this.http.get<Array<SubmissionComparisonDTO>>(`${this.resourceUrl}/${exerciseId}/check-plagiarism`, { observe: 'response' });
+    }
+
+    /**
+     * Check plagiarism with JPlag
+     *
+     * @param exerciseId
+     */
+    checkPlagiarismJPlag(exerciseId: number): Observable<HttpResponse<Blob>> {
+        return this.http.get(`${this.resourceUrl}/${exerciseId}/check-plagiarism`, {
+            observe: 'response',
+            responseType: 'blob',
+            params: {
+                strategy: 'JPlag',
+            },
+        });
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
Plagiarism detection for text exercises does not support JPlag yet. However, our current plagiarism detection algorithm is quite slow so JPlag might be the preferable option. The user should be able to decide which strategy/algorithm to use when triggering the plagiarism detection.

### Description
The Artemis client application can now call the `/check-plagiarism` endpoint for text exercises and pass an optional `strategy` parameter to specify the strategy to use for text exercise comparison. If no `strategy` parameter is specified, the algorithm will default to the current implementation.

Example request to trigger the plagiarism detection using JPlag:
`GET http://localhost:9000/api/text-exercises/13/check-plagiarism?strategy=JPlag`

**Note**: As discussed with @krusche, this PR does not contain tests for the new functionality. These tests will be implemented in a follow-up PR.

### Steps for Testing

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a text exercise
4. Create similar submissions for the text exercise on multiple student accounts
5. Log in as the course instructor and navigate to the exercise details view

Make sure that:
1. Clicking on "Check Plagiarism" now offers a third option called "JPlag"
2. Clicking on "JPlag" correctly sets the `strategy=JPlag` parameter in the `GET` request
3. The server responds with a ZIP file containing the JPlag output (a bunch of HTML files, no need to check those)

### Screenshots
<img width="644" alt="Screenshot 2020-10-05 at 12 14 38" src="https://user-images.githubusercontent.com/21973908/95070663-bbfd3b00-0708-11eb-968a-0f6f7ecf32ca.png">
