### PR TITLE
Fixed sort programming exercise by programming language

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -820,7 +820,7 @@ public abstract class Exercise extends DomainObject {
      */
     public enum ExerciseSearchColumn {
 
-        ID("id"), TITLE("title"), COURSE_TITLE("course.title");
+        ID("id"), TITLE("title"), PROGRAMMING_LANGUAGE("programmingLanguage"), COURSE_TITLE("course.title");
 
         private String mappedColumnName;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest2.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [ ] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [ ] Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Sorting programming exercises by programming language, in the "import programming exercise" modal, did not work. 

### Description
<!-- Describe your changes in detail -->
Added the missing "programming language" in *ExerciseSearchColumn*  Enum.(src/main/java/de/tum/in/www1/artemis/domain/Exercise.java)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration - <random_course> - Exercises
3. Click on "Import programming exercise"
4. Try to sort the programming exercises by "Programming Language"

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Exercise.java: 92%

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:

![new](https://user-images.githubusercontent.com/45761921/103583072-5d9a5100-4edf-11eb-8566-697af72a0ca0.gif)

After:
![working](https://user-images.githubusercontent.com/45761921/103583075-60954180-4edf-11eb-8a93-b0c9bcf18041.gif)

