### PR TITLE
Fix crashes when short answer question answers are undefined

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.html
@@ -14,7 +14,7 @@
                         class="short-answer-question-container__input"
                         type="text"
                         [disabled]="clickDisabled"
-                        value="{{ getSubmittedTextForSpot(element) !== undefined ? getSubmittedTextForSpot(element).text : '' }}"
+                        value="{{ getSubmittedTextForSpotAsString(element) }}"
                         id="solution-{{ i }}-{{ j }}-{{ question.id }}"
                         (change)="setSubmittedText()"
                     />
@@ -40,8 +40,8 @@
                         class="short-answer-question-container__input"
                         disabled
                         [style.background]="getBackgroundColourForInputField(element)"
-                        value="{{ getSubmittedTextForSpot(element)?.text !== undefined ? getSubmittedTextForSpot(element).text : '' }}"
-                        size="{{ getSubmittedTextForSpot(element)?.text !== undefined ? getSubmittedTextForSpot(element).text!.length + 2 : 5 }}"
+                        value="{{ getSubmittedTextForSpotAsString(element) }}"
+                        size="{{ getSubmittedTextSizeForSpot(element) }}"
                     />
                     <div
                         *ngIf="shortAnswerQuestionUtil.getSpot(shortAnswerQuestionUtil.getSpotNr(element), question).invalid"
@@ -51,8 +51,8 @@
                             class="short-answer-question-container__input"
                             style="background: grey"
                             disabled
-                            value="{{ getSubmittedTextForSpot(element)?.text !== undefined ? getSubmittedTextForSpot(element).text : '' }}"
-                            size="{{ getSubmittedTextForSpot(element)?.text !== undefined ? getSubmittedTextForSpot(element).text!.length + 2 : 5 }}"
+                            value="{{ getSubmittedTextForSpotAsString(element) }}"
+                            size="{{ getSubmittedTextSizeForSpot(element) }}"
                         />
                     </div>
                 </div>
@@ -61,8 +61,8 @@
                         class="short-answer-question-container__input"
                         disabled
                         [style.background]="'lightgreen'"
-                        value="{{ getSampleSolutionForSpot(element) !== undefined ? getSampleSolutionForSpot(element).text : '' }}"
-                        size="{{ getSampleSolutionForSpot(element) !== undefined ? getSampleSolutionForSpot(element).text!.length + 2 : 5 }}"
+                        value="{{ getSampleSolutionForSpotAsString(element) }}"
+                        size="{{ getSampleSolutionSizeForSpot(element) }}"
                     />
                 </div>
                 &nbsp;

--- a/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.ts
@@ -129,12 +129,48 @@ export class ShortAnswerQuestionComponent {
     }
 
     /**
+     * Returns the submitted text as string for a short answer for the given spot tag
+     * @param spotTag Spot tag for which to get the submitted text
+     */
+    getSubmittedTextForSpotAsString(spotTag: string): string {
+        const submittedText = this.getSubmittedTextForSpot(spotTag);
+        return submittedText?.text ?? '';
+    }
+
+    /**
+     * Returns the size for a submitted text for a short answer for the given spot tag
+     * @param spotTag Spot tag for which to get the submitted text
+     */
+    getSubmittedTextSizeForSpot(spotTag: string): number {
+        const submittedText = this.getSubmittedTextForSpotAsString(spotTag);
+        return submittedText !== '' ? submittedText.length + 2 : 5;
+    }
+
+    /**
      * Returns the sample solution for a short answer for the given spot tag
      * @param spotTag Spot tag for which to get the sample solution
      */
     getSampleSolutionForSpot(spotTag: string): ShortAnswerSolution {
         const index = this.question.spots!.findIndex((spot) => spot.spotNr === this.shortAnswerQuestionUtil.getSpotNr(spotTag));
         return this.sampleSolutions[index];
+    }
+
+    /**
+     * Returns the sample solution as text for a short answer for the given spot tag
+     * @param spotTag Spot tag for which to get the sample solution
+     */
+    getSampleSolutionForSpotAsString(spotTag: string): string {
+        const sampleSolution = this.getSampleSolutionForSpot(spotTag);
+        return sampleSolution?.text ?? '';
+    }
+
+    /**
+     * Returns the size for a sample solution for a short answer for the given spot tag
+     * @param spotTag Spot tag for which to get the submitted text
+     */
+    getSampleSolutionSizeForSpot(spotTag: string): number {
+        const sampleSolution = this.getSampleSolutionForSpotAsString(spotTag);
+        return sampleSolution !== '' ? sampleSolution.length + 2 : 5;
     }
 
     /**


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Fixes #2532 which is a regression from #2528.

### Description
For some reason the expression evaluation in templates is different (that's also why we couldn't use the `??` operator), so this still crashed when trying to access `undefined.text` even after #2528. Maybe one of our experts knows an explanation.

### Steps for Testing
Simply create a new short answer question quiz. Then go in preview mode and submit without entering any answers. Without this fix a lot of warnings will be printed in the console (can freeze the browser) and the content will not be displayed correctly (since it crashes midway). Make sure short answer question quizzes work as expected during testing.

### Screenshots
Preview a quiz and submit without entering answers:
![grafik](https://user-images.githubusercontent.com/72132281/101940179-63558d00-3be6-11eb-94dd-c0584c9e7a3d.png)
After submitting it will look broken and print warnings in the console without the fix:
![grafik](https://user-images.githubusercontent.com/72132281/101940094-40c37400-3be6-11eb-9172-be5001d85c3e.png)
With this fix everything displays correctly:
![grafik](https://user-images.githubusercontent.com/72132281/101940245-7bc5a780-3be6-11eb-8671-4ca0fb232431.png)

