### PR TITLE
[Chore] Improve test coverage BambooService

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
@@ -692,6 +692,7 @@ public class BambooService implements ContinuousIntegrationService {
                 artifactLabelFilter.add("Build log");
                 buildResult.getArtifacts().setArtifacts(
                         buildResult.getArtifacts().getArtifacts().stream().filter(artifact -> !artifactLabelFilter.contains(artifact.getName())).collect(Collectors.toList()));
+                buildResult.getArtifacts().setSize(buildResult.getArtifacts().getArtifacts().size());
             }
 
             // search for version control information

--- a/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
@@ -121,7 +121,7 @@ public class BambooRequestMockProvider {
      * This method mocks that the programming exercise with the same project name already exists (depending on the boolean input exists), based on the programming exercise title
      *
      * @param exercise the programming exercise that might already exist
-     * @param exists whether the programming exercise with the same title exists
+     * @param exists   whether the programming exercise with the same title exists
      * @throws IOException
      * @throws URISyntaxException
      */
@@ -247,14 +247,24 @@ public class BambooRequestMockProvider {
         mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
     }
 
+    /**
+     * This method mocks that the artifact page the latest build result is empty
+     */
     public void mockRetrieveEmptyArtifactPage() throws URISyntaxException, JsonProcessingException, MalformedURLException {
+        var indexOfResponse = "href=\"/download/1\"";
         var noArtifactsResponse = "";
-        URL url = new URL("https://bamboo.ase.in.tum.de/download/");
-        final var uri = UriComponentsBuilder.fromUri(url.toURI()).build().toUri();
+        final var uri = new URL("https://bamboo.ase.in.tum.de/download/").toURI();
+        final var uri2 = new URL("https://bamboo.ase.in.tum.de/download/1").toURI();
 
-        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(noArtifactsResponse));
+        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.TEXT_HTML).body(indexOfResponse));
+        mockServer.expect(requestTo(uri2)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(noArtifactsResponse));
     }
 
