### PR TITLE
[Bugfix] Fix for Missing Axes Labels in Exam-Scores

### DIFF
--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
@@ -23,6 +23,7 @@ import * as Chart from 'chart.js';
 import { ChartDataSets, ChartOptions, ChartType, LinearTickOptions } from 'chart.js';
 import { BaseChartDirective, Label } from 'ng2-charts';
 import { DataSet } from 'app/exercises/quiz/manage/statistics/quiz-statistic/quiz-statistic.component';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
     selector: 'jhi-exam-scores',
@@ -68,6 +69,7 @@ export class ExamScoresComponent implements OnInit, OnDestroy {
         private changeDetector: ChangeDetectorRef,
         private languageHelper: JhiLanguageHelper,
         private localeConversionService: LocaleConversionService,
+        private translateService: TranslateService,
     ) {}
 
     ngOnInit() {
@@ -150,6 +152,14 @@ export class ExamScoresComponent implements OnInit, OnDestroy {
                             min: 0,
                             max: this.calculateTickMax(),
                         } as LinearTickOptions,
+                    },
+                ],
+                xAxes: [
+                    {
+                        scaleLabel: {
+                            display: true,
+                            labelString: this.translateService.instant('artemisApp.examScores.xAxes'),
+                        },
                     },
                 ],
             },

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
@@ -145,6 +145,10 @@ export class ExamScoresComponent implements OnInit, OnDestroy {
             scales: {
                 yAxes: [
                     {
+                        scaleLabel: {
+                            display: true,
+                            labelString: this.translateService.instant('artemisApp.examScores.yAxes'),
+                        },
                         ticks: {
                             maxTicksLimit: 11,
                             beginAtZero: true,

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -9,12 +9,11 @@ import { ShortAnswerQuestionUtil } from 'app/exercises/quiz/shared/short-answer-
 import { TranslateService } from '@ngx-translate/core';
 import { FileUploaderService } from 'app/shared/http/file-uploader.service';
 import { Duration, Option } from './quiz-exercise-interfaces';
-import { NgbDate } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDate, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import * as moment from 'moment';
 import { Moment } from 'moment';
 import { Location } from '@angular/common';
 import { JhiAlertService } from 'ng-jhipster';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ComponentCanDeactivate } from 'app/shared/guard/can-deactivate.model';
 import { QuizQuestion, QuizQuestionType, ScoringType } from 'app/entities/quiz/quiz-question.model';
 import { Exercise, ExerciseCategory } from 'app/entities/exercise.model';

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -60,6 +60,7 @@
         },
         "examScores": {
             "xAxes": "Ergebnis in %",
+            "yAxes": "Anzahl an TeilnehmerInnen",
             "maxPoints": "Maximale Punktzahl",
             "title": "Klausur Ergebnisse",
             "examStatisticsTitle": "Klausur Statistik",

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -59,6 +59,7 @@
             }
         },
         "examScores": {
+            "xAxes": "Ergebnis in %",
             "maxPoints": "Maximale Punktzahl",
             "title": "Klausur Ergebnisse",
             "examStatisticsTitle": "Klausur Statistik",

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -60,7 +60,7 @@
         },
         "examScores": {
             "xAxes": "Ergebnis in %",
-            "yAxes": "Anzahl an TeilnehmerInnen",
+            "yAxes": "Teilnehmeranzahl",
             "maxPoints": "Maximale Punktzahl",
             "title": "Klausur Ergebnisse",
             "examStatisticsTitle": "Klausur Statistik",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -60,6 +60,7 @@
         },
         "examScores": {
             "xAxes": "Score in %",
+            "yAxes": "Number of Participants",
             "maxPoints": "Maximum Points",
             "title": "Exam Scores",
             "examStatisticsTitle": "Exam Statistics",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -59,6 +59,7 @@
             }
         },
         "examScores": {
+            "xAxes": "Score in %",
             "maxPoints": "Maximum Points",
             "title": "Exam Scores",
             "examStatisticsTitle": "Exam Statistics",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The labels for the bar chart used in the exam-scores page were missing.

### Description
<!-- Describe your changes in detail -->

Added the labels for the x-axes and the y-axes

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to the exam-scores of an exam
4. See that the x-axes and y-axes have correct labels in english and german

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/29718932/96904286-31059a00-1497-11eb-8e3b-9dd17b6ee737.png)
![image](https://user-images.githubusercontent.com/29718932/96904317-3bc02f00-1497-11eb-8a08-be153e717aeb.png)
