### PR TITLE
Add missing modal text translations

### DIFF
--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
@@ -13,7 +13,7 @@ import { JhiAlertService } from 'ng-jhipster';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Exam } from 'app/entities/exam.model';
 import { ConfirmAutofocusModalComponent } from 'app/shared/components/confirm-autofocus-button.component';
-
+import { TranslateService } from '@ngx-translate/core';
 import * as moment from 'moment';
 
 @Component({
@@ -43,6 +43,7 @@ export class StudentExamsComponent implements OnInit {
         private courseService: CourseManagementService,
         private jhiAlertService: JhiAlertService,
         private modalService: NgbModal,
+        private translateService: TranslateService,
     ) {}
 
     /**
@@ -106,7 +107,7 @@ export class StudentExamsComponent implements OnInit {
         if (this.studentExams && this.studentExams.length) {
             const modalRef = this.modalService.open(ConfirmAutofocusModalComponent, { keyboard: true, size: 'lg' });
             modalRef.componentInstance.title = 'artemisApp.studentExams.generateStudentExams';
-            modalRef.componentInstance.text = 'artemisApp.studentExams.studentExamGenerationModalText';
+            modalRef.componentInstance.text = this.translateService.instant('artemisApp.studentExams.studentExamGenerationModalText');
             modalRef.result.then(() => {
                 this.generateStudentExams();
             });
@@ -219,7 +220,7 @@ export class StudentExamsComponent implements OnInit {
     handleUnlockAllRepositories() {
         const modalRef = this.modalService.open(ConfirmAutofocusModalComponent, { keyboard: true, size: 'lg' });
         modalRef.componentInstance.title = 'artemisApp.studentExams.unlockAllRepositories';
-        modalRef.componentInstance.text = 'artemisApp.studentExams.unlockAllRepositoriesModalText';
+        modalRef.componentInstance.text = this.translateService.instant('artemisApp.studentExams.unlockAllRepositoriesModalText');
         modalRef.result.then(() => {
             this.unlockAllRepositories();
         });
@@ -256,7 +257,7 @@ export class StudentExamsComponent implements OnInit {
     handleLockAllRepositories() {
         const modalRef = this.modalService.open(ConfirmAutofocusModalComponent, { keyboard: true, size: 'lg' });
         modalRef.componentInstance.title = 'artemisApp.studentExams.lockAllRepositories';
-        modalRef.componentInstance.text = 'artemisApp.studentExams.lockAllRepositoriesModalText';
+        modalRef.componentInstance.text = this.translateService.instant('artemisApp.studentExams.lockAllRepositoriesModalText');
         modalRef.result.then(() => {
             this.lockAllRepositories();
         });


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
The texts of the modals was not translated.
Before:
![grafik](https://user-images.githubusercontent.com/72132281/101985462-73be4400-3c88-11eb-8e1d-85cb3f89cc48.png)
After:
![grafik](https://user-images.githubusercontent.com/72132281/101985465-77ea6180-3c88-11eb-8f72-ab80981534cc.png)

### Description
I used the TranslateService to translate the texts.

### Steps for Testing
1. Create an exam or go to an existing one
2. Enter "Student Exams"
3. Check the modal texts of "Lock all repositories", "Unlock all repositories" and "Generate individual exams" (only shows up when overwriting existing exams afaik). You don't need to test if the buttons work, just if all the text is translated properly.

