### PR TITLE
Set default value such that seconds and milliseconds are 0

### DIFF
--- a/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.ts
+++ b/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, EventEmitter, forwardRef, Input, Output, ViewChild } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { isMoment, Moment } from 'moment';
 import * as moment from 'moment';
+import { isMoment, Moment } from 'moment';
 
 @Component({
     selector: 'jhi-date-time-picker',
@@ -42,7 +42,7 @@ export class FormDateTimePickerComponent implements ControlValueAccessor {
     @Input() value: any;
     @Input() disabled: boolean;
     @Input() error: boolean;
-    @Input() startAt: Moment; // Default selected date.
+    @Input() startAt: Moment = moment().startOf('minutes'); // Default selected date. By default this sets it to the current time without seconds or milliseconds;
     @Input() min: Moment; // Dates before this date are not selectable.
     @Input() max: Moment; // Dates after this date are not selectable.
     @Output() valueChange = new EventEmitter();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes: #1649

As: https://github.com/ls1intum/Artemis/pull/2431 was closed due inactivity I thought i can fix it quickly myself

### Description
<!-- Describe your changes in detail -->
Just one line: 58109f12af87a05825f7f16be3927e736568f888

How does it work?
https://daniel-projects.firebaseapp.com/owlng/date-time-picker#starting-view
`The moment that the picker opens to is determined by first checking if any date or time is currently selected, if so it will open to the month or year containing that date and timer is set to that moment. Otherwise it will open to the month or year containing today's date and set to current time. This behavior can be overridden by using the [startAt] property of owl-date-time. In this case the calendar will open to the month or year containing the startAt date and timer is set to startAt time.`
The trick is to just set startAt to the current moment BUT without seconds and milliseconds

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Just try the date time picker at any point in Artemis, and select a date and see that seconds are set to 0

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
No changes

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/29718932/101476339-e4debe00-394d-11eb-88c5-2d0cc4dc50a4.png)
