### PR TITLE
Restrict usernames to numbers and letters

### DIFF
--- a/src/main/webapp/app/account/register/register.component.ts
+++ b/src/main/webapp/app/account/register/register.component.ts
@@ -22,12 +22,12 @@ export class RegisterComponent implements OnInit, AfterViewInit {
     errorUserExists = false;
     success = false;
 
-    defaultEmailPattern = '^[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$|^[_.@A-Za-z0-9-]+$';
+    usernamePattern = '^[a-zA-Z0-9]*';
 
     registerForm = this.fb.group({
         firstName: ['', [Validators.required, Validators.minLength(2)]],
         lastName: ['', [Validators.required, Validators.minLength(2)]],
-        login: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50), Validators.pattern(this.defaultEmailPattern)]],
+        login: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50), Validators.pattern(this.usernamePattern)]],
         email: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(100), Validators.email]],
         password: ['', [Validators.required, Validators.minLength(8), Validators.maxLength(100)]],
         confirmPassword: ['', [Validators.required, Validators.minLength(8), Validators.maxLength(100)]],

--- a/src/main/webapp/i18n/de/register.json
+++ b/src/main/webapp/i18n/de/register.json
@@ -8,7 +8,7 @@
             "validate": {
                 "login": {
                     "required": "Dein Benutzername wird benötigt.",
-                    "minlength": "Dein Benutzername muss mindestens 1 Zeichen lang sein",
+                    "minlength": "Dein Benutzername muss mindestens 4 Zeichen lang sein",
                     "maxlength": "Dein Benutzername darf nicht länger als 50 Zeichen sein",
                     "pattern": "Dein Benutzername darf nur Kleinbuchstaben und Ziffern enthalten"
                 }

--- a/src/main/webapp/i18n/en/register.json
+++ b/src/main/webapp/i18n/en/register.json
@@ -8,7 +8,7 @@
             "validate": {
                 "login": {
                     "required": "Your username is required.",
-                    "minlength": "Your username is required to be at least 1 character.",
+                    "minlength": "Your username is required to be at least 4 character.",
                     "maxlength": "Your username cannot be longer than 50 characters.",
                     "pattern": "Your username can only contain letters and digits."
                 }


### PR DESCRIPTION
Fixes #2824

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [ ] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
See issue

### Steps for Testing
Try creating users in registration
1. Try none-alphanumeric usernames -> denied
2. Try normal usernames -> works

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->


