### PR TITLE
Bugfix: instructor dashboard button naming

### DIFF
--- a/src/main/webapp/i18n/de/course.json
+++ b/src/main/webapp/i18n/de/course.json
@@ -78,7 +78,7 @@
                     "forbidden": "Der Kurzname muss mit einem Buchstaben beginnen und darf keine Sonderzeichen beinhalten."
                 }
             },
-            "instructorDashboard": "Instruktor Dashboard",
+            "instructorDashboard": "Instruktor Kurs Dashboard",
             "presentationScoreEnabled": {
                 "title": "Präsentationsbewertung aktiviert",
                 "description": "Aktiviere diese Checkbox und definiere, wie viele Präsentationen ein Student halten muss, um den Notenbonus für die Vorlesung zu erhalten. Nach der Aktivierung kannst du bei der Erstellung jeder Übung definieren, ob dieses Feature dafür aktiviert sein soll."

--- a/src/main/webapp/i18n/en/course.json
+++ b/src/main/webapp/i18n/en/course.json
@@ -78,7 +78,7 @@
                     "forbidden": "Short Name must start with a letter and cannot contain special characters."
                 }
             },
-            "instructorDashboard": "Instructor Dashboard",
+            "instructorDashboard": "Instructor Course Dashboard",
             "presentationScoreEnabled": {
                 "title": "Presentation Score",
                 "description": "Activate this checkbox to define the amount of presentations a student has to hold to receive the grade bonus for the course. Afterwards you can define for every created exercise, if this feature should be activated."


### PR DESCRIPTION
Bugfix: fixed this bug #2084

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
Fixes #2084 
#2084 

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis as a student or instructor
2. Navigate to Course Management
3.  Check that the Instructor dashboard button is named correctly as: Instructor Course Dashboard in German and English

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
* ExerciseService.java: TODO
* programming-exercise.component.ts TODO

### Screenshots
![image](https://user-images.githubusercontent.com/63906424/95871607-24ce5e00-0d6e-11eb-9507-92453ad86166.png)


