### PR TITLE
Add a missing translation for invalid modeling assessments

### DIFF
--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
@@ -230,7 +230,7 @@ export class ExampleModelingSubmissionComponent implements OnInit {
     public saveExampleAssessment(): void {
         this.checkScoreBoundaries();
         if (!this.assessmentsAreValid) {
-            this.jhiAlertService.error('artemisApp.modelingAssessment.invalidAssessments');
+            this.jhiAlertService.error('modelingAssessment.invalidAssessments');
             return;
         }
         if (this.assessmentExplanation !== this.exampleSubmission.assessmentExplanation && this.feedbacks) {

--- a/src/main/webapp/i18n/de/modelingAssessment.json
+++ b/src/main/webapp/i18n/de/modelingAssessment.json
@@ -4,6 +4,7 @@
         "conflicts": "Konflikte",
         "assessor": "Bewertet von: {{firstName}} {{lastName}}",
         "noModel": "Kein Modell zum Darstellen gefunden.",
+        "invalidAssessments": "Deine Bewertung ist nicht gültig!",
         "messages": {
             "noConflicts": "Konflikte konnten nicht geladen werden",
             "conflictsResolved": "Alle Konflikte wurden bearbeitet."

--- a/src/main/webapp/i18n/en/modelingAssessment.json
+++ b/src/main/webapp/i18n/en/modelingAssessment.json
@@ -3,6 +3,7 @@
         "points": "Points",
         "assessor": "Assessor: {{firstName}} {{lastName}}",
         "noModel": "No model found to display",
+        "invalidAssessments": "Your assessments are not valid!",
         "messages": {
             "noConflicts": "Conflicts could not be loaded",
             "conflictsResolved": "All conflicts have been processed."


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
Fixes the missing translation seen in #2494. #2529 only fixed the issue causing the error with the missing translation to show up.

### Description
The referenced translation simply didn't exist. I fixed the path and added translations.

### Steps for Testing
Actually, since #2529 I don't know how to give a field an invalid amount of credits (it always gets reset to 0), so I changed some things locally to check the translation. Otherwise the testing steps would be the same as in #2494. (If you managed to specify an invalid amount of credits the proper message will show up instead of "translation not found".)

