### PR TITLE
Fix Websocket connection with HTML5 style URLs

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ClientForwardResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ClientForwardResource.java
@@ -1,7 +1,7 @@
 package de.tum.in.www1.artemis.web.rest;
 
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 public class ClientForwardResource {
@@ -10,7 +10,7 @@ public class ClientForwardResource {
      * Forwards any unmapped paths (except those containing a period) to the client index.html
      * @return Forward Instruction for Browser
      */
-    @GetMapping("/**/{path:[^\\.]*}")
+    @RequestMapping({ "/{path:[^\\.]*}", "/{path:^(?!websocket).*}/**/{path:[^\\.]*}" })
     public String forward() {
         return "forward:/";
     }

--- a/src/main/webapp/app/core/websocket/websocket.service.ts
+++ b/src/main/webapp/app/core/websocket/websocket.service.ts
@@ -143,9 +143,7 @@ export class JhiWebsocketService implements IWebsocketService, OnDestroy {
         if (!this.connectedPromise) {
             this.connection = this.createConnection();
         }
-        // building absolute path so that websocket doesn't fail when deploying with a context path
-        const loc = window.location;
-        let url = '//' + loc.host + loc.pathname + 'websocket/tracker';
+        let url = `//${window.location.host}/websocket/tracker`;
         const authToken = this.authServerProvider.getToken();
         if (authToken) {
             url += '?access_token=' + authToken;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
Introducing HTML Push-style URLs (#2454) broke some WebSocket calls. This PR fixes this by:
1. Updating the Forwarding Pattern to not forward WebSocket endpoints to `index.html` and
2. Fixing the WebSocket URL to not include the path.