### PR TITLE
[Bugfix] multiple user statistics REST call + PR review improvements #2658

### DIFF
--- a/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
+++ b/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 import { StatisticsService } from 'app/admin/statistics/statistics.service';
 import { ChartDataSets, ChartOptions, ChartType } from 'chart.js';
 import { BaseChartDirective, Label } from 'ng2-charts';
@@ -11,13 +11,13 @@ import { Graphs, SpanType } from 'app/entities/statistics.model';
     selector: 'jhi-statistics-graph',
     templateUrl: './statistics-graph.component.html',
 })
-export class StatisticsGraphComponent implements OnInit, OnChanges {
+export class StatisticsGraphComponent implements OnChanges {
     @Input()
     graphType: Graphs;
     @Input()
     currentSpan: SpanType;
 
-    // html properties
+    // Html properties
     LEFT = false;
     RIGHT = true;
     SpanType = SpanType;
@@ -36,7 +36,7 @@ export class StatisticsGraphComponent implements OnInit, OnChanges {
     chartData: ChartDataSets[] = [];
     dataForSpanType: number[];
 
-    // left arrow -> decrease, right arrow -> increase
+    // Left arrow -> decrease, right arrow -> increase
     private currentPeriod = 0;
 
     @ViewChild(BaseChartDirective) chart: BaseChartDirective;
@@ -51,10 +51,6 @@ export class StatisticsGraphComponent implements OnInit, OnChanges {
         this.currentSpan = changes.currentSpan?.currentValue;
         this.barChartLabels = [];
         this.currentPeriod = 0;
-        this.initializeChart();
-    }
-
-    ngOnInit() {
         this.amountOfStudents = this.translateService.instant('statistics.amountOfStudents');
         this.chartName = this.translateService.instant(`statistics.${this.graphType.toString().toLowerCase()}`);
         this.initializeChart();

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
@@ -27,7 +27,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
     error: string;
     success: string;
     routeData: Subscription;
-    routerEventSubscription?: Subscription;
+    navigationEndSubscription?: Subscription;
     links: any;
     totalItems: string;
     itemsPerPage: number;
@@ -69,7 +69,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
             this.registerChangeInUsers();
         });
         this.isVisible = this.activatedRoute.children.length === 0;
-        this.routerEventSubscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+        this.navigationEndSubscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
             this.isVisible = this.activatedRoute.children.length === 0;
             if (this.isVisible) {
                 this.loadAll();
@@ -83,8 +83,8 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
     ngOnDestroy() {
         this.routeData.unsubscribe();
         this.dialogErrorSource.unsubscribe();
-        if (this.routerEventSubscription) {
-            this.eventManager.destroy(this.routerEventSubscription);
+        if (this.navigationEndSubscription) {
+            this.navigationEndSubscription.unsubscribe();
         }
     }
 

--- a/src/main/webapp/app/admin/user-management/user-management.component.ts
+++ b/src/main/webapp/app/admin/user-management/user-management.component.ts
@@ -25,7 +25,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     currentAccount?: User;
     users: User[];
     userListSubscription?: Subscription;
-    routerEventSubscription?: Subscription;
+    navigationEndSubscription?: Subscription;
     totalItems = 0;
     itemsPerPage = ITEMS_PER_PAGE;
     page!: number;
@@ -86,7 +86,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
             this.handleNavigation();
         });
         this.isVisible = this.activatedRoute.children.length === 0;
-        this.routerEventSubscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+        this.navigationEndSubscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
             this.isVisible = this.activatedRoute.children.length === 0;
             if (this.isVisible) {
                 this.loadAll();
@@ -99,10 +99,10 @@ export class UserManagementComponent implements OnInit, OnDestroy {
      */
     ngOnDestroy(): void {
         if (this.userListSubscription) {
-            this.eventManager.destroy(this.userListSubscription);
+            this.userListSubscription.unsubscribe();
         }
-        if (this.routerEventSubscription) {
-            this.eventManager.destroy(this.routerEventSubscription);
+        if (this.navigationEndSubscription) {
+            this.navigationEndSubscription.unsubscribe();
         }
         this.dialogErrorSource.unsubscribe();
     }

--- a/src/main/webapp/app/lecture/lecture.component.ts
+++ b/src/main/webapp/app/lecture/lecture.component.ts
@@ -19,7 +19,7 @@ export class LectureComponent implements OnInit, OnDestroy {
     lectures: Lecture[];
     currentAccount: any;
     eventSubscriber: Subscription;
-    routerEventSubscription?: Subscription;
+    navigationEndSubscription?: Subscription;
     courseId: number;
     isVisible: boolean;
 
@@ -58,7 +58,7 @@ export class LectureComponent implements OnInit, OnDestroy {
         });
         this.registerChangeInLectures();
         this.isVisible = this.route.children.length === 0;
-        this.routerEventSubscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
+        this.navigationEndSubscription = this.router.events.pipe(filter((event) => event instanceof NavigationEnd)).subscribe(() => {
             this.isVisible = this.route.children.length === 0;
             if (this.isVisible) {
                 this.loadAll();
@@ -67,10 +67,10 @@ export class LectureComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
-        this.eventManager.destroy(this.eventSubscriber);
+        this.eventSubscriber.unsubscribe();
         this.dialogErrorSource.unsubscribe();
-        if (this.routerEventSubscription) {
-            this.eventManager.destroy(this.routerEventSubscription);
+        if (this.navigationEndSubscription) {
+            this.navigationEndSubscription.unsubscribe();
         }
     }
 

--- a/src/test/javascript/spec/component/statistics/statistics-graph.component.spec.ts
+++ b/src/test/javascript/spec/component/statistics/statistics-graph.component.spec.ts
@@ -81,11 +81,12 @@ describe('StatisticsGraphComponent', () => {
                 graphData[i] = i + 1;
             }
             spy.and.returnValue(of(graphData));
-
-            component.ngOnInit();
+            const changes = { currentSpan: { currentValue: span } as SimpleChange };
+            component.ngOnChanges(changes);
 
             expect(component.dataForSpanType).to.equal(graphData);
             expect(component.chartData[0].data).to.equal(graphData);
+            expect(component.currentSpan).to.equal(span);
         }
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Since #2658 was urgent to merge, this PR introduces the PR reviews done in the other PR
- User-Statistics:
    - When accessing the page, both ngOnChanges and ngOnInit are executed, which both call the same REST call


### Description
<!-- Describe your changes in detail -->
- Renamed the Subscription and not `this.eventManager.destroy()` is used, but rather a direct `.unsubcribe()` is used
- Since ngOnChanges is also executed on page access (Even before ngOnInit), ngOnInit is not needed
- Adapted user-statistics client tests accordingly
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

PR-review:
1. Log in to Artemis
2. Navigate to Server Administration -> system notifications while looking at the network tab (f12)
3. There should be an entry like system-notifications?page=0&size=50&sort=id,asc
4. When navigating to another page (like course management), there should not be such an call again
5. When navigating into the system notifications again and again, make sure this network call is always executed once
6. Perform step 2. - 5. with

- Server Administration -> system-notifications (network call named like system-notifications?page=0&size=50&sort=id,asc)
- Server Administration -> user-management (network call named like users?page=0&pageSize=50&searchTerm=&sortingOrder=ASCENDING&sortedColumn=id)
- Course Management -> Lectures (Choosing a course with only one lecture makes it more convenient to test, network call named like lectures?withLectureUnits=0)

User-statistics:
1. Access Server Administration -> User-statistics + Open Network tab
2. Make sure everything is loaded without errors and unsuspected behaviour
3. Check that for every graphType, there is only one REST call (like data?span=WEEK&periodIndex=0&graphType=CREATED_RESULTS)
