### PR TITLE
[Bugfix] add sorting to instructor dashboards

### DIFF
--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.ts
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.ts
@@ -152,11 +152,9 @@ export class AssessmentDashboardComponent implements OnInit, AfterViewInit {
                     this.numberOfOpenComplaints = this.stats.numberOfOpenComplaints;
                     this.numberOfAssessmentLocks = this.stats.numberOfAssessmentLocks;
                     this.totalNumberOfAssessmentLocks = this.stats.totalNumberOfAssessmentLocks;
-
-                    // the received leaderboard from the server is still empty. TODO: fill on server side
                     const tutorLeaderboardEntry = this.stats.tutorLeaderboardEntries?.find((entry) => entry.userId === this.tutor.id);
+                    this.sortService.sortByProperty(this.stats.tutorLeaderboardEntries, 'points', false);
                     if (tutorLeaderboardEntry) {
-                        this.sortService.sortByProperty(this.stats.tutorLeaderboardEntries, 'points', false);
                         this.numberOfTutorAssessments = tutorLeaderboardEntry.numberOfAssessments;
                         this.numberOfTutorComplaints = tutorLeaderboardEntry.numberOfTutorComplaints;
                     } else {
@@ -194,8 +192,8 @@ export class AssessmentDashboardComponent implements OnInit, AfterViewInit {
                     this.numberOfOpenMoreFeedbackRequests = this.stats.numberOfOpenMoreFeedbackRequests;
                     this.numberOfAssessmentLocks = this.stats.numberOfAssessmentLocks;
                     const tutorLeaderboardEntry = this.stats.tutorLeaderboardEntries?.find((entry) => entry.userId === this.tutor.id);
+                    this.sortService.sortByProperty(this.stats.tutorLeaderboardEntries, 'points', false);
                     if (tutorLeaderboardEntry) {
-                        this.sortService.sortByProperty(this.stats.tutorLeaderboardEntries, 'points', false);
                         this.numberOfTutorAssessments = tutorLeaderboardEntry.numberOfAssessments;
                         this.numberOfTutorComplaints = tutorLeaderboardEntry.numberOfTutorComplaints;
                         this.numberOfTutorMoreFeedbackRequests = tutorLeaderboardEntry.numberOfTutorMoreFeedbackRequests;

--- a/src/main/webapp/app/course/dashboards/instructor-course-dashboard/instructor-course-dashboard.component.ts
+++ b/src/main/webapp/app/course/dashboards/instructor-course-dashboard/instructor-course-dashboard.component.ts
@@ -81,6 +81,7 @@ export class InstructorCourseDashboardComponent implements OnInit {
             map((res: HttpResponse<StatsForDashboard>) => Object.assign({}, this.stats, res.body)),
             tap((stats) => {
                 this.stats = StatsForDashboard.from(stats);
+                this.sortService.sortByProperty(this.stats.tutorLeaderboardEntries, 'points', false);
                 this.dataForAssessmentPieChart = [this.stats.numberOfSubmissions.total - this.stats.totalNumberOfAssessments.total, this.stats.totalNumberOfAssessments.total];
             }),
             catchError((response: string) => {

--- a/src/main/webapp/app/exercises/shared/dashboards/instructor/instructor-exercise-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/instructor/instructor-exercise-dashboard.component.ts
@@ -7,6 +7,7 @@ import { Exercise } from 'app/entities/exercise.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { ResultService } from 'app/exercises/shared/result/result.service';
 import { DueDateStat } from 'app/course/dashboards/instructor-course-dashboard/due-date-stat.model';
+import { SortService } from 'app/shared/service/sort.service';
 
 @Component({
     selector: 'jhi-instructor-exercise-dashboard',
@@ -29,6 +30,7 @@ export class InstructorExerciseDashboardComponent implements OnInit {
         private jhiAlertService: JhiAlertService,
         private resultService: ResultService,
         private router: Router,
+        private sortService: SortService,
     ) {}
 
     /**
@@ -84,6 +86,7 @@ export class InstructorExerciseDashboardComponent implements OnInit {
 
         this.exerciseService.getStatsForInstructors(exerciseId).subscribe(
             (res: HttpResponse<StatsForDashboard>) => {
+                this.sortService.sortByProperty(this.stats.tutorLeaderboardEntries, 'points', false);
                 this.stats = StatsForDashboard.from(Object.assign({}, this.stats, res.body));
                 this.setStatistics();
             },

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
@@ -261,8 +261,8 @@ export class ExerciseAssessmentDashboardComponent implements OnInit, AfterViewIn
                     this.numberOfMoreFeedbackRequests = this.statsForDashboard.numberOfMoreFeedbackRequests;
                     this.numberOfOpenMoreFeedbackRequests = this.statsForDashboard.numberOfOpenMoreFeedbackRequests;
                     const tutorLeaderboardEntry = this.statsForDashboard.tutorLeaderboardEntries?.find((entry) => entry.userId === this.tutor!.id);
+                    this.sortService.sortByProperty(this.statsForDashboard.tutorLeaderboardEntries, 'points', false);
                     if (tutorLeaderboardEntry) {
-                        this.sortService.sortByProperty(this.statsForDashboard.tutorLeaderboardEntries, 'points', false);
                         this.numberOfTutorAssessments = tutorLeaderboardEntry.numberOfAssessments;
                         this.numberOfTutorComplaints = tutorLeaderboardEntry.numberOfTutorComplaints;
                         this.numberOfTutorMoreFeedbackRequests = tutorLeaderboardEntry.numberOfTutorMoreFeedbackRequests;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Tutor leaderboard of the instructor dashboards was not sorted by points initially, like the other dashboards were. This PR fixes that.

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Management -> Select Instructor Dashboard
3. The tutors in the leaderboard (on the bottom) should be sorted by points.
4. Go in a exam specific instructor dashboard, and check the same.
![image](https://user-images.githubusercontent.com/33342534/111473088-f264ca80-872a-11eb-9f6e-77ada09f1cd4.png)
---->
![image](https://user-images.githubusercontent.com/33342534/111473127-ff81b980-872a-11eb-91ea-1548df8b0d98.png)

