### PR TITLE
Store "use ssh" setting in local storage

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -252,9 +252,9 @@
                 >
                 <pre
                     *ngIf="sshEnabled"
-                    class="btn btn-primary d-inline-flex align-items-center ml-0"
+                    class="btn btn-primary d-inline-flex align-items-center ml-0 use-ssh"
                     style="border-top-left-radius: 0; border-bottom-left-radius: 0"
-                    (click)="useSsh = !useSsh"
+                    (click)="toggleUseSsh()"
                     >{{ useSsh ? 'USE HTTPS' : 'USE SSH' }}</pre
                 >
             </div>

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -18,6 +18,7 @@ import { User } from 'app/core/user/user.model';
 import { TranslateService } from '@ngx-translate/core';
 import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
+import { LocalStorageService } from 'ngx-webstorage';
 
 @Component({
     selector: 'jhi-exercise-details-student-actions',
@@ -62,6 +63,7 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit {
         private router: Router,
         private translateService: TranslateService,
         private profileService: ProfileService,
+        private localStorage: LocalStorageService,
     ) {}
 
     /**
@@ -84,6 +86,14 @@ export class ExerciseDetailsStudentActionsComponent implements OnInit {
                 this.baseUrl = info.versionControlUrl;
             }
         });
+
+        this.useSsh = this.localStorage.retrieve('useSsh') || false;
+        this.localStorage.observe('useSsh').subscribe((useSsh) => (this.useSsh = useSsh || false));
+    }
+
+    public toggleUseSsh(): void {
+        this.useSsh = !this.useSsh;
+        this.localStorage.store('useSsh', this.useSsh);
     }
 
     /**

--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -51,7 +51,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
 
     let localStorageUseSshRetrieveStub: SinonStub;
     let localStorageUseSshObserveStub: SinonStub;
-    let localStorageUseSshObserveStubSubject: Subject<boolean|undefined>;
+    let localStorageUseSshObserveStubSubject: Subject<boolean | undefined>;
     let localStorageUseSshStoreStub: SinonStub;
 
     const team = { id: 1, students: [{ id: 99 } as User] } as Team;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [X] ~I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [X] I documented the TypeScript code using JSDoc style.
- [X] ~I added multiple screenshots/screencasts of my UI changes~
- [X] ~I translated all the newly inserted strings into German and English~

### Motivation and Context
#2317 and #2363
TL;DR: Remember if `git clone ssh://` or `git clone https://`

### Description
Use the `localStorage` to remember which setting was last ued.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Find programming exercise (and start if needed)
2. Click on "Clone exercise"
3. Find `https://` url.
4. Click "USE SSH" and find `ssh://` url.
5. Reload page, repeat 1 & 2.
6. Find `ssh://` url.
7. Click "USE HTTPS" and find `https://` url.
8. Reload page, repeat 3-7 until it gets boring.

### Test Coverage
* exercies-details-tsudent-actions.component.ts 71% -> 75%
