### PR TITLE
[Bugifx] Properly round the score for programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseGradingService.java
@@ -384,7 +384,7 @@ public class ProgrammingExerciseGradingService {
             }
 
             // The score is calculated as a percentage of the maximum points
-            long score = (long) (successfulTestPoints / maxScoreRespectingZeroPointExercises * 100.0);
+            long score = Math.round(successfulTestPoints / maxScoreRespectingZeroPointExercises * 100.0);
 
             result.setScore(score);
         }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
@@ -181,7 +181,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
         assertThat(result1.getFeedbacks()).hasSize(3);
 
         // Assertions result2 - calculated
-        assertThat(result2.getScore()).isEqualTo(66L);
+        assertThat(result2.getScore()).isEqualTo(67L);
         assertThat(result2.getResultString()).isEqualTo("1 of 3 passed");
         assertThat(result2.getHasFeedback()).isTrue();
         assertThat(result2.isSuccessful()).isFalse();
@@ -756,7 +756,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 11L, "2 of 3 passed, 9 issues", true, 12, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 12L, "2 of 3 passed, 9 issues", true, 12, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
     }
@@ -834,7 +834,7 @@ public class ProgrammingExerciseGradingServiceTest extends AbstractSpringIntegra
             var results = participation.getResults();
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
-            testParticipationResult(singleResult, 4L, "1 of 3 passed, 2 issues", true, 5, AssessmentType.AUTOMATIC);
+            testParticipationResult(singleResult, 5L, "1 of 3 passed, 2 issues", true, 5, AssessmentType.AUTOMATIC);
             assertThat(singleResult).isEqualTo(participation.findLatestResult());
         }
         {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Score can be 99% when all test cases pass.

### Description
- Properly round the score instead of casting to long.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
One example:
1. Create a programming exercise and modify it to have 3 test cases (or any number).
2. The solution should always have 100% score.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->

_Nothing changed._
