### PR TITLE
Bugfix: Fix instructor checklist counts

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -128,7 +128,7 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
      */
     @Query("""
             SELECT COUNT(p.id)
-            FROM StudentParticipation p left join  p.submissions s left join s.results r
+            FROM StudentParticipation p join  p.submissions s join s.results r
             WHERE p.exercise.id = :exerciseId
                 AND p.testRun = FALSE
                 AND s.submitted = TRUE

--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -116,27 +116,6 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
 
     /**
      * @param exerciseId id of exercise
-     * @param correctionRound correction round to find completed assessments by
-     * @return the number of completed assessments for the specified correction round of an exam exercise
-     */
-    @Query("""
-            SELECT COUNT(DISTINCT p)
-            FROM StudentParticipation p WHERE p.exercise.id = :exerciseId
-            AND p.testRun = FALSE
-            AND (SELECT COUNT(r)
-                FROM p.results r
-                WHERE r.assessor IS NOT NULL
-                AND r.rated = TRUE
-                AND r.submission = (select max(id) from p.submissions)
-                AND r.submission.submitted = TRUE
-                AND r.completionDate IS NOT NULL
-                AND (p.exercise.dueDate IS NULL OR r.submission.submissionDate <= p.exercise.dueDate)
-            ) >= (:correctionRound + 1L)
-            """)
-    long countNumberOfFinishedAssessmentsByCorrectionRoundsAndExerciseIdIgnoreTestRuns(@Param("exerciseId") Long exerciseId, @Param("correctionRound") long correctionRound);
-
-    /**
-     * @param exerciseId id of exercise
      * @return the number of completed assessments for the specified correction round of an exam exercise
      */
     @Query("""

--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -127,7 +127,7 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
      * @return a list that contains the count of manual assessments for each studentParticipation of the exercise
      */
     @Query("""
-            SELECT COUNT(p.id)
+            SELECT COUNT(r.id)
             FROM StudentParticipation p join  p.submissions s join s.results r
             WHERE p.exercise.id = :exerciseId
                 AND p.testRun = FALSE

--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -183,6 +183,7 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
         // depending on the number of correctionRounds we create 1 or 2 DueDateStats that contain the sum of all participations:
         // with either 1 or more manual results, OR 2 or more manual results
         correctionRoundsDataStats[0] = new DueDateStat(countlist.stream().filter(x -> x >= 1L).count(), 0L);
+        // so far the number of correctionRounds is limited to 2
         if (numberOfCorrectionRounds == 2) {
             correctionRoundsDataStats[1] = new DueDateStat(countlist.stream().filter(x -> x >= 2L).count(), 0L);
         }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -124,7 +124,7 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
 
     /**
      * @param exerciseId id of exercise
-     * @return the number of completed assessments for the specified correction round of an exam exercise
+     * @return a list that contains the count of manual assessments for each studentParticipation of the exercise
      */
     @Query("""
             SELECT COUNT(p.id)
@@ -167,7 +167,7 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
 
     /**
      * Use this method only for exams!
-     * Given an exerciseId and a correctionRound, return the number of assessments for that exerciseId and correctionRound that have been finished
+     * Given an exerciseId and the number of correctionRounds, return the number of assessments that have been finished, for that exerciseId and each correctionRound
      *
      * @param exercise  - the exercise we are interested in
      * @param numberOfCorrectionRounds - the correction round we want finished assessments for
@@ -176,8 +176,12 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
     default DueDateStat[] countNumberOfFinishedAssessmentsForExamExerciseForCorrectionRound(Exercise exercise, int numberOfCorrectionRounds) {
         DueDateStat[] correctionRoundsDataStats = new DueDateStat[numberOfCorrectionRounds];
 
+        // here we receive a list which contains an entry for each studentparticipation of the exercise.
+        // the entry simply is the number of already created and submitted manual results, so the number is either 1 or 2
         List<Long> countlist = countNumberOfFinishedAssessmentsByExerciseIdIgnoreTestRuns(exercise.getId());
 
+        // depending on the number of correctionRounds we create 1 or 2 DueDateStats that contain the sum of all participations:
+        // with either 1 or more manual results, OR 2 or more manual results
         correctionRoundsDataStats[0] = new DueDateStat(countlist.stream().filter(x -> x >= 1L).count(), 0L);
         if (numberOfCorrectionRounds == 2) {
             correctionRoundsDataStats[1] = new DueDateStat(countlist.stream().filter(x -> x >= 2L).count(), 0L);

--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -140,14 +140,15 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
      * @return the number of completed assessments for the specified correction round of an exam exercise
      */
     @Query("""
-            SELECT COUNT(DISTINCT p) as countOfRound
-            FROM StudentParticipation p left join fetch  p.submissions s left join fetch s.results r
+            SELECT COUNT(p.id)
+            FROM StudentParticipation p left join  p.submissions s left join s.results r
             WHERE p.exercise.id = :exerciseId
                 AND p.testRun = FALSE
                 AND s.submitted = TRUE
                 AND r.completionDate IS NOT NULL
                 AND r.rated = TRUE
                 AND r.assessor IS NOT NULL
+                GROUP BY p.id
             """)
     List<Long> countNumberOfFinishedAssessmentsByExerciseIdIgnoreTestRuns(@Param("exerciseId") Long exerciseId);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/AssessmentDashboardService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AssessmentDashboardService.java
@@ -65,23 +65,25 @@ public class AssessmentDashboardService {
             if (exercise instanceof ProgrammingExercise) {
                 numberOfSubmissions = new DueDateStat(programmingExerciseRepository.countSubmissionsByExerciseIdSubmitted(exercise.getId(), examMode), 0L);
                 log.info("StatsTimeLog: number of submitted submissions done in " + TimeLogUtil.formatDurationFrom(start) + " for programming exercise " + exercise.getId());
-                totalNumberOfAssessments = new DueDateStat(programmingExerciseRepository.countAssessmentsByExerciseIdSubmitted(exercise.getId(), examMode), 0L);
-                log.info("StatsTimeLog: number of submitted assessments done in " + TimeLogUtil.formatDurationFrom(start) + " for programming exercise " + exercise.getId());
             }
             else {
                 numberOfSubmissions = submissionRepository.countSubmissionsForExercise(exercise.getId(), examMode);
                 log.info("StatsTimeLog: number of submitted submissions done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
-                totalNumberOfAssessments = resultRepository.countNumberOfFinishedAssessmentsForExercise(exercise.getId(), examMode);
-                log.info("StatsTimeLog: number of submitted assessments done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
+            }
+            exercise.setNumberOfSubmissions(numberOfSubmissions);
+
+            // set number of correctionrounds. If it isn't an exam the default is 1. If it is an exam we fetch the number of correction rounds which is set for the exam
+            int numberOfCorrectionRounds = 1;
+            if (examMode) {
+                numberOfCorrectionRounds = exercise.getExerciseGroup().getExam().getNumberOfCorrectionRoundsInExam();
             }
 
-            exercise.setNumberOfSubmissions(numberOfSubmissions);
-            exercise.setTotalNumberOfAssessments(totalNumberOfAssessments);
-
-            final DueDateStat[] numberOfAssessmentsOfCorrectionRounds = resultRepository.countNrOfAssessmentsOfCorrectionRoundsForDashboard(exercise, examMode,
-                    totalNumberOfAssessments);
+            final DueDateStat[] numberOfAssessmentsOfCorrectionRounds = resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(exercise,
+                    numberOfCorrectionRounds);
             log.info("StatsTimeLog: number of assessments per correction round in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
+
             exercise.setNumberOfAssessmentsOfCorrectionRounds(numberOfAssessmentsOfCorrectionRounds);
+            exercise.setTotalNumberOfAssessments(numberOfAssessmentsOfCorrectionRounds[0]);
 
             complaintService.calculateNrOfOpenComplaints(exercise, examMode);
             log.info("StatsTimeLog: number of open complaints done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());

--- a/src/main/java/de/tum/in/www1/artemis/service/AssessmentDashboardService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AssessmentDashboardService.java
@@ -74,12 +74,15 @@ public class AssessmentDashboardService {
 
             // set number of correctionrounds. If it isn't an exam the default is 1. If it is an exam we fetch the number of correction rounds which is set for the exam
             int numberOfCorrectionRounds = 1;
+            final DueDateStat[] numberOfAssessmentsOfCorrectionRounds;
             if (examMode) {
                 numberOfCorrectionRounds = exercise.getExerciseGroup().getExam().getNumberOfCorrectionRoundsInExam();
+                numberOfAssessmentsOfCorrectionRounds = resultRepository.countNumberOfFinishedAssessmentsForExamExerciseForCorrectionRound(exercise, numberOfCorrectionRounds);
             }
-
-            final DueDateStat[] numberOfAssessmentsOfCorrectionRounds = resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(exercise,
-                    numberOfCorrectionRounds);
+            else {
+                numberOfAssessmentsOfCorrectionRounds = new DueDateStat[1];
+                numberOfAssessmentsOfCorrectionRounds[0] = new DueDateStat(resultRepository.countNumberOfFinishedAssessmentsForExercise(exercise.getId()), 0L);
+            }
             log.info("StatsTimeLog: number of assessments per correction round in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
 
             exercise.setNumberOfAssessmentsOfCorrectionRounds(numberOfAssessmentsOfCorrectionRounds);

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -631,7 +631,7 @@ public class ExamService {
             log.info("StatsTimeLog: number of complaints finished done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
             // number of assessments done
             numberOfAssessmentsFinishedOfCorrectionRoundsByExercise
-                    .add(resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(exercise, numberOfCorrectionRoundsInExam));
+                    .add(resultRepository.countNumberOfFinishedAssessmentsForExamExerciseForCorrectionRound(exercise, numberOfCorrectionRoundsInExam));
 
             log.info("StatsTimeLog: number of assessments done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
             // get number of all generated participations

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 import javax.validation.constraints.NotNull;
 
+import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.audit.AuditEvent;
@@ -615,6 +616,8 @@ public class ExamService {
         List<Long> numberOfComplaintResponsesByExercise = new ArrayList<>();
         List<DueDateStat[]> numberOfAssessmentsFinishedOfCorrectionRoundsByExercise = new ArrayList<>();
         List<Long> numberOfParticipationsGeneratedByExercise = new ArrayList<>();
+        List<Long> numberOfParticipationsForAssessmentGeneratedByExercise = new ArrayList<>();
+
 
         // loop over all exercises and retrieve all needed counts for the properties at once
         exam.getExerciseGroups().forEach(exerciseGroup -> exerciseGroup.getExercises().forEach(exercise -> {
@@ -624,29 +627,39 @@ public class ExamService {
             log.info("StatsTimeLog: number of complaints open done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
             // number of complaints finished
             numberOfComplaintResponsesByExercise.add(complaintResponseRepository
-                    .countByComplaint_Result_Participation_Exercise_Id_AndComplaint_ComplaintType_AndSubmittedTimeIsNotNull(exercise.getId(), ComplaintType.COMPLAINT));
+                .countByComplaint_Result_Participation_Exercise_Id_AndComplaint_ComplaintType_AndSubmittedTimeIsNotNull(exercise.getId(), ComplaintType.COMPLAINT));
 
             log.info("StatsTimeLog: number of complaints finished done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
             // number of assessments done
             numberOfAssessmentsFinishedOfCorrectionRoundsByExercise
-                    .add(resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(exercise, numberOfCorrectionRoundsInExam));
+                .add(resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(exercise, numberOfCorrectionRoundsInExam));
 
             log.info("StatsTimeLog: number of assessments done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
             // get number of all generated participations
-            numberOfParticipationsGeneratedByExercise.add(studentParticipationRepository.countParticipationsIgnoreTestRunsByExerciseId(exercise.getId()));
+            var countOfParticipations = studentParticipationRepository.countParticipationsIgnoreTestRunsByExerciseId(exercise.getId());
+            numberOfParticipationsGeneratedByExercise.add(countOfParticipations);
 
             log.info("StatsTimeLog: number of generated participations in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
+            if(!(exercise instanceof QuizExercise || exercise.getAssessmentType() == AssessmentType.AUTOMATIC)){
+                numberOfParticipationsForAssessmentGeneratedByExercise.add(countOfParticipations);
+            }
         }));
 
         long totalNumberOfComplaints = 0;
         long totalNumberOfComplaintResponse = 0;
         Long[] totalNumberOfAssessmentsFinished = new Long[numberOfCorrectionRoundsInExam];
         long totalNumberOfParticipationsGenerated = 0;
+        long totalNumberOfParticipationsForAssessment = 0;
 
         // sum up all counts for the different properties
         for (Long numberOfParticipations : numberOfParticipationsGeneratedByExercise) {
             totalNumberOfParticipationsGenerated += numberOfParticipations != null ? numberOfParticipations : 0;
         }
+        // sum up all counts for the different properties
+        for (Long numberOfParticipationsForAssessment : numberOfParticipationsForAssessmentGeneratedByExercise) {
+            totalNumberOfParticipationsForAssessment += numberOfParticipationsForAssessment != null ? numberOfParticipationsForAssessment : 0;
+        }
+
         for (DueDateStat[] dateStats : numberOfAssessmentsFinishedOfCorrectionRoundsByExercise) {
             for (int i = 0; i < numberOfCorrectionRoundsInExam; i++) {
                 if (totalNumberOfAssessmentsFinished[i] == null) {
@@ -687,6 +700,7 @@ public class ExamService {
         log.info("StatsTimeLog: number of student exams started done in " + TimeLogUtil.formatDurationFrom(start));
         long numberOfStudentExamsSubmitted = studentExamRepository.countStudentExamsSubmittedByExamIdIgnoreTestRuns(exam.getId());
         log.info("StatsTimeLog: number of student exams submitted done in " + TimeLogUtil.formatDurationFrom(start));
+        examChecklistDTO.setNumberOfTotalParticipationsForAssessment(totalNumberOfParticipationsForAssessment);
         examChecklistDTO.setNumberOfExamsStarted(numberOfStudentExamsStarted);
         examChecklistDTO.setNumberOfExamsSubmitted(numberOfStudentExamsSubmitted);
         return examChecklistDTO;

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -9,7 +9,6 @@ import java.util.stream.Stream;
 
 import javax.validation.constraints.NotNull;
 
-import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.audit.AuditEvent;
@@ -20,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.ComplaintType;
 import de.tum.in.www1.artemis.domain.enumeration.IncludedInOverallScore;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
@@ -618,7 +618,6 @@ public class ExamService {
         List<Long> numberOfParticipationsGeneratedByExercise = new ArrayList<>();
         List<Long> numberOfParticipationsForAssessmentGeneratedByExercise = new ArrayList<>();
 
-
         // loop over all exercises and retrieve all needed counts for the properties at once
         exam.getExerciseGroups().forEach(exerciseGroup -> exerciseGroup.getExercises().forEach(exercise -> {
             // number of complaints open
@@ -627,12 +626,12 @@ public class ExamService {
             log.info("StatsTimeLog: number of complaints open done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
             // number of complaints finished
             numberOfComplaintResponsesByExercise.add(complaintResponseRepository
-                .countByComplaint_Result_Participation_Exercise_Id_AndComplaint_ComplaintType_AndSubmittedTimeIsNotNull(exercise.getId(), ComplaintType.COMPLAINT));
+                    .countByComplaint_Result_Participation_Exercise_Id_AndComplaint_ComplaintType_AndSubmittedTimeIsNotNull(exercise.getId(), ComplaintType.COMPLAINT));
 
             log.info("StatsTimeLog: number of complaints finished done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
             // number of assessments done
             numberOfAssessmentsFinishedOfCorrectionRoundsByExercise
-                .add(resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(exercise, numberOfCorrectionRoundsInExam));
+                    .add(resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(exercise, numberOfCorrectionRoundsInExam));
 
             log.info("StatsTimeLog: number of assessments done in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
             // get number of all generated participations
@@ -640,7 +639,7 @@ public class ExamService {
             numberOfParticipationsGeneratedByExercise.add(countOfParticipations);
 
             log.info("StatsTimeLog: number of generated participations in " + TimeLogUtil.formatDurationFrom(start) + " for exercise " + exercise.getId());
-            if(!(exercise instanceof QuizExercise || exercise.getAssessmentType() == AssessmentType.AUTOMATIC)){
+            if (!(exercise instanceof QuizExercise || exercise.getAssessmentType() == AssessmentType.AUTOMATIC)) {
                 numberOfParticipationsForAssessmentGeneratedByExercise.add(countOfParticipations);
             }
         }));

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamChecklistDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamChecklistDTO.java
@@ -11,6 +11,8 @@ public class ExamChecklistDTO {
 
     private Long[] numberOfTotalExamAssessmentsFinishedByCorrectionRound; // all exercises summed up
 
+    private Long numberOfTotalParticipationsForAssessment; // all exercises summed up
+
     private Long numberOfExamsSubmitted;
 
     private Long numberOfExamsStarted;
@@ -20,6 +22,15 @@ public class ExamChecklistDTO {
     private Long numberOfAllComplaintsDone;
 
     private boolean allExamExercisesAllStudentsPrepared;
+
+    public Long getNumberOfTotalParticipationsForAssessment() {
+        return numberOfTotalParticipationsForAssessment;
+    }
+
+    public void setNumberOfTotalParticipationsForAssessment(Long numberOfTotalParticipationsForAssessment) {
+        this.numberOfTotalParticipationsForAssessment = numberOfTotalParticipationsForAssessment;
+    }
+
 
     public Long getNumberOfExamsStarted() {
         return numberOfExamsStarted;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamChecklistDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamChecklistDTO.java
@@ -31,7 +31,6 @@ public class ExamChecklistDTO {
         this.numberOfTotalParticipationsForAssessment = numberOfTotalParticipationsForAssessment;
     }
 
-
     public Long getNumberOfExamsStarted() {
         return numberOfExamsStarted;
     }

--- a/src/main/webapp/app/entities/exam-checklist.model.ts
+++ b/src/main/webapp/app/entities/exam-checklist.model.ts
@@ -7,6 +7,8 @@ export class ExamChecklist {
 
     public numberOfExamsStarted: number;
 
+    public numberOfTotalParticipationsForAssessment: number;
+
     public numberOfTotalExamAssessmentsFinishedByCorrectionRound?: number[]; // all exercises summed up
 
     public numberOfAllComplaints?: number;

--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
@@ -296,7 +296,7 @@
                                 <jhi-progress-bar
                                     [denominator]="examChecklist.numberOfTotalParticipationsForAssessment"
                                     [numerator]="finishedByCorrectionRound!"
-                                    [percentage]="(finishedByCorrectionRound! / (examChecklist.numberOfTotalParticipationsForAssessment)) * 100"
+                                    [percentage]="(finishedByCorrectionRound! / examChecklist.numberOfTotalParticipationsForAssessment) * 100"
                                 >
                                 </jhi-progress-bar>
                             </div>

--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.html
@@ -294,9 +294,9 @@
                             <span> {{ 'artemisApp.examManagement.checklist.textitems.correctionRound' | translate }} {{ index + 1 }}: </span>
                             <div style="padding-top: 5px">
                                 <jhi-progress-bar
-                                    [denominator]="examChecklist.numberOfGeneratedStudentExams! * exam.numberOfExercisesInExam!"
+                                    [denominator]="examChecklist.numberOfTotalParticipationsForAssessment"
                                     [numerator]="finishedByCorrectionRound!"
-                                    [percentage]="(finishedByCorrectionRound! / (examChecklist.numberOfGeneratedStudentExams! * exam.numberOfExercisesInExam!)) * 100"
+                                    [percentage]="(finishedByCorrectionRound! / (examChecklist.numberOfTotalParticipationsForAssessment)) * 100"
                                 >
                                 </jhi-progress-bar>
                             </div>

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -1242,6 +1242,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         assertThat(examChecklistDTO).isNotEqualTo(null);
         assertThat(examChecklistDTO.getNumberOfGeneratedStudentExams()).isEqualTo(15L);
         assertThat(examChecklistDTO.getAllExamExercisesAllStudentsPrepared()).isEqualTo(true);
+        assertThat(examChecklistDTO.getNumberOfTotalParticipationsForAssessment()).isEqualTo(75);
 
         // set start and submitted date as results are created below
         studentExams.forEach(studentExam -> {

--- a/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
@@ -568,7 +568,7 @@ public class ResultServiceIntegrationTest extends AbstractSpringIntegrationBambo
         textSubmission.addResult(r2);
         submissionRepository.save(textSubmission);
 
-        var assessments = resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(textExercise, 2);
+        var assessments = resultRepository.countNumberOfFinishedAssessmentsForExamExerciseForCorrectionRound(textExercise, 2);
         assertThat(assessments[0].getInTime()).isEqualTo(1);    // correction round 1
         assertThat(assessments[1].getInTime()).isEqualTo(1);    // correction round 2
     }
@@ -614,7 +614,7 @@ public class ResultServiceIntegrationTest extends AbstractSpringIntegrationBambo
         programmingSubmission.addResult(r2);
         submissionRepository.save(programmingSubmission);
 
-        var assessments = resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(programmingExercise, 2);
+        var assessments = resultRepository.countNumberOfFinishedAssessmentsForExamExerciseForCorrectionRound(programmingExercise, 2);
         assertThat(assessments[0].getInTime()).isEqualTo(1);    // correction round 1
         assertThat(assessments[1].getInTime()).isEqualTo(1);    // correction round 2
     }

--- a/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
@@ -568,7 +568,7 @@ public class ResultServiceIntegrationTest extends AbstractSpringIntegrationBambo
         textSubmission.addResult(r2);
         submissionRepository.save(textSubmission);
 
-        var assessments = resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(programmingExercise, 2);
+        var assessments = resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(textExercise, 2);
         assertThat(assessments[0].getInTime()).isEqualTo(1);    // correction round 1
         assertThat(assessments[1].getInTime()).isEqualTo(1);    // correction round 2
     }

--- a/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
@@ -568,10 +568,9 @@ public class ResultServiceIntegrationTest extends AbstractSpringIntegrationBambo
         textSubmission.addResult(r2);
         submissionRepository.save(textSubmission);
 
-        long assessments = resultRepository.countNumberOfFinishedAssessmentsByCorrectionRoundsAndExerciseIdIgnoreTestRuns(textExercise.getId(), 0);
-        assertThat(assessments).isEqualTo(1);
-        assessments = resultRepository.countNumberOfFinishedAssessmentsByCorrectionRoundsAndExerciseIdIgnoreTestRuns(textExercise.getId(), 1);
-        assertThat(assessments).isEqualTo(1);
+        var assessments = resultRepository.countNumberOfFinishedAssessmentsForExerciseForCorrectionRound(programmingExercise, 2);
+        assertThat(assessments[0].getInTime()).isEqualTo(1);    // correction round 1
+        assertThat(assessments[1].getInTime()).isEqualTo(1);    // correction round 2
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
1. Currently there is a bug where when working with quizzes or programming assessments with only automatic feedback the counts within the assessment progress display all exercise participations. 
Fix: 
Only display assessment count for exercises with manual assessment. This means excluding quizzes and exercises that have the assessment type set to 'Automatic'

2. There also was another issue when loading the assessment dashboard. When the `countNumberOfFinishedAssessmentsByCorrectionRoundsAndExerciseIdIgnoreTestRuns` query in the ResultRepository was called, it took several seconds for exams with many participations. Since it was called for each exercise it took several minutes in total.
Fix: 
We use a much simpler query that gets all the participations and a count of their manual results. We then determine the number of first and second correction results with java streams.

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
