### PR TITLE
Critical fix for enter not creating linebreaks in programming exercise creation

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -1,6 +1,6 @@
 <div class="row justify-content-center">
     <div class="col-lg-8 col-sm-12">
-        <form name="editForm" role="form" novalidate (ngSubmit)="save()" #editForm="ngForm" (keydown.enter)="$event.preventDefault()">
+        <form name="editForm" role="form" novalidate (ngSubmit)="save()" #editForm="ngForm" (keydown.enter)="($event.target.tagName == 'TEXTAREA')">
             <h4 *ngIf="!programmingExercise.id" id="jhi-programming-exercise-heading-create" jhiTranslate="artemisApp.programmingExercise.home.generateLabel">
                 Generate new Programming Exercise
             </h4>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The change introduced in #2145 caused a bug that made line breaks in text-boxes (e.g. the problem statement, grading criteria) using the enter key not possible anymore.


### Description
- Enter now targets only the text box but is not dismissed completely.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create Programming exercises and check that enter does not perform a submit and that you can create line breaks in text blocks (e.g. the problem statement, grading criteria)

