### PR TITLE
[Bugfix] Validation of Misleading Mappings for Short Answer Questions

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -656,7 +656,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
                     question.title !== '' &&
                     shortAnswerQuestion.correctMappings &&
                     shortAnswerQuestion.correctMappings.length > 0 &&
-                    this.shortAnswerQuestionUtil.validateNoMisleadingCorrectShortAnswerMapping(shortAnswerQuestion) &&
+                    this.shortAnswerQuestionUtil.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion) &&
                     this.shortAnswerQuestionUtil.everySpotHasASolution(shortAnswerQuestion.correctMappings, shortAnswerQuestion.spots) &&
                     this.shortAnswerQuestionUtil.everyMappedSolutionHasASpot(shortAnswerQuestion.correctMappings) &&
                     shortAnswerQuestion.solutions?.filter((solution) => solution.text!.trim() === '').length === 0 &&
@@ -901,7 +901,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
                         translateValues: { index: index + 1 },
                     });
                 }
-                if (!this.shortAnswerQuestionUtil.validateNoMisleadingCorrectShortAnswerMapping(shortAnswerQuestion)) {
+                if (!this.shortAnswerQuestionUtil.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion)) {
                     invalidReasons.push({
                         translateKey: 'artemisApp.quizExercise.invalidReasons.misleadingCorrectMapping',
                         translateValues: { index: index + 1 },

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/short-answer-question-statistic/short-answer-question-statistic.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/short-answer-question-statistic/short-answer-question-statistic.component.ts
@@ -118,19 +118,4 @@ export class ShortAnswerQuestionStatisticComponent extends QuestionStatisticComp
         });
         this.updateData();
     }
-
-    /**
-     * Get the solution that was mapped to the given spot in the sample solution
-     *
-     * @param spot {object} the spot that the solution should be mapped to
-     * @return the mapped solution or undefined if no solution has been mapped to this location
-     */
-    correctSolutionForSpot(spot: ShortAnswerSpot) {
-        const currMapping = this.shortAnswerQuestionUtil.solveShortAnswer(this.question).filter((mapping) => mapping.spot!.id === spot.id)[0];
-        if (currMapping) {
-            return currMapping.solution;
-        } else {
-            return undefined;
-        }
-    }
 }

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/short-answer-question-statistic/short-answer-question-statistic.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/short-answer-question-statistic/short-answer-question-statistic.component.ts
@@ -8,7 +8,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
 import { ShortAnswerQuestion } from 'app/entities/quiz/short-answer-question.model';
 import { QuizExerciseService } from 'app/exercises/quiz/manage/quiz-exercise.service';
-import { ShortAnswerSpot } from 'app/entities/quiz/short-answer-spot.model';
 import { ShortAnswerQuestionStatistic } from 'app/entities/quiz/short-answer-question-statistic.model';
 import { ShortAnswerSolution } from 'app/entities/quiz/short-answer-solution.model';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';

--- a/src/main/webapp/app/exercises/quiz/shared/short-answer-question-util.service.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/short-answer-question-util.service.ts
@@ -4,6 +4,7 @@ import { ShortAnswerQuestion } from 'app/entities/quiz/short-answer-question.mod
 import { ShortAnswerMapping } from 'app/entities/quiz/short-answer-mapping.model';
 import { ShortAnswerSpot } from 'app/entities/quiz/short-answer-spot.model';
 import { ShortAnswerSolution } from 'app/entities/quiz/short-answer-solution.model';
