### PR TITLE
Fix the Edit button in the Detail view of exercise hints

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-detail.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-detail.component.html
@@ -21,7 +21,7 @@
                 </dd>
             </dl>
 
-            <button type="button" [routerLink]="['..', 'edit']" class="btn btn-primary">
+            <button type="button" [routerLink]="['edit']" class="btn btn-primary">
                 <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
             </button>
         </div>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context

On `develop` you get a "Bad Request" when clicking `Edit` on the details page of an exercise hint:
![grafik](https://user-images.githubusercontent.com/72132281/104220986-8fac3580-5440-11eb-9755-4e9dcd98f70e.png)

### Description

Fixes the URL to point to the correct route.

### Steps for Testing

1. View the details of an existing exercise hint (you might need to create one). You can find the exercise hints when clicking on the Id of a programming exercise and then on "Exercise Hints" there.
2. Make sure the edit button works.

