### PR TITLE
[Bugfix] - Only create one result for exam quiz evaluations

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamQuizService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamQuizService.java
@@ -174,37 +174,38 @@ public class ExamQuizService {
                         resultExisting = true;
                         result = participation.getResults().iterator().next();
                     }
-                    // delete result from quizSubmission, to be able to set a new one
-                    if (quizSubmission.getLatestResult() != null) {
-                        resultService.deleteResultWithComplaint(quizSubmission.getLatestResult().getId());
-                    }
-                    result.setRated(true);
-                    result.setAssessmentType(AssessmentType.AUTOMATIC);
-                    result.setCompletionDate(ZonedDateTime.now());
-
-                    // set submission to calculate scores
-                    result.setSubmission(quizSubmission);
-                    // calculate scores and update result and submission accordingly
-                    quizSubmission.calculateAndUpdateScores(quizExercise);
-                    result.evaluateSubmission();
-                    // remove submission to follow save order for ordered collections
-                    result.setSubmission(null);
-
-                    // NOTE: we save participation, submission and result here individually so that one exception (e.g. duplicated key) cannot destroy multiple student answers
-                    submissionRepository.save(quizSubmission);
-                    result = resultRepository.save(result);
-
-                    // add result to participation
-                    participation.addResult(result);
-                    studentParticipationRepository.save(participation);
-
-                    // add result to submission
-                    result.setSubmission(quizSubmission);
-                    quizSubmission.addResult(result);
-                    submissionRepository.save(quizSubmission);
-
-                    // Add result so that it can be returned (and processed later)
+                    // Only create Results once after the first evaluation
                     if (!resultExisting) {
+                        // delete result from quizSubmission, to be able to set a new one
+                        if (quizSubmission.getLatestResult() != null) {
+                            resultService.deleteResultWithComplaint(quizSubmission.getLatestResult().getId());
+                        }
+                        result.setRated(true);
+                        result.setAssessmentType(AssessmentType.AUTOMATIC);
+                        result.setCompletionDate(ZonedDateTime.now());
+
+                        // set submission to calculate scores
+                        result.setSubmission(quizSubmission);
+                        // calculate scores and update result and submission accordingly
+                        quizSubmission.calculateAndUpdateScores(quizExercise);
+                        result.evaluateSubmission();
+                        // remove submission to follow save order for ordered collections
+                        result.setSubmission(null);
+
+                        // NOTE: we save participation, submission and result here individually so that one exception (e.g. duplicated key) cannot destroy multiple student answers
+                        submissionRepository.save(quizSubmission);
+                        result = resultRepository.save(result);
+
+                        // add result to participation
+                        participation.addResult(result);
+                        studentParticipationRepository.save(participation);
+
+                        // add result to submission
+                        result.setSubmission(quizSubmission);
+                        quizSubmission.addResult(result);
+                        submissionRepository.save(quizSubmission);
+
+                        // Add result so that it can be returned (and processed later)
                         createdResults.add(result);
                     }
                 }

--- a/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.html
@@ -269,7 +269,7 @@
                         <div class="col">
                             <button class="btn btn-outline-secondary" (click)="addTextSolution()">
                                 <i class="fa fa-plus"></i>
-                                <span jhiTranslate="artemisApp.dragAndDropQuestion.addDragItemText"></span>
+                                <span jhiTranslate="artemisApp.shortAnswerQuestion.addShortAnswerSolution"></span>
                             </button>
                         </div>
                     </div>

--- a/src/main/webapp/i18n/de/shortAnswerQuestion.json
+++ b/src/main/webapp/i18n/de/shortAnswerQuestion.json
@@ -28,7 +28,8 @@
                 "visual": "Visuell",
                 "visualModeHeadline": "Visueller Modus",
                 "visualModeExplanation": "Bitte markiere ein Wort und drücke anschließend auf Spot erzeugen um einen neuen Spot mit der zugehörigen Lösung zu erstellen"
-            }
+            },
+            "addShortAnswerSolution": "Short Answer Lösung hinzufügen"
         }
     }
 }

--- a/src/main/webapp/i18n/en/shortAnswerQuestion.json
+++ b/src/main/webapp/i18n/en/shortAnswerQuestion.json
@@ -28,7 +28,8 @@
                 "visual": "Visual",
                 "visualModeHeadline": "Visual Mode",
                 "visualModeExplanation": "Please highlight one word an click on the Add Spot button to create one spot with the corresponding solution"
-            }
+            },
+            "addShortAnswerSolution": "Add Short Answer Solution"
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

Fixes https://github.com/ls1intum/Artemis/issues/2908
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The evaluate button in the student exams in only supposed to be clicked once. When clicking multiple times, the newly created results have no reference to the participation. As a result, the amount of points the student got is not shown in the view anymore.

### Description
<!-- Describe your changes in detail -->
We deactivated the creation and saving of new results after the first evaluation.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create a exam with an (short answer) quiz question
3. Participate
4. After the exam is over, click on evaluate once in the student exams page
5. Click on "View" to view the student participations and make sure that every student has the correct result/amount of points in the table
6. Go back to the student exams page and click on evaluate again
7. Check that the results still are correctly displayed
8. Should also work for other quiz exercise types

**Re-evaluate**
1. Also, please check that the re-evaluation of short answer quizzes remains correct
2. Exercise-groups -> Re-evaluate
3. The "Add solution" button for short answer quizzes should now be called "Add Short Answer Solution" (Also check german translation is correct "Short Answer Lösung hinzufügen")
4. add a new solution (Which in the best case, a student typed in somewhere so you can check it gets counted as correct)
5. Make sure to map it to the spot where you want the option to be a correct input
6. save the re-evaluation and check that the student now get credits for this spot

### **Thinking task for Dev's**
Could not creating new results after the first evaluation be a problem somewhere I am not aware of?

### Screenshots

How the student participation view should not look after the second/third/fourth... evaluate
![Screenshot 2021-02-22 at 17 30 15](https://user-images.githubusercontent.com/44401560/108738411-de66e800-7533-11eb-9bf5-2f80f33e4b09.png)

How it should look like:
![Screenshot 2021-02-22 at 17 30 47](https://user-images.githubusercontent.com/44401560/108738449-e4f55f80-7533-11eb-9e4a-63ac8b43172f.png)
