### PR TITLE
Add scheduling to docs for gitlab setup

### DIFF
--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -66,7 +66,7 @@ In addition, you have to start Artemis with the profiles ``gitlab`` and
 
 ::
 
-   --spring.profiles.active=dev,jenkins,gitlab,artemis
+   --spring.profiles.active=dev,jenkins,gitlab,artemis,scheduling
 
 Please read :doc:`../setup` for more details.
 


### PR DESCRIPTION
Without scheduling certain features don't work