### PR TITLE
Allow adding solutions in short answer quiz re-evaluation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
@@ -233,7 +233,7 @@ public class ShortAnswerQuestion extends QuizQuestion {
     }
 
     /**
-     * check all solutions for unset inValid states or state changes
+     * check all solutions for unset invalid states or state changes
      *
      * @param originalQuestion the original ShortAnswer-object, which will be compared with this question
      */
@@ -245,7 +245,7 @@ public class ShortAnswerQuestion extends QuizQuestion {
                 solution.setInvalid(false);
             }
             ShortAnswerSolution originalSolution = originalQuestion.findSolutionById(solution.getId());
-            // reset invalid solution if it already set to true (it's not possible to set a solution valid again)
+            // reset invalid solution if it was already set to true (it's not possible to set a solution valid again)
             solution.setInvalid(solution.isInvalid() || (originalSolution != null && originalSolution.isInvalid() != null && originalSolution.isInvalid()));
         }
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
@@ -197,6 +197,7 @@ public class ShortAnswerQuestion extends QuizQuestion {
         if (originalQuizQuestion instanceof ShortAnswerQuestion) {
             ShortAnswerQuestion shortAnswerOriginalQuestion = (ShortAnswerQuestion) originalQuizQuestion;
             undoUnallowedSpotChanges(shortAnswerOriginalQuestion);
+            checkInvalidSolutions(shortAnswerOriginalQuestion);
         }
     }
 
@@ -229,6 +230,24 @@ public class ShortAnswerQuestion extends QuizQuestion {
         }
         // remove the added spots
         this.getSpots().removeAll(notAllowedAddedSpots);
