### PR TITLE
Bugfix/programming exercise dashboard submissions bug

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Submission.java
@@ -157,7 +157,7 @@ public abstract class Submission extends DomainObject {
      */
     @JsonIgnore
     public void removeAutomaticResults() {
-        this.results = this.results.stream().filter(result -> !result.isAutomatic()).collect(Collectors.toList());
+        this.results = this.results.stream().filter(result -> result == null || !result.isAutomatic()).collect(Collectors.toList());
     }
 
     @Nullable


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I documented the Java code using JavaDoc style.


### Motivation and Context
Fixes a bug, where a programming assessment would not appear in the exercise dashboard, after the tutors assessment

### Description
Handled the case when a result is null, therefore no NPE is thrown anymore.
Also extended exam test to check this.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Create an exam with a programming assessment, assess in the first and second correction round. Go to the exercise dashboard. If you are able to see the result, you just assessed in the second correction round it works as it should.

### Screenshots
<img src="https://user-images.githubusercontent.com/33342534/105036760-4326b280-5a5d-11eb-8c5e-fa63220cf49c.png" width="400" >
--->
<img src="https://user-images.githubusercontent.com/33342534/105036862-68b3bc00-5a5d-11eb-8d99-472d4a8f4b29.png" width="400" >

<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
