### PR TITLE
[Bugfix] Missing Unsubscribe from Route Event Subscriptions

### DIFF
--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
@@ -27,6 +27,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
     error: string;
     success: string;
     routeData: Subscription;
+    routerEventSubscription?: Subscription;
     links: any;
     totalItems: string;
     itemsPerPage: number;
@@ -68,7 +69,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
             this.registerChangeInUsers();
         });
         this.isVisible = this.activatedRoute.children.length === 0;
-        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+        this.routerEventSubscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
             this.isVisible = this.activatedRoute.children.length === 0;
             if (this.isVisible) {
                 this.loadAll();
@@ -82,6 +83,9 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
     ngOnDestroy() {
         this.routeData.unsubscribe();
         this.dialogErrorSource.unsubscribe();
+        if (this.routerEventSubscription) {
+            this.eventManager.destroy(this.routerEventSubscription);
+        }
     }
 
     /**

--- a/src/main/webapp/app/admin/user-management/user-management.component.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.component.ts
@@ -25,6 +25,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     currentAccount?: User;
     users: User[];
     userListSubscription?: Subscription;
+    routerEventSubscription?: Subscription;
     totalItems = 0;
     itemsPerPage = ITEMS_PER_PAGE;
     page!: number;
@@ -85,7 +86,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
             this.handleNavigation();
         });
         this.isVisible = this.activatedRoute.children.length === 0;
-        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+        this.routerEventSubscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
             this.isVisible = this.activatedRoute.children.length === 0;
             if (this.isVisible) {
                 this.loadAll();
@@ -99,6 +100,9 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         if (this.userListSubscription) {
             this.eventManager.destroy(this.userListSubscription);
+        }
+        if (this.routerEventSubscription) {
+            this.eventManager.destroy(this.routerEventSubscription);
         }
         this.dialogErrorSource.unsubscribe();
     }

--- a/src/main/webapp/app/lecture/lecture.component.ts
+++ b/src/main/webapp/app/lecture/lecture.component.ts
@@ -19,6 +19,7 @@ export class LectureComponent implements OnInit, OnDestroy {
     lectures: Lecture[];
     currentAccount: any;
     eventSubscriber: Subscription;
+    routerEventSubscription?: Subscription;
     courseId: number;
     isVisible: boolean;
 
@@ -57,7 +58,7 @@ export class LectureComponent implements OnInit, OnDestroy {
         });
         this.registerChangeInLectures();
         this.isVisible = this.route.children.length === 0;
-        this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+        this.routerEventSubscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
             this.isVisible = this.route.children.length === 0;
             if (this.isVisible) {
                 this.loadAll();
@@ -68,6 +69,9 @@ export class LectureComponent implements OnInit, OnDestroy {
     ngOnDestroy() {
         this.eventManager.destroy(this.eventSubscriber);
         this.dialogErrorSource.unsubscribe();
+        if (this.routerEventSubscription) {
+            this.eventManager.destroy(this.routerEventSubscription);
+        }
     }
 
     trackId(index: number, item: Lecture) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When navigating to specific pages (system-notifications, user-management, lectures overview) a specific REST call is executed
- Firstly, this call is executed when leaving the page, which should not happen
- Secondly, every time the page is re-entered, one additional call of this query is added, leading to a potentially endless series of calls. (Also when leaving the page)


### Description
<!-- Describe your changes in detail -->
Fixed this issue by unsubscribing to the event when leaving the page.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Server Administration -> system notifications while looking at the network tab (f12)
3. There should be an entry like `system-notifications?page=0&size=50&sort=id,asc`
4. When navigating to another page (like course management), there should not be such an call again
5. When navigating into the system notifications again and again, make sure this network call is always executed **once**

6. Perform step 2. - 5. with 
- Server Administration -> system-notifications (network call named like `system-notifications?page=0&size=50&sort=id,asc`)
- Server Administration -> user-management (network call named like `users?page=0&pageSize=50&searchTerm=&sortingOrder=ASCENDING&sortedColumn=id`)
- Course Management -> Lectures (Choosing a course with only one lecture makes it more convenient to test, network call named like `lectures?withLectureUnits=0`)
