### PR TITLE
Bugfix: _meta undefined in result-details-chart when legend clicked

### DIFF
--- a/src/main/webapp/app/shared/chart/presets/scoreChartPreset.ts
+++ b/src/main/webapp/app/shared/chart/presets/scoreChartPreset.ts
@@ -27,12 +27,14 @@ export class ScoreChartPreset implements ChartPreset {
                 generateLabels: () =>
                     [
                         {
+                            datasetIndex: 0,
                             text: this.labels[0],
                             fillStyle: '#28a745',
                             strokeStyle: '#28a745',
                             lineWidth: 1,
                         },
                         {
+                            datasetIndex: 1,
                             text: this.labels[1],
                             fillStyle: this.redTransparentPattern,
                             strokeStyle: '#dc3545',


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I investigated the following sentry issue:
 https://sentry.io/organizations/ls1intum/issues/1991312466/?project=1440029&query=assigned%3Ahello%40stefanwaldhauser.me&statsPeriod=14d#request

I could reproduce the issue. The issue happens when clicking on the label of the result-details graph. The reason is the default label click handler for chart.js. https://www.chartjs.org/docs/latest/configuration/legend.html#custom-on-click-actions
![image](https://user-images.githubusercontent.com/29718932/100126712-9bd33800-2e7e-11eb-9684-0ade156406c1.png)

As you can see it expects that `legendItem.datasetIndex` exists. This was not set. I added it in 95ea2728974e9141c2b4f0e7b11f39ae00cb7870. This now fixes the bug and the default click handler works (hides the element in the gaph)



### Description
<!-- Describe your changes in detail -->
Added `legendItem.datasetIndex` in 95ea2728974e9141c2b4f0e7b11f39ae00cb7870



### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Create a programming exercise, participate in it via the online code editor

![image](https://user-images.githubusercontent.com/29718932/100126546-5d3d7d80-2e7e-11eb-97d0-8a1a1efff2fa.png)
![image](https://user-images.githubusercontent.com/29718932/100126612-73e3d480-2e7e-11eb-975d-a0c659790456.png)
