### PR TITLE
Fix an issue with multiple file upload submissions with the same file names

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
@@ -98,12 +98,12 @@ public class Attachment extends DomainObject implements Serializable {
     public void beforeCreate() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // move file if necessary (id at this point will be null, so placeholder will be inserted)
-            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(),
-                    true);
+            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + File.separator,
+                    getLecture().getId(), true);
         }
         else if (attachmentType == AttachmentType.FILE && getAttachmentUnit() != null) {
             // move file if necessary (id at this point will be null, so placeholder will be inserted)
-            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getAttachmentUnitFilePath() + getAttachmentUnit().getId() + '/',
+            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getAttachmentUnitFilePath() + getAttachmentUnit().getId() + File.separator,
                     getAttachmentUnit().getId(), true);
         }
     }
@@ -131,12 +131,12 @@ public class Attachment extends DomainObject implements Serializable {
     public void onUpdate() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // move file and delete old file if necessary
-            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(),
-                    true);
+            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + File.separator,
+                    getLecture().getId(), true);
         }
         else if (attachmentType == AttachmentType.FILE && getAttachmentUnit() != null) {
             // move file and delete old file if necessary
-            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getAttachmentUnitFilePath() + getAttachmentUnit().getId() + '/',
+            link = fileService.manageFilesForUpdatedFilePath(prevLink, link, FilePathService.getAttachmentUnitFilePath() + getAttachmentUnit().getId() + File.separator,
                     getAttachmentUnit().getId(), true);
         }
     }
@@ -149,12 +149,13 @@ public class Attachment extends DomainObject implements Serializable {
     public void onDelete() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // delete old file if necessary
-            fileService.manageFilesForUpdatedFilePath(prevLink, null, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + '/', getLecture().getId(), true);
+            fileService.manageFilesForUpdatedFilePath(prevLink, null, FilePathService.getLectureAttachmentFilepath() + getLecture().getId() + File.separator, getLecture().getId(),
+                    true);
         }
         else if (attachmentType == AttachmentType.FILE && getAttachmentUnit() != null) {
             // delete old file if necessary
-            fileService.manageFilesForUpdatedFilePath(prevLink, null, FilePathService.getAttachmentUnitFilePath() + getAttachmentUnit().getId() + '/', getAttachmentUnit().getId(),
-                    true);
+            fileService.manageFilesForUpdatedFilePath(prevLink, null, FilePathService.getAttachmentUnitFilePath() + getAttachmentUnit().getId() + File.separator,
+                    getAttachmentUnit().getId(), true);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
@@ -67,6 +68,12 @@ public class FileService implements DisposableBean {
         else {
             return null;
         }
+    }
+
+    @CacheEvict(value = "files", key = "#path")
+    public void resetOnPath(String path) {
+        log.info("Invalidate files cache for " + path);
+        // Intentionally blank
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -225,7 +225,7 @@ public class FileService implements DisposableBean {
                 exerciseId = Long.parseLong(shouldBeExerciseId);
             }
             catch (IllegalArgumentException e) {
-                throw new FilePathParsingException("Unexpected String in upload file path. Course ID should be present here: " + actualPath);
+                throw new FilePathParsingException("Unexpected String in upload file path. Exercise ID should be present here: " + actualPath);
             }
             return "/api/files/file-upload-exercises/" + exerciseId + "/submissions/" + id + "/" + filename;
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -122,11 +122,17 @@ public class FileUploadSubmissionService extends SubmissionService {
         }
 
         // Note: we can only delete the file, if the file name was changed (i.e. the new file name is different), otherwise this will cause issues
-        if (oldFilePath != null && !oldFilePath.equals(newFilePath)) {
+        if (oldFilePath != null) {
             // check if we already had file associated with this submission
-            fileUploadSubmission.onDelete();
+            if (!oldFilePath.equals(newFilePath)) { // different name
+                // IMPORTANT: only delete the file when it has changed the name
+                fileUploadSubmission.onDelete();
+            }
+            else { // same name
+                   // IMPORTANT: invalidate the cache so that the new file with the same name will be downloaded (and not a potentially cached one)
+                fileService.resetOnPath(newLocalFilePath);
+            }
         }
-
         // update submission properties
         // NOTE: from now on we always set submitted to true to prevent problems here!
         fileUploadSubmission.setSubmitted(true);

--- a/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
@@ -224,7 +224,7 @@ public class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         }
         String responsePath = response.get("path").asText();
         // move file from temp folder to correct folder
-        String attachmentPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, FilePathService.getLectureAttachmentFilepath() + lecture.getId() + '/',
+        String attachmentPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, FilePathService.getLectureAttachmentFilepath() + lecture.getId() + File.separator,
                 lecture.getId(), true);
 
         attachment.setLink(attachmentPath);

--- a/src/test/java/de/tum/in/www1/artemis/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadSubmissionIntegrationTest.java
@@ -103,6 +103,32 @@ public class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrati
     }
 
     @Test
