### PR TITLE
Bugfix/exam student import/remove multiple rest calls

### DIFF
--- a/src/main/webapp/app/exam/manage/exam-management.service.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.service.ts
@@ -150,7 +150,7 @@ export class ExamManagementService {
 
     /**
      * Remove a student to the registered users for an exam
-     * @param courseId The course id.
+     * @param courseId The course id
      * @param examId The id of the exam from which to remove the student
      * @param studentLogin Login of the student
      * @param withParticipationsAndSubmission

--- a/src/main/webapp/app/exam/manage/students/students-exam-import-dialog/students-exam-import-dialog.component.html
+++ b/src/main/webapp/app/exam/manage/students/students-exam-import-dialog/students-exam-import-dialog.component.html
@@ -1,4 +1,4 @@
-<form id="studentsImportDialogForm" name="importForm" role="form" novalidate (ngSubmit)="importStudents()">
+<form id="studentsImportDialogForm" name="importForm" role="form" novalidate>
     <div class="modal-header">
         <h4 class="modal-title">
             <span [jhiTranslate]="'artemisApp.examManagement.examStudents.importStudents.dialogTitle'"> Import students into: </span>
@@ -76,7 +76,7 @@
             <button *ngIf="!hasImported" type="button" class="btn btn-default cancel" data-dismiss="modal" (click)="clear()">
                 <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
             </button>
-            <button *ngIf="!hasImported; else buttonAfterImport" type="submit" class="btn btn-primary" [disabled]="isSubmitDisabled">
+            <button *ngIf="!hasImported; else buttonAfterImport" type="submit" class="btn btn-primary" [disabled]="isSubmitDisabled" (click)="importStudents()">
                 <fa-icon [icon]="'upload'" class="mr-2"></fa-icon>
                 <span jhiTranslate="entity.action.to-import">Import</span>
                 <fa-icon class="ml-1" [hidden]="!isImporting" [spin]="true" [icon]="'circle-notch'"></fa-icon>

--- a/src/main/webapp/app/exam/manage/students/students-exam-import-dialog/students-exam-import-dialog.component.html
+++ b/src/main/webapp/app/exam/manage/students/students-exam-import-dialog/students-exam-import-dialog.component.html
@@ -76,13 +76,21 @@
             <button *ngIf="!hasImported" type="button" class="btn btn-default cancel" data-dismiss="modal" (click)="clear()">
                 <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
             </button>
-            <button *ngIf="!hasImported; else buttonAfterImport" type="submit" class="btn btn-primary" [disabled]="isSubmitDisabled" (click)="importStudents()">
+            <button
+                *ngIf="!hasImported; else buttonAfterImport"
+                type="submit"
+                id="import"
+                name="importButton"
+                class="btn btn-primary"
+                [disabled]="isSubmitDisabled"
+                (click)="importStudents()"
+            >
                 <fa-icon [icon]="'upload'" class="mr-2"></fa-icon>
                 <span jhiTranslate="entity.action.to-import">Import</span>
                 <fa-icon class="ml-1" [hidden]="!isImporting" [spin]="true" [icon]="'circle-notch'"></fa-icon>
             </button>
             <ng-template #buttonAfterImport>
-                <button class="btn btn-success" (click)="onFinish()">
+                <button class="btn btn-success" id="finish-button" (click)="onFinish()">
                     <fa-icon [icon]="'check'" class="mr-2"></fa-icon>
                     <span jhiTranslate="entity.action.finish">Finish</span>
                 </button>

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-import-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-import-dialog.component.spec.ts
@@ -19,6 +19,7 @@ import { AlertErrorComponent } from 'app/shared/alert/alert-error.component';
 import { StudentDTO } from 'app/entities/student-dto.model';
 import { HttpResponse } from '@angular/common/http';
 import { of } from 'rxjs';
+import { By } from '@angular/platform-browser';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -163,5 +164,46 @@ describe('StudentExamImportDialogComponent', () => {
 
         expect(component.numberOfStudentsImported).to.equal(importedStudents.length);
         expect(component.numberOfStudentsNotImported).to.equal(notImportedStudents.length);
+    });
+
+    it('should invoke REST call on "Import" but not on "Finish"', function () {
+        const studentsToImport: StudentDTO[] = [
+            { registrationNumber: '1', firstName: 'Max', lastName: 'Mustermann', login: 'login1' },
+            { registrationNumber: '2', firstName: 'Bob', lastName: 'Ross', login: 'login2' },
+        ];
+        const studentsNotFound: StudentDTO[] = [{ registrationNumber: '3', firstName: 'Some', lastName: 'Dude', login: 'login3' }];
+
+        const fakeResponse = { body: studentsNotFound } as HttpResponse<StudentDTO[]>;
+        sinon.replace(examManagementService, 'addStudentsToExam', sinon.fake.returns(of(fakeResponse)));
+
+        component.studentsToImport = studentsToImport;
+
+        fixture.detectChanges();
+
+        expect(component.hasImported).to.be.false;
+        expect(component.isSubmitDisabled).to.be.false;
+        const importButton = fixture.debugElement.query(By.css('#import'));
+        expect(importButton).to.exist;
+
+        importButton.nativeElement.click();
+
+        expect(examManagementService.addStudentsToExam).to.have.been.calledOnce;
+        expect(component.isImporting).to.be.false;
+        expect(component.hasImported).to.be.true;
+        expect(component.notFoundStudents.length).to.equal(studentsNotFound.length);
+
+        // Reset call counter
+        sinon.restore();
+        sinon.replace(examManagementService, 'addStudentsToExam', sinon.fake.returns(of(fakeResponse)));
+
+        component.hasImported = true;
+        fixture.detectChanges();
+
+        const finishButton = fixture.debugElement.query(By.css('#finish-button'));
+        expect(finishButton).to.exist;
+
+        finishButton.nativeElement.click();
+
+        expect(examManagementService.addStudentsToExam).to.not.have.been.called;
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When importing students for an exam, the REST call to save the students is called two times, once when clicking on _Import_ and once after clicking _Finish_. Since nothing changes between those two, the REST call after the _Finish_ click can be removed.

### Description
<!-- Describe your changes in detail -->
- The students are now saved only once, after clicking _Import_ in the Dialog
- Added test to test changed behavior

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create a exam
3. Navigate to Students and click in import Students
4. Open your browser network tab
5. Import students using a .csv file and make sure a `students` call in the network tab appears
6. Click on finish and make sure no additional `students` call is shown in the network tab (e.g. like shown in the screenshot)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Two Calls before changes:
![Screenshot 2021-01-30 at 17 02 17](https://user-images.githubusercontent.com/44401560/106361204-f8d6e880-631c-11eb-9353-a26ff8513964.png)
One Call after:
![Screenshot 2021-01-30 at 15 37 34](https://user-images.githubusercontent.com/44401560/106361091-4ef75c00-631c-11eb-932a-bebc5f49e7e3.png)

