### PR TITLE
Bugfix: Fetch correct file content in plagiarism split view

### DIFF
--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
@@ -100,6 +100,7 @@ export class TextSubmissionViewerComponent implements OnChanges {
         this.currentFile = file;
         this.loading = true;
 
+        this.repositoryService.setDomain([DomainType.PARTICIPATION, { id: this.plagiarismSubmission.submissionId }]);
         this.repositoryService.getFile(file).subscribe(
             ({ fileContent }) => {
                 this.loading = false;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
I just found out that we don't update the domain of the `CodeEditorRepositoryFileService` before fetching the content of submissions to compare in the plagiarism split view. This only happens for programming exercises and causes the split view to display the same submission twice.

### Description
I just had to add one line to update the domain before fetching the file content.

### Steps for Testing
1. Log in to Artemis
2. Navigate to Course Administration
3. Go to the details page of a programming exercise
4. Start plagiarism detection for this exercise
5. Inspect the results and make sure the split view displays the correct submissions
