### PR TITLE
[Enhancement] Number of SCA issues in result string

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
@@ -289,7 +289,7 @@ public class ProgrammingExerciseGradingService {
             updateScore(result, successfulTestCases, testCases, staticCodeAnalysisFeedback, exercise);
 
             // Create a new result string that reflects passed, failed & not executed test cases.
-            updateResultString(result, successfulTestCases, testCasesForCurrentDate, exercise);
+            updateResultString(result, successfulTestCases, testCasesForCurrentDate, staticCodeAnalysisFeedback, exercise);
         }
         // Case 2: There are no test cases that are executed before the due date has passed. We need to do this to differentiate this case from a build error.
         else if (testCases.size() > 0 && result.getFeedbacks().size() > 0 && testCaseFeedback.size() > 0) {
@@ -442,11 +442,19 @@ public class ProgrammingExerciseGradingService {
      * @param result of the build run.
      * @param successfulTestCases test cases with positive feedback.
      * @param allTests of the given programming exercise.
+     * @param scaFeedback for the result
+     * @param exercise to which this result and the test cases belong
      */
-    private void updateResultString(Result result, Set<ProgrammingExerciseTestCase> successfulTestCases, Set<ProgrammingExerciseTestCase> allTests, ProgrammingExercise exercise) {
+    private void updateResultString(Result result, Set<ProgrammingExerciseTestCase> successfulTestCases, Set<ProgrammingExerciseTestCase> allTests, List<Feedback> scaFeedback,
+            ProgrammingExercise exercise) {
         if (result.getAssessmentType() == AssessmentType.AUTOMATIC) {
             // Create a new result string that reflects passed, failed & not executed test cases.
             String newResultString = successfulTestCases.size() + " of " + allTests.size() + " passed";
+
+            // Show number of found quality issues if static code analysis is enabled
+            if (Boolean.TRUE.equals(exercise.isStaticCodeAnalysisEnabled())) {
+                newResultString += ", " + scaFeedback.size() + " quality issues found";
+            }
             result.setResultString(newResultString);
         }
         else {

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
@@ -294,6 +294,7 @@ public class ProgrammingExerciseGradingService {
         // Case 2: There are no test cases that are executed before the due date has passed. We need to do this to differentiate this case from a build error.
         else if (testCases.size() > 0 && result.getFeedbacks().size() > 0 && testCaseFeedback.size() > 0) {
             removeAllTestCaseFeedbackAndSetScoreToZero(result, staticCodeAnalysisFeedback);
+            updateResultString(result, Set.of(), testCasesForCurrentDate, staticCodeAnalysisFeedback, exercise);
         }
         // Case 3: If there is no test case feedback, the build has failed or it has previously fallen under case 2. In this case we just return the original result without
         // changing it.
@@ -478,7 +479,6 @@ public class ProgrammingExerciseGradingService {
         result.setFeedbacks(staticCodeAnalysisFeedback);
         result.hasFeedback(staticCodeAnalysisFeedback.size() > 0);
         result.setScore(0L);
-        result.setResultString("0 of 0 passed");
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
@@ -453,7 +453,8 @@ public class ProgrammingExerciseGradingService {
 
             // Show number of found quality issues if static code analysis is enabled
             if (Boolean.TRUE.equals(exercise.isStaticCodeAnalysisEnabled())) {
-                newResultString += ", " + scaFeedback.size() + " quality issues found";
+                String issueTerm = scaFeedback.size() == 1 ? "issue" : "issues";
+                newResultString += ", " + scaFeedback.size() + " quality " + issueTerm + " found";
             }
             result.setResultString(newResultString);
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
@@ -294,7 +294,9 @@ public class ProgrammingExerciseGradingService {
         // Case 2: There are no test cases that are executed before the due date has passed. We need to do this to differentiate this case from a build error.
         else if (testCases.size() > 0 && result.getFeedbacks().size() > 0 && testCaseFeedback.size() > 0) {
             removeAllTestCaseFeedbackAndSetScoreToZero(result, staticCodeAnalysisFeedback);
-            updateResultString(result, Set.of(), testCasesForCurrentDate, staticCodeAnalysisFeedback, exercise);
+
+            // In this case, test cases won't be displayed but static code analysis feedback must be shown in the result string.
+            updateResultString(result, Set.of(), Set.of(), staticCodeAnalysisFeedback, exercise);
         }
         // Case 3: If there is no test case feedback, the build has failed or it has previously fallen under case 2. In this case we just return the original result without
         // changing it.

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
@@ -453,8 +453,8 @@ public class ProgrammingExerciseGradingService {
 
             // Show number of found quality issues if static code analysis is enabled
             if (Boolean.TRUE.equals(exercise.isStaticCodeAnalysisEnabled())) {
-                String issueTerm = scaFeedback.size() == 1 ? "issue" : "issues";
-                newResultString += ", " + scaFeedback.size() + " quality " + issueTerm + " found";
+                String issueTerm = scaFeedback.size() == 1 ? ", 1 issue" : ", " + scaFeedback.size() + " issues";
+                newResultString += issueTerm;
             }
             result.setResultString(newResultString);
         }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
@@ -669,7 +669,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 60L, "3 of 3 passed, 21 quality issues found", true, 24, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 60L, "3 of 3 passed, 21 issues", true, 24, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -677,7 +677,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 71L, "3 of 3 passed, 5 quality issues found", true, 8, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 71L, "3 of 3 passed, 5 issues", true, 8, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
 
@@ -706,7 +706,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 0L, "3 of 3 passed, 21 quality issues found", true, 24, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 0L, "3 of 3 passed, 21 issues", true, 24, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -714,7 +714,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 11L, "2 of 3 passed, 9 quality issues found", true, 12, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 11L, "2 of 3 passed, 9 issues", true, 12, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
     }
@@ -743,7 +743,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 79L, "3 of 3 passed, 6 quality issues found", true, 9, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 79L, "3 of 3 passed, 6 issues", true, 9, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
 
@@ -772,7 +772,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 19L, "3 of 3 passed, 16 quality issues found", true, 19, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 19L, "3 of 3 passed, 16 issues", true, 19, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
     }
@@ -790,7 +790,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 4L, "1 of 3 passed, 2 quality issues found", true, 5, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 4L, "1 of 3 passed, 2 issues", true, 5, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -798,7 +798,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 40L, "2 of 3 passed, 4 quality issues found", true, 7, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 40L, "2 of 3 passed, 4 issues", true, 7, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -806,7 +806,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 0L, "1 of 3 passed, 7 quality issues found", true, 10, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 0L, "1 of 3 passed, 7 issues", true, 10, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -814,7 +814,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 26L, "2 of 3 passed, 6 quality issues found", true, 9, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 26L, "2 of 3 passed, 6 issues", true, 9, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -822,7 +822,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 60L, "3 of 3 passed, 11 quality issues found", true, 14, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 60L, "3 of 3 passed, 11 issues", true, 14, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
@@ -669,7 +669,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 60L, "3 of 3 passed", true, 24, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 60L, "3 of 3 passed, 21 quality issues found", true, 24, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -677,7 +677,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 71L, "3 of 3 passed", true, 8, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 71L, "3 of 3 passed, 5 quality issues found", true, 8, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
 
@@ -706,7 +706,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 0L, "3 of 3 passed", true, 24, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 0L, "3 of 3 passed, 21 quality issues found", true, 24, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -714,7 +714,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 11L, "2 of 3 passed", true, 12, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 11L, "2 of 3 passed, 9 quality issues found", true, 12, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
     }
@@ -743,7 +743,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 79L, "3 of 3 passed", true, 9, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 79L, "3 of 3 passed, 6 quality issues found", true, 9, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
 
@@ -772,7 +772,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 19L, "3 of 3 passed", true, 19, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 19L, "3 of 3 passed, 16 quality issues found", true, 19, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
     }
@@ -790,7 +790,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 4L, "1 of 3 passed", true, 5, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 4L, "1 of 3 passed, 2 quality issues found", true, 5, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -798,7 +798,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 40L, "2 of 3 passed", true, 7, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 40L, "2 of 3 passed, 4 quality issues found", true, 7, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -806,7 +806,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 0L, "1 of 3 passed", true, 10, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 0L, "1 of 3 passed, 7 quality issues found", true, 10, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -814,7 +814,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 26L, "2 of 3 passed", true, 9, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 26L, "2 of 3 passed, 6 quality issues found", true, 9, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {
@@ -822,7 +822,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 60L, "3 of 3 passed", true, 14, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 60L, "3 of 3 passed, 11 quality issues found", true, 14, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
@@ -373,6 +373,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
         feedbacks.add(new Feedback().text("test1").positive(true).type(FeedbackType.AUTOMATIC));
         feedbacks.add(new Feedback().text("test2").positive(true).type(FeedbackType.AUTOMATIC));
         feedbacks.add(new Feedback().text("test3").positive(false).type(FeedbackType.AUTOMATIC));
+        result.setAssessmentType(AssessmentType.AUTOMATIC);
         result.feedbacks(feedbacks);
         result.successful(false);
         Long scoreBeforeUpdate = result.getScore();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR allows students to directly see, whether static code analysis issues were found.

### Description
<!-- Describe your changes in detail -->

- If SCA is enabled, the result string is extended by the following term: ", 1 issue" or ", x issues" if x=0 or x>1. x is the number of visible static code analysis feedback items.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

_No hidden tests_
1. Create a programming exercise with SCA
2. Participate in the programming exercise
3. Submit a solution
--> Check if the result string is displayed properly
4. Let the build fail
--> Build failed should be displayed

_Hidden tests_
1. Create a programming exercise with SCA, a release date and activate run after due date
2. Navigate to grading and select `run after due date` for each test case
2. Participate in the programming exercise
3. Submit a solution
--> Check if the result string is displayed properly (0 of 0 passed, x issues found)
4. Let the build fail
--> Build failed should be displayed

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
Adapted old tests to check for the enhanced result string

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/16407766/97211135-dfbf1880-17be-11eb-94c8-d9d2f1ba11d5.png)

