### PR TITLE
Improve Exam Complaint Information

### DIFF
--- a/src/main/webapp/i18n/de/complaint.json
+++ b/src/main/webapp/i18n/de/complaint.json
@@ -7,7 +7,7 @@
             "title": "Beschwerde",
             "info": "Die Limitierung der Beschwerdenanzahl bezieht sich auf offene und abgelehnte Beschwerden. Wenn deine Beschwerde angenommen wird, wird sie nicht auf deine Gesamtzahl der Beschwerden angerechnet.",
             "description": "Du kannst insgesamt bis zu {{ maxComplaintNumber }} Beschwerden in diesem Kurs einreichen.",
-            "descriptionExam": "Du kannst beliebig viele Beschwerden für die Klausur einreichen.",
+            "descriptionExam": "Du kannst zu jeder manuell korrigierten Aufgabe der Klausur eine Beschwerde einreichen.",
             "descriptionExtended": "Jeder Student darf insgesamt bis zu {{ maxComplaintNumber }} Beschwerden in diesem Kurs einreichen. Du hast noch <strong style=color:red;>{{ allowedComplaints }}</strong> Beschwerden übrig.",
             "descriptionTeam": "Ihr könnt insgesamt bis zu {{ maxComplaintNumber }} Beschwerden als Team in diesem Kurs einreichen.",
             "descriptionTeamExtended": "Jedes Team darf insgesamt bis zu {{ maxComplaintNumber }} Beschwerden in diesem Kurs einreichen. Ihr habt noch <strong style=color:red;>{{ allowedComplaints }}</strong> Beschwerden übrig.",

--- a/src/main/webapp/i18n/en/complaint.json
+++ b/src/main/webapp/i18n/en/complaint.json
@@ -7,7 +7,7 @@
             "title": "Complaint",
             "info": "The complaint limit refers to open and rejected complaints. If your complaint is accepted it will not count towards your total number of complaints.",
             "description": "You can submit up to {{ maxComplaintNumber }} complaints in total in this course.",
-            "descriptionExam": "You can submit a complaint for each manually assessed exercise in this exam.",
+            "descriptionExam": "You can submit one complaint for each manually assessed exercise in this exam.",
             "descriptionExtended": "Every student is allowed to submit up to {{ maxComplaintNumber }} complaints in total in this course. You still have <strong style=color:red;>{{ allowedComplaints }}</strong> complaints left.",
             "descriptionTeam": "You can submit up to {{ maxComplaintNumber }} complaints as a team for this whole course.",
             "descriptionTeamExtended": "Every team is allowed to submit up to {{ maxComplaintNumber }} complaints in total in this course. Your team still has <strong style=color:red;>{{ allowedComplaints }}</strong> complaints left.",

--- a/src/main/webapp/i18n/en/complaint.json
+++ b/src/main/webapp/i18n/en/complaint.json
@@ -7,7 +7,7 @@
             "title": "Complaint",
             "info": "The complaint limit refers to open and rejected complaints. If your complaint is accepted it will not count towards your total number of complaints.",
             "description": "You can submit up to {{ maxComplaintNumber }} complaints in total in this course.",
-            "descriptionExam": "You can submit as many complaints as you like for an exam.",
+            "descriptionExam": "You can submit a complaint for each manually assessed exercise in this exam.",
             "descriptionExtended": "Every student is allowed to submit up to {{ maxComplaintNumber }} complaints in total in this course. You still have <strong style=color:red;>{{ allowedComplaints }}</strong> complaints left.",
             "descriptionTeam": "You can submit up to {{ maxComplaintNumber }} complaints as a team for this whole course.",
             "descriptionTeamExtended": "Every team is allowed to submit up to {{ maxComplaintNumber }} complaints in total in this course. Your team still has <strong style=color:red;>{{ allowedComplaints }}</strong> complaints left.",


### PR DESCRIPTION
### Checklist
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
The complaint information text for exams can be misleading. In EIDI and Patterns some students thought that they can submit multiple complaints about one exercse. I updated these strings to address this misunderstanding.

### Steps for Testing
Just check that the text is more understandable now.

### Test Coverage
nothing changed