### PR TITLE
Remove back buttons in administrations/management views

### DIFF
--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management-detail.component.html
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management-detail.component.html
@@ -17,7 +17,4 @@
         <dt><span jhiTranslate="artemisApp.systemNotification.expireDate">Expire Date</span></dt>
         <dd>{{ notification.expireDate | artemisDate }}</dd>
     </dl>
-    <button type="submit" routerLink="/admin/system-notification-management" class="btn btn-info">
-        <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
-    </button>
 </div>

--- a/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
+++ b/src/main/webapp/app/assessment/assessment-header/assessment-header.component.html
@@ -1,7 +1,6 @@
 <h3 class="top-container">
     <!--back button only used in assessment dashboard-->
     <div class="row-container mr-2">
-        <fa-icon *ngIf="!hideBackButton" [icon]="'arrow-left'" (click)="navigateBack.emit()" class="back-button mr-2"></fa-icon>
         <span jhiTranslate="artemisApp.assessment.assessment">Assessment</span>
     </div>
     <jhi-alert></jhi-alert>

--- a/src/main/webapp/app/assessment/assessment-header/assessment-header.component.ts
+++ b/src/main/webapp/app/assessment/assessment-header/assessment-header.component.ts
@@ -13,9 +13,6 @@ import { Result } from 'app/entities/result.model';
     styleUrls: ['./assessment-header.component.scss'],
 })
 export class AssessmentHeaderComponent {
-    @Input() hideBackButton: boolean;
-    @Output() navigateBack = new EventEmitter<void>();
-
     @Input() isLoading: boolean;
     @Input() saveBusy: boolean;
     @Input() submitBusy: boolean;

--- a/src/main/webapp/app/assessment/assessment-layout/assessment-layout.component.html
+++ b/src/main/webapp/app/assessment/assessment-layout/assessment-layout.component.html
@@ -1,5 +1,4 @@
 <jhi-assessment-header
-    [hideBackButton]="hideBackButton"
     (navigateBack)="navigateBack.emit()"
     [isLoading]="isLoading"
     [saveBusy]="saveBusy"

--- a/src/main/webapp/app/assessment/assessment-layout/assessment-layout.component.ts
+++ b/src/main/webapp/app/assessment/assessment-layout/assessment-layout.component.ts
@@ -17,7 +17,6 @@ import { Complaint, ComplaintType } from 'app/entities/complaint.model';
 export class AssessmentLayoutComponent {
     @HostBinding('class.assessment-container') readonly assessmentContainerClass = true;
 
-    @Input() hideBackButton = false;
     @Output() navigateBack = new EventEmitter<void>();
 
     @Input() isLoading: boolean;

--- a/src/main/webapp/app/course/manage/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/course-detail.component.html
@@ -65,10 +65,6 @@
                 </ng-container>
             </dl>
 
-            <button type="submit" (click)="previousState()" class="btn btn-info mr-1">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back">Back</span>
-            </button>
-
             <button type="button" [routerLink]="['/course-management', course.id, 'edit']" class="btn btn-primary mr-1">
                 <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit">Edit</span>
             </button>

--- a/src/main/webapp/app/course/manage/course-detail.component.ts
+++ b/src/main/webapp/app/course/manage/course-detail.component.ts
@@ -64,13 +64,6 @@ export class CourseDetailComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Go back to the previous page.
-     */
-    previousState() {
-        window.history.back();
-    }
-
-    /**
      * On destroy unsubscribe all subscriptions.
      */
     ngOnDestroy() {

--- a/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
@@ -95,9 +95,6 @@
                 <dd *ngIf="formattedConfirmationEndText" class="editor-outline-background" [innerHTML]="formattedConfirmationEndText"></dd>
                 <span *ngIf="!formattedConfirmationEndText" jhiTranslate="artemisApp.exam.notSet"></span>
             </dl>
-            <button type="submit" (click)="previousState()" class="btn btn-info">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
-            </button>
 
             <button type="button" [routerLink]="getEditRoute()" class="btn btn-primary">
                 <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>

--- a/src/main/webapp/app/exam/manage/exams/exam-detail.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-detail.component.ts
@@ -34,13 +34,6 @@ export class ExamDetailComponent implements OnInit {
     }
 
     /**
-     * Go back.
-     */
-    previousState() {
-        window.history.back();
-    }
-
-    /**
      * Returns the route for editing the exam.
      */
     getEditRoute() {

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-detail.component.html
@@ -18,10 +18,6 @@
                 <dd class="editor-outline-background" [innerHTML]="fileUploadExercise.sampleSolution! | htmlForMarkdown"></dd>
             </dl>
 
-            <button type="submit" (click)="previousState()" class="btn btn-info">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
-            </button>
-
             <button type="button" [routerLink]="getEditRoute()" class="btn btn-primary">
                 <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
             </button>

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-detail.component.ts
@@ -80,13 +80,6 @@ export class FileUploadExerciseDetailComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Returns to previous state (same behaviour as back button in the browser)
-     */
-    previousState() {
-        window.history.back();
-    }
-
-    /**
      * Unsubscribes on component destruction
      */
     ngOnDestroy() {

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.html
@@ -1,5 +1,4 @@
 <jhi-assessment-layout
-    [hideBackButton]="hideBackButton"
     (navigateBack)="navigateBack()"
     [isLoading]="isLoading"
     [nextSubmissionBusy]="nextSubmissionBusy"

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.html
@@ -29,10 +29,6 @@
                 </dd>
             </dl>
 
-            <button type="submit" (click)="previousState()" class="btn btn-info">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
-            </button>
-
             <button type="button" [routerLink]="['/course-management', modelingExercise.course?.id, 'modeling-exercises', modelingExercise.id, 'edit']" class="btn btn-primary">
                 <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
             </button>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.ts
@@ -52,10 +52,6 @@ export class ModelingExerciseDetailComponent implements OnInit, OnDestroy {
         });
     }
 
-    previousState() {
-        window.history.back();
-    }
-
     ngOnDestroy() {
         this.subscription.unsubscribe();
         this.eventManager.destroy(this.eventSubscriber);

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -99,10 +99,6 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
         );
     }
 
-    previousState() {
-        window.history.back();
-    }
-
     /**
      * Returns the route for editing the exercise. Exam and course exercises have different routes.
      */
@@ -189,7 +185,6 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
                     content: 'Deleted a programming exercise',
                 });
                 this.dialogErrorSource.next('');
