### PR TITLE
Remove resolver caching and add documentation for defining routes and breadcrumbs

### DIFF
--- a/docs/dev/setup/distributed.rst
+++ b/docs/dev/setup/distributed.rst
@@ -58,7 +58,7 @@ Artemis uses a discovery service to solve the issue (named `JHipster Registry
 <https://www.jhipster.tech/jhipster-registry/>`_).
 
 Discovery service
-^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^
 JHipster registry contains Eureka, the discovery service where all instances can register themselves and fetch the other registered instances.
 
 Eureka can be configured like this within Artemis:

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management-detail.component.html
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management-detail.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="notification && isVisible">
+<div *ngIf="notification">
     <h2>
         <span jhiTranslate="artemisApp.systemNotification.systemNotification">System notification</span>
         [{{ notification.id }}]

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management-detail.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management-detail.component.ts
@@ -1,6 +1,5 @@
-import { filter } from 'rxjs/operators';
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { SystemNotification } from 'app/entities/system-notification.model';
 import { SystemNotificationService } from 'app/shared/notification/system-notification/system-notification.service';
 
@@ -10,7 +9,6 @@ import { SystemNotificationService } from 'app/shared/notification/system-notifi
 })
 export class SystemNotificationManagementDetailComponent implements OnInit {
     notification: SystemNotification;
-    isVisible: boolean;
 
     constructor(private systemNotificationService: SystemNotificationService, private route: ActivatedRoute, private router: Router) {}
 
@@ -21,7 +19,5 @@ export class SystemNotificationManagementDetailComponent implements OnInit {
         this.route.data.subscribe(({ notification }) => {
             this.notification = notification.body ? notification.body : notification;
         });
-        this.isVisible = this.route.children.length === 0;
-        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => (this.isVisible = this.route.children.length === 0));
     }
 }

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
@@ -68,7 +68,12 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
             this.registerChangeInUsers();
         });
         this.isVisible = this.activatedRoute.children.length === 0;