+    @WithMockUser(value = "student3")
+    public void submitFileUploadSubmissionTwiceSameFile() throws Exception {
+        FileUploadSubmission submission = ModelFactory.generateFileUploadSubmission(false);
+        FileUploadSubmission returnedSubmission = performInitialSubmission(releasedFileUploadExercise.getId(), submission);
+        String actualFilePath = FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()).concat("file.png");
+        String publicFilePath = fileService.publicPathForActualPath(actualFilePath, returnedSubmission.getId());
+        assertThat(returnedSubmission).as("submission correctly posted").isNotNull();
+        assertThat(returnedSubmission.getFilePath()).isEqualTo(publicFilePath);
+        var fileBytes = Files.readAllBytes(Path.of(actualFilePath));
+        assertThat(fileBytes.length > 0).as("Stored file has content").isTrue();
+        checkDetailsHidden(returnedSubmission, true);
+
+        submission = ModelFactory.generateFileUploadSubmission(false);
+        returnedSubmission = performInitialSubmission(releasedFileUploadExercise.getId(), submission);
+        actualFilePath = FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()).concat("file.png");
+        publicFilePath = fileService.publicPathForActualPath(actualFilePath, returnedSubmission.getId());
+        assertThat(returnedSubmission).as("submission correctly posted").isNotNull();
+        assertThat(returnedSubmission.getFilePath()).isEqualTo(publicFilePath);
+        fileBytes = Files.readAllBytes(Path.of(actualFilePath));
+        assertThat(fileBytes.length > 0).as("Stored file has content").isTrue();
+        checkDetailsHidden(returnedSubmission, true);
+
+        // TODO: upload a real file from the file system twice with the same and with different names and test both works correctly
+    }
+
+    @Test
     @WithMockUser(value = "student1")
     public void submitFileUploadSubmission_wrongExercise() throws Exception {
         FileUploadSubmission submission = ModelFactory.generateFileUploadSubmission(false);

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -146,7 +146,7 @@ public class GitUtilService {
 
     public void updateFile(REPOS repo, FILES fileToUpdate, String content) {
         try {
-            PrintWriter writer = new PrintWriter(getCompleteRepoPathStringByType(repo) + '/' + fileToUpdate, "UTF-8");
+            PrintWriter writer = new PrintWriter(getCompleteRepoPathStringByType(repo) + File.separator + fileToUpdate, "UTF-8");
             writer.print(content);
             writer.close();
         }
@@ -156,7 +156,7 @@ public class GitUtilService {
 
     public String getFileContent(REPOS repo, FILES fileToRead) {
         try {
-            byte[] encoded = Files.readAllBytes(Paths.get(getCompleteRepoPathStringByType(repo) + '/' + fileToRead));
+            byte[] encoded = Files.readAllBytes(Paths.get(getCompleteRepoPathStringByType(repo) + File.separator + fileToRead));
             return new String(encoded, Charset.defaultCharset());
         }
         catch (IOException ex) {


### PR DESCRIPTION
Fixes #2472 
Fixes #1243 

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
If the file name is the same on a subsequent upload, the file is not overwritten properly. This PR fixes it.

### Steps for Testing
1. Submit a file to a file upload exercise with the same name multiple times (with small changes) 
2. Make sure the latest version of the file (e.g. a PDF showing v1, v2, v3, etc. always with the same name, e.g. document.pdf) is accessible.