### PR TITLE
[Bugfix] - Re-evaluate cannot handle more than 9 spots

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.scss
+++ b/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.scss
@@ -30,6 +30,12 @@
         }
     }
 
+    /* change highlight color to light green when dragging the item above a drop location */
+    .drop-hover,
+    .dnd-drag-over {
+        background: rgb(144, 238, 144) !important;
+    }
+
     .match-percentage-container {
         display: flex;
         justify-content: center;

--- a/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.ts
@@ -616,7 +616,7 @@ export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, Afte
         this.question.spots = cloneDeep(this.backupQuestion.spots);
         // split on every whitespace. !!!only exception: [-spot 1] is not split!!! for more details see description in ngOnInit.
         const textForEachLine = this.question.text!.split(/\n+/g);
-        this.textParts = textForEachLine.map((t) => t.split(/\s+(?![^[]]*])/g));
+        this.textParts = textForEachLine.map((t) => t.split(/\s+(?![^[]?[\d]]*])/g));
         this.question.explanation = this.backupQuestion.explanation;
         this.question.hint = this.backupQuestion.hint;
     }
@@ -662,9 +662,9 @@ export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, Afte
 
         // split on every whitespace. !!!only exception: [-spot 1] is not split!!! for more details see description in ngOnInit.
         const textForEachLine = this.question.text!.split(/\n+/g);
-        this.textParts = textForEachLine.map((t) => t.split(/\s+(?![^[]]*])/g));
+        this.textParts = textForEachLine.map((t) => t.split(/\s+(?![^[]?[\d]]*])/g));
 
-        this.textParts = this.textParts.map((part) => part.filter((text) => text !== '[-spot ' + spotToDelete.spotNr + ']'));
+        this.textParts = this.textParts.map((part) => part.filter((text) => !text || !text.includes('[-spot ' + spotToDelete.spotNr + ']')));
 
         this.question.text = this.textParts.map((textPart) => textPart.join(' ')).join('\n');
     }
@@ -692,7 +692,7 @@ export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, Afte
         this.question.text = this.textParts.map((textPart) => textPart.join(' ')).join('\n');
         // split on every whitespace. !!!only exception: [-spot 1] is not split!!! for more details see description in ngOnInit.
         const textForEachLine = this.question.text.split(/\n+/g);
-        this.textParts = textForEachLine.map((t) => t.split(/\s+(?![^[]]*])/g));
+        this.textParts = textForEachLine.map((t) => t.split(/\s+(?![^[]?[\d]]*])/g));
     }
 
     /**

--- a/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.ts
@@ -96,7 +96,7 @@ export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, Afte
         const textForEachLine = this.question.text!.split(/\n+/g);
         this.textParts = textForEachLine.map((t) => {
             const indentation = this.shortAnswerQuestionUtil.getIndentation(t);
-            const lineParts = t.split(/\s+(?![^[]]*])/g);
+            const lineParts = t.split(/\s+(?![^[]?[\d]]*])/g);
             lineParts[1] = indentation.concat(lineParts[1]);
             return lineParts;
         });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For short answer questions which have more than 9 spots, the regex parses the text incorrectly, which results in an NullPointerExeption. 

### Description
<!-- Describe your changes in detail -->
Adapted the regex(es) a bit so that numbers with two digits are also recognized (I assume nobody will create a quiz with >= 100 spots, if this is the case, another digit would need to be noticed by the regex)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create a short answer quiz with more than 9 spots (also map solutions to them)
3. make sure when editing it after creating the exercise, everything is displayed correctly (+ no errors in the console)
4. run the test, after it click on re-evaluate
5. Every spot should be displayed and functionalities like adding solutions or deleting spots should be possible as well
6. When dragging a solution to a spot to make a mapping (to tell the quiz that this solution is a correct answer for this spot) the spot should get green when hovering over one