### PR TITLE
Hotfix client test issues

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/actions/code-editor-actions.component.ts
@@ -98,13 +98,15 @@ export class CodeEditorActionsComponent implements OnInit, OnDestroy, OnChanges 
      * @param changes
      */
     ngOnChanges(changes: SimpleChanges): void {
-        if (changes.editorState && changes.editorState.previousValue === EditorState.SAVING && this.commitState === CommitState.COMMITTING) {
-            if (changes.editorState.currentValue === EditorState.CLEAN) {
-                this.commitState = CommitState.CLEAN;
-            } else {
-                this.commitState = CommitState.UNCOMMITTED_CHANGES;
+        setTimeout(() => {
+            if (changes.editorState && changes.editorState.previousValue === EditorState.SAVING && this.commitState === CommitState.COMMITTING) {
+                if (changes.editorState.currentValue === EditorState.CLEAN) {
+                    this.commitState = CommitState.CLEAN;
+                } else {
+                    this.commitState = CommitState.UNCOMMITTED_CHANGES;
+                }
             }
-        }
+        });
     }
 
     ngOnDestroy(): void {

--- a/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { CookieService } from 'ngx-cookie-service';
 import { TranslateModule } from '@ngx-translate/core';
@@ -268,7 +268,7 @@ describe('CodeEditorActionsComponent', () => {
         expect(commitButton.nativeElement.disabled).to.be.false;
     });
 
-    it('should not commit if unsavedFiles exist, instead should save files with commit set to true', () => {
+    it('should not commit if unsavedFiles exist, instead should save files with commit set to true', fakeAsync(() => {
         const unsavedFiles = { fileName: 'lorem ipsum fileContent lorem ipsum' };
         const saveObservable = new Subject<null>();
         const saveChangedFilesStub = stub(comp, 'saveChangedFiles');
@@ -301,10 +301,15 @@ describe('CodeEditorActionsComponent', () => {
             editorState: new SimpleChange(EditorState.SAVING, EditorState.CLEAN, true),
         });
 
+        tick();
+
         expect(comp.isBuilding).to.be.true;
         expect(comp.commitState).to.equal(CommitState.CLEAN);
 
         fixture.detectChanges();
         expect(commitButton.nativeElement.disabled).to.be.false;
-    });
+
+        fixture.destroy();
+        flush();
+    }));
 });

--- a/src/test/javascript/spec/integration/code-editor/code-editor-container.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-container.integration.spec.ts
@@ -359,7 +359,7 @@ describe('CodeEditorContainerIntegration', () => {
 
         // init saving
         container.actions.saveChangedFiles().subscribe();
-        expect(container.commitState).to.equal(CommitState.CLEAN);
+        expect(container.commitState).to.equal(CommitState.UNCOMMITTED_CHANGES);
         expect(container.editorState).to.equal(EditorState.SAVING);
 
         // emit saving result
@@ -433,7 +433,7 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.fileBrowser.errorFiles).to.be.empty;
     });
 
-    it('should first save unsaved files before triggering commit', () => {
+    it('should first save unsaved files before triggering commit', fakeAsync(() => {
         cleanInitialize();
         const successfulSubmission = { id: 1, buildFailed: false } as ProgrammingSubmission;
         const successfulResult = { id: 4, successful: true, feedbacks: [] as Feedback[], participation: { id: 3 } } as Result;
@@ -460,6 +460,7 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.commitState).to.equal(CommitState.COMMITTING);
         expect(container.fileBrowser.status.commitState).to.equal(CommitState.COMMITTING);
         saveFilesSubject.next({ [unsavedFile]: undefined });
+
         expect(container.editorState).to.equal(EditorState.CLEAN);
         subscribeForLatestResultOfParticipationSubject.next(successfulResult);
         getLatestPendingSubmissionSubject.next({
@@ -468,6 +469,7 @@ describe('CodeEditorContainerIntegration', () => {
             participationId: successfulResult!.participation!.id!,
         });
         containerFixture.detectChanges();
+        tick();
 
         // waiting for build result
         expect(container.commitState).to.equal(CommitState.CLEAN);
@@ -483,7 +485,10 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.buildOutput.isBuilding).to.be.false;
         expect(container.buildOutput.rawBuildLogs).to.deep.equal(expectedBuildLog);
         expect(container.fileBrowser.errorFiles).to.be.empty;
-    });
+
+        containerFixture.destroy();
+        flush();
+    }));
 
     it('should enter conflict mode if a git conflict between local and remote arises', fakeAsync(() => {
         const guidedTourMapping = {} as GuidedTourMapping;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

The PR #2228 introduced a test issue in `src/test/javascript/spec/integration/code-editor/code-editor-container.integration.spec.ts`

This led to the bad situations that client tests in Bamboo and Github actions hung during execution and never finished. This PR aims to fix this.

The problem was a `Expression has changed after it was checked` error. I applied the fix on https://blog.angular-university.io/angular-debugging/ and used `setTimeout` in the corresponding `ngOnChanges` method. I then had to use some fakeAsync magic in the tests so that they still pass.

### Steps for Testing
1. Try out the online code editor as described in #2228 and check that everything is still working correctly
2. Quickly review the test code if it now makes sense.