### PR TITLE
[Enhancement] Submissions assessment dashboards

### DIFF
--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
@@ -31,7 +31,8 @@
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th jhiSortBy="latestResult.assessor.name">
-                        <a class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessor">Reviewer</a>
+                        <a *ngIf="numberOfCorrectionrounds == 1" class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessor">Reviewer</a>
+                        <a *ngIf="numberOfCorrectionrounds == 2" class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessors">Reviewers</a>
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th>

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
@@ -62,7 +62,8 @@
                         {{ submission.participation.participantName }}
                     </td>
                     <td>
-                        <span *ngIf="submission.latestResult && submission.latestResult?.assessor">{{ submission.latestResult!.assessor!.name }}</span>
+                        <div *ngIf="submission.results.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
+                        <div *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</div>
                     </td>
                     <td *ngFor="let item of [].constructor(numberOfCorrectionrounds); let correctionRound = index">
                         <span *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR', 'ROLE_TA']">

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
@@ -51,7 +51,12 @@
                     </td>
                     <td>
                         <ng-container *ngIf="submission.participation.submissions">
-                            {{ submission.participation.submissions.length }}
+                            <a
+                                *ngIf="exercise.isAtLeastInstructor"
+                                [routerLink]="['/course-management', courseId, 'exercises', exercise.id, 'participations', submission.participation.id, 'submissions']"
+                            >
+                                {{ submission.participation.submissions.length }}
+                            </a>
                         </ng-container>
                     </td>
                     <td>

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.html
@@ -68,7 +68,7 @@
                         {{ submission.participation.participantName }}
                     </td>
                     <td>
