### PR TITLE
Add tests for the TextExamSummaryComponent

### DIFF
--- a/src/test/javascript/spec/component/exam/participate/summary/text-exam-summary.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/text-exam-summary.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import { TextExamSummaryComponent } from 'app/exam/participate/summary/exercises/text-exam-summary/text-exam-summary.component';
+import { TextSubmission } from 'app/entities/text-submission.model';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('TextExamSummaryComponent', () => {
+    let fixture: ComponentFixture<TextExamSummaryComponent>;
+    let component: TextExamSummaryComponent;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({ declarations: [TextExamSummaryComponent] })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(TextExamSummaryComponent);
+                component = fixture.componentInstance;
+            });
+    });
+
+    it('should initialize', () => {
+        fixture.detectChanges();
+        expect(component).to.be.ok;
+        expect(fixture.debugElement.nativeElement.querySelector('div').innerHTML).to.equal('No submission');
+    });
+
+    it('should display the submission text', () => {
+        const submissionText = 'A test submission text';
+        component.submission = { text: submissionText } as TextSubmission;
+        fixture.detectChanges();
+        expect(component).to.be.ok;
+        expect(fixture.debugElement.nativeElement.querySelector('div').innerHTML).to.equal(submissionText);
+    });
+});


### PR DESCRIPTION
### Checklist
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)

### Description

The `TextExamSummaryComponent` is small, so adding a few tests is an easy improvement for the overall coverage.

### Test Coverage

`webapp/app/exam/participate/summary/exercises/text-exam-summary/text-exam-summary.component.ts`: `0%` -> `100%`