### PR TITLE
Make sure the breadcrumbs container leaves a margin even when invisible

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -204,16 +204,18 @@
         </ul>
     </div>
 </nav>
-<div class="breadcrumb-container" *ngIf="breadcrumbs && breadcrumbs.length > 0">
-    <ol class="breadcrumb" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_TA', 'ROLE_INSTRUCTOR']">
-        <li *ngFor="let breadcrumb of breadcrumbs" class="breadcrumb-item">
-            <a class="breadcrumb-link" [routerLink]="breadcrumb.uri" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" *ngIf="breadcrumb.translate">{{
-                breadcrumb.label | translate
-            }}</a>
-            <a class="breadcrumb-link" [routerLink]="breadcrumb.uri" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" *ngIf="!breadcrumb.translate">{{
-                breadcrumb.label
-            }}</a>
-        </li>
-    </ol>
+<div class="breadcrumb-container">
+    <div *ngIf="breadcrumbs && breadcrumbs.length > 0">
+        <ol class="breadcrumb" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_TA', 'ROLE_INSTRUCTOR']">
+            <li *ngFor="let breadcrumb of breadcrumbs" class="breadcrumb-item">
+                <a class="breadcrumb-link" [routerLink]="breadcrumb.uri" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" *ngIf="breadcrumb.translate">{{
+                    breadcrumb.label | translate
+                }}</a>
+                <a class="breadcrumb-link" [routerLink]="breadcrumb.uri" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" *ngIf="!breadcrumb.translate">{{
+                    breadcrumb.label
+                }}</a>
+            </li>
+        </ol>
+    </div>
 </div>
 <jhi-guided-tour></jhi-guided-tour>

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -46,6 +46,7 @@ Navbar
     background-color: #e4e5e6;
     overflow: auto;
     margin-left: -15px;
+    min-height: 0.5rem;
     .breadcrumb {
         color: #0065bd;
         background-color: #e4e5e6;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
![grafik](https://user-images.githubusercontent.com/72132281/101899033-6ed89200-3bad-11eb-8694-d2b81caf7ab7.png)
was not the desired outcome and does not look very good.

### Description
The breadcrumb container now leaves a margin between navbar header and content even when there are no breadcrumbs.

### Steps for Testing

1. Check that the margin looks good/correct from a student view (Courses)
2. Check that the margin looks good/correct from a instructor view (Course or System Administration)
3. Repeat both steps with a System Notification and/or Warning active

### Screenshots
![grafik](https://user-images.githubusercontent.com/72132281/101899206-b65f1e00-3bad-11eb-95e5-dc36b58c1eb0.png)
![grafik](https://user-images.githubusercontent.com/72132281/101899182-ae9f7980-3bad-11eb-9e62-8a3d3e033b6c.png)
![grafik](https://user-images.githubusercontent.com/72132281/101899190-b0693d00-3bad-11eb-9eb4-3faa88d6cc8b.png)
![grafik](https://user-images.githubusercontent.com/72132281/101899213-bb23d200-3bad-11eb-8f37-c3b372790555.png)
![grafik](https://user-images.githubusercontent.com/72132281/101899224-bced9580-3bad-11eb-864f-4b0e64a2c1e3.png)