-                        <div *ngIf="submission.results.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
+                        <div *ngIf="submission.results?.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
                         <div *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</div>
                     </td>
                     <td *ngFor="let item of [].constructor(numberOfCorrectionrounds); let correctionRound = index">

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment-dashboard.component.ts
@@ -25,7 +25,7 @@ export class FileUploadAssessmentDashboardComponent implements OnInit {
     predicate = 'id';
     reverse = false;
     numberOfCorrectionrounds = 1;
-
+    courseId: number;
     private cancelConfirmationText: string;
 
     constructor(
@@ -58,6 +58,7 @@ export class FileUploadAssessmentDashboardComponent implements OnInit {
             })
             .subscribe((exercise) => {
                 this.exercise = exercise;
+                this.courseId = exercise.course ? exercise.course.id! : exercise.exerciseGroup!.exam!.course!.id!;
                 this.getSubmissions();
                 this.numberOfCorrectionrounds = this.exercise.exerciseGroup ? this.exercise!.exerciseGroup.exam!.numberOfCorrectionRoundsInExam! : 1;
                 this.setPermissions();

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
@@ -129,7 +129,8 @@
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th jhiSortBy="latestResult.assessor.name">
-                        <a class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessor">Reviewer</a>
+                        <a *ngIf="numberOfCorrectionrounds == 1" class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessor">Reviewer</a>
+                        <a *ngIf="numberOfCorrectionrounds == 2" class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessors">Reviewers</a>
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th *ngIf="exercise.course || (exercise.exerciseGroup && numberOfCorrectionrounds == 1)">

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
@@ -159,7 +159,8 @@
                     </td>
                     <td>{{ submission.latestResult && submission.latestResult!.assessmentType }}</td>
                     <td>
-                        <span *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</span>
+                        <div *ngIf="submission.results.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
+                        <div *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</div>
                     </td>
 
                     <td *ngFor="let item of [].constructor(numberOfCorrectionrounds); let correctionRound = index">

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
@@ -152,7 +152,16 @@
                     <td>
                         <jhi-result [participation]="submission.participation"></jhi-result>
                     </td>
-                    <td>{{ submission.participation.submissions.length }}</td>
+                    <td>
+                        <ng-container *ngIf="submission.participation.submissions">
+                            <a
+                                *ngIf="exercise.isAtLeastInstructor"
+                                [routerLink]="['/course-management', courseId, 'exercises', exercise.id, 'participations', submission.participation.id, 'submissions']"
+                            >
+                                {{ submission.participation.submissions.length }}
+                            </a>
+                        </ng-container>
+                    </td>
                     <td>
                         {{ submission.durationInMinutes }}
                         minutes

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
@@ -169,7 +169,7 @@
                     </td>
                     <td>{{ submission.latestResult && submission.latestResult!.assessmentType }}</td>
                     <td>
-                        <div *ngIf="submission.results.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
+                        <div *ngIf="submission.results?.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
                         <div *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</div>
                     </td>
 

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.ts
@@ -36,6 +36,7 @@ export class ModelingAssessmentDashboardComponent implements OnInit, OnDestroy {
     predicate: string;
     reverse: boolean;
     nextOptimalSubmissionIds: number[] = [];
+    courseId: number;
     numberOfCorrectionrounds = 1;
 
     private cancelConfirmationText: string;
@@ -90,6 +91,7 @@ export class ModelingAssessmentDashboardComponent implements OnInit, OnDestroy {
             this.exerciseService.find(params['exerciseId']).subscribe((res: HttpResponse<Exercise>) => {
                 if (res.body!.type === ExerciseType.MODELING) {
                     this.exercise = res.body as ModelingExercise;
+                    this.courseId = this.exercise.course ? this.exercise.course.id! : this.exercise.exerciseGroup!.exam!.course!.id!;
                     this.getSubmissions(true);
                     this.numberOfCorrectionrounds = this.exercise.exerciseGroup ? this.exercise!.exerciseGroup.exam!.numberOfCorrectionRoundsInExam! : 1;
                     this.setPermissions();

--- a/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.html
@@ -71,7 +71,7 @@
                     </td>
                     <td>{{ assessmentTypeTranslationKey(submission.latestResult) | translate }}</td>
                     <td *ngIf="newManualResultAllowed">
-                        <div *ngIf="submission.results.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
+                        <div *ngIf="submission.results?.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
                         <div *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</div>
                     </td>
                     <ng-container *ngIf="newManualResultAllowed">

--- a/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.html
@@ -65,7 +65,8 @@
                     </td>
                     <td>{{ assessmentTypeTranslationKey(submission.latestResult) | translate }}</td>
                     <td *ngIf="newManualResultAllowed">
-                        <span *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</span>
+                        <div *ngIf="submission.results.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
+                        <div *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</div>
                     </td>
                     <ng-container *ngIf="newManualResultAllowed">
                         <td *ngFor="let item of [].constructor(numberOfCorrectionrounds); let correctionRound = index">

--- a/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.html
@@ -56,7 +56,12 @@
                     </td>
                     <td>
                         <ng-container *ngIf="submission.participation.submissions">
-                            {{ submission.participation.submissions.length }}
+                            <a
+                                *ngIf="exercise.isAtLeastInstructor"
+                                [routerLink]="['/course-management', courseId, 'exercises', exercise.id, 'participations', submission.participation.id, 'submissions']"
+                            >
+                                {{ submission.participation.submissions.length }}
+                            </a>
                         </ng-container>
                     </td>
                     <td>

--- a/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.html
@@ -30,7 +30,8 @@
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th *ngIf="newManualResultAllowed" jhiSortBy="latestResult.assessor.name">
-                        <a class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessor">Reviewer</a>
+                        <a *ngIf="numberOfCorrectionrounds == 1" class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessor">Reviewer</a>
+                        <a *ngIf="numberOfCorrectionrounds == 2" class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessors">Reviewers</a>
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <ng-container *ngIf="newManualResultAllowed">

--- a/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-assessment-dashboard.component.ts
@@ -26,6 +26,7 @@ export class ProgrammingAssessmentDashboardComponent implements OnInit {
     busy = false;
     predicate = 'id';
     reverse = false;
+    courseId: number;
     numberOfCorrectionrounds = 1;
     newManualResultAllowed: boolean;
     automaticType = AssessmentType.AUTOMATIC;
@@ -59,6 +60,7 @@ export class ProgrammingAssessmentDashboardComponent implements OnInit {
             })
             .subscribe((exercise) => {
                 this.exercise = exercise;
+                this.courseId = exercise.course ? exercise.course.id! : exercise.exerciseGroup!.exam!.course!.id!;
                 this.getSubmissions();
                 this.numberOfCorrectionrounds = this.exercise.exerciseGroup ? this.exercise!.exerciseGroup.exam!.numberOfCorrectionRoundsInExam! : 1;
                 this.setPermissions();

--- a/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
@@ -35,7 +35,8 @@
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th jhiSortBy="latestResult.assessor.name">
-                        <a class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessor">Reviewer</a>
+                        <a *ngIf="numberOfCorrectionrounds == 1" class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessor">Reviewer</a>
+                        <a *ngIf="numberOfCorrectionrounds == 2" class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.assessors">Reviewers</a>
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
                     <th *ngIf="exercise.course || (exercise.exerciseGroup && numberOfCorrectionrounds == 1)">

--- a/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
@@ -59,7 +59,12 @@
                     </td>
                     <td>
                         <ng-container *ngIf="submission.participation.submissions">
-                            {{ submission.participation.submissions.length }}
+                            <a
+                                *ngIf="exercise.isAtLeastInstructor"
+                                [routerLink]="['/course-management', courseId, 'exercises', exercise.id, 'participations', submission.participation.id, 'submissions']"
+                            >
+                                {{ submission.participation.submissions.length }}
+                            </a>
                         </ng-container>
                     </td>
                     <td>{{ 'artemisApp.exerciseAssessmentDashboard.languages.' + (submission.language || 'UNKNOWN') | translate }}</td>

--- a/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
@@ -75,7 +75,7 @@
                     </td>
                     <td>{{ assessmentTypeTranslationKey(submission.latestResult) | translate }}</td>
                     <td>
-                        <div *ngIf="submission.results.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
+                        <div *ngIf="submission.results?.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
                         <div *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</div>
                     </td>
                     <td *ngFor="let item of [].constructor(numberOfCorrectionrounds); let correctionRound = index">

--- a/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.html
@@ -69,7 +69,8 @@
                     </td>
                     <td>{{ assessmentTypeTranslationKey(submission.latestResult) | translate }}</td>
                     <td>
-                        <span *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</span>
+                        <div *ngIf="submission.results.length > 1 && submission.results[0].assessor">{{ submission.results[0].assessor!.name }}</div>
+                        <div *ngIf="submission.latestResult && submission.latestResult!.assessor">{{ submission.latestResult!.assessor!.name }}</div>
                     </td>
                     <td *ngFor="let item of [].constructor(numberOfCorrectionrounds); let correctionRound = index">
                         <span *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR', 'ROLE_TA']">

--- a/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment-dashboard/text-assessment-dashboard.component.ts
@@ -25,6 +25,7 @@ export class TextAssessmentDashboardComponent implements OnInit {
     predicate = 'id';
     reverse = false;
     numberOfCorrectionrounds = 1;
+    courseId: number;
 
     private cancelConfirmationText: string;
 
@@ -57,6 +58,7 @@ export class TextAssessmentDashboardComponent implements OnInit {
             })
             .subscribe((exercise) => {
                 this.exercise = exercise;
+                this.courseId = exercise.course ? exercise.course.id! : exercise.exerciseGroup!.exam!.course!.id!;
                 this.getSubmissions();
                 this.numberOfCorrectionrounds = this.exercise.exerciseGroup ? this.exercise!.exerciseGroup.exam!.numberOfCorrectionRoundsInExam! : 1;
                 this.setPermissions();

--- a/src/main/webapp/i18n/de/assessment.json
+++ b/src/main/webapp/i18n/de/assessment.json
@@ -47,6 +47,7 @@
                     "assessmentType": "Bewertungsart",
                     "student": "Student",
                     "assessor": "Prüfer/in",
+                    "assessors": "Prüfer/innen",
                     "action": "Bewertungsaktionen",
                     "assessmentFirst": "Korrekturrunde 1",
                     "assessmentSecond": "Korrekturrunde 2"

--- a/src/main/webapp/i18n/en/assessment.json
+++ b/src/main/webapp/i18n/en/assessment.json
@@ -47,6 +47,7 @@
                     "assessmentType": "Assessment Type",
                     "student": "Student",
                     "assessor": "Reviewer",
+                    "assessors": "Reviewers",
                     "action": "Assessment Actions",
                     "assessmentFirst": "Correction Round 1",
                     "assessmentSecond": "Correction Round 2"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Submissions pages were only showing the last assessor, if there were two correction rounds. Now the first assessor is shown too. 
Additionally a link was added to the submissions count, which leads to all of the students' submissions.
Those changes were applied to all four ...-assessment-dashboards
![image](https://user-images.githubusercontent.com/33342534/110081158-cdb43e80-7d8b-11eb-8e4d-43e731809011.png)


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. go to course -> exercises -> "Submissions" for all four exercise types (fileupload, text, programming, modeling). There the link to the submissions should work, a second assessor should not be shown as those exercises do not have a second assessment.
2. go to an exam which has second correction enabled, then click on exercise-groups -> "Submissions" 
3. check again for all four exercise types if the submission links work, and also check if both assessors are displayed correctly.
