### PR TITLE
Speedup the Assessment Dashboard for Large Exams

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ComplaintResponseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ComplaintResponseRepository.java
@@ -43,16 +43,11 @@ public interface ComplaintResponseRepository extends JpaRepository<ComplaintResp
      * @return number of complaints associated to exercise exerciseId without test runs
      */
     @Query("""
-            SELECT COUNT (DISTINCT p) FROM StudentParticipation p
-            WHERE p.exercise.id = :#{#exerciseId}
-            AND p.testRun = FALSE
-            AND EXISTS (Select s FROM p.submissions s
-                        WHERE s.results IS NOT EMPTY
-                        AND EXISTS (SELECT c FROM Complaint c
-                            WHERE EXISTS (SELECT r.id FROM s.results r
-                                WHERE r.id = c.result.id) AND c.complaintType = :#{#complaintType}
-                                AND EXISTS (SELECT cr FROM ComplaintResponse cr
-                                    WHERE cr.complaint.id = c.id AND cr.submittedTime IS NOT NULL)))
+            SELECT COUNT (DISTINCT cr) FROM ComplaintResponse cr
+            WHERE cr.submittedTime IS NOT NULL
+            AND cr.complaint.complaintType = :#{#complaintType}
+            AND cr.complaint.result.participation.exercise.id = :#{#exerciseId}
+            AND cr.complaint.result.participation.testRun = FALSE
             """)
     long countByComplaintResultParticipationExerciseIdAndComplaintComplaintTypeIgnoreTestRuns(long exerciseId, ComplaintType complaintType);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
For the EidI exam with about 1800 students, the exam assessment dashboard takes over four minutes each time we load the page. This PR aims to reduce the load times until they match the load times of the assessment dashboards of equally large courses (e.g. PGdP).

This fixes #2874.

### Description
- Replace four levels deep nested sub-queries by (implicit) joins in `countByComplaintResultParticipationExerciseIdAndComplaintComplaintTypeIgnoreTestRuns`. This logic should be closer to the 'magic' `countByComplaint_Result_Participation_Exercise_Id_AndComplaint_ComplaintType_AndSubmittedTimeIsNotNull` now.
  - [ ] TODO: Check that this was the problem / improves the perfomance. -> Will be checked by @krusche when this PR is merged in `develop`.

### Steps for Testing
0. Have an exam with assessments and complaints and at least a few submissions.
1. Check that the complaint statistics and progress bars for the assessment dashboard are the same with this bugfix PR and without it. Only the performance should improve (but you would need a large exam to check that).
2. Check that doing tests runs and assessing them, including answered and unanswered complaints has no effect on the numbers in the dashboard.

### Test Coverage
Same as before. The code that we changed in this PR is covered.
![image](https://user-images.githubusercontent.com/11130248/108085835-0955c580-7076-11eb-90e1-2224bb3fe136.png)
