### PR TITLE
Fix the login screen shortly displaying even when logged in

### DIFF
--- a/src/main/webapp/app/home/home.component.html
+++ b/src/main/webapp/app/home/home.component.html
@@ -1,93 +1,95 @@
-<div class="row">
-    <div class="col-md-8 offset-md-2 text-center">
-        <h1 jhiTranslate="home.title">Welcome to Artemis!</h1>
-        <p class="lead" jhiTranslate="home.subtitle">Interactive Learning with Individual Feedback</p>
-        <div *ngIf="!accountName" class="lead" [jhiTranslate]="'home.pleaseSignIn'">Please sign in with your account.</div>
-        <div *ngIf="accountName" class="lead" [jhiTranslate]="'home.pleaseSignInAccount'" [translateValues]="{ account: accountName }">Please sign in with your account.</div>
+<div [hidden]="loading">
+    <div class="row">
+        <div class="col-md-8 offset-md-2 text-center">
+            <h1 jhiTranslate="home.title">Welcome to Artemis!</h1>
+            <p class="lead" jhiTranslate="home.subtitle">Interactive Learning with Individual Feedback</p>
+            <div *ngIf="!accountName" class="lead" [jhiTranslate]="'home.pleaseSignIn'">Please sign in with your account.</div>
+            <div *ngIf="accountName" class="lead" [jhiTranslate]="'home.pleaseSignInAccount'" [translateValues]="{ account: accountName }">Please sign in with your account.</div>
+        </div>
     </div>
-</div>
-<div class="row mt-3">
-    <div class="col-md-6 offset-md-3">
-        <div class="row">
-            <div class="col-12 d-flex justify-content-center">
-                <form name="loginForm" class="login-form" role="form" (change)="inputChange($event)" (ngSubmit)="login()">
-                    <div class="form-group">
-                        <div class="alert alert-danger mt-1" *ngIf="authenticationError && !captchaRequired" jhiTranslate="home.errors.failedToLogin">
-                            <span class="bold">Failed to sign in!</span> Please check your username and password and try again.
+    <div class="row mt-3">
+        <div class="col-md-6 offset-md-3">
+            <div class="row">
+                <div class="col-12 d-flex justify-content-center">
+                    <form name="loginForm" class="login-form" role="form" (change)="inputChange($event)" (ngSubmit)="login()">
+                        <div class="form-group">
+                            <div class="alert alert-danger mt-1" *ngIf="authenticationError && !captchaRequired" jhiTranslate="home.errors.failedToLogin">
+                                <span class="bold">Failed to sign in!</span> Please check your username and password and try again.
+                            </div>
+                            <div class="alert alert-info mt-1" *ngIf="externalUserManagementActive && authenticationAttempts >= 3 && !captchaRequired">
+                                <span [innerHTML]="'home.errors.loginWarning' | translate: { url: externalUserManagementUrl, name: externalUserManagementName }"></span>
+                            </div>
+                            <div class="alert alert-danger mt-1" *ngIf="externalUserManagementActive && captchaRequired">
+                                <span
+                                    [innerHTML]="'home.errors.externalUserManagementWarning' | translate: { url: externalUserManagementUrl, name: externalUserManagementName }"
+                                ></span>
+                            </div>
                         </div>
-                        <div class="alert alert-info mt-1" *ngIf="externalUserManagementActive && authenticationAttempts >= 3 && !captchaRequired">
-                            <span [innerHTML]="'home.errors.loginWarning' | translate: { url: externalUserManagementUrl, name: externalUserManagementName }"></span>
+                        <div class="form-group">
+                            <label class="font-weight-bold" for="username" jhiTranslate="global.form.username">Login</label>
+                            <input
+                                type="text"
+                                class="form-control"
+                                autocomplete="username"
+                                name="username"
+                                id="username"
+                                placeholder="{{ 'global.form.username.placeholder' | translate }}"
+                                [pattern]="usernameRegexPattern"
+                                [(ngModel)]="username"
+                                #usernameForm="ngModel"
+                                [ngModelOptions]="{ updateOn: 'blur' }"
+                            />
+                            <div class="help-block" *ngIf="usernameForm.errors && (usernameForm.dirty || usernameForm.touched)" [jhiTranslate]="errorMessageUsername">
+                                <p class="text-primary small">Invalid username</p>
+                            </div>
                         </div>
