### PR TITLE
Make "Apollon already destroyed" error more visible in browser console

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@fortawesome/fontawesome-svg-core": "1.2.32",
         "@fortawesome/free-regular-svg-icons": "5.15.1",
         "@fortawesome/free-solid-svg-icons": "5.15.1",
-        "@ls1intum/apollon": "2.2.9",
+        "@ls1intum/apollon": "2.2.10",
         "@ng-bootstrap/ng-bootstrap": "7.0.0",
         "@ngx-translate/core": "13.0.0",
         "@ngx-translate/http-loader": "6.0.0",

--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
@@ -237,8 +237,6 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         this.autoSaveInterval = window.setInterval(() => {
             this.autoSaveTimer++;
             if (this.autoSaveTimer >= 60 && !this.canDeactivate()) {
-                // attempt once every 60 seconds to save
-                this.autoSaveTimer = 0;
                 this.saveDiagram();
             }
         }, 1000);
@@ -265,6 +263,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         }
         this.updateSubmissionModel();
         this.isSaving = true;
+        this.autoSaveTimer = 0;
 
         if (this.submission.id) {
             this.modelingSubmissionService.update(this.submission, this.modelingExercise.id!).subscribe(

--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
@@ -237,6 +237,8 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         this.autoSaveInterval = window.setInterval(() => {
             this.autoSaveTimer++;
             if (this.autoSaveTimer >= 60 && !this.canDeactivate()) {
+                // attempt once every 60 seconds to save
+                this.autoSaveTimer = 0;
                 this.saveDiagram();
             }
         }, 1000);
@@ -263,7 +265,6 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         }
         this.updateSubmissionModel();
         this.isSaving = true;
-        this.autoSaveTimer = 0;
 
         if (this.submission.id) {
             this.modelingSubmissionService.update(this.submission, this.modelingExercise.id!).subscribe(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,10 +1352,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@ls1intum/apollon@2.2.9":
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.2.9.tgz#771a7c8ca0ec17af2291b5daea315d57e2824a07"
-  integrity sha512-kt74T6HqXV47Ni/iBrk6BQ719NGUWadSZJtqFYIXCF63lK6sARKV5EGqQm89SyHobAUunqjm/aOs2ZHy53OoNg==
+"@ls1intum/apollon@2.2.10":
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/@ls1intum/apollon/-/apollon-2.2.10.tgz#f0c27608ce5ad8b8fcea2da375cf837d0dad7c62"
+  integrity sha512-7gaHRxH7VzRGLq/quK7V9t+F22Mn7OKdE8nvZ+JzIxr+eeP/UZruos1jKUmQ7+CswMaSMOeyeNRhOSaJLzwMyg==
   dependencies:
     is-mobile "2.2.2"
     pepjs "0.5.2"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Related issue: #2324
In the new apollon release the error messages are adapted and a browser console error is thrown with the intention to make the error more visible to users in order to get more data about the error.

@krusche talked about resetting the auto save timer in the timer itself to reduce the amount of errors. After having another look at the error I decided against it, because it would **not** reduce the amount of errors. The problem is that the error is thrown in the canDeactivate() method of the check if we already reached the saving time. In this commit I did the change, but reverted later again https://github.com/ls1intum/Artemis/pull/2327/commits/cbfe2a87d6b09f3ad199a015e834e8c3895ff606

In two weeks I want to start to work on a PR which fixes the issue #2324