### PR TITLE
[Bugfix] [Exam] Assess empty submissions and unsubmitted exams for multiple correction rounds

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
@@ -235,7 +235,7 @@ public class Exam extends DomainObject {
     }
 
     public Integer getNumberOfCorrectionRoundsInExam() {
-        return numberOfCorrectionRoundsInExam;
+        return this.numberOfCorrectionRoundsInExam != null ? this.numberOfCorrectionRoundsInExam : 1;
     }
 
     public void setNumberOfCorrectionRoundsInExam(Integer numberOfCorrectionRoundsInExam) {

--- a/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StudentExamService.java
@@ -278,9 +278,12 @@ public class StudentExamService {
             final var studentParticipations = participationService.findByStudentIdAndIndividualExercisesWithEagerSubmissionsResult(user.getId(), exercisesOfUser.get(user));
             for (final var studentParticipation : studentParticipations) {
                 if (studentParticipation.findLatestSubmission().isPresent()) {
-                    // required so that the submission is counted in the assessment dashboard
-                    studentParticipation.findLatestSubmission().get().submitted(true);
-                    submissionService.addResultWithFeedback(studentParticipation, assessor, 0L, "You did not submit your exam");
+                    for (int correctionRound = 0; correctionRound < exam.getNumberOfCorrectionRoundsInExam(); correctionRound++) {
+                        // required so that the submission is counted in the assessment dashboard
+                        studentParticipation.findLatestSubmission().get().submitted(true);
+                        submissionService.addResultWithFeedbackByCorrectionRound(studentParticipation, assessor, 0L, "You did not submit your exam", correctionRound);
+                    }
+
                 }
             }
         }
@@ -305,9 +308,11 @@ public class StudentExamService {
             final var studentParticipations = participationService.findByStudentIdAndIndividualExercisesWithEagerSubmissionsResult(user.getId(), exercisesOfUser.get(user));
             for (final var studentParticipation : studentParticipations) {
                 if (studentParticipation.findLatestSubmission().isPresent() && studentParticipation.findLatestSubmission().get().isEmpty()) {
-                    // required so that the submission is counted in the assessment dashboard
-                    studentParticipation.findLatestSubmission().get().submitted(true);
-                    submissionService.addResultWithFeedback(studentParticipation, assessor, 0L, "Empty submission");
+                    for (int correctionRound = 0; correctionRound < exam.getNumberOfCorrectionRoundsInExam(); correctionRound++) {
+                        // required so that the submission is counted in the assessment dashboard
+                        studentParticipation.findLatestSubmission().get().submitted(true);
+                        submissionService.addResultWithFeedbackByCorrectionRound(studentParticipation, assessor, 0L, "Empty submission", correctionRound);
+                    }
                 }
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
@@ -375,7 +375,6 @@ public class SubmissionService {
      */
     public Result saveNewResult(Submission submission, final Result result) {
         result.setSubmission(null);
-        submission.setResults(new ArrayList<>());
         if (result.getParticipation() == null) {
             result.setParticipation(submission.getParticipation());
         }
@@ -395,10 +394,11 @@ public class SubmissionService {
      * @param assessor the assessor
      * @param score the score which should be set
      * @param feedbackText the feedback text for the
+     * @param correctionRound the currectCorrection round
      */
-    public void addResultWithFeedback(StudentParticipation studentParticipation, User assessor, long score, String feedbackText) {
+    public void addResultWithFeedbackByCorrectionRound(StudentParticipation studentParticipation, User assessor, long score, String feedbackText, int correctionRound) {
         if (studentParticipation.getExercise().isExamExercise() && studentParticipation.findLatestSubmission().isPresent()
-                && studentParticipation.findLatestSubmission().get().getLatestResult() == null) {
+                && studentParticipation.findLatestSubmission().get().getResultForCorrectionRound(correctionRound) == null) {
             final var latestSubmission = studentParticipation.findLatestSubmission().get();
             Result result = new Result();
             result.setParticipation(studentParticipation);

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -627,6 +627,43 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testAssessUnsubmittedStudentExamsForMultipleCorrectionRounds() throws Exception {
+        prepareStudentExamsForConduction();
+        exam2.setNumberOfCorrectionRoundsInExam(2);
+        exam2.setStartDate(ZonedDateTime.now().minusMinutes(10));
+        exam2.setEndDate(ZonedDateTime.now().minusMinutes(8));
+        exam2 = examRepository.save(exam2);
+
+        request.postWithoutLocation("/api/courses/" + course2.getId() + "/exams/" + exam2.getId() + "/student-exams/assess-unsubmitted-and-empty-student-exams", Optional.empty(),
+                HttpStatus.OK, null);
+        database.changeUser("instructor1");
+        Set<StudentExam> unsubmittedStudentExams = studentExamRepository.findAllUnsubmittedWithExercisesByExamId(exam2.getId());
+        Map<User, List<Exercise>> exercisesOfUser = unsubmittedStudentExams.stream().collect(Collectors.toMap(StudentExam::getUser, studentExam -> studentExam.getExercises()
+                .stream().filter(exercise -> exercise instanceof ModelingExercise || exercise instanceof TextExercise).collect(Collectors.toList())));
+        for (final var user : exercisesOfUser.keySet()) {
+            final var studentParticipations = studentParticipationRepository.findByStudentIdAndIndividualExercisesWithEagerSubmissionsResult(user.getId(),
+                    exercisesOfUser.get(user));
+            for (final var studentParticipation : studentParticipations) {
+                if (studentParticipation.findLatestSubmission().isPresent()) {
+                    assertThat(Objects.requireNonNull(studentParticipation.findLatestSubmission().get().getResults()).size()).isEqualTo(exam2.getNumberOfCorrectionRoundsInExam());
+                    for (var result : Objects.requireNonNull(studentParticipation.findLatestSubmission().get().getResults())) {
+                        assertThat(result).isNotNull();
+                        assertThat(result.getScore()).isEqualTo(0);
+                        assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
+                        result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).get();
+                        assertThat(result.getFeedbacks()).isNotEmpty();
+                        assertThat(result.getFeedbacks().get(0).getDetailText()).isEqualTo("You did not submit your exam");
+                    }
+                }
+                else {
+                    fail("StudentParticipation which is part of an unsubmitted StudentExam contains no submission or result after automatic assessment of unsubmitted student exams call.");
+                }
+            }
+        }
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testAssessEmptyExamSubmissions() throws Exception {
         final var studentExams = prepareStudentExamsForConduction();
         // submit student exam with empty submissions
@@ -657,6 +694,49 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
                     result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).get();
                     assertThat(result.getFeedbacks()).isNotEmpty();
                     assertThat(result.getFeedbacks().get(0).getDetailText()).isEqualTo("Empty submission");
+                }
+                else {
+                    fail("StudentParticipation which is part of an unsubmitted StudentExam contains no submission or result after automatic assessment of unsubmitted student exams call.");
+                }
+            }
+        }
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testAssessEmptyExamSubmissionsForMultipleCorrectionRounds() throws Exception {
+        final var studentExams = prepareStudentExamsForConduction();
+        // submit student exam with empty submissions
+        for (final var studentExam : studentExams) {
+            studentExam.setSubmitted(true);
+            studentExam.setSubmissionDate(ZonedDateTime.now());
+            studentExamRepository.save(studentExam);
+        }
+        // this test should be after the end date of the exam
+        exam2.setStartDate(ZonedDateTime.now().minusMinutes(10));
+        exam2.setEndDate(ZonedDateTime.now().minusMinutes(7));
+        exam2.setNumberOfCorrectionRoundsInExam(2);
+        examRepository.save(exam2);
+
+        request.postWithoutLocation("/api/courses/" + course2.getId() + "/exams/" + exam2.getId() + "/student-exams/assess-unsubmitted-and-empty-student-exams", Optional.empty(),
+                HttpStatus.OK, null);
+        database.changeUser("instructor1");
+        Map<User, List<Exercise>> exercisesOfUser = studentExams.stream().collect(Collectors.toMap(StudentExam::getUser, studentExam -> studentExam.getExercises().stream()
+                .filter(exercise -> exercise instanceof ModelingExercise || exercise instanceof TextExercise).collect(Collectors.toList())));
+        for (final var user : exercisesOfUser.keySet()) {
+            final var studentParticipations = studentParticipationRepository.findByStudentIdAndIndividualExercisesWithEagerSubmissionsResult(user.getId(),
+                    exercisesOfUser.get(user));
+            for (final var studentParticipation : studentParticipations) {
+                if (studentParticipation.findLatestSubmission().isPresent()) {
+                    assertThat(Objects.requireNonNull(studentParticipation.findLatestSubmission().get().getResults()).size()).isEqualTo(exam2.getNumberOfCorrectionRoundsInExam());
+                    for (var result : Objects.requireNonNull(studentParticipation.findLatestSubmission().get().getResults())) {
+                        assertThat(result).isNotNull();
+                        assertThat(result.getScore()).isEqualTo(0);
+                        assertThat(result.getAssessmentType()).isEqualTo(AssessmentType.SEMI_AUTOMATIC);
+                        result = resultRepository.findByIdWithEagerFeedbacks(result.getId()).get();
+                        assertThat(result.getFeedbacks()).isNotEmpty();
+                        assertThat(result.getFeedbacks().get(0).getDetailText()).isEqualTo("Empty submission");
+                    }
                 }
                 else {
                     fail("StudentParticipation which is part of an unsubmitted StudentExam contains no submission or result after automatic assessment of unsubmitted student exams call.");


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
Fixes #2730

### Description
Add result for every correction round, instead of just one result.

### Steps for Testing
1. Create an exam with 2 correction rounds and participate in it with 3 users.
2. With one user don't submit your exam
3. With another user, submit your exam but do not add anything to your submissions.
4. With the last user fill your submissions and submit your exam
4. Once the exam is over, go to "student exams" and assess all unsubmitted exams and empty submissions
5. Assess the submissions via the assessment dashboard. You should also see the submissions of one student for every correction round.
6. In the summary of the other students, you should see the automatic feedback

### Test Coverage
`StudentExamService` -> 90%