### PR TITLE
[Bugfix] Another flaky test fix

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -1225,7 +1225,8 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
         var instructor = database.getUserByLogin("instructor1");
         StudentExam testRunConfiguration = new StudentExam();
         testRunConfiguration.setExercises(new ArrayList<>());
-        var exam = database.addExerciseGroupsAndExercisesToExam(exam1, false);
+        var exam = database.addExam(course1);
+        exam = database.addTextModelingProgrammingExercisesToExam(exam, false);
         exam.getExerciseGroups().forEach(exerciseGroup -> testRunConfiguration.getExercises().add(exerciseGroup.getExercises().iterator().next()));
         testRunConfiguration.setExam(exam);
         testRunConfiguration.setWorkingTime(6000);


### PR DESCRIPTION
### Motivation and Context
`testCreateTestRun()` also showed flaky behaviour
![image](https://user-images.githubusercontent.com/15110960/95321929-082cb480-089c-11eb-8f2f-3ebf044ab59f.png)


### Description
Implement the same fix to flaky test as in #2166
![image](https://user-images.githubusercontent.com/15110960/95324594-4330e700-08a0-11eb-945f-566b8684a56b.png)


### Steps for Testing
1. Rerun the server test build a few times on bamboo 

2. You can also replace the tag **`@Test`** with **`@RepeatedTest(100)`**  for `testCreateTestRun()` locally to run the test 100 times in sequence.

