### PR TITLE
User-statistics-fix

### DIFF
--- a/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
+++ b/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
@@ -108,7 +108,10 @@ export class StatisticsGraphComponent implements OnInit, OnChanges {
                 endDate = moment().subtract(-this.currentPeriod, 'months');
                 const daysInMonth = endDate.diff(startDate, 'days');
                 this.barChartLabels = this.getLabelsForMonth(daysInMonth);
-                this.chartTime = now.add(this.currentPeriod, 'months').format('MMMM YYYY');
+                this.chartTime = now
+                    .add(this.currentPeriod, 'months')
+                    .subtract(Math.floor(this.barChartLabels.length / 2) - 1, 'days')
+                    .format('MMMM YYYY');
                 break;
             case SpanType.QUARTER:
                 const prefix = this.translateService.instant('calendar_week');
@@ -126,7 +129,7 @@ export class StatisticsGraphComponent implements OnInit, OnChanges {
                 break;
             case SpanType.YEAR:
                 this.barChartLabels = this.getMonths();
-                this.chartTime = now.add(this.currentPeriod, 'years').format('YYYY');
+                this.chartTime = now.add(this.currentPeriod, 'years').subtract(5, 'months').format('YYYY');
                 break;
         }
     }

--- a/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
+++ b/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
@@ -110,7 +110,7 @@ export class StatisticsGraphComponent implements OnInit, OnChanges {
                 this.barChartLabels = this.getLabelsForMonth(daysInMonth);
                 this.chartTime = now
                     .add(this.currentPeriod, 'months')
-                    .subtract(Math.ceil(this.barChartLabels.length / 2.0) - 1, 'days')
+                    .subtract(Math.floor(this.barChartLabels.length / 2.0) - 1, 'days')
                     .format('MMMM YYYY');
                 break;
             case SpanType.QUARTER:

--- a/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
+++ b/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
@@ -110,7 +110,7 @@ export class StatisticsGraphComponent implements OnInit, OnChanges {
                 this.barChartLabels = this.getLabelsForMonth(daysInMonth);
                 this.chartTime = now
                     .add(this.currentPeriod, 'months')
-                    .subtract(Math.floor(this.barChartLabels.length / 2) - 1, 'days')
+                    .subtract(Math.ceil(this.barChartLabels.length / 2.0) - 1, 'days')
                     .format('MMMM YYYY');
                 break;
             case SpanType.QUARTER:


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Month and year displayed in the Month and Year Tab was chosen by the Month/Year of the very right date of the chart. Since this can be confusing, this should be changed.

### Description
<!-- Describe your changes in detail -->
- The Year displayed in the year tab is now the year of the 7th bar, which is the right side of the middle of the chart
- The Month displayed in the Month tab is now depending on the length of the month. Its always the right bar next to the middle of the chart:
       If the length of the month is odd, like December, the month of the 17th bar is chosen
       If the length of month is even, like November, the month of the 16th. bar is chosen as the right center of the chart

(for months with odd lengths, choosing the middle bar would lead to never displaying 30 day months like November, August etc., hence the bar right next to the middle is chosen)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Server Administration -> User statistics
3. Make sure that the above mentioned months and years are shown

(edge cases are hard to test, you could check out the branch locally and play around with the time of your pc, like seen in the screenshot)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
November has 30 days:
<img width="1402" alt="Screenshot 2021-01-15 at 14 46 24" src="https://user-images.githubusercontent.com/44401560/103653993-98df6300-4f65-11eb-9086-a390681762d0.png">


December has 31 days:
When it's the 14.01.2021:
<img width="1403" alt="Screenshot 2021-01-14 at 14 49 45" src="https://user-images.githubusercontent.com/44401560/103654060-b3b1d780-4f65-11eb-90ed-32403341afac.png">
When it's the 15.01.2021:
<img width="1402" alt="Screenshot 2021-01-15 at 14 48 22" src="https://user-images.githubusercontent.com/44401560/103654091-bca2a900-4f65-11eb-8325-9a700bb17b00.png">


Year:
<img width="1402" alt="Screenshot 2021-01-14 at 14 50 34" src="https://user-images.githubusercontent.com/44401560/103654122-c5937a80-4f65-11eb-9247-4b75c86d4dd8.png">


