### PR TITLE
Bugfix/quiz exercises/space at start of lines

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.ts
@@ -95,7 +95,12 @@ export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, Afte
          * these [ ] brackets.
          * **/
         const textForEachLine = this.question.text!.split(/\n+/g);
-        this.textParts = textForEachLine.map((t) => t.split(/\s+(?![^[]]*])/g));
+        this.textParts = textForEachLine.map((t) => {
+            const indentation = this.shortAnswerQuestionUtil.getIndentation(t);
+            const lineParts = t.split(/\s+(?![^[]]*])/g);
+            lineParts[1] = indentation.concat(lineParts[1]);
+            return lineParts;
+        });
 
         /** Assign status booleans and strings **/
         this.showVisualMode = false;

--- a/src/main/webapp/app/exercises/quiz/shared/short-answer-question-util.service.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/short-answer-question-util.service.ts
@@ -387,9 +387,7 @@ export class ShortAnswerQuestionUtil {
         return questionText.split(/\n/g).map((line) => {
             const spots = line.match(spotRegExpo) || [];
             const texts = line.split(spotRegExpo);
-            return interleave(texts, spots)
-                .map((x) => x.trim())
-                .filter((x) => x.length > 0);
+            return interleave(texts, spots).filter((x) => x.length > 0);
         });
     }
 
@@ -431,6 +429,61 @@ export class ShortAnswerQuestionUtil {
      * @returns {string[][]}
      */
     transformTextPartsIntoHTML(textParts: string[][], artemisMarkdown: ArtemisMarkdownService): string[][] {
-        return textParts.map((textPart) => textPart.map((element) => artemisMarkdown.htmlForMarkdown(element)));
+        const formattedTextParts = textParts.map((textPart) => textPart.map((element) => artemisMarkdown.htmlForMarkdown(element.trim())));
+        return this.addIndentationToTextParts(textParts, formattedTextParts);
+    }
+
+    /**
+     * @function addIndentationToTextParts
+     * @desc Formats the first word of each line with the indentation it originally had.
+     * @param originalTextParts {string[][]} the text parts without html formatting
+     * @param formattedTextParts {string[][]} the text parts with html formatting
+     */
+    addIndentationToTextParts(originalTextParts: string[][], formattedTextParts: string[][]): string[][] {
+        for (let i = 0; i < formattedTextParts.length; i++) {
+            const element = formattedTextParts[i][0];
+            const firstWord = this.getFirstWord(originalTextParts[i][0]);
+            if (firstWord === '') {
+                continue;
+            }
+            const firstWordIndex = element.indexOf(firstWord);
+            const whitespace = '&nbsp;'.repeat(this.getIndentation(originalTextParts[i][0]).length);
+            formattedTextParts[i][0] = [element.substring(0, firstWordIndex), whitespace, element.substring(firstWordIndex).trim()].join('');
+        }
+        return formattedTextParts;
+    }
+
+    /**
+     * @function getIndentation
+     * @desc Returns the whitespace in front of the text.
+     * @param text {string} the text for which we get the indentation
+     */
+    getIndentation(text: string): string {
+        if (text.startsWith('`')) {
+            text = text.substring(1);
+        }
+        let index = 0;
+        let indentation = '';
+        while (text[index] === ' ') {
+            indentation = indentation.concat(' ');
+            index++;
+        }
+        return indentation;
+    }
+
+    /**
+     * @function getFirstWord
+     * @desc Returns the first word in a text.
+     * @param text {string} for which the first word is returned
+     */
+    getFirstWord(text: string): string {
+        const words = text.split(' ').filter((word) => word !== '');
+        if (words.length === 0) {
+            return '';
+        } else if (words[0] === '`') {
+            return words[1];
+        } else {
+            return words[0].startsWith('`') ? words[0].substring(1) : words[0];
+        }
     }
 }

--- a/src/test/javascript/spec/component/short-answer-quiz/short-answer-question-util.service.spec.ts
+++ b/src/test/javascript/spec/component/short-answer-quiz/short-answer-question-util.service.spec.ts
@@ -1,0 +1,50 @@
+import { ShortAnswerQuestionUtil } from 'app/exercises/quiz/shared/short-answer-question-util.service';
+import { ArtemisMarkdownService } from 'app/shared/markdown.service';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('ShortAnswerQuestionUtil', () => {
+    let shortAnswerQuestionUtil: ShortAnswerQuestionUtil;
+    let artemisMarkdownService: ArtemisMarkdownService;
+
+    beforeEach(fakeAsync(() => {
+        TestBed.configureTestingModule({ providers: [ArtemisMarkdownService] });
+        artemisMarkdownService = TestBed.inject(ArtemisMarkdownService);
+        shortAnswerQuestionUtil = new ShortAnswerQuestionUtil();
+    }));
+
+    it('Should transform text parts to html correctly', fakeAsync(() => {
+        const originalTextParts1 = [['random text'], ['    some more text', '[-spot 1]'], ['last paragraph']];
+        const formattedTextParts1 = [['<p>random text</p>'], ['<p>&nbsp;&nbsp;&nbsp;&nbsp;some more text</p>', '<p>[-spot 1]</p>'], ['<p>last paragraph</p>']];
+        expect(shortAnswerQuestionUtil.transformTextPartsIntoHTML(originalTextParts1, artemisMarkdownService)).to.eql(formattedTextParts1);
+        const originalTextParts2 = [['`random code`'], ['`    some more code`', '[-spot 1]'], ['`last code paragraph`']];
+        const formattedTextParts2 = [
+            ['<p><code>random code</code></p>'],
+            ['<p><code>&nbsp;&nbsp;&nbsp;&nbsp;some more code</code></p>', '<p>[-spot 1]</p>'],
+            ['<p><code>last code paragraph</code></p>'],
+        ];
+        expect(shortAnswerQuestionUtil.transformTextPartsIntoHTML(originalTextParts2, artemisMarkdownService)).to.eql(formattedTextParts2);
+    }));
+
+    it('Should return the correct indentation', fakeAsync(() => {
+        const sentence1 = '    this is a test';
+        const sentence2 = '  `another test`';
+        const sentence3 = '`last test`';
+        expect(shortAnswerQuestionUtil.getIndentation(sentence1)).to.equal('    ');
+        expect(shortAnswerQuestionUtil.getIndentation(sentence2)).to.equal('  ');
+        expect(shortAnswerQuestionUtil.getIndentation(sentence3)).to.equal('');
+    }));
+
+    it('Should return first word of a sentence', fakeAsync(() => {
+        const sentence1 = '         this is a test';
+        const sentence2 = '    `another test`';
+        const sentence3 = '';
+        expect(shortAnswerQuestionUtil.getFirstWord(sentence1)).to.equal('this');
+        expect(shortAnswerQuestionUtil.getFirstWord(sentence2)).to.equal('another');
+        expect(shortAnswerQuestionUtil.getFirstWord(sentence3)).to.equal('');
+    }));
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #2569 

### Description
<!-- Describe your changes in detail -->
Added line indentation support for the short answer quiz exercises

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to Exercises
4. Create a quiz exercise with a short answer question
5. Add a code to the editor, such as the following:
```
`public class Foo {`
`    public `[-spot 1]`() {}`
`}`
[-option 1] Foo
```
6. Save
7. Check if the indentation is present in (pre)view mode.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/63168603/103575381-4dcc3e00-4eda-11eb-911a-900788f2770a.png)
