### PR TITLE
Fix issue with BuildLogType detection for empty log entry.

### DIFF
--- a/src/main/webapp/app/entities/build-log.model.ts
+++ b/src/main/webapp/app/entities/build-log.model.ts
@@ -29,7 +29,14 @@ export class BuildLogEntryArray extends Array<BuildLogEntry> {
      */
     static fromBuildLogs(buildLogs: BuildLogEntry[]) {
         const mappedLogs = buildLogs.map(({ log, ...rest }) => {
-            const logType = log && log.trimLeft().startsWith('[ERROR]') ? BuildLogType.ERROR : log.trimLeft().startsWith('WARNING') ? BuildLogType.WARNING : BuildLogType.OTHER;
+            let logType = BuildLogType.OTHER;
+            if (log) {
+                if (log.trimLeft().startsWith('[ERROR]')) {
+                    logType = BuildLogType.ERROR;
+                } else if (log.trimLeft().startsWith('WARNING')) {
+                    logType = BuildLogType.WARNING;
+                }
+            }
             return {
                 log,
                 type: logType,


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) locally.

### Motivation and Context
Fixes #2392: The build log is sometimes not shown.

### Description
The build log returned from the server does not always contain a `log` attribute, which causes the client to fail as it expects it due to a faulty if-statement.
I've fixed the if-statement to only use `log.trimLeft()` if the log is present.

### Steps for Testing
1. Review the code
(If possible: Create a Haskell programming exercise and produce a build error, the logs should still be displayed.)
  