### PR TITLE
Try to resolve flaky-ness in the CourseScoresComponent test

### DIFF
--- a/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
@@ -52,17 +52,18 @@ describe('CourseScoresComponent', () => {
         type: ExerciseType.QUIZ,
         maxScore: 2,
     } as Exercise;
+    const sharedDueDate = moment().add(4, 'minutes');
     const exerciseTwo = {
         title: 'exercise two',
         id: 2,
-        dueDate: moment().add(4, 'minutes'),
+        dueDate: sharedDueDate,
         type: ExerciseType.QUIZ,
         maxScore: 3,
     } as Exercise;
     const exerciseThree = {
         title: 'exercise three',
         id: 3,
-        dueDate: moment().add(4, 'minutes'),
+        dueDate: sharedDueDate,
         type: ExerciseType.FILE_UPLOAD,
         maxScore: 0,
         bonusPoints: 1,


### PR DESCRIPTION
### Motivation and Context

The test for the `CourseScoresComponent` failed from time to time. It looks to me like `moment().add(4, 'minutes')` sometimes evaluated to different times even when both called "at the same time" (during construction). Apparently the build agents have a noticeable delay from time to time.

### Description

`moment().add(4, 'minutes')` is only evaluated once and the result cached. That will guarantee that both `dueDates` of the exercises are the same time.

### Test Coverage

Unchanged.
