### PR TITLE
Fix flaky K6 exam test

### DIFF
--- a/src/test/k6/ExamAPIs.js
+++ b/src/test/k6/ExamAPIs.js
@@ -218,7 +218,7 @@ export default function (data) {
                                     simulateSubmission(artemis, simulation, TestResult.BUILD_ERROR);
                                 }
                                 programmingSubmissionCounter++;
-                                sleep(20);
+                                sleep(40);
                                 break;
                         }
                         sleep(10);

--- a/src/test/k6/requests/exam.js
+++ b/src/test/k6/requests/exam.js
@@ -18,7 +18,7 @@ export function newExam(artemis, course) {
     const currentDate = new Date();
     const visibleDate = new Date(currentDate.getTime() + 30000); // Visible in 30 secs
     const startDate = new Date(currentDate.getTime() + 60000); // Starting in 30 secs
-    const endDate = new Date(currentDate.getTime() + 240000); // Ending in 240 secs
+    const endDate = new Date(currentDate.getTime() + 360000); // Ending in 360 secs
 
     const exam = {
         course: course,


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The K6 exam tests are flaky on TS2. The reason behind it is mentioned in PR: https://github.com/ls1intum/Artemis/pull/2921

### Description
<!-- Describe your changes in detail -->
We increase the sleep time in order to wait a bit longer for the result coming from the CI.
