### PR TITLE
[Bugfix] multiple user statistics REST call

### DIFF
--- a/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
+++ b/src/main/webapp/app/admin/statistics/statistics-graph.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
 import { StatisticsService } from 'app/admin/statistics/statistics.service';
 import { ChartDataSets, ChartOptions, ChartType } from 'chart.js';
 import { BaseChartDirective, Label } from 'ng2-charts';
@@ -11,13 +11,13 @@ import { Graphs, SpanType } from 'app/entities/statistics.model';
     selector: 'jhi-statistics-graph',
     templateUrl: './statistics-graph.component.html',
 })
-export class StatisticsGraphComponent implements OnInit, OnChanges {
+export class StatisticsGraphComponent implements OnChanges {
     @Input()
     graphType: Graphs;
     @Input()
     currentSpan: SpanType;
 
-    // html properties
+    // Html properties
     LEFT = false;
     RIGHT = true;
     SpanType = SpanType;
@@ -36,7 +36,7 @@ export class StatisticsGraphComponent implements OnInit, OnChanges {
     chartData: ChartDataSets[] = [];
     dataForSpanType: number[];
 
-    // left arrow -> decrease, right arrow -> increase
+    // Left arrow -> decrease, right arrow -> increase
     private currentPeriod = 0;
 
     @ViewChild(BaseChartDirective) chart: BaseChartDirective;
@@ -51,10 +51,6 @@ export class StatisticsGraphComponent implements OnInit, OnChanges {
         this.currentSpan = changes.currentSpan?.currentValue;
         this.barChartLabels = [];
         this.currentPeriod = 0;
-        this.initializeChart();
-    }
-
-    ngOnInit() {
         this.amountOfStudents = this.translateService.instant('statistics.amountOfStudents');
         this.chartName = this.translateService.instant(`statistics.${this.graphType.toString().toLowerCase()}`);
         this.initializeChart();

--- a/src/test/javascript/spec/component/statistics/statistics-graph.component.spec.ts
+++ b/src/test/javascript/spec/component/statistics/statistics-graph.component.spec.ts
@@ -82,10 +82,12 @@ describe('StatisticsGraphComponent', () => {
             }
             spy.and.returnValue(of(graphData));
 
-            component.ngOnInit();
+            const changes = { currentSpan: { currentValue: span } as SimpleChange };
+            component.ngOnChanges(changes);
 
             expect(component.dataForSpanType).to.equal(graphData);
             expect(component.chartData[0].data).to.equal(graphData);
+            expect(component.currentSpan).to.equal(span);
         }
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- User-Statistics:
    - When accessing the page, both ngOnChanges and ngOnInit are executed, which both call the same REST call


### Description
<!-- Describe your changes in detail -->
- Since ngOnChanges is also executed on page access (Even before ngOnInit), ngOnInit is not needed
- Adapted user-statistics client tests accordingly
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Access Server Administration -> User-statistics + Open Network tab
2. Make sure everything is loaded without errors and unsuspected behaviour
3. Check that for every graphType, there is only one REST call (like `data?span=WEEK&periodIndex=0&graphType=CREATED_RESULTS`)
4. Also click available buttons and check everything's correct (arrows, tabs)