### PR TITLE
Fix jasmin test error

### DIFF
--- a/src/test/javascript/spec/helpers/jasmine.jest.fix.ts
+++ b/src/test/javascript/spec/helpers/jasmine.jest.fix.ts
@@ -1,3 +1,0 @@
-// these two lines solve typescript errors, because both, jest and jasmine define expect, simply import this combined expect to make sure Typescript does not complain
-type JestExpect = <T>(actual: T) => jest.Matchers<T> & jasmine.Matchers<T>;
-export declare const expect: JestExpect;

--- a/src/test/javascript/spec/helpers/jest.fix.ts
+++ b/src/test/javascript/spec/helpers/jest.fix.ts
@@ -1,0 +1,8 @@
+// male sure that jest except is available and preferred to prevent TypeScript errors
+type JestExpect = <T>(actual: T) => jest.Matchers<T>;
+export declare const expect: JestExpect;
+
+// an alternative would be to use the following to combine jest and jasmine expect
+// however, this does not work for some reasons any more and leads to an exception
+// type JestJasminExpect = <T>(actual: T) => jest.Matchers<T> & jasmine.Matchers<T>;
+// export declare const expect: JestJasminExpect;

--- a/src/test/javascript/spec/service/course.service.spec.ts
+++ b/src/test/javascript/spec/service/course.service.spec.ts
@@ -11,7 +11,7 @@ import { Course } from 'app/entities/course.model';
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { MockRouter } from '../helpers/mocks/mock-router';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('Course Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/exam-participation.service.spec.ts
+++ b/src/test/javascript/spec/service/exam-participation.service.spec.ts
@@ -11,12 +11,15 @@ import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.serv
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
 import { TranslateService } from '@ngx-translate/core';
 import { ArtemisTestModule } from '../test.module';
-import { expect } from '../helpers/jasmine.jest.fix';
 import { TextExercise } from 'app/entities/text-exercise.model';
 import { Course } from 'app/entities/course.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { TextSubmission } from 'app/entities/text-submission.model';
 import { Result } from 'app/entities/result.model';
+
+// Note: for some reason the normal "import { expect } from '../helpers/jasmine.jest.fix';" does not work here and leads to an exception
+type JestExpect = <T>(actual: T) => jest.Matchers<T>;
+export declare const expect: JestExpect;
 
 describe('Exam Participation Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/exam-participation.service.spec.ts
+++ b/src/test/javascript/spec/service/exam-participation.service.spec.ts
@@ -16,10 +16,7 @@ import { Course } from 'app/entities/course.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { TextSubmission } from 'app/entities/text-submission.model';
 import { Result } from 'app/entities/result.model';
-
-// Note: for some reason the normal "import { expect } from '../helpers/jasmine.jest.fix';" does not work here and leads to an exception
-type JestExpect = <T>(actual: T) => jest.Matchers<T>;
-export declare const expect: JestExpect;
+import { expect } from '../helpers/jest.fix';
 
 describe('Exam Participation Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/file-upload-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/file-upload-exercise.service.spec.ts
@@ -10,7 +10,7 @@ import { MockTranslateService } from '../helpers/mocks/service/mock-translate.se
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
 import { Course } from 'app/entities/course.model';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('FileUploadExercise Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/file-upload-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/file-upload-submission.service.spec.ts
@@ -3,7 +3,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { map, take } from 'rxjs/operators';
 import { FileUploadSubmissionService } from 'app/exercises/file-upload/participate/file-upload-submission.service';
 import { FileUploadSubmission } from 'app/entities/file-upload-submission.model';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('FileUploadSubmission Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/modeling-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/modeling-exercise.service.spec.ts
@@ -10,7 +10,7 @@ import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { routes } from 'app/exercises/modeling/manage/modeling-exercise.route';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ArtemisModelingExerciseModule } from 'app/exercises/modeling/manage/modeling-exercise.module';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('ModelingExercise Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/modeling-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/modeling-submission.service.spec.ts
@@ -3,7 +3,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { take } from 'rxjs/operators';
 import { ModelingSubmissionService } from 'app/exercises/modeling/participate/modeling-submission.service';
 import { ModelingSubmission } from 'app/entities/modeling-submission.model';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('ModelingSubmission Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/participation.service.spec.ts
+++ b/src/test/javascript/spec/service/participation.service.spec.ts
@@ -5,7 +5,7 @@ import * as moment from 'moment';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
 import { Participation } from 'app/entities/participation/participation.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('Participation Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/programming-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise.service.spec.ts
@@ -14,7 +14,7 @@ import { FormsModule } from '@angular/forms';
 import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 import { ArtemisProgrammingExerciseManagementModule } from 'app/exercises/programming/manage/programming-exercise-management.module';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('ProgrammingExercise Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/quiz-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/quiz-exercise.service.spec.ts
@@ -9,7 +9,7 @@ import { Course } from 'app/entities/course.model';
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { ArtemisTestModule } from '../test.module';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('QuizExercise Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/rating.service.spec.ts
+++ b/src/test/javascript/spec/service/rating.service.spec.ts
@@ -9,7 +9,7 @@ import { ArtemisTestModule } from '../test.module';
 import { RatingService } from 'app/exercises/shared/rating/rating.service';
 import { Rating } from 'app/entities/rating.model';
 import { Result } from 'app/entities/result.model';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('Rating Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/text-assessments.service.spec.ts
+++ b/src/test/javascript/spec/service/text-assessments.service.spec.ts
@@ -4,7 +4,7 @@ import { take } from 'rxjs/operators';
 import { TextSubmission } from 'app/entities/text-submission.model';
 import { TextAssessmentsService } from 'app/exercises/text/assess/text-assessments.service';
 import { SERVER_API_URL } from 'app/app.constants';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 import { Result } from 'app/entities/result.model';
 import { Feedback } from 'app/entities/feedback.model';
 import { FeedbackConflict } from 'app/entities/feedback-conflict';

--- a/src/test/javascript/spec/service/text-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/text-exercise.service.spec.ts
@@ -10,7 +10,7 @@ import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { Router } from '@angular/router';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
 import { MockRouter } from '../helpers/mocks/mock-router';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('TextExercise Service', () => {
     let injector: TestBed;

--- a/src/test/javascript/spec/service/text-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/text-submission.service.spec.ts
@@ -3,7 +3,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { take } from 'rxjs/operators';
 import { TextSubmissionService } from 'app/exercises/text/participate/text-submission.service';
 import { TextSubmission } from 'app/entities/text-submission.model';
-import { expect } from '../helpers/jasmine.jest.fix';
+import { expect } from '../helpers/jest.fix';
 
 describe('TextSubmission Service', () => {
     let injector: TestBed;


### PR DESCRIPTION
Currently, the client tests fail due to a weird error

```
Summary of all failing tests
FAIL src/test/javascript/spec/service/exam-participation.service.spec.ts
  ● Test suite failed to run

    [96msrc/test/javascript/spec/helpers/jasmine.jest.fix.ts[0m:[93m2[0m:[93m64[0m - [91merror[0m[90m TS2694: [0mNamespace 'jasmine' has no exported member 'Matchers'.

    [7m2[0m type JestExpect = <T>(actual: T) => jest.Matchers<T> & jasmine.Matchers<T>;
    [7m [0m [91m                                                               ~~~~~~~~[0m


Test Suites: 1 failed, 172 passed, 173 total
```

This PR aims to fix it