-        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => (this.isVisible = this.activatedRoute.children.length === 0));
+        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+            this.isVisible = this.activatedRoute.children.length === 0;
+            if (this.isVisible) {
+                this.loadAll();
+            }
+        });
     }
 
     /**

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.route.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.route.ts
@@ -51,6 +51,13 @@ export const systemNotificationManagementRoute: Route = {
                 pageTitle: 'artemisApp.systemNotification.systemNotifications',
                 breadcrumbLabelVariable: 'notification.body.id',
             },
+        },
+        {
+            // Create a new path without a component defined to prevent resolver caching and the SystemNotificationManagementDetailComponent from being always rendered
+            path: ':id',
+            resolve: {
+                notification: SystemNotificationManagementResolve,
+            },
             children: [
                 {
                     path: 'edit',

--- a/src/main/webapp/app/admin/user-management/user-management-detail.component.html
+++ b/src/main/webapp/app/admin/user-management/user-management-detail.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="user && isVisible">
+<div *ngIf="user">
     <h2>
         <span jhiTranslate="userManagement.detail.title">User </span>[<b>{{ user.login }}</b
         >]

--- a/src/main/webapp/app/admin/user-management/user-management-detail.component.ts
+++ b/src/main/webapp/app/admin/user-management/user-management-detail.component.ts
@@ -1,6 +1,5 @@
-import { filter } from 'rxjs/operators';
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { User } from 'app/core/user/user.model';
 
 @Component({
@@ -9,9 +8,8 @@ import { User } from 'app/core/user/user.model';
 })
 export class UserManagementDetailComponent implements OnInit {
     user: User;
-    isVisible: boolean;
 
-    constructor(private route: ActivatedRoute, private router: Router) {}
+    constructor(private route: ActivatedRoute) {}
 
     /**
      * Retrieve the user from the user management activated route data {@link UserMgmtResolve} subscription
@@ -21,7 +19,5 @@ export class UserManagementDetailComponent implements OnInit {
         this.route.data.subscribe(({ user }) => {
             this.user = user.body ? user.body : user;
         });
-        this.isVisible = this.route.children.length === 0;
-        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => (this.isVisible = this.route.children.length === 0));
     }
 }

--- a/src/main/webapp/app/admin/user-management/user-management.component.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.component.ts
@@ -85,7 +85,12 @@ export class UserManagementComponent implements OnInit, OnDestroy {
             this.handleNavigation();
         });
         this.isVisible = this.activatedRoute.children.length === 0;
-        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => (this.isVisible = this.activatedRoute.children.length === 0));
+        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+            this.isVisible = this.activatedRoute.children.length === 0;
+            if (this.isVisible) {
+                this.loadAll();
+            }
+        });
     }
 
     /**

--- a/src/main/webapp/app/admin/user-management/user-management.route.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.route.ts
@@ -54,6 +54,13 @@ export const userMgmtRoute: Route = {
                 pageTitle: 'userManagement.home.title',
                 breadcrumbLabelVariable: 'user.body.login',
             },
+        },
+        {
+            // Create a new path without a component defined to prevent resolver caching and the UserManagementDetailComponent from being always rendered
+            path: ':login',
+            resolve: {
+                user: UserMgmtResolve,
+            },
             children: [
                 {
                     path: 'edit',

--- a/src/main/webapp/app/course/manage/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/course-detail.component.html
@@ -1,4 +1,4 @@
-<div class="row justify-content-center" *ngIf="isVisible">
+<div class="row justify-content-center">
     <div class="col-8">
         <div *ngIf="course">
             <div>
@@ -111,4 +111,3 @@
         </div>
     </div>
 </div>
-<router-outlet></router-outlet>

--- a/src/main/webapp/app/course/manage/course-detail.component.ts
+++ b/src/main/webapp/app/course/manage/course-detail.component.ts
@@ -1,6 +1,5 @@
-import { filter } from 'rxjs/operators';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { ActivatedRoute, Router, NavigationEnd } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { Subscription } from 'rxjs/Subscription';
 import { JhiEventManager } from 'ng-jhipster';
@@ -17,7 +16,6 @@ import { JhiAlertService } from 'ng-jhipster';
 export class CourseDetailComponent implements OnInit, OnDestroy {
     CachingStrategy = CachingStrategy;
     course: Course;
-    isVisible: boolean;
     private eventSubscriber: Subscription;
 
     constructor(
@@ -36,8 +34,6 @@ export class CourseDetailComponent implements OnInit, OnDestroy {
             this.course = course;
         });
         this.registerChangeInCourses();
-        this.isVisible = this.route.children.length === 0;
-        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => (this.isVisible = this.route.children.length === 0));
     }
 
     /**

--- a/src/main/webapp/app/course/manage/course-management.route.ts
+++ b/src/main/webapp/app/course/manage/course-management.route.ts
@@ -68,6 +68,16 @@ export const courseManagementState: Routes = [
             breadcrumbLabelVariable: 'course.title',
         },
         canActivate: [UserRouteAccessService],
+    },
+    {
+        // Create a new path without a component defined to prevent resolver caching and the CourseDetailComponent from being always rendered
+        path: ':courseId',
+        resolve: {
+            course: CourseResolve,
+        },
+        data: {
+            breadcrumbLabelVariable: 'course.title',
+        },
         children: [
             {
                 path: 'exercises',
@@ -75,6 +85,7 @@ export const courseManagementState: Routes = [
                 data: {
                     authorities: [Authority.INSTRUCTOR, Authority.TA, Authority.ADMIN],
                     pageTitle: 'artemisApp.course.exercises',
+                    breadcrumbLabelVariable: '',
                 },
                 canActivate: [UserRouteAccessService],
             },
@@ -84,6 +95,7 @@ export const courseManagementState: Routes = [
                 data: {
                     authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
                     pageTitle: 'artemisApp.course.home.editLabel',
+                    breadcrumbLabelVariable: '',
                 },
                 canActivate: [UserRouteAccessService],
             },
@@ -93,6 +105,7 @@ export const courseManagementState: Routes = [
                 data: {
                     authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
                     pageTitle: 'userManagement.groups',
+                    breadcrumbLabelVariable: '',
                 },
                 canActivate: [UserRouteAccessService],
             },
@@ -102,6 +115,7 @@ export const courseManagementState: Routes = [
                 data: {
                     authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
                     pageTitle: 'artemisApp.ratingList.pageTitle',
+                    breadcrumbLabelVariable: '',
                 },
                 canActivate: [UserRouteAccessService],
             },
@@ -111,6 +125,7 @@ export const courseManagementState: Routes = [
                 data: {
                     authorities: ['ROLE_ADMIN', 'ROLE_INSTRUCTOR'],
                     pageTitle: 'artemisApp.learningGoal.manageLearningGoals.title',
+                    breadcrumbLabelVariable: '',
                 },
                 canActivate: [UserRouteAccessService],
             },
@@ -119,6 +134,7 @@ export const courseManagementState: Routes = [
                 path: 'goal-management',
                 data: {
                     pageTitle: 'artemisApp.learningGoal.manageLearningGoals.title',
+                    breadcrumbLabelVariable: '',
                 },
                 children: [
                     {
@@ -126,7 +142,6 @@ export const courseManagementState: Routes = [
                         component: CreateLearningGoalComponent,
                         data: {
                             authorities: ['ROLE_ADMIN', 'ROLE_INSTRUCTOR'],
-                            breadcrumbLabelVariable: '',
                             pageTitle: 'artemisApp.learningGoal.createLearningGoal.title',
                         },
                         canActivate: [UserRouteAccessService],
@@ -136,7 +151,6 @@ export const courseManagementState: Routes = [
                         component: EditLearningGoalComponent,
                         data: {
                             authorities: ['ROLE_ADMIN', 'ROLE_INSTRUCTOR'],
-                            breadcrumbLabelVariable: '',
                             pageTitle: 'artemisApp.learningGoal.editLearningGoal.title',
                         },
                         canActivate: [UserRouteAccessService],

--- a/src/main/webapp/app/lecture/lecture.component.ts
+++ b/src/main/webapp/app/lecture/lecture.component.ts
@@ -59,7 +59,9 @@ export class LectureComponent implements OnInit, OnDestroy {
         this.isVisible = this.route.children.length === 0;
         this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
             this.isVisible = this.route.children.length === 0;
-            this.loadAll();
+            if (this.isVisible) {
+                this.loadAll();
+            }
         });
     }
 


### PR DESCRIPTION
### Checklist

- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context

Caching the resolver data risks breakages when the user edits said data (e.g. a course). Removing it is the simplest solution (and also gets rid of some extra `router-outlet`s.)

### Description

Removes caching and adds a more detailed description to the client guidelines on how I (plan to) handle routes and breadcrumbs.

### Steps for Testing

1. Check that you can still view the details, list overview, edit and create pages for:
    - Courses (Course Management)
    - Users (System Administration)
    - System Notifications (System Administration)
2. Test that data is updated when switching pages after editing (for the same pages as above)
3. Verify that the breadcrumbs still display the same as on develop (for the same pages as above)
