### PR TITLE
[Bugfix] K6 wrong compare operator

### DIFF
--- a/src/test/k6/requests/programmingExercise.js
+++ b/src/test/k6/requests/programmingExercise.js
@@ -128,7 +128,7 @@ export function configureScaCategories(artemis, exerciseId, scaCategories, progr
     let patchedCategories;
     switch (programmingLanguage) {
         case 'JAVA':
-            let badPracticeCategory = scaCategories.find((category) => (category.name = 'Bad Practice'));
+            let badPracticeCategory = scaCategories.find((category) => category.name === 'Bad Practice');
             if (!badPracticeCategory) {
                 fail(`FAILTEST: Could not find SCA category "Bad Practice" for exercise: ${exerciseId}`);
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes a bug in the K6 tests, @derLalla noticed. 

### Description
<!-- Describe your changes in detail -->
Wrong operator for comparison.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Use this branch to run the K6 tests.
--> All tests should pass