### PR TITLE
Do not unlock exam programming exercises on edit

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
@@ -139,7 +139,7 @@ public class Exam extends DomainObject {
         return visibleDate;
     }
 
-    public void setVisibleDate(ZonedDateTime visibleDate) {
+    public void setVisibleDate(@NotNull ZonedDateTime visibleDate) {
         this.visibleDate = visibleDate;
     }
 
@@ -148,7 +148,7 @@ public class Exam extends DomainObject {
         return startDate;
     }
 
-    public void setStartDate(ZonedDateTime startDate) {
+    public void setStartDate(@NotNull ZonedDateTime startDate) {
         this.startDate = startDate;
     }
 
@@ -157,7 +157,7 @@ public class Exam extends DomainObject {
         return endDate;
     }
 
-    public void setEndDate(ZonedDateTime endDate) {
+    public void setEndDate(@NotNull ZonedDateTime endDate) {
         this.endDate = endDate;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -30,19 +31,19 @@ public class Exam extends DomainObject {
     /**
      * student can see the exam in the UI from this date onwards
      */
-    @Column(name = "visible_date")
+    @Column(name = "visible_date", nullable = false)
     private ZonedDateTime visibleDate;
 
     /**
      * student can start working on exam from this date onwards
      */
-    @Column(name = "start_date")
+    @Column(name = "start_date", nullable = false)
     private ZonedDateTime startDate;
 
     /**
      * student can work on exam until this date
      */
-    @Column(name = "end_date")
+    @Column(name = "end_date", nullable = false)
     private ZonedDateTime endDate;
 
     @Column(name = "publish_results_date")
@@ -133,6 +134,7 @@ public class Exam extends DomainObject {
         this.title = title;
     }
 
+    @NotNull
     public ZonedDateTime getVisibleDate() {
         return visibleDate;
     }
@@ -141,6 +143,7 @@ public class Exam extends DomainObject {
         this.visibleDate = visibleDate;
     }
 
+    @NotNull
     public ZonedDateTime getStartDate() {
         return startDate;
     }
@@ -149,6 +152,7 @@ public class Exam extends DomainObject {
         this.startDate = startDate;
     }
 
+    @NotNull
     public ZonedDateTime getEndDate() {
         return endDate;
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -123,7 +123,7 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
      * @return List<ProgrammingExercise> (can be empty)
      */
     @Query("select pe from ProgrammingExercise pe left join fetch pe.exerciseGroup eg left join fetch eg.exam e where e.endDate > :#{#dateTime}")
-    List<ProgrammingExercise> findAllWithEagerExamAllByExamEndDateAfterDate(@Param("dateTime") ZonedDateTime dateTime);
+    List<ProgrammingExercise> findAllWithEagerExamByExamEndDateAfterDate(@Param("dateTime") ZonedDateTime dateTime);
 
     /**
      * In distinction to other exercise types, students can have multiple submissions in a programming exercise.

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -338,6 +338,7 @@ public class ExerciseService {
 
         // Programming exercises have some special stuff that needs to be cleaned up (solution/template participation, build plans, etc.).
         if (exercise instanceof ProgrammingExercise) {
+            // TODO: delete all schedules related to this programming exercise
             programmingExerciseService.delete(exercise.getId(), deleteBaseReposBuildPlans);
         }
         else {

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamDateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamDateService.java
@@ -4,6 +4,8 @@ import java.time.ZonedDateTime;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.validation.constraints.NotNull;
+
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.exam.Exam;
@@ -60,6 +62,7 @@ public class ExamDateService {
      * @return the latest end date or the exam end date if no student exams are found. May return <code>null</code>, if the exam has no start/end date.
      * @throws EntityNotFoundException if no exam with the given examId can be found
      */
+    @NotNull
     public ZonedDateTime getLatestIndividualExamEndDate(Long examId) {
         final var exam = examRepository.findByIdElseThrow(examId);
         return getLatestIndividualExamEndDate(exam);
@@ -73,6 +76,7 @@ public class ExamDateService {
      * @param exam the exam
      * @return the latest end date or the exam end date if no student exams are found. May return <code>null</code>, if the exam has no start/end date.
      */
+    @NotNull
     public ZonedDateTime getLatestIndividualExamEndDate(Exam exam) {
         var maxWorkingTime = studentExamRepository.findMaxWorkingTimeByExamId(exam.getId());
         return maxWorkingTime.map(timeInSeconds -> exam.getStartDate().plusSeconds(timeInSeconds)).orElse(exam.getEndDate());

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamDateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamDateService.java
@@ -32,9 +32,9 @@ public class ExamDateService {
      * @return true if the exam is over and the students cannot submit anymore
      * @throws EntityNotFoundException if no exam with the given examId can be found
      */
-    public boolean isExamOver(Long examId) {
+    public boolean isExamWithGracePeriodOver(Long examId) {
         final var exam = examRepository.findByIdElseThrow(examId);
-        return isExamOver(exam);
+        return isExamWithGracePeriodOver(exam);
     }
 
     /**
@@ -46,7 +46,7 @@ public class ExamDateService {
      * @return true if the exam is over and the students cannot submit anymore
      * @throws EntityNotFoundException if no exam with the given examId can be found
      */
-    public boolean isExamOver(Exam exam) {
+    public boolean isExamWithGracePeriodOver(Exam exam) {
         var now = ZonedDateTime.now();
         return getLatestIndividualExamEndDate(exam).plusSeconds(exam.getGracePeriod()).isBefore(now);
     }
@@ -74,9 +74,6 @@ public class ExamDateService {
      * @return the latest end date or the exam end date if no student exams are found. May return <code>null</code>, if the exam has no start/end date.
      */
     public ZonedDateTime getLatestIndividualExamEndDate(Exam exam) {
-        if (exam.getStartDate() == null) {
-            return null;
-        }
         var maxWorkingTime = studentExamRepository.findMaxWorkingTimeByExamId(exam.getId());
         return maxWorkingTime.map(timeInSeconds -> exam.getStartDate().plusSeconds(timeInSeconds)).orElse(exam.getEndDate());
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -357,11 +357,6 @@ public class ExamService {
         long numberOfExercises = exam.getNumberOfExercisesInExam() != null ? exam.getNumberOfExercisesInExam() : 0;
         long numberOfOptionalExercises = numberOfExercises - exerciseGroups.stream().filter(ExerciseGroup::getIsMandatory).count();
 
-        // Check that the start and end date of the exam is set
-        if (exam.getStartDate() == null || exam.getEndDate() == null) {
-            throw new BadRequestAlertException("The start and end date must be set for the exam", "Exam", "artemisApp.exam.validation.startAndEndMustBeSet");
-        }
-
         // Ensure that all exercise groups have at least one exercise
         for (ExerciseGroup exerciseGroup : exam.getExerciseGroups()) {
             if (exerciseGroup.getExercises().isEmpty()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -326,6 +326,7 @@ public class ProgrammingExerciseService {
     public ProgrammingExercise updateProgrammingExercise(ProgrammingExercise programmingExercise, @Nullable String notificationText) {
         ProgrammingExercise savedProgrammingExercise = programmingExerciseRepository.save(programmingExercise);
 
+        // TODO: in case of an exam exercise, this is not necessary
         scheduleOperations(programmingExercise.getId());
 
         // Only send notification for course exercises

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -87,7 +87,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
                     .findAllByManualAssessmentAndDueDateAfterDate(ZonedDateTime.now());
             programmingExercisesWithFutureManualAssessment.forEach(this::scheduleExercise);
 
-            List<ProgrammingExercise> programmingExercisesWithExam = programmingExerciseRepository.findAllWithEagerExamAllByExamEndDateAfterDate(ZonedDateTime.now());
+            List<ProgrammingExercise> programmingExercisesWithExam = programmingExerciseRepository.findAllWithEagerExamByExamEndDateAfterDate(ZonedDateTime.now());
             programmingExercisesWithExam.forEach(this::scheduleExamExercise);
             log.info("Scheduled " + programmingExercisesWithBuildAfterDueDate.size() + " programming exercises with a buildAndTestAfterDueDate.");
             log.info("Scheduled " + programmingExercisesWithFutureManualAssessment.size() + " programming exercises with future manual assessment.");
@@ -115,7 +115,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     private static boolean needsToBeScheduled(ProgrammingExercise exercise) {
         // Exam exercises need to be scheduled
-        if (isExamExercise(exercise)) {
+        if (exercise.isExamExercise()) {
             return true;
         }
         // Manual assessed programming exercises as well
@@ -135,7 +135,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
 
     private void scheduleExercise(ProgrammingExercise exercise) {
         try {
-            if (isExamExercise(exercise)) {
+            if (exercise.isExamExercise()) {
                 scheduleExamExercise(exercise);
             }
             else {
@@ -178,14 +178,20 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
             return;
         }
         var unlockDate = getExamProgrammingExerciseUnlockDate(exercise);
+
+        // BEFORE EXAM
         if (unlockDate.isAfter(ZonedDateTime.now())) {
             // Use the custom date from the exam rather than the of the exercise's lifecycle
             scheduleService.scheduleTask(exercise, ExerciseLifecycle.RELEASE, Set.of(new Tuple<>(unlockDate, unlockAllStudentRepositories(exercise))));
         }
-        else if (examDateService.getLatestIndividualExamEndDate(exam).isBefore(ZonedDateTime.now())) {
+        // DURING EXAM
+        else if (examDateService.getLatestIndividualExamEndDate(exam).isAfter(ZonedDateTime.now())) {
             // This is only a backup (e.g. a crash of this node and restart during the exam)
+            // TODO: Christian Femers: this can lead to a weired edge case after the normal exam end date and before the last individual exam end date (in case of working time
+            // extensions)
             scheduleService.scheduleTask(exercise, ExerciseLifecycle.RELEASE, Set.of(new Tuple<>(ZonedDateTime.now().plusSeconds(5), unlockAllStudentRepositories(exercise))));
         }
+        // NOTHING TO DO AFTER EXAM
 
         if (exercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null && exercise.getBuildAndTestStudentSubmissionsAfterDueDate().isAfter(ZonedDateTime.now())) {
             scheduleService.scheduleTask(exercise, ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE, buildAndTestRunnableForExercise(exercise));
@@ -356,10 +362,6 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
         }).collect(Collectors.toSet());
         // 3. Schedule all tasks
         scheduleService.scheduleTask(exercise, ExerciseLifecycle.DUE, tasks);
-    }
-
-    private static boolean isExamExercise(ProgrammingExercise exercise) {
-        return exercise.isExamExercise();
     }
 
     private static ZonedDateTime getExamProgrammingExerciseUnlockDate(ProgrammingExercise exercise) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -181,6 +181,7 @@ public class ExamResource {
 
         // We can't test dates for equality as the dates retrieved from the database lose precision. Also use instant to take timezones into account
         Comparator<ZonedDateTime> comparator = Comparator.comparing(date -> date.truncatedTo(ChronoUnit.SECONDS).toInstant());
+        // TODO: we could limit this to changes in the start date
         if (comparator.compare(originalExam.getVisibleDate(), updatedExam.getVisibleDate()) != 0
                 || comparator.compare(originalExam.getStartDate(), updatedExam.getStartDate()) != 0) {
             // get all exercises

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -470,7 +470,6 @@ public class ExamResource {
     public ResponseEntity<List<StudentExam>> generateStudentExams(@PathVariable Long courseId, @PathVariable Long examId) {
         long start = System.nanoTime();
         log.info("REST request to generate student exams for exam {}", examId);
-
         final var exam = examRepository.findByIdWithRegisteredUsersExerciseGroupsAndExercisesElseThrow(examId);
 
         Optional<ResponseEntity<List<StudentExam>>> courseAndExamAccessFailure = examAccessService.checkCourseAndExamAccessForInstructor(courseId, exam);
@@ -753,23 +752,7 @@ public class ExamResource {
     @PreAuthorize("hasAnyRole('TA', 'INSTRUCTOR', 'ADMIN')")
     public ResponseEntity<ExamInformationDTO> getLatestIndividualEndDateOfExam(@PathVariable Long courseId, @PathVariable Long examId) {
         log.debug("REST request to get latest individual end date of exam : {}", examId);
-
         Optional<ResponseEntity<ExamInformationDTO>> courseAndExamAccessFailure = examAccessService.checkCourseAndExamAccessForTeachingAssistant(courseId, examId);
-
-        if (courseAndExamAccessFailure.isPresent()) {
-            return courseAndExamAccessFailure.get();
-        }
-
-        ZonedDateTime latestIndividualEndDateOfExam = examDateService.getLatestIndividualExamEndDate(examId);
-
-        if (latestIndividualEndDateOfExam == null) {
-            return ResponseEntity.notFound().build();
-        }
-        else {
-            ExamInformationDTO examInformationDTO = new ExamInformationDTO();
-            examInformationDTO.latestIndividualEndDate = latestIndividualEndDateOfExam;
-            return ResponseEntity.ok().body(examInformationDTO);
-        }
+        return courseAndExamAccessFailure.orElseGet(() -> ResponseEntity.ok().body(new ExamInformationDTO(examDateService.getLatestIndividualExamEndDate(examId))));
     }
-
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -908,6 +908,7 @@ public class ProgrammingExerciseResource {
         if (!authCheckService.isAtLeastInstructorInCourse(course, user)) {
             return forbidden();
         }
+
         exerciseService.logDeletion(programmingExercise, course, user);
         exerciseService.delete(exerciseId, deleteStudentReposBuildPlans, deleteBaseReposBuildPlans);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, programmingExercise.getTitle())).build();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -404,7 +404,7 @@ public class StudentExamResource {
             return forbidden();
         }
 
-        if (!this.examDateService.isExamOver(exam)) {
+        if (!this.examDateService.isExamWithGracePeriodOver(exam)) {
             // you can only grade not submitted exams if the exam is over
             return badRequest();
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamInformationDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/ExamInformationDTO.java
@@ -7,5 +7,17 @@ public class ExamInformationDTO {
     public ExamInformationDTO() {
     }
 
-    public ZonedDateTime latestIndividualEndDate;
+    public ExamInformationDTO(ZonedDateTime latestIndividualEndDate) {
+        this.latestIndividualEndDate = latestIndividualEndDate;
+    }
+
+    private ZonedDateTime latestIndividualEndDate;
+
+    public ZonedDateTime getLatestIndividualEndDate() {
+        return latestIndividualEndDate;
+    }
+
+    public void setLatestIndividualEndDate(ZonedDateTime latestIndividualEndDate) {
+        this.latestIndividualEndDate = latestIndividualEndDate;
+    }
 }

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -1571,7 +1571,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         exam1.setEndDate(now);
         exam1.setGracePeriod(180);
         final var exam = examRepository.save(exam1);
-        final var isOver = examDateService.isExamOver(exam.getId());
+        final var isOver = examDateService.isExamWithGracePeriodOver(exam.getId());
         assertThat(isOver).isFalse();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -410,18 +410,6 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    public void testGenerateStudentExamsNoDates_badRequest() throws Exception {
-        Exam exam = database.setupExamWithExerciseGroupsExercisesRegisteredStudents(course1);
-        exam.setStartDate(null);
-        examRepository.save(exam);
-
-        // invoke generate student exams
-        request.postListWithResponseBody("/api/courses/" + course1.getId() + "/exams/" + exam.getId() + "/generate-student-exams", Optional.empty(), StudentExam.class,
-                HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testGenerateStudentExamsNoExerciseGroups_badRequest() throws Exception {
         Exam exam = database.addExamWithExerciseGroup(course1, true);
         exam.setStartDate(now());
@@ -1434,14 +1422,6 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    public void testLatestExamEndDate_noStartDate_notFound() throws Exception {
-        exam1.setStartDate(null);
-        examRepository.save(exam1);
-        request.get("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/latest-end-date", HttpStatus.NOT_FOUND, ExamInformationDTO.class);
-    }
-
-    @Test
-    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testLatestExamEndDate() throws Exception {
         // Setup exam and user
         User user = userRepo.findOneByLogin("student1").get();
@@ -1460,7 +1440,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         ExamInformationDTO examInfo = request.get("/api/courses/" + exam2.getCourse().getId() + "/exams/" + exam2.getId() + "/latest-end-date", HttpStatus.OK,
                 ExamInformationDTO.class);
         // Check that latest end date is equal to endDate (no specific student working time). Do not check for equality as we lose precision when saving to the database
-        assertThat(examInfo.latestIndividualEndDate).isEqualToIgnoringNanos(exam2.getEndDate());
+        assertThat(examInfo.getLatestIndividualEndDate()).isEqualToIgnoringNanos(exam2.getEndDate());
 
         // Set student exam with working time and save
         studentExam.setWorkingTime(3600);
@@ -1470,7 +1450,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         ExamInformationDTO examInfo2 = request.get("/api/courses/" + exam2.getCourse().getId() + "/exams/" + exam2.getId() + "/latest-end-date", HttpStatus.OK,
                 ExamInformationDTO.class);
         // Check that latest end date is equal to startDate + workingTime
-        assertThat(examInfo2.latestIndividualEndDate).isEqualToIgnoringNanos(exam2.getStartDate().plusHours(1));
+        assertThat(examInfo2.getLatestIndividualEndDate()).isEqualToIgnoringNanos(exam2.getStartDate().plusHours(1));
     }
 
     @Test
@@ -1517,17 +1497,6 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         final var exam = examRepository.save(exam1);
         final var latestIndividualExamEndDate = examDateService.getLatestIndividualExamEndDate(exam.getId());
         assertThat(latestIndividualExamEndDate.isEqual(exam.getEndDate())).isTrue();
-    }
-
-    @Test
-    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    public void testGetAllIndividualExamEndDates_noStartDate() {
-        final var now = ZonedDateTime.now().truncatedTo(ChronoUnit.MINUTES);
-        exam1.setStartDate(null);
-        exam1.setEndDate(now);
-        final var exam = examRepository.save(exam1);
-        final var individualExamEndDates = examDateService.getAllIndividualExamEndDates(exam);
-        assertThat(individualExamEndDates).isNull();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/ExerciseUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExerciseUnitIntegrationTest.java
@@ -130,10 +130,7 @@ public class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationBamboo
         }
 
         List<ExerciseUnit> exerciseUnitsOfLecture = request.getList("/api/lectures/" + lecture1.getId() + "/exercise-units", HttpStatus.OK, ExerciseUnit.class);
-        persistedExerciseUnits.forEach(exerciseUnit -> {
-            assertThat(exerciseUnitsOfLecture.contains(persistedExerciseUnits));
-        });
-
+        assertThat(exerciseUnitsOfLecture).containsAll(persistedExerciseUnits);
     }
 
     @Test


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.


### Motivation and Context
There is a small logic error in the code when editing exercises it can happen that the student repos are unlocked

### Description
Fix the logic issue

### Steps for Testing
1. Create an exam with programming exercises
2. Participate as student
3. Check that the student repository of the programming exercise is locked after the exam (i.e. the student only has read access)
4. Edit the programming exercises and wait shortly
5. Double check that the student repos is still locked for the student (i.e. the student only has read and **not** write access)
