### PR TITLE
Improve Quiz Scheduling Robustness

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/QuizSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizSubmissionIntegrationTest.java
@@ -1,8 +1,11 @@
 package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.security.Principal;
 import java.time.Duration;
@@ -414,12 +417,13 @@ public class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
          * The time we wait in between needs to be relatively high to make sure the concurrent tasks are finished in time, especially sending out the exercise can easily take up to
          * 100 ms, so we should leave about 200 ms for that, similar for the completion of all saving/updating/scheduling operations.
          */
+        int timeFactor = 30;
         List<Course> courses = database.createCoursesWithExercisesAndLectures(true);
         Course course = courses.get(0);
         String publishQuizPath = "/topic/courses/" + course.getId() + "/quizExercises";
         long time = System.currentTimeMillis();
         log.debug("// Creating the quiz exercise");
-        QuizExercise quizExercise = database.createQuiz(course, ZonedDateTime.now().plus(600, ChronoUnit.MILLIS), null);
+        QuizExercise quizExercise = database.createQuiz(course, ZonedDateTime.now().plus(60 * timeFactor, ChronoUnit.MILLIS), null);
         quizExercise.duration(60);
         quizExercise.setIsPlannedToStart(true);
         quizExercise.setIsVisibleBeforeStart(true);
@@ -432,16 +436,16 @@ public class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         verify(messagingTemplate, never()).send(eq(publishQuizPath), any());
 
         // wait a bit
-        TimeUnit.MILLISECONDS.sleep(400 - (System.currentTimeMillis() - time));
+        TimeUnit.MILLISECONDS.sleep(30 * timeFactor - (System.currentTimeMillis() - time));
         time = System.currentTimeMillis();
 
         // reschedule
         log.debug("// Rescheduling the quiz");
-        quizExercise.releaseDate(ZonedDateTime.now().plus(700, ChronoUnit.MILLIS));
+        quizExercise.releaseDate(ZonedDateTime.now().plus(70 * timeFactor, ChronoUnit.MILLIS));
         quizExercise = quizExerciseService.save(quizExercise);
 
         // wait for the old release date to pass
-        TimeUnit.MILLISECONDS.sleep(400 - (System.currentTimeMillis() - time));
+        TimeUnit.MILLISECONDS.sleep(40 * timeFactor - (System.currentTimeMillis() - time));
         time = System.currentTimeMillis();
 
         // check that quiz has still not started now
@@ -456,7 +460,7 @@ public class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         assertThat(quizSubmissionRepository.count()).isZero();
 
         // wait for the new release date to pass
-        TimeUnit.MILLISECONDS.sleep(600 - (System.currentTimeMillis() - time));
+        TimeUnit.MILLISECONDS.sleep(60 * timeFactor - (System.currentTimeMillis() - time));
 
         // check that quiz has started
         log.debug("// Check that the quiz has started");
@@ -489,6 +493,9 @@ public class QuizSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         quizScheduleService.updateQuizExercise(quizExercise);
         // ... directly delete the quiz
         exerciseRepository.delete(quizExercise);
+
+        // wait a little bit
+        TimeUnit.MILLISECONDS.sleep(100);
 
         // the deleted quiz should get removed, no submissions should be saved
         quizScheduleService.processCachedQuizSubmissions();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest2.ase.in.tum.de.
   Cases tested (tested with two users on TS2.):
   - Start quiz at the set time regularly.
   - Start quiz before the set time via "Start now".
   - Reschedule quiz start one minute into the future and wait for start.
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The test `testQuizSubmitScheduledAndDeleted` was a bit flaky, especially on the build servers and possibly other slower machines. The underlying cause seems to be inconsistent updates to the `QuizExerciseCache`'s exercise object that can have a bad timing due to the concurrent and distributed nature. This PR fixes the potential problem.

### Description
- Improve the timing and waiting times in the test case
- Improve the serialization of the `QuizExerciseCache`

### Steps for Testing
- Review the Code
- Run the tests
- Check that Quiz-Participation still works in Artemis (use TS2 if possible).
  Create a quiz exercise with start date, and participate in it, maybe even with more than one student.

### Test Coverage
Should be unchanged.
