### PR TITLE
Move breadcrumbs below the navbar

### DIFF
--- a/src/main/webapp/app/shared/layouts/main/main.component.html
+++ b/src/main/webapp/app/shared/layouts/main/main.component.html
@@ -6,7 +6,7 @@
     <div class="container-fluid main-container">
         <jhi-system-notification></jhi-system-notification>
         <jhi-connection-notification></jhi-connection-notification>
-        <div class="card jh-card">
+        <div class="card">
             <div class="card-body">
                 <router-outlet></router-outlet>
                 <router-outlet name="popup"></router-outlet>

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -20,12 +20,6 @@
         </a>
     </div>
     <div class="navbar-collapse collapse" id="navbarResponsive" [ngbCollapse]="isNavbarCollapsed" [ngSwitch]="isAuthenticated()">
-        <ol class="breadcrumb" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_TA', 'ROLE_INSTRUCTOR']">
-            <li *ngFor="let breadcrumb of breadcrumbs" class="breadcrumb-item">
-                <a [routerLink]="breadcrumb.uri" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">{{ breadcrumb.label }}</a>
-            </li>
-        </ol>
-
         <ul class="navbar-nav ml-auto">
             <li *ngIf="currAccount && !examModeActive()" class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
                 <a class="guided-tour-overview nav-link" routerLink="courses" (click)="collapseNavbar()" id="overview-menu">
@@ -204,4 +198,11 @@
         </ul>
     </div>
 </nav>
+<div class="breadcrumb-container">
+    <ol class="breadcrumb" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_TA', 'ROLE_INSTRUCTOR']">
+        <li *ngFor="let breadcrumb of breadcrumbs" class="breadcrumb-item">
+            <a class="breadcrumb-link" [routerLink]="breadcrumb.uri" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">{{ breadcrumb.label }}</a>
+        </li>
+    </ol>
+</div>
 <jhi-guided-tour></jhi-guided-tour>

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -109,6 +109,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
         let index = 0;
         const parts = fullURI.split('/');
         for (const part of parts) {
+            if (part === '') {
+                continue;
+            }
             const crumb = new Breadcrumb();
             crumb.label = part;
             path += part + '/';

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -40,16 +40,20 @@ Navbar
             color: #fff;
         }
     }
+}
 
+.breadcrumb-container {
+    background-color: #e4e5e6;
+    overflow: auto;
     .breadcrumb {
         color: #0065bd;
-        background-color: #353d47;
+        background-color: #e4e5e6;
         margin-left: 1rem;
         margin-bottom: 0;
-    }
-
-    .breadcrumb-item {
-        font-size: medium;
+        padding: 10px 16px 10px 16px;
+        .breadcrumb-link {
+            font-weight: normal;
+        }
     }
 }
 

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -55,6 +55,13 @@ Navbar
             font-weight: normal;
         }
     }
+    .breadcrumb-item::before {
+        content: '>';
+    }
+    // Hide the first divider
+    .breadcrumb-item:first-of-type::before {
+        content: '';
+    }
 }
 
 @media screen and (min-width: 768px) {

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -45,6 +45,7 @@ Navbar
 .breadcrumb-container {
     background-color: #e4e5e6;
     overflow: auto;
+    margin-left: -15px;
     .breadcrumb {
         color: #0065bd;
         background-color: #e4e5e6;
@@ -52,7 +53,7 @@ Navbar
         margin-bottom: 0;
         padding: 10px 16px 10px 16px;
         .breadcrumb-link {
-            font-weight: normal;
+            font-weight: lighter;
         }
     }
     .breadcrumb-item::before {

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -52,10 +52,12 @@ Navbar
         margin-left: 1rem;
         margin-bottom: 0;
         padding: 10px 16px 10px 16px;
+
         .breadcrumb-link {
             font-weight: lighter;
         }
     }
+
     .breadcrumb-item::before {
         content: '>';
     }

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -137,12 +137,6 @@ Generic styles
 
 /* other generic styles */
 
-.jh-card {
-    @media (min-width: 577px) {
-        margin-top: 20px;
-    }
-}
-
 // This class refers to the gutter inserted by split.js for its split view
 .gutter {
     background-color: #f1f1f1;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Requested on Slack by @krusche.

### Description
The previously breadcrumbs were cramped between the logo and navbar menu, which scaled badly on smaller displays and with longer crumb-paths. The new position has more space vertically and horizontally.

### Steps for Testing

1. Log in to Artemis
2. Navigate to several pages and check the crumbs are working and displayed correctly

### Screenshots
The crumbs are more slim now and below the navbar:
![grafik](https://user-images.githubusercontent.com/72132281/99187162-346a0980-2755-11eb-89b3-61bfc1887255.png)
![grafik](https://user-images.githubusercontent.com/72132281/99187177-595e7c80-2755-11eb-90ab-f90d64537fbe.png)

If there is not enough horizontal space, the crumbs will overflow into a new line (and not be outside the visible window any more):
![grafik](https://user-images.githubusercontent.com/72132281/99187201-7d21c280-2755-11eb-8500-a084090b2b46.png)

