### PR TITLE
Updated ngx-device-detector to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "ngx-chips": "2.2.2",
         "ngx-clipboard": "14.0.1",
         "ngx-cookie-service": "10.1.1",
-        "ngx-device-detector": "2.0.0",
+        "ngx-device-detector": "2.0.1",
         "ngx-image-cropper": "3.3.1",
         "ngx-moment": "5.0.0",
         "ngx-treeview": "10.0.2",

--- a/src/test/javascript/jest-global-mocks.ts
+++ b/src/test/javascript/jest-global-mocks.ts
@@ -13,3 +13,17 @@ Object.defineProperty(window, 'sessionStorage', { value: mock() });
 Object.defineProperty(window, 'getComputedStyle', {
     value: () => ['-webkit-appearance'],
 });
+
+Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+    })),
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8579,10 +8579,10 @@ ngx-cookie-service@10.1.1:
   dependencies:
     tslib "^2.0.0"
 
-ngx-device-detector@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ngx-device-detector/-/ngx-device-detector-2.0.0.tgz#1a239d0d65f3cb155221fcdde531b6df4c774863"
-  integrity sha512-0minaW2+Y6dJSKhQrcE3yi8lRa2oAhttgLY5K/K1KRcAPy5yhojY/hpuJko7ANYhttOSxrzxEWhf3novEiSXcg==
+ngx-device-detector@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ngx-device-detector/-/ngx-device-detector-2.0.1.tgz#c7b88e152987379ed7d7afa65e4f736b231c6dc0"
+  integrity sha512-H0iWZDJTVe7hBfQLKOxs4bi5y5tt3gafwNMf9nGpuplkguhkp1Wx6hC54oy1b2jOpyq/TcbDXHTvF8mCt2jU8g==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- Nothing to check here

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- New version of ngx-device-detector

### Description
<!-- Describe your changes in detail -->
- Updated ngx-device-detector to 2.0.1 and mocked `window.matchMedia`

2.0.1 uses 'window.matchMedia' however Jest uses jsdom to create a browser environment. JSDom doesn't however support window.matchMedia so we have to mock it. See https://jestjs.io/docs/en/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Nothing to test. All client tests should pass 

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/29718932/100340940-339a6880-2fdc-11eb-8943-350bd106b37c.png)

