### PR TITLE
Fix end of line warnings of prettier during client building

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,7 @@ printWidth: 180
 singleQuote: true
 tabWidth: 4
 trailingComma: all
+endOfLine: auto
 
 # java rules:
 overrides:


### PR DESCRIPTION
### Checklist
Not really applicable. I compiled and run everything locally and made sure no warnings are in the build log. Then I deployed to the test server and made sure it didn't crash during compiling and did a cursory test if things still work.
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
I noticed that I get a lot of warnings from prettier in the build log when compiling the client:
![grafik](https://user-images.githubusercontent.com/72132281/95862120-b932c380-0d62-11eb-899e-39504aff7765.png)
Those seem to be due to the different line endings on different operating systems.

### Description
I changed prettier to automatically accept the line endings I have on windows. References:
- https://github.com/prettier/eslint-plugin-prettier/issues/219#issuecomment-610262026
- https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-delete-cr-prettier-prettier

### Steps for Testing
1. Compile the client
2. Look into the log to see if there are warnings
(Those warnings are also visible from the browser's console, so you can look there instead if you want.)
