### PR TITLE
Fix Partial Programming Exercise Deletion

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -671,8 +671,11 @@ public class ProgrammingExerciseService {
         // TODO: This method does not accept a programming exercise to solve issues with nested Transactions.
         // It would be good to refactor the delete calls and move the validity checks down from the resources to the service methods (e.g. EntityNotFound).
         ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId).get();
-        if (deleteBaseReposBuildPlans) {
+        final var templateRepositoryUrlAsUrl = programmingExercise.getTemplateRepositoryUrlAsUrl();
+        final var solutionRepositoryUrlAsUrl = programmingExercise.getSolutionRepositoryUrlAsUrl();
+        final var testRepositoryUrlAsUrl = programmingExercise.getTestRepositoryUrlAsUrl();
 
+        if (deleteBaseReposBuildPlans) {
             final var templateBuildPlanId = programmingExercise.getTemplateBuildPlanId();
             if (templateBuildPlanId != null) {
                 continuousIntegrationService.get().deleteBuildPlan(programmingExercise.getProjectKey(), templateBuildPlanId);
@@ -684,21 +687,29 @@ public class ProgrammingExerciseService {
             continuousIntegrationService.get().deleteProject(programmingExercise.getProjectKey());
 
             if (programmingExercise.getTemplateRepositoryUrl() != null) {
-                final var templateRepositoryUrlAsUrl = programmingExercise.getTemplateRepositoryUrlAsUrl();
                 versionControlService.get().deleteRepository(templateRepositoryUrlAsUrl);
-                gitService.deleteLocalRepository(templateRepositoryUrlAsUrl);
             }
             if (programmingExercise.getSolutionRepositoryUrl() != null) {
-                final var solutionRepositoryUrlAsUrl = programmingExercise.getSolutionRepositoryUrlAsUrl();
                 versionControlService.get().deleteRepository(solutionRepositoryUrlAsUrl);
-                gitService.deleteLocalRepository(solutionRepositoryUrlAsUrl);
             }
             if (programmingExercise.getTestRepositoryUrl() != null) {
-                final var testRepositoryUrlAsUrl = programmingExercise.getTestRepositoryUrlAsUrl();
                 versionControlService.get().deleteRepository(testRepositoryUrlAsUrl);
-                gitService.deleteLocalRepository(testRepositoryUrlAsUrl);
             }
             versionControlService.get().deleteProject(programmingExercise.getProjectKey());
+        }
+        /*
+         * Always delete the local copies of the repository because they can (in theory) be restored by cloning again, but they block the creation of new programming exercises with
+         * the same short name as a deleted one. The instructors might have missed selecting deleteBaseReposBuildPlans, and delete those manually later. This however leaves no
+         * chance to remove the Artemis-local repositories on the server. In summary, they should and can always be deleted.
+         */
+        if (programmingExercise.getTemplateRepositoryUrl() != null) {
+            gitService.deleteLocalRepository(templateRepositoryUrlAsUrl);
+        }
+        if (programmingExercise.getSolutionRepositoryUrl() != null) {
+            gitService.deleteLocalRepository(solutionRepositoryUrlAsUrl);
+        }
+        if (programmingExercise.getTestRepositoryUrl() != null) {
+            gitService.deleteLocalRepository(testRepositoryUrlAsUrl);
         }
 
         SolutionProgrammingExerciseParticipation solutionProgrammingExerciseParticipation = programmingExercise.getSolutionParticipation();

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -66,6 +66,10 @@ public class GitService {
     @Value("${artemis.git.email}")
     private String ARTEMIS_GIT_EMAIL;
 
+    /*
+     * TODO FIXME this should to be distributed, because storage is distributed as well!
+     */
+
     private final Map<Path, Repository> cachedRepositories = new ConcurrentHashMap<>();
 
     private final Map<Path, Path> cloneInProgressOperations = new ConcurrentHashMap<>();

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -66,10 +66,6 @@ public class GitService {
     @Value("${artemis.git.email}")
     private String ARTEMIS_GIT_EMAIL;
 
-    /*
-     * TODO FIXME this should to be distributed, because storage is distributed as well!
-     */
-
     private final Map<Path, Repository> cachedRepositories = new ConcurrentHashMap<>();
 
     private final Map<Path, Path> cloneInProgressOperations = new ConcurrentHashMap<>();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
Deleting a programming exercise without deleting the build plans and repositories in the VCS will cause the creation of a new exercise with the same short name to fail more or less silently, without the user having a chance to fix this problem.

_This problem occurs regularly on production (in PGdP we had it a few times) and has no workaround, leaving the short name unusable and no error message. I therefore regard this fix as significant._

See Sentry `ARTEMIS-GZF` or https://sentry.io/share/issue/b430b961d17645648774ab63c6afb619/.

### Description
- Always delete the local repositories because they remain locally otherwise and cause the creation of a new exercise to fail.
- Fixed useless cloning of a repository when a participation is deleted

### Steps for Testing
1. Create a new programming exercise in a course as instructor
2. Delete if partially, so **don't** select "Delete All Build Plans and Repositories"
3. Then delete the Build Plans and Repositories manually over BitBucket and Bamboo
    You need to find the projects for this exercise on both and delete those projects completely.
4. Trying to create a new exercise with the same short name used in **1.** should succeed and the repositories should contain the template content (not be empty!).
