### PR TITLE
Workaround for null pointer exception in resume exercise on Jenkins setup

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Team.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Team.java
@@ -197,6 +197,12 @@ public class Team extends AbstractAuditingEntity implements Participant {
     }
 
     @Override
+    @JsonIgnore
+    public Set<User> getParticipants() {
+        return getStudents();
+    }
+
+    @Override
     public String toString() {
         return "Team{" + "id=" + getId() + ", name='" + getName() + "'" + ", shortName='" + getShortName() + "'" + ", image='" + getImage() + "'" + "}";
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/User.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/User.java
@@ -276,6 +276,12 @@ public class User extends AbstractAuditingEntity implements Participant {
     }
 
     @Override
+    @JsonIgnore
+    public Set<User> getParticipants() {
+        return Set.of(this);
+    }
+
+    @Override
     public String toString() {
         return "User{" + "login='" + login + '\'' + ", firstName='" + firstName + '\'' + ", lastName='" + lastName + '\'' + ", email='" + email + '\'' + ", imageUrl='" + imageUrl
                 + '\'' + ", activated='" + activated + '\'' + ", langKey='" + langKey + '\'' + ", activationKey='" + activationKey + '\'' + "}";

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/Participant.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/Participant.java
@@ -1,5 +1,10 @@
 package de.tum.in.www1.artemis.domain.participation;
 
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import de.tum.in.www1.artemis.domain.User;
+
 public interface Participant {
 
     Long getId();
@@ -8,4 +13,10 @@ public interface Participant {
 
     String getParticipantIdentifier();
 
+    /**
+     * convenience method
+     * @return either the user itself in a singleton set or all participants of a team
+     */
+    @JsonIgnore
+    Set<User> getParticipants();
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -30,7 +30,10 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
     List<ProgrammingExercise> findByCourseIdWithLatestResultForTemplateSolutionParticipations(@Param("courseId") Long courseId);
 
     @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation", "teamAssignmentConfig", "categories" })
-    Optional<ProgrammingExercise> findWithTemplateParticipationAndSolutionParticipationById(Long exerciseId);
+    Optional<ProgrammingExercise> findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(Long exerciseId);
+
+    @EntityGraph(type = LOAD, attributePaths = { "templateParticipation", "solutionParticipation" })
+    Optional<ProgrammingExercise> findWithTemplateAndSolutionParticipationById(Long exerciseId);
 
     @EntityGraph(type = LOAD, attributePaths = "testCases")
     Optional<ProgrammingExercise> findWithTestCasesById(Long exerciseId);
@@ -40,7 +43,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
             + "left join fetch tp.results as tpr left join fetch sp.results as spr left join fetch tpr.feedbacks left join fetch spr.feedbacks "
             + "left join fetch tpr.submission left join fetch spr.submission " + "where pe.id = :#{#exerciseId} and (tpr.id = (select max(id) from tp.results) or tpr.id = null) "
             + "and (spr.id = (select max(id) from sp.results) or spr.id = null)")
-    Optional<ProgrammingExercise> findWithTemplateAndSolutionParticipationById(@Param("exerciseId") Long exerciseId);
+    Optional<ProgrammingExercise> findWithTemplateAndSolutionParticipationLatestResultById(@Param("exerciseId") Long exerciseId);
 
     @Query("select distinct pe from ProgrammingExercise as pe left join fetch pe.studentParticipations")
     List<ProgrammingExercise> findAllWithEagerParticipations();

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureService.java
@@ -5,9 +5,8 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.transaction.Transactional;
-
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -216,23 +216,8 @@ public class ParticipationService {
             participation.setExercise(exercise);
         }
 
-        // specific to programming exercises
         if (exercise instanceof ProgrammingExercise) {
-            ProgrammingExerciseStudentParticipation programmingExerciseStudentParticipation = (ProgrammingExerciseStudentParticipation) participation;
-            programmingExerciseStudentParticipation = forkRepository(programmingExerciseStudentParticipation);
-            programmingExerciseStudentParticipation = configureRepository((ProgrammingExercise) exercise, programmingExerciseStudentParticipation);
-            programmingExerciseStudentParticipation = copyBuildPlan(programmingExerciseStudentParticipation);
-            // Restore programming exercise that got removed due to saving the programmingExerciseStudentParticipation
-            programmingExerciseStudentParticipation.setProgrammingExercise((ProgrammingExercise) exercise);
-            programmingExerciseStudentParticipation = configureBuildPlan(programmingExerciseStudentParticipation);
-            // we might need to perform an empty commit (depends on the CI system), we perform this here, because it should not trigger a new programming submission
-            programmingExerciseStudentParticipation = performEmptyCommit(programmingExerciseStudentParticipation);
-            // Note: we configure the repository webhook last, so that the potential empty commit does not trigger a new programming submission (see empty-commit-necessary)
-            programmingExerciseStudentParticipation = configureRepositoryWebHook(programmingExerciseStudentParticipation);
-            programmingExerciseStudentParticipation.setInitializationState(INITIALIZED);
-            programmingExerciseStudentParticipation.setInitializationDate(ZonedDateTime.now());
-            // after saving, we need to make sure the object that is used after the if statement is the right one
-            participation = programmingExerciseStudentParticipation;
+            participation = startProgrammingExercise((ProgrammingExercise) exercise, (ProgrammingExerciseStudentParticipation) participation);
         }
         else {// for all other exercises: QuizExercise, ModelingExercise, TextExercise, FileUploadExercise
             if (participation.getInitializationState() == null || participation.getInitializationState() == UNINITIALIZED || participation.getInitializationState() == FINISHED) {
@@ -254,6 +239,35 @@ public class ParticipationService {
             }
         }
         return save(participation);
+    }
+
+    /**
+     * Start a programming exercise participation (which does not exist yet) by creating and configuring a student git repository (step 1) and a student build plan (step 2)
+     * based on the templates in the given programming exercise
+     *
+     * @param exercise the programming exercise that the currently active user (student) wants to start
+     * @param participation inactive participation
+     * @return started participation
+     */
+    private StudentParticipation startProgrammingExercise(ProgrammingExercise exercise, ProgrammingExerciseStudentParticipation participation) {
+        // Step 1a) create the student repository (based on the template repository)
+        participation = forkRepository(participation);
+        // Step 1b) configure the student repository (e.g. access right, etc.)
+        participation = configureRepository(exercise, participation);
+        // Step 2a) create the build plan (based on the BASE build plan)
+        participation = copyBuildPlan(participation);
+        // Step 2b) configure the build plan (e.g. access right, hooks, etc.)
+        participation = configureBuildPlan(participation);
+        // Step 2c) we might need to perform an empty commit (as a workaround, depending on the CI system) here, because it should not trigger a new programming submission
+        // (when the web hook was already initialized, see below)
+        participation = performEmptyCommit(participation);
+        // Note: we configure the repository webhook last, so that the potential empty commit does not trigger a new programming submission (see empty-commit-necessary)
+        // Step 1c) configure the web hook of the student repository
+        participation = configureRepositoryWebHook(participation);
+        participation.setInitializationState(INITIALIZED);
+        participation.setInitializationDate(ZonedDateTime.now());
+        // after saving, we need to make sure the object that is used after the if statement is the right one
+        return participation;
     }
 
     /**
@@ -479,15 +493,20 @@ public class ParticipationService {
     }
 
     /**
-     * Service method to resume inactive participation (with previously deleted build plan)
+     * Resume an inactive programming exercise participation (with previously deleted build plan) by creating and configuring a student build plan (step 2)
+     * based on the template (BASE) in the corresponding programming exercise, also compare {@link #startProgrammingExercise}
      *
      * @param participation inactive participation
      * @return resumed participation
      */
-    public ProgrammingExerciseStudentParticipation resumeExercise(ProgrammingExerciseStudentParticipation participation) {
+    public ProgrammingExerciseStudentParticipation resumeProgrammingExercise(ProgrammingExerciseStudentParticipation participation) {
+        // this method assumes that the student git repository already exists (compare startProgrammingExercise) so steps 1, 2 and 5 are not necessary
+        // Step 2a) create the build plan (based on the BASE build plan)
         participation = copyBuildPlan(participation);
+        // Step 2b) configure the build plan (e.g. access right, hooks, etc.)
         participation = configureBuildPlan(participation);
-        // Note: the repository webhook already exists so we don't need to set it up again
+        // Note: the repository webhook (step 1c) already exists so we don't need to set it up again, the empty commit hook (step 2c) is also not necessary here
+        // and must be handled by the calling method in case it would be necessary
         participation.setInitializationState(INITIALIZED);
         participation = save(participation);
         if (participation.getInitializationDate() == null) {

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseExportService.java
@@ -100,7 +100,8 @@ public class ProgrammingExerciseExportService {
      */
     public File exportStudentRepositories(long programmingExerciseId, @NotNull List<ProgrammingExerciseStudentParticipation> participations,
             RepositoryExportOptionsDTO repositoryExportOptions) {
-        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId).get();
+        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId)
+                .get();
 
         if (repositoryExportOptions.isExportAllParticipants()) {
             log.info(

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseParticipationService.java
@@ -13,7 +13,6 @@ import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.BuildPlanType;
@@ -121,7 +120,6 @@ public class ProgrammingExerciseParticipationService {
      * @return the participation for the given exercise and user.
      * @throws EntityNotFoundException if there is no participation for the given exercise and user.
      */
-    @Transactional(readOnly = true)
     @NotNull
     public ProgrammingExerciseStudentParticipation findStudentParticipationByExerciseAndStudentId(Exercise exercise, String username) throws EntityNotFoundException {
         Optional<ProgrammingExerciseStudentParticipation> participation;
@@ -135,8 +133,6 @@ public class ProgrammingExerciseParticipationService {
         if (participation.isEmpty()) {
             throw new EntityNotFoundException("participation could not be found by exerciseId " + exercise.getId() + " and user " + username);
         }
-        // Make sure the template participation is not a proxy object in this case
-        Hibernate.initialize(participation.get().getProgrammingExercise().getTemplateParticipation());
         return participation.get();
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -614,7 +614,8 @@ public class ProgrammingExerciseService {
      * @throws EntityNotFoundException the programming exercise could not be found.
      */
     public ProgrammingExercise findWithTemplateParticipationAndSolutionParticipationById(Long programmingExerciseId) throws EntityNotFoundException {
-        Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId);
+        Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId);
         if (programmingExercise.isPresent()) {
             return programmingExercise.get();
         }
@@ -631,7 +632,7 @@ public class ProgrammingExerciseService {
      * @throws EntityNotFoundException the programming exercise could not be found.
      */
     public ProgrammingExercise findWithTemplateAndSolutionParticipationWithResultsById(Long programmingExerciseId) throws EntityNotFoundException {
-        Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationById(programmingExerciseId);
+        Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationLatestResultById(programmingExerciseId);
         if (programmingExercise.isPresent()) {
             return programmingExercise.get();
         }
@@ -704,7 +705,8 @@ public class ProgrammingExerciseService {
      */
     public ProgrammingExercise updateProblemStatement(Long programmingExerciseId, String problemStatement, @Nullable String notificationText)
             throws EntityNotFoundException, IllegalAccessException {
-        Optional<ProgrammingExercise> programmingExerciseOpt = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId);
+        Optional<ProgrammingExercise> programmingExerciseOpt = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId);
         if (programmingExerciseOpt.isEmpty()) {
             throw new EntityNotFoundException("Programming exercise not found with id: " + programmingExerciseId);
         }
@@ -808,7 +810,8 @@ public class ProgrammingExerciseService {
     public void delete(Long programmingExerciseId, boolean deleteBaseReposBuildPlans) {
         // TODO: This method does not accept a programming exercise to solve issues with nested Transactions.
         // It would be good to refactor the delete calls and move the validity checks down from the resources to the service methods (e.g. EntityNotFound).
-        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId).get();
+        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId)
+                .get();
         final var templateRepositoryUrlAsUrl = programmingExercise.getTemplateRepositoryUrlAsUrl();
         final var solutionRepositoryUrlAsUrl = programmingExercise.getSolutionRepositoryUrlAsUrl();
         final var testRepositoryUrlAsUrl = programmingExercise.getTestRepositoryUrlAsUrl();

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingExerciseService.java
@@ -450,7 +450,16 @@ public class ProgrammingExerciseService {
 
                     try {
                         Resource[] projectTypeTestFileResources = resourceLoaderService.getResources(projectTypeTemplatePath);
-                        fileService.copyResources(projectTypeTestFileResources, projectTypePrefix, packagePath, false);
+                        // filter non existing resources to avoid exceptions
+                        List<Resource> existingProjectTypeTestFileResources = new ArrayList<>();
+                        for (Resource resource : projectTypeTestFileResources) {
+                            if (resource.exists()) {
+                                existingProjectTypeTestFileResources.add(resource);
+                            }
+                        }
+                        if (!existingProjectTypeTestFileResources.isEmpty()) {
+                            fileService.copyResources(existingProjectTypeTestFileResources.toArray(new Resource[] {}), projectTypePrefix, packagePath, false);
+                        }
                     }
                     catch (FileNotFoundException ignored) {
                     }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -141,7 +141,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
             // as the VCS-server performs the request
             SecurityUtils.setAuthorizationObject();
 
-            participationService.resumeExercise((ProgrammingExerciseStudentParticipation) programmingExerciseParticipation);
+            participationService.resumeProgrammingExercise((ProgrammingExerciseStudentParticipation) programmingExerciseParticipation);
             // Note: in this case we do not need an empty commit: when we trigger the build manually (below), subsequent commits will work correctly
             try {
                 continuousIntegrationService.get().triggerBuild(programmingExerciseParticipation);
@@ -416,7 +416,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
                     || !programmingExerciseParticipation.getInitializationState().hasCompletedState(InitializationState.INITIALIZED))) {
 
                 // in this case, we first have to resume the exercise: this includes that we again setup the build plan properly before we trigger it
-                participationService.resumeExercise((ProgrammingExerciseStudentParticipation) programmingExerciseParticipation);
+                participationService.resumeProgrammingExercise((ProgrammingExerciseStudentParticipation) programmingExerciseParticipation);
                 // Note: in this case we do not need an empty commit: when we trigger the build manually (below), subsequent commits will work correctly
             }
             continuousIntegrationService.get().triggerBuild(programmingExerciseParticipation);

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -140,6 +140,12 @@ public class ProgrammingSubmissionService extends SubmissionService {
             // This is needed as a request using a custom query is made using the ProgrammingExerciseRepository, but the user is not authenticated
             // as the VCS-server performs the request
             SecurityUtils.setAuthorizationObject();
+
+            // Refetch the programming exercise with the template participation and assign it to programmingExerciseParticipation to make sure it is initialized (and not a proxy)
+            final var programmingExercise = programmingExerciseRepository
+                    .findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseParticipation.getProgrammingExercise().getId()).get();
+            programmingExerciseParticipation.setProgrammingExercise(programmingExercise);
+
             participationService.resumeExercise((ProgrammingExerciseStudentParticipation) programmingExerciseParticipation);
             // Note: in this case we do not need an empty commit: when we trigger the build manually (below), subsequent commits will work correctly
             try {
@@ -411,6 +417,13 @@ public class ProgrammingSubmissionService extends SubmissionService {
         try {
             if (programmingExerciseParticipation instanceof ProgrammingExerciseStudentParticipation && (programmingExerciseParticipation.getBuildPlanId() == null
                     || !programmingExerciseParticipation.getInitializationState().hasCompletedState(InitializationState.INITIALIZED))) {
+
+                // Refetch the programming exercise with the template participation and assign it to programmingExerciseParticipation to make sure it is initialized (and not a
+                // proxy)
+                final var programmingExercise = programmingExerciseRepository
+                        .findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseParticipation.getProgrammingExercise().getId()).get();
+                programmingExerciseParticipation.setProgrammingExercise(programmingExercise);
+
                 // in this case, we first have to resume the exercise: this includes that we again setup the build plan properly before we trigger it
                 participationService.resumeExercise((ProgrammingExerciseStudentParticipation) programmingExerciseParticipation);
                 // Note: in this case we do not need an empty commit: when we trigger the build manually (below), subsequent commits will work correctly

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -141,11 +141,6 @@ public class ProgrammingSubmissionService extends SubmissionService {
             // as the VCS-server performs the request
             SecurityUtils.setAuthorizationObject();
 
-            // Refetch the programming exercise with the template participation and assign it to programmingExerciseParticipation to make sure it is initialized (and not a proxy)
-            final var programmingExercise = programmingExerciseRepository
-                    .findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseParticipation.getProgrammingExercise().getId()).get();
-            programmingExerciseParticipation.setProgrammingExercise(programmingExercise);
-
             participationService.resumeExercise((ProgrammingExerciseStudentParticipation) programmingExerciseParticipation);
             // Note: in this case we do not need an empty commit: when we trigger the build manually (below), subsequent commits will work correctly
             try {
@@ -237,7 +232,8 @@ public class ProgrammingSubmissionService extends SubmissionService {
     public void triggerInstructorBuildForExercise(Long exerciseId) throws EntityNotFoundException {
         // Async can't access the authentication object. We need to do any security checks before this point.
         SecurityUtils.setAuthorizationObject();
-        Optional<ProgrammingExercise> optionalProgrammingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(exerciseId);
+        Optional<ProgrammingExercise> optionalProgrammingExercise = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(exerciseId);
         if (optionalProgrammingExercise.isEmpty()) {
             throw new EntityNotFoundException("Programming exercise with id " + exerciseId + " not found.");
         }
@@ -353,7 +349,8 @@ public class ProgrammingSubmissionService extends SubmissionService {
                 .findSolutionParticipationByProgrammingExerciseId(programmingExerciseId);
         // If no commitHash is provided, use the last commitHash for the test repository.
         if (commitHash == null) {
-            Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId);
+            Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository
+                    .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId);
             if (programmingExercise.isEmpty()) {
                 throw new EntityNotFoundException("Programming exercise with id " + programmingExerciseId + " not found.");
             }
@@ -417,12 +414,6 @@ public class ProgrammingSubmissionService extends SubmissionService {
         try {
             if (programmingExerciseParticipation instanceof ProgrammingExerciseStudentParticipation && (programmingExerciseParticipation.getBuildPlanId() == null
                     || !programmingExerciseParticipation.getInitializationState().hasCompletedState(InitializationState.INITIALIZED))) {
-
-                // Refetch the programming exercise with the template participation and assign it to programmingExerciseParticipation to make sure it is initialized (and not a
-                // proxy)
-                final var programmingExercise = programmingExerciseRepository
-                        .findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseParticipation.getProgrammingExercise().getId()).get();
-                programmingExerciseParticipation.setProgrammingExercise(programmingExercise);
 
                 // in this case, we first have to resume the exercise: this includes that we again setup the build plan properly before we trigger it
                 participationService.resumeExercise((ProgrammingExerciseStudentParticipation) programmingExerciseParticipation);
@@ -514,7 +505,8 @@ public class ProgrammingSubmissionService extends SubmissionService {
      * @throws EntityNotFoundException if the programming exercise does not exist.
      */
     public ProgrammingExercise setTestCasesChanged(Long programmingExerciseId, boolean testCasesChanged) throws EntityNotFoundException {
-        Optional<ProgrammingExercise> optionalProgrammingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId);
+        Optional<ProgrammingExercise> optionalProgrammingExercise = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId);
         if (optionalProgrammingExercise.isEmpty()) {
             throw new EntityNotFoundException("Programming exercise with id " + programmingExerciseId + " not found.");
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ProgrammingSubmissionService.java
@@ -302,6 +302,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
     public ProgrammingSubmission createSubmissionWithLastCommitHashForParticipation(ProgrammingExerciseParticipation participation, SubmissionType submissionType)
             throws IllegalStateException {
         ObjectId lastCommitHash = getLastCommitHashForParticipation(participation);
+        // TODO: we should not create a new submission here, but simply use the existing one with the last CommitHash
         return createSubmissionWithCommitHashAndSubmissionType(participation, lastCommitHash, submissionType);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketBambooUpdateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketBambooUpdateService.java
@@ -66,7 +66,7 @@ public class BitbucketBambooUpdateService implements ContinuousIntegrationUpdate
     }
 
     @Override
-    public void updatePlanRepository(String bambooProject, String buildPlanKey, String bambooRepositoryName, String bitbucketProject, String bitbucketRepository,
+    public void updatePlanRepository(String bambooProjectKey, String buildPlanKey, String bambooRepositoryName, String bitbucketProjectKey, String bitbucketRepositoryName,
             Optional<List<String>> optionalTriggeredByRepositories) {
         try {
             log.debug("Update plan repository for build plan " + buildPlanKey);
@@ -76,7 +76,7 @@ public class BitbucketBambooUpdateService implements ContinuousIntegrationUpdate
                         + " to the student repository : Could not find assignment nor Assignment repository");
             }
 
-            updateBambooPlanRepository(bambooRepository, bitbucketRepository, bitbucketProject, buildPlanKey);
+            updateBambooPlanRepository(bambooRepository, bitbucketRepositoryName, bitbucketProjectKey, buildPlanKey);
 
             // Overwrite triggers if needed, incl workaround for different repo names, triggered by is present means that the exercise (the BASE build plan) is imported from a
             // previous exercise

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
@@ -53,6 +53,8 @@ public interface ContinuousIntegrationService {
      * Configure the build plan with the given participation on the CI system. Common configurations: - update the repository in the build plan - set appropriate user permissions -
      * initialize/enable the build plan so that it works
      *
+     * **Important**: make sure that participation.programmingExercise.templateParticipation is initialized, otherwise an org.hibernate.LazyInitializationException can occur
+     *
      * @param participation contains the unique identifier for build plan on CI system and the url of user's personal repository copy
      */
     void configureBuildPlan(ProgrammingExerciseParticipation participation);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
@@ -89,7 +89,8 @@ public interface ContinuousIntegrationService {
 
     /**
      * Get the plan key of the finished build, the information of the build gets passed via the requestBody. The requestBody must match the information passed from the
-     * bamboo-server-notification-plugin, the body is described here: https://github.com/ls1intum/bamboo-server-notification-plugin
+     * (bamboo|jenkins)-server-notification-plugin, the body is described here: https://github.com/ls1intum/bamboo-server-notification-plugin or here:
+     * https://github.com/ls1intum/jenkins-server-notification-plugin
      *
      * @param requestBody The request Body received from the CI-Server.
      * @return the plan key of the build
@@ -99,7 +100,8 @@ public interface ContinuousIntegrationService {
 
     /**
      * Get the result of the finished build, the information of the build gets passed via the requestBody. The requestBody must match the information passed from the
-     * bamboo-server-notification-plugin, the body is described here: https://github.com/ls1intum/bamboo-server-notification-plugin
+     * (bamboo|jenkins)-server-notification-plugin, the body is described here: https://github.com/ls1intum/bamboo-server-notification-plugin or here:
+     * https://github.com/ls1intum/jenkins-server-notification-plugin
      *
      * @param participation The participation for which the build finished
      * @param requestBody   The request Body received from the CI-Server.
@@ -168,18 +170,18 @@ public interface ContinuousIntegrationService {
     void enablePlan(String projectKey, String planKey);
 
     /**
-     * Updates the configured repository for a given plan to the given Bamboo Server repository.
+     * Updates the configured exercise repository for a given build plan to the given repository, this is a key method in the Artemis system structure.
      *
-     * @param bambooProject         The key of the project, e.g. 'EIST16W1'.
-     * @param bambooPlan            The key of the plan, which is usually the name combined with the project, e.g. 'PROJECT-GA56HUR'.
-     * @param bambooRepositoryName  The name of the configured repository in the CI plan.
-     * @param repoProjectName       The key of the project that contains the repository.
-     * @param repoUrl               The url of the newly to be referenced repository.
-     * @param templateRepositoryUrl The url of the template repository (that should be replaced).
-     * @param triggeredBy           Optional list of repositories that should trigger the new build plan. If empty, no triggers get overwritten
+     * @param buildProjectKey                   The key of the build project, e.g. 'EIST16W1', which is normally the programming exercise project key.
+     * @param buildPlanKey                      The key of the build plan, which is usually the name combined with the project, e.g. 'EIST16W1-GA56HUR'.
+     * @param ciRepoName                        The name of the configured repository in the CI plan, normally 'assignment' (or 'test').
+     * @param repoProjectKey                    The key of the project that contains the repository, e.g. 'EIST16W1', which is normally the programming exercise project key.
+     * @param newRepoUrl                        The url of the newly to be referenced repository.
+     * @param existingRepoUrl                   The url of the existing repository (which should be replaced).
+     * @param optionalTriggeredByRepositories   Optional list of repositories that should trigger the new build plan. If empty, no triggers get overwritten.
      */
-    void updatePlanRepository(String bambooProject, String bambooPlan, String bambooRepositoryName, String repoProjectName, String repoUrl, String templateRepositoryUrl,
-            Optional<List<String>> triggeredBy);
+    void updatePlanRepository(String buildProjectKey, String buildPlanKey, String ciRepoName, String repoProjectKey, String newRepoUrl, String existingRepoUrl,
+            Optional<List<String>> optionalTriggeredByRepositories);
 
     /**
      * Gives overall roles permissions for the defined project. A role can e.g. be all logged in users

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationUpdateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationUpdateService.java
@@ -12,11 +12,11 @@ public interface ContinuousIntegrationUpdateService {
      * Updates the configured repository for a given plan to the given CI Server repository (and do other related stuff).
      *
      * @param projectKey       The key of the project, e.g. 'EIST16W1'.
-     * @param buildPlanKey     The key of the buildPlan, which is usually the name, e.g. 'ga56hur'.
-     * @param ciRepositoryName The name of the configured repository in the CI plan.
+     * @param buildPlanKey     The key of the buildPlan, which is usually the username, e.g. 'ga56hur'.
+     * @param ciRepoName       The name of the configured repository in the continuous integration plan, normally 'assignment' or 'test'
      * @param repoProjectKey   The key of the project that contains the repository.
-     * @param repoName         The lower level identifier of the repository.
+     * @param vcsRepoName      The lower level identifier of the repository in the version control system
      * @param triggeredBy      Optional list of repositories that should trigger the new build plan. If empty, no triggers get overwritten
      */
-    void updatePlanRepository(String projectKey, String buildPlanKey, String ciRepositoryName, String repoProjectKey, String repoName, Optional<List<String>> triggeredBy);
+    void updatePlanRepository(String projectKey, String buildPlanKey, String ciRepoName, String repoProjectKey, String vcsRepoName, Optional<List<String>> triggeredBy);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooService.java
@@ -116,13 +116,13 @@ public class BambooService implements ContinuousIntegrationService {
 
     @Override
     public void configureBuildPlan(ProgrammingExerciseParticipation participation) {
-        String buildPlanId = participation.getBuildPlanId();
-        URL repositoryUrl = participation.getRepositoryUrlAsUrl();
-        String planProject = getProjectKeyFromBuildPlanId(buildPlanId);
-        String planKey = participation.getBuildPlanId();
-        updatePlanRepository(planProject, planKey, ASSIGNMENT_REPO_NAME, urlService.getProjectKeyFromUrl(repositoryUrl), repositoryUrl.toString(),
-                participation.getProgrammingExercise().getTemplateRepositoryUrl(), Optional.empty());
-        enablePlan(planProject, planKey);
+        final var buildPlanId = participation.getBuildPlanId();
+        final var repositoryUrl = participation.getRepositoryUrlAsUrl();
+        final var projectKey = getProjectKeyFromBuildPlanId(buildPlanId);
+        final var planKey = participation.getBuildPlanId();
+        final var repoProjectName = urlService.getProjectKeyFromUrl(repositoryUrl);
+        updatePlanRepository(projectKey, planKey, ASSIGNMENT_REPO_NAME, repoProjectName, participation.getRepositoryUrl(), null /* not needed */, Optional.empty());
+        enablePlan(projectKey, planKey);
     }
 
     @Override
@@ -486,12 +486,11 @@ public class BambooService implements ContinuousIntegrationService {
     }
 
     @Override
-    public void updatePlanRepository(String bambooProject, String buildPlanKey, String bambooRepositoryName, String repoProjectName, String repoUrl, String templateRepositoryUrl,
+    public void updatePlanRepository(String buildProjectKey, String buildPlanKey, String ciRepoName, String repoProjectKey, String newRepoUrl, String existingRepoUrl,
             Optional<List<String>> optionalTriggeredByRepositories) throws BambooException {
         try {
-            final var repositoryName = versionControlService.get().getRepositoryName(new URL(repoUrl));
-            continuousIntegrationUpdateService.get().updatePlanRepository(bambooProject, buildPlanKey, bambooRepositoryName, repoProjectName, repositoryName,
-                    optionalTriggeredByRepositories);
+            final var vcsRepoName = versionControlService.get().getRepositoryName(new URL(newRepoUrl));
+            continuousIntegrationUpdateService.get().updatePlanRepository(buildProjectKey, buildPlanKey, ciRepoName, repoProjectKey, vcsRepoName, optionalTriggeredByRepositories);
         }
         catch (MalformedURLException e) {
             throw new BambooException(e.getMessage(), e);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
@@ -330,14 +330,24 @@ public class GitLabService extends AbstractVersionControlService {
             }
         }
         final var instructors = userService.getInstructors(programmingExercise.getCourseViaExerciseGroupOrCourseMember());
-        final var teachingAssistants = userService.getTutors(programmingExercise.getCourseViaExerciseGroupOrCourseMember());
+        final var tutors = userService.getTutors(programmingExercise.getCourseViaExerciseGroupOrCourseMember());
         for (final var instructor : instructors) {
-            final var userId = gitLabUserManagementService.getUserId(instructor.getLogin());
-            gitLabUserManagementService.addUserToGroups(userId, List.of(programmingExercise), MAINTAINER);
+            try {
+                final var userId = gitLabUserManagementService.getUserId(instructor.getLogin());
+                gitLabUserManagementService.addUserToGroups(userId, List.of(programmingExercise), MAINTAINER);
+            }
+            catch (GitLabException ignored) {
+                // ignore the exception and continue with the next user, one non existing user or issue here should not prevent the creation of the whole programming exercise
+            }
         }
-        for (final var ta : teachingAssistants) {
-            final var userId = gitLabUserManagementService.getUserId(ta.getLogin());
-            gitLabUserManagementService.addUserToGroups(userId, List.of(programmingExercise), GUEST);
+        for (final var tutor : tutors) {
+            try {
+                final var userId = gitLabUserManagementService.getUserId(tutor.getLogin());
+                gitLabUserManagementService.addUserToGroups(userId, List.of(programmingExercise), GUEST);
+            }
+            catch (GitLabException ignored) {
+                // ignore the exception and continue with the next user, one non existing user or issue here should not prevent the creation of the whole programming exercise
+            }
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsService.java
@@ -190,9 +190,9 @@ public class JenkinsService implements ContinuousIntegrationService {
         headers.setContentType(MediaType.APPLICATION_XML);
         final var entity = new HttpEntity(writeXmlToString(jobXmlDocument), headers);
 
-        URI uri = Endpoint.PLAN_CONFIG.buildEndpoint(JENKINS_SERVER_URL.toString(), buildProjectKey, repoProjectKey).build(true).toUri();
+        URI uri = Endpoint.PLAN_CONFIG.buildEndpoint(JENKINS_SERVER_URL.toString(), buildProjectKey, buildPlanKey).build(true).toUri();
 
-        final var errorMessage = "Error trying to configure build plan in Jenkins " + repoProjectKey;
+        final var errorMessage = "Error trying to configure build plan in Jenkins " + buildPlanKey;
         try {
             final var response = restTemplate.exchange(uri, HttpMethod.POST, entity, String.class);
             if (response.getStatusCode() != HttpStatus.OK) {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -233,7 +233,8 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
                 // We sent a notification to the instructor about the success of the repository locking and stashing operations.
                 long numberOfFailedLockOperations = failedLockOperations.size();
                 long numberOfFailedStashOperations = failedStashOperations.size();
-                Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId);
+                Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository
+                        .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId);
                 if (programmingExercise.isEmpty()) {
                     throw new EntityNotFoundException("programming exercise not found with id " + programmingExerciseId);
                 }
@@ -287,7 +288,8 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
                 // We sent a notification to the instructor about the success of the repository unlocking operation.
                 long numberOfFailedUnlockOperations = failedUnlockOperations.size();
-                Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId);
+                Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository
+                        .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId);
                 if (programmingExercise.isEmpty()) {
                     throw new EntityNotFoundException("programming exercise not found with id " + programmingExerciseId);
                 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -151,10 +151,10 @@ public class ParticipationResource {
     }
 
     /**
-     * POST /courses/:courseId/exercises/:exerciseId/resume-participation: resume the participation of the current user in the exercise identified by participationId
+     * POST /courses/:courseId/exercises/:exerciseId/resume-participation: resume the participation of the current user in the exercise identified by exerciseId
      *
      * @param courseId   only included for API consistency, not actually used
-     * @param exerciseId participationId of the exercise for which to resume participation
+     * @param exerciseId of the exercise for which to resume participation
      * @param principal  current user principal
      * @return ResponseEntity with status 200 (OK) and with updated participation as a body, or with status 500 (Internal Server Error)
      */

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -151,7 +151,7 @@ public class ParticipationResource {
     }
 
     /**
-     * POST /courses/:courseId/exercises/:exerciseId/resume-participation: resume the participation of the current user in the exercise identified by exerciseId
+     * PUT /courses/:courseId/exercises/:exerciseId/resume-programming-participation: resume the participation of the current user in the given programming exercise
      *
      * @param courseId   only included for API consistency, not actually used
      * @param exerciseId of the exercise for which to resume participation
@@ -192,7 +192,7 @@ public class ParticipationResource {
             return forbidden();
         }
 
-        participation = participationService.resumeExercise(participation);
+        participation = participationService.resumeProgrammingExercise(participation);
         // Note: in this case we might need an empty commit to make sure the build plan works correctly for subsequent student commits
         participation = participationService.performEmptyCommit(participation);
         addLatestResultToParticipation(participation);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -181,7 +181,7 @@ public class ParticipationResource {
 
         ProgrammingExerciseStudentParticipation participation = programmingExerciseParticipationService.findStudentParticipationByExerciseAndStudentId(programmingExercise,
                 principal.getName());
-        // explicitly set the exercise here to make sure that
+        // explicitly set the exercise here to make sure that the templateParticipation and solutionParticipation are initialized in case they should be used again
         participation.setProgrammingExercise(programmingExercise);
 
         User user = userService.getUserWithGroupsAndAuthorities();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -734,7 +734,8 @@ public class ProgrammingExerciseResource {
     public ResponseEntity<ProgrammingExercise> getProgrammingExercise(@PathVariable long exerciseId) {
         // TODO: Split this route in two: One for normal and one for exam exercises
         log.debug("REST request to get ProgrammingExercise : {}", exerciseId);
-        Optional<ProgrammingExercise> optionalProgrammingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(exerciseId);
+        Optional<ProgrammingExercise> optionalProgrammingExercise = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(exerciseId);
 
         if (optionalProgrammingExercise.isEmpty()) {
             return notFound();
@@ -775,7 +776,7 @@ public class ProgrammingExerciseResource {
         log.debug("REST request to get ProgrammingExercise : {}", exerciseId);
 
         User user = userService.getUserWithGroupsAndAuthorities();
-        Optional<ProgrammingExercise> programmingExerciseOpt = programmingExerciseRepository.findWithTemplateAndSolutionParticipationById(exerciseId);
+        Optional<ProgrammingExercise> programmingExerciseOpt = programmingExerciseRepository.findWithTemplateAndSolutionParticipationLatestResultById(exerciseId);
         if (programmingExerciseOpt.isPresent()) {
             ProgrammingExercise programmingExercise = programmingExerciseOpt.get();
             Course course = programmingExercise.getCourseViaExerciseGroupOrCourseMember();
@@ -808,7 +809,8 @@ public class ProgrammingExerciseResource {
     public ResponseEntity<Void> deleteProgrammingExercise(@PathVariable long exerciseId, @RequestParam(defaultValue = "false") boolean deleteStudentReposBuildPlans,
             @RequestParam(defaultValue = "false") boolean deleteBaseReposBuildPlans) {
         log.info("REST request to delete ProgrammingExercise : {}", exerciseId);
-        Optional<ProgrammingExercise> optionalProgrammingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(exerciseId);
+        Optional<ProgrammingExercise> optionalProgrammingExercise = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(exerciseId);
         if (optionalProgrammingExercise.isEmpty()) {
             return notFound();
         }
@@ -847,7 +849,8 @@ public class ProgrammingExerciseResource {
     public ResponseEntity<Void> combineTemplateRepositoryCommits(@PathVariable long exerciseId) {
         log.debug("REST request to combine the commits of the template repository of ProgrammingExercise with id: {}", exerciseId);
 
-        Optional<ProgrammingExercise> programmingExerciseOptional = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(exerciseId);
+        Optional<ProgrammingExercise> programmingExerciseOptional = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(exerciseId);
         if (programmingExerciseOptional.isEmpty()) {
             return notFound();
         }
@@ -990,7 +993,8 @@ public class ProgrammingExerciseResource {
     public ResponseEntity<String> generateStructureOracleForExercise(@PathVariable long exerciseId) {
         log.debug("REST request to generate the structure oracle for ProgrammingExercise with id: {}", exerciseId);
 
-        Optional<ProgrammingExercise> programmingExerciseOptional = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(exerciseId);
+        Optional<ProgrammingExercise> programmingExerciseOptional = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(exerciseId);
         if (programmingExerciseOptional.isEmpty()) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createAlert(applicationName, "programmingExerciseNotFound", "The programming exercise does not exist"))
                     .body(null);
@@ -1046,7 +1050,7 @@ public class ProgrammingExerciseResource {
     @GetMapping(Endpoints.TEST_CASE_STATE)
     @PreAuthorize("hasAnyRole('TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<ProgrammingExerciseTestCaseStateDTO> hasAtLeastOneStudentResult(@PathVariable long exerciseId) {
-        Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(exerciseId);
+        Optional<ProgrammingExercise> programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(exerciseId);
         if (programmingExercise.isEmpty()) {
             return notFound();
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
@@ -158,6 +158,7 @@ public class ProgrammingSubmissionResource {
      * @param lastGraded if true, will not use the most recent submission, but the most recent GRADED submission. This submission could e.g. be created before the deadline or after the deadline by the INSTRUCTOR.
      * @return 404 if there is no participation for the given id, 403 if the user mustn't access the participation, 200 if the build was triggered, a result already exists or the build is running.
      */
+    // TODO: we should definitly change this URL, it does not make sense to use /programming-submissions/{participationId}
     @PostMapping(Constants.PROGRAMMING_SUBMISSION_RESOURCE_PATH + "{participationId}/trigger-failed-build")
     @PreAuthorize("hasAnyRole('USER', 'TA', 'INSTRUCTOR', 'ADMIN')")
     @FeatureToggle(Feature.PROGRAMMING_EXERCISES)

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
@@ -139,15 +139,14 @@ public class ProgrammingSubmissionResource {
                 || (submissionType.equals(SubmissionType.INSTRUCTOR) && !authCheckService.isAtLeastInstructorForExercise(participation.getExercise()))) {
             return forbidden();
         }
-        ProgrammingSubmission submission;
+
         try {
-            submission = programmingSubmissionService.createSubmissionWithLastCommitHashForParticipation(programmingExerciseParticipation, submissionType);
+            ProgrammingSubmission submission = programmingSubmissionService.createSubmissionWithLastCommitHashForParticipation(programmingExerciseParticipation, submissionType);
+            programmingSubmissionService.triggerBuildAndNotifyUser(submission);
         }
         catch (IllegalStateException ex) {
             return notFound();
         }
-
-        programmingSubmissionService.triggerBuildAndNotifyUser(submission);
 
         return ResponseEntity.ok().build();
     }

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
@@ -10,8 +10,6 @@ import static org.mockito.Mockito.doReturn;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -45,7 +43,6 @@ import de.tum.in.www1.artemis.service.connectors.bitbucket.BitbucketService;
 import de.tum.in.www1.artemis.service.connectors.bitbucket.dto.BitbucketRepositoryDTO;
 import de.tum.in.www1.artemis.service.ldap.LdapUserService;
 import de.tum.in.www1.artemis.util.AbstractArtemisIntegrationTest;
-import de.tum.in.www1.artemis.util.Verifiable;
 
 @SpringBootTest(properties = { "artemis.athene.token-validity-in-seconds=10800",
         "artemis.athene.base64-secret=YWVuaXF1YWRpNWNlaXJpNmFlbTZkb283dXphaVF1b29oM3J1MWNoYWlyNHRoZWUzb2huZ2FpM211bGVlM0VpcAo=" })
@@ -91,23 +88,36 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
     }
 
     @Override
-    public List<Verifiable> mockConnectorRequestsForStartParticipation(ProgrammingExercise exercise, String username, Set<User> users, boolean ltiUserExists)
+    public void mockConnectorRequestsForStartParticipation(ProgrammingExercise exercise, String username, Set<User> users, boolean ltiUserExists, HttpStatus status)
             throws IOException, URISyntaxException {
-        final var verifications = new LinkedList<Verifiable>();
+        // Step 1a)
+        bitbucketRequestMockProvider.mockForkRepositoryForParticipation(exercise, username, status);
+        // Step 1b)
         bitbucketRequestMockProvider.mockConfigureRepository(exercise, username, users, ltiUserExists);
+        // Step 2a)
         bambooRequestMockProvider.mockCopyBuildPlanForParticipation(exercise, username);
+        // Step 2b)
+        // Note: no need to mock empty commit (Step 2c) because this is done on a git repository
         mockUpdatePlanRepositoryForParticipation(exercise, username);
-        bambooRequestMockProvider.mockEnablePlan(exercise.getProjectKey(), username);
+        // Step 1c)
         bitbucketRequestMockProvider.mockAddWebHooks(exercise);
-        return verifications;
+    }
+
+    @Override
+    public void mockConnectorRequestsForResumeParticipation(ProgrammingExercise exercise, String username, Set<User> users, boolean ltiUserExists)
+            throws IOException, URISyntaxException {
+        // Step 2a)
+        bambooRequestMockProvider.mockCopyBuildPlanForParticipation(exercise, username);
+        // Step 2b)
+        mockUpdatePlanRepositoryForParticipation(exercise, username);
     }
 
     @Override
     public void mockUpdatePlanRepositoryForParticipation(ProgrammingExercise exercise, String username) throws IOException, URISyntaxException {
         final var projectKey = exercise.getProjectKey();
         final var bitbucketRepoName = projectKey.toLowerCase() + "-" + username;
-
         mockUpdatePlanRepository(exercise, username, ASSIGNMENT_REPO_NAME, bitbucketRepoName, List.of());
+        bambooRequestMockProvider.mockEnablePlan(exercise.getProjectKey(), username);
     }
 
     @Override
@@ -173,9 +183,8 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
     }
 
     @Override
-    public List<Verifiable> mockConnectorRequestsForImport(ProgrammingExercise sourceExercise, ProgrammingExercise exerciseToBeImported, boolean recreateBuildPlans)
+    public void mockConnectorRequestsForImport(ProgrammingExercise sourceExercise, ProgrammingExercise exerciseToBeImported, boolean recreateBuildPlans)
             throws IOException, URISyntaxException, GitAPIException {
-        final var verifications = new ArrayList<Verifiable>();
         final var projectKey = exerciseToBeImported.getProjectKey();
         final var templateRepoName = exerciseToBeImported.generateRepositoryName(RepositoryType.TEMPLATE);
         final var solutionRepoName = exerciseToBeImported.generateRepositoryName(RepositoryType.SOLUTION);
@@ -220,8 +229,6 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
             // Mocks for recreating the build plans
             mockBambooBuildPlanCreation(exerciseToBeImported);
         }
-
-        return verifications;
     }
 
     @Override

--- a/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ParticipationIntegrationTest.java
@@ -284,10 +284,11 @@ public class ParticipationIntegrationTest extends AbstractSpringIntegrationBambo
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void resumeProgrammingExerciseParticipation() throws Exception {
-        var participation = ModelFactory.generateProgrammingExerciseStudentParticipation(InitializationState.INITIALIZED, programmingExercise, database.getUserByLogin("student1"));
+        var participation = ModelFactory.generateProgrammingExerciseStudentParticipation(InitializationState.INACTIVE, programmingExercise, database.getUserByLogin("student1"));
         participationRepo.save(participation);
-        request.putWithResponseBody("/api/courses/" + course.getId() + "/exercises/" + programmingExercise.getId() + "/resume-programming-participation", null,
-                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+        var updatedParticipation = request.putWithResponseBody("/api/courses/" + course.getId() + "/exercises/" + programmingExercise.getId() + "/resume-programming-participation",
+                null, ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
+        assertThat(updatedParticipation.getInitializationState()).isEqualTo(InitializationState.INITIALIZED);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -200,8 +200,7 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
 
         for (var programmingExercise : programmingExercises) {
             for (var user : users) {
-                mockForkRepositoryForParticipation(programmingExercise, user.getParticipantIdentifier(), HttpStatus.CREATED);
-                mockConnectorRequestsForStartParticipation(programmingExercise, user.getParticipantIdentifier(), Set.of(user), true);
+                mockConnectorRequestsForStartParticipation(programmingExercise, user.getParticipantIdentifier(), Set.of(user), true, HttpStatus.CREATED);
             }
         }
 

--- a/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/bitbucket/BitbucketRequestMockProvider.java
@@ -130,7 +130,6 @@ public class BitbucketRequestMockProvider {
         final var projectKey = exercise.getProjectKey();
         final var templateRepoName = exercise.generateRepositoryName(RepositoryType.TEMPLATE);
         final var clonedRepoName = projectKey.toLowerCase() + "-" + username.toLowerCase();
-
         mockForkRepository(projectKey, projectKey, templateRepoName, clonedRepoName, status);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/MockDelegate.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/MockDelegate.java
@@ -16,15 +16,16 @@ import de.tum.in.www1.artemis.domain.Team;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.service.connectors.bamboo.dto.BambooBuildResultDTO;
-import de.tum.in.www1.artemis.util.Verifiable;
 
 public interface MockDelegate {
 
     void mockConnectorRequestsForSetup(ProgrammingExercise exercise) throws Exception;
 
-    List<Verifiable> mockConnectorRequestsForImport(ProgrammingExercise sourceExercise, ProgrammingExercise exerciseToBeImported, boolean recreateBuildPlans) throws Exception;
+    void mockConnectorRequestsForImport(ProgrammingExercise sourceExercise, ProgrammingExercise exerciseToBeImported, boolean recreateBuildPlans) throws Exception;
 
-    List<Verifiable> mockConnectorRequestsForStartParticipation(ProgrammingExercise exercise, String username, Set<User> users, boolean ltiUserExists) throws Exception;
+    void mockConnectorRequestsForStartParticipation(ProgrammingExercise exercise, String username, Set<User> users, boolean ltiUserExists, HttpStatus status) throws Exception;
+
+    void mockConnectorRequestsForResumeParticipation(ProgrammingExercise exercise, String username, Set<User> users, boolean ltiUserExists) throws Exception;
 
     void mockUpdatePlanRepositoryForParticipation(ProgrammingExercise exercise, String username) throws IOException, URISyntaxException;
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -107,16 +107,18 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
         programmingExerciseTestService.createProgrammingExercise_noTutors_created();
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ExerciseMode.class)
     @WithMockUser(username = studentLogin, roles = "USER")
-    public void startProgrammingExercise_student_correctInitializationState() throws Exception {
-        programmingExerciseTestService.startProgrammingExercise_student_correctInitializationState();
+    public void startProgrammingExercise_correctInitializationState(ExerciseMode exerciseMode) throws Exception {
+        programmingExerciseTestService.startProgrammingExercise_correctInitializationState(exerciseMode);
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ExerciseMode.class)
     @WithMockUser(username = studentLogin, roles = "USER")
-    public void startProgrammingExercise_team_correctInitializationState() throws Exception {
-        programmingExerciseTestService.startProgrammingExercise_team_correctInitializationState();
+    public void resumeProgrammingExercise_correctInitializationState(ExerciseMode exerciseMode) throws Exception {
+        programmingExerciseTestService.resumeProgrammingExercise_correctInitializationState(exerciseMode);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -121,6 +121,13 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
         programmingExerciseTestService.resumeProgrammingExercise_correctInitializationState(exerciseMode);
     }
 
+    @ParameterizedTest
+    @EnumSource(ExerciseMode.class)
+    @WithMockUser(username = studentLogin, roles = "USER")
+    public void resumeProgrammingExercise_doesNotExist(ExerciseMode exerciseMode) throws Exception {
+        programmingExerciseTestService.resumeProgrammingExercise_doesNotExist(exerciseMode);
+    }
+
     @Test
     @WithMockUser(username = studentLogin, roles = "USER")
     public void startProgrammingExerciseStudentSubmissionFailedWithBuildlog() throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
@@ -126,6 +126,13 @@ class ProgrammingExerciseGitlabJenkinsIntegrationTest extends AbstractSpringInte
         programmingExerciseTestService.resumeProgrammingExercise_correctInitializationState(exerciseMode);
     }
 
+    @ParameterizedTest
+    @EnumSource(ExerciseMode.class)
+    @WithMockUser(username = studentLogin, roles = "USER")
+    public void resumeProgrammingExercise_doesNotExist(ExerciseMode exerciseMode) throws Exception {
+        programmingExerciseTestService.resumeProgrammingExercise_doesNotExist(exerciseMode);
+    }
+
     @Test
     @WithMockUser(username = studentLogin, roles = "USER")
     public void startProgrammingExerciseStudentRetrieveEmptyArtifactPage() throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
@@ -112,22 +112,24 @@ class ProgrammingExerciseGitlabJenkinsIntegrationTest extends AbstractSpringInte
         programmingExerciseTestService.createProgrammingExercise_noTutors_created();
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(ExerciseMode.class)
     @WithMockUser(username = studentLogin, roles = "USER")
-    public void startProgrammingExercise_student_correctInitializationState() throws Exception {
-        programmingExerciseTestService.startProgrammingExercise_student_correctInitializationState();
+    public void startProgrammingExercise_correctInitializationState(ExerciseMode exerciseMode) throws Exception {
+        programmingExerciseTestService.startProgrammingExercise_correctInitializationState(exerciseMode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ExerciseMode.class)
+    @WithMockUser(username = studentLogin, roles = "USER")
+    public void resumeProgrammingExercise_correctInitializationState(ExerciseMode exerciseMode) throws Exception {
+        programmingExerciseTestService.resumeProgrammingExercise_correctInitializationState(exerciseMode);
     }
 
     @Test
     @WithMockUser(username = studentLogin, roles = "USER")
     public void startProgrammingExerciseStudentRetrieveEmptyArtifactPage() throws Exception {
         programmingExerciseTestService.startProgrammingExerciseStudentRetrieveEmptyArtifactPage();
-    }
-
-    @Test
-    @WithMockUser(username = studentLogin, roles = "USER")
-    public void startProgrammingExercise_team_correctInitializationState() throws Exception {
-        programmingExerciseTestService.startProgrammingExercise_team_correctInitializationState();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -116,7 +116,8 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         course = database.addCourseWithOneProgrammingExerciseAndTestCases();
         programmingExercise = programmingExerciseRepository.findAllWithEagerTemplateAndSolutionParticipations().get(0);
         programmingExerciseInExam = database.addCourseExamExerciseGroupWithOneProgrammingExerciseAndTestCases();
-        programmingExerciseInExam = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseInExam.getId()).get();
+        programmingExerciseInExam = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseInExam.getId())
+                .get();
 
         participation1 = database.addStudentParticipationForProgrammingExercise(programmingExercise, "student1");
         participation2 = database.addStudentParticipationForProgrammingExercise(programmingExercise, "student2");
@@ -1045,7 +1046,7 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_asInstrutor() throws Exception {
         bambooRequestMockProvider.enableMockingOfRequests();
-        programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExercise.getId()).get();
+        programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExercise.getId()).get();
         bambooRequestMockProvider.mockTriggerBuild(programmingExercise.getSolutionParticipation());
         final var testCases = programmingExerciseTestCaseRepository.findByExerciseId(programmingExercise.getId());
         final var updates = testCases.stream().map(testCase -> {
@@ -1113,7 +1114,7 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void resetTestCaseWeights_asInstructor() throws Exception {
         bambooRequestMockProvider.enableMockingOfRequests();
-        programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExercise.getId()).get();
+        programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExercise.getId()).get();
         bambooRequestMockProvider.mockTriggerBuild(programmingExercise.getSolutionParticipation());
         final var endpoint = ProgrammingExerciseGradingResource.RESET.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
         programmingExerciseTestCaseRepository.findByExerciseId(programmingExercise.getId()).forEach(test -> {

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTest.java
@@ -54,7 +54,8 @@ class ProgrammingExerciseTest extends AbstractSpringIntegrationBambooBitbucketJi
         // There should still be only 1 programming exercise.
         assertThat(programmingExerciseRepository.count()).isEqualTo(1);
         // The programming exercise in the db should also be updated.
-        ProgrammingExercise programmingExerciseFromDb = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExercise.getId()).get();
+        ProgrammingExercise programmingExerciseFromDb = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExercise.getId()).get();
         assertThat(programmingExerciseFromDb.getProblemStatement()).isEqualTo(newProblem);
         assertThat(programmingExerciseFromDb.getTitle()).isEqualTo(newTitle);
     }
@@ -62,14 +63,16 @@ class ProgrammingExerciseTest extends AbstractSpringIntegrationBambooBitbucketJi
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     void updateProgrammingExerciseOnce() throws Exception {
-        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId).get();
+        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId)
+                .get();
         updateProgrammingExercise(programmingExercise, "new problem 1", "new title 1");
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     void updateProgrammingExerciseTwice() throws Exception {
-        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId).get();
+        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId)
+                .get();
         updateProgrammingExercise(programmingExercise, "new problem 1", "new title 1");
         updateProgrammingExercise(programmingExercise, "new problem 2", "new title 2");
     }
@@ -83,7 +86,7 @@ class ProgrammingExerciseTest extends AbstractSpringIntegrationBambooBitbucketJi
 
         assertThat(updatedProgrammingExercise.getProblemStatement()).isEqualTo(newProblem);
 
-        ProgrammingExercise fromDb = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseId).get();
+        ProgrammingExercise fromDb = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseId).get();
         assertThat(fromDb.getProblemStatement()).isEqualTo(newProblem);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestCaseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestCaseServiceTest.java
@@ -148,7 +148,8 @@ public class ProgrammingExerciseTestCaseServiceTest extends AbstractSpringIntegr
         testCaseService.reset(programmingExercise.getId());
 
         Set<ProgrammingExerciseTestCase> testCases = testCaseRepository.findByExerciseId(programmingExercise.getId());
-        ProgrammingExercise updatedProgrammingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExercise.getId()).get();
+        ProgrammingExercise updatedProgrammingExercise = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExercise.getId()).get();
         assertThat(testCases.stream().mapToDouble(ProgrammingExerciseTestCase::getWeight).sum()).isEqualTo(testCases.size());
         assertThat(updatedProgrammingExercise.getTestCasesChanged()).isTrue();
         verify(groupNotificationService, times(1)).notifyInstructorGroupAboutExerciseUpdate(updatedProgrammingExercise, Constants.TEST_CASES_CHANGED_NOTIFICATION);
@@ -181,7 +182,8 @@ public class ProgrammingExerciseTestCaseServiceTest extends AbstractSpringIntegr
 
         testCaseService.update(programmingExercise.getId(), programmingExerciseTestCaseDTOS);
 
-        ProgrammingExercise updatedProgrammingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(programmingExercise.getId()).get();
+        ProgrammingExercise updatedProgrammingExercise = programmingExerciseRepository
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExercise.getId()).get();
 
         assertThat(testCaseRepository.findById(testCase.getId()).get().getWeight()).isEqualTo(400);
         assertThat(updatedProgrammingExercise.getTestCasesChanged()).isTrue();

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionAndResultIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionAndResultIntegrationTest.java
@@ -559,7 +559,7 @@ class ProgrammingSubmissionAndResultIntegrationTest extends AbstractSpringIntegr
     }
 
     private void setBuildAndTestAfterDueDateForProgrammingExercise(ZonedDateTime buildAndTestAfterDueDate) {
-        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(exerciseId).get();
+        ProgrammingExercise programmingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(exerciseId).get();
         programmingExercise.setBuildAndTestStudentSubmissionsAfterDueDate(buildAndTestAfterDueDate);
         programmingExerciseRepository.save(programmingExercise);
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
@@ -175,7 +175,8 @@ public class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrat
             participations.add((ProgrammingExerciseParticipation) submission.getParticipation());
         }
 
-        ProgrammingExercise updatedProgrammingExercise = programmingExerciseRepository.findWithTemplateParticipationAndSolutionParticipationById(exercise.getId()).get();
+        ProgrammingExercise updatedProgrammingExercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(exercise.getId())
+                .get();
         assertThat(updatedProgrammingExercise.getTestCasesChanged()).isFalse();
         verify(groupNotificationService, times(1)).notifyInstructorGroupAboutExerciseUpdate(updatedProgrammingExercise, Constants.TEST_CASES_CHANGED_RUN_COMPLETED_NOTIFICATION);
         verify(websocketMessagingService, times(1)).sendMessage("/topic/programming-exercises/" + exercise.getId() + "/test-cases-changed", false);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/StaticCodeAnalysisIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/StaticCodeAnalysisIntegrationTest.java
@@ -123,7 +123,7 @@ class StaticCodeAnalysisIntegrationTest extends AbstractSpringIntegrationBambooB
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     void testUpdateStaticCodeAnalysisCategories() throws Exception {
         ProgrammingExercise exerciseWithSolutionParticipation = programmingExerciseRepository
-                .findWithTemplateParticipationAndSolutionParticipationById(programmingExerciseSCAEnabled.getId()).get();
+                .findWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesById(programmingExerciseSCAEnabled.getId()).get();
         bambooRequestMockProvider.mockTriggerBuild(exerciseWithSolutionParticipation.getSolutionParticipation());
         var endpoint = parameterizeEndpoint("/api" + StaticCodeAnalysisResource.Endpoints.CATEGORIES, programmingExerciseSCAEnabled);
         // Change the first category

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseCleanupService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseCleanupService.java
@@ -5,11 +5,11 @@ import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Table;
-import javax.transaction.Transactional;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Test utility service that allows to truncate all tables in the test database.

--- a/src/test/java/de/tum/in/www1/artemis/util/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ProgrammingExerciseTestService.java
@@ -464,10 +464,15 @@ public class ProgrammingExerciseTestService {
                 ProgrammingExerciseStudentParticipation.class, HttpStatus.NOT_FOUND);
     }
 
-    // TODO: add 3 more test cases how to resume an exercise:
-    // 1. Invoke the REST Call for a new programming submission (which happens as part of the webhook after pushing code to git)
-    // 2. Trigger one build of the participation
+    // TODO: add several more test cases for resuming a programming exercise:
+    // 1. Invoke the REST Call from the VCS for a new programming submission (which happens as part of the webhook after pushing code to git)
+    // notifyPush, see postSubmission(...) in ProgrammingSubmissionAndResultIntegrationTest
+    // 2. Trigger one build of the participation (also see ProgrammingSubmissionAndResultIntegrationTest)
+    // 2a: request.postWithoutLocation("/api/programming-submissions/" + id + "/trigger-build", null, HttpStatus.OK, new HttpHeaders());
+    // 2b: request.postWithoutLocation("/api/programming-submissions/" + id + "/trigger-build?submissionType=INSTRUCTOR", null, HttpStatus.OK, new HttpHeaders());
+    // 2c: request.postWithoutLocation("/api/programming-submissions/" + id + "/trigger-failed-build", null, HttpStatus.OK, new HttpHeaders());
     // 3. Trigger all builds of the corresponding exercise
+    // @PostMapping("/programming-exercises/{exerciseId}/trigger-instructor-build-all")
 
     // TEST
     public void resumeProgrammingExercise_correctInitializationState(ExerciseMode exerciseMode) throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/util/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ProgrammingExerciseTestService.java
@@ -463,11 +463,12 @@ public class ProgrammingExerciseTestService {
         final Course course = setupCourseWithProgrammingExercise(exerciseMode);
         Participant participant = (exerciseMode == TEAM) ? setupTeam(userRepo.findOneByLogin(studentLogin).get()) : userRepo.findOneByLogin(studentLogin).orElseThrow();
 
-        // TODO: resume instead of start
+        // TODO: create a participation and set it to inactive (also set build plan id to null)
+        // TODO: mock resume instead of start
         final var verifications = mockDelegate.mockConnectorRequestsForStartParticipation(exercise, participant.getParticipantIdentifier(), participant.getParticipants(), true);
-        final var path = ParticipationResource.Endpoints.ROOT + ParticipationResource.Endpoints.START_PARTICIPATION.replace("{courseId}", String.valueOf(course.getId()))
-                .replace("{exerciseId}", String.valueOf(exercise.getId()));
-        final var participation = request.postWithResponseBody(path, null, ProgrammingExerciseStudentParticipation.class, HttpStatus.CREATED);
+
+        var participation = request.putWithResponseBody("/api/courses/" + course.getId() + "/exercises/" + exercise.getId() + "/resume-programming-participation", null,
+                ProgrammingExerciseStudentParticipation.class, HttpStatus.OK);
 
         for (final var verification : verifications) {
             verification.performVerification();


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Fixes #2600 and #2601 

### Description
Implements a workaround and adds TODOs for future improvements
I also tried to improve the JavaDoc and method parameter names

### Steps for Testing
1. Create and participate in a programming exercise on TS2 (Gitlab / Jenkins) 
2. Cleanup the build plan (not the repository) several times and try out the following methods
3. Resume the exercise (as student) by clicking on resume exercise
4. Resume the exercise by pushing into the repo (the build should automatically get started afterwards and you should still receive a result)
5. Trigger a build as instructor (should automatically resume the exercise)
6. Trigger all builds as instructor (should automatically resume the exercise for multiple users)

**Important:** please review that I did not mix up anything while renaming parameters and variables

### Test Coverage
no changes

### Screenshots
no UI changes