### PR TITLE
Restrict the html students can use when asking questions

### DIFF
--- a/src/main/webapp/app/overview/student-questions/student-question-answer/student-question-answer.component.html
+++ b/src/main/webapp/app/overview/student-questions/student-question-answer/student-question-answer.component.html
@@ -104,7 +104,7 @@
             <div class="row">
                 <div
                     class="col mt-1 answer-text markdown-preview"
-                    [innerHTML]="studentQuestionAnswer.answerText ? (studentQuestionAnswer.answerText | htmlForMarkdown) : ''"
+                    [innerHTML]="studentQuestionAnswer.answerText ? (studentQuestionAnswer.answerText | htmlForMarkdown: []:allowedHtmlTags:allowedHtmlAttributes) : ''"
                     [ngbTooltip]="studentQuestionAnswer.tutorApproved ? ('artemisApp.courseOverview.exerciseDetails.faq.approvedLabel' | translate) : ''"
                 ></div>
             </div>

--- a/src/main/webapp/app/overview/student-questions/student-question-answer/student-question-answer.component.ts
+++ b/src/main/webapp/app/overview/student-questions/student-question-answer/student-question-answer.component.ts
@@ -31,6 +31,10 @@ export class StudentQuestionAnswerComponent implements OnInit {
     EditorMode = EditorMode;
     courseId: number;
 
+    // Only allow certain html tags and no attributes
+    allowedHtmlTags: string[] = ['b', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup', 'p'];
+    allowedHtmlAttributes: string[] = [];
+
     constructor(private studentQuestionAnswerService: StudentQuestionAnswerService, private route: ActivatedRoute) {}
 
     /**

--- a/src/main/webapp/app/overview/student-questions/student-question-answer/student-question-answer.component.ts
+++ b/src/main/webapp/app/overview/student-questions/student-question-answer/student-question-answer.component.ts
@@ -32,8 +32,8 @@ export class StudentQuestionAnswerComponent implements OnInit {
     courseId: number;
 
     // Only allow certain html tags and no attributes
-    allowedHtmlTags: string[] = ['b', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup', 'p'];
-    allowedHtmlAttributes: string[] = [];
+    allowedHtmlTags: string[] = ['a', 'b', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup', 'p'];
+    allowedHtmlAttributes: string[] = ['href'];
 
     constructor(private studentQuestionAnswerService: StudentQuestionAnswerService, private route: ActivatedRoute) {}
 

--- a/src/main/webapp/app/overview/student-questions/student-question/student-question.component.html
+++ b/src/main/webapp/app/overview/student-questions/student-question/student-question.component.html
@@ -28,7 +28,10 @@
     </div>
     <div class="row">
         <jhi-student-votes [questionId]="studentQuestion.id" [votes]="studentQuestion.votes" (interactVotes)="interactVotes($event)"></jhi-student-votes>
-        <div class="col question-text markdown-preview" [innerHTML]="studentQuestion.questionText ? (studentQuestion.questionText | htmlForMarkdown) : ''"></div>
+        <div
+            class="col question-text markdown-preview"
+            [innerHTML]="studentQuestion.questionText ? (studentQuestion.questionText | htmlForMarkdown: []:allowedHtmlTags) : ''"
+        ></div>
     </div>
     <div class="row pl-2 mb-2">
         <span class="text-black-50 question-subtitle">{{ studentQuestion.author!.name }} - {{ studentQuestion.creationDate | artemisDate: 'short' }}</span>

--- a/src/main/webapp/app/overview/student-questions/student-question/student-question.component.html
+++ b/src/main/webapp/app/overview/student-questions/student-question/student-question.component.html
@@ -30,7 +30,7 @@
         <jhi-student-votes [questionId]="studentQuestion.id" [votes]="studentQuestion.votes" (interactVotes)="interactVotes($event)"></jhi-student-votes>
         <div
             class="col question-text markdown-preview"
-            [innerHTML]="studentQuestion.questionText ? (studentQuestion.questionText | htmlForMarkdown: []:allowedHtmlTags) : ''"
+            [innerHTML]="studentQuestion.questionText ? (studentQuestion.questionText | htmlForMarkdown: []:allowedHtmlTags:allowedHtmlAttributes) : ''"
         ></div>
     </div>
     <div class="row pl-2 mb-2">

--- a/src/main/webapp/app/overview/student-questions/student-question/student-question.component.ts
+++ b/src/main/webapp/app/overview/student-questions/student-question/student-question.component.ts
@@ -31,6 +31,7 @@ export class StudentQuestionComponent implements OnInit {
     isEditMode: boolean;
     EditorMode = EditorMode;
     courseId: number;
+    allowedHtmlTags: string[] = ['b', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup'];
 
     constructor(private studentQuestionService: StudentQuestionService, private route: ActivatedRoute) {}
 

--- a/src/main/webapp/app/overview/student-questions/student-question/student-question.component.ts
+++ b/src/main/webapp/app/overview/student-questions/student-question/student-question.component.ts
@@ -33,8 +33,8 @@ export class StudentQuestionComponent implements OnInit {
     courseId: number;
 
     // Only allow certain html tags and no attributes
-    allowedHtmlTags: string[] = ['b', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup', 'p'];
-    allowedHtmlAttributes: string[] = [];
+    allowedHtmlTags: string[] = ['a', 'b', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup', 'p'];
+    allowedHtmlAttributes: string[] = ['href'];
 
     constructor(private studentQuestionService: StudentQuestionService, private route: ActivatedRoute) {}
 

--- a/src/main/webapp/app/overview/student-questions/student-question/student-question.component.ts
+++ b/src/main/webapp/app/overview/student-questions/student-question/student-question.component.ts
@@ -31,7 +31,10 @@ export class StudentQuestionComponent implements OnInit {
     isEditMode: boolean;
     EditorMode = EditorMode;
     courseId: number;
+
+    // Only allow certain html tags and no attributes
     allowedHtmlTags: string[] = ['b', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup'];
+    allowedHtmlAttributes: string[] = [];
 
     constructor(private studentQuestionService: StudentQuestionService, private route: ActivatedRoute) {}
 

--- a/src/main/webapp/app/overview/student-questions/student-question/student-question.component.ts
+++ b/src/main/webapp/app/overview/student-questions/student-question/student-question.component.ts
@@ -33,7 +33,7 @@ export class StudentQuestionComponent implements OnInit {
     courseId: number;
 
     // Only allow certain html tags and no attributes
-    allowedHtmlTags: string[] = ['b', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup'];
+    allowedHtmlTags: string[] = ['b', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup', 'p'];
     allowedHtmlAttributes: string[] = [];
 
     constructor(private studentQuestionService: StudentQuestionService, private route: ActivatedRoute) {}

--- a/src/main/webapp/app/overview/student-questions/student-question/student-question.service.ts
+++ b/src/main/webapp/app/overview/student-questions/student-question/student-question.service.ts
@@ -55,30 +55,6 @@ export class StudentQuestionService {
     }
 
     /**
-     * find all questions for id of exercise
-     * @param {number} courseId
-     * @param {number} exerciseId
-     * @return {Observable<EntityArrayResponseType>}
-     */
-    findQuestionsForExercise(courseId: number, exerciseId: number): Observable<EntityArrayResponseType> {
-        return this.http
-            .get<StudentQuestion[]>(`${this.resourceUrl}${courseId}/exercises/${exerciseId}/student-questions`, { observe: 'response' })
-            .pipe(map((res: EntityArrayResponseType) => this.convertDateArrayFromServer(res)));
-    }
-
-    /**
-     * find all questions for id of lecture
-     * @param {number} courseId
-     * @param {number} lectureId
-     * @return {Observable<EntityArrayResponseType>}
-     */
-    findQuestionsForLecture(courseId: number, lectureId: number): Observable<EntityArrayResponseType> {
-        return this.http
-            .get<StudentQuestion[]>(`${this.resourceUrl}${courseId}/lectures/${lectureId}/student-questions`, { observe: 'response' })
-            .pipe(map((res: EntityArrayResponseType) => this.convertDateArrayFromServer(res)));
-    }
-
-    /**
      * find all questions for id of course
      * @param {number} courseId
      * @return {Observable<EntityArrayResponseType>}

--- a/src/main/webapp/app/shared/markdown.service.ts
+++ b/src/main/webapp/app/shared/markdown.service.ts
@@ -93,13 +93,19 @@ export class ArtemisMarkdownService {
      * @param {string} markdownText the original markdown text
      * @param {showdown.ShowdownExtension[]} extensions to use for markdown parsing
      * @param {string[]} allowedHtmlTags to allow during sanitization
+     * @param {string[]} allowedHtmlAttributes to allow during sanitization
      * @returns {string} the resulting html as a SafeHtml object that can be inserted into the angular template
      */
-    safeHtmlForMarkdown(markdownText?: string, extensions: showdown.ShowdownExtension[] = [], allowedHtmlTags: string[] = []): SafeHtml {
+    safeHtmlForMarkdown(
+        markdownText?: string,
+        extensions: showdown.ShowdownExtension[] = [],
+        allowedHtmlTags: string[] | undefined = undefined,
+        allowedHtmlAttributes: string[] | undefined = undefined,
+    ): SafeHtml {
         if (!markdownText || markdownText === '') {
             return '';
         }
-        const convertedString = this.htmlForMarkdown(markdownText, [...extensions, ...addCSSClass], allowedHtmlTags);
+        const convertedString = this.htmlForMarkdown(markdownText, [...extensions, ...addCSSClass], allowedHtmlTags, allowedHtmlAttributes);
         return this.sanitizer.bypassSecurityTrustHtml(convertedString);
     }
 
@@ -110,9 +116,15 @@ export class ArtemisMarkdownService {
      * @param {string} markdownText the original markdown text
      * @param {showdown.ShowdownExtension[]} extensions to use for markdown parsing
      * @param {string[]} allowedHtmlTags to allow during sanitization
+     * @param {string[]} allowedHtmlAttributes to allow during sanitization
      * @returns {string} the resulting html as a SafeHtml object that can be inserted into the angular template
      */
-    htmlForMarkdown(markdownText?: string, extensions: showdown.ShowdownExtension[] = [], allowedHtmlTags: string[] = []): string {
+    htmlForMarkdown(
+        markdownText?: string,
+        extensions: showdown.ShowdownExtension[] = [],
+        allowedHtmlTags: string[] | undefined = undefined,
+        allowedHtmlAttributes: string[] | undefined = undefined,
+    ): string {
         if (!markdownText || markdownText === '') {
             return '';
         }
@@ -128,10 +140,14 @@ export class ArtemisMarkdownService {
             extensions: [...extensions, showdownKatex(), ...addCSSClass],
         });
         const html = converter.makeHtml(markdownText);
-        if (allowedHtmlTags.length === 0) {
-            return DOMPurify.sanitize(html);
+        const purifyParameters = {};
+        if (allowedHtmlTags) {
+            purifyParameters['ALLOWED_TAGS'] = allowedHtmlTags;
         }
-        return DOMPurify.sanitize(html, { ALLOWED_TAGS: allowedHtmlTags });
+        if (allowedHtmlAttributes) {
+            purifyParameters['ALLOWED_ATTR'] = allowedHtmlAttributes;
+        }
+        return DOMPurify.sanitize(html, purifyParameters);
     }
 
     /**

--- a/src/main/webapp/app/shared/markdown.service.ts
+++ b/src/main/webapp/app/shared/markdown.service.ts
@@ -92,13 +92,14 @@ export class ArtemisMarkdownService {
      *
      * @param {string} markdownText the original markdown text
      * @param {showdown.ShowdownExtension[]} extensions to use for markdown parsing
+     * @param {string[]} allowedHtmlTags to allow during sanitization
      * @returns {string} the resulting html as a SafeHtml object that can be inserted into the angular template
      */
-    safeHtmlForMarkdown(markdownText?: string, extensions: showdown.ShowdownExtension[] = []): SafeHtml {
+    safeHtmlForMarkdown(markdownText?: string, extensions: showdown.ShowdownExtension[] = [], allowedHtmlTags: string[] = []): SafeHtml {
         if (!markdownText || markdownText === '') {
             return '';
         }
-        const convertedString = this.htmlForMarkdown(markdownText, [...extensions, ...addCSSClass]);
+        const convertedString = this.htmlForMarkdown(markdownText, [...extensions, ...addCSSClass], allowedHtmlTags);
         return this.sanitizer.bypassSecurityTrustHtml(convertedString);
     }
 
@@ -108,9 +109,10 @@ export class ArtemisMarkdownService {
      *
      * @param {string} markdownText the original markdown text
      * @param {showdown.ShowdownExtension[]} extensions to use for markdown parsing
+     * @param {string[]} allowedHtmlTags to allow during sanitization
      * @returns {string} the resulting html as a SafeHtml object that can be inserted into the angular template
      */
-    htmlForMarkdown(markdownText?: string, extensions: showdown.ShowdownExtension[] = []): string {
+    htmlForMarkdown(markdownText?: string, extensions: showdown.ShowdownExtension[] = [], allowedHtmlTags: string[] = []): string {
         if (!markdownText || markdownText === '') {
             return '';
         }
@@ -126,7 +128,10 @@ export class ArtemisMarkdownService {
             extensions: [...extensions, showdownKatex(), ...addCSSClass],
         });
         const html = converter.makeHtml(markdownText);
-        return DOMPurify.sanitize(html);
+        if (allowedHtmlTags.length === 0) {
+            return DOMPurify.sanitize(html);
+        }
+        return DOMPurify.sanitize(html, { ALLOWED_TAGS: allowedHtmlTags });
     }
 
     /**

--- a/src/main/webapp/app/shared/pipes/html-for-markdown.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/html-for-markdown.pipe.ts
@@ -13,9 +13,10 @@ export class HtmlForMarkdownPipe implements PipeTransform {
      * Converts markdown into html, sanitizes it and then declares it as safe to bypass further security.
      * @param {string} markdown the original markdown text
      * @param {ShowdownExtension[]} extensions to use for markdown parsing
+     * @param {string[]} allowedHtmlTags to allow during sanitization
      * @returns {string} the resulting html as a SafeHtml object that can be inserted into the angular template
      */
-    transform(markdown?: string, extensions: ShowdownExtension[] = []): SafeHtml {
-        return this.markdownService.safeHtmlForMarkdown(markdown, extensions);
+    transform(markdown?: string, extensions: ShowdownExtension[] = [], allowedHtmlTags: string[] = []): SafeHtml {
+        return this.markdownService.safeHtmlForMarkdown(markdown, extensions, allowedHtmlTags);
     }
 }

--- a/src/main/webapp/app/shared/pipes/html-for-markdown.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/html-for-markdown.pipe.ts
@@ -14,9 +14,15 @@ export class HtmlForMarkdownPipe implements PipeTransform {
      * @param {string} markdown the original markdown text
      * @param {ShowdownExtension[]} extensions to use for markdown parsing
      * @param {string[]} allowedHtmlTags to allow during sanitization
+     * @param {string[]} allowedHtmlAttributes to allow during sanitization
      * @returns {string} the resulting html as a SafeHtml object that can be inserted into the angular template
      */
-    transform(markdown?: string, extensions: ShowdownExtension[] = [], allowedHtmlTags: string[] = []): SafeHtml {
-        return this.markdownService.safeHtmlForMarkdown(markdown, extensions, allowedHtmlTags);
+    transform(
+        markdown?: string,
+        extensions: ShowdownExtension[] = [],
+        allowedHtmlTags: string[] | undefined = undefined,
+        allowedHtmlAttributes: string[] | undefined = undefined,
+    ): SafeHtml {
+        return this.markdownService.safeHtmlForMarkdown(markdown, extensions, allowedHtmlTags, allowedHtmlAttributes);
     }
 }

--- a/src/test/javascript/spec/service/markdown.service.spec.ts
+++ b/src/test/javascript/spec/service/markdown.service.spec.ts
@@ -3,11 +3,19 @@ import * as sinonChai from 'sinon-chai';
 import { ArtemisMarkdownService } from 'app/shared/markdown.service';
 import { MultipleChoiceQuestion } from 'app/entities/quiz/multiple-choice-question.model';
 import { ShortAnswerQuestion } from 'app/entities/quiz/short-answer-question.model';
+import { getTestBed } from '@angular/core/testing';
 
 chai.use(sinonChai);
 const expect = chai.expect;
 
 describe('Markdown Service', () => {
+    let markdownService: ArtemisMarkdownService;
+
+    beforeEach(() => {
+        const injector = getTestBed();
+        markdownService = injector.get(ArtemisMarkdownService);
+    });
+
     const hintText = 'Add an explanation here (only visible in feedback after quiz has ended)';
     const markdownHint = '[hint] ' + hintText;
     const explanationText = 'Add an explanation here (only visible in feedback after quiz has ended)';
@@ -71,5 +79,45 @@ describe('Markdown Service', () => {
         expect(markdownElement.text).to.equal(markdownString);
         expect(markdownElement.hint).to.equal(hintText);
         expect(markdownElement.explanation).to.equal(explanationText);
+    });
+
+    it('should return sanitized markdown for undefined input', () => {
+        const emptyMarkdown = undefined;
+        const safeMarkdown = markdownService.htmlForMarkdown(emptyMarkdown);
+        expect(safeMarkdown).to.equal('');
+    });
+
+    it('should return sanitized markdown for html input', () => {
+        const markdownString = '<b style="background-color: blue">Will this render blue?</b>';
+
+        // Don't disable any html tags or tags
+        const safeMarkdownWithTagsAndAttributes = markdownService.htmlForMarkdown(markdownString);
+        expect(safeMarkdownWithTagsAndAttributes).to.equal('<p><b style="background-color: blue">Will this render blue?</b></p>');
+
+        // Don't disable any html tags but disallow attributes
+        const safeMarkdownWithTags = markdownService.htmlForMarkdown(markdownString, [], undefined, []);
+        expect(safeMarkdownWithTags).to.equal('<p><b>Will this render blue?</b></p>');
+
+        // Don't disable any html tags and allow one specific attribute
+        const safeMarkdownWithTagsAndAttributeA = markdownService.htmlForMarkdown(markdownString, [], undefined, ['unused']);
+        expect(safeMarkdownWithTagsAndAttributeA).to.equal('<p><b>Will this render blue?</b></p>');
+        const safeMarkdownWithTagsAndAttributeB = markdownService.htmlForMarkdown(markdownString, [], undefined, ['style']);
+        expect(safeMarkdownWithTagsAndAttributeB).to.equal('<p><b style="background-color: blue">Will this render blue?</b></p>');
+
+        // Don't disable any html attributes but disallow tags (attributes of disallowed tags are gone too)
+        const safeMarkdownWithAttributes = markdownService.htmlForMarkdown(markdownString, [], []);
+        expect(safeMarkdownWithAttributes).to.equal('Will this render blue?');
+
+        // Only allow one specific html tag but disallow attributes
+        const safeMarkdownWithSingleTagAndNoAttributes = markdownService.htmlForMarkdown(markdownString, [], ['b'], []);
+        expect(safeMarkdownWithSingleTagAndNoAttributes).to.equal('<b>Will this render blue?</b>');
+
+        // Only allow one specific html tag and allow all attributes
+        const safeMarkdownWithSingleTagAndAttributes = markdownService.htmlForMarkdown(markdownString, [], ['b']);
+        expect(safeMarkdownWithSingleTagAndAttributes).to.equal('<b style="background-color: blue">Will this render blue?</b>');
+
+        // Disable all html tags or attributes
+        const safeMarkdownWithoutExtras = markdownService.htmlForMarkdown(markdownString, [], [], []);
+        expect(safeMarkdownWithoutExtras).to.equal('Will this render blue?');
     });
 });


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context

Closes #2585.

### Description

Restricts the html tags students can use to what is listed at https://www.w3schools.com/html/html_formatting.asp (plus `a`). No attributes except `href` are allowed. This only changes the Student Questions and Answers, Problem Statements etc. are not affected.

### Steps for Testing

1. Write a question or answer with malicious html
2. The html should be sanitized before display

Examples:
- `<div style="-moz-transform: scaleX(-1); -webkit-transform: scaleX(-1); -o-transform: scaleX(-1); transform: scaleX(-1);">Test</div>` should not work. (Displayed as normal text.)  
- `<b style="background-color: blue">Test</b>` should not work. (Displayed as bold text with the default background color.)  
- `<i>Test</i>` should work. (Displayed as italic text.)  
- `<a href="https://duckduckgo.com">Test</a>` should work. (Displayed as link.)  

You can use the `Preview` of your question, which is not sanitized (since it is only your input), to see how things *would* look if they weren't properly sanitized.

Not sanitized preview:
![grafik](https://user-images.githubusercontent.com/72132281/102911650-9fa5aa80-447c-11eb-9fb7-c628a13e6e30.png)

Display to you and other students after saving:
![grafik](https://user-images.githubusercontent.com/72132281/102915450-2610bb00-4482-11eb-9fd6-44c8d60101fd.png)


