### PR TITLE
Fix documentation compiler warnings

### DIFF
--- a/docs/user/exercises/programming-exercise-setup.inc
+++ b/docs/user/exercises/programming-exercise-setup.inc
@@ -102,6 +102,7 @@ Exercise Creation
       creation of the exercise.
     - **Preview**: Given the short name of the exercise and the short name of the course, Artemis displays a preview of the
       generated repositories and build plans.
+
     |
 
     .. figure:: programming/programming-options-general-information.png
@@ -110,6 +111,7 @@ Exercise Creation
     - **Categories:** Instructors can freely define up to two categories per exercise. The categories are visible to students
       and should be used consistently to group similar kinds of exercises.
     - **Difficulty:** Instructors can give students information about the difficulty of the exercise.
+
     |
 
     .. figure:: programming/programming-options-mode.png
@@ -118,6 +120,7 @@ Exercise Creation
     - **Mode:** The mode determines whether students work on the exercise alone or in teams. **Cannot** be changed after the exercise creation.
     - **Team size:** If ``Team`` mode is chosen, instructors can additionally give recommendations for the team size. Instructors/Tutors define the teams after
       the exercise creation.
+
     |
 
     .. figure:: programming/programming-options-programming-language.png
@@ -127,6 +130,7 @@ Exercise Creation
       Refer to the :ref:`programming exercise features <programming_features>` for an overview of the supported features for each template.
     - **Project Type:** Determines the project structure of the template. Not available for all programming languages.
     - **Package Name:** The package name used for this exercise. Not available for all programming languages.
+
     |
 
     .. figure:: programming/programming-options-timeline.png
@@ -146,6 +150,7 @@ Exercise Creation
       This date must be after the due date. The results created by this test run will be rated.
     - **Manual Review:** Instructors/Tutors have to manually review the latest student submissions after the automatic tests were executed.
     - **Assessment Due Date:** The deadline for the manual reviews. On this date, all manual assessments will be released to the students.
+
     |
 
     .. figure:: programming/programming-options-score.png
@@ -157,6 +162,7 @@ Exercise Creation
         The achieved total points will count towards the total course/exam score
       - ``Bonus``: The achieved **Points** will count towards the total course/exam score as a bonus.
       - ``No``: The achieved **Points** will **not** count towards the total course/exam score.
+
     |
 
     .. figure:: programming/programming-options-sca.png
@@ -174,18 +180,21 @@ Exercise Creation
       .. note::
         Given an exercise with 10 **Points**. If **Max Static Code Analysis Penalty** is 20%, at most 2 points will be deducted
         from the points achieved by passing test cases for code quality issues in the submission.
+
     |
 
     .. figure:: programming/programming-options-instructions.png
               :align: center
 
     - **Problem Statement:** The problem statement of the exercise. Refer to :ref:`interactive problem statement <interactive_problem_statement>` for more information.
+
     |
 
     .. figure:: programming/programming-options-grading-instructions.png
               :align: center
 
     - **Grading Instructions:** Available if **Manual Review** is active. Create instructions for the manual assessment of the exercise.
+
     |
 
     .. figure:: programming/programming-options-advanced-configuration.png

--- a/docs/user/exercises/programming.rst
+++ b/docs/user/exercises/programming.rst
@@ -48,7 +48,7 @@ Setup
 
 The following sections describe the supported features and the process of creating a new programming exercise.
 
-.. include:: programming-exercise-setup.rst
+.. include:: programming-exercise-setup.inc
 
 Online Editor
 -------------


### PR DESCRIPTION
### Motivation and Context

Some recent PR(s) introduced changes which cause compiler warnings when building the documentation:
```
user/exercises/programming-exercise-setup.rst:105: WARNING: Bullet list ends without a blank line; unexpected unindent.
user/exercises/programming-exercise-setup.rst:113: WARNING: Bullet list ends without a blank line; unexpected unindent.
user/exercises/programming-exercise-setup.rst:121: WARNING: Bullet list ends without a blank line; unexpected unindent.
user/exercises/programming-exercise-setup.rst:130: WARNING: Bullet list ends without a blank line; unexpected unindent.
user/exercises/programming-exercise-setup.rst:149: WARNING: Bullet list ends without a blank line; unexpected unindent.
user/exercises/programming-exercise-setup.rst:160: WARNING: Bullet list ends without a blank line; unexpected unindent.
user/exercises/programming-exercise-setup.rst:177: WARNING: Bullet list ends without a blank line; unexpected unindent.
user/exercises/programming-exercise-setup.rst:183: WARNING: Bullet list ends without a blank line; unexpected unindent.
user/exercises/programming-exercise-setup.rst:189: WARNING: Bullet list ends without a blank line; unexpected unindent.

user/exercises/programming-exercise-setup.rst:4: WARNING: duplicate label programming_features, other instance in user/exercises/programming.rst
```

### Description

The first error messages are easy to solve, I just added blank lines. The last warning is trickier due to how `includes` works: It copies the entire included file as text into the current file while compiling, which then causes a compiler warning because the label is defined twice. Following https://stackoverflow.com/questions/16262163/sphinxs-include-directive-and-duplicate-label-warnings and https://github.com/sphinx-doc/sphinx/issues/1668 it is common/best practice to give files which are only included the `.inc` extension, which means they're compiled themselves, but only inside the included files. That avoids the duplicated label issue. We can rename it to `.inc` here because we don't need the file standalone.

The visual layout of the documentation does not change.
