### PR TITLE
Change the layout of elements on the exercise groups page

### DIFF
--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -13,7 +13,7 @@
 <div class="mt-3 text-right" style="font-size: 0.85rem">Number of exercise groups: {{ exerciseGroups ? exerciseGroups.length : 0 }}</div>
 <div *ngFor="let exerciseGroup of exerciseGroups; let i = index" class="mt-3" style="border: 1px solid #cccccc">
     <div class="d-flex p-3" style="background-color: #e1e1e1">
-        <div class="mr-3 d-flex justify-content-center">
+        <div class="mr-3 d-flex justify-content-center" style="align-items: center">
             <a *ngIf="course?.isAtLeastInstructor" (click)="moveUp(i)" [class.disabled]="i == 0" class="border-0 p-0 mr-1 bg-transparent">
                 <fa-icon [icon]="'angle-up'" style="font-size: 1.3rem"></fa-icon>
             </a>
@@ -32,7 +32,7 @@
         <div class="d-flex justify-content-end" style="flex: 1">
             <div class="d-flex flex-column justify-content-center">
                 <div class="btn-group flex-btn-group-container">
-                    <div class="btn-group-vertical mr-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
+                    <div class="mr-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" style="margin-right: 0 !important">
                         <a *ngIf="course?.isAtLeastInstructor" [routerLink]="[exerciseGroup.id, 'quiz-exercises', 'new']" class="btn btn-info btn-sm mr-1 mb-1">
                             <fa-icon [icon]="'plus'"></fa-icon>
                             <span class="d-none d-md-inline">{{ 'artemisApp.examManagement.exerciseGroup.addQuizExercise' | translate }}</span>
@@ -325,8 +325,9 @@
                                 </div>
                             </td>
                         </ng-container>
-                        <td class="align-middle d-flex justify-content-end">
+                        <td class="align-middle">
                             <jhi-exam-exercise-row-buttons
+                                class="d-flex justify-content-end"
                                 [course]="course"
                                 [exam]="exam"
                                 [exercise]="exercise"

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -32,8 +32,13 @@
         <div class="d-flex justify-content-end" style="flex: 1">
             <div class="d-flex flex-column justify-content-center">
                 <div class="btn-group flex-btn-group-container">
-                    <div class="mr-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" style="margin-right: 0 !important">
-                        <a *ngIf="course?.isAtLeastInstructor" [routerLink]="[exerciseGroup.id, 'quiz-exercises', 'new']" class="btn btn-info btn-sm mr-1 mb-1">
+                    <div class="btn-group-vertical mr-1 mb-1" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" style="justify-content: end">
+                        <a
+                            *ngIf="course?.isAtLeastInstructor"
+                            [routerLink]="[exerciseGroup.id, 'quiz-exercises', 'new']"
+                            class="btn btn-info btn-sm mr-1 mb-1"
+                            style="max-height: 44%"
+                        >
                             <fa-icon [icon]="'plus'"></fa-icon>
                             <span class="d-none d-md-inline">{{ 'artemisApp.examManagement.exerciseGroup.addQuizExercise' | translate }}</span>
                         </a>

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -196,7 +196,12 @@
                             <fa-icon [icon]="exerciseIcon(exercise)"></fa-icon>
                         </td>
                         <td class="align-middle">
-                            {{ exercise.title }}
+                            <a
+                                *ngIf="course.isAtLeastInstructor && exercise.type !== exerciseType.QUIZ"
+                                [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id]"
+                            >
+                                <span>{{ exercise.title }}</span>
+                            </a>
                         </td>
                         <td class="align-middle">
                             {{ exercise.maxPoints }}

--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -202,6 +202,7 @@
                             >
                                 <span>{{ exercise.title }}</span>
                             </a>
+                            <span *ngIf="!course.isAtLeastInstructor || exercise.type === exerciseType.QUIZ">{{ exercise.title }}</span>
                         </td>
                         <td class="align-middle">
                             {{ exercise.maxPoints }}


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Several items were misaligned (see the screenshot).

### Description

Aligns the programming exercise icons, and the arrows next to the title. Makes the "Add Quiz" button smaller and aligns it with the other buttons. Also made exercise titles clickable (when not a Quiz exercise and when the user is a instructor).

### Steps for Testing

1. Create or view an existing exercise groups page
2. Make sure the arrows next to the title are centered in the middle
3. Check that exercise buttons for programming exercises are centered
4. The "Add Quiz" button is aligned with the other "Add ..." buttons
5. The exercise title for exercises other than Quiz exercises should be clickable only for instructors

### Screenshots

Before:
![grafik](https://user-images.githubusercontent.com/72132281/106947904-54451400-672b-11eb-8e46-d299a6b87f5d.png)

After:
![grafik](https://user-images.githubusercontent.com/72132281/107016339-1e8d4300-679e-11eb-921f-00b799f76d89.png)
