### PR TITLE
Fixed checkout path replacement placeholder

### DIFF
--- a/src/main/resources/templates/jenkins/c/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/c/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         stages {
             stage('Checkout') {
                 steps {
-                    dir('#testCheckoutPath') {
+                    dir('#testsCheckoutPath') {
                         checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[credentialsId: '#gitCredentials', name: 'tests', url: '#testRepository']]])
                     }
                     dir('#assignmentCheckoutPath') {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
New generated C exercises using Jenkins pipelines cannot build correctly, as a placeholder (`#testCheckoutPath`) in `src/main/resources/templates/jenkins/c/Jenkinsfile` may probably contain a typo and will not be replaced correctly during the build plan creation. After changing the placeholder to `#testsCheckoutPath`, the problem seems to be resolved.

### Description
<!-- Describe your changes in detail -->
The REPLACE_TESTS_CHECKOUT_PATH in `src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java` does not correspond to the one contained in the template, avoiding the correct replacement.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Enable the C programming language in `src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsProgrammingLanguageFeatureService.java` by uncommenting the C language line.
2. Generate a new C exercise in Artemis
3. Submit or run the exercise
4. Check if the exercise executed the tests by returning the test results

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![Screenshot from 2020-12-18 09-35-26](https://user-images.githubusercontent.com/45761921/102611528-5c230780-412f-11eb-95b3-96f83248de63.png)
![Screenshot from 2020-12-18 09-35-48](https://user-images.githubusercontent.com/45761921/102611533-5cbb9e00-412f-11eb-9d32-2b8fe9224d11.png)
![Screenshot from 2020-12-18 09-45-51](https://user-images.githubusercontent.com/45761921/102611535-5d543480-412f-11eb-8113-637d5e123cbc.png)

