### PR TITLE
[Enhancement] Add tooltip for folder rename action

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/code-editor.module.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/code-editor.module.ts
@@ -21,11 +21,13 @@ import { FeatureToggleModule } from 'app/shared/feature-toggle/feature-toggle.mo
 import { CodeEditorConfirmRefreshModalComponent } from 'app/exercises/programming/shared/code-editor/actions/code-editor-confirm-refresh-modal.component';
 import { CodeEditorContainerComponent } from 'app/exercises/programming/shared/code-editor/container/code-editor-container.component';
 import { ArtemisProgrammingManualAssessmentModule } from 'app/exercises/programming/assess/programming-manual-assessment.module';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
     imports: [
         AceEditorModule,
         MomentModule,
+        NgbModule,
         ArtemisSharedModule,
         FeatureToggleModule,
         TreeviewModule.forRoot(),

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser-folder.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser-folder.component.html
@@ -27,6 +27,8 @@
             class="btn btn-small"
             [ngbTooltip]="'artemisApp.editor.fileBrowser.renameFolderDisabledTooltip' | translate"
             [disableTooltip]="disableActions || !(isCompressed && item.children && item.children.length)"
+            container="body"
+            placement="bottom"
         >
             <fa-icon [icon]="'edit'" title="{{ 'artemisApp.editor.fileBrowser.renameFolder' | translate }}"></fa-icon>
         </button>

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser-folder.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser-folder.component.html
@@ -21,16 +21,16 @@
         <button [disabled]="disableActions" (click)="setCreatingNodeInFolder($event, FileType.FOLDER)" class="btn btn-small">
             <fa-icon [icon]="'folder'" title="{{ 'artemisApp.editor.fileBrowser.createFolder' | translate }}"></fa-icon>
         </button>
-        <button
-            [disabled]="disableActions || (isCompressed && item.children && item.children.length)"
-            (click)="setRenamingNode($event)"
-            class="btn btn-small"
-            [ngbTooltip]="'artemisApp.editor.fileBrowser.renameFolderDisabledTooltip' | translate"
-            [disableTooltip]="disableActions || !(isCompressed && item.children && item.children.length)"
-            container="body"
-            placement="bottom"
-        >
-            <fa-icon [icon]="'edit'" title="{{ 'artemisApp.editor.fileBrowser.renameFolder' | translate }}"></fa-icon>
+        <button [disabled]="disableActions || (isCompressed && item.children && item.children.length)" (click)="setRenamingNode($event)" class="btn btn-small">
+            <fa-icon
+                [icon]="'edit'"
+                title="{{
+                    (!disableActions && isCompressed && item.children && item.children.length
+                        ? 'artemisApp.editor.fileBrowser.renameFolderDisabledTooltip'
+                        : 'artemisApp.editor.fileBrowser.renameFolder'
+                    ) | translate
+                }}"
+            ></fa-icon>
         </button>
         <button [disabled]="disableActions" (click)="deleteNode($event)" class="btn btn-small">
             <fa-icon [icon]="'trash'" title="{{ 'artemisApp.editor.fileBrowser.deleteFolder' | translate }}"></fa-icon>

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser-folder.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser-folder.component.html
@@ -21,7 +21,13 @@
         <button [disabled]="disableActions" (click)="setCreatingNodeInFolder($event, FileType.FOLDER)" class="btn btn-small">
             <fa-icon [icon]="'folder'" title="{{ 'artemisApp.editor.fileBrowser.createFolder' | translate }}"></fa-icon>
         </button>
-        <button [disabled]="disableActions || (isCompressed && item.children && item.children.length)" (click)="setRenamingNode($event)" class="btn btn-small">
+        <button
+            [disabled]="disableActions || (isCompressed && item.children && item.children.length)"
+            (click)="setRenamingNode($event)"
+            class="btn btn-small"
+            [ngbTooltip]="'artemisApp.editor.fileBrowser.renameFolderDisabledTooltip' | translate"
+            [disableTooltip]="disableActions || !(isCompressed && item.children && item.children.length)"
+        >
             <fa-icon [icon]="'edit'" title="{{ 'artemisApp.editor.fileBrowser.renameFolder' | translate }}"></fa-icon>
         </button>
         <button [disabled]="disableActions" (click)="deleteNode($event)" class="btn btn-small">

--- a/src/main/webapp/i18n/de/editor.json
+++ b/src/main/webapp/i18n/de/editor.json
@@ -65,6 +65,7 @@
                 "createFile": "Datei erstellen",
                 "renameFolder": "Verzeichnis umbenennen",
                 "renameFile": "Datei umbenennen",
+                "renameFolderDisabledTooltip": "Um Verzeichnisse umzubenennen, deaktiviere das Zusammenfassen von Verzeichnissen in der obrigen Leiste.",
                 "deleteFolder": "Verzeichnis löschen",
                 "deleteFile": "Datei löschen",
                 "compressTree": "Leere Verzeichnisse zusammenfassen"

--- a/src/main/webapp/i18n/en/editor.json
+++ b/src/main/webapp/i18n/en/editor.json
@@ -69,6 +69,7 @@
                 "createFile": "Create file",
                 "renameFolder": "Rename folder",
                 "renameFile": "Rename file",
+                "renameFolderDisabledTooltip": "To rename this folder, deactivate the combining of folders in the toolbar above.",
                 "deleteFolder": "Delete folder",
                 "deleteFile": "Delete file",
                 "compressTree": "Combine empty folders"

--- a/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
@@ -28,6 +28,7 @@ import { MockCodeEditorRepositoryFileService } from '../../helpers/mocks/service
 import { MockCodeEditorConflictStateService } from '../../helpers/mocks/service/mock-code-editor-conflict-state.service';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockCookieService } from '../../helpers/mocks/service/mock-cookie.service';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -51,7 +52,7 @@ describe('CodeEditorFileBrowserComponent', () => {
 
     beforeEach(async () => {
         return TestBed.configureTestingModule({
-            imports: [TranslateModule.forRoot(), ArtemisTestModule, AceEditorModule, TreeviewModule.forRoot()],
+            imports: [TranslateModule.forRoot(), ArtemisTestModule, AceEditorModule, TreeviewModule.forRoot(), NgbModule],
             declarations: [
                 CodeEditorFileBrowserComponent,
                 MockComponent(CodeEditorStatusComponent),


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

While the online code editor supports renaming folders, this is kind of hidden and might not be clear to students (See #2360).

### Description
<!-- Describe your changes in detail -->

When the renaming action is disabled, I added a tooltip to describe how to enable renaming folders.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to the online editor
3. Check that the tooltip for the rename action of folders is visible when the action itself is disabled.
4. Check that the tooltip is not visible when the rename action is enabled.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->

Nothing changed.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="538" alt="Bildschirmfoto 2020-11-09 um 13 54 21" src="https://user-images.githubusercontent.com/13920539/98543704-26b70e80-2293-11eb-8d14-277e200d26c5.png">
