### PR TITLE
Fix leaving modeling submission

### DIFF
--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
@@ -502,7 +502,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
             return true;
         }
         const model: UMLModel = this.modelingEditor.getCurrentModel();
-        const explanationIsUpToDate = this.explanation === this.submission.explanationText;
+        const explanationIsUpToDate = this.explanation === (this.submission.explanationText ?? '');
         return !this.modelHasUnsavedChanges(model) && explanationIsUpToDate;
     }
 


### PR DESCRIPTION
Fixes the problematic behavior:

When user tries to leave modeling editor, the alert for unsaved changes appear even though there is no unsaved change.