### PR TITLE
Increase the z-index of the menu dropdown

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.scss
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.scss
@@ -36,6 +36,6 @@
     font-weight: bold;
 }
 
-.dropdown-menu {
+.dropdown-menu-index {
     z-index: 2000;
 }

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.scss
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.scss
@@ -35,3 +35,7 @@
     font-size: 18px;
     font-weight: bold;
 }
+
+.dropdown-menu {
+    z-index: 2000;
+}

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.scss
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.scss
@@ -35,7 +35,3 @@
     font-size: 18px;
     font-weight: bold;
 }
-
-.dropdown-menu-index {
-    z-index: 2000;
-}

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -59,7 +59,7 @@
                         <span jhiTranslate="global.menu.admin.main">Server Administration</span>
                     </span>
                 </a>
-                <ul class="dropdown-menu" ngbDropdownMenu>
+                <ul class="dropdown-menu dropdown-menu-index" ngbDropdownMenu>
                     <li>
                         <a class="dropdown-item" routerLink="admin/upcoming-exams-and-exercises" routerLinkActive="active" (click)="collapseNavbar()">
                             <fa-icon [icon]="'book-open'" [fixedWidth]="true"></fa-icon>

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -168,7 +168,7 @@
                         <img [src]="getImageUrl()" class="profile-image img-circle" alt="Avatar" />
                     </span>
                 </a>
-                <ul class="dropdown-menu" ngbDropdownMenu>
+                <ul class="dropdown-menu dropdown-menu-index" ngbDropdownMenu>
                     <li>
                         <h6 class="dropdown-header" jhiTranslate="global.menu.language">Language</h6>
                     </li>

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -42,6 +42,10 @@ Navbar
     }
 }
 
+.dropdown-menu-index {
+    z-index: 2000;
+}
+
 .breadcrumb-container {
     background-color: #e4e5e6;
     overflow: auto;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context

Closes #2727.

### Description

The `.stick-top` class of the jhi-exam-navigation bar sets a z-index of 1020 which causes it to be rendered on top of the dropdown.

Giving the dropdown an index of 1021 would fix this issue already. I gave it an index of 2000 to be a bit more robust against future changes.

### Steps for Testing

1. Start a test run for an exam
2. Check that you can view the dropdowns of the navbar while working on the test run

### Screenshots

The dropdown is now above the bar:
![grafik](https://user-images.githubusercontent.com/72132281/106468645-7e35d680-649e-11eb-8dac-d0ecaa648276.png)

The navigation dropdown is also visible:
![grafik](https://user-images.githubusercontent.com/72132281/106496449-307c9680-64bd-11eb-9aa8-f14b75b3b43d.png)
