### PR TITLE
Disable false-positive eslint warnings

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -23,9 +23,6 @@ import { ShortAnswerQuestion } from 'app/entities/quiz/short-answer-question.mod
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { DragAndDropQuestion } from 'app/entities/quiz/drag-and-drop-question.model';
 import { Course } from 'app/entities/course.model';
-import { DragAndDropQuestionEditComponent } from 'app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component';
-import { MultipleChoiceQuestionEditComponent } from 'app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component';
-import { ShortAnswerQuestionEditComponent } from 'app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component';
 import { QuizQuestionEdit } from 'app/exercises/quiz/manage/quiz-question-edit.interface';
 import { ExerciseGroupService } from 'app/exam/manage/exercise-groups/exercise-group.service';
 import { ExerciseGroup } from 'app/entities/exercise-group.model';
@@ -38,6 +35,14 @@ import { DragAndDropMapping } from 'app/entities/quiz/drag-and-drop-mapping.mode
 import { QuizConfirmImportInvalidQuestionsModalComponent } from 'app/exercises/quiz/manage/quiz-confirm-import-invalid-questions-modal.component';
 import * as Sentry from '@sentry/browser';
 import { cloneDeep } from 'lodash';
+
+// False-positives:
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { DragAndDropQuestionEditComponent } from 'app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { MultipleChoiceQuestionEditComponent } from 'app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { ShortAnswerQuestionEditComponent } from 'app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component';
 
 export interface Reason {
     translateKey: string;

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-details/plagiarism-details.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-details/plagiarism-details.component.ts
@@ -1,9 +1,13 @@
 import { Component, Input } from '@angular/core';
 import { Subject } from 'rxjs';
 import { PlagiarismComparison } from 'app/exercises/shared/plagiarism/types/PlagiarismComparison';
-import { TextSubmissionElement } from 'app/exercises/shared/plagiarism/types/text/TextSubmissionElement';
-import { ModelingSubmissionElement } from 'app/exercises/shared/plagiarism/types/modeling/ModelingSubmissionElement';
 import { Exercise } from 'app/entities/exercise.model';
+
+// False-positives:
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { TextSubmissionElement } from 'app/exercises/shared/plagiarism/types/text/TextSubmissionElement';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { ModelingSubmissionElement } from 'app/exercises/shared/plagiarism/types/modeling/ModelingSubmissionElement';
 
 @Component({
     selector: 'jhi-plagiarism-details',

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.ts
@@ -2,7 +2,11 @@ import { Component, Input } from '@angular/core';
 import { Subject } from 'rxjs';
 import { PlagiarismStatus } from 'app/exercises/shared/plagiarism/types/PlagiarismStatus';
 import { PlagiarismComparison } from 'app/exercises/shared/plagiarism/types/PlagiarismComparison';
+
+// False-positives:
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { TextSubmissionElement } from 'app/exercises/shared/plagiarism/types/text/TextSubmissionElement';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ModelingSubmissionElement } from 'app/exercises/shared/plagiarism/types/modeling/ModelingSubmissionElement';
 
 @Component({


### PR DESCRIPTION
Compiling develop currently gives several lint warnings (which are also reported on newly created PRs). Those appear to be false-positives, since the variables are used, so I disabled those warnings.

Error log:
```
 WARNING  Compiled with 3 warnings                                                                                                                                                                                                                                                                          18:15:24

Module Warning (from ./node_modules/eslint-loader/dist/cjs.js):

\webapp\app\exercises\quiz\manage\quiz-exercise-detail.component.ts
  26:10  warning  'DragAndDropQuestionEditComponent' is defined but never used     @typescript-eslint/no-unused-vars
  27:10  warning  'MultipleChoiceQuestionEditComponent' is defined but never used  @typescript-eslint/no-unused-vars
  28:10  warning  'ShortAnswerQuestionEditComponent' is defined but never used     @typescript-eslint/no-unused-vars

✖ 3 problems (0 errors, 3 warnings)

Module Warning (from ./node_modules/eslint-loader/dist/cjs.js):

\webapp\app\exercises\shared\plagiarism\plagiarism-details\plagiarism-details.component.ts
  4:10  warning  'TextSubmissionElement' is defined but never used      @typescript-eslint/no-unused-vars
  5:10  warning  'ModelingSubmissionElement' is defined but never used  @typescript-eslint/no-unused-vars

✖ 2 problems (0 errors, 2 warnings)

Module Warning (from ./node_modules/eslint-loader/dist/cjs.js):

\webapp\app\exercises\shared\plagiarism\plagiarism-header\plagiarism-header.component.ts
  5:10  warning  'TextSubmissionElement' is defined but never used      @typescript-eslint/no-unused-vars
  6:10  warning  'ModelingSubmissionElement' is defined but never used  @typescript-eslint/no-unused-vars

✖ 2 problems (0 errors, 2 warnings)

```