### PR TITLE
[Bugfix] Return always a score for an exam quiz

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
@@ -116,10 +116,11 @@ export class QuizExamSummaryComponent implements OnInit {
             const submittedAnswer = this.submission.submittedAnswers.find((answer) => {
                 return answer && answer.quizQuestion ? answer.quizQuestion.id === quizQuestionId : false;
             });
-            if (submittedAnswer && submittedAnswer.scoreInPoints) {
+            if (submittedAnswer && submittedAnswer.scoreInPoints !== undefined) {
                 return Math.round(submittedAnswer.scoreInPoints * 100) / 100;
             }
         }
+        return 0;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #2753.  
If the score of an exam quiz is 0, the received score is undefined instead of 0. Therefore the info message contains the variable name {{ paramScore }} instead of 0.

### Description
<!-- Describe your changes in detail -->
When getting the score of a quiz exercise, we now check if a score is !== undefined instead of just using it's boolean representation. As the score 0 results into false and leads to an undefined score.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create an exam with a quiz exercise
3. Participate in the exam and do not solve the quiz correctly. You need to receive 0 points.
4. After the exam has finished go to the exam summary and click on the `?` of `Your Score 0 / 5 (?)`
5. Verify that the text is correct and no variable names are shown

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
This is just a display bugfix. No changes in the code coverage.


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

The false info message containing the variable name: 
![image](https://user-images.githubusercontent.com/33484318/107031837-23a8bd00-67b3-11eb-94b2-e3aa4580803d.png)

The correct info message:
![image](https://user-images.githubusercontent.com/33484318/107032518-41c2ed00-67b4-11eb-86c1-b5b0c51557cd.png)
