### PR TITLE
[Hotfix] Fix that participationId is undefined when evaluating Complaints for Programming Exercises

### DIFF
--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
@@ -461,7 +461,10 @@ export class ExerciseAssessmentDashboardComponent implements OnInit, AfterViewIn
      * @param complaint that we want to show
      */
     viewComplaint(complaint: Complaint) {
-        this.openAssessmentEditor(complaint.result!.submission!);
+        const submission: Submission = complaint.result?.submission!;
+        // For programming exercises we need the participationId
+        submission.participation = complaint.result?.participation;
+        this.openAssessmentEditor(submission);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with locally
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
ParticipationId was undefined and therefore the students submission could not be loaded.

### Description
<!-- Describe your changes in detail -->
- Assured that participationId ist available

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration -> Assessment Dashboard
3. Evaluate complaints of programming exercises
4. Check that you can open a submission

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Nothing changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
![image](https://user-images.githubusercontent.com/41108487/99897623-50acff80-2c9b-11eb-8346-785d98159240.png)

Now:
![image](https://user-images.githubusercontent.com/41108487/99897631-5c98c180-2c9b-11eb-8f6a-e7962aa6ba1d.png)
