### PR TITLE
Fix wrong exam end (confirmation) label texts

### DIFF
--- a/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
@@ -134,11 +134,11 @@
                 <dd *ngIf="formattedConfirmationStartText" class="editor-outline-background" [innerHTML]="formattedConfirmationStartText"></dd>
                 <span *ngIf="!formattedConfirmationStartText" jhiTranslate="artemisApp.exam.notSet"></span>
 
-                <dt><span jhiTranslate="artemisApp.examManagement.startText">Exam end text</span></dt>
+                <dt><span jhiTranslate="artemisApp.examManagement.endText">Exam end text</span></dt>
                 <dd *ngIf="formattedEndText" class="editor-outline-background" [innerHTML]="formattedEndText"></dd>
                 <span *ngIf="!formattedEndText" jhiTranslate="artemisApp.exam.notSet"></span>
 
-                <dt><span jhiTranslate="artemisApp.examManagement.confirmationStartText">Exam end confirmation text</span></dt>
+                <dt><span jhiTranslate="artemisApp.examManagement.confirmationEndText">Exam end confirmation text</span></dt>
                 <dd *ngIf="formattedConfirmationEndText" class="editor-outline-background" [innerHTML]="formattedConfirmationEndText"></dd>
                 <span *ngIf="!formattedConfirmationEndText" jhiTranslate="artemisApp.exam.notSet"></span>
             </dl>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Closes  #2920.

### Description

Changes the label texts to the correct ones.

### Steps for Testing

Open the details page/checklist of an exam and check that the labels are correct.

### Screenshots

The text looks like this now:
![grafik](https://user-images.githubusercontent.com/72132281/108872603-9eb70380-75fa-11eb-8fbd-78888307a0a0.png)
