### PR TITLE
Documentation: Testservers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,3 +9,6 @@ tests:
 
 database:
 - src/main/resources/config/liquibase/master.xml
+
+documentation:
+- docs/*

--- a/docs/dev/testservers.rst
+++ b/docs/dev/testservers.rst
@@ -1,0 +1,31 @@
+.. _testservers:
+
+Test Servers
+============
+
+Test Server 1-3
+---------------
+
+Deployment via Bamboo. Only for branches of the ``ls1intum/Artemis`` repository, no forks.
+Guide available in the Artemis Developer Confluence Space: `Deploying changes to test server`_.
+
+.. _`Deploying changes to test server`: https://confluence.ase.in.tum.de/display/ArTEMiS/Deploying+changes+to+test+server
+
+Test Server 5
+-------------
+
+
+Pull requests on GitHub can be deployed to TS5_, including forks.
+To invoke a deployment, you need to be part of the `ls1intum` GitHub organization.
+
+The deployment can be started using the `Test Server Deployment Workflow`_.
+(Refer to the `GitHub documentation "Manually running a workflow"`_.)
+Supply the pull request number to initiate the deployment (e.g. ``42`` for PR #42).
+TS5 is locked to a pull request using the `lock:artemistest5`_ label, which is automatically applied on deployment.
+Remove the label from the PR once the test server is free to use by other developers.
+
+
+.. _TS5: https://artemistest5.ase.in.tum.de
+.. _`Test Server Deployment Workflow`: https://github.com/ls1intum/Artemis/actions?query=workflow%3A%22Testserver+Deployment%22
+.. _`GitHub documentation "Manually running a workflow"`: https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
+.. _`lock:artemistest5`: https://github.com/ls1intum/Artemis/pulls?q=is%3Aopen+is%3Apr+label%3Alock%3Aartemistest5

--- a/docs/dev/testservers.rst
+++ b/docs/dev/testservers.rst
@@ -18,10 +18,11 @@ Test Server 5
 Pull requests on GitHub can be deployed to TS5_, including forks.
 To invoke a deployment, you need to be part of the `ls1intum` GitHub organization.
 
-The deployment can be started using the `Test Server Deployment Workflow`_.
+Start the deployment using the `Test Server Deployment Workflow`_.
 (Refer to the `GitHub documentation "Manually running a workflow"`_.)
 Supply the pull request number to initiate the deployment (e.g. ``42`` for PR #42).
-TS5 is locked to a pull request using the `lock:artemistest5`_ label, which is automatically applied on deployment.
+TS5 is locked to a pull request using the `lock:artemistest5`_ label.
+The workflow applies the lock label automatically on deployment.
 Remove the label from the PR once the test server is free to use by other developers.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ All these exercises are supposed to be run either live in the lecture with insta
    dev/system-design
    dev/use-local-user-management
    Guided Tour <dev/guided-tour>
+   dev/testservers
 
 
 .. toctree::


### PR DESCRIPTION
This PR outlines the Testserver Options we can offer right now as part of the `/docs`.