-                this.previousState();
             },
             (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
         );

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-detail.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-detail.component.html
@@ -2,11 +2,6 @@
     <jhi-alert></jhi-alert>
 
     <div class="row">
-        <div class="col">
-            <button type="submit" (click)="previousState()" class="btn btn-info">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
-            </button>
-        </div>
         <div class="col text-right">
             <label class="mr-1">
                 <input type="checkbox" name="keepOriginalSize" [(ngModel)]="crop" />&nbsp;<span jhiTranslate="artemisApp.apollonDiagram.detail.crop">Crop</span>

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-detail.component.ts
@@ -200,11 +200,4 @@ export class ApollonDiagramDetailComponent implements OnInit, OnDestroy {
             document.body.removeChild(anchor);
         }, 0);
     }
-
-    /**
-     * Revert to the previous state, equivalent with pressing the back button on your browser
-     */
-    previousState() {
-        window.history.back();
-    }
 }

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-list.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-list.component.html
@@ -6,9 +6,6 @@
 
 <div class="row">
     <div class="col">
-        <button type="submit" (click)="previousState()" class="btn btn-info">
-            <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
-        </button>
         <button (click)="openCreateDiagramDialog(courseId)" class="btn btn-primary">
             <fa-icon [icon]="'plus'"></fa-icon>
             <span jhiTranslate="artemisApp.apollonDiagram.home.createLabel">Create a New Apollon Diagram</span>

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-list.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { JhiAlertService } from 'ng-jhipster';
 import { ApollonDiagramCreateFormComponent } from 'app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-create-form.component';
@@ -25,7 +25,6 @@ export class ApollonDiagramListComponent implements OnInit {
         private modalService: NgbModal,
         private sortService: SortService,
         private route: ActivatedRoute,
-        private router: Router,
     ) {
         this.predicate = 'id';
         this.reverse = true;
@@ -93,12 +92,5 @@ export class ApollonDiagramListComponent implements OnInit {
 
     sortRows() {
         this.sortService.sortByProperty(this.apollonDiagrams, this.predicate, this.reverse);
-    }
-
-    /**
-     * Revert to the previous state, equivalent with pressing the back button on your browser
-     */
-    previousState() {
-        window.history.back();
     }
 }

--- a/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-detail.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-detail.component.html
@@ -21,10 +21,6 @@
                 </dd>
             </dl>
 
-            <button type="submit" (click)="previousState()" class="btn btn-info">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
-            </button>
-
             <button type="button" [routerLink]="['..', 'edit']" class="btn btn-primary">
                 <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
             </button>

--- a/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-detail.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-detail.component.ts
@@ -39,11 +39,4 @@ export class ExerciseHintDetailComponent implements OnInit, OnDestroy {
             this.paramSub.unsubscribe();
         }
     }
