### PR TITLE
Athene: REST Templates and Health Indicator

### DIFF
--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -120,8 +120,7 @@ have to configure the file ``application-artemis.yml`` in the folder
            name: Artemis
            email: artemis@in.tum.de
        athene:
-           submit-url: http://localhost/submit
-           feedback-consistency-url: http://localhost:8001/feedback_consistency
+           url: http://localhost
            base64-secret: YWVuaXF1YWRpNWNlaXJpNmFlbTZkb283dXphaVF1b29oM3J1MWNoYWlyNHRoZWUzb2huZ2FpM211bGVlM0VpcAo=
            token-validity-in-seconds: 10800
 
@@ -417,8 +416,7 @@ HTTP. We need to extend the configuration in the file
    artemis:
      # ...
      athene:
-       submit-url: http://localhost/submit
-       feedback-consistency-url: http://localhost:8001/feedback_consistency
+       url: http://localhost
        base64-secret: YWVuaXF1YWRpNWNlaXJpNmFlbTZkb283dXphaVF1b29oM3J1MWNoYWlyNHRoZWUzb2huZ2FpM211bGVlM0VpcAo=
        token-validity-in-seconds: 10800
 

--- a/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/RestTemplateConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
+import de.tum.in.www1.artemis.config.auth.AtheneAuthorizationInterceptor;
 import de.tum.in.www1.artemis.config.auth.JiraAuthorizationInterceptor;
 import de.tum.in.www1.artemis.service.connectors.bamboo.BambooAuthorizationInterceptor;
 import de.tum.in.www1.artemis.service.connectors.bitbucket.BitbucketAuthorizationInterceptor;
@@ -65,6 +66,12 @@ public class RestTemplateConfiguration {
         return initializeRestTemplateWithInterceptors(bambooAuthorizationInterceptor, createRestTemplate());
     }
 
+    @Bean
+    @Profile("athene")
+    public RestTemplate atheneRestTemplate(AtheneAuthorizationInterceptor atheneAuthorizationInterceptor) {
+        return initializeRestTemplateWithInterceptors(atheneAuthorizationInterceptor, createRestTemplate());
+    }
+
     // Note: for certain requests, e.g. health(), we would like to have shorter timeouts, therefore we need additional rest templates, because
     // it is recommended to keep the timeout settings constant per rest template
 
