### PR TITLE
Fix the layout for importing existing quiz questions

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
@@ -341,7 +341,7 @@
             <hr />
         </ng-template>
         <ng-template #existingQuestionsFromCourseTemplate>
-            <div class="form-group question-options">
+            <div class="form-group question-options existing-question-container">
                 <div class="existing-question-select-course w-100">
                     <span jhiTranslate="artemisApp.quizExercise.selectCourse" class="font-weight-bold align-middle"></span>
                     <select class="form-control ml-5" [(ngModel)]="selectedCourseId" (change)="onCourseSelect()" style="flex: 1">
@@ -370,7 +370,7 @@
                     <div>&nbsp;</div>
                     <span jhiTranslate="artemisApp.quizExercise.noQuestionsFound"></span>
                 </div>
-                <div class="table-responsive" *ngIf="existingQuestions.length !== 0">
+                <div class="table-responsive existing-question-table" *ngIf="existingQuestions.length !== 0">
                     <table class="table table-striped">
                         <thead class="thead-dark">
                             <tr>

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.scss
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.scss
@@ -138,9 +138,16 @@
         }
     }
 
+    .existing-question-container {
+        flex-direction: column;
+        max-width: 1600px;
+        margin: auto;
+    }
+
     .existing-question-select-course {
         display: flex;
         align-items: center;
+        padding-bottom: 10px;
     }
 
     .existing-question-filter {
@@ -182,6 +189,10 @@
                 }
             }
         }
+    }
+
+    .existing-question-table {
+        padding-top: 10px;
     }
 }
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context

Displaying the contents next to each other looks wrong, and doesn't scale correctly. (See the screenshot.)

### Description

The contents are now displayed in a column, not in a row, which means they are below each other. Additionally some padding was added to reduce cramping and the width was limit to better fit wide screens.

### Steps for Testing

- Create a new quiz and try to "Add Existing Questions"
- Once you select a course the items in question are visible

### Screenshots

Before:
![grafik](https://user-images.githubusercontent.com/72132281/107155511-16d5c600-6979-11eb-81e6-38b743e86a59.png)

After (example 1):
![grafik](https://user-images.githubusercontent.com/72132281/107155072-a5951380-6976-11eb-8f1c-a7f46e7daffa.png)
<hr>

After (example 2):
![grafik](https://user-images.githubusercontent.com/72132281/107155491-03c2f600-6979-11eb-9b01-c6ac3c111f8b.png)



