### PR TITLE
[Bugfix] Fix issue with labels for zero point exercises with bonus

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.html
@@ -20,10 +20,10 @@
                     {{ calculateAchievedPoints(exercise) }}
                 </td>
                 <td>
-                    <span *ngIf="exercise.maxScore">{{ exercise.maxScore }}</span>
+                    <span *ngIf="exercise.maxScore != undefined">{{ exercise.maxScore }}</span>
                 </td>
                 <td>
-                    <span *ngIf="exercise.bonusPoints">{{ exercise.bonusPoints }}</span>
+                    <span *ngIf="exercise.bonusPoints != undefined">{{ exercise.bonusPoints }}</span>
                 </td>
             </tr>
             <tr>

--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
@@ -64,7 +64,7 @@
                     </h5>
                 </div>
             </div>
-            <div class="row" *ngIf="exercise.maxScore">
+            <div class="row" *ngIf="exercise.maxScore != undefined">
                 <div class="col-6">
                     <h5>{{ 'artemisApp.courseOverview.exerciseDetails.points' | translate }}</h5>
                 </div>

--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.html
@@ -18,7 +18,7 @@
         </div>
         <div class="col-12 col-sm-auto flex-sm-shrink-0 col-lg-4 mt-4 mt-lg-0 d-flex flex-column justify-content-center align-items-start">
             <table class="exercise-details-table">
-                <tr *ngIf="exercise.maxScore">
+                <tr *ngIf="exercise.maxScore != undefined">
                     <td>
                         <h6>{{ 'artemisApp.courseOverview.exerciseDetails.points' | translate }}</h6>
                     </td>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Follow-up of #2539, issue with wrong point labels.
### Description
<!-- Describe your changes in detail -->
- added `!= undefined`
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create Exercise with 0 points and with e.g. 10 bonus points
4. Check that for the exercise detail view and exercise participation view the points are displayed correctly (e.g 0 (Bonus: 10) -> see screenshots below)
Exam exercises:
1. Create exam with same exercise setup as above (you can also import them) and also with 0 points and 0 bonus points
2. Participate and set the result release date of the exam 
3. Check Summary table that 0 points and 0 bonus points are displayed with value 0 (see screenshot below)

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Nothing changed.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
exercise detail view:
<img width="1657" alt="image" src="https://user-images.githubusercontent.com/41108487/102687249-f9447580-41ed-11eb-93cd-2d8c1c43373b.png">

exam summary view:
<img width="1309" alt="image" src="https://user-images.githubusercontent.com/41108487/102687265-12e5bd00-41ee-11eb-817e-07721f5f5711.png">

exercise participation view:
<img width="1662" alt="image" src="https://user-images.githubusercontent.com/41108487/102687278-33157c00-41ee-11eb-98bc-68d5abaee8b8.png">