### PR TITLE
Expose the missing programming exercise overview as route

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-management-routing.module.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-management-routing.module.ts
@@ -5,6 +5,7 @@ import { ProgrammingExerciseDetailComponent } from 'app/exercises/programming/ma
 import { ProgrammingExerciseUpdateComponent } from 'app/exercises/programming/manage/update/programming-exercise-update.component';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
+import { ProgrammingExerciseComponent } from 'app/exercises/programming/manage/programming-exercise.component';
 import { map } from 'rxjs/operators';
 import { HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
@@ -83,6 +84,15 @@ export const routes: Routes = [
         },
         canActivate: [UserRouteAccessService],
         canDeactivate: [CanDeactivateGuard],
+    },
+    {
+        path: ':courseId/programming-exercises',
+        component: ProgrammingExerciseComponent,
+        data: {
+            authorities: [Authority.TA, Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.programmingExercise.home.title',
+        },
+        canActivate: [UserRouteAccessService],
     },
 ];
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Addresses an issue noted first in https://github.com/ls1intum/Artemis/pull/2283#pullrequestreview-521226410. In the long term I'll have a look at either removing the `quiz-exercises`, `programming-exercises`, etc. subroutes completely (not sure how feasible or reasonable that is) or restyling them to direct to `exercises`. However, `ProgrammingExerciseComponent` already exists, so this is a good short-term fix.

### Description
The component already existed, the route to it just wasn't set up, so I did that.

### Steps for Testing

1. Open a programming exercise
2. Click on the "programming-exercises" breadcrumb
3. Before it did nothing (error in console), now displays a list

### Screenshots
The list of programming exercises now visible:
![grafik](https://user-images.githubusercontent.com/72132281/98402357-6ef1e900-2067-11eb-93ac-23de2f3cc4f7.png)

