### PR TITLE
Disable Hazelcast Multicast join.

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
@@ -107,6 +107,8 @@ public class CacheConfiguration {
         Config config = new Config();
         config.setInstanceName(instanceName);
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getAdvancedNetworkConfig().getJoin().getAutoDetectionConfig().setEnabled(false);
+        config.getAdvancedNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         // Allows using @SpringAware and therefore Spring Services in distributed tasks
         config.setManagedContext(new SpringManagedContext(applicationContext));
         config.setClassLoader(applicationContext.getClassLoader());

--- a/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
@@ -107,8 +107,8 @@ public class CacheConfiguration {
         Config config = new Config();
         config.setInstanceName(instanceName);
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
-        config.getAdvancedNetworkConfig().getJoin().getAutoDetectionConfig().setEnabled(false);
-        config.getAdvancedNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        // Always enable TcpIp config: There has to be at least one join-config and we can not use multicast as this creates unwanted clusters
+        // If registration == null -> this will never connect to any instance as no other ip addresses are added
         config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
 
         // Allows using @SpringAware and therefore Spring Services in distributed tasks
@@ -150,7 +150,6 @@ public class CacheConfiguration {
 
                 // In the local configuration, the hazelcast port is the http-port + the hazelcastPort as offset
                 config.getNetworkConfig().setPort(serverProperties.getPort() + hazelcastPort); // Own port
-                config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
                 for (ServiceInstance instance : discoveryClient.getInstances(serviceId)) {
                     String clusterMember = instance.getHost() + ":" + (instance.getPort() + hazelcastPort); // Address where the other instance is expected
                     log.info("Adding Hazelcast (dev) cluster member {}", clusterMember);
@@ -161,7 +160,6 @@ public class CacheConfiguration {
                 config.setClusterName("prod");
                 config.setInstanceName(instanceName);
                 config.getNetworkConfig().setPort(hazelcastPort); // Own port
-                config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
                 for (ServiceInstance instance : discoveryClient.getInstances(serviceId)) {
                     String clusterMember = instance.getHost() + ":" + hazelcastPort; // Address where the other instance is expected
                     log.info("Adding Hazelcast (prod) cluster member {}", clusterMember);

--- a/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
@@ -109,6 +109,8 @@ public class CacheConfiguration {
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config.getAdvancedNetworkConfig().getJoin().getAutoDetectionConfig().setEnabled(false);
         config.getAdvancedNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
+
         // Allows using @SpringAware and therefore Spring Services in distributed tasks
         config.setManagedContext(new SpringManagedContext(applicationContext));
         config.setClassLoader(applicationContext.getClassLoader());

--- a/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
@@ -107,6 +107,7 @@ public class CacheConfiguration {
         Config config = new Config();
         config.setInstanceName(instanceName);
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getAutoDetectionConfig().setEnabled(false);
         // Always enable TcpIp config: There has to be at least one join-config and we can not use multicast as this creates unwanted clusters
         // If registration == null -> this will never connect to any instance as no other ip addresses are added
         config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);


### PR DESCRIPTION
### Checklist
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
Hazelcast is used to distribute data structures between several Artemis instances.
This is particularly useful for large instance of Artemis (like our production instances), but should not occur when running tests (the test instances should not connect to each other).


### Description
This PR disables the Hazelcast multicast join-method **AND ENABLES** the TcpIp join-method.
If the TcpIp join-method is disabled as well, this causes the multicast join-method to get enabled as a fallback.
We thus enable TcpIp, but do not add peers if the registration (via the JHipster Registry) is not present.

### Steps for Testing
1. Run the tests of a branch on Bamboo
2. Make sure that the build agents **did not** connect to TS3
