### PR TITLE
Fix a route mismatch when trying to create lectures

### DIFF
--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.route.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.route.ts
@@ -36,8 +36,8 @@ export const systemNotificationManagementRoute: Routes = [
         },
     },
     {
-        path: 'system-notification-management/:id',
-        component: SystemNotificationManagementDetailComponent,
+        path: 'system-notification-management/new',
+        component: SystemNotificationManagementUpdateComponent,
         resolve: {
             notification: SystemNotificationManagementResolve,
         },
@@ -46,8 +46,8 @@ export const systemNotificationManagementRoute: Routes = [
         },
     },
     {
-        path: 'system-notification-management/new',
-        component: SystemNotificationManagementUpdateComponent,
+        path: 'system-notification-management/:id',
+        component: SystemNotificationManagementDetailComponent,
         resolve: {
             notification: SystemNotificationManagementResolve,
         },

--- a/src/main/webapp/app/admin/user-management/user-management.route.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.route.ts
@@ -36,16 +36,6 @@ export const userMgmtRoute1: Route = {
 };
 
 export const userMgmtRoute2: Route = {
-    path: 'user-management/:login',
-    component: UserManagementDetailComponent,
-    resolve: {
-        user: UserMgmtResolve,
-    },
-    data: {
-        pageTitle: 'userManagement.home.title',
-    },
-};
-export const userMgmtRoute3: Route = {
     path: 'user-management/new',
     component: UserManagementUpdateComponent,
     resolve: {
@@ -53,6 +43,16 @@ export const userMgmtRoute3: Route = {
     },
     data: {
         pageTitle: 'userManagement.home.createLabel',
+    },
+};
+export const userMgmtRoute3: Route = {
+    path: 'user-management/:login',
+    component: UserManagementDetailComponent,
+    resolve: {
+        user: UserMgmtResolve,
+    },
+    data: {
+        pageTitle: 'userManagement.home.title',
     },
 };
 

--- a/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint.route.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint.route.ts
@@ -33,8 +33,8 @@ export class ExerciseHintResolve implements Resolve<ExerciseHint | null> {
 
 export const exerciseHintRoute: Routes = [
     {
-        path: ':courseId/exercises/:exerciseId/hints/:hintId',
-        component: ExerciseHintDetailComponent,
+        path: ':courseId/exercises/:exerciseId/hints/new',
+        component: ExerciseHintUpdateComponent,
         resolve: {
             exerciseHint: ExerciseHintResolve,
         },
@@ -45,8 +45,8 @@ export const exerciseHintRoute: Routes = [
         canActivate: [UserRouteAccessService],
     },
     {
-        path: ':courseId/exercises/:exerciseId/hints/new',
-        component: ExerciseHintUpdateComponent,
+        path: ':courseId/exercises/:exerciseId/hints/:hintId',
+        component: ExerciseHintDetailComponent,
         resolve: {
             exerciseHint: ExerciseHintResolve,
         },

--- a/src/main/webapp/app/lecture/lecture.route.ts
+++ b/src/main/webapp/app/lecture/lecture.route.ts
@@ -39,6 +39,18 @@ export const lectureRoute: Routes = [
         canActivate: [UserRouteAccessService],
     },
     {
+        path: ':courseId/lectures/new',
+        component: LectureUpdateComponent,
+        resolve: {
+            lecture: LectureResolve,
+        },
+        data: {
+            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.lecture.home.title',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
         path: ':courseId/lectures/:id',
         component: LectureDetailComponent,
         resolve: {
@@ -59,18 +71,6 @@ export const lectureRoute: Routes = [
         data: {
             authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
             pageTitle: 'artemisApp.lecture.attachments.title',
-        },
-        canActivate: [UserRouteAccessService],
-    },
-    {
-        path: ':courseId/lectures/new',
-        component: LectureUpdateComponent,
-        resolve: {
-            lecture: LectureResolve,
-        },
-        data: {
-            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-            pageTitle: 'artemisApp.lecture.home.title',
         },
         canActivate: [UserRouteAccessService],
     },


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Fixes a regression from #2309 which causes a 400 Bad Request when trying to create a new lecture.
Without `/view`, the router tried to parse `/lectures/new/` as `/lectures/:id` and `new` obviously doesn't fit into an `:id` parameter.
(This now matches what we had in the course-management by default: https://github.com/ls1intum/Artemis/blob/6ff4f589cd14caf305ce035c230e7284033ece97/src/main/webapp/app/course/manage/course-management.route.ts#L47-L70)

### Description
To fix this, I moved the `/lectures/new` routing above `/lectures/:id` which causes it to be tested first. (The git diff looks weird, but it's a simple move.) Same happened in the three other places (see test steps).

### Steps for Testing

1. Click the "Create Lecture" button from the lectures overview
2. Click the "Create a new user" button from the user management
3. Click the "Create a new system notification" button from the system notification management
4. Click the "Create a new Exercise Hint" button from the programming exercise hints page
    programming exercise id -> Manage Hints -> create a new exercise hint