-
-    /**
-     * Navigates back one step in the browser history
-     */
-    previousState() {
-        window.history.back();
-    }
 }

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.html
@@ -18,10 +18,6 @@
                 <dd class="editor-outline-background" [innerHTML]="formattedSampleSolution"></dd>
             </dl>
 
-            <button type="submit" (click)="previousState()" class="btn btn-info">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
-            </button>
-
             <button type="button" [routerLink]="getEditRoute()" class="btn btn-primary">
                 <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
             </button>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-detail.component.ts
@@ -87,13 +87,6 @@ export class TextExerciseDetailComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Go back.
-     */
-    previousState() {
-        window.history.back();
-    }
-
-    /**
      * Unsubscribe from changes of text exercise on destruction of component.
      */
     ngOnDestroy() {

--- a/src/main/webapp/app/lecture/lecture-attachments.component.html
+++ b/src/main/webapp/app/lecture/lecture-attachments.component.html
@@ -172,10 +172,6 @@
 
             <div class="row mt-3">
                 <div class="col-12">
-                    <button type="submit" (click)="previousState()" class="btn btn-info">
-                        <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
-                    </button>
-
                     <button type="button" [routerLink]="['../edit']" class="btn btn-primary">
                         <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span
                             jhiTranslate="entity.action.editEntity"

--- a/src/main/webapp/app/lecture/lecture-attachments.component.ts
+++ b/src/main/webapp/app/lecture/lecture-attachments.component.ts
@@ -65,10 +65,6 @@ export class LectureAttachmentsComponent implements OnInit, OnDestroy {
         this.dialogErrorSource.unsubscribe();
     }
 
-    previousState() {
-        window.history.back();
-    }
-
     addAttachment() {
         const newAttachment = new Attachment();
         newAttachment.lecture = this.lecture;

--- a/src/main/webapp/app/lecture/lecture-detail.component.ts
+++ b/src/main/webapp/app/lecture/lecture-detail.component.ts
@@ -19,11 +19,4 @@ export class LectureDetailComponent implements OnInit {
             this.lecture = lecture;
         });
     }
-
-    /**
-     * Revert to the previous state, equivalent with pressing the back button on your browser
-     */
-    previousState() {
-        window.history.back();
-    }
 }

--- a/src/test/javascript/spec/component/assessment-shared/assessment-header.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-header.component.spec.ts
@@ -63,29 +63,6 @@ describe('AssessmentHeaderComponent', () => {
         expect(alertComponent).toBeTruthy();
     });
 
