### PR TITLE
Removed Error when value is undefined

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -158,7 +158,7 @@
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
                         <!-- TODO: Had to Remove Date Pipe as UI did not update when sorting. Investigate the reason -->
-                        {{ value ? value.format('MMM DD YYYY, HH:mm:ss') : '' }}
+                        {{ formatDate(value) }}
                     </ng-template>
                 </ngx-datatable-column>
 

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -158,7 +158,7 @@
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
                         <!-- TODO: Had to Remove Date Pipe as UI did not update when sorting. Investigate the reason -->
-                        {{ value.format('MMM DD YYYY, HH:mm:ss') }}
+                        {{ value ? value.format('MMM DD YYYY, HH:mm:ss') : '' }}
                     </ng-template>
                 </ngx-datatable-column>
 

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { ActivatedRoute } from '@angular/router';
 import { DifferencePipe } from 'ngx-moment';
 import { HttpResponse } from '@angular/common/http';
+import * as moment from 'moment';
 import { Moment } from 'moment';
 import { Course } from 'app/entities/course.model';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
@@ -321,5 +322,9 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
     ngOnDestroy() {
         this.paramSub.unsubscribe();
         this.programmingSubmissionService.unsubscribeAllWebsocketTopics(this.exercise);
+    }
+
+    formatDate(date: Moment | Date | undefined) {
+        return date ? moment(date).format('MMM DD YYYY, HH:mm:ss') : '';
     }
 }

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.html
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.html
@@ -126,7 +126,7 @@
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
                         <!-- TODO: Had to Remove Date Pipe as UI did not update when sorting. Investigate the reason -->
-                        {{ value ? value.format('MMM DD YYYY, HH:mm:ss') : '' }}
+                        {{ formatDate(value) }}
                     </ng-template>
                 </ngx-datatable-column>
 

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.html
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.html
@@ -126,7 +126,7 @@
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
                         <!-- TODO: Had to Remove Date Pipe as UI did not update when sorting. Investigate the reason -->
-                        {{ value.format('MMM DD YYYY, HH:mm:ss') }}
+                        {{ value ? value.format('MMM DD YYYY, HH:mm:ss') : '' }}
                     </ng-template>
                 </ngx-datatable-column>
 

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.ts
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
-import { JhiEventManager } from 'ng-jhipster';
+import { JhiAlertService, JhiEventManager } from 'ng-jhipster';
 import { Participation } from 'app/entities/participation/participation.model';
 import { ParticipationService } from './participation.service';
 import { ActivatedRoute } from '@angular/router';
@@ -14,9 +14,10 @@ import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { areManualResultsAllowed } from 'app/exercises/shared/exercise/exercise-utils';
 import { FeatureToggle } from 'app/shared/feature-toggle/feature-toggle.service';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
-import { JhiAlertService } from 'ng-jhipster';
 import { formatTeamAsSearchResult } from 'app/exercises/shared/team/team.utils';
 import { AccountService } from 'app/core/auth/account.service';
+import * as moment from 'moment';
+import { Moment } from 'moment';
 
 enum FilterProp {
     ALL = 'all',
@@ -42,7 +43,6 @@ export class ParticipationComponent implements OnInit, OnDestroy {
     paramSub: Subscription;
     exercise: Exercise;
     newManualResultAllowed: boolean;
-
     hasLoadedPendingSubmissions = false;
     presentationScoreEnabled = false;
 
@@ -113,6 +113,10 @@ export class ParticipationComponent implements OnInit, OnDestroy {
                 this.hasAccessRights();
             });
         });
+    }
+
+    formatDate(date: Moment | Date | undefined) {
+        return date ? moment(date).format('MMM DD YYYY, HH:mm:ss') : '';
     }
 
     hasAccessRights() {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #2318 . There was an error when certain dates where undefined in the exercise scores and in the participation table.

### Description
<!-- Describe your changes in detail -->
Added a ternary operator to handle the undefined case

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to Exercise Scores / Participations Page of an exercise and see that no error occurs when a date is set to null or undefined
