### PR TITLE
Refactor lecture routes to use child routes

### DIFF
--- a/src/main/webapp/app/lecture/lecture-attachments.component.ts
+++ b/src/main/webapp/app/lecture/lecture-attachments.component.ts
@@ -53,7 +53,7 @@ export class LectureAttachmentsComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.notificationText = undefined;
-        this.activatedRoute.data.subscribe(({ lecture }) => {
+        this.activatedRoute.parent!.data.subscribe(({ lecture }) => {
             this.lecture = lecture;
             this.attachmentService.findAllByLectureId(this.lecture.id!).subscribe((attachmentsResponse: HttpResponse<Attachment[]>) => {
                 this.attachments = attachmentsResponse.body!;

--- a/src/main/webapp/app/lecture/lecture-detail.component.html
+++ b/src/main/webapp/app/lecture/lecture-detail.component.html
@@ -1,4 +1,4 @@
-<div class="row justify-content-center">
+<div class="row justify-content-center" *ngIf="isVisible">
     <div class="col-8">
         <div *ngIf="lecture">
             <h2><span jhiTranslate="artemisApp.lecture.detail.title">Lecture</span> {{ lecture.id }}</h2>
@@ -42,3 +42,4 @@
         </div>
     </div>
 </div>
+<router-outlet></router-outlet>

--- a/src/main/webapp/app/lecture/lecture-detail.component.ts
+++ b/src/main/webapp/app/lecture/lecture-detail.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { Lecture } from 'app/entities/lecture.model';
+import { filter } from 'rxjs/operators';
 
 @Component({
     selector: 'jhi-lecture-detail',
@@ -8,8 +9,9 @@ import { Lecture } from 'app/entities/lecture.model';
 })
 export class LectureDetailComponent implements OnInit {
     lecture: Lecture;
+    isVisible: boolean;
 
-    constructor(private activatedRoute: ActivatedRoute) {}
+    constructor(private activatedRoute: ActivatedRoute, private router: Router) {}
 
     /**
      * Life cycle hook called by Angular to indicate that Angular is done creating the component
@@ -18,5 +20,7 @@ export class LectureDetailComponent implements OnInit {
         this.activatedRoute.data.subscribe(({ lecture }) => {
             this.lecture = lecture;
         });
+        this.isVisible = this.activatedRoute.children.length === 0;
+        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => (this.isVisible = this.activatedRoute.children.length === 0));
     }
 }

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-attachment-unit/create-attachment-unit.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-attachment-unit/create-attachment-unit.component.ts
@@ -11,6 +11,7 @@ import { finalize } from 'rxjs/operators';
 import { onError } from 'app/shared/util/global.utils';
 import { JhiAlertService } from 'ng-jhipster';
 import { AttachmentUnitFormComponent, AttachmentUnitFormData } from 'app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component';
+import { combineLatest } from 'rxjs';
 
 @Component({
     selector: 'jhi-create-attachment-unit',
@@ -37,9 +38,10 @@ export class CreateAttachmentUnitComponent implements OnInit {
     ) {}
 
     ngOnInit() {
-        this.activatedRoute.paramMap.subscribe((params) => {
+        const lectureRoute = this.activatedRoute.parent!.parent!;
+        combineLatest(lectureRoute.paramMap, lectureRoute.parent!.paramMap).subscribe(([params, parentParams]) => {
             this.lectureId = Number(params.get('lectureId'));
-            this.courseId = Number(params.get('courseId'));
+            this.courseId = Number(parentParams.get('courseId'));
         });
         this.attachmentUnitToCreate = new AttachmentUnit();
         this.attachmentToCreate = new Attachment();

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-exercise-unit/create-exercise-unit.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-exercise-unit/create-exercise-unit.component.ts
@@ -8,7 +8,7 @@ import { JhiAlertService } from 'ng-jhipster';
 import { concatMap, finalize, switchMap, take } from 'rxjs/operators';
 import { Exercise } from 'app/entities/exercise.model';
 import { SortService } from 'app/shared/service/sort.service';
-import { forkJoin, Observable } from 'rxjs';
+import { forkJoin, Observable, combineLatest } from 'rxjs';
 import { ExerciseUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/exerciseUnit.service';
 
 @Component({
@@ -37,12 +37,13 @@ export class CreateExerciseUnitComponent implements OnInit {
 
     ngOnInit(): void {
         this.isLoading = true;
-        this.activatedRoute.paramMap
+        const lectureRoute = this.activatedRoute.parent!.parent!;
+        combineLatest(lectureRoute.paramMap, lectureRoute.parent!.paramMap)
             .pipe(
                 take(1),
-                switchMap((params) => {
+                switchMap(([params, parentParams]) => {
                     this.lectureId = Number(params.get('lectureId'));
-                    this.courseId = Number(params.get('courseId'));
+                    this.courseId = Number(parentParams.get('courseId'));
 
                     const courseObservable = this.courseManagementService.findWithExercises(this.courseId);
                     const exerciseUnitObservable = this.exerciseUnitService.findAllByLectureId(this.lectureId);

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-text-unit/create-text-unit.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-text-unit/create-text-unit.component.ts
@@ -7,6 +7,7 @@ import { TextUnitFormData } from 'app/lecture/lecture-unit/lecture-unit-manageme
 import { onError } from 'app/shared/util/global.utils';
 import { finalize } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
+import { combineLatest } from 'rxjs';
 
 @Component({
     selector: 'jhi-create-text-unit',
@@ -21,9 +22,10 @@ export class CreateTextUnitComponent implements OnInit {
     constructor(private activatedRoute: ActivatedRoute, private router: Router, private textUnitService: TextUnitService, private alertService: JhiAlertService) {}
 
     ngOnInit(): void {
-        this.activatedRoute.paramMap.subscribe((params) => {
+        const lectureRoute = this.activatedRoute.parent!.parent!;
+        combineLatest(lectureRoute.paramMap, lectureRoute.parent!.paramMap).subscribe(([params, parentParams]) => {
             this.lectureId = Number(params.get('lectureId'));
-            this.courseId = Number(params.get('courseId'));
+            this.courseId = Number(parentParams.get('courseId'));
         });
         this.textUnitToCreate = new TextUnit();
     }

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-video-unit/create-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/create-video-unit/create-video-unit.component.ts
@@ -7,6 +7,7 @@ import { VideoUnitService } from 'app/lecture/lecture-unit/lecture-unit-manageme
 import { onError } from 'app/shared/util/global.utils';
 import { JhiAlertService } from 'ng-jhipster';
 import { finalize } from 'rxjs/operators';
+import { combineLatest } from 'rxjs';
 
 @Component({
     selector: 'jhi-create-video-unit',
@@ -22,9 +23,10 @@ export class CreateVideoUnitComponent implements OnInit {
     constructor(private activatedRoute: ActivatedRoute, private router: Router, private videoUnitService: VideoUnitService, private alertService: JhiAlertService) {}
 
     ngOnInit(): void {
-        this.activatedRoute.paramMap.subscribe((params) => {
+        const lectureRoute = this.activatedRoute.parent!.parent!;
+        combineLatest(lectureRoute.paramMap, lectureRoute.parent!.paramMap).subscribe(([params, parentParams]) => {
             this.lectureId = Number(params.get('lectureId'));
-            this.courseId = Number(params.get('courseId'));
+            this.courseId = Number(parentParams.get('courseId'));
         });
         this.videoUnitToCreate = new VideoUnit();
     }

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-attachment-unit/edit-attachment-unit.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-attachment-unit/edit-attachment-unit.component.ts
@@ -10,7 +10,7 @@ import { AttachmentUnitFormComponent, AttachmentUnitFormData } from 'app/lecture
 import { Attachment, AttachmentType } from 'app/entities/attachment.model';
 import { FileUploaderService } from 'app/shared/http/file-uploader.service';
 import { AttachmentService } from 'app/lecture/attachment.service';
-import { forkJoin } from 'rxjs';
+import { forkJoin, combineLatest } from 'rxjs';
 import * as moment from 'moment';
 
 @Component({
@@ -39,12 +39,13 @@ export class EditAttachmentUnitComponent implements OnInit {
 
     ngOnInit(): void {
         this.isLoading = true;
-        this.activatedRoute.paramMap
+        const lectureRoute = this.activatedRoute.parent!.parent!;
+        combineLatest(this.activatedRoute.paramMap, lectureRoute.paramMap)
             .pipe(
                 take(1),
-                switchMap((params) => {
+                switchMap(([params, parentParams]) => {
                     const attachmentUnitId = Number(params.get('attachmentUnitId'));
-                    this.lectureId = Number(params.get('lectureId'));
+                    this.lectureId = Number(parentParams.get('lectureId'));
                     return this.attachmentUnitService.findById(attachmentUnitId, this.lectureId);
                 }),
                 finalize(() => {

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-text-unit/edit-text-unit.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-text-unit/edit-text-unit.component.ts
@@ -7,6 +7,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { onError } from 'app/shared/util/global.utils';
 import { finalize, switchMap, take } from 'rxjs/operators';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { combineLatest } from 'rxjs';
 
 @Component({
     selector: 'jhi-edit-text-unit',
@@ -23,12 +24,13 @@ export class EditTextUnitComponent implements OnInit {
 
     ngOnInit(): void {
         this.isLoading = true;
-        this.activatedRoute.paramMap
+        const lectureRoute = this.activatedRoute.parent!.parent!;
+        combineLatest(this.activatedRoute.paramMap, lectureRoute.paramMap)
             .pipe(
                 take(1),
-                switchMap((params) => {
+                switchMap(([params, parentParams]) => {
                     const textUnitId = Number(params.get('textUnitId'));
-                    this.lectureId = Number(params.get('lectureId'));
+                    this.lectureId = Number(parentParams.get('lectureId'));
                     return this.textUnitService.findById(textUnitId, this.lectureId);
                 }),
                 finalize(() => (this.isLoading = false)),

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-video-unit/edit-video-unit.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/edit-video-unit/edit-video-unit.component.ts
@@ -7,6 +7,7 @@ import { JhiAlertService } from 'ng-jhipster';
 import { onError } from 'app/shared/util/global.utils';
 import { finalize, switchMap, take } from 'rxjs/operators';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { combineLatest } from 'rxjs';
 
 @Component({
     selector: 'jhi-edit-video-unit',
@@ -23,12 +24,13 @@ export class EditVideoUnitComponent implements OnInit {
 
     ngOnInit(): void {
         this.isLoading = true;
-        this.activatedRoute.paramMap
+        const lectureRoute = this.activatedRoute.parent!.parent!;
+        combineLatest(this.activatedRoute.paramMap, lectureRoute.paramMap)
             .pipe(
                 take(1),
-                switchMap((params) => {
+                switchMap(([params, parentParams]) => {
                     const videoUnitId = Number(params.get('videoUnitId'));
-                    this.lectureId = Number(params.get('lectureId'));
+                    this.lectureId = Number(parentParams.get('lectureId'));
                     return this.videoUnitService.findById(videoUnitId, this.lectureId);
                 }),
                 finalize(() => {

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.component.html
@@ -1,71 +1,74 @@
-<jhi-alert></jhi-alert>
+<div *ngIf="isVisible">
+    <jhi-alert></jhi-alert>
 
-<div *ngIf="isLoading" class="d-flex justify-content-center">
-    <div class="spinner-border" role="status">
-        <span class="sr-only">{{ 'loading' | translate }}</span>
+    <div *ngIf="isLoading" class="d-flex justify-content-center">
+        <div class="spinner-border" role="status">
+            <span class="sr-only">{{ 'loading' | translate }}</span>
+        </div>
     </div>
-</div>
 
-<div *ngIf="!isLoading" class="container">
-    <!-- Lecture Unit Rows-->
-    <div class="row mb-4" *ngFor="let lectureUnit of lectureUnits; index as i; trackBy: identify">
-        <div class="col-1 my-auto mx-auto">
-            <jhi-learning-goals-popover
-                [courseId]="lecture?.course?.id"
-                [learningGoals]="lectureUnit.learningGoals"
-                [navigateTo]="'learningGoalManagement'"
-            ></jhi-learning-goals-popover>
-        </div>
-        <div class="col-9 mx-auto col-md-7 offset-md-2" [ngSwitch]="lectureUnit.type">
-            <jhi-exercise-unit *ngSwitchCase="LectureUnitType.EXERCISE" [exerciseUnit]="lectureUnit" [isPresentationMode]="true" [course]="lecture?.course"></jhi-exercise-unit>
-            <jhi-attachment-unit *ngSwitchCase="LectureUnitType.ATTACHMENT" [attachmentUnit]="lectureUnit"></jhi-attachment-unit>
-            <jhi-video-unit *ngSwitchCase="LectureUnitType.VIDEO" [videoUnit]="lectureUnit"></jhi-video-unit>
-            <jhi-text-unit *ngSwitchCase="LectureUnitType.TEXT" [textUnit]="lectureUnit"></jhi-text-unit>
-        </div>
-        <div class="col-1 my-auto">
-            <div class="container">
-                <div class="row mx-auto mb-1">
-                    <button id="{{ 'up-' + i }}" type="button" class="btn btn-primary btn-circle" (click)="moveUp(i)" [disabled]="i === 0">
-                        <fa-icon [icon]="'arrow-up'" [fixedWidth]="true" [size]="'lg'"></fa-icon>
-                    </button>
-                </div>
-                <div class="row mx-auto">
-                    <button id="{{ 'down-' + i }}" type="button" class="btn btn-primary btn-circle" (click)="moveDown(i)" [disabled]="i === lectureUnits.length - 1">
-                        <fa-icon [icon]="'arrow-down'" [fixedWidth]="true" [size]="'lg'"></fa-icon>
-                    </button>
+    <div *ngIf="!isLoading" class="container">
+        <!-- Lecture Unit Rows-->
+        <div class="row mb-4" *ngFor="let lectureUnit of lectureUnits; index as i; trackBy: identify">
+            <div class="col-1 my-auto mx-auto">
+                <jhi-learning-goals-popover
+                    [courseId]="lecture?.course?.id"
+                    [learningGoals]="lectureUnit.learningGoals"
+                    [navigateTo]="'learningGoalManagement'"
+                ></jhi-learning-goals-popover>
+            </div>
+            <div class="col-9 mx-auto col-md-7 offset-md-2" [ngSwitch]="lectureUnit.type">
+                <jhi-exercise-unit *ngSwitchCase="LectureUnitType.EXERCISE" [exerciseUnit]="lectureUnit" [isPresentationMode]="true" [course]="lecture?.course"></jhi-exercise-unit>
+                <jhi-attachment-unit *ngSwitchCase="LectureUnitType.ATTACHMENT" [attachmentUnit]="lectureUnit"></jhi-attachment-unit>
+                <jhi-video-unit *ngSwitchCase="LectureUnitType.VIDEO" [videoUnit]="lectureUnit"></jhi-video-unit>
+                <jhi-text-unit *ngSwitchCase="LectureUnitType.TEXT" [textUnit]="lectureUnit"></jhi-text-unit>
+            </div>
+            <div class="col-1 my-auto">
+                <div class="container">
+                    <div class="row mx-auto mb-1">
+                        <button id="{{ 'up-' + i }}" type="button" class="btn btn-primary btn-circle" (click)="moveUp(i)" [disabled]="i === 0">
+                            <fa-icon [icon]="'arrow-up'" [fixedWidth]="true" [size]="'lg'"></fa-icon>
+                        </button>
+                    </div>
+                    <div class="row mx-auto">
+                        <button id="{{ 'down-' + i }}" type="button" class="btn btn-primary btn-circle" (click)="moveDown(i)" [disabled]="i === lectureUnits.length - 1">
+                            <fa-icon [icon]="'arrow-down'" [fixedWidth]="true" [size]="'lg'"></fa-icon>
+                        </button>
+                    </div>
                 </div>
             </div>
+            <div class="col-1 my-auto">
+                <button
+                    class="rounded-pill"
+                    *jhiHasAnyAuthority="['ROLE_INSTRUCTOR', 'ROLE_ADMIN']"
+                    jhiDeleteButton
+                    [actionType]="getActionType(lectureUnit)"
+                    [entityTitle]="getLectureUnitName(lectureUnit)"
+                    [deleteQuestion]="getDeleteQuestionKey(lectureUnit)"
+                    [deleteConfirmationText]="getDeleteConfirmationTextKey(lectureUnit)"
+                    (delete)="deleteLectureUnit(lectureUnit.id)"
+                    [dialogError]="dialogError$"
+                >
+                    <fa-icon [icon]="'times'"></fa-icon>
+                </button>
+                <button *ngIf="editButtonAvailable(lectureUnit)" class="btn mt-1 btn-sm btn-primary edit rounded-pill" (click)="editButtonClicked(lectureUnit)">
+                    <fa-icon [icon]="'pencil-alt'"></fa-icon>
+                    <span class="d-none d-md-inline">{{ 'entity.action.edit' | translate }}</span>
+                </button>
+            </div>
         </div>
-        <div class="col-1 my-auto">
-            <button
-                class="rounded-pill"
-                *jhiHasAnyAuthority="['ROLE_INSTRUCTOR', 'ROLE_ADMIN']"
-                jhiDeleteButton
-                [actionType]="getActionType(lectureUnit)"
-                [entityTitle]="getLectureUnitName(lectureUnit)"
-                [deleteQuestion]="getDeleteQuestionKey(lectureUnit)"
-                [deleteConfirmationText]="getDeleteConfirmationTextKey(lectureUnit)"
-                (delete)="deleteLectureUnit(lectureUnit.id)"
-                [dialogError]="dialogError$"
-            >
-                <fa-icon [icon]="'times'"></fa-icon>
-            </button>
-            <button *ngIf="editButtonAvailable(lectureUnit)" class="btn mt-1 btn-sm btn-primary edit rounded-pill" (click)="editButtonClicked(lectureUnit)">
-                <fa-icon [icon]="'pencil-alt'"></fa-icon>
-                <span class="d-none d-md-inline">{{ 'entity.action.edit' | translate }}</span>
-            </button>
-        </div>
-    </div>
 
-    <!-- Unit Creation Card Row-->
-    <div class="row">
-        <div class="col-10 col-md-8 offset-md-2 mx-auto">
-            <jhi-unit-creation-card
-                (createExerciseUnit)="createExerciseUnit()"
-                (createAttachmentUnit)="createAttachmentUnit()"
-                (createVideoUnit)="createVideoUnit()"
-                (createTextUnit)="createTextUnit()"
-            ></jhi-unit-creation-card>
+        <!-- Unit Creation Card Row-->
+        <div class="row">
+            <div class="col-10 col-md-8 offset-md-2 mx-auto">
+                <jhi-unit-creation-card
+                    (createExerciseUnit)="createExerciseUnit()"
+                    (createAttachmentUnit)="createAttachmentUnit()"
+                    (createVideoUnit)="createVideoUnit()"
+                    (createTextUnit)="createTextUnit()"
+                ></jhi-unit-creation-card>
+            </div>
         </div>
     </div>
 </div>
+<router-outlet></router-outlet>

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.component.ts
@@ -22,6 +22,7 @@ export class LectureUnitManagementComponent implements OnInit, OnDestroy {
     lectureId: number;
     lectureUnits: LectureUnit[] = [];
     lecture: Lecture;
+    isVisible: boolean;
     isLoading = false;
     updateOrderSubject: Subject<any>;
     updateOrderSubjectSubscription: Subscription;
@@ -46,13 +47,14 @@ export class LectureUnitManagementComponent implements OnInit, OnDestroy {
         this.dialogErrorSource.unsubscribe();
         this.navigationEndSubscription.unsubscribe();
     }
+
     ngOnInit(): void {
         this.navigationEndSubscription = this.router.events.pipe(filter((value) => value instanceof NavigationEnd)).subscribe(() => {
             this.loadData();
         });
 
         this.updateOrderSubject = new Subject();
-        this.activatedRoute.params.subscribe((params) => {
+        this.activatedRoute.parent!.params.subscribe((params) => {
             this.lectureId = +params['lectureId'];
             if (this.lectureId) {
                 this.loadData();
@@ -63,6 +65,9 @@ export class LectureUnitManagementComponent implements OnInit, OnDestroy {
         this.updateOrderSubjectSubscription = this.updateOrderSubject.pipe(debounceTime(1000)).subscribe(() => {
             this.updateOrder();
         });
+
+        this.isVisible = this.activatedRoute.children.length === 0;
+        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => (this.isVisible = this.activatedRoute.children.length === 0));
     }
 
     loadData() {

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.module.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.module.ts
@@ -2,7 +2,6 @@ import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 import { LectureUnitManagementComponent } from 'app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.component';
 import { NgModule } from '@angular/core';
-import { lectureUnitRoute } from 'app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.route';
 import { RouterModule } from '@angular/router';
 import { UnitCreationCardComponent } from './unit-creation-card/unit-creation-card.component';
 import { CreateExerciseUnitComponent } from './create-exercise-unit/create-exercise-unit.component';
@@ -22,15 +21,13 @@ import { ArtemisMarkdownEditorModule } from 'app/shared/markdown-editor/markdown
 import { LectureUnitLayoutComponent } from './lecture-unit-layout/lecture-unit-layout.component';
 import { ArtemisLearningGoalsModule } from 'app/course/learning-goals/learning-goal.module';
 
-const ENTITY_STATES = [...lectureUnitRoute];
-
 @NgModule({
     imports: [
         ArtemisMarkdownEditorModule,
         ArtemisSharedModule,
         ReactiveFormsModule,
         ArtemisSharedComponentModule,
-        RouterModule.forChild(ENTITY_STATES),
+        RouterModule.forChild([]),
         ArtemisCoursesModule,
         FormDateTimePickerModule,
         ArtemisLearningGoalsModule,

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.route.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.route.ts
@@ -9,166 +9,73 @@ import { CreateTextUnitComponent } from 'app/lecture/lecture-unit/lecture-unit-m
 import { EditTextUnitComponent } from 'app/lecture/lecture-unit/lecture-unit-management/edit-text-unit/edit-text-unit.component';
 import { CreateVideoUnitComponent } from 'app/lecture/lecture-unit/lecture-unit-management/create-video-unit/create-video-unit.component';
 import { EditVideoUnitComponent } from 'app/lecture/lecture-unit/lecture-unit-management/edit-video-unit/edit-video-unit.component';
-import { CourseResolve } from 'app/course/manage/course-management.route';
-import { LectureResolve } from 'app/lecture/lecture.route';
 
-// TODO: The /edit routes have no crumb because individual attachments have no route => make child of overview
 export const lectureUnitRoute: Routes = [
     {
-        path: ':courseId/lectures/:lectureId/unit-management',
+        path: 'unit-management',
         component: LectureUnitManagementComponent,
-        resolve: {
-            course: CourseResolve,
-            lecture: LectureResolve,
-        },
         data: {
             authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-            // HACK: The path is a composite, so we need to define both parts
-            breadcrumbs: [
-                { variable: 'course.title', path: 'course.id' },
-                { label: 'artemisApp.lecture.home.title', path: 'lectures' },
-                { variable: 'lecture.title', path: 'lecture.id' },
-                { label: 'artemisApp.lectureUnit.home.title', path: 'unit-management' },
-            ],
             pageTitle: 'artemisApp.lectureUnit.home.title',
         },
         canActivate: [UserRouteAccessService],
-    },
-    {
-        path: ':courseId/lectures/:lectureId/unit-management/exercise-units/create',
-        component: CreateExerciseUnitComponent,
-        resolve: {
-            course: CourseResolve,
-            lecture: LectureResolve,
-        },
-        data: {
-            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-            // HACK: The path is a composite, so we need to define both parts
-            breadcrumbs: [
-                { variable: 'course.title', path: 'course.id' },
-                { label: 'artemisApp.lecture.home.title', path: 'lectures' },
-                { variable: 'lecture.title', path: 'lecture.id' },
-                { label: 'artemisApp.lectureUnit.home.title', path: 'unit-management' },
-                { label: 'artemisApp.videoUnit.createExerciseUnit.title', path: 'create' },
-            ],
-            pageTitle: 'artemisApp.exerciseUnit.createExerciseUnit.title',
-        },
-    },
-    {
-        path: ':courseId/lectures/:lectureId/unit-management/attachment-units/create',
-        component: CreateAttachmentUnitComponent,
-        resolve: {
-            course: CourseResolve,
-            lecture: LectureResolve,
-        },
-        data: {
-            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-            // HACK: The path is a composite, so we need to define both parts
-            breadcrumbs: [
-                { variable: 'course.title', path: 'course.id' },
-                { label: 'artemisApp.lecture.home.title', path: 'lectures' },
-                { variable: 'lecture.title', path: 'lecture.id' },
-                { label: 'artemisApp.lectureUnit.home.title', path: 'unit-management' },
-                { label: 'artemisApp.videoUnit.createAttachmentUnit.title', path: 'create' },
-            ],
-            pageTitle: 'artemisApp.attachmentUnit.createAttachmentUnit.title',
-        },
-    },
-    {
-        path: ':courseId/lectures/:lectureId/unit-management/attachment-units/:attachmentUnitId/edit',
-        component: EditAttachmentUnitComponent,
-        resolve: {
-            course: CourseResolve,
-            lecture: LectureResolve,
-        },
-        data: {
-            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-            // HACK: The path is a composite, so we need to define both parts
-            breadcrumbs: [
-                { variable: 'course.title', path: 'course.id' },
-                { label: 'artemisApp.lecture.home.title', path: 'lectures' },
-                { variable: 'lecture.title', path: 'lecture.id' },
-                { label: 'artemisApp.lectureUnit.home.title', path: 'unit-management' },
-            ],
-            pageTitle: 'artemisApp.attachmentUnit.editAttachmentUnit.title',
-        },
-    },
-    {
-        path: ':courseId/lectures/:lectureId/unit-management/video-units/create',
-        component: CreateVideoUnitComponent,
-        resolve: {
-            course: CourseResolve,
-            lecture: LectureResolve,
-        },
-        data: {
-            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-            // HACK: The path is a composite, so we need to define both parts
-            breadcrumbs: [
-                { variable: 'course.title', path: 'course.id' },
-                { label: 'artemisApp.lecture.home.title', path: 'lectures' },
-                { variable: 'lecture.title', path: 'lecture.id' },
-                { label: 'artemisApp.lectureUnit.home.title', path: 'unit-management' },
-                { label: 'artemisApp.videoUnit.createVideoUnit.title', path: 'create' },
-            ],
-            pageTitle: 'artemisApp.videoUnit.createVideoUnit.title',
-        },
-    },
-    {
-        path: ':courseId/lectures/:lectureId/unit-management/video-units/:videoUnitId/edit',
-        component: EditVideoUnitComponent,
-        resolve: {
-            course: CourseResolve,
-            lecture: LectureResolve,
-        },
-        data: {
-            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-            // HACK: The path is a composite, so we need to define both parts
-            breadcrumbs: [
-                { variable: 'course.title', path: 'course.id' },
-                { label: 'artemisApp.lecture.home.title', path: 'lectures' },
-                { variable: 'lecture.title', path: 'lecture.id' },
-                { label: 'artemisApp.lectureUnit.home.title', path: 'unit-management' },
-            ],
-            pageTitle: 'artemisApp.videoUnit.editVideoUnit.title',
-        },
-    },
-    {
-        path: ':courseId/lectures/:lectureId/unit-management/text-units/create',
-        component: CreateTextUnitComponent,
-        resolve: {
-            course: CourseResolve,
-            lecture: LectureResolve,
-        },
-        data: {
-            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-            // HACK: The path is a composite, so we need to define both parts
-            breadcrumbs: [
-                { variable: 'course.title', path: 'course.id' },
-                { label: 'artemisApp.lecture.home.title', path: 'lectures' },
-                { variable: 'lecture.title', path: 'lecture.id' },
-                { label: 'artemisApp.lectureUnit.home.title', path: 'unit-management' },
-                { label: 'artemisApp.videoUnit.createVideoUnit.title', path: 'create' },
-            ],
-            pageTitle: 'artemisApp.textUnit.createTextUnit.title',
-        },
-    },
-    {
-        path: ':courseId/lectures/:lectureId/unit-management/text-units/:textUnitId/edit',
-        component: EditTextUnitComponent,
-        resolve: {
-            course: CourseResolve,
-            lecture: LectureResolve,
-        },
-        data: {
-            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-            // HACK: The path is a composite, so we need to define both parts
-            breadcrumbs: [
-                { variable: 'course.title', path: 'course.id' },
-                { label: 'artemisApp.lecture.home.title', path: 'lectures' },
-                { variable: 'lecture.title', path: 'lecture.id' },
-                { label: 'artemisApp.lectureUnit.home.title', path: 'unit-management' },
-            ],
-            pageTitle: 'artemisApp.textUnit.editTextUnit.title',
-        },
+        children: [
+            {
+                path: 'exercise-units/create',
+                component: CreateExerciseUnitComponent,
+                data: {
+                    authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+                    pageTitle: 'artemisApp.exerciseUnit.createExerciseUnit.title',
+                },
+            },
+            {
+                path: 'attachment-units/create',
+                component: CreateAttachmentUnitComponent,
+                data: {
+                    authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+                    pageTitle: 'artemisApp.attachmentUnit.createAttachmentUnit.title',
+                },
+            },
+            {
+                path: 'video-units/create',
+                component: CreateVideoUnitComponent,
+                data: {
+                    authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+                    pageTitle: 'artemisApp.videoUnit.createVideoUnit.title',
+                },
+            },
+            {
+                path: 'text-units/create',
+                component: CreateTextUnitComponent,
+                data: {
+                    authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+                    pageTitle: 'artemisApp.textUnit.createTextUnit.title',
+                },
+            },
+            {
+                path: 'attachment-units/:attachmentUnitId/edit',
+                component: EditAttachmentUnitComponent,
+                data: {
+                    authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+                    pageTitle: 'artemisApp.attachmentUnit.editAttachmentUnit.title',
+                },
+            },
+            {
+                path: 'video-units/:videoUnitId/edit',
+                component: EditVideoUnitComponent,
+                data: {
+                    authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+                    pageTitle: 'artemisApp.videoUnit.editVideoUnit.title',
+                },
+            },
+            {
+                path: 'text-units/:textUnitId/edit',
+                component: EditTextUnitComponent,
+                data: {
+                    authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+                    pageTitle: 'artemisApp.textUnit.editTextUnit.title',
+                },
+            },
+        ],
     },
 ];

--- a/src/main/webapp/app/lecture/lecture-update.component.ts
+++ b/src/main/webapp/app/lecture/lecture-update.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { HttpResponse } from '@angular/common/http';
-import { Observable, combineLatest } from 'rxjs';
+import { Observable } from 'rxjs';
 import { JhiAlertService } from 'ng-jhipster';
 import { LectureService } from './lecture.service';
 import { CourseManagementService } from '../course/manage/course-management.service';
@@ -38,10 +38,14 @@ export class LectureUpdateComponent implements OnInit {
      */
     ngOnInit() {
         this.isSaving = false;
-        // Wait for both subscriptions to load
-        combineLatest(this.activatedRoute.data, this.activatedRoute.parent!.data).subscribe(([routeData, parentRouteData]) => {
-            this.lecture = routeData['lecture'];
-            this.lecture.course = parentRouteData['course'];
+        // Create a new lecture to use unless we fetch an existing lecture
+        this.lecture = new Lecture();
+        this.activatedRoute.parent!.data.subscribe((data) => {
+            const lecture = data['lecture'];
+            if (lecture) {
+                this.lecture = lecture;
+            }
+            this.lecture.course = data['course'];
         });
     }
 

--- a/src/main/webapp/app/lecture/lecture.route.ts
+++ b/src/main/webapp/app/lecture/lecture.route.ts
@@ -12,14 +12,14 @@ import { Lecture } from 'app/entities/lecture.model';
 import { LectureAttachmentsComponent } from 'app/lecture/lecture-attachments.component';
 import { Authority } from 'app/shared/constants/authority.constants';
 import { CourseResolve } from 'app/course/manage/course-management.route';
+import { lectureUnitRoute } from 'app/lecture/lecture-unit/lecture-unit-management/lecture-unit-management.route';
 
 @Injectable({ providedIn: 'root' })
 export class LectureResolve implements Resolve<Lecture> {
     constructor(private service: LectureService) {}
 
     resolve(route: ActivatedRouteSnapshot): Observable<Lecture> {
-        // TODO: This should always use lectureId and never just 'id'
-        const id = route.params['lectureId'] ? route.params['lectureId'] : route.params['id'] ? route.params['id'] : undefined;
+        const id = route.params['lectureId'] ? route.params['lectureId'] : undefined;
         if (id) {
             return this.service.find(id).pipe(
                 filter((response: HttpResponse<Lecture>) => response.ok),
@@ -51,9 +51,6 @@ export const lectureRoute: Routes = [
             {
                 path: 'new',
                 component: LectureUpdateComponent,
-                resolve: {
-                    lecture: LectureResolve,
-                },
                 data: {
                     authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
                     pageTitle: 'global.generic.create',
@@ -61,7 +58,7 @@ export const lectureRoute: Routes = [
                 canActivate: [UserRouteAccessService],
             },
             {
-                path: ':id',
+                path: ':lectureId',
                 component: LectureDetailComponent,
                 resolve: {
                     lecture: LectureResolve,
@@ -72,40 +69,27 @@ export const lectureRoute: Routes = [
                     pageTitle: 'artemisApp.lecture.home.title',
                 },
                 canActivate: [UserRouteAccessService],
-            },
-            {
-                path: ':id/attachments',
-                component: LectureAttachmentsComponent,
-                resolve: {
-                    lecture: LectureResolve,
-                },
-                data: {
-                    authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-                    // HACK: The path is a composite, so we need to define both parts
-                    breadcrumbs: [
-                        { variable: 'lecture.title', path: 'lecture.id' },
-                        { label: 'artemisApp.lecture.attachments.title', path: 'attachments' },
-                    ],
-                    pageTitle: 'artemisApp.lecture.attachments.title',
-                },
-                canActivate: [UserRouteAccessService],
-            },
-            {
-                path: ':id/edit',
-                component: LectureUpdateComponent,
-                resolve: {
-                    lecture: LectureResolve,
-                },
-                data: {
-                    authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
-                    // HACK: The path is a composite, so we need to define both parts
-                    breadcrumbs: [
-                        { variable: 'lecture.title', path: 'lecture.id' },
-                        { label: 'global.generic.edit', path: 'edit' },
-                    ],
-                    pageTitle: 'global.generic.edit',
-                },
-                canActivate: [UserRouteAccessService],
+                children: [
+                    {
+                        path: 'attachments',
+                        component: LectureAttachmentsComponent,
+                        data: {
+                            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+                            pageTitle: 'artemisApp.lecture.attachments.title',
+                        },
+                        canActivate: [UserRouteAccessService],
+                    },
+                    {
+                        path: 'edit',
+                        component: LectureUpdateComponent,
+                        data: {
+                            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+                            pageTitle: 'global.generic.edit',
+                        },
+                        canActivate: [UserRouteAccessService],
+                    },
+                    ...lectureUnitRoute,
+                ],
             },
         ],
     },

--- a/src/test/javascript/spec/component/lecture-unit/attachment-unit/create-attachment-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/attachment-unit/create-attachment-unit.component.spec.ts
@@ -52,16 +52,28 @@ describe('CreateAttachmentUnitComponent', () => {
                 {
                     provide: ActivatedRoute,
                     useValue: {
-                        paramMap: Observable.of({
-                            get: (key: string) => {
-                                switch (key) {
-                                    case 'courseId':
-                                        return 1;
-                                    case 'lectureId':
-                                        return 1;
-                                }
+                        parent: {
+                            parent: {
+                                paramMap: Observable.of({
+                                    get: (key: string) => {
+                                        switch (key) {
+                                            case 'lectureId':
+                                                return 1;
+                                        }
+                                    },
+                                }),
+                                parent: {
+                                    paramMap: Observable.of({
+                                        get: (key: string) => {
+                                            switch (key) {
+                                                case 'courseId':
+                                                    return 1;
+                                            }
+                                        },
+                                    }),
+                                },
                             },
-                        }),
+                        },
                     },
                 },
             ],

--- a/src/test/javascript/spec/component/lecture-unit/attachment-unit/edit-attachment-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/attachment-unit/edit-attachment-unit.component.spec.ts
@@ -70,13 +70,23 @@ describe('EditAttachmentUnitComponent', () => {
                         paramMap: Observable.of({
                             get: (key: string) => {
                                 switch (key) {
-                                    case 'lectureId':
-                                        return 1;
                                     case 'attachmentUnitId':
                                         return 1;
                                 }
                             },
                         }),
+                        parent: {
+                            parent: {
+                                paramMap: Observable.of({
+                                    get: (key: string) => {
+                                        switch (key) {
+                                            case 'lectureId':
+                                                return 1;
+                                        }
+                                    },
+                                }),
+                            },
+                        },
                     },
                 },
             ],

--- a/src/test/javascript/spec/component/lecture-unit/exercise-unit/create-exercise-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/exercise-unit/create-exercise-unit.component.spec.ts
@@ -57,16 +57,28 @@ describe('CreateExerciseUnitComponent', () => {
                 {
                     provide: ActivatedRoute,
                     useValue: {
-                        paramMap: Observable.of({
-                            get: (key: string) => {
-                                switch (key) {
-                                    case 'courseId':
-                                        return 1;
-                                    case 'lectureId':
-                                        return 1;
-                                }
+                        parent: {
+                            parent: {
+                                paramMap: Observable.of({
+                                    get: (key: string) => {
+                                        switch (key) {
+                                            case 'lectureId':
+                                                return 1;
+                                        }
+                                    },
+                                }),
+                                parent: {
+                                    paramMap: Observable.of({
+                                        get: (key: string) => {
+                                            switch (key) {
+                                                case 'courseId':
+                                                    return 1;
+                                            }
+                                        },
+                                    }),
+                                },
                             },
-                        }),
+                        },
                     },
                 },
             ],

--- a/src/test/javascript/spec/component/lecture-unit/lecture-unit-management.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/lecture-unit-management.component.spec.ts
@@ -15,7 +15,7 @@ import { VideoUnitComponent } from 'app/overview/course-lectures/video-unit/vide
 import { TextUnitComponent } from 'app/overview/course-lectures/text-unit/text-unit.component';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MockRouter } from '../../helpers/mocks/mock-router';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import { ActivatedRoute, Params, Router, RouterOutlet } from '@angular/router';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { LectureService } from 'app/lecture/lecture.service';
 import { JhiAlertService } from 'ng-jhipster';
@@ -87,6 +87,7 @@ describe('LectureUnitManagementComponent', () => {
                 MockComponent(AlertComponent),
                 MockDirective(DeleteButtonDirective),
                 MockDirective(HasAnyAuthorityDirective),
+                MockDirective(RouterOutlet),
             ],
             providers: [
                 MockProvider(LectureUnitService),
@@ -96,12 +97,15 @@ describe('LectureUnitManagementComponent', () => {
                 {
                     provide: ActivatedRoute,
                     useValue: {
-                        params: {
-                            subscribe: (fn: (value: Params) => void) =>
-                                fn({
-                                    lectureId: 1,
-                                }),
+                        parent: {
+                            params: {
+                                subscribe: (fn: (value: Params) => void) =>
+                                    fn({
+                                        lectureId: 1,
+                                    }),
+                            },
                         },
+                        children: [],
                     },
                 },
             ],

--- a/src/test/javascript/spec/component/lecture-unit/text-unit/create-text-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/text-unit/create-text-unit.component.spec.ts
@@ -46,14 +46,28 @@ describe('CreateTextUnitComponent', () => {
                 {
                     provide: ActivatedRoute,
                     useValue: {
-                        paramMap: Observable.of({
-                            get: () => {
-                                return {
-                                    lectureId: 1,
-                                    courseId: 1,
-                                };
+                        parent: {
+                            parent: {
+                                paramMap: Observable.of({
+                                    get: (key: string) => {
+                                        switch (key) {
+                                            case 'lectureId':
+                                                return 1;
+                                        }
+                                    },
+                                }),
+                                parent: {
+                                    paramMap: Observable.of({
+                                        get: (key: string) => {
+                                            switch (key) {
+                                                case 'courseId':
+                                                    return 1;
+                                            }
+                                        },
+                                    }),
+                                },
                             },
-                        }),
+                        },
                     },
                 },
             ],

--- a/src/test/javascript/spec/component/lecture-unit/text-unit/edit-text-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/text-unit/edit-text-unit.component.spec.ts
@@ -50,12 +50,18 @@ describe('EditTextUnitComponent', () => {
                     useValue: {
                         paramMap: Observable.of({
                             get: () => {
-                                return {
-                                    textUnitId: 1,
-                                    lectureId: 1,
-                                };
+                                return { textUnitId: 1 };
                             },
                         }),
+                        parent: {
+                            parent: {
+                                paramMap: Observable.of({
+                                    get: () => {
+                                        return { lectureId: 1 };
+                                    },
+                                }),
+                            },
+                        },
                     },
                 },
             ],

--- a/src/test/javascript/spec/component/lecture-unit/video-unit/create-video-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/video-unit/create-video-unit.component.spec.ts
@@ -47,16 +47,28 @@ describe('CreateVideoUnitComponent', () => {
                 {
                     provide: ActivatedRoute,
                     useValue: {
-                        paramMap: Observable.of({
-                            get: (key: string) => {
-                                switch (key) {
-                                    case 'courseId':
-                                        return 1;
-                                    case 'lectureId':
-                                        return 1;
-                                }
+                        parent: {
+                            parent: {
+                                paramMap: Observable.of({
+                                    get: (key: string) => {
+                                        switch (key) {
+                                            case 'lectureId':
+                                                return 1;
+                                        }
+                                    },
+                                }),
+                                parent: {
+                                    paramMap: Observable.of({
+                                        get: (key: string) => {
+                                            switch (key) {
+                                                case 'courseId':
+                                                    return 1;
+                                            }
+                                        },
+                                    }),
+                                },
                             },
-                        }),
+                        },
                     },
                 },
             ],

--- a/src/test/javascript/spec/component/lecture-unit/video-unit/edit-video-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/video-unit/edit-video-unit.component.spec.ts
@@ -54,11 +54,21 @@ describe('EditVideoUnitComponent', () => {
                                 switch (key) {
                                     case 'videoUnitId':
                                         return 1;
-                                    case 'lectureId':
-                                        return 1;
                                 }
                             },
                         }),
+                        parent: {
+                            parent: {
+                                paramMap: Observable.of({
+                                    get: (key: string) => {
+                                        switch (key) {
+                                            case 'lectureId':
+                                                return 1;
+                                        }
+                                    },
+                                }),
+                            },
+                        },
                     },
                 },
             ],

--- a/src/test/javascript/spec/component/lecture/lecture-attachments.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture/lecture-attachments.component.spec.ts
@@ -85,11 +85,13 @@ describe('LectureAttachmentsComponent', () => {
                 {
                     provide: ActivatedRoute,
                     useValue: {
-                        data: {
-                            subscribe: (fn: (value: any) => void) =>
-                                fn({
-                                    lecture,
-                                }),
+                        parent: {
+                            data: {
+                                subscribe: (fn: (value: any) => void) =>
+                                    fn({
+                                        lecture,
+                                    }),
+                            },
                         },
                     },
                 },


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [ ] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Follow-up to the last breadcrumbs PR. Also fixes some issues @jpbernius noted on Slack.

### Description

Resolves several TODOs/workaround and makes the lecture unit routes use child routes, which allows us to reuse courses, lectures, etc. fetched by parent components in future PRs. (If we want to do that.)

### Steps for Testing

1. Navigate to Course Administration
3. Test that everything accessible after clicking "Lectures" on a course works as intended and displays correct breadcrumbs

### Screenshots

TODO (Can't deploy on test server atm.)
