### PR TITLE
Add websocket broker health indicator

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/websocket/WebsocketBrokerHealthIndicator.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/websocket/WebsocketBrokerHealthIndicator.java
@@ -1,0 +1,26 @@
+package de.tum.in.www1.artemis.config.websocket;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.context.ApplicationListener;
+import org.springframework.messaging.simp.broker.BrokerAvailabilityEvent;
+import org.springframework.stereotype.Component;
+
+import de.tum.in.www1.artemis.service.connectors.ConnectorHealth;
+
+@Component
+public class WebsocketBrokerHealthIndicator implements HealthIndicator, ApplicationListener<BrokerAvailabilityEvent> {
+
+    private boolean isBrokerAvailable = false; // Will be updated to true by event listener once connection is established
+
+    @Override
+    public Health health() {
+        return new ConnectorHealth(isBrokerAvailable).asActuatorHealth();
+    }
+
+    @Override
+    public void onApplicationEvent(BrokerAvailabilityEvent event) {
+        // The event is fired if the broker gets (un-)available
+        this.isBrokerAvailable = event.isBrokerAvailable();
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/config/websocket/WebsocketBrokerHealthIndicator.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/websocket/WebsocketBrokerHealthIndicator.java
@@ -1,5 +1,10 @@
 package de.tum.in.www1.artemis.config.websocket;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.context.ApplicationListener;
@@ -13,9 +18,15 @@ public class WebsocketBrokerHealthIndicator implements HealthIndicator, Applicat
 
     private boolean isBrokerAvailable = false; // Will be updated to true by event listener once connection is established
 
+    // Split the addresses by comma
+    @Value("#{'${spring.websocket.broker.addresses}'.split(',')}")
+    private List<String> brokerAddresses;
+
     @Override
     public Health health() {
-        return new ConnectorHealth(isBrokerAvailable).asActuatorHealth();
+        Map<String, Object> additionalInformation = new HashMap<>();
+        additionalInformation.put("ipAddresses", brokerAddresses);
+        return new ConnectorHealth(isBrokerAvailable, additionalInformation).asActuatorHealth();
     }
 
     @Override

--- a/src/main/webapp/app/admin/health/health.component.html
+++ b/src/main/webapp/app/admin/health/health.component.html
@@ -35,7 +35,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>Websocket Connection</td>
+                    <td>Websocket Connection (Client -> Server)</td>
                     <td class="text-center">
                         <jhi-connection-status></jhi-connection-status>
                     </td>

--- a/src/main/webapp/i18n/de/health.json
+++ b/src/main/webapp/i18n/de/health.json
@@ -25,7 +25,8 @@
             "continuousIntegrationServer": "Kontinuierlicher Integrationsserver",
             "versionControlServer": "Versionskontrollserver",
             "userManagement": "Nutzerverwaltung",
-            "hazelcast": "Hazelcast"
+            "hazelcast": "Hazelcast",
+            "websocketBroker": "Websocket Broker (Server -> Broker)"
         },
         "table": {
             "service": "Dienst Name",

--- a/src/main/webapp/i18n/en/health.json
+++ b/src/main/webapp/i18n/en/health.json
@@ -25,7 +25,8 @@
             "continuousIntegrationServer": "Continuous Integration Server",
             "versionControlServer": "Version Control Server",
             "userManagement": "User Management",
-            "hazelcast": "Hazelcast"
+            "hazelcast": "Hazelcast",
+            "websocketBroker": "Websocket Broker (Server -> Broker)"
         },
         "table": {
             "service": "Service name",


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
This PR adds a health indicator for the status of the connection from the server to the broker.
The broker is needed if Artemis is running on multiple instances (see https://artemis-platform.readthedocs.io/en/latest/dev/setup/distributed/#websockets), but is currently not included in the Health status (and thus, not in the monitoring tools).

### Description
This PR adds a health indicator that is based on the [BrokerAvailabilityEvent](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/messaging/simp/broker/BrokerAvailabilityEvent.html).
It is fired if the state of the broker changes, i.e. if the broker gets available or unavailable.
The current status is stored in the WebsocketBrokerHealthIndicator and will be sent to the client, along with the IP address(es) of the broker(s) used.

### Steps for Testing
Please test the PR both on one of TS1/TS2 and one of TS3/TS5.

1. Log in to Artemis with an admin account
2. Navigate to Server Administration > Health
3. Make sure that the new "Websocket Broker" status is added.
4. Click on the "eye" to see the ip-addresses: It should be empty on TS3 and TS5 and should contain one entry on TS1 and TS2.



### Screenshots
![Peek 2021-01-03 16-42](https://user-images.githubusercontent.com/5084100/103484870-534e5900-4df2-11eb-8910-9830245de107.gif)