-                        <div class="alert alert-danger mt-1" *ngIf="externalUserManagementActive && captchaRequired">
-                            <span
-                                [innerHTML]="'home.errors.externalUserManagementWarning' | translate: { url: externalUserManagementUrl, name: externalUserManagementName }"
-                            ></span>
+                        <div class="form-group">
+                            <label class="font-weight-bold" for="password" jhiTranslate="login.form.password">Password</label>
+                            <input
+                                type="password"
+                                class="form-control"
+                                autocomplete="password"
+                                name="password"
+                                id="password"
+                                placeholder="{{ 'login.form.password.placeholder' | translate }}"
+                                [(ngModel)]="password"
+                            />
                         </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="font-weight-bold" for="username" jhiTranslate="global.form.username">Login</label>
-                        <input
-                            type="text"
-                            class="form-control"
-                            autocomplete="username"
-                            name="username"
-                            id="username"
-                            placeholder="{{ 'global.form.username.placeholder' | translate }}"
-                            [pattern]="usernameRegexPattern"
-                            [(ngModel)]="username"
-                            #usernameForm="ngModel"
-                            [ngModelOptions]="{ updateOn: 'blur' }"
-                        />
-                        <div class="help-block" *ngIf="usernameForm.errors && (usernameForm.dirty || usernameForm.touched)" [jhiTranslate]="errorMessageUsername">
-                            <p class="text-primary small">Invalid username</p>
+                        <div class="form-group">
+                            <div class="form-check">
+                                <label class="form-check-label" for="rememberMe">
+                                    <input class="form-check-input" type="checkbox" name="rememberMe" id="rememberMe" [(ngModel)]="rememberMe" checked />
+                                    <span jhiTranslate="login.form.rememberme">Remember me</span>
+                                </label>
+                            </div>
+                            <div class="form-check">
+                                <label class="form-check-label" for="acceptTerms">
+                                    <input class="form-check-input" type="checkbox" name="acceptTerms" id="acceptTerms" [(ngModel)]="acceptTerms" checked />
+                                    <a [routerLink]="['datenschutz']" jhiTranslate="login.form.acceptTerms">Accept terms</a>
+                                </label>
+                            </div>
                         </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="font-weight-bold" for="password" jhiTranslate="login.form.password">Password</label>
-                        <input
-                            type="password"
-                            class="form-control"
-                            autocomplete="password"
-                            name="password"
-                            id="password"
-                            placeholder="{{ 'login.form.password.placeholder' | translate }}"
-                            [(ngModel)]="password"
-                        />
-                    </div>
-                    <div class="form-group">
-                        <div class="form-check">
-                            <label class="form-check-label" for="rememberMe">
-                                <input class="form-check-input" type="checkbox" name="rememberMe" id="rememberMe" [(ngModel)]="rememberMe" checked />
-                                <span jhiTranslate="login.form.rememberme">Remember me</span>
-                            </label>
-                        </div>
-                        <div class="form-check">
-                            <label class="form-check-label" for="acceptTerms">
-                                <input class="form-check-input" type="checkbox" name="acceptTerms" id="acceptTerms" [(ngModel)]="acceptTerms" checked />
-                                <a [routerLink]="['datenschutz']" jhiTranslate="login.form.acceptTerms">Accept terms</a>
-                            </label>
-                        </div>
-                    </div>
-                    <button
-                        type="submit"
-                        [disabled]="isSubmittingLogin || !acceptTerms || !password || password.length < 4 || !username || username.length < 4"
-                        class="btn btn-primary"
-                    >
-                        <span *ngIf="isSubmittingLogin" class="mr-1"><fa-icon [icon]="'circle-notch'" spin="true"></fa-icon></span>
-                        <span jhiTranslate="login.form.button"> Sign in </span>
-                    </button>
-                </form>
+                        <button
+                            type="submit"
+                            [disabled]="isSubmittingLogin || !acceptTerms || !password || password.length < 4 || !username || username.length < 4"
+                            class="btn btn-primary"
+                        >
+                            <span *ngIf="isSubmittingLogin" class="mr-1"><fa-icon [icon]="'circle-notch'" spin="true"></fa-icon></span>
+                            <span jhiTranslate="login.form.button"> Sign in </span>
+                        </button>
+                    </form>
+                </div>
             </div>
         </div>
     </div>
