### PR TITLE
[Hotfix] Display View Assessment button also after the assessment due date

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise/exercise-utils.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise-utils.ts
@@ -159,10 +159,5 @@ export const areManualResultsAllowed = (exercise: Exercise) => {
     // Only allow new results if manual reviews are activated and the due date/after due date has passed
     const progEx = exercise as ProgrammingExercise;
     const relevantDueDate = progEx.buildAndTestStudentSubmissionsAfterDueDate ?? progEx.dueDate;
-    return (
-        progEx.isAtLeastTutor === true &&
-        progEx.assessmentType === AssessmentType.SEMI_AUTOMATIC &&
-        (!relevantDueDate || moment(relevantDueDate).isBefore(now())) &&
-        (!progEx.assessmentDueDate || progEx.assessmentDueDate.isAfter(now()))
-    );
+    return progEx.isAtLeastTutor === true && progEx.assessmentType === AssessmentType.SEMI_AUTOMATIC && (!relevantDueDate || moment(relevantDueDate).isBefore(now()));
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features locally
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The assessment view button was not displayed anymore after the assessment due date has passed.

### Description
<!-- Describe your changes in detail -->
- Removed check for assessment due date, as the button should be displayed disregarding the assessment due date

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a programming exercise with manual assessment and assessment due date and participate and assess or use exercise with participations and manual assessments and add a assessment due date 
4. Check that in the exercise scores view the button is displayed also after the assessment due date

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Nothing changed


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/41108487/101467272-616b9f80-3942-11eb-9c42-43b0e8546306.png)
