### PR TITLE
Fix an edge case when the programming exercise is inactive during exams

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -135,7 +135,7 @@ public class ParticipationService {
                 participation.setInitializationDate(ZonedDateTime.now());
             }
             // TODO: load submission with exercise for exam edge case:
-            // clients creates missing participaiton for exercise, call on server succeeds, but response to client is lost
+            // clients creates missing participation for exercise, call on server succeeds, but response to client is lost
             // -> client tries to create participation again. In this case the submission is not loaded from db -> client errors
             if (optionalStudentParticipation.isEmpty() || !submissionRepository.existsByParticipationId(participation.getId())) {
                 // initialize a modeling, text, file upload or quiz submission

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -15,7 +15,7 @@ export class ExamNavigationBarComponent implements OnInit {
     @Input() exerciseIndex = 0;
     @Input() endDate: Moment;
 
-    @Output() onExerciseChanged = new EventEmitter<{ exercise: Exercise; force: boolean }>();
+    @Output() onExerciseChanged = new EventEmitter<{ exercise: Exercise; forceSave: boolean }>();
     @Output() examAboutToEnd = new EventEmitter<void>();
     @Output() onExamHandInEarly = new EventEmitter<void>();
 
@@ -48,14 +48,14 @@ export class ExamNavigationBarComponent implements OnInit {
         this.examAboutToEnd.emit();
     }
 
-    changeExercise(exerciseIndex: number, force: boolean) {
+    changeExercise(exerciseIndex: number, forceSave: boolean) {
         // out of index -> do nothing
         if (exerciseIndex > this.exercises.length - 1 || exerciseIndex < 0) {
             return;
         }
         // set index and emit event
         this.exerciseIndex = exerciseIndex;
-        this.onExerciseChanged.emit({ exercise: this.exercises[exerciseIndex], force });
+        this.onExerciseChanged.emit({ exercise: this.exercises[exerciseIndex], forceSave });
         this.setExerciseButtonStatus(exerciseIndex);
     }
 

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -32,6 +32,7 @@ import { cloneDeep } from 'lodash';
 import { Course } from 'app/entities/course.model';
 import { FileUploadSubmission } from 'app/entities/file-upload-submission.model';
 import { FileUploadExamSubmissionComponent } from 'app/exam/participate/exercises/file-upload/file-upload-exam-submission.component';
+import * as Sentry from '@sentry/browser';
 
 type GenerateParticipationStatus = 'generating' | 'failed' | 'success';
 
@@ -228,13 +229,14 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
                         });
                     } else if (exercise.type === ExerciseType.PROGRAMMING) {
                         // We need to provide a submission to update the navigation bar status indicator
+                        // This is important otherwise the save mechanisms would not work properly
                         if (!participation.submissions || participation.submissions.length === 0) {
                             participation.submissions = [];
                             participation.submissions.push(ProgrammingSubmission.createInitialCleanSubmissionForExam());
                         }
                     }
 
-                    // adding back the deleted exercise
+                    // reconnect the participation with the exercise, in case this relationship was deleted before (e.g. due to breaking circular dependencies)
                     participation.exercise = exercise;
 
                     // setup subscription for programming exercises
@@ -256,7 +258,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
      * @param exercise to check
      * @returns true if valid, false otherwise
      */
