### PR TITLE
Improve deletion process of temporary git repositories after plagiarism checks

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Repository.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Repository.java
@@ -80,4 +80,9 @@ public class Repository extends org.eclipse.jgit.internal.storage.file.FileRepos
     public void setFiles(Collection<File> files) {
         this.files = files;
     }
+
+    public void closeBeforeDelete() {
+        super.close();
+        super.doClose();
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseExportService.java
@@ -340,8 +340,8 @@ public class ProgrammingExerciseExportService {
             log.info("Delete project root directory " + projectPath.toFile());
             FileUtils.deleteDirectory(projectPath.toFile());
         }
-        catch (IOException e) {
-            log.warn("The project root directory '" + projectPath.toString() + "' could not be deleted.");
+        catch (IOException ex) {
+            log.warn("The project root directory '" + projectPath.toString() + "' could not be deleted.", ex);
         }
     }
 
@@ -456,10 +456,6 @@ public class ProgrammingExerciseExportService {
         // We can always delete the repository as it won't be used by the student (separate path)
         if (repository != null) {
             try {
-                // if repository is not closed, it causes weird IO issues when trying to delete the repository again
-                // java.io.IOException: Unable to delete file: ...\.git\objects\pack\...
-                repository.close();
-
                 log.info("Delete temporary repository " + repository.getLocalPath().toString());
                 gitService.deleteLocalRepository(repository);
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseExportService.java
@@ -7,6 +7,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -71,6 +74,8 @@ public class ProgrammingExerciseExportService {
     private final ZipFileService zipFileService;
 
     private final UrlService urlService;
+
+    private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
 
     public ProgrammingExerciseExportService(ProgrammingExerciseRepository programmingExerciseRepository, FileService fileService, GitService gitService,
             ZipFileService zipFileService, UrlService urlService) {
@@ -184,7 +189,7 @@ public class ProgrammingExerciseExportService {
 
         final var numberOfParticipations = programmingExercise.getStudentParticipations().size();
         log.info("Download repositories for JPlag programming comparison with " + numberOfParticipations + " participations");
-        downloadRepositories(programmingExercise);
+        List<Repository> repositories = downloadRepositories(programmingExercise);
         log.info("Downloading repositories done");
 
         final var projectKey = programmingExercise.getProjectKey();
@@ -206,9 +211,7 @@ public class ProgrammingExerciseExportService {
         JPlagResult result = jplag.run();
         log.info("JPlag programming comparison finished with " + result.getComparisons().size() + " comparisons");
 
-        log.info("Will cleanup repositories");
-        cleanupRepositories(programmingExercise);
-        log.info("Cleanup repositories done");
+        cleanupResourcesAsync(programmingExercise, repositories);
 
         TextPlagiarismResult textPlagiarismResult = new TextPlagiarismResult(result);
         textPlagiarismResult.setExerciseId(programmingExercise.getId());
@@ -216,6 +219,16 @@ public class ProgrammingExerciseExportService {
         log.info("JPlag programming comparison for " + numberOfParticipations + " participations done in " + TimeLogUtil.formatDurationFrom(start));
 
         return textPlagiarismResult;
+    }
+
+    private void cleanupResourcesAsync(final ProgrammingExercise programmingExercise, final List<Repository> repositories) {
+        executor.schedule(() -> {
+            log.info("Will delete local repositories");
+            deleteLocalRepositories(repositories);
+            // delete project root folder in the repos download folder
+            deleteReposDownloadProjectRootDirectory(programmingExercise);
+            log.info("Delete repositories done");
+        }, 10, TimeUnit.SECONDS);
     }
 
     /**
@@ -236,7 +249,7 @@ public class ProgrammingExerciseExportService {
         final var numberOfParticipations = programmingExercise.getStudentParticipations().size();
 
         log.info("Download repositories for JPlag programming comparison with " + numberOfParticipations + " participations");
-        downloadRepositories(programmingExercise);
+        List<Repository> repositories = downloadRepositories(programmingExercise);
         log.info("Downloading repositories done");
 
         final var output = "output";
@@ -281,14 +294,10 @@ public class ProgrammingExerciseExportService {
             FileSystemUtils.deleteRecursively(outputFolderFile);
         }
 
-        log.info("Will cleanup repositories");
-        cleanupRepositories(programmingExercise);
-        log.info("Cleanup repositories done");
+        cleanupResourcesAsync(programmingExercise, repositories);
 
-        // TODO: we should delete two remaining root folders <project-key>
-
-        log.info("Schedule deletion of zip file in 5 minutes");
-        fileService.scheduleForDeletion(zipFilePath, 5);
+        log.info("Schedule deletion of zip file in 1 minute");
+        fileService.scheduleForDeletion(zipFilePath, 1);
 
         log.info("JPlag programming report for " + numberOfParticipations + " participations done in " + TimeLogUtil.formatDurationFrom(start));
 
@@ -305,32 +314,16 @@ public class ProgrammingExerciseExportService {
         };
     }
 
-    private void cleanupRepositories(ProgrammingExercise programmingExercise) {
-        programmingExercise.getStudentParticipations().parallelStream().forEach(participation -> {
-            var programmingExerciseParticipation = (ProgrammingExerciseParticipation) participation;
+    private void deleteLocalRepositories(List<Repository> repositories) {
+        repositories.parallelStream().forEach(repository -> {
+            var localPath = repository.getLocalPath();
             try {
-                if (programmingExerciseParticipation.getRepositoryUrlAsUrl() == null) {
-                    return;
-                }
-                Repository repo = gitService.getOrCheckoutRepositoryForJPlag(programmingExerciseParticipation, REPO_DOWNLOAD_CLONE_PATH);
-                deleteTempLocalRepository(repo);
+                deleteTempLocalRepository(repository);
             }
-            catch (GitException | GitAPIException | InterruptedException ex) {
-                log.error("cleanup student repository " + programmingExerciseParticipation.getRepositoryUrlAsUrl() + " in exercise '" + programmingExercise.getTitle()
-                        + "' did not work as expected: " + ex.getMessage());
+            catch (GitException ex) {
+                log.error("delete repository " + localPath + " did not work as expected: " + ex.getMessage());
             }
         });
-        try {
-            Repository templateRepo = gitService.getOrCheckoutRepository(programmingExercise.getTemplateParticipation(), REPO_DOWNLOAD_CLONE_PATH);
-            deleteTempLocalRepository(templateRepo);
-        }
-        catch (GitException | GitAPIException | InterruptedException ex) {
-            log.error("cleanup template repository " + programmingExercise.getTemplateParticipation().getRepositoryUrlAsUrl() + " in exercise '" + programmingExercise.getTitle()
-                    + "' did not work as expected: " + ex.getMessage());
-        }
-
-        // delete project root folder in the repos download folder
-        deleteReposDownloadProjectRootDirectory(programmingExercise);
     }
 
     private void deleteReposDownloadProjectRootDirectory(ProgrammingExercise programmingExercise) {
@@ -345,7 +338,8 @@ public class ProgrammingExerciseExportService {
         }
     }
 
-    private void downloadRepositories(ProgrammingExercise programmingExercise) {
+    private List<Repository> downloadRepositories(ProgrammingExercise programmingExercise) {
+        List<Repository> downloadedRepositores = new ArrayList<>();
         programmingExercise.getStudentParticipations().parallelStream().forEach(participation -> {
             var programmingExerciseParticipation = (ProgrammingExerciseParticipation) participation;
             try {
@@ -355,8 +349,7 @@ public class ProgrammingExerciseExportService {
                 }
                 Repository repo = gitService.getOrCheckoutRepositoryForJPlag(programmingExerciseParticipation, REPO_DOWNLOAD_CLONE_PATH);
                 gitService.resetToOriginMaster(repo); // start with clean state
-
-                repo.close();
+                downloadedRepositores.add(repo);
             }
             catch (GitException | GitAPIException | InterruptedException ex) {
                 log.error("clone student repository " + programmingExerciseParticipation.getRepositoryUrlAsUrl() + " in exercise '" + programmingExercise.getTitle()
@@ -367,14 +360,15 @@ public class ProgrammingExerciseExportService {
         // clone the template repo
         try {
             Repository templateRepo = gitService.getOrCheckoutRepository(programmingExercise.getTemplateParticipation(), REPO_DOWNLOAD_CLONE_PATH);
-
             gitService.resetToOriginMaster(templateRepo); // start with clean state
-            templateRepo.close();
+            downloadedRepositores.add(templateRepo);
         }
         catch (GitException | GitAPIException | InterruptedException ex) {
             log.error("clone template repository " + programmingExercise.getTemplateParticipation().getRepositoryUrlAsUrl() + " in exercise '" + programmingExercise.getTitle()
                     + "' did not work as expected: " + ex.getMessage());
         }
+
+        return downloadedRepositores;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -652,16 +652,18 @@ public class GitService {
     /**
      * Deletes a local repository folder.
      *
-     * @param repo Local Repository Object.
+     * @param repository Local Repository Object.
      * @throws IOException if the deletion of the repository failed.
      */
-    public void deleteLocalRepository(Repository repo) throws IOException {
-        Path repoPath = repo.getLocalPath();
+    public void deleteLocalRepository(Repository repository) throws IOException {
+        Path repoPath = repository.getLocalPath();
         cachedRepositories.remove(repoPath);
-        repo.close();
+        // if repository is not closed, it causes weird IO issues when trying to delete the repository again
+        // java.io.IOException: Unable to delete file: ...\.git\objects\pack\...
+        repository.closeBeforeDelete();
         FileUtils.deleteDirectory(repoPath.toFile());
-        repo.setContent(null);
-        log.debug("Deleted Repository at " + repoPath);
+        repository.setContent(null);
+        log.info("Deleted Repository at " + repoPath);
     }
 
     /**


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
Improve deletion process of temporary git repositories after plagiarism checks

### Description
* Artemis keeps the repository references of JGit instead of creating new ones (and pulling again changes) just for the deletion
*  The deletion is triggered async (10s later) so that the user initiating the plagiarism check does not need to wait for the deletion process, which can take a couple of seconds or minutes for exercises with many (>2000) students.

### Steps for Testing
1. Participate in a programming exercises at least with 5 student accounts
2. Make sure to add significant similar code (e.g. the solution to the MergeSort algorithm) for all participants
3. Navigate to the programming exercise view page and click on Check plagiarism, try out both scenarios (with and without `Generate JPlag Report`) multiple times. Wait at least 10s after the last successful check so that the Artemis server can cleanup the git repositories.

Check that no errors occur in the client (console) and check that the zip file includes a proper plagiarism report (`Generate JPlag Report` active) or Artemis shows the plagiarism cases directly in the browser in the inspector

In case you have access to the server: 
* check that there are no errors or warnings
* check that all artifacts are removed in the `repos-download` folder (10s for the git repos, 1min for the zip file when `Generate JPlag Report` is active)


### Test Coverage
no changes

### Screenshots

![image](https://user-images.githubusercontent.com/744067/102719362-ef09a080-42ed-11eb-8d8b-9e3995a52adf.png)


<img width="459" alt="image" src="https://user-images.githubusercontent.com/744067/102719350-dbf6d080-42ed-11eb-86fa-544fde648fb6.png">
