### PR TITLE
Increase Course Registration Message Max Length from 255 to 2000

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -294,8 +294,8 @@ public class CourseResource {
     }
 
     private void validateRegistrationConfirmationMessage(Course course) {
-        if (course.getRegistrationConfirmationMessage() != null && course.getRegistrationConfirmationMessage().length() > 255) {
-            throw new BadRequestAlertException("Confirmation registration message must be shorter than 255 characters", ENTITY_NAME, "confirmationRegistrationMessageInvalid",
+        if (course.getRegistrationConfirmationMessage() != null && course.getRegistrationConfirmationMessage().length() > 2000) {
+            throw new BadRequestAlertException("Confirmation registration message must be shorter than 2000 characters", ENTITY_NAME, "confirmationRegistrationMessageInvalid",
                     true);
         }
     }

--- a/src/main/resources/config/liquibase/changelog/20201102143912_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20201102143912_changelog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="femers" id="20201102143912">
+        <modifyDataType columnName="registration_confirmation_message" newDataType="varchar(2000)" tableName="course"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -90,4 +90,5 @@
     <include file="classpath:config/liquibase/changelog/20200926154829_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20201015224743_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20201026115657_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20201102143912_changelog.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/main/webapp/app/course/manage/course-update.component.ts
+++ b/src/main/webapp/app/course/manage/course-update.component.ts
@@ -112,7 +112,7 @@ export class CourseUpdateComponent implements OnInit {
                 studentQuestionsEnabled: new FormControl(this.course.studentQuestionsEnabled),
                 registrationEnabled: new FormControl(this.course.registrationEnabled),
                 registrationConfirmationMessage: new FormControl(this.course.registrationConfirmationMessage, {
-                    validators: [Validators.maxLength(255)],
+                    validators: [Validators.maxLength(2000)],
                 }),
                 presentationScore: new FormControl({ value: this.course.presentationScore, disabled: this.course.presentationScore === 0 }, [
                     Validators.min(1),


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] **Wait for reviewing and testing on the test servers until the DB changes are approved.**
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Registration messages can easily be longer than 255 characters and such a strong limitation does not make sense. Instructors might not be able to have a bilingual message or include important legal information. We should allow longer registration messages.

### Description
- Increase the maximum registration message length in the database, server and client.

### Steps for Testing
0. Review the code
1. Create a course with long registration message (255 + chars)
2. Check that it is displayed correctly when a student registers.

### Test Coverage
_Unchanged._

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
