### PR TITLE
Fix incorrect repository link

### DIFF
--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
@@ -69,7 +69,7 @@
             ></jhi-programming-assessment-repo-export>
             <a
                 class="ml-2 mr-5"
-                href="{{ adjustedtRepositoryURL() }}"
+                href="{{ adjustedRepositoryURL() }}"
                 target="_blank"
                 rel="noopener noreferrer"
                 jhiTranslate="artemisApp.exerciseAssessmentDashboard.programmingExercise.goToRepo"

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
@@ -69,7 +69,7 @@
             ></jhi-programming-assessment-repo-export>
             <a
                 class="ml-2 mr-5"
-                href="{{ participation.repositoryUrl }}"
+                href="{{ adjustedtRepositoryURL() }}"
                 target="_blank"
                 rel="noopener noreferrer"
                 jhiTranslate="artemisApp.exerciseAssessmentDashboard.programmingExercise.goToRepo"

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -313,7 +313,7 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
     /**
      * Removes the username from the repositoryURL
      */
-    adjustedtRepositoryURL(): string {
+    adjustedRepositoryURL(): string {
         if (this.participation.repositoryUrl != null) {
            const splitted = this.participation.repositoryUrl.split('@', 2);
             return 'http://' + splitted[1];

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -309,16 +309,19 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
     readOnly() {
         return !this.isAtLeastInstructor && !!this.complaint && this.isAssessor;
     }
-    
+
     /**
-     * Removes the username from the repositoryURL
+     * Removes the login from the repositoryURL
      */
     adjustedRepositoryURL(): string {
-        if (this.participation.repositoryUrl != null) {
-           const splitted = this.participation.repositoryUrl.split('@', 2);
-            return 'http://' + splitted[1];
+        let newRepositoryUrl: string = this.participation.repositoryUrl || '';
+        if (this.participation.student != null && this.participation.repositoryUrl != null) {
+            const userName = this.participation.student.login + '@';
+            if (this.participation.repositoryUrl.includes(userName)) {
+                newRepositoryUrl = this.participation.repositoryUrl.replace(userName, '');
+            }
         }
-        return '';
+        return newRepositoryUrl;
     }
 
     private handleSaveOrSubmitSuccessWithAlert(response: HttpResponse<Result>, translationKey: string): void {

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -315,12 +315,12 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
      */
     adjustedtRepositoryURL(): string {
         if (this.participation.repositoryUrl != null) {
-           const splitted = this.participation.repositoryUrl.split("@", 2);
+           const splitted = this.participation.repositoryUrl.split('@', 2);
             return 'http://' + splitted[1];
         }
         return '';
     }
-    
+
     private handleSaveOrSubmitSuccessWithAlert(response: HttpResponse<Result>, translationKey: string): void {
         this.participationForManualResult.results![0] = this.manualResult = response.body!;
         this.jhiAlertService.clear();

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -309,7 +309,18 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
     readOnly() {
         return !this.isAtLeastInstructor && !!this.complaint && this.isAssessor;
     }
-
+    
+    /**
+     * Removes the username from the repositoryURL
+     */
+    adjustedtRepositoryURL(): string {
+        if (this.participation.repositoryUrl != null) {
+           const splitted = this.participation.repositoryUrl.split("@", 2);
+            return 'http://' + splitted[1];
+        }
+        return '';
+    }
+    
     private handleSaveOrSubmitSuccessWithAlert(response: HttpResponse<Result>, translationKey: string): void {
         this.participationForManualResult.results![0] = this.manualResult = response.body!;
         this.jhiAlertService.clear();


### PR DESCRIPTION
This PR is related to the Bug https://github.com/ls1intum/Artemis/issues/1860

The implemented solution is a quick fix, that removes the username from the `repositoryURL`. At the moment I do not understand the system good enough to say, if the `repositoryURL` needs to be stored this way. The quick fix should work for TumIDs because they don't consist of `@`