### PR TITLE
Fix the layout of exercise groups

### DIFF
--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -190,15 +190,15 @@
                         <td class="align-middle">
                             {{ exercise.maxPoints }}
                         </td>
-                        <td>{{ exercise.bonusPoints }}</td>
-                        <td>{{ exerciseService.isIncludedInScore(exercise) }}</td>
+                        <td class="align-middle">{{ exercise.bonusPoints }}</td>
+                        <td class="align-middle">{{ exerciseService.isIncludedInScore(exercise) }}</td>
                         <!-- Programming exercise specific cells -->
                         <ng-container *ngIf="exerciseGroupToExerciseTypesDict.get(exerciseGroup.id)?.includes(exerciseType.PROGRAMMING)">
                             <ng-container *ngIf="exercise.type === exerciseType.PROGRAMMING; else emptyProgrammingCells">
                                 <td class="align-middle">
                                     {{ exercise.shortName }}
                                 </td>
-                                <td>
+                                <td class="align-middle">
                                     <div>
                                         <span *ngIf="exercise.templateParticipation?.repositoryUrl">
                                             <!--Checks if the programming exercise has a setup with VCS and CI, if this not the case
@@ -256,7 +256,7 @@
                                         <ng-template #noVersionControlAndContinuousIntegrationAvailableTest>Test</ng-template>
                                     </div>
                                 </td>
-                                <td>
+                                <td class="align-middle">
                                     <span *ngIf="exercise.templateParticipation?.buildPlanId"
                                         ><a
                                             *ngIf="
@@ -284,7 +284,7 @@
                                     >
                                     <ng-template #noVersionControlAndContinuousIntegrationAvailableSolution>Solution</ng-template><br />
                                 </td>
-                                <td class="d-none d-md-table-cell">
+                                <td class="align-middle d-none d-md-table-cell">
                                     <div class="d-flex justify-content-between">{{ 'artemisApp.programmingExercise.offlineIde' | translate }}: {{ exercise.allowOfflineIde }}</div>
                                     <div class="d-flex justify-content-between">
                                         {{ 'artemisApp.programmingExercise.onlineEditor' | translate }}: {{ exercise.allowOnlineEditor }}
@@ -319,7 +319,7 @@
                                 </div>
                             </td>
                         </ng-container>
-                        <td class="d-flex justify-content-end">
+                        <td class="align-middle d-flex justify-content-end">
                             <jhi-exam-exercise-row-buttons
                                 [course]="course"
                                 [exam]="exam"

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -179,7 +179,13 @@
                 <tbody>
                     <tr *ngFor="let exercise of exerciseGroup.exercises">
                         <td class="align-middle">
-                            {{ exercise.id }}
+                            <a
+                                *ngIf="course.isAtLeastInstructor && exercise.type !== exerciseType.QUIZ"
+                                [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id]"
+                            >
+                                <span>{{ exercise.id }}</span>
+                            </a>
+                            <span *ngIf="!course.isAtLeastInstructor || exercise.type === exerciseType.QUIZ">{{ exercise.id }}</span>
                         </td>
                         <td class="align-middle" style="font-size: 1.35rem">
                             <fa-icon [icon]="exerciseIcon(exercise)"></fa-icon>

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -68,16 +68,6 @@
     </button>
 
     <button
-        *ngIf="course.isAtLeastInstructor && exercise.type !== exerciseType.QUIZ"
-        type="submit"
-        [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id]"
-        class="btn btn-info btn-sm mr-1"
-    >
-        <fa-icon [icon]="'eye'"></fa-icon>
-        <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
-    </button>
-
-    <button
         *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.QUIZ"
         type="submit"
         [routerLink]="['/course-management', course.id, 'quiz-exercises', exercise.id, 'preview']"


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context

The text was not properly aligned previously and looked bad:
![grafik](https://user-images.githubusercontent.com/72132281/106601945-9409d100-655c-11eb-8cd8-9873dbb9f0a4.png)

Additionally the `View` button was redundant to having a click-able id like we have in most other views.

### Description

- Changed the text to be aligned in the middle.
- Removed the view button.
- Made the id clickable for instructors on exercises other than quizzes (preserving the previous behaviour).

### Steps for Testing

1. Navigate to an existing exam or create one
2. View an exercise group with exercises with different types (or create some)
3. Make sure the text of a row is aligned in the middle and does not change its vertical position
4. Check that clicking the id of an exercise is possible when you are an instructor and it is not a quiz
5. Check that clicking the id of an exercise is not possible when it is a quiz or you are not an instructor

### Screenshots

The text is aligned now:
![grafik](https://user-images.githubusercontent.com/72132281/106602100-d0d5c800-655c-11eb-9549-c973daf24244.png)

IDs are clickable for non-quiz exercises when viewing as instructor:
![grafik](https://user-images.githubusercontent.com/72132281/106602146-e4812e80-655c-11eb-835f-a99c2a36a0d4.png)