+import { cloneDeep } from 'lodash';
 
 @Injectable({ providedIn: 'root' })
 export class ShortAnswerQuestionUtil {
@@ -101,48 +102,59 @@ export class ShortAnswerQuestionUtil {
     }
 
     /**
-     * Validate that all correct mappings (and any combination of them that doesn't use a spot or solution twice)
-     * can be used in a 100% correct solution.
-     * This means that if any pair of solutions share a possible spot, then they must share all spots,
-     * or in other words the sets of possible spots for these two solutions must be identical
+     * Validate that no mapping exists that makes it impossible to solve the question.
+     * We create iterate through all spots and remove all possible mappings (solutions) for that spot.
+     * If there are still mappings (solutions) left for the other spots everything is ok.
+     * In case we have multiple mappings for spots, we check whether there are an equal or greater amount of mappings than spots.
      *
      * @param question {object} the question to check
      * @return {boolean} true, if the condition is met, otherwise false
      */
 
-    validateNoMisleadingCorrectShortAnswerMapping(question: ShortAnswerQuestion) {
+    validateNoMisleadingShortAnswerMapping(question: ShortAnswerQuestion) {
         if (!question.correctMappings) {
             // no correct mappings at all means there can be no misleading mappings
             return true;
         }
-        let amountOfSolutionsThatShareOneSpot = 0;
-        // iterate through all pairs of solutions
-        if (question.solutions) {
-            for (let i = 0; i < question.solutions.length; i++) {
-                for (let j = 0; j < i; j++) {
-                    // if these two solutions have one common spot, they must share all spots
-                    const solution1 = question.solutions[i];
-                    const solution2 = question.solutions[j];
-                    const shareOneSpot = question.spots?.some((spot) => {
-                        const isMappedWithSolution1 = this.isMappedTogether(question.correctMappings, solution1, spot);
-                        const isMappedWithSolution2 = this.isMappedTogether(question.correctMappings, solution2, spot);
-                        return isMappedWithSolution1 && isMappedWithSolution2;
-                    }, this);
-                    if (shareOneSpot) {
-                        amountOfSolutionsThatShareOneSpot++;
-                        const allSpotsForSolution1 = this.getAllSpotsForSolutions(question.correctMappings, solution1);
-                        const allSpotsForSolution2 = this.getAllSpotsForSolutions(question.correctMappings, solution2);
-                        // there have to be a least as many solutions that share all spots as the amount of existing spots
-                        if (!this.isSameSetOfSpots(allSpotsForSolution1, allSpotsForSolution2) === true && amountOfSolutionsThatShareOneSpot <= question.spots!.length) {
-                            // condition is violated for this pair of solutions
-                            return false;
-                        }
+
+        let unusedMappings: ShortAnswerMapping[] = cloneDeep(question.correctMappings);
+        const spotsCanBeSolved: boolean[] = [];
+
+        for (const spot of question.spots!) {
+            let atLeastOneMapping = false;
+            const solutionsForSpots = this.getAllSolutionsForSpot(question.correctMappings, spot)!;
+
+            solutionsForSpots.forEach((solution) => {
+                if (unusedMappings.length > 0 && unusedMappings.length !== question.correctMappings!.length) {
+                    atLeastOneMapping = true;
+                }
+                // unusedMappings.length > 0 will be always true for the first iteration, therefore we need a special checks
+                if (unusedMappings.length === question.correctMappings!.length) {
+                    // We need to verify if the first spot, has mappings (solutions) that is only for itself
+                    // In case there are multiple mappings (solutions) for spots, we use hasSpotEnoughSolutions
+                    const allSolutionsForSpot = this.getAllSolutionsForSpot(question.correctMappings, spot)!;
+                    const allSolutionsOnlyForSpot = allSolutionsForSpot.filter(
+                        (solutionForSpot) => this.getAllSpotsForSolutions(question.correctMappings, solutionForSpot)!.length === 1,
+                    );
+
+                    if (allSolutionsOnlyForSpot.length > 0) {
+                        atLeastOneMapping = true;
                     }
                 }
+                // remove every solution for a spot in the mapping
+                unusedMappings = unusedMappings.filter((mapping) => !this.isSameSolution(solution, mapping.solution));
+            });
+
+            // In case there are multiple mappings for the spots there have to be at least as many solutions as spots
+            const hasSpotEnoughSolutions = this.getAllSolutionsForSpot(question.correctMappings, spot)!.length >= question.spots!.length;
+            // Check whether a mapping is still left to solve the spot correctly.
+            if (atLeastOneMapping || hasSpotEnoughSolutions) {
+                spotsCanBeSolved.push(true);
+            } else {
+                spotsCanBeSolved.push(false);
             }
         }
-        // condition was met for all pairs of solutions
-        return true;
+        return !spotsCanBeSolved.includes(false);
     }
 
     /**

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
@@ -1404,7 +1404,7 @@ describe('QuizExercise Management Detail Component', () => {
                 });
 
                 it('should put reason for misleading correct mappings ', () => {
-                    const shortAnswerUtilMisleadingStub = stub(shortAnswerQuestionUtil, 'validateNoMisleadingCorrectShortAnswerMapping').returns(false);
+                    const shortAnswerUtilMisleadingStub = stub(shortAnswerQuestionUtil, 'validateNoMisleadingShortAnswerMapping').returns(false);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.misleadingCorrectMapping');
                     shortAnswerUtilMisleadingStub.restore();
                 });

--- a/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
+++ b/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
@@ -40,6 +40,17 @@ describe('ShortAnswerQuestionUtil', () => {
     solutionUnmapped.text = 'Solution 2';
     solutionUnmapped.id = 2;
 
+    const addMappingToQuestionAndCheckMisleadingMapping = (spotForMapping: ShortAnswerSpot, solutionForMapping: ShortAnswerSolution, toBeTrue: boolean) => {
+        const mappingToCheck = new ShortAnswerMapping(spotForMapping, solutionForMapping);
+        shortAnswerQuestion.correctMappings!.push(mappingToCheck);
+        const hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        if (toBeTrue) {
+            expect(hasNoMisleadingMapping).to.be.true;
+        } else {
+            expect(hasNoMisleadingMapping).to.be.false;
+        }
+    };
+
     beforeEach(async () => {
         TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), ArtemisTestModule],
@@ -163,50 +174,26 @@ describe('ShortAnswerQuestionUtil', () => {
         shortAnswerQuestion.spots!.push(spot2, spot3);
         shortAnswerQuestion.solutions!.push(solution2, solution3);
 
-        const mapping2 = new ShortAnswerMapping(spot2, solution2);
-        const mapping3 = new ShortAnswerMapping(spot3, solution3);
+        addMappingToQuestionAndCheckMisleadingMapping(spot2, solution2, false);
 
-        shortAnswerQuestion.correctMappings!.push(mapping2, mapping3);
-        let hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
-        expect(hasNoMisleadingMapping).to.be.true;
+        addMappingToQuestionAndCheckMisleadingMapping(spot3, solution3, true);
 
-        const mapping4 = new ShortAnswerMapping(spot2, solution);
-        shortAnswerQuestion.correctMappings!.push(mapping4);
-        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
-        expect(hasNoMisleadingMapping).to.be.false;
+        addMappingToQuestionAndCheckMisleadingMapping(spot2, solution, false);
 
-        const mapping5 = new ShortAnswerMapping(spot, solution2);
-        shortAnswerQuestion.correctMappings!.push(mapping5);
-        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
-        expect(hasNoMisleadingMapping).to.be.true;
+        addMappingToQuestionAndCheckMisleadingMapping(spot, solution2, true);
 
-        const mapping6 = new ShortAnswerMapping(spot, solution3);
-        shortAnswerQuestion.correctMappings!.push(mapping6);
-        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
-        expect(hasNoMisleadingMapping).to.be.false;
+        addMappingToQuestionAndCheckMisleadingMapping(spot, solution3, false);
 
-        const mapping7 = new ShortAnswerMapping(spot2, solution3);
-        shortAnswerQuestion.correctMappings!.push(mapping7);
-        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
-        expect(hasNoMisleadingMapping).to.be.false;
+        addMappingToQuestionAndCheckMisleadingMapping(spot2, solution3, false);
 
-        const mapping8 = new ShortAnswerMapping(spot3, solution);
-        shortAnswerQuestion.correctMappings!.push(mapping8);
-        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
-        expect(hasNoMisleadingMapping).to.be.false;
+        addMappingToQuestionAndCheckMisleadingMapping(spot3, solution, false);
 
-        const mapping9 = new ShortAnswerMapping(spot3, solution2);
-        shortAnswerQuestion.correctMappings!.push(mapping9);
-        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
-        expect(hasNoMisleadingMapping).to.be.true;
+        addMappingToQuestionAndCheckMisleadingMapping(spot3, solution2, true);
 
         const solution4 = new ShortAnswerSolution();
         solution4.text = 'Solution 4';
         solution4.id = 4;
-        const mapping10 = new ShortAnswerMapping(spot, solution4);
-        shortAnswerQuestion.correctMappings!.push(mapping10);
-        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
-        expect(hasNoMisleadingMapping).to.be.true;
+        addMappingToQuestionAndCheckMisleadingMapping(spot, solution4, true);
     });
 
     it('should split the question text into text parts and transform to html', () => {

--- a/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
+++ b/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
@@ -134,13 +134,79 @@ describe('ShortAnswerQuestionUtil', () => {
         hasAtLeastAsManySolutionsAsSpots = service.atLeastAsManySolutionsAsSpots(faultyShortAnswerQuestion);
         expect(hasAtLeastAsManySolutionsAsSpots).to.be.false;
 
-        // TODO more complex tests for validateNoMisleadingCorrectShortAnswerMapping(), after the logic issue is fixed
-        let hasMisleadingMapping = service.validateNoMisleadingCorrectShortAnswerMapping(shortAnswerQuestion);
-        expect(hasMisleadingMapping).to.be.true;
+        let hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.true;
         // @ts-ignore
         shortAnswerQuestion.correctMappings = undefined;
-        hasMisleadingMapping = service.validateNoMisleadingCorrectShortAnswerMapping(shortAnswerQuestion);
-        expect(hasMisleadingMapping).to.be.true;
+        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.true;
+    });
+
+    it('should check for misleading mappings', () => {
+        // This is done as the correctMappings is undefined (see previous test)
+        shortAnswerQuestion.correctMappings = [mapping];
+
+        const spot2 = new ShortAnswerSpot();
+        spot2.spotNr = 2;
+        spot2.id = 2;
+        const spot3 = new ShortAnswerSpot();
+        spot3.spotNr = 3;
+        spot3.id = 3;
+
+        const solution2 = new ShortAnswerSolution();
+        solution2.text = 'Solution 2';
+        solution2.id = 2;
+        const solution3 = new ShortAnswerSolution();
+        solution3.text = 'Solution 3';
+        solution3.id = 3;
+
+        shortAnswerQuestion.spots!.push(spot2, spot3);
+        shortAnswerQuestion.solutions!.push(solution2, solution3);
+
+        const mapping2 = new ShortAnswerMapping(spot2, solution2);
+        const mapping3 = new ShortAnswerMapping(spot3, solution3);
+
+        shortAnswerQuestion.correctMappings!.push(mapping2, mapping3);
+        let hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.true;
+
+        const mapping4 = new ShortAnswerMapping(spot2, solution);
+        shortAnswerQuestion.correctMappings!.push(mapping4);
+        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.false;
+
+        const mapping5 = new ShortAnswerMapping(spot, solution2);
+        shortAnswerQuestion.correctMappings!.push(mapping5);
+        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.true;
+
+        const mapping6 = new ShortAnswerMapping(spot, solution3);
+        shortAnswerQuestion.correctMappings!.push(mapping6);
+        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.false;
+
+        const mapping7 = new ShortAnswerMapping(spot2, solution3);
+        shortAnswerQuestion.correctMappings!.push(mapping7);
+        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.false;
+
+        const mapping8 = new ShortAnswerMapping(spot3, solution);
+        shortAnswerQuestion.correctMappings!.push(mapping8);
+        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.false;
+
+        const mapping9 = new ShortAnswerMapping(spot3, solution2);
+        shortAnswerQuestion.correctMappings!.push(mapping9);
+        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.true;
+
+        const solution4 = new ShortAnswerSolution();
+        solution4.text = 'Solution 4';
+        solution4.id = 4;
+        const mapping10 = new ShortAnswerMapping(spot, solution4);
+        shortAnswerQuestion.correctMappings!.push(mapping10);
+        hasNoMisleadingMapping = service.validateNoMisleadingShortAnswerMapping(shortAnswerQuestion);
+        expect(hasNoMisleadingMapping).to.be.true;
     });
 
     it('should split the question text into text parts and transform to html', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #1711.

### Description
<!-- Describe your changes in detail -->
- Rewrote logic for misleading mappings
- Added tests

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create new Quiz Exercise with a Short Answer Question
4. Type in quiz and question title
5. Try out different mappings (solvable and unsolvable) and check if the validation is correct. You can orientate on the screenshots below, but please try out also different ones (you can also orientate on the test case in short-answer-question-util.service.spec.ts)

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/41108487/107133518-5785fe80-68e9-11eb-95e6-bb1f4d1c1916.png">


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
1 to 1 mapping:
<img width="1653" alt="image" src="https://user-images.githubusercontent.com/41108487/107133123-4e932e00-68e5-11eb-95da-16acc7ce2d3f.png">


1 to 1 and n to 1 mappings:
<img width="1659" alt="image" src="https://user-images.githubusercontent.com/41108487/107133115-3e7b4e80-68e5-11eb-81ab-f534e0775f75.png">

n to m mappings:
<img width="1646" alt="image" src="https://user-images.githubusercontent.com/41108487/107133136-68347580-68e5-11eb-8b24-661ddedf18d2.png">

Misleading mapping -> unsolvable question (if "is" is used for spot 1 then spot 2 cannot be solved correctly anymore):
<img width="1649" alt="image" src="https://user-images.githubusercontent.com/41108487/107133155-85694400-68e5-11eb-8836-c4c83cf8436f.png">
