### PR TITLE
Fix an oversight in the text assessment dashboard

### DIFF
--- a/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.html
+++ b/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.html
@@ -60,7 +60,7 @@
 </ng-template>
 
 <ng-template #noSubmission>
-    <div *ngIf="">
+    <div *ngIf="!loadingInitialSubmission">
         <div *ngIf="noNewSubmissions" class="alert alert-warning text-center mt-4" role="alert">
             <p jhiTranslate="artemisApp.textAssessment.notFound">We haven't found any new text submission without an assessment, please go back.</p>
             <a [routerLink]="exerciseDashboardLink" class="btn btn-info btn-sm mr-1 mb-1 assessment-dashboard">


### PR DESCRIPTION
### Checklist

- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context

Follow-up to #2994. Currently the "Exercise Dashboard" button is not displayed when there are no assessments left. So you had to go via the breadcrumbs.

### Description

The content of the `*ngIf` was simply missing/wrong, which is fixed now.

### Steps for Testing

1. Start assessing a text exercise
![grafik](https://user-images.githubusercontent.com/72132281/111304850-84e76a00-8656-11eb-8e77-54ed29b8c9fb.png)
2. Assess until there are no more assessments left
3. The following message should be displayed
![grafik](https://user-images.githubusercontent.com/72132281/111304883-93ce1c80-8656-11eb-8cd5-cb8c278956ae.png)
4. Make sure the button works as expected.
