### PR TITLE
Fix a bug in the lecture routes

### DIFF
--- a/src/main/webapp/app/lecture/lecture.route.ts
+++ b/src/main/webapp/app/lecture/lecture.route.ts
@@ -92,6 +92,7 @@ export const lectureRoute: Routes = [
                 },
                 data: {
                     breadcrumbLabelVariable: 'lecture.title',
+                    breadcrumbs: [],
                 },
                 children: [
                     {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context

The breadcrumbs are currently broken when accessing anything inside a lecture (e.g. attachments or units).

Before:
![grafik](https://user-images.githubusercontent.com/72132281/105013969-1fa13f00-5a40-11eb-9fb0-18d563e5167c.png)
After:
![grafik](https://user-images.githubusercontent.com/72132281/105014180-6727cb00-5a40-11eb-91b4-04f601cf8ea3.png)

### Steps for Testing

1. Go to an existing lecture or create one
2. Make sure all sub-routes (create, edit, attachments, units) work and display breadcrumbs correctly