-    it('should show or hide a back button', () => {
-        component.hideBackButton = false;
-        fixture.detectChanges();
-        let backButton = fixture.debugElement.query(By.css('fa-icon.back-button'));
-        expect(backButton).toBeTruthy();
-
-        component.hideBackButton = true;
-        fixture.detectChanges();
-        backButton = fixture.debugElement.query(By.css('fa-icon.back-button'));
-        expect(backButton).toBeFalsy();
-    });
-
-    it('should emit event on back button', () => {
-        spyOn(component.navigateBack, 'emit');
-        component.hideBackButton = false;
-        fixture.detectChanges();
-
-        const backButton = fixture.debugElement.query(By.css('fa-icon.back-button'));
-
-        backButton.nativeElement.click();
-        expect(component.navigateBack.emit).toHaveBeenCalledTimes(1);
-    });
-
     it('should hide right side row-container if loading', () => {
         component.isLoading = false;
         fixture.detectChanges();

--- a/src/test/javascript/spec/component/assessment-shared/assessment-layout.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-layout.component.spec.ts
@@ -61,18 +61,6 @@ describe('AssessmentLayoutComponent', () => {
         expect(complaintsForTutorComponent).toBeTruthy();
     });
 
-    it('should show or hide a back button', () => {
-        component.hideBackButton = false;
-        fixture.detectChanges();
-        let backButton = fixture.debugElement.query(By.css('fa-icon.back-button'));
-        expect(backButton).toBeTruthy();
-
-        component.hideBackButton = true;
-        fixture.detectChanges();
-        backButton = fixture.debugElement.query(By.css('fa-icon.back-button'));
-        expect(backButton).toBeFalsy();
-    });
-
     it('Assessors should be allowed to respond if test run ', () => {
         component.complaint = new Complaint();
         component.isTestRun = true;

--- a/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -7,9 +7,8 @@ import { TranslateService } from '@ngx-translate/core';
 import { ArtemisTestModule } from '../../test.module';
 import { By } from '@angular/platform-browser';
 import { mockedActivatedRoute } from '../../helpers/mocks/activated-route/mock-activated-route-query-param-map';
-import { ActivatedRoute, convertToParamMap, ParamMap, Router } from '@angular/router';
-import { Mutable } from '../../helpers/mutable';
-import { BehaviorSubject, of, throwError } from 'rxjs';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
 import { JhiLanguageHelper } from 'app/core/language/language.helper';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
@@ -168,19 +167,6 @@ describe('ModelingAssessmentEditorComponent', () => {
             modelingSubmissionStub.restore();
             accountStub.restore();
         }));
-    });
-    it('should show or hide a back button', () => {
-        const route = fixture.debugElement.injector.get(ActivatedRoute) as Mutable<ActivatedRoute>;
-        const queryParamMap = route.queryParamMap as BehaviorSubject<ParamMap>;
-        queryParamMap.next(convertToParamMap({ hideBackButton: 'true' }));
-        fixture.detectChanges();
-        let assessmentHeaderComponent: AssessmentHeaderComponent = fixture.debugElement.query(By.directive(AssessmentHeaderComponent)).componentInstance;
-        expect(assessmentHeaderComponent.hideBackButton).to.be.true;
-
-        queryParamMap.next(convertToParamMap({ hideBackButton: undefined }));
-        fixture.detectChanges();
-        assessmentHeaderComponent = fixture.debugElement.query(By.directive(AssessmentHeaderComponent)).componentInstance;
-        expect(assessmentHeaderComponent.hideBackButton).to.be.false;
     });
 
     it('should propagate isAtLeastInstructor', fakeAsync(() => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

 The management views use breadcrumbs now for navigating back. This PR removes any back arrows that were missed and back buttons.

### Description
<!-- Describe your changes in detail -->

- Removed back arrows and back buttons. 
- Removed tests that tested back buttons

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Administration pages
3. Check if back buttons are removed in all of detail views (all exercises , course, exam)
4. Check if back buttons are removed in assessment views

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
assessment-header.component.ts 100%
course-detail.component.ts 64.52%
file-upload-exercise-detail.component.ts 81.25%
modeling-exercise-detail.component.ts 79.31%
programming-exercise-detail.component.ts 50.06%
exercise-hint-detail.component.ts 84.62%
text-exercise-detail.component.ts 47.54%
lecture-attachments.component.ts  96.97%


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/11298674/100444553-e1c11380-30ab-11eb-8295-225010b451ff.png)
![image](https://user-images.githubusercontent.com/11298674/100445018-b1c64000-30ac-11eb-8f53-4e9eddfadf4a.png)
![image](https://user-images.githubusercontent.com/11298674/100445211-fa7df900-30ac-11eb-8224-218dc9c19206.png)
![image](https://user-images.githubusercontent.com/11298674/100445403-56e11880-30ad-11eb-96b6-d6052a2d3709.png)
![image](https://user-images.githubusercontent.com/11298674/100445476-724c2380-30ad-11eb-8e8c-acb38f352a46.png)
![image](https://user-images.githubusercontent.com/11298674/100445817-03bb9580-30ae-11eb-8417-b5f5802a8406.png)
![image](https://user-images.githubusercontent.com/11298674/100445942-382f5180-30ae-11eb-878a-59a4d56b6789.png)
![image](https://user-images.githubusercontent.com/11298674/100446044-6876f000-30ae-11eb-8c14-be60b7b46e76.png)
![image](https://user-images.githubusercontent.com/11298674/100446117-82183780-30ae-11eb-9511-78d6a9a0683c.png)
![image](https://user-images.githubusercontent.com/11298674/100446218-affd7c00-30ae-11eb-90e7-ace3bdafe219.png)
![image](https://user-images.githubusercontent.com/11298674/100446465-27331000-30af-11eb-9e6c-810c6fdee5e8.png)
![image](https://user-images.githubusercontent.com/11298674/100446566-5184cd80-30af-11eb-9651-51dec7c54b61.png)
![image](https://user-images.githubusercontent.com/11298674/100446621-6b261500-30af-11eb-9628-9cfe541a441e.png)


