### PR TITLE
[Hotfix] Fix Assessment Lock View and Null Index Column when locking Submission

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -50,6 +50,8 @@ public class ProgrammingSubmissionService extends SubmissionService {
 
     private final ResultRepository resultRepository;
 
+    private final FeedbackRepository feedbackRepository;
+
     private final ProgrammingExerciseParticipationService programmingExerciseParticipationService;
 
     private final GroupNotificationService groupNotificationService;
@@ -69,7 +71,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
             WebsocketMessagingService websocketMessagingService, Optional<VersionControlService> versionControlService, ResultRepository resultRepository,
             Optional<ContinuousIntegrationService> continuousIntegrationService, ParticipationService participationService, SimpMessageSendingOperations messagingTemplate,
             ProgrammingExerciseParticipationService programmingExerciseParticipationService, GitService gitService, StudentParticipationRepository studentParticipationRepository,
-            CourseService courseService, ExamService examService) {
+            CourseService courseService, ExamService examService, FeedbackRepository feedbackRepository) {
         super(submissionRepository, userService, authCheckService, courseService, resultRepository, examService, studentParticipationRepository, participationService);
         this.programmingSubmissionRepository = programmingSubmissionRepository;
         this.programmingExerciseRepository = programmingExerciseRepository;
@@ -82,6 +84,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
         this.programmingExerciseParticipationService = programmingExerciseParticipationService;
         this.gitService = gitService;
         this.resultRepository = resultRepository;
+        this.feedbackRepository = feedbackRepository;
     }
 
     /**
@@ -659,6 +662,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
         newResult.setAssessmentType(AssessmentType.SEMI_AUTOMATIC);
         // Copy automatic feedbacks into the manual result
         for (Feedback feedback : automaticFeedbacks) {
+            feedback = feedbackRepository.save(feedback);
             feedback.setResult(newResult);
         }
         newResult.setFeedbacks(automaticFeedbacks);

--- a/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
+++ b/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
@@ -48,8 +48,8 @@
                                     courseId,
                                     submission.participation.exercise.type + '-exercises',
                                     submission.participation.exercise.id,
-                                    'submissions',
-                                    submission.id,
+                                    submission.participation.exercise.type !== PROGRAMMING_EXERCISE ? 'submissions' : 'code-editor',
+                                    submission.participation.exercise.type !== PROGRAMMING_EXERCISE ? submission.id : submission.participation.id,
                                     'assessment'
                                 ]"
                                 class="btn btn-outline-secondary btn-sm mb-1"

--- a/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.ts
+++ b/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.ts
@@ -7,16 +7,19 @@ import { Submission, SubmissionExerciseType } from 'app/entities/submission.mode
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { HttpResponse } from '@angular/common/http';
 import { Course } from 'app/entities/course.model';
-import { Exercise, getIcon, getIconTooltip } from 'app/entities/exercise.model';
+import { Exercise, ExerciseType, getIcon, getIconTooltip } from 'app/entities/exercise.model';
 import { JhiAlertService } from 'ng-jhipster';
 import { ModelingAssessmentService } from 'app/exercises/modeling/assess/modeling-assessment.service';
 import { TextAssessmentsService } from 'app/exercises/text/assess/text-assessments.service';
+import { ProgrammingAssessmentManualResultService } from 'app/exercises/programming/assess/manual-result/programming-assessment-manual-result.service';
 
 @Component({
     selector: 'jhi-assessment-locks',
     templateUrl: './assessment-locks.component.html',
 })
 export class AssessmentLocksComponent implements OnInit {
+    PROGRAMMING_EXERCISE = ExerciseType.PROGRAMMING;
+
     course: Course;
     courseId: number;
     tutorId: number;
@@ -35,6 +38,7 @@ export class AssessmentLocksComponent implements OnInit {
         private modelingAssessmentService: ModelingAssessmentService,
         private textAssessmentsService: TextAssessmentsService,
         private fileUploadAssessmentsService: FileUploadAssessmentsService,
+        private programmingAssessmentService: ProgrammingAssessmentManualResultService,
         translateService: TranslateService,
         private location: Location,
         private courseService: CourseManagementService,
@@ -82,6 +86,9 @@ export class AssessmentLocksComponent implements OnInit {
                     break;
                 case SubmissionExerciseType.FILE_UPLOAD:
                     this.fileUploadAssessmentsService.cancelAssessment(canceledSubmission.id!).subscribe();
+                    break;
+                case SubmissionExerciseType.PROGRAMMING:
+                    this.programmingAssessmentService.cancelAssessment(canceledSubmission.id!).subscribe();
                     break;
                 default:
                     break;

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -113,17 +113,19 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
             let participationId;
             if (!params['participationId']) {
                 // Check if error is thrown and show info about error
-                if (this.route.snapshot.data.studentParticipationId.error && this.route.snapshot.data.studentParticipationId.error.errorKey === 'lockedSubmissionsLimitReached') {
+                const response = this.route.snapshot.data.studentParticipationId;
+                if (response?.error?.errorKey === 'lockedSubmissionsLimitReached') {
                     this.lockLimitReached = true;
                     return;
-                } else if (this.route.snapshot.data.studentParticipationId.error.status === 404) {
+                } else if (response?.error?.status === 404) {
                     // there are no unassessed submission, nothing we have to worry about
                     this.onError('artemisApp.exerciseAssessmentDashboard.noSubmissions');
-                } else if (this.route.snapshot.data.studentParticipationId.error) {
-                    this.onError(this.route.snapshot.data.studentParticipationId.error);
+                    return;
+                } else if (response?.error) {
+                    this.onError(response?.error);
                     return;
                 }
-                participationId = Number(this.route.snapshot.data.studentParticipationId);
+                participationId = Number(response);
                 // Update the url with the new id, without reloading the page, to make the history consistent
                 const newUrl = window.location.hash.replace('#', '').replace('new', `${participationId}`);
                 this.location.go(newUrl);
@@ -202,11 +204,12 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
      * Cancel the assessment
      */
     cancel(): void {
-        const confirmCancel = window.confirm(this.cancelConfirmationText);
         this.cancelBusy = true;
+        const confirmCancel = window.confirm(this.cancelConfirmationText);
         if (confirmCancel && this.exercise && this.submission) {
             this.manualResultService.cancelAssessment(this.submission.id!).subscribe(() => this.navigateBack());
         }
+        this.cancelBusy = false;
     }
 
     /**

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
@@ -456,26 +456,12 @@ export class ExerciseAssessmentDashboardComponent implements OnInit, AfterViewIn
         this.openingAssessmentEditorForNewSubmission = false;
     }
 
-    async openCodeEditorWithStudentSubmission(participationId: number) {
-        const route = `/course-management/${this.courseId}/${this.exercise.type}-exercises/${this.exercise.id}/code-editor/${participationId}/assessment`;
-        if (this.isTestRun) {
-            await this.router.navigate([route], { queryParams: { testRun: this.isTestRun } });
-        } else {
-            await this.router.navigate([route]);
-        }
-    }
-
     /**
      * Show complaint depending on the exercise type
      * @param complaint that we want to show
      */
     viewComplaint(complaint: Complaint) {
-        if (this.exercise.type === ExerciseType.PROGRAMMING) {
-            // this.openCodeEditorWithStudentSubmission(complaint.result!.participation!.id!);
-            this.openAssessmentEditor(complaint.result!.submission!);
-        } else {
-            this.openAssessmentEditor(complaint.result!.submission!);
-        }
+        this.openAssessmentEditor(complaint.result!.submission!);
     }
 
     /**

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
@@ -244,8 +244,8 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
         comp.cancel();
 
         expect(confirmSpy).to.be.calledOnce;
-        expect(comp.cancelBusy).to.be.true;
         tick(100);
+        expect(comp.cancelBusy).to.be.false;
         expect(navigateBackStub).to.be.calledOnce;
         expect(cancelBackStub).to.be.calledOnce;
     }));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features locally
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Wrong routing when clicking on `Open assessment` and nothing happened when clicking on `Cancel assessment`.
Null index issue when locking submission.

### Description
<!-- Describe your changes in detail -->
- Add logic for programming exercises
- Fixed null index issue when locking submission
- Removed not needed code 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create programming exercise, participate and go to assessment dashboard
4. Start new assessment of some submission but DO NOT submit
5. Navigate back
6. Click on `Assessments locked by you`
7. Check that you can open and cancel the assessment
8. Try this a few times and check if everything works as expected

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Nothing changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![video](https://user-images.githubusercontent.com/41108487/99743934-02e79a00-2ad7-11eb-9a26-73a1c73eb8bf.gif)