-</div>
-<div *ngIf="isRegistrationEnabled">
-    <br /><br />
-    <div class="d-flex justify-content-center">
-        <span jhiTranslate="global.messages.info.register.noaccount">You don't have an account yet?</span>&nbsp;
-        <a class="alert-link" routerLink="account/register" jhiTranslate="global.messages.info.register.link">Register a new account</a>
-    </div>
-    <div class="d-flex justify-content-center">
-        <a class="alert-link" routerLink="account/reset/request" jhiTranslate="login.password.forgot">Did you forget your password?</a>
+    <div *ngIf="isRegistrationEnabled">
+        <br /><br />
+        <div class="d-flex justify-content-center">
+            <span jhiTranslate="global.messages.info.register.noaccount">You don't have an account yet?</span>&nbsp;
+            <a class="alert-link" routerLink="account/register" jhiTranslate="global.messages.info.register.link">Register a new account</a>
+        </div>
+        <div class="d-flex justify-content-center">
+            <a class="alert-link" routerLink="account/reset/request" jhiTranslate="login.password.forgot">Did you forget your password?</a>
+        </div>
     </div>
 </div>

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnInit, Renderer2 } from '@angular/core';
+import { AfterViewChecked, Component, ElementRef, OnInit, Renderer2 } from '@angular/core';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { JhiEventManager } from 'ng-jhipster';
 import { Router } from '@angular/router';
@@ -19,7 +19,7 @@ import { StateStorageService } from 'app/core/auth/state-storage.service';
     templateUrl: './home.component.html',
     styleUrls: ['home.scss'],
 })
-export class HomeComponent implements OnInit, AfterViewInit {
+export class HomeComponent implements OnInit, AfterViewChecked {
     authenticationError = false;
     authenticationAttempts = 0;
     account: User;
@@ -31,6 +31,8 @@ export class HomeComponent implements OnInit, AfterViewInit {
     captchaRequired = false;
     credentials: Credentials;
     isRegistrationEnabled = false;
+    loading = true;
+    inputFocused = false;
 
     // if the server is not connected to an external user management such as JIRA, we accept all valid username patterns
     usernameRegexPattern = /^[a-z0-9_-]{3,50}$/; // default, might be overridden in ngOnInit
@@ -79,6 +81,11 @@ export class HomeComponent implements OnInit, AfterViewInit {
         });
         this.accountService.identity().then((user) => {
             this.currentUserCallback(user!);
+
+            // Once this has loaded and the user is not defined, we know we need the user to log in
+            if (!user) {
+                this.loading = false;
+            }
         });
         this.registerAuthenticationSuccess();
     }
@@ -91,8 +98,18 @@ export class HomeComponent implements OnInit, AfterViewInit {
         });
     }
 
-    ngAfterViewInit() {
-        this.renderer.selectRootElement('#username', true).focus();
+    ngAfterViewChecked() {
+        // Only focus the username input once, not on every update
+        if (this.inputFocused || this.loading) {
+            return;
+        }
+
+        // Focus on the input as soon as it is visible
+        const input = this.renderer.selectRootElement('#username', true);
+        if (input) {
+            input.focus();
+            this.inputFocused = true;
+        }
     }
 
     login() {


### PR DESCRIPTION
### Checklist

- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context

We opening the main page (e.g. "https://artemistest.ase.in.tum.de") you'd often see the login screen for a split second before being redirected to the courses page.

### Description

The login page now only displays when we actually need the user to log in.

### Code reviewing

I suggest using https://github.com/ls1intum/Artemis/pull/2521/files?w=1 or selecting "Hide whitespace changes" in the diff settings to reduce the visual noise.

### Steps for Testing

It is best to compare this to the previous behaviour. Enter the URL of the Artemis instance without any further paths. (E.g. just "https://artemistest.ase.in.tum.de") On older versions you will see the login screen, with this fix you will not.

The LTI Integration of edX will also need to be tested. (Would be nice if one of the seecx tutors could give this a go.)

Gif of the wrong behaviour:
![loginGif](https://user-images.githubusercontent.com/72132281/101526683-42dec600-398d-11eb-99d9-17a8fe4673bc.gif)
