### PR TITLE
[Bugfix] Fix possible NPE in dashboard call

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
@@ -515,7 +515,7 @@ public class ProgrammingExercise extends Exercise {
         }
         for (var submission : participation.getSubmissions()) {
             var result = submission.getResult();
-            if (result == null) {
+            if (result == null || result.getCompletionDate() == null) {
                 continue;
             }
             // NOTE: for the dashboard we only use rated results with completion date or automatic result


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I encountered a problem on TS3 where the `for-dashboard` call was failing because of a null pointer exception. The ProgrammingExercise.findLatestSubmissionWithRatedResultWithCompletionDate does not actually check whether a completion date exists. This can lead to a NPE, as the completion date is taken for comparison.

### Description
<!-- Describe your changes in detail -->

- Only consider results with a completion date to fix the NPE

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Code review

