### PR TITLE
Fix an issue with bitbucket authentication

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketAuthorizationInterceptor.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketAuthorizationInterceptor.java
@@ -38,7 +38,7 @@ public class BitbucketAuthorizationInterceptor implements ClientHttpRequestInter
             request.getHeaders().setContentType(MediaType.APPLICATION_JSON);
         }
         // prefer bitbucket token if it is available
-        if (bitbucketToken.isPresent() && !isCreateProjectRequest(request)) {
+        if (bitbucketToken.isPresent() && !needsBasicAuth(request)) {
             request.getHeaders().setBearerAuth(bitbucketToken.get());
         }
         else {
@@ -48,7 +48,19 @@ public class BitbucketAuthorizationInterceptor implements ClientHttpRequestInter
         return execution.execute(request, body);
     }
 
-    private boolean isCreateProjectRequest(HttpRequest request) {
-        return request.getURI().toString().endsWith("projects") && HttpMethod.POST.equals(request.getMethod());
+    private static boolean needsBasicAuth(HttpRequest request) {
+        return isCreateProjectRequest(request) || isCreateUserRequest(request) || isAddUserToGroupsRequest(request);
+    }
+
+    private static boolean isCreateProjectRequest(HttpRequest request) {
+        return request.getURI().toString().endsWith("latest/projects") && HttpMethod.POST.equals(request.getMethod());
+    }
+
+    private static boolean isCreateUserRequest(HttpRequest request) {
+        return request.getURI().toString().contains("latest/admin/users") && HttpMethod.POST.equals(request.getMethod());
+    }
+
+    private static boolean isAddUserToGroupsRequest(HttpRequest request) {
+        return request.getURI().toString().endsWith("latest/admin/users/add-groups") && HttpMethod.POST.equals(request.getMethod());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
@@ -312,7 +312,7 @@ public class BitbucketService extends AbstractVersionControlService {
         }
         catch (HttpClientErrorException e) {
             log.error("Could not create Bitbucket user " + username, e);
-            throw new BitbucketException("Error while creating user");
+            throw new BitbucketException("Error while creating user", e);
         }
     }
 


### PR DESCRIPTION
some requests only support basic auth and no token authentication
Fixes #2411 

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

1. Participate in a programming exercise over LTI (edx)
2. No error should occur when you click on start exercise with an edx user that cannot be mapped to a TUM user

@simonzilker has experienced the issue and might be able to help during testing