### PR TITLE
added time details for student review to exam summary

### DIFF
--- a/src/main/webapp/app/exam/participate/information/exam-information.component.html
+++ b/src/main/webapp/app/exam/participate/information/exam-information.component.html
@@ -15,6 +15,22 @@
             {{ studentExam.workingTime | artemisDurationFromSeconds }}
         </span>
     </div>
+    <div class="mb-2">
+        <span class="mx-2" *ngIf="exam && exam.examStudentReviewStart && studentExam.ended">
+            <strong class="font-weight-bold">{{ 'artemisApp.exam.examStudentReviewStart' | translate }}:</strong>
+            {{ exam.examStudentReviewStart | artemisDate: 'long-date' }}
+            -
+            {{ exam.examStudentReviewStart | artemisDate: 'time' }}
+        </span>
+    </div>
+    <div class="mb-2">
+        <span class="mx-2" *ngIf="exam && exam.examStudentReviewEnd && studentExam.ended">
+            <strong class="font-weight-bold">{{ 'artemisApp.exam.examStudentReviewEnd' | translate }}:</strong>
+            {{ exam.examStudentReviewEnd | artemisDate: 'long-date' }}
+            -
+            {{ exam.examStudentReviewEnd | artemisDate: 'time' }}
+        </span>
+    </div>
     <div class="mb-2" *ngIf="exam && (exam.examiner || exam.moduleNumber || exam.courseName)">
         <span class="mx-2" *ngIf="exam.examiner">
             <strong class="font-weight-bold">{{ 'artemisApp.examManagement.examiner' | translate }}:</strong>

--- a/src/main/webapp/app/exam/participate/information/exam-information.component.html
+++ b/src/main/webapp/app/exam/participate/information/exam-information.component.html
@@ -18,17 +18,13 @@
     <div class="mb-2">
         <span class="mx-2" *ngIf="exam && exam.examStudentReviewStart && studentExam.ended">
             <strong class="font-weight-bold">{{ 'artemisApp.exam.examStudentReviewStart' | translate }}:</strong>
-            {{ exam.examStudentReviewStart | artemisDate: 'long-date' }}
-            -
-            {{ exam.examStudentReviewStart | artemisDate: 'time' }}
+            {{ exam.examStudentReviewStart | artemisDate }}
         </span>
     </div>
     <div class="mb-2">
         <span class="mx-2" *ngIf="exam && exam.examStudentReviewEnd && studentExam.ended">
             <strong class="font-weight-bold">{{ 'artemisApp.exam.examStudentReviewEnd' | translate }}:</strong>
-            {{ exam.examStudentReviewEnd | artemisDate: 'long-date' }}
-            -
-            {{ exam.examStudentReviewEnd | artemisDate: 'time' }}
+            {{ exam.examStudentReviewEnd | artemisDate }}
         </span>
     </div>
     <div class="mb-2" *ngIf="exam && (exam.examiner || exam.moduleNumber || exam.courseName)">

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -13,13 +13,13 @@
     </h2>
 </div>
 <jhi-exam-information [exam]="studentExam.exam" [studentExam]="studentExam"></jhi-exam-information>
-<div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam">
-    <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam"></jhi-exam-points-summary>
-</div>
 <div class="mb-4 text-center" *ngIf="studentExam && studentExam.exam && isBeforeStudentReviewEnd() && isAfterStudentReviewStart()">
     <a class="btn btn-success" style="cursor: default; pointer-events: none">
         {{ 'artemisApp.exam.studentReviewEnabled' | translate }}
     </a>
+</div>
+<div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam">
+    <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam"></jhi-exam-points-summary>
 </div>
 <h4 class="mb-0">{{ 'artemisApp.exam.exercises' | translate }}</h4>
 <div *ngFor="let exercise of studentExam.exercises; let i = index">

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -16,6 +16,11 @@
 <div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam">
     <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam"></jhi-exam-points-summary>
 </div>
+<div class="mb-4 text-center" *ngIf="studentExam && studentExam.exam && isBeforeStudentReviewEnd() && isAfterStudentReviewStart()">
+    <a class="btn btn-success" style="cursor: default; pointer-events: none">
+        {{ 'artemisApp.exam.studentReviewEnabled' | translate }}
+    </a>
+</div>
 <h4 class="mb-0">{{ 'artemisApp.exam.exercises' | translate }}</h4>
 <div *ngFor="let exercise of studentExam.exercises; let i = index">
     <div class="question card">

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
@@ -152,4 +152,14 @@ export class ExamParticipationSummaryComponent implements OnInit {
         }
         return false;
     }
+
+    isBeforeStudentReviewEnd() {
+        if (this.isTestRun) {
+            return true;
+        }
+        if (this.studentExam?.exam?.examStudentReviewStart && this.studentExam.exam.examStudentReviewEnd) {
+            return this.serverDateService.now().isBefore(this.studentExam.exam.examStudentReviewEnd);
+        }
+        return false;
+    }
 }

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -217,6 +217,7 @@
             "courseName": "Kursname",
             "examStudentReviewStart": "Beginn der Klausureinsicht",
             "examStudentReviewEnd": "Ende der Klausureinsicht",
+            "studentReviewEnabled": "Klausureinsicht ist offen",
             "maxPoints": "Anzahl an erreichbaren Punkten",
             "numberOfExercisesInExam": "Anzahl an Aufgaben in der Klausur",
             "numberOfCorrectionRoundsInExam": "Anzahl der Korrekturrunden der Klausur",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -41,6 +41,7 @@
             "publishResultsDate": "Release Date of Results",
             "examStudentReviewStart": "Begin of Student Review",
             "examStudentReviewEnd": "End of Student Review",
+            "studentReviewEnabled": "Review is open",
             "duration": "Duration",
             "nrOfStudents": "Registered Students",
             "created": "New exam created",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
resolves https://github.com/ls1intum/Artemis/issues/1923

In the exam summary students could not see the time when they could review and create complaints. The date/times are shown now, also a tag that shows that the review is open.


### Description
<!-- Describe your changes in detail -->

![image](https://user-images.githubusercontent.com/33342534/109629786-7f612e80-7b44-11eb-82b8-0e7f7bda0620.png)



### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. check the exam summary of a student. When the exam is over (and the instructor set review times) you are able to see the review time, and when you are in the review time you can see an "review is open" tag.
2. when the exam is not over yet, you should not be able to see the info about the review in the heading.
--> 
![image](https://user-images.githubusercontent.com/33342534/109433435-9272e200-7a10-11eb-9252-e7b47b399a92.png)
