### PR TITLE
Bugfix: Fix 'Assessments locked by you' - Views

### DIFF
--- a/src/main/webapp/app/course/manage/course-management.service.ts
+++ b/src/main/webapp/app/course/manage/course-management.service.ts
@@ -19,7 +19,7 @@ import { StudentParticipation } from 'app/entities/participation/student-partici
 import { AccountService } from 'app/core/auth/account.service';
 import { ParticipationWebsocketService } from 'app/overview/participation-websocket.service';
 import { createRequestOption } from 'app/shared/util/request-util';
-import { getLatestSubmissionResult, Submission } from 'app/entities/submission.model';
+import { getLatestSubmissionResult, setLatestSubmissionResult, Submission } from 'app/entities/submission.model';
 import { SubjectObservablePair } from 'app/utils/rxjs.utils';
 import { participationStatus } from 'app/exercises/shared/exercise/exercise-utils';
 
@@ -261,10 +261,14 @@ export class CourseManagementService {
                 tap((res) =>
                     res.body!.forEach((submission: Submission) => {
                         // reconnect some associations
-                        if (getLatestSubmissionResult(submission)) {
-                            getLatestSubmissionResult(submission)!.submission = submission;
-                            getLatestSubmissionResult(submission)!.participation = submission.participation;
-                            submission.participation!.results = [getLatestSubmissionResult(submission)!];
+                        if (submission) {
+                            const latestResult = getLatestSubmissionResult(submission);
+                            setLatestSubmissionResult(submission, latestResult);
+                            if (latestResult) {
+                                latestResult.submission = submission;
+                                latestResult.participation = submission.participation;
+                                submission.participation!.results = [latestResult];
+                            }
                         }
                     }),
                 ),


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, when going to a Dashboard -> 'Assessments locked by you' you are not able to access the assessments, because the view is not loaded correctly. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration -> a Dashboard -> 'Assessments locked by you'
3. Check if you can open your locked assessments
