### PR TITLE
Test coverage config change

### DIFF
--- a/src/test/javascript/jest.config.js
+++ b/src/test/javascript/jest.config.js
@@ -12,13 +12,14 @@ module.exports = {
             },
         },
     },
+    collectCoverageFrom: ['src/main/webapp/**/*.{js,jsx,ts,tsx}', '!src/main/webapp/**/*.module.{js,jsx,ts,tsx}'],
     coverageThreshold: {
         global: {
             // TODO: in the future, the following values should be increase to 80%
-            statements: 71,
-            branches: 46,
-            functions: 54,
-            lines: 70,
+            statements: 55,
+            branches: 38,
+            functions: 45,
+            lines: 54,
         },
     },
     preset: 'jest-preset-angular',


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Collecting test coverage metrics for all classes of the webapp

### Description
<!-- Describe your changes in detail -->

- adding `collectCoverageFrom: ['src/main/webapp/**/*.{js,jsx,ts,tsx}', '!src/main/webapp/**/*.module.{js,jsx,ts,tsx}'],` to jest.config.js (getting coverage for all files except for module files, because IMO it does not make sense to test them)
- adjusting thresholds in jest.config.js to ensure that test coverage does not decrease
 ```        
statements: 55%,  (current coverage 55.67%)
branches: 38%, (current coverage 38.04%)
functions: 45%, (current coverage 45.21%)
lines: 54%, (current coverage 54.57%)
```
