### PR TITLE
[Bugfix] SCA and Sequential Test Runs active at the same time

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -244,9 +244,10 @@ public class ProgrammingExerciseResource {
     /**
      * Validates static code analysis settings
      * 1. The flag staticCodeAnalysisEnabled must not be null
-     * 2. Static code analysis can only be enabled for supported programming languages
-     * 3. Static code analysis max penalty must only be set if static code analysis is enabled
-     * 4. Static code analysis max penalty must be positive
+     * 2. Static code analysis and sequential test runs can't be active at the same time
+     * 3. Static code analysis can only be enabled for supported programming languages
+     * 4. Static code analysis max penalty must only be set if static code analysis is enabled
+     * 5. Static code analysis max penalty must be positive
      *
      * @param programmingExercise exercise to validate
      * @return Optional validation error response

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -260,6 +260,13 @@ public class ProgrammingExerciseResource {
                     .headers(HeaderUtil.createAlert(applicationName, "The static code analysis flag must be set to true or false", "staticCodeAnalysisFlagNotSet")).body(null));
         }
 
+        // Check that programming exercise doesn't have sequential test runs and static code analysis enabled
+        if (Boolean.TRUE.equals(programmingExercise.isStaticCodeAnalysisEnabled()) && programmingExercise.hasSequentialTestRuns()) {
+            return Optional.of(ResponseEntity.badRequest().headers(
+                    HeaderUtil.createAlert(applicationName, "The static code analysis with sequential test runs is not supported at the moment", "staticCodeAnalysisAndSequential"))
+                    .body(null));
+        }
+
         // Static code analysis is only supported for Java at the moment
         if (Boolean.TRUE.equals(programmingExercise.isStaticCodeAnalysisEnabled()) && !programmingLanguageFeature.isStaticCodeAnalysis()) {
             return Optional.of(ResponseEntity.badRequest()

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -203,7 +203,7 @@
                             class="form-check-input custom-control-input"
                             id="field_staticCodeAnalysisEnabled"
                             name="staticCodeAnalysisEnabled"
-                            [disabled]="!!programmingExercise.id"
+                            [disabled]="!!programmingExercise.id || programmingExercise.sequentialTestRuns"
                             [(ngModel)]="programmingExercise.staticCodeAnalysisEnabled"
                             (change)="onStaticCodeAnalysisChanged()"
                         />
@@ -300,7 +300,7 @@
                                 type="checkbox"
                                 name="sequentialTestRuns"
                                 id="field_sequentialTestRuns"
-                                [disabled]="!!programmingExercise.id"
+                                [disabled]="!!programmingExercise.id || programmingExercise.staticCodeAnalysisEnabled"
                                 [(ngModel)]="programmingExercise.sequentialTestRuns"
                                 checked
                             />

--- a/src/main/webapp/i18n/de/programmingExercise.json
+++ b/src/main/webapp/i18n/de/programmingExercise.json
@@ -48,7 +48,7 @@
             "noVersionControlAndContinuousIntegrationAvailable": "Setup ohne Verbindung zur VCS und CI",
             "sequentialTestRuns": {
                 "title": "Sequentielle Testläufe",
-                "description": "Aktiviere diese Checkbox um zuerst Struktur- und erst im Anschluss Verhaltenstests duchzuführen. Dieses Feature hilft Studenten dabei, sich auf die aktuell anliegende Herausforderung zu konzentrieren. Bei Aktivierung werden im Test Repository zusätzliche Informationen bereitgestellt. ACHTUNG: Kann nicht nachträglich geändert werden!"
+                "description": "Aktiviere diese Checkbox um zuerst Struktur- und erst im Anschluss Verhaltenstests duchzuführen. Statische Code Analyse wird nicht unterstützt. Dieses Feature hilft Studenten dabei, sich auf die aktuell anliegende Herausforderung zu konzentrieren. Bei Aktivierung werden im Test Repository zusätzliche Informationen bereitgestellt. ACHTUNG: Kann nicht nachträglich geändert werden!"
             },
             "checkoutSolutionRepository": {
                 "title": "Checke Repository der Lösung aus",
@@ -56,7 +56,7 @@
             },
             "enableStaticCodeAnalysis": {
                 "title": "Aktiviere Statische Code Analyse",
-                "description": "Durch Aktivierung dieser Option werden Abgaben einer Statischen Code Analyse unterzogen. Zusätzliche Optionen stehen in der Bewertungssicht zur Verfügung. Diese Option kann nach der Erstellung der Aufgabe nicht mehr geändert werden."
+                "description": "Durch Aktivierung dieser Option werden Abgaben einer Statischen Code Analyse unterzogen. Sequentielle Testläufe werden nicht unterstützt. Zusätzliche Optionen stehen in der Bewertungssicht zur Verfügung. Diese Option kann nach der Erstellung der Aufgabe nicht mehr geändert werden."
             },
             "maxStaticCodeAnalysisPenalty": {
                 "title": "Max Statische Code Analyse Strafe",

--- a/src/main/webapp/i18n/en/programmingExercise.json
+++ b/src/main/webapp/i18n/en/programmingExercise.json
@@ -48,7 +48,7 @@
             "noVersionControlAndContinuousIntegrationAvailable": "Setup without connection to the VCS and CI",
             "sequentialTestRuns": {
                 "title": "Sequential Test Runs",
-                "description": "Activate to first run structural and then behavior test. This feature can help students to better concentrate on the immediate challenge at hand. If activated, you will be provided with more information in a readme file within the test repository. ATTENTION: Can not be changed after creation!"
+                "description": "Activate to first run structural and then behavior test. Does not support static code analysis. This feature can help students to better concentrate on the immediate challenge at hand. If activated, you will be provided with more information in a readme file within the test repository. ATTENTION: Can not be changed after creation!"
             },
             "checkoutSolutionRepository": {
                 "title": "Check out repository of sample solution",
@@ -56,7 +56,7 @@
             },
             "enableStaticCodeAnalysis": {
                 "title": "Enable Static Code Analysis",
-                "description": "This option enables the execution of static code analysis. Additional options are available on the grading page. This option can't be changed after the creation of the exercise."
+                "description": "This option enables the execution of static code analysis. Sequential test runs are not supported. Additional options are available on the grading page. This option can't be changed after the creation of the exercise."
             },
             "maxStaticCodeAnalysisPenalty": {
                 "title": "Max Static Code Analysis Penalty",

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -685,6 +685,17 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void createProgrammingExercise_staticCodeAnalysisAndSequential_badRequest() throws Exception {
+        programmingExercise.setId(null);
+        programmingExercise.setTitle("New title");
+        programmingExercise.setShortName("NewShortname");
+        programmingExercise.setStaticCodeAnalysisEnabled(true);
+        programmingExercise.setSequentialTestRuns(true);
+        request.post(ROOT + SETUP, programmingExercise, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_unsupportedProgrammingLanguageForStaticCodeAnalysis_badRequest() throws Exception {
         programmingExercise.setId(null);
         programmingExercise.setTitle("New title");

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -1536,6 +1536,7 @@ public class DatabaseUtilService {
         programmingExercise.setAssessmentType(AssessmentType.AUTOMATIC);
         programmingExercise.setGradingInstructions("Lorem Ipsum");
         programmingExercise.setTitle(title);
+        programmingExercise.setProjectType(ProjectType.ECLIPSE);
         programmingExercise.setAllowOnlineEditor(true);
         programmingExercise.setStaticCodeAnalysisEnabled(enableStaticCodeAnalysis);
         if (enableStaticCodeAnalysis) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
@derLalla noticed the build breaks if sequential test runs and static code analysis is active at the same time. This is the case because the configuration files are copied into the test repository only for non-sequential tests. As the template contains the SCA dependencies but the config file references are missing, the build fails.

### Description
- SCA and sequential test runs can't be active at the same time. SCA is not supported for sequential at the moment but this might change in the future

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create a programming exercise
3. Check that sequential and static code analysis can't be activated at the same time.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Increased the coverage by fixing a problem in the test setup (project type was always missing)
