### PR TITLE
[Enhancement] Jenkins: improve detection of new pipeline scripts

### DIFF
--- a/docs/dev/setup/programming-exercises.rst
+++ b/docs/dev/setup/programming-exercises.rst
@@ -54,7 +54,7 @@ The builds steps (including used docker images, the checkout process, the actual
 A sample ``Jenkinsfile`` can be found at ``src/main/resources/templates/jenkins/java/Jenkinsfile``.
 Note that the ``Jenkinsfile`` **must** start either
 
-- with `pipeline` (there must not be a comment before pipeline, but there can be one at any other position, if the Jenkinsfile-syntax allows it)
+- with ``pipeline`` (there must not be a comment before pipeline, but there can be one at any other position, if the Jenkinsfile-syntax allows it)
 - or the special comment ``// ARTEMIS: JenkinsPipeline`` in the first line.
 
 The variables `#dockerImage`, `#testRepository`, `#assignmentRepository`, `#jenkinsNotificationToken` and `#notificationsUrl` will automatically be replaced (for the normal Jenkinsfile, within the Jenkinsfile-staticCodeAnalysis, #staticCodeAnalysisScript is also replaced).

--- a/docs/dev/setup/programming-exercises.rst
+++ b/docs/dev/setup/programming-exercises.rst
@@ -52,7 +52,10 @@ It is extended by a ``Jenkinsfile`` that is dependent on the used programming la
 The builds steps (including used docker images, the checkout process, the actual build steps, and the reporting of the results to Artemis) is included in the ``Jenkinsfile``.
 
 A sample ``Jenkinsfile`` can be found at ``src/main/resources/templates/jenkins/java/Jenkinsfile``.
-Note that the ``Jenkinsfile`` **must** start with `pipeline` (there must not be a comment before pipeline, but there can be one at any other position, if the Jenkinsfile-syntax allows it).
+Note that the ``Jenkinsfile`` **must** start either
+
+- with `pipeline` (there must not be a comment before pipeline, but there can be one at any other position, if the Jenkinsfile-syntax allows it)
+- or the special comment ``// ARTEMIS: JenkinsPipeline`` in the first line.
 
 The variables `#dockerImage`, `#testRepository`, `#assignmentRepository`, `#jenkinsNotificationToken` and `#notificationsUrl` will automatically be replaced (for the normal Jenkinsfile, within the Jenkinsfile-staticCodeAnalysis, #staticCodeAnalysisScript is also replaced).
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsService.java
@@ -66,6 +66,8 @@ public class JenkinsService implements ContinuousIntegrationService {
 
     private static final Logger log = LoggerFactory.getLogger(JenkinsService.class);
 
+    private static final String PIPELINE_SCRIPT_DETECTION_COMMENT = "// ARTEMIS: JenkinsPipeline";
+
     @Value("${artemis.continuous-integration.url}")
     private URL JENKINS_SERVER_URL;
 
@@ -171,9 +173,10 @@ public class JenkinsService implements ContinuousIntegrationService {
             throw new IllegalArgumentException("Pipeline Script not found");
         }
 
-        String pipeLineScript = scriptNode.getFirstChild().getTextContent();
-        // If the script does not start with "pipeline", it is not actually a pipeline script, but a deprecated programming exercise with an old configuration
-        if (!pipeLineScript.trim().startsWith("pipeline")) {
+        String pipeLineScript = scriptNode.getFirstChild().getTextContent().trim();
+        // If the script does not start with "pipeline" or the special comment,
+        // it is not actually a pipeline script, but a deprecated programming exercise with an old configuration
+        if (!pipeLineScript.startsWith("pipeline") && !pipeLineScript.startsWith(PIPELINE_SCRIPT_DETECTION_COMMENT)) {
             log.debug("Pipeline Script not found");
             throw new IllegalArgumentException("Pipeline Script not found");
         }

--- a/src/main/resources/templates/jenkins/c/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/c/Jenkinsfile
@@ -1,3 +1,5 @@
+// ARTEMIS: JenkinsPipeline
+
 pipeline {
         agent {
             docker {

--- a/src/main/resources/templates/jenkins/java/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/java/Jenkinsfile
@@ -1,3 +1,5 @@
+// ARTEMIS: JenkinsPipeline
+
 pipeline {
         agent {
             docker {

--- a/src/main/resources/templates/jenkins/java/Jenkinsfile-staticCodeAnalysis
+++ b/src/main/resources/templates/jenkins/java/Jenkinsfile-staticCodeAnalysis
@@ -1,3 +1,5 @@
+// ARTEMIS: JenkinsPipeline
+
 pipeline {
         agent {
             docker {

--- a/src/main/resources/templates/jenkins/python/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/python/Jenkinsfile
@@ -1,3 +1,5 @@
+// ARTEMIS: JenkinsPipeline
+
 pipeline {
         agent {
             docker {


### PR DESCRIPTION
### Checklist
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).

### Motivation and Context
#2306 introduced declarative Jenkins pipelines to run the build/test jobs. Jenkins pipeline scripts are not limited to declarative ones. Therefore, just checking if it starts with `pipeline` to detect a pipeline script is not enough in the general case.
Examples for different allowed starts are `podTemplate` (https://github.com/ls1intum/Artemis/issues/2169#issuecomment-725527442) for Kubernetes setups, `node` for scripted pipelines, or anything else that the Groovy language allows (comments, `def`, `package`, `import`, …).


### Description
This PR introduces the special comment `// ARTEMIS: JenkinsPipeline` that has to be at the start of `Jenkinsfile`s to detect if it is a new pipeline script or an older non-pipeline script.
This enables a server admin to have more freedom in choosing a template for the build jobs without breaking the import of older exercises while still providing an easy method for Artemis to check if it is a new script or not.
The previous check making sure the script starts with `pipeline` has been left in place to not break scripts created in between #2306 and this PR.

### Steps for Testing
This change only affects setups with Jenkins as CI runner. Basically the same testing steps as in #2306 apply.
Additional things to look out for:
* The import of older exercises in pre-pipeline format should still work.
* The import of exercises already in the pipeline format but without the introduced comment should work.

### Test Coverage
* unchanged

### Additional comments
@snowball77, @axel1200: You might be interested in this change, too. 
