### PR TITLE
[Bugfix] Fixes code line highlighting for tutors and wrongly invoked method for students

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -800,6 +800,32 @@ public class ProgrammingExerciseResource {
     }
 
     /**
+     * GET /programming-exercises/:exerciseId/with-template-and-solution-participation
+     *
+     * @param exerciseId the id of the programmingExercise to retrieve
+     * @return the ResponseEntity with status 200 (OK) and the programming exercise with template and solution participation, or with status 404 (Not Found)
+     */
+    @GetMapping(Endpoints.PROGRAMMING_EXERCISE_WITH_TEMPLATE_AND_SOLUTION_PARTICIPATION)
+    @PreAuthorize("hasAnyRole('TA', 'INSTRUCTOR', 'ADMIN')")
+    public ResponseEntity<ProgrammingExercise> getProgrammingExerciseWithTemplateAndSolutionParticipation(@PathVariable long exerciseId) {
+        log.debug("REST request to get programming exercise with template and solution participation : {}", exerciseId);
+
+        User user = userService.getUserWithGroupsAndAuthorities();
+        Optional<ProgrammingExercise> programmingExerciseOpt = programmingExerciseRepository.findWithTemplateAndSolutionParticipationById(exerciseId);
+        if (programmingExerciseOpt.isPresent()) {
+            ProgrammingExercise programmingExercise = programmingExerciseOpt.get();
+            Course course = programmingExercise.getCourseViaExerciseGroupOrCourseMember();
+            if (!authCheckService.isAtLeastTeachingAssistantInCourse(course, user)) {
+                return forbidden();
+            }
+            return ResponseEntity.ok(programmingExercise);
+        }
+        else {
+            return notFound();
+        }
+    }
+
+    /**
      * DELETE /programming-exercises/:id : delete the "id" programmingExercise.
      *
      * @param exerciseId the id of the programmingExercise to delete
@@ -1250,6 +1276,8 @@ public class ProgrammingExerciseResource {
         public static final String PROBLEM = PROGRAMMING_EXERCISE + "/problem-statement";
 
         public static final String PROGRAMMING_EXERCISE_WITH_PARTICIPATIONS = PROGRAMMING_EXERCISE + "/with-participations";
+
+        public static final String PROGRAMMING_EXERCISE_WITH_TEMPLATE_AND_SOLUTION_PARTICIPATION = PROGRAMMING_EXERCISE + "/with-template-and-solution-participation";
 
         public static final String COMBINE_COMMITS = PROGRAMMING_EXERCISE + "/combine-template-commits";
 

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
@@ -42,6 +42,7 @@
         [participation]="participation"
         [showEditorInstructions]="showEditorInstructions"
         [isTutorAssessment]="true"
+        [highlightFileChanges]="true"
         [readOnlyManualFeedback]="readOnly()"
         (onUpdateFeedback)="onUpdateFeedback($event)"
         (onFileLoad)="onFileLoad($event)"

--- a/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-base-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-base-container.component.ts
@@ -242,7 +242,7 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
     loadExercise(exerciseId: number): Observable<ProgrammingExercise> {
         return this.exercise && this.exercise.id === exerciseId
             ? Observable.of(this.exercise)
-            : this.exerciseService.findWithTemplateAndSolutionParticipation(exerciseId).pipe(map(({ body }) => body!));
+            : this.exerciseService.findWithTemplateAndSolutionParticipationAndResults(exerciseId).pipe(map(({ body }) => body!));
     }
 
     /**

--- a/src/main/webapp/app/exercises/programming/manage/services/programming-exercise.service.ts
+++ b/src/main/webapp/app/exercises/programming/manage/services/programming-exercise.service.ts
@@ -148,12 +148,22 @@ export class ProgrammingExerciseService {
     }
 
     /**
-     * Finds the programming exercise for the given exerciseId with the corresponding participation's
+     * Finds the programming exercise for the given exerciseId with the corresponding participation's with results
+     * @param programmingExerciseId of the programming exercise to retrieve
+     */
+    findWithTemplateAndSolutionParticipationAndResults(programmingExerciseId: number): Observable<EntityResponseType> {
+        return this.http
+            .get<ProgrammingExercise>(`${this.resourceUrl}/${programmingExerciseId}/with-participations`, { observe: 'response' })
+            .pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)));
+    }
+
+    /**
+     * Finds the programming exercise for the given exerciseId with the template and solution participation
      * @param programmingExerciseId of the programming exercise to retrieve
      */
     findWithTemplateAndSolutionParticipation(programmingExerciseId: number): Observable<EntityResponseType> {
         return this.http
-            .get<ProgrammingExercise>(`${this.resourceUrl}/${programmingExerciseId}/with-participations`, { observe: 'response' })
+            .get<ProgrammingExercise>(`${this.resourceUrl}/${programmingExerciseId}/with-template-and-solution-participation`, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)));
     }
 

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
@@ -25,6 +25,7 @@
         [errorFiles]="errorFiles"
         [editorState]="editorState"
         [isTutorAssessment]="isTutorAssessment"
