### PR TITLE
Fix missing time comparison for build after due in scheduling

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -154,7 +154,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
             scheduleService.cancelScheduledTaskForLifecycle(exercise, ExerciseLifecycle.DUE);
         }
         // For exercises with buildAndTestAfterDueDate
-        if (exercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null) {
+        if (exercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null && ZonedDateTime.now().isBefore(exercise.getBuildAndTestStudentSubmissionsAfterDueDate())) {
             scheduleService.scheduleTask(exercise, ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE, buildAndTestRunnableForExercise(exercise));
             log.debug("Scheduled build and test for student submissions after due date for Programming Exercise \"" + exercise.getTitle() + "\" (#" + exercise.getId() + ") for "
                     + exercise.getBuildAndTestStudentSubmissionsAfterDueDate() + ".");


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).

### Motivation and Context
Fix this, otherwise every update to a build-after-due programming exercise causes a "Trigger-All" action. This is very expensive, we should fix this as soon as possible.

### Description
- Add missing date-time comparison in the check

### Steps for Testing
- Check that programming exercises with build after due are still build at the specified time, but updates to the time and problem statement afterwards don't cause a full build.

### Test Coverage
_Unchanged._

