### PR TITLE
[Bugfix] Shorten paths in build logs

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
@@ -1,6 +1,9 @@
 package de.tum.in.www1.artemis.service.connectors.bamboo;
 
-import static de.tum.in.www1.artemis.config.Constants.*;
+import static de.tum.in.www1.artemis.config.Constants.ASSIGNMENT_DIRECTORY;
+import static de.tum.in.www1.artemis.config.Constants.ASSIGNMENT_REPO_NAME;
+import static de.tum.in.www1.artemis.config.Constants.SETUP_COMMIT_MESSAGE;
+import static de.tum.in.www1.artemis.config.Constants.TEST_REPO_NAME;
 
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
@@ -876,7 +876,7 @@ public class BambooService implements ContinuousIntegrationService {
             }
 
             // Replace some unnecessary information and hide complex details to make it easier to read the important information
-            logString = logString.replaceAll("/opt/bamboo-agent-home/xml-data/build-dir/", "");
+            logString = logString.replaceAll("/opt/bambooagent/bamboo-agent-home/xml-data/build-dir/", "");
 
             filteredBuildLogs.add(new BuildLogEntry(unfilteredBuildLog.getTime(), logString, unfilteredBuildLog.getProgrammingSubmission()));
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis.service.connectors.bamboo;
 
-import static de.tum.in.www1.artemis.config.Constants.ASSIGNMENT_REPO_NAME;
-import static de.tum.in.www1.artemis.config.Constants.SETUP_COMMIT_MESSAGE;
-import static de.tum.in.www1.artemis.config.Constants.TEST_REPO_NAME;
+import static de.tum.in.www1.artemis.config.Constants.*;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -61,6 +59,9 @@ import de.tum.in.www1.artemis.service.connectors.bamboo.dto.*;
 public class BambooService implements ContinuousIntegrationService {
 
     private final Logger log = LoggerFactory.getLogger(BambooService.class);
+
+    // Match Unix and Windows paths because the notification plugin uses '/' and reports Windows paths like '/C:/
+    private final static Pattern ASSIGNMENT_PATH = Pattern.compile("(/[^\0]+)*" + ASSIGNMENT_DIRECTORY);
 
     @Value("${artemis.continuous-integration.url}")
     private URL bambooServerUrl;
@@ -876,7 +877,7 @@ public class BambooService implements ContinuousIntegrationService {
             }
 
             // Replace some unnecessary information and hide complex details to make it easier to read the important information
-            logString = logString.replaceAll("/opt/bambooagent/bamboo-agent-home/xml-data/build-dir/", "");
+            logString = ASSIGNMENT_PATH.matcher(logString).replaceAll("");
 
             filteredBuildLogs.add(new BuildLogEntry(unfilteredBuildLog.getTime(), logString, unfilteredBuildLog.getProgrammingSubmission()));
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The build logs should not show the absolute file path to the source files causing the issue.

### Description
<!-- Describe your changes in detail -->
Use a regex to remove the path up to the assignment directory. The regex should work for both Unix and Windows paths. Note: Bamboo always uses '/' to report paths. Window paths start with '/C:/...'
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a programming exercise
4. Participate in the exercise
5. Let the build fail
6. Check the build logs
--> Paths to the source file should start with src

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Coverage is the same. I will deliver a small test targeting the regex in a follow up

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![Screenshot 2020-11-19 180839](https://user-images.githubusercontent.com/16407766/99699538-55eb2e00-2a92-11eb-9558-dac1e80809bf.png)
Before on Windows
![image](https://user-images.githubusercontent.com/16407766/99699573-656a7700-2a92-11eb-83f9-6cbe1f8753fa.png)
After on Windows
