### PR TITLE
[Bugfix] Fix NPE of Exercises Scores page

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
@@ -8,7 +8,7 @@ import { Course } from 'app/entities/course.model';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { SourceTreeService } from 'app/exercises/programming/shared/service/sourceTree.service';
 import { take, tap } from 'rxjs/operators';
-import { of, zip } from 'rxjs';
+import { of, zip, forkJoin } from 'rxjs';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { ProgrammingSubmissionService } from 'app/exercises/programming/participate/programming-submission.service';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
@@ -90,11 +90,12 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
     ngOnInit() {
         this.paramSub = this.route.params.subscribe((params) => {
             this.isLoading = true;
-            this.courseService.find(params['courseId']).subscribe((res: HttpResponse<Course>) => {
-                this.course = res.body!;
-            });
-            this.exerciseService.find(params['exerciseId']).subscribe((res: HttpResponse<Exercise>) => {
-                this.exercise = res.body!;
+            const findCourse = this.courseService.find(params['courseId']);
+            const findExercise = this.exerciseService.find(params['exerciseId']);
+
+            forkJoin(findCourse, findExercise).subscribe(([courseRes, exerciseRes]) => {
+                this.course = courseRes.body!;
+                this.exercise = exerciseRes.body!;
                 // After both calls are done, the loading flag is removed. If the exercise is not a programming exercise, only the result call is needed.
                 zip(this.getResults(), this.loadAndCacheProgrammingExerciseSubmissionState())
                     .pipe(take(1))


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) locally.
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes the following Sentry issue: https://sentry.io/organizations/ls1intum/issues/1751948618
The problem was that the REST calls are asynchronous and sometimes the exercise call finished early then the course call.

### Description
<!-- Describe your changes in detail -->
- Use forkJoin to ensure that both response are available before setting the variables course and exercise

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to a Course and click on the score button of an exercise
4. Refresh the page like >10 times and see if a error is thrown.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
Nothing changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Exercise Score Page:

![image](https://user-images.githubusercontent.com/41108487/97982639-62a22d80-1dd4-11eb-82bf-16e6281a3f7c.png)
