### PR TITLE
Fix missing/wrong info in the course information view

### DIFF
--- a/src/main/webapp/app/course/manage/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/course-detail.component.html
@@ -39,7 +39,8 @@
                 </dd>
                 <dt><span jhiTranslate="artemisApp.course.semester">Semester</span></dt>
                 <dd>
-                    <span>{{ course.semester }}</span>
+                    <span *ngIf="course.semester && course.semester !== ''">{{ course.semester }}</span>
+                    <span *ngIf="!course.semester || course.semester === ''">{{ 'global.generic.unset' | translate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.course.testCourse.title">Test Course</span></dt>
                 <dd>

--- a/src/main/webapp/app/course/manage/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/course-detail.component.html
@@ -37,6 +37,15 @@
                 <dd>
                     <span>{{ course.endDate | artemisDate }}</span>
                 </dd>
+                <dt><span jhiTranslate="artemisApp.course.semester">Semester</span></dt>
+                <dd>
+                    <span>{{ course.semester }}</span>
+                </dd>
+                <dt><span jhiTranslate="artemisApp.course.testCourse.title">Test Course</span></dt>
+                <dd>
+                    <span *ngIf="course.testCourse">{{ 'global.generic.yes' | translate }}</span>
+                    <span *ngIf="!course.testCourse">{{ 'global.generic.no' | translate }}</span>
+                </dd>
                 <dt><span jhiTranslate="artemisApp.course.onlineCourse.title">Online Course</span></dt>
                 <dd>
                     <span *ngIf="course.onlineCourse">{{ 'global.generic.yes' | translate }}</span>

--- a/src/main/webapp/app/course/manage/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/course-detail.component.html
@@ -37,10 +37,10 @@
                 <dd>
                     <span>{{ course.endDate | artemisDate }}</span>
                 </dd>
-                <dt><span jhiTranslate="artemisApp.course.onlineCourse">Online Course</span></dt>
+                <dt><span jhiTranslate="artemisApp.course.onlineCourse.title">Online Course</span></dt>
                 <dd>
-                    <span *ngIf="course.onlineCourse">{{ 'artemisApp.course.onlineCourseTrue' | translate }}</span>
-                    <span *ngIf="!course.onlineCourse">{{ 'artemisApp.course.onlineCourseFalse' | translate }}</span>
+                    <span *ngIf="course.onlineCourse">{{ 'global.generic.yes' | translate }}</span>
+                    <span *ngIf="!course.onlineCourse">{{ 'global.generic.no' | translate }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.course.presentationScoreEnabled.title">Presentation Score Enabled</span></dt>
                 <dd>

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -5,7 +5,8 @@
         "generic": {
             "yes": "Ja",
             "no": "Nein",
-            "emptyList": "Keine Elemente verfügbar"
+            "emptyList": "Keine Elemente verfügbar",
+            "unset": "Nicht gesetzt"
         },
         "menu": {
             "home": "Startseite",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -5,7 +5,8 @@
         "generic": {
             "yes": "Yes",
             "no": "No",
-            "emptyList": "No items available"
+            "emptyList": "No items available",
+            "unset": "Unset"
         },
         "menu": {
             "home": "Home",


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Description

Pretty straight forward. The old version wasn't updated to use the new translation string (I fixed that for the course overview in #2210 but didn't know this information was displayed here as well). This also adds the missing `Semester` and `Test Course` columns which are new since #2215.

Before:
![grafik](https://user-images.githubusercontent.com/72132281/97560109-90efc980-19de-11eb-972e-0a3663a2e39b.png)
After:
![grafik](https://user-images.githubusercontent.com/72132281/97560043-7cabcc80-19de-11eb-86f2-83c6ec98494c.png)


### Steps for Testing

1. Open the course information by clicking on the ID number in the course management dashboard/list
2. Check `[object Object]` is gone and Semester and Test Course are displayed correctly


