### PR TITLE
[Bugfix] Fix course archival flacky tests

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExportService.java
@@ -99,7 +99,7 @@ public class CourseExportService {
             return exportedCoursePath;
         }
         catch (Exception e) {
-            logMessageAndAppendToList("Failed to export the entire course " + course.getTitle(), exportErrors);
+            logMessageAndAppendToList("Failed to export the entire course " + course.getTitle() + ": " + e.getMessage(), exportErrors);
             return Optional.empty();
         }
         finally {

--- a/src/main/java/de/tum/in/www1/artemis/service/ZipFileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ZipFileService.java
@@ -61,7 +61,7 @@ public class ZipFileService {
      */
     public Path createZipFileWithFolderContent(Path zipFilePath, Path contentRootPath) throws IOException {
         try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFilePath))) {
-            Files.walk(contentRootPath).filter(path -> !Files.isDirectory(path)).forEach(path -> {
+            Files.walk(contentRootPath).filter(path -> !Files.isDirectory(path) && Files.exists(path)).forEach(path -> {
                 ZipEntry zipEntry = new ZipEntry(contentRootPath.relativize(path).toString());
                 copyToZipFile(zipOutputStream, path, zipEntry);
             });

--- a/src/main/java/de/tum/in/www1/artemis/service/ZipFileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ZipFileService.java
@@ -26,7 +26,7 @@ public class ZipFileService {
      */
     public void createZipFile(Path zipFilePath, List<Path> paths, boolean createDirsInZipFile) throws IOException {
         try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFilePath))) {
-            paths.stream().filter(path -> !Files.isDirectory(path)).forEach(path -> {
+            paths.stream().filter(path -> !Files.isDirectory(path) && Files.exists(path)).forEach(path -> {
                 var zipPath = createDirsInZipFile ? path : path.getFileName();
                 ZipEntry zipEntry = new ZipEntry(zipPath.toString());
                 copyToZipFile(zipOutputStream, path, zipEntry);
@@ -44,7 +44,7 @@ public class ZipFileService {
      */
     public void createZipFile(Path zipFilePath, List<Path> paths, Path pathsRoot) throws IOException {
         try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFilePath))) {
-            paths.stream().filter(path -> !Files.isDirectory(path)).forEach(path -> {
+            paths.stream().filter(path -> !Files.isDirectory(path) && Files.exists(path)).forEach(path -> {
                 ZipEntry zipEntry = new ZipEntry(pathsRoot.relativize(path).toString());
                 copyToZipFile(zipOutputStream, path, zipEntry);
             });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The following tests fail randomly on TS5:
- `ProgrammingExerciseGitlabJenkinsIntegrationTest > testArchiveCourseWithProgrammingExercise()`
- `ProgrammingExerciseBitbucketBambooIntegrationTest > exportInstructorRepositories()`

It fails because the current zipping functions throw an exception when attempting to zip non-existant files.

### Description
<!-- Describe your changes in detail -->
The zipping functions now zip files that exist.
