### PR TITLE
Fixed gradle docker target

### DIFF
--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -1,12 +1,12 @@
 jib {
     from {
-        image = "adoptopenjdk:15-jre-hotspot"
+        image = "openjdk:15-jdk-alpine"
     }
     to {
         image = "artemis:latest"
     }
     container {
-        entrypoint = ["bash", "-c", "chmod +x /entrypoint.sh && sync && /entrypoint.sh"]
+        entrypoint = ["/bin/sh", "-c", "chmod +x /entrypoint.sh && sync && /entrypoint.sh"]
         ports = ["8080"]
         environment = [
             SPRING_OUTPUT_ANSI_ENABLED: "ALWAYS",

--- a/src/main/jib/entrypoint.sh
+++ b/src/main/jib/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "The application will start in ${JHIPSTER_SLEEP}s..." && sleep ${JHIPSTER_SLEEP}
-exec java ${JAVA_OPTS} -noverify -XX:+AlwaysPreTouch -Djava.security.egd=file:/dev/./urandom -cp /app/resources/:/app/classes/:/app/libs/* "de.tum.in.www1.artemis.ArTeMiSApp"  "$@"
+exec java ${JAVA_OPTS} -noverify -XX:+AlwaysPreTouch -Djava.security.egd=file:/dev/./urandom -cp /app/resources/:/app/classes/:/app/libs/* "de.tum.in.www1.artemis.ArtemisApp"  "$@"


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I tried to build Kubernetes docker images from the source. However, the Jhipster config files are broken. First, the base docker image does not exist on Docker hub. I changed it to use Alpine JDK 15. Second, the Main class is misspelled inside the jib template used during the build.

### Description
<!-- Describe your changes in detail -->
1. Used Alpine instead of Openjdk 15 als base image
2. Fixed the missspelled Artemis main class

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Use grade to locally build the docker image as described in the Jhipster documentation.
./gradlew -Pprod bootJar jibDockerBuild -x test