### PR TITLE
Add client test for grading statistics

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/grading/charts/category-issues-chart.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/grading/charts/category-issues-chart.component.ts
@@ -61,7 +61,7 @@ export class CategoryIssuesChartComponent implements OnChanges {
                         : numIssues > maxGradedIssues
                         ? '#dc3545'
                         : '#ffc107',
-                tooltip: `${numStudents} student${numStudents !== 1 ? 's' : ''} have ${numIssues} issue${numIssues !== 1 ? 's' : ''}.`,
+                tooltip: `${numStudents} student${numStudents !== 1 ? 's' : ''} ${numStudents !== 1 ? 'have' : 'has'} ${numIssues} issue${numIssues !== 1 ? 's' : ''}.`,
             };
         });
 

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-configure-grading.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-configure-grading.component.spec.ts
@@ -39,6 +39,9 @@ import { MockCookieService } from '../../helpers/mocks/service/mock-cookie.servi
 import { MockProgrammingExerciseService } from '../../helpers/mocks/service/mock-programming-exercise.service';
 import { MockRouter } from '../../helpers/mocks/mock-router';
 import { StaticCodeAnalysisCategory, StaticCodeAnalysisCategoryState } from 'app/entities/static-code-analysis-category.model';
+import { CategoryIssuesMap, ProgrammingExerciseGradingStatistics, TestCaseStatsMap } from 'app/entities/programming-exercise-test-case-statistics.model';
+import { CategoryIssuesChartComponent } from 'app/exercises/programming/manage/grading/charts/category-issues-chart.component';
+import { TestCasePassedBuildsChartComponent } from 'app/exercises/programming/manage/grading/charts/test-case-passed-builds-chart.component';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -59,6 +62,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
     let testCasesChangedStub: SinonStub;
     let getExerciseTestCaseStateStub: SinonStub;
     let loadExerciseStub: SinonStub;
+    let loadStatisticsStub: SinonStub;
     let programmingExerciseWebsocketService: ProgrammingExerciseWebsocketService;
 
     let routeSubject: Subject<Params>;
@@ -82,9 +86,33 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
         staticCodeAnalysisEnabled: true,
     } as ProgrammingExercise;
     const testCases1 = [
-        { id: 1, testName: 'testBubbleSort', active: true, weight: 1, bonusMultiplier: 1, bonusPoints: 0, afterDueDate: false },
-        { id: 2, testName: 'testMergeSort', active: true, weight: 1, bonusMultiplier: 1, bonusPoints: 0, afterDueDate: true },
-        { id: 3, testName: 'otherTest', active: false, weight: 1, bonusMultiplier: 1, bonusPoints: 0, afterDueDate: false },
+        {
+            id: 1,
+            testName: 'testBubbleSort',
+            active: true,
+            weight: 1,
+            bonusMultiplier: 1,
+            bonusPoints: 0,
+            afterDueDate: false,
+        },
+        {
+            id: 2,
+            testName: 'testMergeSort',
+            active: true,
+            weight: 1,
+            bonusMultiplier: 1,
+            bonusPoints: 0,
+            afterDueDate: true,
+        },
+        {
+            id: 3,
+            testName: 'otherTest',
+            active: false,
+            weight: 1,
+            bonusMultiplier: 1,
+            bonusPoints: 0,
+            afterDueDate: false,
+        },
     ] as ProgrammingExerciseTestCase[];
     const codeAnalysisCategories1 = [
         {
@@ -169,6 +197,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
                 updateCategoriesStub = stub(gradingService, 'updateCodeAnalysisCategories');
                 notifyTestCasesSpy = spy(gradingService, 'notifyTestCases');
                 resetTestCasesStub = stub(gradingService, 'reset');
+                loadStatisticsStub = stub(gradingService, 'getGradingStatistics');
 
                 // @ts-ignore
                 (router as MockRouter).setUrl('/');
@@ -618,6 +647,58 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
         expect(comp.hasUpdatedGradingConfig).to.be.true;
 
         fixture.detectChanges();
+
+        tick();
+        fixture.destroy();
+        flush();
+    }));
+
+    it('should load and calculate grading statistics correctly', fakeAsync(() => {
+        const stats = {
+            numParticipations: 5,
+            testCaseStatsMap: {
+                testBubbleSort: { numPassed: 2, numFailed: 3 },
+                testMergeSort: { numPassed: 1, numFailed: 4 },
+                otherTest: { numPassed: 1, numFailed: 0 },
+            },
+            categoryIssuesMap: {
+                'Bad Practice': { 1: 2, 2: 2, 3: 1 },
+                Styling: { 0: 3, 2: 1, 5: 1 },
+            },
+        } as ProgrammingExerciseGradingStatistics;
+
+        loadStatisticsStub.returns(of(stats));
+
+        initGradingComponent({ tab: 'code-analysis' });
+
+        fixture.detectChanges();
+
+        expect(comp.maxIssuesPerCategory).to.equal(5);
+        expect(comp.gradingStatistics).to.deep.equal(stats);
+
+        fixture.detectChanges();
+        tick();
+
+        const issueCharts = debugElement.queryAll(By.directive(CategoryIssuesChartComponent)).map((d) => d.componentInstance);
+
+        expect(issueCharts[0].columns).to.have.lengthOf(11);
+        expect(issueCharts[0].columns[0].tooltip).to.equal('2 students have 1 issue.');
+        expect(issueCharts[0].columns[1].tooltip).to.equal('2 students have 2 issues.');
+        expect(issueCharts[0].columns[2].tooltip).to.equal('1 student has 3 issues.');
+
+        expect(issueCharts[1].columns).to.have.lengthOf(11);
+        expect(issueCharts[1].columns[1].tooltip).to.equal('1 student has 2 issues.');
+        expect(issueCharts[1].columns[4].tooltip).to.equal('1 student has 5 issues.');
+
+        comp.selectTab('test-cases');
+
+        fixture.detectChanges();
+        tick();
+
+        const percentageCharts = debugElement.queryAll(By.directive(TestCasePassedBuildsChartComponent)).map((d) => d.componentInstance);
+
+        expect(percentageCharts[0].tooltip).to.equal('40% passed, 60% failed of 5 students.');
+        expect(percentageCharts[1].tooltip).to.equal('20% passed, 80% failed of 5 students.');
 
         tick();
         fixture.destroy();

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-configure-grading.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-configure-grading.component.spec.ts
@@ -700,7 +700,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         expect(percentageCharts[0].tooltip).to.equal('40% passed, 60% failed of 5 students.');
         expect(percentageCharts[1].tooltip).to.equal('20% passed, 80% failed of 5 students.');
-      
+
         tick();
         fixture.destroy();
         flush();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Increase test coverage.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

* programming-exercise-configure-grading.component.ts: 82.24% -> 89.07%
