### PR TITLE
Add View Button to the Instructor Actions of the Course Exercise Details

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -38,6 +38,15 @@
         <div class="col-auto d-md-flex align-items-center" *ngIf="exercise.isAtLeastInstructor">
             <span class="mr-1">{{ 'artemisApp.courseOverview.exerciseDetails.instructorActions.title' | translate }}</span>
             <div class="btn-group flex-btn-group-container">
+                <button
+                    *ngIf="exercise.type !== QUIZ"
+                    type="submit"
+                    [routerLink]="['/course-management', courseId, exercise.type + '-exercises', exercise.id]"
+                    class="btn btn-info btn-sm mr-1"
+                >
+                    <fa-icon [icon]="'eye'"></fa-icon>
+                    <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
+                </button>
                 <button type="submit" [routerLink]="['/course-management', courseId, 'exercises', exercise.id, 'scores']" class="btn btn-info btn-sm mr-1">
                     <fa-icon [icon]="'eye'"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="entity.action.scores">Scores</span>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
After adding the first new instructor actions like "Edit" in #2185, we (me and other PGdP instructors) noticed that we use "View" often, and I am frequently accessing it (for months now) by going to "Edit" and then using the breadcrumbs to go to view by clicking on the ID. I am now certain that a dedicated "View" button makes sense to navigate faster and more efficiently.

Some use cases for using "View":
 - Check the template and solution results for programming exercises
 - Open the template, solution and test build plans or repositories of programming exercises
 - View the solution and grading criteria and e.g. open links from the markdown
 - Some of the exercise actions that were added (in #2478) at the top of the view page

### Description
 - Added the button that was already present in the management and exam pages to the instructor actions

### Steps for Testing
0. Prerequisite: Be instructor in a course with all five exercise types
1. Check for each exercise type _apart from quizzes_: The view button is displayed and works (leads to the exercise details page)
2. Check that for quiz exercises the button is not present

### Test Coverage
_Unchanged._

### Screenshots
![image](https://user-images.githubusercontent.com/11130248/104821115-eeefb880-5839-11eb-82ec-d89cb05088c2.png)

