### PR TITLE
Bugfix/programming exercise/c template rotx

### DIFF
--- a/src/main/resources/templates/c/readme
+++ b/src/main/resources/templates/c/readme
@@ -5,7 +5,8 @@
 2. [task][Rot0 mit "aAbByYzZ123!%&/()Oau" als Eingabe](TestOutput_0)
 3. [task][Rot1 mit "aAbByYzZ123!%&/()Oau" als Eingabe](TestOutput_1)
 4. [task][Rot26 mit "aAbByYzZ123!%&/()Oau" als Eingabe](TestOutput_26)
-5. [task][Zufällige Eingaben](TestOutputRandom_0, TestOutputRandom_1, TestOutputRandom_2, TestOutputRandom_3, TestOutputRandom_4, TestOutputRandom_5, TestOutputRandom_6, TestOutputRandom_7, TestOutputRandom_8, TestOutputRandom_9)
+5. [task][Rot1563 mit "eIxK4zuaarER" als Eingabe](TestOutput_1563)
+6. [task][Zufällige Eingaben](TestOutputRandom_0, TestOutputRandom_1, TestOutputRandom_2, TestOutputRandom_3, TestOutputRandom_4, TestOutputRandom_5, TestOutputRandom_6, TestOutputRandom_7, TestOutputRandom_8, TestOutputRandom_9)
 
 #### Adress Sanitizer
 1. [task][Adress Sanitizer Kompilieren](TestCompileASan)

--- a/src/main/resources/templates/c/solution/rotX.c
+++ b/src/main/resources/templates/c/solution/rotX.c
@@ -5,10 +5,10 @@
 
 #define MAX_BUFFER_SIZE 1024
 
-char rotX(char in, unsigned rot);
-unsigned readRotCount();
+char rotX(char in, char rot);
+char readRotCount();
 
-char rotX(char in, unsigned rot) {
+char rotX(char in, char rot) {
     if(isalpha(in)) { // We only want to convert alphabet characters
         if(isupper(in)) {
             return 'A' + ((in - 'A') + rot) % 26;
@@ -18,7 +18,7 @@ char rotX(char in, unsigned rot) {
     return in;
 }
 
-unsigned readRotCount() {
+char readRotCount() {
     int rot = -1;
     do
     {   
@@ -26,20 +26,21 @@ unsigned readRotCount() {
         fflush(stdout);
         if(!scanf("%i", &rot)) {
             // Clear input if user did not enter a valid int:
-            int c;
-            while ((c = getchar()) != '\n' && c != EOF);
+            int c  = 0;
+            while ((c = getchar()) != '\n' && c != EOF) {};
         }
     } while (rot < 0);
-    return (unsigned)rot;
+    return (char)(rot%26); // Perform modulo since it does not change the result
 }
 
 int main() {
-    unsigned rot = readRotCount();
+    char rot = readRotCount();
     char buff[MAX_BUFFER_SIZE];
 
     printf("Enter text:\n");
     // Read MAX_BUFFER_SIZE - 1 chars. Don't forget about the '\0' at the end!
     size_t n = read(STDIN_FILENO, buff, MAX_BUFFER_SIZE - 1);
+    buff[n] = '\0'; // Ensure we terminate the string with '\0'. Important for printing later.
     for (size_t i = 0; i < n && buff[i]; i++)
     {
         // Replace character by character:
@@ -47,5 +48,4 @@ int main() {
     }
     // Print the result:
     printf("%s", buff);
-    
 }

--- a/src/main/resources/templates/c/test/Tests.py
+++ b/src/main/resources/templates/c/test/Tests.py
@@ -13,7 +13,7 @@ from random import choices, randint
 def main():
     # Makefile location:
     # Artemis expects it to be located in ../assignment
-    makefileLocation: str = "../assignment"
+    makefileLocation: str = "../Solution"
 
     # Create a new instace of the tester:
     tester: Tester = Tester()
@@ -33,6 +33,8 @@ def main():
                               "aAbByYzZ123!%&/()Oau", [testCompile.name], name="TestOutput_1"))
     tester.addTest(TestOutput(makefileLocation, 26,
                               "aAbByYzZ123!%&/()Oau", [testCompile.name], name="TestOutput_26"))
+    tester.addTest(TestOutput(makefileLocation, 1563,
+                              "eIxK4zuaarER", [testCompile.name], name="TestOutput_1563"))
 
     # Random RotX tests:
     for i in range(0, 10):

--- a/src/main/resources/templates/c/test/Tests.py
+++ b/src/main/resources/templates/c/test/Tests.py
@@ -13,7 +13,7 @@ from random import choices, randint
 def main():
     # Makefile location:
     # Artemis expects it to be located in ../assignment
-    makefileLocation: str = "../Solution"
+    makefileLocation: str = "../assignment"
 
     # Create a new instace of the tester:
     tester: Tester = Tester()

--- a/src/main/resources/templates/c/test/tests/TestOutput.py
+++ b/src/main/resources/templates/c/test/tests/TestOutput.py
@@ -60,7 +60,7 @@ class TestOutput(AbstractProgramTest):
         printTester("Waiting for: '{}'".format(expected))
         while True:
             if self.pWrap.hasTerminated() and not self.pWrap.canReadLineStdout():
-                self.__progTerminatedUnexpectedly()
+                self._progTerminatedUnexpectedly()
             # Read a single line form the programm output:
             line: str = self.pWrap.readLineStdout()
             # Perform a "student save" compare:

--- a/src/test/k6/resource/constants_c.js
+++ b/src/test/k6/resource/constants_c.js
@@ -4,7 +4,8 @@ export const programmingExerciseProblemStatementC = '### Tests\n' + '\n';
     '2. [task][Rot0 mit "aAbByYzZ123!%&/()Oau" als Eingabe](TestOutput_0)\n' +
     '3. [task][Rot1 mit "aAbByYzZ123!%&/()Oau" als Eingabe](TestOutput_1)\n' +
     '4. [task][Rot26 mit "aAbByYzZ123!%&/()Oau" als Eingabe](TestOutput_26)\n' +
-    '5. [task][Zufällige Eingaben](TestOutputRandom_0, TestOutputRandom_1, TestOutputRandom_2, TestOutputRandom_3, TestOutputRandom_4, TestOutputRandom_5, TestOutputRandom_6, TestOutputRandom_7, TestOutputRandom_8, TestOutputRandom_9)\n' +
+    '5. [task][Rot1563 mit "eIxK4zuaarER" als Eingabe](TestOutput_1563)\n' +
+    '6. [task][Zufällige Eingaben](TestOutputRandom_0, TestOutputRandom_1, TestOutputRandom_2, TestOutputRandom_3, TestOutputRandom_4, TestOutputRandom_5, TestOutputRandom_6, TestOutputRandom_7, TestOutputRandom_8, TestOutputRandom_9)\n' +
     '\n' +
     '#### Adress Sanitizer\n' +
     '1. [task][Adress Sanitizer Kompilieren](TestCompileASan)\n' +


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes the C-Template rotX exercise.

### Description
<!-- Describe your changes in detail -->
* Fixed printing null characters in some random cases for the rotX solution.
* Fixed `__progTerminatedUnexpectedly()` -> `_progTerminatedUnexpectedly()` since we internally switched to `AbstractProgramTest` as base class.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create a new C-Programming exercise
3. Run the solution template a couple of times -> Tests won't fail any more

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
* ExerciseService.java: 85%
* programming-exercise.component.ts 95%
