### PR TITLE
Fix a GitHub Actions warning about using triple-equals

### DIFF
--- a/src/main/webapp/app/exercises/text/participate/text-result/text-result-block.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-result/text-result-block.ts
@@ -29,7 +29,7 @@ export class TextResultBlock {
     }
 
     get feedbackType(): FeedbackType {
-        if (!this.feedback || this.feedback.credits == undefined || Feedback.isEmpty(this.feedback)) {
+        if (!this.feedback || this.feedback.credits === undefined || Feedback.isEmpty(this.feedback)) {
             return FeedbackType.BLANK;
         } else if (this.feedback.credits > 0) {
             return FeedbackType.POSITIVE;


### PR DESCRIPTION
Resolves the following warning:
![grafik](https://user-images.githubusercontent.com/72132281/98256357-c1a3a600-1f7e-11eb-82b9-512f46b15ae6.png)
