### PR TITLE
Changed system-notification components to be compatible with strict templates

### DIFF
--- a/docs/dev/guidelines/client.rst
+++ b/docs/dev/guidelines/client.rst
@@ -354,18 +354,20 @@ When creating a completely new route you will have to register the new paths in 
 	}
 
 12. Strict Template Check
-===================================
+=========================
 
 To prevent errors for strict template rule in TypeScript, Artemis uses following approaches.
 
 Use ArtemisTranslatePipe instead of TranslatePipe
-**************************************************
-Do not use placeholder="{{ 'global.form.newpassword.placeholder' | translate }}"
-Use placeholder="{{ 'global.form.newpassword.placeholder' | artemisTranslate }}"
+*************************************************
+Do not use ``placeholder="{{ 'global.form.newpassword.placeholder' | translate }}"``
+
+Use ``placeholder="{{ 'global.form.newpassword.placeholder' | artemisTranslate }}"``
 
 Use ArtemisTimeAgoPipe instead of TimeAgoPipe
 *********************************************
-Do not use <span [ngbTooltip]="submittedDate | artemisDate">{{ submittedDate | amTimeAgo }}</span>
-Use <span [ngbTooltip]="submittedDate | artemisDate">{{ submittedDate | artemisTimeAgo }}</span>
+Do not use ``<span [ngbTooltip]="submittedDate | artemisDate">{{ submittedDate | amTimeAgo }}</span>``
+
+Use ``<span [ngbTooltip]="submittedDate | artemisDate">{{ submittedDate | artemisTimeAgo }}</span>``
 
 Some parts of these guidelines are adapted from https://github.com/microsoft/TypeScript-wiki/blob/master/Coding-guidelines.md

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.html
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.html
@@ -48,9 +48,9 @@
                             </a>
                             <button
                                 jhiDeleteButton
-                                [entityTitle]="notification.title"
+                                [entityTitle]="!!notification.title ? notification.title : ''"
                                 deleteQuestion="artemisApp.systemNotification.delete.question"
-                                (delete)="deleteNotification(notification.id)"
+                                (delete)="deleteNotification(notification.id!)"
                                 [dialogError]="dialogError$"
                             >
                                 <fa-icon [icon]="'times'"></fa-icon>

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
@@ -25,7 +25,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
     success: string;
     routeData: Subscription;
     links: any;
-    totalItems: string;
+    totalItems: number;
     itemsPerPage: number;
     page: number;
     predicate: string;
@@ -58,7 +58,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
      * Initializes current account and system notifications
      */
     ngOnInit() {
-        this.accountService.identity().then((user) => {
+        this.accountService.identity().then((user: User) => {
             this.currentAccount = user!;
             this.loadAll();
             this.registerChangeInUsers();
@@ -167,7 +167,7 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
 
     private onSuccess(data: SystemNotification[], headers: HttpHeaders) {
         this.links = this.parseLinks.parse(headers.get('link')!);
-        this.totalItems = headers.get('X-Total-Count')!;
+        this.totalItems = Number(headers.get('X-Total-Count')!);
         this.notifications = data;
     }
 }

--- a/src/main/webapp/app/shared/notification/system-notification/system-notification.component.ts
+++ b/src/main/webapp/app/shared/notification/system-notification/system-notification.component.ts
@@ -6,6 +6,7 @@ import { AccountService } from 'app/core/auth/account.service';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
 import { User } from 'app/core/user/user.model';
 import { SystemNotificationService } from 'app/shared/notification/system-notification/system-notification.service';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
     selector: 'jhi-system-notification',
@@ -17,7 +18,7 @@ export class SystemNotificationComponent implements OnInit {
     readonly WARNING = SystemNotificationType.WARNING;
     notification: SystemNotification | undefined;
     alertClass: string;
-    alertIcon: string;
+    alertIcon: IconProp;
     websocketChannel: string;
 
     constructor(


### PR DESCRIPTION
### Motivation and Context

We want to use strict templates in Angular. This PR introduces small changes to fix various issues

### Description

Changed system-notification components to be compatible with strict templates. Also updated the layout of the documentation.
Before:
![grafik](https://user-images.githubusercontent.com/72132281/111050873-754a0480-844f-11eb-98e7-f143cb1269fc.png)
After:
![grafik](https://user-images.githubusercontent.com/72132281/111050876-7a0eb880-844f-11eb-9112-1f5520e97bce.png)