-    private isExerciseParticipationValid(exercise: Exercise): boolean {
+    private static isExerciseParticipationValid(exercise: Exercise): boolean {
         // check if there is at least one participation with state === Initialized or state === FINISHED
         return (
             exercise.studentParticipations !== undefined &&
@@ -446,12 +448,17 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
      * update the current exercise from the navigation
      * @param exerciseChange
      */
-    onExerciseChange(exerciseChange: { exercise: Exercise; force: boolean }): void {
+    onExerciseChange(exerciseChange: { exercise: Exercise; forceSave: boolean }): void {
         const activeComponent = this.activeSubmissionComponent;
         if (activeComponent) {
             activeComponent.onDeactivate();
         }
-        this.triggerSave(exerciseChange.force);
+        try {
+            this.triggerSave(exerciseChange.forceSave);
+        } catch (error) {
+            // an error here should never lead to the wrong exercise being shown
+            Sentry.captureException(error);
+        }
         this.initializeExercise(exerciseChange.exercise);
     }
 
@@ -459,8 +466,8 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
      * update the current exercise from the navigation
      * @param exerciseChange
      */
-    saveFileUpload(exerciseChange: { exercise: Exercise; force: boolean }): void {
-        this.triggerSave(exerciseChange.force);
+    saveFileUpload(exerciseChange: { exercise: Exercise; forceSave: boolean }): void {
+        this.triggerSave(exerciseChange.forceSave);
         this.initializeExercise(exerciseChange.exercise);
     }
 
@@ -472,13 +479,14 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
     private initializeExercise(exercise: Exercise) {
         this.activeExercise = exercise;
         // if we do not have a valid participation for the exercise -> initialize it
-        if (!this.isExerciseParticipationValid(exercise)) {
+        if (!ExamParticipationComponent.isExerciseParticipationValid(exercise)) {
             // TODO: after client is online again, subscribe is not executed, might be a problem of the Observable in createParticipationForExercise
             this.createParticipationForExercise(exercise).subscribe((participation) => {
                 if (participation) {
                     // for programming exercises -> wait for latest submission before showing exercise
                     if (exercise.type === ExerciseType.PROGRAMMING) {
                         const subscription = this.createProgrammingExerciseSubmission(exercise.id!, participation.id!);
+                        // we have to create a fake submission here, otherwise the navigation bar status will not work and the save mechanism might have problems
                         participation.submissions = [ProgrammingSubmission.createInitialCleanSubmissionForExam()];
                         this.programmingSubmissionSubscriptions.push(subscription);
                     }
@@ -490,6 +498,9 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         }
     }
 
+    /**
+     * this will make sure that the component is displayed in the user interface
+     */
     private activateActiveComponent() {
         this.submissionComponentVisited[this.activeExerciseIndex] = true;
         const activeComponent = this.activeSubmissionComponent;
@@ -499,14 +510,16 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
     }
 
     /**
-     * creates a participation for the exercise, if it did not exist already
+     * This is a fallback mechanism in case the instructor did not prepare the exercise start before the student started it on the client.
+     * In this case, no participation and not submission exist and first need to be created on the server before the student can work on this exercise locally
      * @param exercise
      */
     createParticipationForExercise(exercise: Exercise): Observable<StudentParticipation | undefined> {
         this.generateParticipationStatus.next('generating');
         return this.courseExerciseService.startExercise(this.exam.course!.id!, exercise.id!).pipe(
             map((createdParticipation: StudentParticipation) => {
-                exercise.studentParticipations!.push(createdParticipation);
+                // note: it is important that we exchange the existing student participation and that we do not push it
+                exercise.studentParticipations = [createdParticipation];
                 if (createdParticipation.submissions && createdParticipation.submissions.length > 0) {
                     createdParticipation.submissions[0].isSynced = true;
                 }
@@ -528,16 +541,17 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
      * 4) exam is about to end (<1s left)
      *      --> in this case, we can even save all submissions with isSynced = true
      *
-     * @param force is set to true, when the current exercise should be saved (even if there are no changes)
+     * @param forceSave is set to true, when the current exercise should be saved (even if there are no changes)
      */
-    triggerSave(force: boolean) {
+    triggerSave(forceSave: boolean) {
         // before the request, we would mark the submission as isSynced = true
         // right after the response - in case it was successful - we mark the submission as isSynced = false
         this.autoSaveTimer = 0;
 
         const activeComponent = this.activeSubmissionComponent;
 
-        if ((activeComponent && force) || activeComponent?.hasUnsavedChanges()) {
+        // in the case saving is forced, we mark the current exercise as not synced, so it will definitely be saved
+        if ((activeComponent && forceSave) || activeComponent?.hasUnsavedChanges()) {
             const activeSubmission = activeComponent?.getSubmission();
             if (activeSubmission) {
                 // this will lead to a save below, because isSynced will be set to false
@@ -546,40 +560,46 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
             activeComponent.updateSubmissionFromView();
         }
 
-        // goes through all exercises and checks if there are unsynced submissions
+        // go through ALL student exam exercises and check if there are unsynced submissions
+        // we do this, because due to connectivity problems, other submissions than the currently active one might have not been saved to the server yet
         const submissionsToSync: { exercise: Exercise; submission: Submission }[] = [];
         this.studentExam.exercises!.forEach((exercise: Exercise) => {
-            exercise.studentParticipations!.forEach((participation) => {
-                participation
-                    .submissions!.filter((submission) => !submission.isSynced)
-                    .forEach((unsynchedSubmission) => {
-                        submissionsToSync.push({ exercise, submission: unsynchedSubmission });
-                    });
-            });
+            if (exercise.studentParticipations) {
+                exercise.studentParticipations!.forEach((participation) => {
+                    if (participation.submissions) {
+                        participation.submissions
+                            .filter((submission) => !submission.isSynced)
+                            .forEach((unsynchedSubmission) => {
+                                submissionsToSync.push({ exercise, submission: unsynchedSubmission });
+                            });
+                    }
+                });
+            }
         });
 
         // if no connection available -> don't try to sync, except it is forced
-        if (force || !this.disconnected) {
+        // based on the submissions that need to be saved and the exercise, we perform different actions
+        if (forceSave || !this.disconnected) {
             submissionsToSync.forEach((submissionToSync: { exercise: Exercise; submission: Submission }) => {
                 switch (submissionToSync.exercise.type) {
                     case ExerciseType.TEXT:
                         this.textSubmissionService.update(submissionToSync.submission as TextSubmission, submissionToSync.exercise.id!).subscribe(
-                            () => this.onSaveSubmissionSuccess(submissionToSync.submission),
+                            () => ExamParticipationComponent.onSaveSubmissionSuccess(submissionToSync.submission),
                             () => this.onSaveSubmissionError(),
                         );
                         break;
                     case ExerciseType.MODELING:
                         this.modelingSubmissionService.update(submissionToSync.submission as ModelingSubmission, submissionToSync.exercise.id!).subscribe(
-                            () => this.onSaveSubmissionSuccess(submissionToSync.submission),
+                            () => ExamParticipationComponent.onSaveSubmissionSuccess(submissionToSync.submission),
                             () => this.onSaveSubmissionError(),
                         );
                         break;
                     case ExerciseType.PROGRAMMING:
-                        // nothing to do
+                        // nothing to do here, because programming exercises are submitted differently
                         break;
                     case ExerciseType.QUIZ:
                         this.examParticipationService.updateQuizSubmission(submissionToSync.exercise.id!, submissionToSync.submission as QuizSubmission).subscribe(
-                            () => this.onSaveSubmissionSuccess(submissionToSync.submission),
+                            () => ExamParticipationComponent.onSaveSubmissionSuccess(submissionToSync.submission),
                             () => this.onSaveSubmissionError(),
                         );
                         break;
@@ -594,7 +614,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
                                 (res) => {
                                     const submissionFromServer = res.body!;
                                     (submissionToSync.submission as FileUploadSubmission).filePath = submissionFromServer.filePath;
-                                    this.onSaveSubmissionSuccess(submissionToSync.submission);
+                                    ExamParticipationComponent.onSaveSubmissionSuccess(submissionToSync.submission);
                                     activeComponent!.updateViewFromSubmission();
                                 },
                                 () => this.onSaveSubmissionError(),
@@ -604,7 +624,8 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
             });
         }
 
-        // overwrite studentExam in localStorage
+        // save the studentExam in localStorage, so that we would be able to retrieve it later on, in case the student needs to reload the page while being offline
+        // NOTE: this recovery behavior is NOT yet implemented
         this.examParticipationService.saveStudentExamToLocalStorage(this.courseId, this.examId, this.studentExam);
     }
 
@@ -612,7 +633,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         this.currentSubmissionComponents.filter((component) => component.hasUnsavedChanges()).forEach((component) => component.updateSubmissionFromView());
     }
 
-    private onSaveSubmissionSuccess(submission: Submission) {
+    private static onSaveSubmissionSuccess(submission: Submission) {
         submission.isSynced = true;
         submission.submitted = true;
     }

--- a/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
@@ -530,7 +530,7 @@ describe('ExamParticipationComponent', () => {
     it('should trigger save and initialize exercise when exercise changed', () => {
         const exercise = new ProgrammingExercise(new Course(), undefined);
         const triggerStub = stub(comp, 'triggerSave');
-        const exerciseChange = { exercise, force: true };
+        const exerciseChange = { exercise, forceSave: true };
         const createParticipationForExerciseStub = stub(comp, 'createParticipationForExercise').returns(of(new StudentParticipation()));
         comp.onExerciseChange(exerciseChange);
         expect(triggerStub).to.have.been.calledWith(true);


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
When the build plan was cleaned up, the programming exercise should have been started within the exam. However this led to an issue displaying the "resume exercise" button. Clicking on it killed the client and led to 20k issues on Sentry and a horrible(!!!) experience for students 👎 

### Description
Fix Fix Fix

### Steps for Testing
1. Create an exam with at least 2 exercises with exact order: 1. programming (only IDE offline activated), 2. text
2. Generate student exams, prepare exercise start
3. Wait 1 week ;-) or cleanup all participations (i.e. delete the build plans within Artemis so that the PESP is displayed as inactive)
4. Switch to the student account, start the exam in the exam mode. Navigate between exercises and verify that no "Resume exercise" button is displayed and that the clone repository button is displayed properly.

The previous behavior (you can verify it on `develop`) showed a resume exercise button, if you click on it, you cannot navigate between exercises any more, because of https://sentry.io/organizations/ls1intum/issues/1988505855/?environment=prod&project=1440029&query=is%3Aunresolved&sort=freq&statsPeriod=14d

You can also see this issue in the following video, proudly provided by one of our nice students (thank you so much!!!)


https://user-images.githubusercontent.com/744067/108558707-9741e280-72fa-11eb-9aba-775ceec8a1cf.mov

