### PR TITLE
[Bugfix] Fix for opening wrong view after editing a sample solution in a modeling exercise

### DIFF
--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-solution.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-solution.component.ts
@@ -67,21 +67,7 @@ export class ExampleModelingSolutionComponent implements OnInit {
         );
     }
 
-    async back() {
-        if (this.exercise.course) {
-            await this.router.navigate(['/course-management', this.exercise.course?.id, 'modeling-exercises', this.exerciseId, 'edit']);
-        } else {
-            await this.router.navigate([
-                '/course-management',
-                this.exercise.exerciseGroup?.exam?.course?.id,
-                'exams',
-                this.exercise.exerciseGroup?.exam?.id,
-                'exercise-groups',
-                this.exercise.exerciseGroup?.id,
-                'modeling-exercises',
-                this.exerciseId,
-                'edit',
-            ]);
-        }
+    back(): void {
+        window.history.back();
     }
 }

--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
@@ -288,25 +288,8 @@ export class ExampleModelingSubmissionComponent implements OnInit {
         this.invalidError = undefined;
     }
 
-    async back() {
-        const courseId = this.exercise.course?.id || this.exercise.exerciseGroup?.exam?.course?.id;
-        if (this.readOnly || this.toComplete) {
-            await this.router.navigate(['/course-management', courseId, 'exercises', this.exerciseId, 'tutor-dashboard']);
-        } else if (this.isExamMode) {
-            await this.router.navigate([
-                '/course-management',
-                courseId,
-                'exams',
-                this.exercise.exerciseGroup?.exam?.id,
-                'exercise-groups',
-                this.exercise.exerciseGroup?.id,
-                'modeling-exercises',
-                this.exerciseId,
-                'edit',
-            ]);
-        } else {
-            await this.router.navigate(['/course-management', courseId, 'modeling-exercises', this.exerciseId, 'edit']);
-        }
+    back(): void {
+        window.history.back();
     }
 
     checkAssessment() {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context

Fixes #2384 : After editing a sample submission / solution in a modeling exercise and get back to the exercise edit page, the cancel/save button now should route back to the entry page the user used to access the exercise edit page. The current behavior is it redirects back to the modeling page.

### Description
The modeling-exercise-update-component is using window.history.back() to get back to the previous page after the user clicks on the Cancel/Save button. This unfortunately leads to conflict with the example-modeling-submission and example-modeling-solution components, because when the user clicks on the back button in these components, it uses router to get back to the exercise edit page, thus polluting the history, making the Cancel/Save buttons in the exercise edit page to behave wrongly.

I made it so that that the submission and solution components in the modeling exercise also use the history API, therefore fixing the bug.

### Steps for Testing

1. Log in to Artemis
2. Navigate to a modeling exercise edit page as an Instructor (Either through Course Overview -> Some Test Course -> Exercises or through Course Management -> Exercises -> Edit , ... there are multiple entry points)
3. Try to create a sample solution / submission and go back using the back button.
4. Save / Cancel the edit. It should now go back to the page you used to access the Edit Modeling Exercise page.

### Test Coverage
Nothing changed.

### Video
(A bit too long to convert to Gif, so I zipped it)
[screen-recording.zip](https://github.com/ls1intum/Artemis/files/5580277/screen-recording.zip)

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
