### PR TITLE
fix(haskell) fix options pragma regex

### DIFF
--- a/src/main/resources/templates/haskell/test/run.sh
+++ b/src/main/resources/templates/haskell/test/run.sh
@@ -19,7 +19,7 @@ $safe && find assignment/ -type l | grep -q . && echo "Cannot build with symlink
 $safe && \
 while IFS= read file; do
   cat $file | tr -d '\n' | grep -qim 1 "{-#[[:space:]]*options" && \
-    echo "Cannot build with \"OPTIONS\" string in source." && exit 1
+    echo "Cannot build with \"{-# OPTIONS..\" pragma in source." && exit 1
 done < <(find assignment/src -type f)
 
 # build the libraries - do not forget to set the right compilation flag (Prod)

--- a/src/main/resources/templates/haskell/test/run.sh
+++ b/src/main/resources/templates/haskell/test/run.sh
@@ -26,7 +26,7 @@ done < <(find assignment/src -type f)
 stack build --allow-different-user --flag test:Prod && \
   # delete the solution and tests (so that students cannot access it) when in safe mode
   ($safe && \
-    (rm -rf solution && rm -rf test/hs) \
+    (rm -rf solution && rm -rf test) \
   ) \
   # run the test executable and return 0
   # Note: as a convention, a failed haskell tasty test suite returns 1, but this stops the JUnit Parser from running.


### PR DESCRIPTION
### What

This is a follow-up to #2674. The regex wasn't quite strict enough. Haskell also allows for line breaks inside its pragmas and ignores cases.

### How
Fix the regex.

### Implementation Notes
`grep` works on a per line basis, so we first remove them using `tr`.