### PR TITLE
[Fix] Add result details in submission page

### DIFF
--- a/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
+++ b/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
@@ -17,13 +17,14 @@
         [rows]="submissions"
         [sorts]="[{ prop: 'id', dir: 'asc' }]"
         [rowClass]=""
+        [scrollbarH]="true"
     >
-        <ngx-datatable-column name="Id" prop="id">
+        <ngx-datatable-column name="Id" prop="id" [minWidth]="60" [width]="60">
             <ng-template ngx-datatable-cell-template let-value="value">
                 {{ value }}
             </ng-template>
         </ngx-datatable-column>
-        <ngx-datatable-column prop="type">
+        <ngx-datatable-column prop="type" [minWidth]="80" [width]="80">
             <ng-template ngx-datatable-header-template>
                 <span jhiTranslate="artemisApp.participation.participationSubmission.submissionType"></span>
             </ng-template>
@@ -31,7 +32,7 @@
                 {{ value }}
             </ng-template>
         </ngx-datatable-column>
-        <ngx-datatable-column prop="submissionDate">
+        <ngx-datatable-column prop="submissionDate" [minWidth]="80" [width]="80">
             <ng-template ngx-datatable-header-template>
                 <span jhiTranslate="artemisApp.participation.participationSubmission.submissionDate"></span>
             </ng-template>
@@ -39,7 +40,7 @@
                 {{ value | artemisDate: 'long':true }}
             </ng-template>
         </ngx-datatable-column>
-        <ngx-datatable-column prop="results">
+        <ngx-datatable-column prop="results" [minWidth]="60" [width]="80">
             <ng-template ngx-datatable-header-template>
                 <span jhiTranslate="artemisApp.participation.participationSubmission.resultCount"></span>
             </ng-template>
@@ -47,23 +48,49 @@
                 {{ value.length || 0 }}
             </ng-template>
         </ngx-datatable-column>
-        <ngx-datatable-column prop="latestResult">
+        <ngx-datatable-column prop="results" [minWidth]="500" [width]="500">
             <ng-template ngx-datatable-header-template>
-                <span jhiTranslate="artemisApp.participation.participationSubmission.lastResult"></span>
+                <span jhiTranslate="artemisApp.participation.participationSubmission.results"></span>
             </ng-template>
             <ng-template ngx-datatable-cell-template let-value="value">
-                <jhi-result [result]="value" [participation]="participation" [showUngradedResults]="true" [showGradedBadge]="true"></jhi-result>
+                <div class="d-flex flex-column">
+                    <div *ngFor="let result of value">
+                        <jhi-result [result]="result" [participation]="participation" [showUngradedResults]="true" [showGradedBadge]="true"></jhi-result>
+                    </div>
+                </div>
             </ng-template>
         </ngx-datatable-column>
-        <ngx-datatable-column prop="latestResult">
+        <ngx-datatable-column prop="results" [minWidth]="180" [width]="180">
+            <ng-template ngx-datatable-header-template>
+                <span jhiTranslate="artemisApp.result.assessmentType"></span>
+            </ng-template>
+            <ng-template ngx-datatable-cell-template let-value="value">
+                <div class="d-flex flex-column">
+                    <div *ngFor="let result of value">{{ result.assessmentType }}</div>
+                </div>
+            </ng-template>
+        </ngx-datatable-column>
+        <ngx-datatable-column prop="results" [minWidth]="200" [width]="200">
             <ng-template ngx-datatable-header-template>
                 <span jhiTranslate="artemisApp.participation.participationSubmission.assessor"></span>
             </ng-template>
             <ng-template ngx-datatable-cell-template let-value="value">
-                {{ value && value.assessor ? value.assessor.name : 'n.a' }}
+                <div class="d-flex flex-column">
+                    <div *ngFor="let result of value">{{ result.assessor ? result.assessor.name : 'n.a' }}</div>
+                </div>
             </ng-template>
         </ngx-datatable-column>
-        <ngx-datatable-column prop="id">
+        <ngx-datatable-column prop="results" [minWidth]="200" [width]="200">
+            <ng-template ngx-datatable-header-template>
+                <span jhiTranslate="artemisApp.exercise.completionDate"></span>
+            </ng-template>
+            <ng-template ngx-datatable-cell-template let-value="value">
+                <div class="d-flex flex-column">
+                    <div *ngFor="let result of value">{{ result.completionDate | artemisDate }}</div>
+                </div>
+            </ng-template>
+        </ngx-datatable-column>
+        <ngx-datatable-column prop="id" [minWidth]="120" [width]="120">
             <ng-template ngx-datatable-header-template>
                 <span jhiTranslate="artemisApp.participation.participationSubmission.action"></span>
             </ng-template>

--- a/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
+++ b/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
@@ -40,7 +40,7 @@
                 {{ value | artemisDate: 'long':true }}
             </ng-template>
         </ngx-datatable-column>
-        <ngx-datatable-column prop="results" [minWidth]="60" [width]="80">
+        <ngx-datatable-column prop="results" [minWidth]="80" [width]="80">
             <ng-template ngx-datatable-header-template>
                 <span jhiTranslate="artemisApp.participation.participationSubmission.resultCount"></span>
             </ng-template>

--- a/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
+++ b/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
@@ -76,7 +76,7 @@
             </ng-template>
             <ng-template ngx-datatable-cell-template let-value="value">
                 <div class="d-flex flex-column">
-                    <div *ngFor="let result of value">{{ result.assessor ? result.assessor.name : 'n.a' }}</div>
+                    <div *ngFor="let result of value">{{ result.assessor?.name || 'n.a' }}</div>
                 </div>
             </ng-template>
         </ngx-datatable-column>

--- a/src/main/webapp/i18n/de/participation.json
+++ b/src/main/webapp/i18n/de/participation.json
@@ -43,7 +43,7 @@
                 "submissionType": "Abgabe Typ",
                 "submissionDate": "Abgabe Datum",
                 "resultCount": "Anzahl Ergebnisse",
-                "lastResult": "Letztes Ergebnis",
+                "results": "Ergebnisse",
                 "assessor": "Bewerter",
                 "submissionsForParticipation": "Abgaben von {{ participant }} für die Übung {{ exercise }}",
                 "action": "Aktion",

--- a/src/main/webapp/i18n/en/participation.json
+++ b/src/main/webapp/i18n/en/participation.json
@@ -43,7 +43,7 @@
                 "submissionType": "Submission Type",
                 "submissionDate": "Submission Date",
                 "resultCount": "Result Count",
-                "lastResult": "Last Result",
+                "results": "Results",
                 "assessor": "Assessor",
                 "submissionsForParticipation": "Submissions of {{ participant }} for Exercise {{ exercise }}",
                 "action": "Action",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #2759 

### Description
<!-- Describe your changes in detail -->
The submission page is extended to display the details about all results that are stored for each submission. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration & generate a programming exercise
3. Participate in it and click on submit one or two times
4. Go to Course Administration -> Exercises -> Participations
5. Click on the little circle arrow to retrigger the build (this will generate a new result for the latest submission)
6. Click on the submission number to navigate to the submission page and make sure the results are displayed

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Nothing changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/11298674/106129558-a3ee7300-6160-11eb-9603-84ecdd9fdb74.png)