+    /**
+     * This method mocks that the build log of a given plan has failed
+     *
+     * @param planKey the build plan id
+     */
     public void mockFetchBuildLogs(String planKey) throws URISyntaxException, JsonProcessingException, MalformedURLException {
         var newDate = new Date().getTime();
         Map firstLogEntry = Map.of("log", "java.lang.AssertionError: BubbleSort does not sort correctly", "date", newDate);

--- a/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
@@ -259,7 +259,7 @@ public class BambooRequestMockProvider {
     }
 
     public void mockFetchBuildLogs(String planKey) throws URISyntaxException, JsonProcessingException, MalformedURLException {
-        var newDate = (new Date()).getTime();
+        var newDate = new Date().getTime();
         Map firstLogEntry = Map.of( "log", "java.lang.AssertionError: BubbleSort does not sort correctly", "date", newDate);
         Map response = Map.of("logEntries", Map.of("logEntry", List.of(firstLogEntry)));
         final var uri = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/result").pathSegment(planKey.toUpperCase() + "-JOB1")

--- a/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
@@ -114,7 +114,7 @@ public class BambooRequestMockProvider {
      */
     public void mockProjectKeyExists(ProgrammingExercise exercise) {
         mockServer.expect(ExpectedCount.once(), requestTo(BAMBOO_SERVER_URL + "/rest/api/latest/project/" + exercise.getProjectKey())).andExpect(method(HttpMethod.GET))
-                .andRespond(withStatus(HttpStatus.OK));
+            .andRespond(withStatus(HttpStatus.OK));
     }
 
     /**
@@ -137,10 +137,10 @@ public class BambooRequestMockProvider {
         bambooSearchDTO.setSearchResults(List.of(searchResult));
 
         mockServer.expect(ExpectedCount.once(), requestTo(BAMBOO_SERVER_URL + "/rest/api/latest/project/" + projectKey)).andExpect(method(HttpMethod.GET))
-                .andRespond(withStatus(HttpStatus.NOT_FOUND));
+            .andRespond(withStatus(HttpStatus.NOT_FOUND));
         final var projectSearchPath = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/search/projects").queryParam("searchTerm", projectName);
         mockServer.expect(ExpectedCount.once(), requestTo(projectSearchPath.build().toUri())).andExpect(method(HttpMethod.GET))
-                .andRespond(withStatus(HttpStatus.OK).body(mapper.writeValueAsString(bambooSearchDTO)).contentType(MediaType.APPLICATION_JSON));
+            .andRespond(withStatus(HttpStatus.OK).body(mapper.writeValueAsString(bambooSearchDTO)).contentType(MediaType.APPLICATION_JSON));
     }
 
     public void mockRemoveAllDefaultProjectPermissions(ProgrammingExercise exercise) {
@@ -148,9 +148,8 @@ public class BambooRequestMockProvider {
         List.of("ANONYMOUS", "LOGGED_IN").stream().map(role -> {
             try {
                 return UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/permissions/project/").pathSegment(projectKey).path("/roles/")
-                        .pathSegment(role).build().toUri();
-            }
-            catch (URISyntaxException e) {
+                    .pathSegment(role).build().toUri();
+            } catch (URISyntaxException e) {
                 throw new AssertionError("Should be able to build URIs for Bamboo roles in mock setup");
             }
         }).forEach(rolePath -> mockServer.expect(ExpectedCount.once(), requestTo(rolePath)).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(HttpStatus.NO_CONTENT)));
@@ -161,18 +160,18 @@ public class BambooRequestMockProvider {
 
         final var instructorURI = buildGivePermissionsURIFor(projectKey, exercise.getCourseViaExerciseGroupOrCourseMember().getInstructorGroupName());
         mockServer.expect(ExpectedCount.once(), requestTo(instructorURI)).andExpect(method(HttpMethod.PUT))
-                .andExpect(content().json(mapper.writeValueAsString(List.of("CREATE", "READ", "ADMINISTRATION")))).andRespond(withStatus(HttpStatus.NO_CONTENT));
+            .andExpect(content().json(mapper.writeValueAsString(List.of("CREATE", "READ", "ADMINISTRATION")))).andRespond(withStatus(HttpStatus.NO_CONTENT));
 
         if (exercise.getCourseViaExerciseGroupOrCourseMember().getTeachingAssistantGroupName() != null) {
             final var tutorURI = buildGivePermissionsURIFor(projectKey, exercise.getCourseViaExerciseGroupOrCourseMember().getTeachingAssistantGroupName());
             mockServer.expect(ExpectedCount.once(), requestTo(tutorURI)).andExpect(method(HttpMethod.PUT)).andExpect(content().json(mapper.writeValueAsString(List.of("READ"))))
-                    .andRespond(withStatus(HttpStatus.NO_CONTENT));
+                .andRespond(withStatus(HttpStatus.NO_CONTENT));
         }
     }
 
     private URI buildGivePermissionsURIFor(String projectKey, String groupName) throws URISyntaxException {
         return UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/permissions/project/").pathSegment(projectKey).path("/groups/").pathSegment(groupName)
-                .build().toUri();
+            .build().toUri();
     }
 
     public List<Verifiable> mockCopyBuildPlanForParticipation(ProgrammingExercise exercise, String username) throws CliClient.RemoteRestException, CliClient.ClientException {
@@ -190,7 +189,7 @@ public class BambooRequestMockProvider {
     }
 
     public List<Verifiable> mockUpdatePlanRepositoryForParticipation(ProgrammingExercise exercise, String username)
-            throws CliClient.RemoteRestException, CliClient.ClientException {
+        throws CliClient.RemoteRestException, CliClient.ClientException {
         final var projectKey = exercise.getProjectKey();
         final var bambooRepoName = Constants.ASSIGNMENT_REPO_NAME;
         final var bitbucketRepoName = projectKey.toLowerCase() + "-" + username;
@@ -199,7 +198,7 @@ public class BambooRequestMockProvider {
     }
 
     public List<Verifiable> mockUpdatePlanRepository(ProgrammingExercise exercise, String planName, String bambooRepoName, String bitbucketRepoName, List<String> triggeredBy)
-            throws CliClient.RemoteRestException, CliClient.ClientException {
+        throws CliClient.RemoteRestException, CliClient.ClientException {
         final var verifications = new LinkedList<Verifiable>();
         final var projectKey = exercise.getProjectKey();
         final var planKey = (projectKey + "-" + planName).toUpperCase();
@@ -243,24 +242,22 @@ public class BambooRequestMockProvider {
     public void mockQueryLatestBuildResultFromBambooServer(String planKey) throws URISyntaxException, JsonProcessingException, MalformedURLException {
         final var response = createBuildResult(planKey);
         final var uri = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/result").pathSegment(planKey.toUpperCase() + "-JOB1")
-                .pathSegment("latest.json").queryParam("expand", "testResults.failedTests.testResult.errors,artifacts,changes,vcsRevisions").build().toUri();
+            .pathSegment("latest.json").queryParam("expand", "testResults.failedTests.testResult.errors,artifacts,changes,vcsRevisions").build().toUri();
 
-        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET))
-                .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
+        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
     }
 
-    public void mockRetrieveEmptyArtifactPage() throws URISyntaxException, JsonProcessingException, MalformedURLException{
+    public void mockRetrieveEmptyArtifactPage() throws URISyntaxException, JsonProcessingException, MalformedURLException {
         var noArtifactsResponse = "";
         URL url = new URL("https://bamboo.ase.in.tum.de/download/");
         final var uri = UriComponentsBuilder.fromUri(url.toURI()).build().toUri();
 
-        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET))
-            .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(noArtifactsResponse));
+        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(noArtifactsResponse));
     }
 
     public void mockFetchBuildLogs(String planKey) throws URISyntaxException, JsonProcessingException, MalformedURLException {
         var newDate = new Date().getTime();
-        Map firstLogEntry = Map.of( "log", "java.lang.AssertionError: BubbleSort does not sort correctly", "date", newDate);
+        Map firstLogEntry = Map.of("log", "java.lang.AssertionError: BubbleSort does not sort correctly", "date", newDate);
         Map response = Map.of("logEntries", Map.of("logEntry", List.of(firstLogEntry)));
         final var uri = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/result").pathSegment(planKey.toUpperCase() + "-JOB1")
             .pathSegment("latest.json").queryParam("expand", "logEntries&max-results=2000").build().toUri();
@@ -315,7 +312,7 @@ public class BambooRequestMockProvider {
         buildArtifact2.setName("Mock Build log");
         buildArtifact2.setProducerJobKey(planKey + "-JOB-1");
         buildArtifact2.setShared(false);
-        artifacts.setArtifacts(List.of(buildArtifact1,buildArtifact2));
+        artifacts.setArtifacts(List.of(buildArtifact1, buildArtifact2));
         artifacts.setSize(2);
         buildResult.setArtifacts(artifacts);
 
@@ -348,7 +345,7 @@ public class BambooRequestMockProvider {
         final var uri = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/plan").pathSegment(planKey + ".json").build().toUri();
 
         mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET))
-                .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
+            .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
     }
 
     public void mockBuildPlanIsValid(final String buildPlanId, final boolean isValid) throws URISyntaxException {
@@ -358,7 +355,7 @@ public class BambooRequestMockProvider {
     }
 
     public Verifiable mockCopyBuildPlan(String sourceProjectKey, String sourcePlanName, String targetProjectKey, String targetPlanName)
-            throws CliClient.RemoteRestException, CliClient.ClientException {
+        throws CliClient.RemoteRestException, CliClient.ClientException {
         final var targetPlanKey = targetProjectKey + "-" + targetPlanName;
         final var sourcePlanKey = sourceProjectKey + "-" + sourcePlanName;
         doReturn(targetPlanKey).when(planHelper).clonePlan(eq(sourcePlanKey), eq(targetPlanKey), eq(targetPlanName), eq(""), anyString(), eq(true));

--- a/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
@@ -114,7 +114,7 @@ public class BambooRequestMockProvider {
      */
     public void mockProjectKeyExists(ProgrammingExercise exercise) {
         mockServer.expect(ExpectedCount.once(), requestTo(BAMBOO_SERVER_URL + "/rest/api/latest/project/" + exercise.getProjectKey())).andExpect(method(HttpMethod.GET))
-            .andRespond(withStatus(HttpStatus.OK));
+                .andRespond(withStatus(HttpStatus.OK));
     }
 
     /**
@@ -137,10 +137,10 @@ public class BambooRequestMockProvider {
         bambooSearchDTO.setSearchResults(List.of(searchResult));
 
         mockServer.expect(ExpectedCount.once(), requestTo(BAMBOO_SERVER_URL + "/rest/api/latest/project/" + projectKey)).andExpect(method(HttpMethod.GET))
-            .andRespond(withStatus(HttpStatus.NOT_FOUND));
+                .andRespond(withStatus(HttpStatus.NOT_FOUND));
         final var projectSearchPath = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/search/projects").queryParam("searchTerm", projectName);
         mockServer.expect(ExpectedCount.once(), requestTo(projectSearchPath.build().toUri())).andExpect(method(HttpMethod.GET))
-            .andRespond(withStatus(HttpStatus.OK).body(mapper.writeValueAsString(bambooSearchDTO)).contentType(MediaType.APPLICATION_JSON));
+                .andRespond(withStatus(HttpStatus.OK).body(mapper.writeValueAsString(bambooSearchDTO)).contentType(MediaType.APPLICATION_JSON));
     }
 
     public void mockRemoveAllDefaultProjectPermissions(ProgrammingExercise exercise) {
@@ -148,8 +148,9 @@ public class BambooRequestMockProvider {
         List.of("ANONYMOUS", "LOGGED_IN").stream().map(role -> {
             try {
                 return UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/permissions/project/").pathSegment(projectKey).path("/roles/")
-                    .pathSegment(role).build().toUri();
-            } catch (URISyntaxException e) {
+                        .pathSegment(role).build().toUri();
+            }
+            catch (URISyntaxException e) {
                 throw new AssertionError("Should be able to build URIs for Bamboo roles in mock setup");
             }
         }).forEach(rolePath -> mockServer.expect(ExpectedCount.once(), requestTo(rolePath)).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(HttpStatus.NO_CONTENT)));
@@ -160,18 +161,18 @@ public class BambooRequestMockProvider {
 
         final var instructorURI = buildGivePermissionsURIFor(projectKey, exercise.getCourseViaExerciseGroupOrCourseMember().getInstructorGroupName());
         mockServer.expect(ExpectedCount.once(), requestTo(instructorURI)).andExpect(method(HttpMethod.PUT))
-            .andExpect(content().json(mapper.writeValueAsString(List.of("CREATE", "READ", "ADMINISTRATION")))).andRespond(withStatus(HttpStatus.NO_CONTENT));
+                .andExpect(content().json(mapper.writeValueAsString(List.of("CREATE", "READ", "ADMINISTRATION")))).andRespond(withStatus(HttpStatus.NO_CONTENT));
 
         if (exercise.getCourseViaExerciseGroupOrCourseMember().getTeachingAssistantGroupName() != null) {
             final var tutorURI = buildGivePermissionsURIFor(projectKey, exercise.getCourseViaExerciseGroupOrCourseMember().getTeachingAssistantGroupName());
             mockServer.expect(ExpectedCount.once(), requestTo(tutorURI)).andExpect(method(HttpMethod.PUT)).andExpect(content().json(mapper.writeValueAsString(List.of("READ"))))
-                .andRespond(withStatus(HttpStatus.NO_CONTENT));
+                    .andRespond(withStatus(HttpStatus.NO_CONTENT));
         }
     }
 
     private URI buildGivePermissionsURIFor(String projectKey, String groupName) throws URISyntaxException {
         return UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/permissions/project/").pathSegment(projectKey).path("/groups/").pathSegment(groupName)
-            .build().toUri();
+                .build().toUri();
     }
 
     public List<Verifiable> mockCopyBuildPlanForParticipation(ProgrammingExercise exercise, String username) throws CliClient.RemoteRestException, CliClient.ClientException {
@@ -189,7 +190,7 @@ public class BambooRequestMockProvider {
     }
 
     public List<Verifiable> mockUpdatePlanRepositoryForParticipation(ProgrammingExercise exercise, String username)
-        throws CliClient.RemoteRestException, CliClient.ClientException {
+            throws CliClient.RemoteRestException, CliClient.ClientException {
         final var projectKey = exercise.getProjectKey();
         final var bambooRepoName = Constants.ASSIGNMENT_REPO_NAME;
         final var bitbucketRepoName = projectKey.toLowerCase() + "-" + username;
@@ -198,7 +199,7 @@ public class BambooRequestMockProvider {
     }
 
     public List<Verifiable> mockUpdatePlanRepository(ProgrammingExercise exercise, String planName, String bambooRepoName, String bitbucketRepoName, List<String> triggeredBy)
-        throws CliClient.RemoteRestException, CliClient.ClientException {
+            throws CliClient.RemoteRestException, CliClient.ClientException {
         final var verifications = new LinkedList<Verifiable>();
         final var projectKey = exercise.getProjectKey();
         final var planKey = (projectKey + "-" + planName).toUpperCase();
@@ -242,9 +243,10 @@ public class BambooRequestMockProvider {
     public void mockQueryLatestBuildResultFromBambooServer(String planKey) throws URISyntaxException, JsonProcessingException, MalformedURLException {
         final var response = createBuildResult(planKey);
         final var uri = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/result").pathSegment(planKey.toUpperCase() + "-JOB1")
-            .pathSegment("latest.json").queryParam("expand", "testResults.failedTests.testResult.errors,artifacts,changes,vcsRevisions").build().toUri();
+                .pathSegment("latest.json").queryParam("expand", "testResults.failedTests.testResult.errors,artifacts,changes,vcsRevisions").build().toUri();
 
-        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
+        mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
     }
 
     /**
@@ -257,7 +259,8 @@ public class BambooRequestMockProvider {
         final var uri2 = new URL("https://bamboo.ase.in.tum.de/download/1").toURI();
 
         mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.TEXT_HTML).body(indexOfResponse));
-        mockServer.expect(requestTo(uri2)).andExpect(method(HttpMethod.GET)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(noArtifactsResponse));
+        mockServer.expect(requestTo(uri2)).andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(noArtifactsResponse));
     }
 
     /**
@@ -270,10 +273,10 @@ public class BambooRequestMockProvider {
         Map firstLogEntry = Map.of("log", "java.lang.AssertionError: BubbleSort does not sort correctly", "date", newDate);
         Map response = Map.of("logEntries", Map.of("logEntry", List.of(firstLogEntry)));
         final var uri = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/result").pathSegment(planKey.toUpperCase() + "-JOB1")
-            .pathSegment("latest.json").queryParam("expand", "logEntries&max-results=2000").build().toUri();
+                .pathSegment("latest.json").queryParam("expand", "logEntries&max-results=2000").build().toUri();
 
         mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET))
-            .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
+                .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
     }
 
     private QueriedBambooBuildResultDTO createBuildResult(final String planKey) throws JsonProcessingException, MalformedURLException {
@@ -355,7 +358,7 @@ public class BambooRequestMockProvider {
         final var uri = UriComponentsBuilder.fromUri(BAMBOO_SERVER_URL.toURI()).path("/rest/api/latest/plan").pathSegment(planKey + ".json").build().toUri();
 
         mockServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET))
-            .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
+                .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));
     }
 
     public void mockBuildPlanIsValid(final String buildPlanId, final boolean isValid) throws URISyntaxException {
@@ -365,7 +368,7 @@ public class BambooRequestMockProvider {
     }
 
     public Verifiable mockCopyBuildPlan(String sourceProjectKey, String sourcePlanName, String targetProjectKey, String targetPlanName)
-        throws CliClient.RemoteRestException, CliClient.ClientException {
+            throws CliClient.RemoteRestException, CliClient.ClientException {
         final var targetPlanKey = targetProjectKey + "-" + targetPlanName;
         final var sourcePlanKey = sourceProjectKey + "-" + sourcePlanName;
         doReturn(targetPlanKey).when(planHelper).clonePlan(eq(sourcePlanKey), eq(targetPlanKey), eq(targetPlanName), eq(""), anyString(), eq(true));

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -342,8 +342,7 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
 
     private ProgrammingExerciseStudentParticipation createUserParticipation(Course course) throws Exception {
         final var path = ROOT + ParticipationResource.Endpoints.START_PARTICIPATION.replace("{courseId}", String.valueOf(course.getId())).replace("{exerciseId}", String.valueOf(exercise.getId()));
-        final var participation = request.postWithResponseBody(path, null, ProgrammingExerciseStudentParticipation.class, HttpStatus.CREATED);
-        return participation;
+        return request.postWithResponseBody(path, null, ProgrammingExerciseStudentParticipation.class, HttpStatus.CREATED);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import de.tum.in.www1.artemis.exception.BambooException;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.lib.ObjectReader;
@@ -27,7 +26,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
@@ -344,10 +342,8 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
 
         User user = userRepo.findOneByLogin(studentLogin).orElseThrow();
         final var verifications = mockConnectorRequestsForStartParticipation(exercise, user.getParticipantIdentifier(), Set.of(user));
-        final var path = ParticipationResource.Endpoints.ROOT
-            + ParticipationResource.Endpoints.START_PARTICIPATION.replace("{courseId}", "" + course.getId()).replace("{exerciseId}", "" + exercise.getId());
+        final var path = ROOT + ParticipationResource.Endpoints.START_PARTICIPATION.replace("{courseId}", String.valueOf(course.getId())).replace("{exerciseId}", String.valueOf(exercise.getId()));
         final var participation = request.postWithResponseBody(path, null, ProgrammingExerciseStudentParticipation.class, HttpStatus.CREATED);
-
 
         // create a submission which fails
         database.createProgrammingSubmission(participation, true);
@@ -373,10 +369,8 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
 
         User user = userRepo.findOneByLogin(studentLogin).orElseThrow();
         final var verifications = mockConnectorRequestsForStartParticipation(exercise, user.getParticipantIdentifier(), Set.of(user));
-        final var path = ParticipationResource.Endpoints.ROOT
-            + ParticipationResource.Endpoints.START_PARTICIPATION.replace("{courseId}", "" + course.getId()).replace("{exerciseId}", "" + exercise.getId());
+        final var path = ROOT + ParticipationResource.Endpoints.START_PARTICIPATION.replace("{courseId}", String.valueOf(course.getId())).replace("{exerciseId}", String.valueOf(exercise.getId()));
         final var participation = request.postWithResponseBody(path, null, ProgrammingExerciseStudentParticipation.class, HttpStatus.CREATED);
-
 
         // create a submission
         database.createProgrammingSubmission(participation, false);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -332,7 +332,7 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
         assertThat(participation.getInitializationState()).as("Participation should be initialized").isEqualTo(InitializationState.INITIALIZED);
     }
 
-    private Course getCourseForExercise () {
+    private Course getCourseForExercise() {
         final var course = exercise.getCourseViaExerciseGroupOrCourseMember();
         programmingExerciseRepository.save(exercise);
         database.addTemplateParticipationForProgrammingExercise(exercise);
@@ -341,7 +341,8 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
     }
 
     private ProgrammingExerciseStudentParticipation createUserParticipation(Course course) throws Exception {
-        final var path = ROOT + ParticipationResource.Endpoints.START_PARTICIPATION.replace("{courseId}", String.valueOf(course.getId())).replace("{exerciseId}", String.valueOf(exercise.getId()));
+        final var path = ROOT + ParticipationResource.Endpoints.START_PARTICIPATION.replace("{courseId}", String.valueOf(course.getId())).replace("{exerciseId}",
+                String.valueOf(exercise.getId()));
         return request.postWithResponseBody(path, null, ProgrammingExerciseStudentParticipation.class, HttpStatus.CREATED);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -90,9 +90,9 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
 
     private final static String teamShortName = "team1";
 
-    private final static String repoBaseUrl = "/api/repository/";
+    private final static String REPOBASEURL = "/api/repository/";
 
-    private final static String participationBaseUrl = "/api/participations/";
+    private final static String PARTICIPATIONBASEURL = "/api/participations/";
 
     LocalRepository exerciseRepo = new LocalRepository();
 
@@ -334,7 +334,7 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
 
     @Test
     @WithMockUser(username = studentLogin, roles = "USER")
-    public void startProgrammingExercise_student_submissionFailedWithBuildlog() throws Exception {
+    public void startProgrammingExerciseStudentSubmissionFailedWithBuildlog() throws Exception {
         final var course = exercise.getCourseViaExerciseGroupOrCourseMember();
         programmingExerciseRepository.save(exercise);
         database.addTemplateParticipationForProgrammingExercise(exercise);
@@ -349,7 +349,7 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
         database.createProgrammingSubmission(participation, true);
         // get the failed build log
         bambooRequestMockProvider.mockFetchBuildLogs(participation.getBuildPlanId());
-        var buildLogs = request.get(repoBaseUrl + participation.getId() + "/buildlogs", HttpStatus.OK, List.class);
+        var buildLogs = request.get(REPOBASEURL + participation.getId() + "/buildlogs", HttpStatus.OK, List.class);
 
         for (final var verification : verifications) {
             verification.performVerification();
@@ -361,7 +361,7 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
 
     @Test
     @WithMockUser(username = studentLogin, roles = "USER")
-    public void startProgrammingExercise_student_retrieveEmptyArtifactPage() throws Exception {
+    public void startProgrammingExerciseStudentRetrieveEmptyArtifactPage() throws Exception {
         final var course = exercise.getCourseViaExerciseGroupOrCourseMember();
         programmingExerciseRepository.save(exercise);
         database.addTemplateParticipationForProgrammingExercise(exercise);
@@ -378,7 +378,7 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
         bambooRequestMockProvider.mockQueryLatestBuildResultFromBambooServer(participation.getBuildPlanId());
         // prepare the artifact to be null
         bambooRequestMockProvider.mockRetrieveEmptyArtifactPage();
-        var artifact = request.get(participationBaseUrl + participation.getId() + "/buildArtifact", HttpStatus.OK, byte[].class);
+        var artifact = request.get(PARTICIPATIONBASEURL + participation.getId() + "/buildArtifact", HttpStatus.OK, byte[].class);
 
         for (final var verification : verifications) {
             verification.performVerification();

--- a/src/test/java/de/tum/in/www1/artemis/service/BambooServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/BambooServiceTest.java
@@ -1,0 +1,127 @@
+package de.tum.in.www1.artemis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
+import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
+import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService.BuildStatus;
+import de.tum.in.www1.artemis.util.*;
+
+public class BambooServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+
+    @Autowired
+    ProgrammingExerciseRepository programmingExerciseRepository;
+
+    @Autowired
+    DatabaseUtilService database;
+
+    private ProgrammingExercise programmingExercise;
+
+    LocalRepository localRepo = new LocalRepository();
+
+    GitUtilService.MockFileRepositoryUrl localRepoUrl;
+
+    ProgrammingExerciseStudentParticipation participation;
+
+    @BeforeEach
+    public void initTestCase() throws Exception {
+        database.addUsers(2, 0, 0);
+        database.addCourseWithOneProgrammingExercise();
+        programmingExercise = programmingExerciseRepository.findAll().get(0);
+
+        // init local repo
+        String currentLocalFileName = "currentFileName";
+        String currentLocalFileContent = "testContent";
+        String currentLocalFolderName = "currentFolderName";
+        localRepo.configureRepos("testLocalRepo", "testOriginRepo");
+        // add file to the repository folder
+        Path filePath = Paths.get(localRepo.localRepoFile + "/" + currentLocalFileName);
+        var file = Files.createFile(filePath).toFile();
+        // write content to the created file
+        FileUtils.write(file, currentLocalFileContent);
+        // add folder to the repository folder
+        filePath = Paths.get(localRepo.localRepoFile + "/" + currentLocalFolderName);
+        Files.createDirectory(filePath).toFile();
+
+        localRepoUrl = new GitUtilService.MockFileRepositoryUrl(localRepo.localRepoFile);
+        // create a participation
+        participation = database.addStudentParticipationForProgrammingExerciseForLocalRepo(programmingExercise, "student1", localRepoUrl.getURL());
+        assertThat(programmingExercise).as("Exercise was correctly set").isEqualTo(participation.getProgrammingExercise());
+
+        // mock return of git path
+        doReturn(gitService.getRepositoryByLocalPath(localRepo.localRepoFile.toPath())).when(gitService).getOrCheckoutRepository(participation.getRepositoryUrlAsUrl(), true);
+        doReturn(gitService.getRepositoryByLocalPath(localRepo.localRepoFile.toPath())).when(gitService).getOrCheckoutRepository(participation.getRepositoryUrlAsUrl(), false);
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        database.resetDatabase();
+        reset(gitService);
+        localRepo.resetLocalRepo();
+    }
+
+    @Test
+    @WithMockUser(username = "student1")
+    public void performEmptySetupCommit_withNullExercise() {
+        // test performEmptyCommit() with empty exercise
+        participation.setProgrammingExercise(null);
+        continuousIntegrationService.performEmptySetupCommit(participation);
+
+        Repository repo = gitService.getRepositoryByLocalPath(localRepo.localRepoFile.toPath());
+        assertThat(repo).as("local repository has been deleted").isNull();
+
+        Repository originRepo = gitService.getRepositoryByLocalPath(localRepo.originRepoFile.toPath());
+        assertThat(originRepo).as("origin repository has not been deleted").isNotNull();
+    }
+
+    @Test
+    @WithMockUser(username = "student1")
+    public void testGetBuildStatus() {
+        Map<String, Boolean> result;
+        BuildStatus buildStatus;
+
+        // INACTIVE
+        doReturn(null).when(continuousIntegrationService).retrieveBuildStatus(any());
+        buildStatus = continuousIntegrationService.getBuildStatus(participation);
+        assertThat(buildStatus).as("buildStatus is inactive").isEqualTo(BuildStatus.INACTIVE);
+
+        result = new HashMap<>(Map.of("isActive", false, "isBuilding", false));
+        doReturn(result).when(continuousIntegrationService).retrieveBuildStatus(any());
+        buildStatus = continuousIntegrationService.getBuildStatus(participation);
+        assertThat(buildStatus).as("buildStatus is inactive").isEqualTo(BuildStatus.INACTIVE);
+
+        result = new HashMap<>(Map.of("isActive", false, "isBuilding", true));
+        doReturn(result).when(continuousIntegrationService).retrieveBuildStatus(any());
+        buildStatus = continuousIntegrationService.getBuildStatus(participation);
+        assertThat(buildStatus).as("buildStatus is inactive").isEqualTo(BuildStatus.INACTIVE);
+
+        // QUEUED
+        result = new HashMap<>(Map.of("isActive", true, "isBuilding", false));
+        doReturn(result).when(continuousIntegrationService).retrieveBuildStatus(any());
+        buildStatus = continuousIntegrationService.getBuildStatus(participation);
+        assertThat(buildStatus).as("buildStatus is queued").isEqualTo(BuildStatus.QUEUED);
+
+        // BUILDING
+        result = new HashMap<>(Map.of("isActive", true, "isBuilding", true));
+        doReturn(result).when(continuousIntegrationService).retrieveBuildStatus(any());
+        buildStatus = continuousIntegrationService.getBuildStatus(participation);
+        assertThat(buildStatus).as("buildStatus is building").isEqualTo(BuildStatus.BUILDING);
+    }
+}

--- a/src/test/java/de/tum/in/www1/artemis/service/BambooServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/BambooServiceTest.java
@@ -77,7 +77,7 @@ public class BambooServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
 
     @Test
     @WithMockUser(username = "student1")
-    public void performEmptySetupCommit_withNullExercise() {
+    public void performEmptySetupCommitWithNullExercise() {
         // test performEmptyCommit() with empty exercise
         participation.setProgrammingExercise(null);
         continuousIntegrationService.performEmptySetupCommit(participation);

--- a/src/test/java/de/tum/in/www1/artemis/service/BambooServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/BambooServiceTest.java
@@ -38,6 +38,9 @@ public class BambooServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
 
     ProgrammingExerciseStudentParticipation participation;
 
+    /**
+     * This method initializes the test case by setting up a local repo
+     */
     @BeforeEach
     public void initTestCase() throws Exception {
         database.addUsers(2, 0, 0);
@@ -75,6 +78,9 @@ public class BambooServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
         localRepo.resetLocalRepo();
     }
 
+    /**
+     * This method tests if the local repo is deleted if the exercise cannot be accessed
+     */
     @Test
     @WithMockUser(username = "student1")
     public void performEmptySetupCommitWithNullExercise() {
@@ -89,6 +95,9 @@ public class BambooServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
         assertThat(originRepo).as("origin repository has not been deleted").isNotNull();
     }
 
+    /**
+     * This method tests if the a build status is correctly
+     */
     @Test
     @WithMockUser(username = "student1")
     public void testGetBuildStatus() {

--- a/src/test/java/de/tum/in/www1/artemis/service/BambooServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/BambooServiceTest.java
@@ -32,8 +32,6 @@ public class BambooServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
     @Autowired
     DatabaseUtilService database;
 
-    private ProgrammingExercise programmingExercise;
-
     LocalRepository localRepo = new LocalRepository();
 
     GitUtilService.MockFileRepositoryUrl localRepoUrl;
@@ -44,7 +42,7 @@ public class BambooServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
     public void initTestCase() throws Exception {
         database.addUsers(2, 0, 0);
         database.addCourseWithOneProgrammingExercise();
-        programmingExercise = programmingExerciseRepository.findAll().get(0);
+        ProgrammingExercise programmingExercise = programmingExerciseRepository.findAll().get(0);
 
         // init local repo
         String currentLocalFileName = "currentFileName";


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)


### Description
<!-- Describe your changes in detail -->
There are no screenshots or relevant code changes, as only test cases were added. 
Thus there is one small change in BambooService.java where the `size` paramters of BambooArtifactsDTO is changed to the actual length of the Artifacts list after the `artifactLabelFilter` filter was applied.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
* The test coverage for BambooService.java was increased from 58% to 77%

