### PR TITLE
[Feature] - Add export button for quizzes in exam exercise row

### DIFF
--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -75,6 +75,11 @@
         <span class="d-none d-md-inline" jhiTranslate="artemisApp.quizExercise.solution">Solution</span>
     </a>
 
+    <button *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.QUIZ" class="btn btn-primary btn-sm mr-1" (click)="exportQuizById(true)">
+        <fa-icon [icon]="'file-export'"></fa-icon>
+        <span class="d-none d-md-inline" jhiTranslate="entity.action.export">Export</span>
+    </button>
+
     <!-- Edit or re-evaluate for quizzes -->
     <ng-container *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.QUIZ">
         <!-- Only show the re-evaluate button after the exam has ended -->

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.ts
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { Subject } from 'rxjs';
 import { JhiEventManager } from 'ng-jhipster';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
@@ -11,6 +11,7 @@ import { ModelingExerciseService } from 'app/exercises/modeling/manage/modeling-
 import { Course } from 'app/entities/course.model';
 import { Exam } from 'app/entities/exam.model';
 import * as moment from 'moment';
+import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
 
 @Component({
     selector: 'jhi-exam-exercise-row-buttons',
@@ -138,5 +139,16 @@ export class ExamExerciseRowButtonsComponent {
             },
             (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
         );
+    }
+
+    /**
+     * Exports questions for the given quiz exercise in json file
+     * @param exportAll If true exports all questions, else exports only those whose export flag is true
+     */
+    exportQuizById(exportAll: boolean) {
+        this.quizExerciseService.find(this.exercise.id!).subscribe((res: HttpResponse<QuizExercise>) => {
+            const exercise = res.body!;
+            this.quizExerciseService.exportQuiz(exercise.quizQuestions, exportAll);
+        });
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After creating a good quiz exercise, a instructor would sometimes like to export the quiz exercise. This is not possible yet.

### Description
<!-- Describe your changes in detail -->
- Added a button in the exam exercise row where it is possible to download a json, containing the quiz exercise(s) information
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create new exam with a exercise group containing a quiz exam
3. Make sure it is possible to click "Export" on the right hand side (see screenshot) und that the json file is a correct containing the information of the quiz

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![Screenshot 2021-02-14 at 16 46 24](https://user-images.githubusercontent.com/44401560/107881377-67eb3a00-6ee4-11eb-81b4-b1697df4c503.png)
