### PR TITLE
Attempt to fix breadcrumb width on Safari

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -72,8 +72,10 @@ Navbar
 
 @media not all and (min-resolution: 0.001dpcm) {
     @supports (-webkit-appearance: none) {
-        .breadcrumb-link {
-            display: block !important;
+        .breadcrumb-item:first-of-type {
+            .breadcrumb-link {
+                display: block !important;
+            }
         }
     }
 }

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -56,6 +56,7 @@ Navbar
 
         .breadcrumb-link {
             font-weight: lighter;
+            display: block;
         }
     }
 

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -63,16 +63,20 @@ Navbar
     .breadcrumb-item::before {
         content: '>';
     }
+
     // Hide the first divider
     .breadcrumb-item:first-of-type::before {
         content: '';
     }
 }
 
-// Change the display to block only on Safari
-@media screen and (min-color-index: 0) and(-webkit-min-device-pixel-ratio:0) {
-    .breadcrumb-link {
-        display: block;
+@media not all and (min-resolution: 0.001dpcm) {
+    @media {
+        .safari10 {
+            .breadcrumb-link {
+                display: block !important;
+            }
+        }
     }
 }
 

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -71,11 +71,9 @@ Navbar
 }
 
 @media not all and (min-resolution: 0.001dpcm) {
-    @media {
-        .safari10 {
-            .breadcrumb-link {
-                display: block !important;
-            }
+    @supports (-webkit-appearance: none) {
+        .breadcrumb-link {
+            display: block !important;
         }
     }
 }

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -56,7 +56,7 @@ Navbar
 
         .breadcrumb-link {
             font-weight: lighter;
-            display: block;
+            display: inline;
         }
     }
 
@@ -66,6 +66,13 @@ Navbar
     // Hide the first divider
     .breadcrumb-item:first-of-type::before {
         content: '';
+    }
+}
+
+// Change the display to block only on Safari
+@media screen and (min-color-index: 0) and(-webkit-min-device-pixel-ratio:0) {
+    .breadcrumb-link {
+        display: block;
     }
 }
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context

Some recent update in the client dependencies broke the breadcrumb display on Safari:
![grafik](https://user-images.githubusercontent.com/72132281/105344826-bb1ee500-5be3-11eb-862f-066eec2f3a94.png)

### Description

Comparing production and test server makes it looks like `display` changed from `block` to `inline`, so we manually override it to `block` again.

### Steps for Testing

Important! The difference is only visible on `Safari`. Other browsers shouldn't show regressions, but it is important that we verify it works on Safari.

1. Check if the breadcrumbs don't line break unintentionally. (Ideally test several routes, e.g. in the course management, or system notifications.)

It should be verified to work on:
- Chrome
- Safari
- Firefox
- Edge(?)
