### PR TITLE
Avoid too large hibernate entity graphs when preparing the exercise start in exams

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ExamRepository.java
@@ -40,9 +40,12 @@ public interface ExamRepository extends JpaRepository<Exam, Long> {
     @EntityGraph(type = LOAD, attributePaths = { "studentExams" })
     Optional<Exam> findWithStudentExamsById(Long examId);
 
-    @EntityGraph(type = LOAD, attributePaths = { "studentExams", "studentExams.exercises", "studentExams.exercises.studentParticipations",
-            "studentExams.exercises.studentParticipations.submissions" })
-    Optional<Exam> findWithStudentExamsExercisesParticipationsSubmissionsById(Long id);
+    @EntityGraph(type = LOAD, attributePaths = { "studentExams", "studentExams.exercises" })
+    Optional<Exam> findWithStudentExamsExercisesById(Long id);
+
+    // IMPORTANT: NEVER use the following EntityGraph because it will lead to crashes for exams with many users
+    // The problem is that 2000 student Exams with 10 exercises and 2000 existing participations would load 2000*10*2000 = 40 mio objects
+    // @EntityGraph(type = LOAD, attributePaths = { "studentExams", "studentExams.exercises", "studentExams.exercises.participations" })
 
     @Query("select distinct exam from Exam exam left join fetch exam.studentExams studentExams left join fetch exam.exerciseGroups exerciseGroups left join fetch exerciseGroups.exercises where (exam.id = :#{#examId})")
     Exam findOneWithEagerExercisesGroupsAndStudentExams(@Param("examId") long examId);

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -288,7 +288,7 @@ public class ExamService {
             Double maxPointsGroup = optionalMaxPointsGroup.orElse(0);
 
             // Counter for exerciseGroup participations. Is calculated by summing up the number of exercise participations
-            long numberOfExeciseGroupParticipants = 0;
+            long numberOfExerciseGroupParticipants = 0;
             // Add information about exercise groups and exercises
             var exerciseGroupDTO = new ExamScoresDTO.ExerciseGroup(exerciseGroup.getId(), exerciseGroup.getTitle(), maxPointsGroup);
             for (Exercise exercise : exerciseGroup.getExercises()) {
@@ -297,11 +297,11 @@ public class ExamService {
                 if (participantsForExercise == null) {
                     participantsForExercise = 0L;
                 }
-                numberOfExeciseGroupParticipants += participantsForExercise;
+                numberOfExerciseGroupParticipants += participantsForExercise;
                 exerciseGroupDTO.containedExercises
                         .add(new ExamScoresDTO.ExerciseGroup.ExerciseInfo(exercise.getId(), exercise.getTitle(), exercise.getMaxScore(), participantsForExercise));
             }
-            exerciseGroupDTO.numberOfParticipants = numberOfExeciseGroupParticipants;
+            exerciseGroupDTO.numberOfParticipants = numberOfExerciseGroupParticipants;
             scores.exerciseGroups.add(exerciseGroupDTO);
         }
 
@@ -447,7 +447,7 @@ public class ExamService {
      * Validates exercise settings.
      *
      * @param exam exam which is validated
-     * @throws BadRequestAlertException
+     * @throws BadRequestAlertException an exception if the exam is not configured correctly
      */
     public void validateForStudentExamGeneration(Exam exam) throws BadRequestAlertException {
         List<ExerciseGroup> exerciseGroups = exam.getExerciseGroups();
@@ -483,8 +483,7 @@ public class ExamService {
 
         // Ensure that all exercises in an exercise group have the same meaning for the exam score calculation
         for (ExerciseGroup exerciseGroup : exam.getExerciseGroups()) {
-            Set<IncludedInOverallScore> meaningsForScoreCalculation = exerciseGroup.getExercises().stream().map(exercise -> exercise.getIncludedInOverallScore())
-                    .collect(Collectors.toSet());
+            Set<IncludedInOverallScore> meaningsForScoreCalculation = exerciseGroup.getExercises().stream().map(Exercise::getIncludedInOverallScore).collect(Collectors.toSet());
             if (meaningsForScoreCalculation.size() > 1) {
                 throw new BadRequestAlertException("All exercises in an exercise group must have the same meaning for the exam score", "Exam",
                         "artemisApp.exam.validation.allExercisesInExerciseGroupOfSameIncludedType");
@@ -498,10 +497,10 @@ public class ExamService {
 
         // Ensure that all exercises in an exercise group have the same amount of max points and max bonus points
         for (ExerciseGroup exerciseGroup : exam.getExerciseGroups()) {
-            Set<Double> maxPointsEarnable = exerciseGroup.getExercises().stream().map(Exercise::getMaxScore).collect(Collectors.toSet());
-            Set<Double> bonusPointsEarnable = exerciseGroup.getExercises().stream().map(Exercise::getBonusPoints).collect(Collectors.toSet());
+            Set<Double> allMaxPoints = exerciseGroup.getExercises().stream().map(Exercise::getMaxScore).collect(Collectors.toSet());
+            Set<Double> allBonusPoints = exerciseGroup.getExercises().stream().map(Exercise::getBonusPoints).collect(Collectors.toSet());
 
-            if (maxPointsEarnable.size() > 1 || bonusPointsEarnable.size() > 1) {
+            if (allMaxPoints.size() > 1 || allBonusPoints.size() > 1) {
                 throw new BadRequestAlertException("All exercises in an exercise group need to give the same amount of points", "Exam",
                         "artemisApp.exam.validation.allExercisesInExerciseGroupGiveSameNumberOfPoints");
             }
@@ -601,14 +600,14 @@ public class ExamService {
      *
      * @param courseId      the id of the course
      * @param examId        the id of the exam
-     * @param studentDtos   the list of students (with at least registration number) who should get access to the exam
+     * @param studentDTOs   the list of students (with at least registration number) who should get access to the exam
      * @return the list of students who could not be registered for the exam, because they could NOT be found in the Artemis database and could NOT be found in the TUM LDAP
      */
-    public List<StudentDTO> registerStudentsForExam(Long courseId, Long examId, List<StudentDTO> studentDtos) {
+    public List<StudentDTO> registerStudentsForExam(Long courseId, Long examId, List<StudentDTO> studentDTOs) {
         var course = courseService.findOne(courseId);
         var exam = findOneWithRegisteredUsers(examId);
-        List<StudentDTO> notFoundStudentsDtos = new ArrayList<>();
-        for (var studentDto : studentDtos) {
+        List<StudentDTO> notFoundStudentsDTOs = new ArrayList<>();
+        for (var studentDto : studentDTOs) {
             var registrationNumber = studentDto.getRegistrationNumber();
             var login = studentDto.getLogin();
             try {
@@ -653,7 +652,7 @@ public class ExamService {
                 log.warn("Error while processing user with registration number " + registrationNumber + ": " + ex.getMessage(), ex);
             }
 
-            notFoundStudentsDtos.add(studentDto);
+            notFoundStudentsDTOs.add(studentDto);
         }
         examRepository.save(exam);
 
@@ -661,18 +660,18 @@ public class ExamService {
             User currentUser = userService.getUserWithGroupsAndAuthorities();
             Map<String, Object> userData = new HashMap<>();
             userData.put("exam", exam.getTitle());
-            for (var studentDto : studentDtos) {
+            for (var studentDto : studentDTOs) {
                 userData.put("student", studentDto.getFirstName() + " " + studentDto.getLastName() + ", " + studentDto.getRegistrationNumber());
             }
             AuditEvent auditEvent = new AuditEvent(currentUser.getLogin(), Constants.ADD_USER_TO_EXAM, userData);
             auditEventRepository.add(auditEvent);
-            log.info("User " + currentUser.getLogin() + " has added multiple users " + studentDtos + " to the exam " + exam.getTitle() + " with id " + exam.getId());
+            log.info("User " + currentUser.getLogin() + " has added multiple users " + studentDTOs + " to the exam " + exam.getTitle() + " with id " + exam.getId());
         }
         catch (Exception ex) {
             log.warn("Could not add audit event to audit log", ex);
         }
 
-        return notFoundStudentsDtos;
+        return notFoundStudentsDTOs;
     }
 
     /**
@@ -738,10 +737,9 @@ public class ExamService {
      * @param examId exam to which the student exams belong
      * @return number of generated Participations
      */
-    public Integer startExercises(Long examId) {
+    public int startExercises(Long examId) {
 
-        var exam = examRepository.findWithStudentExamsExercisesParticipationsSubmissionsById(examId)
-                .orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
+        var exam = examRepository.findWithStudentExamsExercisesById(examId).orElseThrow(() -> new EntityNotFoundException("Exam with id: \"" + examId + "\" does not exist"));
 
         var studentExams = exam.getStudentExams();
         List<StudentParticipation> generatedParticipations = Collections.synchronizedList(new ArrayList<>());
@@ -756,12 +754,17 @@ public class ExamService {
      */
     public void setUpExerciseParticipationsAndSubmissions(List<StudentParticipation> generatedParticipations, StudentExam studentExam) {
         User student = studentExam.getUser();
+
         for (Exercise exercise : studentExam.getExercises()) {
+            SecurityUtils.setAuthorizationObject();
+            // NOTE: it is not ideal to invoke the next line several times (e.g. 2000 student exams with 10 exercises would lead to 20.000 database calls to find a participation).
+            // One optimization could be that we load all participations per exercise once (or per exercise) into a large list (10 * 2000 = 20.000 participations) and then check if
+            // those participations exist in Java, however this might lead to memory issues and might be more difficult to program (and more difficult to understand)
+            var studentParticipations = participationService.findByExerciseAndStudentId(exercise, student.getId());
             // we start the exercise if no participation was found that was already fully initialized
-            if (exercise.getStudentParticipations().stream().noneMatch(studentParticipation -> studentParticipation.getParticipant().equals(student)
+            if (studentParticipations.stream().noneMatch(studentParticipation -> studentParticipation.getParticipant().equals(student)
                     && studentParticipation.getInitializationState() != null && studentParticipation.getInitializationState().hasCompletedState(InitializationState.INITIALIZED))) {
                 try {
-                    SecurityUtils.setAuthorizationObject();
                     if (exercise instanceof ProgrammingExercise) {
                         // Load lazy property
                         final var programmingExercise = programmingExerciseService.findWithTemplateParticipationAndSolutionParticipationById(exercise.getId());
@@ -818,10 +821,10 @@ public class ExamService {
         }
 
         long start = System.nanoTime();
-        log.info("Evaluating {} quiz exercies in exam {}", quizExercises.size(), examId);
+        log.info("Evaluating {} quiz exercises in exam {}", quizExercises.size(), examId);
         // Evaluate all quizzes for that exercise
         quizExercises.forEach(quiz -> examQuizService.evaluateQuizAndUpdateStatistics(quiz.getId()));
-        log.info("Evaluated {} quiz exercies in exam {} in {}", quizExercises.size(), examId, TimeLogUtil.formatDurationFrom(start));
+        log.info("Evaluated {} quiz exercises in exam {} in {}", quizExercises.size(), examId, TimeLogUtil.formatDurationFrom(start));
 
         return quizExercises.size();
     }
@@ -1010,15 +1013,15 @@ public class ExamService {
 
     /**
      *
-     * @param examId
-     * @param withParticipationsAndSubmission
-     * @param student
+     * @param examId the exam for which a student should be unregistered
+     * @param deleteParticipationsAndSubmission whether the participations and submissions of the student should be deleted
+     * @param student the user object that should be unregistered
      */
-    public void unregisterStudentFromExam(Long examId, boolean withParticipationsAndSubmission, User student) {
+    public void unregisterStudentFromExam(Long examId, boolean deleteParticipationsAndSubmission, User student) {
         var exam = findOneWithRegisteredUsers(examId);
         exam.removeRegisteredUser(student);
 
-        // Note: we intentionally do not remove the user from the course, because the student might just have "deregistered" from the exam, but should
+        // Note: we intentionally do not remove the user from the course, because the student might just have "unregistered" from the exam, but should
         // still have access to the course.
         examRepository.save(exam);
 
@@ -1028,7 +1031,7 @@ public class ExamService {
             StudentExam studentExam = optionalStudentExam.get();
 
             // Optionally delete participations and submissions
-            if (withParticipationsAndSubmission) {
+            if (deleteParticipationsAndSubmission) {
                 List<StudentParticipation> participations = participationService.findByStudentIdAndIndividualExercisesWithEagerSubmissionsResult(student.getId(),
                         studentExam.getExercises());
                 for (var participation : participations) {

--- a/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExamService.java
@@ -760,12 +760,14 @@ public class ExamService {
             // NOTE: it is not ideal to invoke the next line several times (e.g. 2000 student exams with 10 exercises would lead to 20.000 database calls to find a participation).
             // One optimization could be that we load all participations per exercise once (or per exercise) into a large list (10 * 2000 = 20.000 participations) and then check if
             // those participations exist in Java, however this might lead to memory issues and might be more difficult to program (and more difficult to understand)
+            // TODO: directly check in the database if the entry exists for the student, exercise and InitializationState.INITIALIZED
             var studentParticipations = participationService.findByExerciseAndStudentId(exercise, student.getId());
             // we start the exercise if no participation was found that was already fully initialized
             if (studentParticipations.stream().noneMatch(studentParticipation -> studentParticipation.getParticipant().equals(student)
                     && studentParticipation.getInitializationState() != null && studentParticipation.getInitializationState().hasCompletedState(InitializationState.INITIALIZED))) {
                 try {
                     if (exercise instanceof ProgrammingExercise) {
+                        // TODO: we should try to move this out of the for-loop into the method which calls this method.
                         // Load lazy property
                         final var programmingExercise = programmingExerciseService.findWithTemplateParticipationAndSolutionParticipationById(exercise.getId());
                         ((ProgrammingExercise) exercise).setTemplateParticipation(programmingExercise.getTemplateParticipation());

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -412,6 +412,7 @@ public class ExamResource {
     @PostMapping(value = "/courses/{courseId}/exams/{examId}/generate-student-exams")
     @PreAuthorize("hasAnyRole('INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<List<StudentExam>> generateStudentExams(@PathVariable Long courseId, @PathVariable Long examId) {
+        long start = System.nanoTime();
         log.info("REST request to generate student exams for exam {}", examId);
 
         final var exam = examService.findOneWithRegisteredUsersAndExerciseGroupsAndExercises(examId);
@@ -432,8 +433,7 @@ public class ExamResource {
             studentExam.getExam().setExerciseGroups(null);
             studentExam.getExam().setStudentExams(null);
         }
-
-        log.info("Generated {} student exams for exam {}", studentExams.size(), examId);
+        log.info("Generated {} student exams in {} for exam {}", studentExams.size(), formatDurationFrom(start), examId);
         return ResponseEntity.ok().body(studentExams);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -492,7 +492,7 @@ public class ExamResource {
         if (courseAndExamAccessFailure.isPresent())
             return courseAndExamAccessFailure.get();
 
-        Integer numberOfGeneratedParticipations = examService.startExercises(examId);
+        int numberOfGeneratedParticipations = examService.startExercises(examId);
 
         log.info("Generated {} participations in {} for student exams of exam {}", numberOfGeneratedParticipations, formatDurationFrom(start), examId);
 


### PR DESCRIPTION
Exams with 1850 students and 8 exercises can lead to a server crashes (out of memory).
This happens, when additional students are added and prepare exercise start is invoked, when already many exercises and participations exist.

The issue is the use of many-to-many relationships in the entity graph. In this PR, I fixes the issue. There are still potential performance improvements (see TODOs in the code), but the crash should not occur any more.

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the coding and design guidelines

1. Create an exam with 2000 test users (a csv can help). Do not use programming exercises to save time.
2. Generate individual student exams and prepare exercise start
3. Now add one more student, generate the missing individual student exams
4. Click again on prepare exercise start. The server should not crash.