@@ -99,6 +106,12 @@ public class RestTemplateConfiguration {
     @Profile("bamboo")
     public RestTemplate shortTimeoutBambooRestTemplate(BambooAuthorizationInterceptor bambooAuthorizationInterceptor) {
         return initializeRestTemplateWithInterceptors(bambooAuthorizationInterceptor, createShortTimeoutRestTemplate());
+    }
+
+    @Bean
+    @Profile("athene")
+    public RestTemplate shortTimeoutAtheneRestTemplate(AtheneAuthorizationInterceptor atheneAuthorizationInterceptor) {
+        return initializeRestTemplateWithInterceptors(atheneAuthorizationInterceptor, createShortTimeoutRestTemplate());
     }
 
     @NotNull

--- a/src/main/java/de/tum/in/www1/artemis/config/auth/AtheneAuthorizationInterceptor.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/auth/AtheneAuthorizationInterceptor.java
@@ -1,0 +1,29 @@
+package de.tum.in.www1.artemis.config.auth;
+
+import java.io.IOException;
+
+import javax.validation.constraints.NotNull;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("athene")
+public class AtheneAuthorizationInterceptor implements ClientHttpRequestInterceptor {
+
+    @Value("${artemis.athene.base64-secret}")
+    private String secret;
+
+    @NotNull
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+        request.getHeaders().set(HttpHeaders.AUTHORIZATION, secret);
+        return execution.execute(request, body);
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/AutomaticTextAssessmentConflictService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AutomaticTextAssessmentConflictService.java
@@ -22,7 +22,7 @@ import de.tum.in.www1.artemis.exception.NetworkingError;
 import de.tum.in.www1.artemis.repository.FeedbackConflictRepository;
 import de.tum.in.www1.artemis.repository.FeedbackRepository;
 import de.tum.in.www1.artemis.repository.TextBlockRepository;
-import de.tum.in.www1.artemis.service.connectors.TextAssessmentConflictService;
+import de.tum.in.www1.artemis.service.connectors.athene.TextAssessmentConflictService;
 import de.tum.in.www1.artemis.service.dto.FeedbackConflictResponseDTO;
 import de.tum.in.www1.artemis.service.dto.TextFeedbackConflictRequestDTO;
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athene/AtheneHealthIndicator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athene/AtheneHealthIndicator.java
@@ -1,0 +1,44 @@
+package de.tum.in.www1.artemis.service.connectors.athene;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import de.tum.in.www1.artemis.service.connectors.ConnectorHealth;
+
+@Component
+@Profile("athene")
+public class AtheneHealthIndicator implements HealthIndicator {
+
+    private final RestTemplate shortTimeoutRestTemplate;
+
+    @Value("${artemis.athene.url}")
+    private String atheneUrl;
+
+    public AtheneHealthIndicator(@Qualifier("shortTimeoutAtheneRestTemplate") RestTemplate shortTimeoutRestTemplate) {
+        this.shortTimeoutRestTemplate = shortTimeoutRestTemplate;
+    }
+
+    @Override
+    public Health health() {
+        ConnectorHealth health;
+        try {
+            final var status = shortTimeoutRestTemplate.getForObject(atheneUrl + "/queueStatus", JsonNode.class);
+            var isUp = status.get("total").isNumber();
+            health = new ConnectorHealth(isUp);
+        }
+        catch (Exception emAll) {
+            health = new ConnectorHealth(emAll);
+        }
+
+        health.setAdditionalInfo(Map.of("url", atheneUrl));
+        return health.asActuatorHealth();
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athene/AtheneHealthIndicator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athene/AtheneHealthIndicator.java
@@ -26,6 +26,9 @@ public class AtheneHealthIndicator implements HealthIndicator {
         this.shortTimeoutRestTemplate = shortTimeoutRestTemplate;
     }
 
+    /**
+     * Ping Athene at /queueStatus and check if the service is available.
+     */
     @Override
     public Health health() {
         ConnectorHealth health;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athene/AtheneService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athene/AtheneService.java
@@ -36,8 +36,8 @@ public class AtheneService {
     @Value("${server.url}")
     private String artemisServerUrl;
 
-    @Value("${artemis.athene.submit-url}")
-    private String submitApiEndpoint;
+    @Value("${artemis.athene.url}")
+    private String atheneUrl;
 
     private final TextAssessmentQueueService textAssessmentQueueService;
 
@@ -157,7 +157,7 @@ public class AtheneService {
 
         try {
             final RequestDTO request = new RequestDTO(exercise.getId(), textSubmissions, artemisServerUrl + ATHENE_RESULT_API_PATH + exercise.getId());
-            ResponseDTO response = connector.invokeWithRetry(submitApiEndpoint, request, maxRetries);
+            ResponseDTO response = connector.invokeWithRetry(atheneUrl + "/submit", request, maxRetries);
             log.info("Remote Service to calculate automatic feedback responded: " + response.detail);
 
             // Register task for exercise as running, AtheneResource calls finishTask on result receive

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/athene/TextAssessmentConflictService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/athene/TextAssessmentConflictService.java
@@ -20,8 +20,8 @@ public class TextAssessmentConflictService {
 
     private final Logger log = LoggerFactory.getLogger(TextAssessmentConflictService.class);
 
-    @Value("${artemis.athene.feedback-consistency-url}")
-    private String API_ENDPOINT;
+    @Value("${artemis.athene.url}")
+    private String atheneUrl;
 
     private final AtheneConnector<Request, Response> connector;
 
@@ -61,7 +61,7 @@ public class TextAssessmentConflictService {
             throws NetworkingError {
         log.info("Calling Remote Service to check feedback consistencies.");
         final Request request = new Request(textFeedbackConflictRequestDTOS, exerciseId);
-        final Response response = connector.invokeWithRetry(API_ENDPOINT, request, maxRetries);
+        final Response response = connector.invokeWithRetry(atheneUrl + "/feedback_consistency", request, maxRetries);
 
         return response.feedbackInconsistencies;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AtheneScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AtheneScheduleService.java
@@ -23,7 +23,7 @@ import de.tum.in.www1.artemis.domain.enumeration.ExerciseLifecycle;
 import de.tum.in.www1.artemis.repository.TextExerciseRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.ExerciseLifecycleService;
-import de.tum.in.www1.artemis.service.connectors.AtheneService;
+import de.tum.in.www1.artemis.service.connectors.athene.AtheneService;
 import io.github.jhipster.config.JHipsterConstants;
 
 @Service

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AtheneResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AtheneResource.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.service.connectors.AtheneService;
+import de.tum.in.www1.artemis.service.connectors.athene.AtheneService;
 import de.tum.in.www1.artemis.web.rest.dto.AtheneDTO;
 
 /**

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -85,7 +85,6 @@ artemis:
         name: Artemis
         email: artemis.in@tum.de
     athene:
-        submit-url: http://localhost/submit
-        feedback-consistency-url: http://localhost:8001/feedback_consistency
+        url: http://localhost
         base64-secret: YWVuaXF1YWRpNWNlaXJpNmFlbTZkb283dXphaVF1b29oM3J1MWNoYWlyNHRoZWUzb2huZ2FpM211bGVlM0VpcAo=
         token-validity-in-seconds: 10800

--- a/src/main/webapp/i18n/de/health.json
+++ b/src/main/webapp/i18n/de/health.json
@@ -26,7 +26,8 @@
             "versionControlServer": "Versionskontrollserver",
             "userManagement": "Nutzerverwaltung",
             "hazelcast": "Hazelcast",
-            "websocketBroker": "Websocket Broker (Server -> Broker)"
+            "websocketBroker": "Websocket Broker (Server -> Broker)",
+            "athene": "Athene"
         },
         "table": {
             "service": "Dienst Name",

--- a/src/main/webapp/i18n/en/health.json
+++ b/src/main/webapp/i18n/en/health.json
@@ -26,7 +26,8 @@
             "versionControlServer": "Version Control Server",
             "userManagement": "User Management",
             "hazelcast": "Hazelcast",
-            "websocketBroker": "Websocket Broker (Server -> Broker)"
+            "websocketBroker": "Websocket Broker (Server -> Broker)",
+            "athene": "Athene"
         },
         "table": {
             "service": "Service name",

--- a/src/test/java/de/tum/in/www1/artemis/AtheneIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AtheneIntegrationTest.java
@@ -26,7 +26,7 @@ import de.tum.in.www1.artemis.domain.TextExercise;
 import de.tum.in.www1.artemis.repository.TextClusterRepository;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.TextBlockService;
-import de.tum.in.www1.artemis.service.connectors.AtheneService;
+import de.tum.in.www1.artemis.service.connectors.athene.AtheneService;
 import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.web.rest.AtheneResource;
 import de.tum.in.www1.artemis.web.rest.dto.AtheneDTO;

--- a/src/test/java/de/tum/in/www1/artemis/connector/athene/AtheneRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/athene/AtheneRequestMockProvider.java
@@ -2,11 +2,15 @@ package de.tum.in.www1.artemis.connector.athene;
 
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
+import java.net.SocketTimeoutException;
 import java.util.List;
 
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
@@ -14,40 +18,50 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.ResponseActions;
 import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.tum.in.www1.artemis.service.dto.FeedbackConflictResponseDTO;
 
 @Component
 @Profile("athene")
 public class AtheneRequestMockProvider {
 
-    @Autowired
-    public RestTemplate restTemplate;
+    private final RestTemplate restTemplate;
 
-    @Value("${artemis.athene.feedback-consistency-url}")
-    private String feedbackConsistencyApiEndpoint;
+    private MockRestServiceServer mockServer;
+
+    private final RestTemplate shortTimeoutRestTemplate;
+
+    private MockRestServiceServer mockServerShortTimeout;
+
+    @Value("${artemis.athene.url}")
+    private String atheneUrl;
 
     @Autowired
     private ObjectMapper mapper;
 
-    private MockRestServiceServer mockServer;
-
-    public void enableMockingOfRequests() {
-        enableMockingOfRequests(false);
+    public AtheneRequestMockProvider(@Qualifier("atheneRestTemplate") RestTemplate restTemplate,
+            @Qualifier("shortTimeoutAtheneRestTemplate") RestTemplate shortTimeoutRestTemplate) {
+        this.restTemplate = restTemplate;
+        this.shortTimeoutRestTemplate = shortTimeoutRestTemplate;
     }
 
-    public void enableMockingOfRequests(boolean ignoreExpectOrder) {
-        MockRestServiceServer.MockRestServiceServerBuilder builder = MockRestServiceServer.bindTo(restTemplate);
-        builder.ignoreExpectOrder(ignoreExpectOrder);
-        mockServer = builder.build();
+    public void enableMockingOfRequests() {
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+        mockServerShortTimeout = MockRestServiceServer.createServer(shortTimeoutRestTemplate);
+        MockitoAnnotations.openMocks(this);
     }
 
     public void reset() {
         if (mockServer != null) {
             mockServer.reset();
+        }
+
+        if (mockServerShortTimeout != null) {
+            mockServerShortTimeout.reset();
         }
     }
 
@@ -55,11 +69,27 @@ public class AtheneRequestMockProvider {
      * This method mocks feedback consistency response coming from Athene
      *
      * @param feedbackConflictResponseDTOs List of response DTOs, ideally an array of feedback conflicts
-     * @throws JsonProcessingException exception related to mapping the values to json
      */
-    public void mockFeedbackConsistency(List<FeedbackConflictResponseDTO> feedbackConflictResponseDTOs) throws JsonProcessingException {
-        String jsonArray = "{ \"feedbackInconsistencies\": " + mapper.writeValueAsString(feedbackConflictResponseDTOs) + "}";
-        mockServer.expect(ExpectedCount.once(), requestTo(feedbackConsistencyApiEndpoint)).andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess().body(jsonArray).contentType(MediaType.APPLICATION_JSON));
+    public void mockFeedbackConsistency(List<FeedbackConflictResponseDTO> feedbackConflictResponseDTOs) {
+        final ObjectNode node = mapper.createObjectNode();
+        node.set("feedbackInconsistencies", mapper.valueToTree(feedbackConflictResponseDTOs));
+        final String json = node.toString();
+
+        mockServer.expect(ExpectedCount.once(), requestTo(atheneUrl + "/feedback_consistency")).andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess().body(json).contentType(MediaType.APPLICATION_JSON));
+    }
+
+    public void mockQueueStatus(boolean success) {
+        final ResponseActions responseActions = mockServerShortTimeout.expect(ExpectedCount.once(), requestTo(atheneUrl + "/queueStatus")).andExpect(method(HttpMethod.GET));
+
+        if (success) {
+            final ObjectNode node = mapper.createObjectNode();
+            node.set("total", mapper.valueToTree(42));
+            final String json = node.toString();
+            responseActions.andRespond(withSuccess().body(json).contentType(MediaType.APPLICATION_JSON));
+        }
+        else {
+            responseActions.andRespond(withException(new SocketTimeoutException()));
+        }
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/connector/athene/AtheneRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/athene/AtheneRequestMockProvider.java
@@ -79,6 +79,22 @@ public class AtheneRequestMockProvider {
                 .andRespond(withSuccess().body(json).contentType(MediaType.APPLICATION_JSON));
     }
 
+    /**
+     * Mocks /submit api from Athene used to submit new exercises for clustering.
+     */
+    public void mockSubmitSubmissions() {
+        final ObjectNode node = mapper.createObjectNode();
+        node.set("detail", mapper.valueToTree("Submission successful"));
+        final String json = node.toString();
+
+        mockServer.expect(ExpectedCount.once(), requestTo(atheneUrl + "/submit")).andExpect(method(HttpMethod.POST)).andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+    }
+
+    /**
+     * Mocks /queueStatus api from Athene used to retrieve meta data on processed jobs. Currently used as a health check endpoint.
+     *
+     * @param success Successful response or timeout.
+     */
     public void mockQueueStatus(boolean success) {
         final ResponseActions responseActions = mockServerShortTimeout.expect(ExpectedCount.once(), requestTo(atheneUrl + "/queueStatus")).andExpect(method(HttpMethod.GET));
 

--- a/src/test/java/de/tum/in/www1/artemis/service/AutomaticFeedbackConflictServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/AutomaticFeedbackConflictServiceTest.java
@@ -20,7 +20,7 @@ import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.FeedbackConflictType;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.repository.*;
-import de.tum.in.www1.artemis.service.connectors.TextAssessmentConflictService;
+import de.tum.in.www1.artemis.service.connectors.athene.TextAssessmentConflictService;
 import de.tum.in.www1.artemis.service.dto.FeedbackConflictResponseDTO;
 import de.tum.in.www1.artemis.util.ModelFactory;
 

--- a/src/test/java/de/tum/in/www1/artemis/service/AutomaticFeedbackConflictServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/AutomaticFeedbackConflictServiceTest.java
@@ -10,9 +10,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 import de.tum.in.www1.artemis.connector.athene.AtheneRequestMockProvider;
@@ -60,8 +57,6 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
         textExercise = (TextExercise) database.addCourseWithOneFinishedTextExercise().getExercises().iterator().next();
 
         atheneRequestMockProvider.enableMockingOfRequests();
-        ReflectionTestUtils.setField(Objects.requireNonNull(ReflectionTestUtils.getField(textAssessmentConflictService, "connector")), "restTemplate",
-                atheneRequestMockProvider.restTemplate);
     }
 
     @AfterEach
@@ -74,11 +69,10 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
      * Creates two text submissions with text blocks and feedback, adds text blocks to a cluster.
      * Mocks TextAssessmentConflictService class to not to connect to remote Athene service
      * Then checks if the text assessment conflicts are created and stored correctly.
-     * @throws JsonProcessingException - exception related to mapping the values to json
      */
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
-    public void createFeedbackConflicts() throws JsonProcessingException {
+    public void createFeedbackConflicts() {
         TextSubmission textSubmission1 = ModelFactory.generateTextSubmission("first text submission", Language.ENGLISH, true);
         TextSubmission textSubmission2 = ModelFactory.generateTextSubmission("second text submission", Language.ENGLISH, true);
         database.saveTextSubmission(textExercise, textSubmission1, "student1");
@@ -123,11 +117,10 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
      * Creates and stores a Text Assessment Conflict in the database.
      * Then sends a conflict with same feedback ids and different conflict type.
      * Checks if the conflict type in the database has changed.
-     * @throws JsonProcessingException - exception related to mapping the values to json
      */
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
-    public void changedFeedbackConflictsType() throws JsonProcessingException {
+    public void changedFeedbackConflictsType() {
         TextSubmission textSubmission = ModelFactory.generateTextSubmission("text submission", Language.ENGLISH, true);
         database.saveTextSubmission(textExercise, textSubmission, "student1");
 
@@ -166,11 +159,10 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
      * Then a same feedback is sent to the conflict checking class.
      * Empty list is returned from the mock object. (meaning: no conflicts have found)
      * Checks if the conflict set as solved in the database.
-     * @throws JsonProcessingException - exception related to mapping the values to json
      */
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
-    public void solveFeedbackConflicts() throws JsonProcessingException {
+    public void solveFeedbackConflicts() {
         TextSubmission textSubmission = ModelFactory.generateTextSubmission("text submission", Language.ENGLISH, true);
         database.saveTextSubmission(textExercise, textSubmission, "student1");
 

--- a/src/test/java/de/tum/in/www1/artemis/service/connectors/AtheneServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/connectors/AtheneServiceTest.java
@@ -29,6 +29,7 @@ import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.TextAssessmentQueueService;
 import de.tum.in.www1.artemis.service.TextSubmissionService;
+import de.tum.in.www1.artemis.service.connectors.athene.AtheneService;
 import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.web.rest.dto.AtheneDTO;
 
@@ -64,11 +65,9 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
     @BeforeEach
     public void init() {
         // Create atheneService and inject @Value fields
-        atheneService = new AtheneService(textSubmissionService, textBlockRepository, textClusterRepository, textExerciseRepository, textAssessmentQueueService);
+        atheneService = new AtheneService(textSubmissionService, textBlockRepository, textClusterRepository, textExerciseRepository, textAssessmentQueueService, restTemplate);
         ReflectionTestUtils.setField(atheneService, "artemisServerUrl", artemisServerUrl);
         ReflectionTestUtils.setField(atheneService, "submitApiEndpoint", SUBMIT_API_ENDPOINT);
-        String apiSecret = "YWVuaXF1YWRpNWNlaXJpNmFlbTZkb283dXphaVF1b29oM3J1MWNoYWlyNHRoZWUzb2huZ2FpM211bGVlM0VpcAo=";
-        ReflectionTestUtils.setField(atheneService, "apiSecret", apiSecret);
 
         // Create example exercise
         ZonedDateTime pastTimestamp = ZonedDateTime.now().minusDays(5);
@@ -111,11 +110,6 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
 
         when(textSubmissionService.getTextSubmissionsWithTextBlocksByExerciseIdAndLanguage(exercise1.getId(), Language.ENGLISH))
                 .thenReturn(ModelFactory.generateTextSubmissions(10));
-
-        // Inject restTemplate to connector of atheneService
-        RemoteArtemisServiceConnector conn = (RemoteArtemisServiceConnector) ReflectionTestUtils.getField(atheneService, "connector");
-        assertThat(conn).isNotNull();
-        ReflectionTestUtils.setField(conn, "restTemplate", restTemplate);
 
         // Create mock server
         MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();

--- a/src/test/java/de/tum/in/www1/artemis/service/connectors/AtheneServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/connectors/AtheneServiceTest.java
@@ -5,25 +5,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import java.time.ZonedDateTime;
 import java.util.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.client.ExpectedCount;
-import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
+import de.tum.in.www1.artemis.connector.athene.AtheneRequestMockProvider;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
 import de.tum.in.www1.artemis.repository.*;
@@ -36,9 +33,13 @@ import de.tum.in.www1.artemis.web.rest.dto.AtheneDTO;
 public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     @Autowired
-    RestTemplate restTemplate;
+    private AtheneRequestMockProvider atheneRequestMockProvider;
 
     @Autowired
+    @Qualifier("atheneRestTemplate")
+    RestTemplate restTemplate;
+
+    @Mock
     TextAssessmentQueueService textAssessmentQueueService;
 
     @Mock
@@ -53,7 +54,8 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
     @Mock
     TextClusterRepository textClusterRepository;
 
-    private static final String SUBMIT_API_ENDPOINT = "http://localhost/submit";
+    @Value("${artemis.athene.url}")
+    private String atheneUrl;
 
     AtheneService atheneService;
 
@@ -67,7 +69,7 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
         // Create atheneService and inject @Value fields
         atheneService = new AtheneService(textSubmissionService, textBlockRepository, textClusterRepository, textExerciseRepository, textAssessmentQueueService, restTemplate);
         ReflectionTestUtils.setField(atheneService, "artemisServerUrl", artemisServerUrl);
-        ReflectionTestUtils.setField(atheneService, "submitApiEndpoint", SUBMIT_API_ENDPOINT);
+        ReflectionTestUtils.setField(atheneService, "atheneUrl", atheneUrl);
 
         // Create example exercise
         ZonedDateTime pastTimestamp = ZonedDateTime.now().minusDays(5);
@@ -78,6 +80,14 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
         exercise1.setId(1L);
 
         when(textExerciseRepository.findById(exercise1.getId())).thenReturn(Optional.ofNullable(exercise1));
+
+        atheneRequestMockProvider.enableMockingOfRequests();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        atheneRequestMockProvider.reset();
+        atheneService.finishTask(exercise1.getId());
     }
 
     /**
@@ -112,15 +122,10 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
                 .thenReturn(ModelFactory.generateTextSubmissions(10));
 
         // Create mock server
-        MockRestServiceServer mockServer = MockRestServiceServer.bindTo(restTemplate).build();
-        mockServer.expect(ExpectedCount.once(), requestTo(SUBMIT_API_ENDPOINT)).andExpect(method(HttpMethod.POST))
-                .andRespond(withSuccess("{ \"detail\": \"Submission successful\" }", MediaType.APPLICATION_JSON));
+        atheneRequestMockProvider.mockSubmitSubmissions();
 
         atheneService.submitJob(exercise1);
         assertThat(atheneService.isTaskRunning(exercise1.getId()));
-
-        // Check if mock server received specified requests
-        mockServer.verify();
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/service/connectors/athene/AtheneHealthIndicatorTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/connectors/athene/AtheneHealthIndicatorTest.java
@@ -1,0 +1,46 @@
+package de.tum.in.www1.artemis.service.connectors.athene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
+import de.tum.in.www1.artemis.connector.athene.AtheneRequestMockProvider;
+
+class AtheneHealthIndicatorTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+
+    @Autowired
+    private AtheneRequestMockProvider atheneRequestMockProvider;
+
+    @Autowired
+    private AtheneHealthIndicator atheneHealthIndicator;
+
+    @BeforeEach
+    public void initTestCase() {
+        atheneRequestMockProvider.enableMockingOfRequests();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        atheneRequestMockProvider.reset();
+    }
+
+    @Test
+    void healthUp() {
+        atheneRequestMockProvider.mockQueueStatus(true);
+        final Health health = atheneHealthIndicator.health();
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+    }
+
+    @Test
+    void healthDown() {
+        atheneRequestMockProvider.mockQueueStatus(false);
+        final Health health = atheneHealthIndicator.health();
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+    }
+}

--- a/src/test/resources/config/application-artemis.yml
+++ b/src/test/resources/config/application-artemis.yml
@@ -56,7 +56,6 @@ artemis:
         name: Artemis
         email: artemis@in.tum.de
     athene:
-        submit-url: http://localhost/submit
-        feedback-consistency-url: http://localhost:8001/feedback_consistency
+        url: http://localhost
         base64-secret: YWVuaXF1YWRpNWNlaXJpNmFlbTZkb283dXphaVF1b29oM3J1MWNoYWlyNHRoZWUzb2huZ2FpM211bGVlM0VpcAo=
         token-validity-in-seconds: 10800


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [X] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [X] ~Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)~
- [X] Server: I implemented the changes with a good performance and prevented too many database calls
- [X] Server: I documented the Java code using JavaDoc style.
- [X] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [X] ~Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)~
- [X] ~Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)~
- [X] ~Client: I documented the TypeScript code using JSDoc style.~
- [X] Client: I added multiple screenshots/screencasts of my UI changes
- [X] Client: I translated all the newly inserted strings into German and English

### Description
- Use `ClientHttpRequestInterceptor` to authenticate all calls to Athene. Replace custom implementation to set the needed HTTP Authorization header.
- Add `HealthIndicator` to monitor the availability of Athene service.

(Needs config update from Ansible PR `#13`.)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. 
    1. Log in to Artemis with Admin user
    2. Open the `Health Checks` page (Server Administration -> Health)
    3. Find Athene in the list of services.

2. 
    1. Login into Artemis (Instructor/admin)
    2. Create Text Exercise with Automatic Assessment
    3. (With different student accounts): Create > 10 submissions: for 5 each: identical content in an English sentence. (e.g. copy a sentence from Wikipedia.)
    4. [Exercise due date] + wait a few minutes
    5. Start assessment, find feedback suggestions (as usual).
    6. Add CONFLICTING assessments (different comment + score for identical sentences)
    7. Navigate out of assessment and back into the assessment
    8. Find conflict marked on feedback.
    9. Click the `Conflict` badge and view conflict.

### Test Coverage
`AtheneHealthIndicator`: 100%
`AtheneAuthorizationInterceptor`: 100%

### Screenshots
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/6382716/111227536-02719280-85e3-11eb-9b18-7861a745ff98.png">

### `application-prod.yml` Update
Configured on:

- [ ] Production
- [ ] Staging
- [X] Test Server 1
- [ ] Test Server 2
- [ ] Test Server 3
- [ ] Test Server 5
