### PR TITLE
Improved visibility of feedback button in external submission

### DIFF
--- a/src/main/webapp/app/exercises/shared/external-submission/external-submission-dialog.component.html
+++ b/src/main/webapp/app/exercises/shared/external-submission/external-submission-dialog.component.html
@@ -52,7 +52,9 @@
             </div>
         </div>
         <div class="form-group mb-2">
-            <a [hidden]="feedbacks.length > 0" (click)="pushFeedback()" jhiTranslate="artemisApp.result.addFeedback">Add feedback</a>
+            <button type="button" class="btn btn-default" [hidden]="feedbacks.length > 0" (click)="pushFeedback()">
+                <span jhiTranslate="artemisApp.result.addFeedback">Add feedback</span>
+            </button>
         </div>
         <div *ngIf="feedbacks.length > 0">
             <div *ngFor="let feedback of feedbacks; let i = index">
@@ -79,9 +81,13 @@
             </div>
         </div>
         <div class="form-group mb-2" *ngIf="feedbacks.length > 0">
-            <a (click)="pushFeedback()" jhiTranslate="artemisApp.result.addFeedback">More feedback</a>
+            <button type="button" class="btn btn-default" (click)="pushFeedback()">
+                <span jhiTranslate="artemisApp.result.addFeedback">More feedback</span>
+            </button>
             &nbsp;
-            <a (click)="popFeedback()" jhiTranslate="artemisApp.result.deleteFeedback">Less feedback</a>
+            <button type="button" class="btn btn-default" (click)="popFeedback()">
+                <span jhiTranslate="artemisApp.result.deleteFeedback">Less feedback</span>
+            </button>
         </div>
         <div class="form-group">
             <h4 class="control-label" jhiTranslate="artemisApp.result.rated">Rated</h4>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When a tutor or instructor views an exercise's overview (which can be reached by clicking on an exercise's ID) there is a yellow button in the top right corner which reads "Add External Submission".
When this button is clicked, student login, result text, and score can be added. Below these field, there is text which reads "Add new Feedback". Clicking this text shows new fields which can be used to add feedback. Because the "Add new Feedback" text is rendered in black it does not look like it has interactive functionality. I think it could be styled in a way which makes it more obvious that this text can be clicked.

### Description
<!-- Describe your changes in detail -->
Replaced `<a>` tag text with a button

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis (as tutor or instructor or admin)
2. Navigate to Course Administration and click on 'exercises' of a random course
3. Choose a random exercise and click on its **id or title** (to display the exercise detail view)
4. Click **add external submission** and check if the **add new feedback and delete last feedback** buttons look nice enough :sparkles: 

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

### Before
![Screenshot from 2021-03-17 08-51-41](https://user-images.githubusercontent.com/45761921/111434101-6ee1b400-86ff-11eb-866d-3115b402c681.png)

### After
![Screenshot from 2021-03-17 08-51-17](https://user-images.githubusercontent.com/45761921/111434114-71dca480-86ff-11eb-9697-57cc11aeedd8.png)
