### PR TITLE
Fix assessment problem with leading whitespaces/tabs

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextBlockService.java
@@ -63,19 +63,21 @@ public class TextBlockService {
 
         // Iterate over Sentences
         for (int end = breakIterator.next(); end != BreakIterator.DONE; start = end, end = breakIterator.next()) {
-            final String sentence = submissionText.substring(start, end).trim();
+            final String sentence = submissionText.substring(start, end);
 
             // The BreakIterator does not take linebreaks into account.
             // Therefore, we split each determined sentence by linebreaks.
             final String[] split = sentence.split(LINE_SEPARATOR);
             for (String lineOrSentence : split) {
-                final int startIndex = start;
-                final int endIndex = start + lineOrSentence.length();
-                start = endIndex + LINE_SEPARATOR_LENGTH;
+                final String lineOrSentenceTrimed = lineOrSentence.trim();
+                final int offset = lineOrSentence.indexOf(lineOrSentenceTrimed);
+                final int startIndex = start + offset;
+                final int endIndex = startIndex + lineOrSentenceTrimed.length();
+                start = start + lineOrSentence.length() + LINE_SEPARATOR_LENGTH;
                 if (startIndex == endIndex || lineOrSentence.isBlank())
                     continue; // Do *not* define a text block for an empty line.
 
-                final TextBlock textBlock = new TextBlock().text(lineOrSentence).startIndex(startIndex).endIndex(endIndex).submission(submission).automatic();
+                final TextBlock textBlock = new TextBlock().text(lineOrSentenceTrimed).startIndex(startIndex).endIndex(endIndex).submission(submission).automatic();
                 textBlock.computeId();
                 blocks.add(textBlock);
             }

--- a/src/test/java/de/tum/in/www1/artemis/service/TextBlockServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/TextBlockServiceTest.java
@@ -57,8 +57,8 @@ public class TextBlockServiceTest {
         final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
 
         assertThat(textBlocks, hasSize(2));
-        assertThat(textBlocks, hasItem(textBlockWithEqualText("Hello World.")));
-        assertThat(textBlocks, hasItem(textBlockWithEqualText("This is a Test.")));
+        assertThat(textBlocks, hasItem(textBlock("Hello World.")));
+        assertThat(textBlocks, hasItem(textBlock("This is a Test.")));
     }
 
     @Test
@@ -67,9 +67,9 @@ public class TextBlockServiceTest {
         final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
 
         assertThat(textBlocks, hasSize(3));
-        assertThat(textBlocks, hasItem(textBlockWithEqualText("Hello World.")));
-        assertThat(textBlocks, hasItem(textBlockWithEqualText("This is a Test")));
-        assertThat(textBlocks, hasItem(textBlockWithEqualText("Another Test")));
+        assertThat(textBlocks, hasItem(textBlock("Hello World.")));
+        assertThat(textBlocks, hasItem(textBlock("This is a Test")));
+        assertThat(textBlocks, hasItem(textBlock("Another Test")));
     }
 
     @Test
@@ -80,11 +80,89 @@ public class TextBlockServiceTest {
         String[] sections = new String[] { "Example:", "This is the first example", "Section 2:", "- Here is a list", "- Of many bullet  points" };
         assertThat(textBlocks, hasSize(sections.length));
         for (String section : sections) {
-            assertThat(textBlocks, hasItem(textBlockWithEqualText(section)));
+            assertThat(textBlocks, hasItem(textBlock(section)));
         }
     }
 
-    private Matcher<TextBlock> textBlockWithEqualText(String expectedText) {
+    @Test
+    public void respectLeadingWhitespace() {
+        final var submission = new TextSubmission(0L).text("   Test.");
+        final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
+
+        assertThat(textBlocks, hasSize(1));
+        assertThat(textBlocks, hasItem(textBlock("Test.")));
+
+        final TextBlock textBlock = textBlocks.iterator().next();
+        assertThat(textBlock.getStartIndex(), equalTo(3));
+        assertThat(textBlock.getEndIndex(), equalTo(8));
+    }
+
+    @Test
+    public void respectLeadingTabs() {
+        final var submission = new TextSubmission(0L).text("\t\t\tTest.");
+        final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
+
+        assertThat(textBlocks, hasSize(1));
+        assertThat(textBlocks, hasItem(textBlock("Test.")));
+
+        final TextBlock textBlock = textBlocks.iterator().next();
+        assertThat(textBlock.getStartIndex(), equalTo(3));
+        assertThat(textBlock.getEndIndex(), equalTo(8));
+    }
+
+    @Test
+    public void splitAssemblaCodeLinesIntoTextBlocks() {
+        final var submission = new TextSubmission(0L).text("""
+                \t\t\tALLOC 3\t\t\t\t\t\t\tLOAD 0
+                \t\t\tREAD\t\t\t\t\t\t\tLOAD 2
+                \t\t\tSTORE 0\t\t\t\t\t\t\tMUL
+                \t\t\tCONST 1\t\t\t\t\t\t\tLOAD 1
+                \t\t\tSTORE 1\t\t\t\t\t\t\tADD
+                \t\t\tCONST 0\t\t\t\t\t\t\tSTORE 1
+                \t\t\tSTORE 2\t\t\t\t\t\t\tJUMP if_else_end
+                \t\t\t\t\t\t\t
+                while_start:\tLOAD 2\t\t\telse:\t\t\t\tLOAD 1
+                \t\t\tCONST 1\t\t\t\t\t\t\tNEG
+                \t\t\tADD\t\t\t\t\t\t\t\tSTORE 1
+                \t\t\tLOAD 0
+                \t\t\tLEQ\t\t\t\tif_else_end:\t\tLOAD 2
+                \t\t\tFJUMP after_while\t\t\t\t\tCONST 1\t
+                \t\t\t\t\t\t\t\t\t\t\tSTORE 2
+                \t\t\tLOAD 1\t\t\t\t\t\t\tJUMP while_start
+                \t\t\tCONST 2
+                \t\t\tMOD\t\t\tafter_while:\t\tLOAD 1
+                \t\t\tCONST 1\t\t\t\t\t\t\tLOAD 2
+                \t\t\tEQ\t\t\t\t\t\t\t\tDIV
+                \t\t\tFJUMP else\t\t\t\t\t\tWRITE
+                \t\t\t\t\t\t\t\t\t\t\tHALT
+                """);
+        final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
+
+        assertThat(textBlocks, hasSize(21));
+        assertThat(textBlocks, hasItem(textBlock(3, 23, "ALLOC 3\t\t\t\t\t\t\tLOAD 0")));
+        assertThat(textBlocks, hasItem(textBlock(27, 44, "READ\t\t\t\t\t\t\tLOAD 2")));
+        assertThat(textBlocks, hasItem(textBlock(48, 65, "STORE 0\t\t\t\t\t\t\tMUL")));
+        assertThat(textBlocks, hasItem(textBlock(69, 89, "CONST 1\t\t\t\t\t\t\tLOAD 1")));
+        assertThat(textBlocks, hasItem(textBlock(93, 110, "STORE 1\t\t\t\t\t\t\tADD")));
+        assertThat(textBlocks, hasItem(textBlock(114, 135, "CONST 0\t\t\t\t\t\t\tSTORE 1")));
+        assertThat(textBlocks, hasItem(textBlock(139, 169, "STORE 2\t\t\t\t\t\t\tJUMP if_else_end")));
+        assertThat(textBlocks, hasItem(textBlock(178, 215, "while_start:\tLOAD 2\t\t\telse:\t\t\t\tLOAD 1")));
+        assertThat(textBlocks, hasItem(textBlock(219, 236, "CONST 1\t\t\t\t\t\t\tNEG")));
+        assertThat(textBlocks, hasItem(textBlock(240, 258, "ADD\t\t\t\t\t\t\t\tSTORE 1")));
+        assertThat(textBlocks, hasItem(textBlock(262, 268, "LOAD 0")));
+        assertThat(textBlocks, hasItem(textBlock(272, 299, "LEQ\t\t\t\tif_else_end:\t\tLOAD 2")));
+        assertThat(textBlocks, hasItem(textBlock(303, 332, "FJUMP after_while\t\t\t\t\tCONST 1")));
+        assertThat(textBlocks, hasItem(textBlock(345, 352, "STORE 2")));
+        assertThat(textBlocks, hasItem(textBlock(356, 385, "LOAD 1\t\t\t\t\t\t\tJUMP while_start")));
+        assertThat(textBlocks, hasItem(textBlock(389, 396, "CONST 2")));
+        assertThat(textBlocks, hasItem(textBlock(400, 426, "MOD\t\t\tafter_while:\t\tLOAD 1")));
+        assertThat(textBlocks, hasItem(textBlock(430, 450, "CONST 1\t\t\t\t\t\t\tLOAD 2")));
+        assertThat(textBlocks, hasItem(textBlock(454, 467, "EQ\t\t\t\t\t\t\t\tDIV")));
+        assertThat(textBlocks, hasItem(textBlock(471, 492, "FJUMP else\t\t\t\t\t\tWRITE")));
+        assertThat(textBlocks, hasItem(textBlock(504, 508, "HALT")));
+    }
+
+    private Matcher<TextBlock> textBlock(String expectedText) {
         return new TypeSafeMatcher<>() {
 
             @Override
@@ -95,6 +173,22 @@ public class TextBlockServiceTest {
             @Override
             protected boolean matchesSafely(TextBlock item) {
                 return Objects.equals(item.getText(), expectedText);
+            }
+        };
+    }
+
+    private Matcher<TextBlock> textBlock(int expectedStartIndex, int expextedEndIndex, String expectedText) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("text block with \"startIndex\" ").appendValue(expectedStartIndex).appendText(", \"endIndex\" ").appendValue(expextedEndIndex)
+                        .appendText(", \"text\" property ").appendValue(expectedText);
+            }
+
+            @Override
+            protected boolean matchesSafely(TextBlock item) {
+                return item.getStartIndex() == expectedStartIndex && item.getEndIndex() == expextedEndIndex && Objects.equals(item.getText(), expectedText);
             }
         };
     }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [X] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [X] Server: I implemented the changes with a good performance and prevented too many database calls
- [X] Server: I documented the Java code using JavaDoc style.

### Description
One exam used text exercises to collect assemply code.
`TextBlockService:splitSubmissionIntoBlocks` cannot deal with leading witespaces or tabs.
This PR handles leading whitespaces/tabs.

### Steps for Testing
1. Use Example Submissions below
2. Check that submission is correctly displayed in assessment

### Example Submissions
<details>
  <summary>Example 1</summary>
  
```assembly
			ALLOC 3							LOAD 0
			READ							LOAD 2
			STORE 0							MUL
			CONST 1							LOAD 1
			STORE 1							ADD
			CONST 0							STORE 1
			STORE 2							JUMP if_else_end
							
while_start:	LOAD 2			else:				LOAD 1
			CONST 1							NEG
			ADD								STORE 1
			LOAD 0
			LEQ				if_else_end:		LOAD 2
			FJUMP after_while					CONST 1	
											STORE 2
			LOAD 1							JUMP while_start
			CONST 2
			MOD			after_while:		LOAD 1
			CONST 1							LOAD 2
			EQ								DIV
			FJUMP else						WRITE
											HALT
```
</details>

<details>
  <summary>Example 2</summary>
  
```assembly
		ALLOC 4
		READ
		STORE 0 //n
		CONST 1
		STORE 1 //x
		CONST 0
		STORE 2 //i

wh:		LOAD 2 
		CONST 1
		ADD
		LOAD 0
		LEQ
		FJUMP end

		LOAD 1
		CONST 2
		MOD
		CONST 1
		EQ
		FJUMP el
		LOAD 0
		LOAD 2
		MUL
		LOAD 1
		ADD
		STORE 1
		JUMP cont

el:		LOAD 1
		NEG
		STORE 1		

cont:	LOAD 2
		CONST 1
		ADD
		STORE 2
		JUMP wh

end:		LOAD 1
		LOAD 2
		WRITE
		HALT
		






```
</details>

<details>
  <summary>Example 3</summary>
  
```assembly
	ALLOC 3
	READ
	STORE 0
	CONST 1
	STORE 1
	CONST 0
	STORE 2
	A:	LOAD 2
	CONST 1
	ADD
	LOAD 0
	LEQ
	FJUMP B
	LOAD 1
	CONST 2
	MOD
	CONST 1
	EQ
	FJUMP C
	LOAD 0
	LOAD 2
	MUL
	LOAD 1
	ADD
	STORE 1
	JUMP D
	C:	LOAD 1
	NEG
	STORE 1
	D:	LOAD 2
	CONST 1
	ADD
	JUMP A
	B:	LOAD 1
	LOAD 2
	DIV
	WRITE
	HALT
```
</details>