### PR TITLE
Remove unique constraint between submission and result

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
@@ -60,6 +60,12 @@ public class FileUploadSubmission extends Submission {
     }
 
     @Override
+    public boolean isEmpty() {
+        // Note: this is very unlikely
+        return filePath == null;
+    }
+
+    @Override
     public String toString() {
         return "FileUploadSubmission{" + "id=" + getId() + ", filePath='" + getFilePath() + "'" + "}";
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
@@ -73,6 +73,11 @@ public class ProgrammingSubmission extends Submission {
     }
 
     @Override
+    public boolean isEmpty() {
+        return false; // programming submissions cannot be empty, they are only created for actual commits in the git repository
+    }
+
+    @Override
     public String toString() {
         return "ProgrammingSubmission{" + "commitHash='" + commitHash + '\'' + ", buildFailed=" + buildFailed + ", buildArtifact=" + buildArtifact + '}';
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
@@ -19,7 +19,6 @@ import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.domain.view.QuizView;
-import de.tum.in.www1.artemis.web.rest.errors.InternalServerErrorException;
 
 /**
  * A Submission.
@@ -98,15 +97,13 @@ public abstract class Submission extends DomainObject {
     }
 
     /**
-     * Is used as a workaround for objects that expect submission to have 1 result
+     * Get the latest result of the submission
      *
-     * @return the latest i.e newest result
+     * @return a {@link Result} or null
      */
     @Nullable
     @JsonIgnore
     public Result getLatestResult() {
-        // in all cases (except 2nd, 3rd correction, etc.) we would like to have the latest result
-        // getLatestResult
         if (!results.isEmpty()) {
             return results.get(results.size() - 1);
         }
@@ -120,14 +117,13 @@ public abstract class Submission extends DomainObject {
     }
 
     /**
-     * currently not used
+     * Get the first result of the submission
      *
-     * @return the first Result of the Submission
+     * @return a {@link Result} or null if no result is present
      */
     @Nullable
     @JsonIgnore
     public Result getFirstResult() {
-        // getLatestResult
         if (!results.isEmpty()) {
             return results.get(0);
         }
@@ -135,19 +131,21 @@ public abstract class Submission extends DomainObject {
     }
 
     /**
-     * Used as a setResult method, as typically the latest result is used
+     * Add a result to the list.
+     * NOTE: You must make sure to correctly persist the result in the database!
      *
-     * @param result
+     * @param result the {@link Result} which should be added
      */
     public void addResult(Result result) {
         this.results.add(result);
-        // At the moment only one result in results is allowed
-        // TODO remove when multi-correction is implemented!
-        if (results.size() > 1) {
-            throw new InternalServerErrorException("Sugbmission.addResult(result): results.size() > 1 | the Submission.results list should not contain more than one element");
-        }
     }
 
+    /**
+     * Set the results list to the specified list.
+     * NOTE: You must correctly persist this change in the database manually!
+     *
+     * @param results The list of {@link Result} which should replace the existing results of the submission
+     */
     @JsonProperty(value = "results", access = JsonProperty.Access.WRITE_ONLY)
     public void setResults(List<Result> results) {
         this.results = results;

--- a/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
@@ -3,7 +3,9 @@ package de.tum.in.www1.artemis.domain;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 import javax.persistence.*;
@@ -57,8 +59,7 @@ public abstract class Submission extends DomainObject {
     @JsonIgnore
     @OneToMany(mappedBy = "submission", cascade = CascadeType.REMOVE)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    // TODO use Set here instead of List
-    private List<SubmissionVersion> versions = new ArrayList<>();
+    private Set<SubmissionVersion> versions = new HashSet<>();
 
     /**
      * A submission can have multiple results, therefore, results are persisted and removed with a submission.
@@ -76,15 +77,12 @@ public abstract class Submission extends DomainObject {
         return submissionDate;
     }
 
-    @Transient
-    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
-    public Long durationInMinutes;
-
     /**
-     * Calculates the duration of a submission in minutes
+     * Calculates the duration of a submission in minutes and adds it into the json response
      *
      * @return duration in minutes or null if it can not be determined
      */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     public Long getDurationInMinutes() {
         if (this.participation == null || this.participation.getInitializationDate() == null || this.submissionDate == null) {
             return null;
@@ -104,7 +102,7 @@ public abstract class Submission extends DomainObject {
     @Nullable
     @JsonIgnore
     public Result getLatestResult() {
-        if (!results.isEmpty()) {
+        if (results != null && !results.isEmpty()) {
             return results.get(results.size() - 1);
         }
         return null;
@@ -124,7 +122,7 @@ public abstract class Submission extends DomainObject {
     @Nullable
     @JsonIgnore
     public Result getFirstResult() {
-        if (!results.isEmpty()) {
+        if (results != null && !results.isEmpty()) {
             return results.get(0);
         }
         return null;
@@ -201,4 +199,10 @@ public abstract class Submission extends DomainObject {
     public void setExampleSubmission(Boolean exampleSubmission) {
         this.exampleSubmission = exampleSubmission;
     }
+
+    /**
+     * determine whether a submission is empty, i.e. the student did not work properly on the corresponding exercise
+     * @return whether the submission is empty (true) or not (false)
+     */
+    public abstract boolean isEmpty();
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/TextSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TextSubmission.java
@@ -90,6 +90,7 @@ public class TextSubmission extends Submission {
         this.blocks = textBlocks;
     }
 
+    @Override
     public boolean isEmpty() {
         return text == null || text.isEmpty();
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizSubmission.java
@@ -119,6 +119,11 @@ public class QuizSubmission extends Submission {
     }
 
     @Override
+    public boolean isEmpty() {
+        return submittedAnswers == null || submittedAnswers.isEmpty();
+    }
+
+    @Override
     public String toString() {
         return "QuizSubmission{" + "id=" + getId() + ", scoreInPoints='" + getScoreInPoints() + ", submittedAnswers='" + getSubmittedAnswers() + "'" + "}";
     }

--- a/src/main/resources/config/liquibase/changelog/20201214214200_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20201214214200_changelog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="krusche" id="20201214214200">
+        <dropForeignKeyConstraint baseTableName="result" constraintName="FK3vct9sad5oubthdmq63n58mnp"/>
+        <dropUniqueConstraint tableName="result" constraintName="UC_RESULTSUBMISSION_ID_COL"/>
+        <addForeignKeyConstraint baseColumnNames="submission_id" baseTableName="result" constraintName="fk_result_submission_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="submission"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -94,4 +94,5 @@
     <include file="classpath:config/liquibase/changelog/20201111141743_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20201117113912_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20201119174900_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20201214214200_changelog.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/src/test/java/de/tum/in/www1/artemis/SubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/SubmissionIntegrationTest.java
@@ -1,0 +1,117 @@
+package de.tum.in.www1.artemis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
+import de.tum.in.www1.artemis.repository.*;
+
+public class SubmissionIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+
+    @Autowired
+    SubmissionRepository submissionRepository;
+
+    @Autowired
+    ResultRepository resultRepository;
+
+    @Test
+    public void addMultipleResultsToOneSubmission() {
+        AssessmentType assessmentType = AssessmentType.MANUAL;
+
+        Submission submission = new TextSubmission();
+        submission = submissionRepository.save(submission);
+
+        Result result1 = new Result().assessmentType(assessmentType).resultString("x points of y").score(100L).rated(true);
+        result1 = resultRepository.save(result1);
+        result1.setSubmission(submission);
+
+        Result result2 = new Result().assessmentType(assessmentType).resultString("x points of y 2").score(200L).rated(true);
+        result2 = resultRepository.save(result2);
+        result2.setSubmission(submission);
+
+        submission.addResult(result1);
+        submission.addResult(result2);
+
+        var savedSubmission = submissionRepository.save(submission);
+        submission = submissionRepository.findWithEagerResultsById(savedSubmission.getId()).orElseThrow();
+
+        assert submission.getResults() != null;
+        assertThat(submission.getResults().size()).isEqualTo(2);
+        assertThat(submission.getFirstResult()).isNotEqualTo(submission.getLatestResult());
+        assertThat(submission.getFirstResult()).isEqualTo(result1);
+        assertThat(submission.getLatestResult()).isEqualTo(result2);
+
+    }
+
+    @Test
+    public void addMultipleResultsToOneSubmissionSavedSequentially() {
+        AssessmentType assessmentType = AssessmentType.MANUAL;
+
+        Submission submission = new TextSubmission();
+        submission = submissionRepository.save(submission);
+
+        Result result1 = new Result().assessmentType(assessmentType).resultString("x points of y").score(100L).rated(true);
+        result1 = resultRepository.save(result1);
+        result1.setSubmission(submission);
+
+        submission.addResult(result1);
+        submission = submissionRepository.save(submission);
+
+        Result result2 = new Result().assessmentType(assessmentType).resultString("x points of y 2").score(200L).rated(true);
+        result2 = resultRepository.save(result2);
+        result2.setSubmission(submission);
+
+        submission.addResult(result2);
+        submission = submissionRepository.save(submission);
+
+        submission = submissionRepository.findWithEagerResultsById(submission.getId()).orElseThrow();
+
+        assert submission.getResults() != null;
+        assertThat(submission.getResults().size()).isEqualTo(2);
+        assertThat(submission.getFirstResult()).isNotEqualTo(submission.getLatestResult());
+        assertThat(submission.getFirstResult()).isEqualTo(result1);
+        assertThat(submission.getLatestResult()).isEqualTo(result2);
+
+    }
+
+    @Test
+    public void updateMultipleResultsFromOneSubmission() {
+        AssessmentType assessmentType = AssessmentType.MANUAL;
+
+        Submission submission = new TextSubmission();
+        submission = submissionRepository.save(submission);
+
+        Result result1 = new Result().assessmentType(assessmentType).resultString("Points 1").score(100L).rated(true);
+        result1 = resultRepository.save(result1);
+        result1.setSubmission(submission);
+
+        submission.addResult(result1);
+        submission = submissionRepository.save(submission);
+
+        Result result2 = new Result().assessmentType(assessmentType).resultString("Points 2").score(200L).rated(true);
+        result2 = resultRepository.save(result2);
+        result2.setSubmission(submission);
+
+        submission.addResult(result2);
+        submission = submissionRepository.save(submission);
+
+        result1.setResultString("New Result #1");
+        result1 = resultRepository.save(result1);
+
+        result2.setResultString("New Result #2");
+        result2 = resultRepository.save(result2);
+
+        submission = submissionRepository.findWithEagerResultsById(submission.getId()).orElseThrow();
+
+        assert submission.getResults() != null;
+        assertThat(submission.getResults().size()).isEqualTo(2);
+        assertThat(submission.getFirstResult()).isNotEqualTo(submission.getLatestResult());
+        assertThat(submission.getFirstResult()).isEqualTo(result1);
+        assertThat(submission.getLatestResult()).isEqualTo(result2);
+
+    }
+
+}


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).

### Motivation and Context
We forgot to remove the unique constraint between submission and result during the last database migration. This PR removes it and it should not be possible to add multiple results to one submission without receiving a database exception

### Steps for Testing
1. Start the server locally in your dev environment
2. Check that no errors occur during startup
3. Check that the constraint in the result table database is set to unique = false now.

<img width="549" alt="image" src="https://user-images.githubusercontent.com/744067/102135553-74a5d000-3e58-11eb-870a-e0057db171bb.png">
