### PR TITLE
Use application link name instead of URL in map.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketBambooUpdateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketBambooUpdateService.java
@@ -46,7 +46,7 @@ public class BitbucketBambooUpdateService implements ContinuousIntegrationUpdate
     @Value("${artemis.version-control.url}")
     private URL bitbucketServerUrl;
 
-    @Value("${artemis.version-control.vcs-application-link-name}")
+    @Value("${artemis.continuous-integration.vcs-application-link-name}")
     private String vcsApplicationLinkName;
 
     private static final String OLD_ASSIGNMENT_REPO_NAME = "Assignment";

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketBambooUpdateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketBambooUpdateService.java
@@ -46,6 +46,9 @@ public class BitbucketBambooUpdateService implements ContinuousIntegrationUpdate
     @Value("${artemis.version-control.url}")
     private URL bitbucketServerUrl;
 
+    @Value("${artemis.version-control.vcs-application-link-name}")
+    private String vcsApplicationLinkName;
+
     private static final String OLD_ASSIGNMENT_REPO_NAME = "Assignment";
 
     private final Logger log = LoggerFactory.getLogger(BitbucketBambooUpdateService.class);
@@ -54,7 +57,7 @@ public class BitbucketBambooUpdateService implements ContinuousIntegrationUpdate
 
     private final RestTemplate bitbucketRestTemplate;
 
-    // url --> Link
+    // application link name --> Link
     private final Map<String, ApplicationLinksDTO.ApplicationLinkDTO> cachedApplicationLinks = new ConcurrentHashMap<>();
 
     public BitbucketBambooUpdateService(@Qualifier("bambooRestTemplate") RestTemplate bambooRestTemplate, @Qualifier("bitbucketRestTemplate") RestTemplate bitbucketRestTemplate) {
@@ -119,7 +122,7 @@ public class BitbucketBambooUpdateService implements ContinuousIntegrationUpdate
         parameters.add("repository.stash.projectKey", bitbucketRepository.getProject().getKey());
         parameters.add("repository.stash.repositoryUrl", bitbucketRepository.getCloneSshUrl());
 
-        Optional<ApplicationLinksDTO.ApplicationLinkDTO> applicationLink = getApplicationLink(bitbucketServerUrl.toString());
+        Optional<ApplicationLinksDTO.ApplicationLinkDTO> applicationLink = getApplicationLink(vcsApplicationLinkName);
         applicationLink.ifPresent(link -> parameters.add("repository.stash.server", link.getId()));
 
         try {
@@ -135,19 +138,19 @@ public class BitbucketBambooUpdateService implements ContinuousIntegrationUpdate
         }
     }
 
-    private Optional<ApplicationLinksDTO.ApplicationLinkDTO> getApplicationLink(String applicationLinkUrl) {
+    private Optional<ApplicationLinksDTO.ApplicationLinkDTO> getApplicationLink(String applicationLinkName) {
         // first try to find the application link from the local cache
-        var cachedLink = findCachedLinkForUrl(applicationLinkUrl);
+        var cachedLink = findCachedLinkForName(applicationLinkName);
         if (cachedLink.isPresent()) {
             return cachedLink;
         }
-        // if there is no local application link available, load them Bamboo server
+        // if there is no local application link available, load them from the Bamboo server
         loadApplicationLinkList();
-        return findCachedLinkForUrl(applicationLinkUrl);
+        return findCachedLinkForName(applicationLinkName);
     }
 
-    private Optional<ApplicationLinksDTO.ApplicationLinkDTO> findCachedLinkForUrl(String url) {
-        return Optional.ofNullable(cachedApplicationLinks.get(url));
+    private Optional<ApplicationLinksDTO.ApplicationLinkDTO> findCachedLinkForName(String name) {
+        return Optional.ofNullable(cachedApplicationLinks.get(name));
     }
 
     private void loadApplicationLinkList() {
@@ -156,8 +159,8 @@ public class BitbucketBambooUpdateService implements ContinuousIntegrationUpdate
         ApplicationLinksDTO links = bambooRestTemplate.exchange(builder.build().toUri(), HttpMethod.GET, null, ApplicationLinksDTO.class).getBody();
         if (links != null && links.getApplicationLinks() != null && links.getApplicationLinks().size() > 0) {
             for (var link : links.getApplicationLinks()) {
-                if (link.getRpcUrl() != null) {
-                    cachedApplicationLinks.put(link.getRpcUrl(), link);
+                if (link.getName() != null) {
+                    cachedApplicationLinks.put(link.getName(), link);
                 }
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bamboo/BambooRequestMockProvider.java
@@ -46,8 +46,8 @@ public class BambooRequestMockProvider {
     @Value("${artemis.continuous-integration.url}")
     private URL bambooServerUrl;
 
-    @Value("${artemis.version-control.url}")
-    private URL bitbucketServerUrl;
+    @Value("${artemis.continuous-integration.vcs-application-link-name}")
+    private String vcsApplicationLinkName;
 
     @Autowired
     private ObjectMapper mapper;
@@ -233,7 +233,7 @@ public class BambooRequestMockProvider {
     public ApplicationLinksDTO createApplicationLink() {
         final var applicationLinks = new ApplicationLinksDTO();
         final var applicationLink = new ApplicationLinksDTO.ApplicationLinkDTO();
-        applicationLink.setRpcUrl(bitbucketServerUrl.toString());
+        applicationLink.setName(vcsApplicationLinkName);
         applicationLink.setId("123b1230-e123-3123-9123-9123e2123123");
         applicationLinks.setApplicationLinks(List.of(applicationLink));
         return applicationLinks;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
See Slack:
"I am having an issue with my local setup. I am not able to get the response from bamboo about the executed test cases or somehow the result cannot be created. When I click on submit, Building and testing... runs forever and then stops. Afterwards I get the button to retrigger the build. Anyone with a similar problem? I updated the bamboo plugin, set the personal token for bitbucket and also disable the XSRF. Help would be much appreciated"

### Description
From Slack:
"We found the issue now: It is not related to the communication between bamboo and artemis, but between bitbucket and bamboo
It is related to the docker setup: When using docker, we create the application link with the internal docker-network-host `bamboo` and `bitbucket` , but in the application-local.yml, we have to use `localhost:8085` and `localhost:7990` . The change introduced in https://github.com/ls1intum/Artemis/pull/2199 now causes an issue as a map is created, that stores the URL of the application link and the application link.
The value received from bamboo is using the bitbucket URL (https://github.com/ls1intum/Artemis/blob/develop/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketBambooUpdateService.java#L160), but it is matched against the URL configured in the config file. Due to the mismatch, no application link is found and thus the repository triggers are not updated (actually, pushing to the base-repository caused the student repo to trigger).
The problem did not occur on the test server as well as a non-Docker setup, as here the URLs match."

This PR uses the application link name (which can be configured in the `application.yml` to get the application link name, not the application link URL (which can mismatch).

### Steps for Testing
1. Create a new programming exercise
2. Participate in it
3. Verify that a new build is triggered once you push and that Artemis receives the result

**Note**: This should be tested using different setups: Docker- and non-Docker setups.
TS1/TS3 use a non-Docker setup, but most developers use a Docker-setup.

