### PR TITLE
Fix Translation for Proportional Without Penalty Scoring of Multiple Choice Quiz Re-evaluate

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.html
@@ -33,7 +33,7 @@
             <select class="form-control" [(ngModel)]="question.scoringType" title="scoring type">
                 <option value="ALL_OR_NOTHING">{{ 'artemisApp.quizExercise.scoringType.all_or_nothing' | translate }}</option>
                 <option value="PROPORTIONAL_WITH_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_with_penalty' | translate }}</option>
-                <option value="PROPORTIONAL_WITHOUT_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_with_penalty' | translate }}</option>
+                <option value="PROPORTIONAL_WITHOUT_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_without_penalty' | translate }}</option>
             </select>
             <span jhiTranslate="artemisApp.quizQuestion.score" class="colon-suffix"></span>
             <span>{{ question.points }}</span>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Re-evaluate of multiple choice quiz question has duplicate translation key:
![image](https://user-images.githubusercontent.com/11130248/110148907-ad14d480-7ddd-11eb-9184-849c5d306e27.png)

### Description
- Fix the translation key

### Steps for Testing
0. Review the code, that the translation key fits the option value
1. Check that the translation of the scoring option is now correct and distinct from the others.
