### PR TITLE
bugfix for wrong amount of complaints shown

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -206,8 +206,6 @@ public class ExerciseResource {
         }
 
         StatsForInstructorDashboardDTO stats = populateCommonStatistics(exercise, exercise.hasExerciseGroup());
-        stats.setNumberOfOpenComplaints(0L);
-        stats.setNumberOfOpenMoreFeedbackRequests(0L);
 
         return ResponseEntity.ok(stats);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Resolves issue https://github.com/ls1intum/Artemis/issues/2124

### Description
In the course dashboard, the amount of already assessed complaints/More Feedback Requests are correct. In the Exercise Assessment Dashboard, the amount of already assessed complaints/More Feedback Requests is not correct, it always displays that all the complaints/requests are evaluated.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a exercise, participate in it and assess it
2. Create a complaint / more feedback request
3. Check that the open complaints/Feedback requests bar is the same as in the course assessment dashboard and is correct.


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Correct view in Course Assessment Dashboard: 0/2 , none of the complaints and feedback requests were evaluated
![Capture1](https://user-images.githubusercontent.com/44401560/97804910-0794fd00-1c53-11eb-8c1f-7e43ae3a3504.JPG)
Incorrect view in Exercise Assessment Dashboard: 2/2 is displayed
![IncorrectView](https://user-images.githubusercontent.com/44401560/97804917-0c59b100-1c53-11eb-8fbf-19a0c02d511b.JPG)
Correct view in Exercise Assessment Dashboard after bugfix: 0/2 is displayed 
![CorrectView](https://user-images.githubusercontent.com/44401560/97804920-0f54a180-1c53-11eb-80b4-f86136afcdea.JPG)

