### PR TITLE
feat(haskell) disable unsafe features in student submissions

### DIFF
--- a/src/main/resources/templates/haskell/test/run.sh
+++ b/src/main/resources/templates/haskell/test/run.sh
@@ -13,7 +13,10 @@ done
 shift $((OPTIND-1))
 
 # check for unsafe OPTIONS and OPTIONS_GHC pragma as they allow to overwrite command line arguments
-$safe && grep -RqFm 1 "OPTIONS" assignment/* && echo "Cannot build with \"OPTIONS\" string in source" && exit 1
+$safe && grep -RqFm 1 "OPTIONS" assignment/* && echo "Cannot build with \"OPTIONS\" string in source." && exit 1
+
+# check for symlinks
+$safe && find assignment/ -type l | grep -q . && echo "Cannot build with symlinks in submission." && exit 1
 
 # build the libraries - do not forget to set the right compilation flag (Prod)
 stack build --allow-different-user --flag test:Prod && \

--- a/src/main/resources/templates/haskell/test/run.sh
+++ b/src/main/resources/templates/haskell/test/run.sh
@@ -15,7 +15,7 @@ shift $((OPTIND-1))
 # check for unsafe OPTIONS and OPTIONS_GHC pragma as they allow to overwrite command line arguments
 $safe && grep -RqFm 1 "OPTIONS" assignment/* && echo "Cannot build with \"OPTIONS\" string in source." && exit 1
 
-# check for symlinks
+# check for symlinks as they might be abused to link to the sample solution
 $safe && find assignment/ -type l | grep -q . && echo "Cannot build with symlinks in submission." && exit 1
 
 # build the libraries - do not forget to set the right compilation flag (Prod)

--- a/src/main/resources/templates/haskell/test/run.sh
+++ b/src/main/resources/templates/haskell/test/run.sh
@@ -12,6 +12,9 @@ while getopts s opt; do
 done
 shift $((OPTIND-1))
 
+# check for unsafe OPTIONS and OPTIONS_GHC pragma as they allow to overwrite command line arguments
+$safe && grep -RqFm 1 "OPTIONS" assignment/* && echo "Cannot build with \"OPTIONS\" string in source" && exit 1
+
 # build the libraries - do not forget to set the right compilation flag (Prod)
 stack build --allow-different-user --flag test:Prod && \
   # delete the solution and tests (so that students cannot access it) when in safe mode

--- a/src/main/resources/templates/haskell/test/test.cabal
+++ b/src/main/resources/templates/haskell/test/test.cabal
@@ -41,6 +41,8 @@ common common-tests
     -- this flag is necessary as it allows interrupts of non-allocating loops
     -- https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/bugs.html#bugs-in-ghc
     -fno-omit-yields
+  if flag(Prod)
+    cpp-options: -DPROD
 
 -- build a submission
 library submission
@@ -49,8 +51,11 @@ library submission
   default-extensions: Safe
   -- The base package by Haskell can be trusted.
   -- See https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/safe_haskell.html#package-trust
-  -- for a description of the flags.
-  ghc-options: -fpackage-trust -trust base
+  -- for a description of the flags. Add more trusted packages if needed.
+  -- `-pgmP nonExistentCPP` disables the pre-processor for security reasons
+  -- by setting it to a non-existent program called `nonExistentCPP`. See
+  -- https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/phases.html
+  ghc-options: -fpackage-trust -trust base -pgmP nonExistentCPP
   hs-source-dirs: assignment/src
   exposed-modules: Exercise
 

--- a/src/main/resources/templates/haskell/test/test/Test.hs
+++ b/src/main/resources/templates/haskell/test/test/Test.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Test where
 
 import qualified Interface as Sub
@@ -68,10 +69,12 @@ main = do
   testRunner $ localOption timeoutOption tests
   where
     resultsPath = "test-reports/results.xml"
-    -- you can change the test runner to terminal output for local testing
-    -- run tests with xml output
+#ifdef PROD 
+    -- on the server (production mode), run tests with xml output
     testRunner = defaultMainWithIngredients [antXMLRunner]
-    -- run tests with terminal output
-    -- testRunner = defaultMain
+#else
+    -- locally, run tests with terminal output
+    testRunner = defaultMain
+#endif    
     -- by default, run for 1 second
     timeoutOption = mkTimeout (1 * 10^6)


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### What
1. This PR disables various unsafe features in student submissions:
    1. the pre-processor: it can be abused to read other files at compile time. In particular, it could be used to extract test and solution data.
    2. passing custom compilation flags: it can be used to re-activate the pre-processor
    3. symlinks: they can be abused to link to solution or testing data.
2. Moreover, this PR changes the test behaviour on local machines by outputting the test results in a pretty format on the console rather than creating a xml.

### Why
1. One of our tutors discovered these security issues. They allow students to cheat by reading either solution or test files.
2. XML is not made to be read by humans. For local tests, the console output is way nicer to read.