### PR TITLE
[Bugfix] Fix NPE for automatic feedback as the build can fail

### DIFF
--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -371,7 +371,7 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
 
     private handleFeedback(): void {
         // Setup automatic feedback
-        this.automaticFeedback = this.automaticResult?.feedbacks!;
+        this.automaticFeedback = this.automaticResult?.feedbacks! ?? [];
         this.automaticFeedback.forEach((feedback) => {
             feedback.id = undefined;
             if (!feedback.credits) {

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -371,7 +371,7 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
 
     private handleFeedback(): void {
         // Setup automatic feedback
-        this.automaticFeedback = this.automaticResult?.feedbacks! ?? [];
+        this.automaticFeedback = this.automaticResult?.feedbacks ?? [];
         this.automaticFeedback.forEach((feedback) => {
             feedback.id = undefined;
             if (!feedback.credits) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Added screenshots

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When the build fails of a student's submission no automatic feedback is created. A null check was missing in the current implementation.

### Description
<!-- Describe your changes in detail -->
- Added null check when setting automatic feedback

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create programming exercise and participate and make your build fail!
4. Assess programming exercise and see that the build fail participation is loaded and you can submit your assessment as usual.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
Nothing changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/41108487/98044822-c4d84e00-1e27-11eb-9625-38b6e3e3b7db.png">

<img width="1672" alt="image" src="https://user-images.githubusercontent.com/41108487/98044838-cefa4c80-1e27-11eb-98ac-63710b605924.png">