+        [highlightFileChanges]="highlightFileChanges"
         [(selectedFile)]="selectedFile"
         [(commitState)]="commitState"
         (onFileChange)="onFileChange($event)"

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
@@ -49,6 +49,8 @@ export class CodeEditorContainerComponent implements ComponentCanDeactivate {
     @Input()
     isTutorAssessment = false;
     @Input()
+    highlightFileChanges = false;
+    @Input()
     readOnlyManualFeedback = false;
     @Output()
     onResizeEditorInstructions = new EventEmitter<void>();

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
@@ -53,6 +53,8 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
     }
     @Input()
     isTutorAssessment = false;
+    @Input()
+    highlightFileChanges = false;
     @Output()
     onToggleCollapse = new EventEmitter<{ event: any; horizontal: boolean; interactable: Interactable; resizableMinWidth?: number; resizableMinHeight?: number }>();
     @Output()
@@ -177,7 +179,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
                     this.unsavedFiles = [];
                 }),
                 switchMap(() => {
-                    if (this.isTutorAssessment) {
+                    if (this.isTutorAssessment && this.highlightFileChanges) {
                         return this.loadFilesWithInformationAboutChange();
                     } else {
                         return Observable.of(undefined);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -375,6 +375,17 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
     }
 
     @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    void testGetProgrammingExerciseWithJustTemplateAndSolutionParticipation() throws Exception {
+        database.addStudentParticipationForProgrammingExercise(programmingExercise, "tutor1");
+        final var path = ROOT + PROGRAMMING_EXERCISE_WITH_TEMPLATE_AND_SOLUTION_PARTICIPATION.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
+        var programmingExerciseServer = request.get(path, HttpStatus.OK, ProgrammingExercise.class);
+        assertThat(programmingExerciseServer.getTitle()).isEqualTo(programmingExercise.getTitle());
+        assertThat(programmingExerciseServer.getSolutionParticipation().getId()).isEqualTo(1);
+        assertThat(programmingExerciseServer.getTemplateParticipation().getId()).isEqualTo(2);
+    }
+
+    @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testGetProgrammingExerciseWithSetupParticipations_instructorNotInCourse_forbidden() throws Exception {
         database.addInstructor("other-instructors", "instructoralt");

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -380,6 +380,7 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         database.addStudentParticipationForProgrammingExercise(programmingExercise, "tutor1");
         final var path = ROOT + PROGRAMMING_EXERCISE_WITH_TEMPLATE_AND_SOLUTION_PARTICIPATION.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
         var programmingExerciseServer = request.get(path, HttpStatus.OK, ProgrammingExercise.class);
+        // Checks
         assertThat(programmingExerciseServer.getTitle()).isEqualTo(programmingExercise.getTitle());
         assertThat(programmingExerciseServer.getSolutionParticipation().getId()).isEqualTo(1);
         assertThat(programmingExerciseServer.getTemplateParticipation().getId()).isEqualTo(2);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -380,7 +380,6 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         database.addStudentParticipationForProgrammingExercise(programmingExercise, "tutor1");
         final var path = ROOT + PROGRAMMING_EXERCISE_WITH_TEMPLATE_AND_SOLUTION_PARTICIPATION.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
         var programmingExerciseServer = request.get(path, HttpStatus.OK, ProgrammingExercise.class);
-        // Checks
         assertThat(programmingExerciseServer.getTitle()).isEqualTo(programmingExercise.getTitle());
         assertThat(programmingExerciseServer.getSolutionParticipation().getId()).isEqualTo(1);
         assertThat(programmingExerciseServer.getTemplateParticipation().getId()).isEqualTo(2);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTest.java
@@ -381,8 +381,8 @@ class ProgrammingExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         final var path = ROOT + PROGRAMMING_EXERCISE_WITH_TEMPLATE_AND_SOLUTION_PARTICIPATION.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
         var programmingExerciseServer = request.get(path, HttpStatus.OK, ProgrammingExercise.class);
         assertThat(programmingExerciseServer.getTitle()).isEqualTo(programmingExercise.getTitle());
-        assertThat(programmingExerciseServer.getSolutionParticipation().getId()).isEqualTo(1);
-        assertThat(programmingExerciseServer.getTemplateParticipation().getId()).isEqualTo(2);
+        assertThat(programmingExerciseServer.getSolutionParticipation().getId()).isNotNull();
+        assertThat(programmingExerciseServer.getTemplateParticipation().getId()).isNotNull();
     }
 
     @Test

--- a/src/test/javascript/spec/helpers/mocks/service/mock-programming-exercise.service.ts
+++ b/src/test/javascript/spec/helpers/mocks/service/mock-programming-exercise.service.ts
@@ -3,6 +3,7 @@ import { of } from 'rxjs';
 export class MockProgrammingExerciseService {
     updateProblemStatement = (exerciseId: number, problemStatement: string) => of();
     findWithTemplateAndSolutionParticipation = (exerciseId: number) => of();
+    findWithTemplateAndSolutionParticipationAndResults = (exerciseId: number) => of();
     find = (exerciseId: number) => of({ body: { id: 4 } });
     getProgrammingExerciseTestCaseState = (exerciseId: number) => of({ body: { released: true, hasStudentResult: true, testCasesChanged: false } });
 }

--- a/src/test/javascript/spec/integration/code-editor/code-editor-instructor.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-instructor.integration.spec.ts
@@ -145,7 +145,7 @@ describe('CodeEditorInstructorIntegration', () => {
                 getBuildLogsStub = stub(buildLogService, 'getBuildLogs');
                 getHintsForExerciseStub = stub(exerciseHintService, 'findByExerciseId').returns(of({ body: exerciseHints }) as Observable<HttpResponse<ExerciseHint[]>>);
 
-                findWithParticipationsStub = stub(programmingExerciseService, 'findWithTemplateAndSolutionParticipation');
+                findWithParticipationsStub = stub(programmingExerciseService, 'findWithTemplateAndSolutionParticipationAndResults');
                 findWithParticipationsStub.returns(findWithParticipationsSubject);
 
                 subscribeForLatestResultOfParticipationStub.returns(subscribeForLatestResultOfParticipationSubject);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) locally
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR solves two issue found during retesting of the manual assessment of programming exercises. Issue 1: when a tutor started an assessment the code line changes were not correctly highlighted as an error was thrown. Issue 2: When a student wanted to view his code in the online editor after receiving a manual assessment, he could not select a file as an error was thrown.

### Description
<!-- Describe your changes in detail -->
- Added new REST Endpoint to just fetch information about the template and solution participation of a exercise (issue1)
- Extended the check so that `file-changes` call is only executed during the assessment (issue2)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a programming exercise, participate and do manual assessments or use a existing programming exercise with manual assessments
4. Log in as tutor and check if the code line highlighting is correct and assess the submission
5. Log in as student and check if you can select files and that the according inline feedback is displayed


### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Nothing changed.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Student View:
<img width="1570" alt="image" src="https://user-images.githubusercontent.com/41108487/105456437-72b80380-5c85-11eb-8a60-06089d0ff6bc.png">

Tutor View:
<img width="1656" alt="image" src="https://user-images.githubusercontent.com/41108487/105456544-a135de80-5c85-11eb-8d83-6ad6b5c527d5.png">

