### PR TITLE
Fix the online courses column name

### DIFF
--- a/src/main/webapp/app/course/manage/course-management.component.html
+++ b/src/main/webapp/app/course/manage/course-management.component.html
@@ -49,7 +49,7 @@
                         ><fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th class="d-none d-md-table-cell" jhiSortBy="onlineCourse">
-                        <span>{{ 'artemisApp.course.onlineCourse' | translate }}</span
+                        <span>{{ 'artemisApp.course.onlineCourse.title' | translate }}</span
                         ><fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th class="d-none d-md-table-cell" jhiSortBy="presentationScore">

--- a/src/main/webapp/app/course/manage/course-management.component.html
+++ b/src/main/webapp/app/course/manage/course-management.component.html
@@ -41,16 +41,16 @@
                         <span>{{ 'artemisApp.course.accessGroups' | translate }}</span>
                     </th>
                     <th jhiSortBy="startDate">
-                        <span>{{ 'artemisApp.course.startDate' | translate }}</span
-                        ><fa-icon [icon]="'sort'"></fa-icon>
+                        <span>{{ 'artemisApp.course.startDate' | translate }}</span>
+                        <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th jhiSortBy="endDate">
-                        <span>{{ 'artemisApp.course.endDate' | translate }}</span
-                        ><fa-icon [icon]="'sort'"></fa-icon>
+                        <span>{{ 'artemisApp.course.endDate' | translate }}</span>
+                        <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th class="d-none d-md-table-cell" jhiSortBy="onlineCourse">
-                        <span>{{ 'artemisApp.course.onlineCourse.title' | translate }}</span
-                        ><fa-icon [icon]="'sort'"></fa-icon>
+                        <span>{{ 'artemisApp.course.onlineCourse.title' | translate }}</span>
+                        <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th class="d-none d-md-table-cell" jhiSortBy="presentationScore">
                         <span>{{ 'artemisApp.course.presentationScoreEnabled.title' | translate }}</span>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server.

### Motivation and Context
Before:
![grafik](https://user-images.githubusercontent.com/72132281/96166561-6bfb5100-0f1e-11eb-876e-d75ae98d6756.png)

After:
![grafik](https://user-images.githubusercontent.com/72132281/96166579-70c00500-0f1e-11eb-8499-0423bb14c61a.png)

### Description
Apparently  #2174 changed the `onlineCourse` entry from a string to a table to include a description, moving the column name into a `title` entry:
https://github.com/ls1intum/Artemis/blob/27ca8c7388f2b8134ef9eca4a9482c9c1dda7ddf/src/main/webapp/i18n/en/course.json#L57-L60
Using `artemisApp.course.onlineCourse.title` instead of just `artemisApp.course.onlineCourse` fixes the issue. (First commit.)
The second commit is just a style fixup.

### Steps for Testing

1. Log in to Artemis
2. Navigate to the course overview/dashboard
3. Look at the column names

