### PR TITLE
[Bugfix] A failed buildlog was not shown in the result details for an exam

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -230,6 +230,9 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
                         }
                     }
 
+                    // adding back the deleted exercise
+                    participation.exercise = exercise;
+
                     // setup subscription for programming exercises
                     if (exercise.type === ExerciseType.PROGRAMMING) {
                         const programmingSubmissionSubscription = this.createProgrammingExerciseSubmission(exercise.id!, participation.id!);
@@ -447,8 +450,6 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         this.generateParticipationStatus.next('generating');
         return this.courseExerciseService.startExercise(this.exam.course!.id!, exercise.id!).pipe(
             map((createdParticipation: StudentParticipation) => {
-                // remove because of circular dependency when converting to JSON
-                delete createdParticipation.exercise;
                 exercise.studentParticipations!.push(createdParticipation);
                 if (createdParticipation.submissions && createdParticipation.submissions.length > 0) {
                     createdParticipation.submissions[0].isSynced = true;

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -10,6 +10,7 @@ import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service'
 import { Exam } from 'app/entities/exam.model';
 import * as moment from 'moment';
 import { getLatestSubmissionResult } from 'app/entities/submission.model';
+import { cloneDeep } from 'lodash';
 
 @Injectable({ providedIn: 'root' })
 export class ExamParticipationService {
@@ -102,9 +103,10 @@ export class ExamParticipationService {
      */
     public submitStudentExam(courseId: number, examId: number, studentExam: StudentExam): Observable<StudentExam> {
         const url = this.getResourceURL(courseId, examId) + '/student-exams/submit';
-        ExamParticipationService.breakCircularDependency(studentExam);
+        const studentExamCopy = cloneDeep(studentExam);
+        ExamParticipationService.breakCircularDependency(studentExamCopy);
 
-        return this.httpClient.post<StudentExam>(url, studentExam).pipe(
+        return this.httpClient.post<StudentExam>(url, studentExamCopy).pipe(
             map((submittedStudentExam: StudentExam) => {
                 return this.convertStudentExamFromServer(submittedStudentExam);
             }),
@@ -130,13 +132,14 @@ export class ExamParticipationService {
                     if (!!participation.submissions) {
                         for (const submission of participation.submissions) {
                             delete submission.participation;
-                            if (!!getLatestSubmissionResult(submission)) {
-                                const result = getLatestSubmissionResult(submission)!;
+                            const result = getLatestSubmissionResult(submission);
+                            if (!!result) {
                                 delete result.participation;
                                 delete result.submission;
                             }
                         }
                     }
+                    delete participation.exercise;
                 }
             }
         });
@@ -150,8 +153,9 @@ export class ExamParticipationService {
      * @param studentExam
      */
     public saveStudentExamToLocalStorage(courseId: number, examId: number, studentExam: StudentExam): void {
-        ExamParticipationService.breakCircularDependency(studentExam);
-        this.localStorageService.store(this.getLocalStorageKeyForStudentExam(courseId, examId), JSON.stringify(studentExam));
+        const studentExamCopy = cloneDeep(studentExam);
+        ExamParticipationService.breakCircularDependency(studentExamCopy);
+        this.localStorageService.store(this.getLocalStorageKeyForStudentExam(courseId, examId), JSON.stringify(studentExamCopy));
     }
 
     /**

--- a/src/main/webapp/app/exercises/programming/shared/utils/programming-exercise.utils.ts
+++ b/src/main/webapp/app/exercises/programming/shared/utils/programming-exercise.utils.ts
@@ -67,6 +67,10 @@ export const isProgrammingExerciseStudentParticipation = (participation: Partici
     return participation && participation.type === ParticipationType.PROGRAMMING;
 };
 
+export const isProgrammingExerciseParticipation = (participation: Participation | undefined): boolean => {
+    return (participation?.type && [ParticipationType.PROGRAMMING, ParticipationType.TEMPLATE, ParticipationType.SOLUTION].includes(participation.type)) || false;
+};
+
 /**
  * The deadline has passed if:
  * - The dueDate is set and the buildAndTestAfterDueDate is not set and the dueDate has passed.

--- a/src/main/webapp/app/exercises/shared/result/result-detail.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.component.ts
@@ -14,7 +14,11 @@ import { StaticCodeAnalysisIssue } from 'app/entities/static-code-analysis-issue
 import { ScoreChartPreset } from 'app/shared/chart/presets/scoreChartPreset';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { TranslateService } from '@ngx-translate/core';
-import { isProgrammingExerciseStudentParticipation, isResultPreliminary } from 'app/exercises/programming/shared/utils/programming-exercise.utils';
+import {
+    isProgrammingExerciseStudentParticipation,
+    isProgrammingExerciseParticipation,
+    isResultPreliminary,
+} from 'app/exercises/programming/shared/utils/programming-exercise.utils';
 import { AssessmentType } from 'app/entities/assessment-type.model';
 
 export enum FeedbackItemType {
@@ -77,6 +81,11 @@ export class ResultDetailComponent implements OnInit {
                 // If the result already has feedbacks assigned to it, don't query the server.
                 switchMap((feedbacks: Feedback[] | undefined | null) => (feedbacks && feedbacks.length ? of(feedbacks) : this.getFeedbackDetailsForResult(this.result.id!))),
                 switchMap((feedbacks: Feedback[] | undefined | null) => {
+                    // In case the exerciseType is not set, we try to set it back if the participation is from a programming exercise
+                    if (!this.exerciseType && isProgrammingExerciseParticipation(this.result?.participation)) {
+                        this.exerciseType = ExerciseType.PROGRAMMING;
+                    }
+
                     /*
                      * If we have feedback, filter it if needed, distinguish between test case and static code analysis
                      * feedback and assign the lists to the component


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
 A failed buildlog for a programming exercise was not shown in the result details for an `exam`, although it is shown in a regular programming exercise.

### Description
<!-- Describe your changes in detail -->
The studentParticipation's reference to its exercise was deleted upon creating the initial participation. But because the result detail modal needs the exercise for reference, the buildlog could not be shown. 
Also saving the exam to localstorage was adapted. The student`s exam reference now gets copied via cloneDeep before all circular dependencies of the student`s exam are deleted to be able to save it as a JSON-String. Otherwise the needed `exercise` reference would get deleted again.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create an exam and add a programming exercise
3. Participate in the exam and create a compile error (e.g. remove a `{`)
4. Wait for the `Build Failed` message and click on it. Now verify that it contains the build log and it is the same as the one shown in the build output at the bottom of the page.
5. After the exam has finished, go back to the exam's summary page and verify that the build log is still accessible

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
No new functionality was added, so the coverage stays the same.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Showing the failed build log:
![image](https://user-images.githubusercontent.com/33484318/106917393-82fdc300-6708-11eb-9876-254df2d164dc.png)

Same build log in the result detail and build output:
![image](https://user-images.githubusercontent.com/33484318/106917473-96109300-6708-11eb-9b43-c48c2134aa4c.png)

Also check that the build log is still accessible in the summary after the exam has ended: 
![image](https://user-images.githubusercontent.com/33484318/106942083-0678dd80-6724-11eb-90c9-125942852870.png)

