### PR TITLE
Actions: Split Workflows into Build, Test and Docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,19 +13,21 @@ on:
     - 'CONTRIBUTING.md'
     - 'LICENSE'
     - 'SECURITY.md'
+    - 'docs/**'
     - '.github/**'
     - '!.github/workflows/build.yml'
   release:
     types:
     - created
 
-# Keep in sync with codeql-analysis.yml
+# Keep in sync with codeql-analysis.yml and test.yml
 env:
   CI: true
   node: 14.x
   java: 15
 
 jobs:
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -69,102 +71,3 @@ jobs:
         asset_path: build/libs/Artemis-${{ github.event.release.tag_name }}.war
         asset_name: Artemis.war
         asset_content_type: application/x-webarchive
-
-  server-tests:
-    if: github.event_name != 'release'
-    runs-on: ubuntu-latest
-#    services:
-#      athene-segmentation:
-#        image: ls1intum/athene-segmentation
-#        ports:
-#          - 8000:8000
-#      athene-embedding:
-#        image: ls1intum/athene-embedding
-#        ports:
-#          - 8001:8000
-#      athene-clustering:
-#        image: ls1intum/athene-clustering
-#        ports:
-#          - 8002:8000
-    steps:
-    - name: Setup Java
-      uses: actions/setup-java@v1
-      with:
-        java-version: '${{ env.java }}'
-    - uses: actions/checkout@v2
-    - name: Cache Gradle dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
-    - name: Java Tests
-      run: ./gradlew --console=plain executeTests jacocoTestReport -x yarn -x webpack jacocoTestCoverageVerification
-    - name: "Codacy: Report coverage"
-      uses: codacy/codacy-coverage-reporter-action@master
-      with:
-        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: build/reports/jacoco/test/jacocoTestReport.xml
-      if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
-    - name: Java Code Style
-      run: ./gradlew spotlessCheck
-      if: success() || failure()
-    - name: Java Documentation
-      run: ./gradlew checkstyleMain -x yarn -x webpack
-      if: success() || failure()
-    - uses: ashley-taylor/junit-report-annotations-action@1.3
-      if: always()
-      with:
-        access-token: ${{ secrets.GITHUB_TOKEN }}
-        path: build/test-results/test/*.xml
-
-  client-tests:
-    if: github.event_name != 'release'
-    runs-on: ubuntu-latest
-    steps:
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '${{ env.node }}'
-    - uses: actions/checkout@v2
-    - name: Cache node modules
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-node_modules-
-    - name: Install Dependencies
-      run: yarn install
-    - name: TypeScript Tests
-      run: yarn test:coverage --ci
-    - name: "Codacy: Report coverage"
-      uses: codacy/codacy-coverage-reporter-action@master
-      with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage/lcov.info
-      if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
-    - name: TypeScript Formatting
-      run: yarn prettier:check
-      if: success() || failure()
-    - name: TypeScript Code Style
-      run: yarn lint
-      if: success() || failure()
-    - uses: ashley-taylor/junit-report-annotations-action@1.3
-      if: always()
-      with:
-        access-token: ${{ secrets.GITHUB_TOKEN }}
-        path: junit.xml
-
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "docs/"
-    - uses: actions/upload-artifact@v1
-      with:
-        name: Documentation
-        path: docs/_build/html/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  pull_request:
+    paths:
+    - 'docs/**'
+  push:
+    branches:
+    - develop
+    - main
+    tags: '[0-9]+.[0-9]+.[0-9]+'
+    paths:
+    - 'docs/**'
+    - '.github/workflows/docs.yml'
+  release:
+    types:
+    - created
+
+jobs:
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        docs-folder: "docs/"
+    - uses: actions/upload-artifact@v1
+      with:
+        name: Documentation
+        path: docs/_build/html/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,10 @@
-name: Build
+name: Build Documentation
 
 on:
   pull_request:
     paths:
     - 'docs/**'
+    - '.github/workflows/docs.yml'
   push:
     branches:
     - develop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Test
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,6 @@ on:
     - 'docs/**'
     - '.github/**'
     - '!.github/workflows/test.yml'
-  release:
-    types:
-    - created
 
 # Keep in sync with codeql-analysis.yml and build.yml
 env:
@@ -29,7 +26,6 @@ env:
 jobs:
 
   server-tests:
-    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     steps:
     - name: Setup Java
@@ -52,12 +48,6 @@ jobs:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: build/reports/jacoco/test/jacocoTestReport.xml
       if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
-    - name: Java Code Style
-      run: ./gradlew spotlessCheck
-      if: success() || failure()
-    - name: Java Documentation
-      run: ./gradlew checkstyleMain -x yarn -x webpack
-      if: success() || failure()
     - uses: ashley-taylor/junit-report-annotations-action@9ac2f823854c677f30e062dfe779445e33e5d380
       if: always()
       with:
@@ -65,8 +55,29 @@ jobs:
         path: build/test-results/test/*.xml
         numFailures: 99
 
+  server-style:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: '${{ env.java }}'
+    - uses: actions/checkout@v2
+    - name: Cache Gradle dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Java Code Style
+      run: ./gradlew spotlessCheck
+      if: success() || failure()
+    - name: Java Documentation
+      run: ./gradlew checkstyleMain -x yarn -x webpack
+      if: success() || failure()
+
   client-tests:
-    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     steps:
     - name: Setup Node.js
@@ -91,15 +102,33 @@ jobs:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/lcov.info
       if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
-    - name: TypeScript Formatting
-      run: yarn prettier:check
-      if: success() || failure()
-    - name: TypeScript Code Style
-      run: yarn lint
-      if: success() || failure()
     - uses: ashley-taylor/junit-report-annotations-action@9ac2f823854c677f30e062dfe779445e33e5d380
       if: always()
       with:
         access-token: ${{ secrets.GITHUB_TOKEN }}
         path: junit.xml
         numFailures: 99
+
+  client-style:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '${{ env.node }}'
+    - uses: actions/checkout@v2
+    - name: Cache node modules
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-node_modules-
+    - name: Install Dependencies
+      run: yarn install
+    - name: TypeScript Formatting
+      run: yarn prettier:check
+      if: success() || failure()
+    - name: TypeScript Code Style
+      run: yarn lint
+      if: success() || failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       with:
         access-token: ${{ secrets.GITHUB_TOKEN }}
         path: build/test-results/test/*.xml
-        ashley-taylor/junit-report-annotations-action: 99
+        numFailures: 99
 
   client-tests:
     if: github.event_name != 'release'
@@ -102,4 +102,4 @@ jobs:
       with:
         access-token: ${{ secrets.GITHUB_TOKEN }}
         path: junit.xml
-        ashley-taylor/junit-report-annotations-action: 99
+        numFailures: 99

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,105 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+    - develop
+    - main
+    tags: '[0-9]+.[0-9]+.[0-9]+'
+    paths-ignore:
+    - 'README.md'
+    - 'CODE_OF_CONDUCT.md'
+    - 'CONTRIBUTING.md'
+    - 'LICENSE'
+    - 'SECURITY.md'
+    - 'docs/**'
+    - '.github/**'
+    - '!.github/workflows/test.yml'
+  release:
+    types:
+    - created
+
+# Keep in sync with codeql-analysis.yml and build.yml
+env:
+  CI: true
+  node: 14.x
+  java: 15
+
+jobs:
+
+  server-tests:
+    if: github.event_name != 'release'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: '${{ env.java }}'
+    - uses: actions/checkout@v2
+    - name: Cache Gradle dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Java Tests
+      run: ./gradlew --console=plain executeTests jacocoTestReport -x yarn -x webpack jacocoTestCoverageVerification
+    - name: "Codacy: Report coverage"
+      uses: codacy/codacy-coverage-reporter-action@master
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: build/reports/jacoco/test/jacocoTestReport.xml
+      if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
+    - name: Java Code Style
+      run: ./gradlew spotlessCheck
+      if: success() || failure()
+    - name: Java Documentation
+      run: ./gradlew checkstyleMain -x yarn -x webpack
+      if: success() || failure()
+    - uses: ashley-taylor/junit-report-annotations-action@1.3
+      if: always()
+      with:
+        access-token: ${{ secrets.GITHUB_TOKEN }}
+        path: build/test-results/test/*.xml
+        ashley-taylor/junit-report-annotations-action: 99
+
+  client-tests:
+    if: github.event_name != 'release'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '${{ env.node }}'
+    - uses: actions/checkout@v2
+    - name: Cache node modules
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-node_modules-
+    - name: Install Dependencies
+      run: yarn install
+    - name: TypeScript Tests
+      run: yarn test:coverage --ci
+    - name: "Codacy: Report coverage"
+      uses: codacy/codacy-coverage-reporter-action@master
+      with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage/lcov.info
+      if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
+    - name: TypeScript Formatting
+      run: yarn prettier:check
+      if: success() || failure()
+    - name: TypeScript Code Style
+      run: yarn lint
+      if: success() || failure()
+    - uses: ashley-taylor/junit-report-annotations-action@1.3
+      if: always()
+      with:
+        access-token: ${{ secrets.GITHUB_TOKEN }}
+        path: junit.xml
+        ashley-taylor/junit-report-annotations-action: 99

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,6 @@ jobs:
           ${{ runner.os }}-gradle-
     - name: Java Code Style
       run: ./gradlew spotlessCheck
-      if: success() || failure()
     - name: Java Documentation
       run: ./gradlew checkstyleMain -x yarn -x webpack
       if: success() || failure()
@@ -128,7 +127,6 @@ jobs:
       run: yarn install
     - name: TypeScript Formatting
       run: yarn prettier:check
-      if: success() || failure()
     - name: TypeScript Code Style
       run: yarn lint
       if: success() || failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Java Documentation
       run: ./gradlew checkstyleMain -x yarn -x webpack
       if: success() || failure()
-    - uses: ashley-taylor/junit-report-annotations-action@1.3
+    - uses: ashley-taylor/junit-report-annotations-action@9ac2f823854c677f30e062dfe779445e33e5d380
       if: always()
       with:
         access-token: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
     - name: TypeScript Code Style
       run: yarn lint
       if: success() || failure()
-    - uses: ashley-taylor/junit-report-annotations-action@1.3
+    - uses: ashley-taylor/junit-report-annotations-action@9ac2f823854c677f30e062dfe779445e33e5d380
       if: always()
       with:
         access-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Split up build.yml into
1. build.yml,
2. test.yml, and
3. docs.yml.

This allows using the Test server action to deploy even though tests are still running.
Also, bump workflow dependency to include fix in ashley-taylor/junit-report-annotations-action#16.