+    }
+
+    /**
+     * check all solutions for unset inValid states or state changes
+     *
+     * @param originalQuestion the original ShortAnswer-object, which will be compared with this question
+     */
+    private void checkInvalidSolutions(ShortAnswerQuestion originalQuestion) {
+        // check every solution of the question
+        for (ShortAnswerSolution solution : this.getSolutions()) {
+            // correct invalid = null to invalid = false
+            if (solution.isInvalid() == null) {
+                solution.setInvalid(false);
+            }
+            ShortAnswerSolution originalSolution = originalQuestion.findSolutionById(solution.getId());
+            // reset invalid solution if it already set to true (it's not possible to set a solution valid again)
+            solution.setInvalid(solution.isInvalid() || (originalSolution != null && originalSolution.isInvalid() != null && originalSolution.isInvalid()));
+        }
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
@@ -197,39 +197,7 @@ public class ShortAnswerQuestion extends QuizQuestion {
         if (originalQuizQuestion instanceof ShortAnswerQuestion) {
             ShortAnswerQuestion shortAnswerOriginalQuestion = (ShortAnswerQuestion) originalQuizQuestion;
             undoUnallowedSpotChanges(shortAnswerOriginalQuestion);
-            undoUnallowedSolutionChanges(shortAnswerOriginalQuestion);
         }
-    }
-
-    /**
-     * undo all solution-changes which are not allowed ( adding them)
-     *
-     * @param originalQuestion the original ShortAnswer-object, which will be compared with this question
-     */
-    private void undoUnallowedSolutionChanges(ShortAnswerQuestion originalQuestion) {
-
-        // find added solutions, which are not allowed to be added
-        Set<ShortAnswerSolution> notAllowedAddedSolutions = new HashSet<>();
-        // check every solution of the question
-        for (ShortAnswerSolution solution : this.getSolutions()) {
-            // check if the solution were already in the originalQuestion -> if not it's an added solution
-            if (originalQuestion.getSolutions().contains(solution)) {
-                // find original solution
-                ShortAnswerSolution originalSolution = originalQuestion.findSolutionById(solution.getId());
-                // correct invalid = null to invalid = false
-                if (solution.isInvalid() == null) {
-                    solution.setInvalid(false);
-                }
-                // reset invalid solution if it already set to true (it's not possible to set a solution valid again)
-                solution.setInvalid(solution.isInvalid() || (originalSolution.isInvalid() != null && originalSolution.isInvalid()));
-            }
-            else {
-                // mark the added solution (adding solutions is not allowed)
-                notAllowedAddedSolutions.add(solution);
-            }
-        }
-        // remove the added solutions
-        this.getSolutions().removeAll(notAllowedAddedSolutions);
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -1000,6 +1000,44 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
+    public void testReEvaluateQuizQuestionWithMoreSolutions() throws Exception {
+        quizExercise = createQuizOnServer(ZonedDateTime.now().minusHours(5), ZonedDateTime.now().minusHours(2));
+        QuizQuestion question = quizExercise.getQuizQuestions().get(2);
+        if (question instanceof ShortAnswerQuestion) {
+            ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) question;
+
+            // demonstrate that the initial shortAnswerQuestion has 2 correct mappings and 2 solutions
+            assertThat(shortAnswerQuestion.getCorrectMappings().size()).isEqualTo(2);
+            assertThat(shortAnswerQuestion.getCorrectMappings().size()).isEqualTo(2);
+
+            // add a solution with an mapping onto spot number 0
+            ShortAnswerSolution newSolution = new ShortAnswerSolution();
+            newSolution.setText("text");
+            newSolution.setId(3L);
+            shortAnswerQuestion.getSolutions().add(newSolution);
+            ShortAnswerMapping newMapping = new ShortAnswerMapping();
+            newMapping.setId(3L);
+            newMapping.setInvalid(false);
+            newMapping.setShortAnswerSolutionIndex(2);
+            newMapping.setSolution(newSolution);
+            newMapping.setSpot(shortAnswerQuestion.getSpots().get(0));
+            newMapping.setShortAnswerSpotIndex(0);
+            shortAnswerQuestion.getCorrectMappings().add(newMapping);
+            quizExercise.getQuizQuestions().remove(2);
+            quizExercise.getQuizQuestions().add(shortAnswerQuestion);
+        }
+        // PUT Request with the newly modified quizExercise
+        QuizExercise updatedQuizExercise = request.putWithResponseBody("/api/quiz-exercises/" + quizExercise.getId() + "/re-evaluate", quizExercise, QuizExercise.class,
+                HttpStatus.OK);
+        // Check that the updatedQuizExercise is equal to the modified quizExercise with special focus on the newly added solution and mapping
+        assertThat(updatedQuizExercise).isEqualTo(quizExercise);
+        ShortAnswerQuestion receivedShortAnswerQuestion = (ShortAnswerQuestion) updatedQuizExercise.getQuizQuestions().get(2);
+        assertThat(receivedShortAnswerQuestion.getSolutions().size()).isEqualTo(3);
+        assertThat(receivedShortAnswerQuestion.getCorrectMappings().size()).isEqualTo(3);
+    }
+
+    @Test
+    @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testPerformStartNow() throws Exception {
         quizExercise = createQuizOnServer(ZonedDateTime.now().plusHours(5), null);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It was not possible until now to change solutions when re-evaluating short answer quiz questions. On request, this should be possible now.

### Description
<!-- Describe your changes in detail -->
- Removed the check which looks and newly added solutions
- Leaves the check which checks for the inValid state of the solution
- Tested the new behaviour with an Server Integration test

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

For a normal Quiz Exercise
1. Log in to Artemis
2. Create an quiz with a short answer question
3. Participate and answer every spot correctly except for one.
4. Check that after the quiz is over, the wrong answer is detected correctly.
5. Go to Course Management, Exercises and Select Re-Evaluate on the quiz
6. Accept your wrong answer as a new solution in the spot
7. Save the re-evaluation
8. Check that as a participant, the quiz results are adapted accordingly and the wrong solution a moment ago is now counted as correct

For an exam
1. Log in to Artemis
2. Create an exam with a short answer question quiz
3. Participate and answer every spot correctly except for one.
4. After the exam is over, go to student exams and click evaluate quizzes
5. Check that the wrong answer is detected correctly. (e.g. in student exams -> view -> check points)
6. Go to the exam overview, exercise groups and click on re-evaluate quiz
7. Accept your wrong answer as a new solution in the spot
8. Save the re-evaluation
9. Check again (in student exams -> view -> check points) that the quiz results are adapted accordingly and the wrong solution a moment ago is now counted as correct


### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Tested changes accordingly
