### PR TITLE
[Bugfix] Participation Deletion Not Possible

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ParticipantScoreRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ParticipantScoreRepository.java
@@ -24,18 +24,9 @@ public interface ParticipantScoreRepository extends JpaRepository<ParticipantSco
 
     List<ParticipantScore> removeAllByExerciseId(Long exerciseId);
 
-    @Query("""
-                    SELECT ps
-                    FROM ParticipantScore ps
-                    WHERE
-                    ps.exercise.id = :exerciseId
-                    AND
-                    (
-                    ps.lastResult.participation.id = :participationId
-                    OR ps.lastRatedResult.participation.id = :participationId
-                    )
-            """)
-    List<ParticipantScore> findAllByParticipationIdAndExerciseId(@Param("exerciseId") Long exerciseId, @Param("participationId") Long participationId);
+    List<ParticipantScore> removeAllByLastResultId(Long lastResultId);
+
+    List<ParticipantScore> removeAllByLastRatedResultId(Long lastResultId);
 
     @EntityGraph(type = LOAD, attributePaths = { "exercise", "lastResult", "lastRatedResult" })
     Optional<ParticipantScore> findParticipantScoreByLastRatedResult(Result result);
@@ -75,8 +66,8 @@ public interface ParticipantScoreRepository extends JpaRepository<ParticipantSco
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW) // ok because of delete
-    default void deleteAllByParticipationIdTransactional(Long participationId, Long exerciseId) {
-        List<ParticipantScore> toDelete = findAllByParticipationIdAndExerciseId(participationId, exerciseId);
-        this.deleteInBatch(toDelete);
+    default void deleteAllByResultIdTransactional(Long resultId) {
+        this.removeAllByLastResultId(resultId);
+        this.removeAllByLastRatedResultId(resultId);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -614,7 +614,6 @@ public class ParticipationService {
     public Participation deleteResultsAndSubmissionsOfParticipation(Long participationId) {
         log.info("Request to delete all results and submissions of participation with id : {}", participationId);
         Participation participation = participationRepository.getOneWithEagerSubmissionsAndResults(participationId);
-        participantScoreRepository.deleteAllByParticipationIdTransactional(participationId, participation.getExercise().getId());
         Set<Submission> submissions = participation.getSubmissions();
         List<Result> resultsToBeDeleted = new ArrayList<>();
 
@@ -623,7 +622,7 @@ public class ParticipationService {
             resultsToBeDeleted.addAll(Objects.requireNonNull(submission.getResults()));
             submissionRepository.deleteById(submission.getId());
         });
-
+        resultsToBeDeleted.forEach(result -> participantScoreRepository.deleteAllByResultIdTransactional(result.getId()));
         // The results that are only connected to a participation are also deleted
         resultsToBeDeleted.forEach(participation::removeResult);
         participation.getResults().forEach(result -> resultRepository.deleteById(result.getId()));

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -15,7 +15,10 @@ import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.BuildPlanType;
 import de.tum.in.www1.artemis.domain.enumeration.InitializationState;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
-import de.tum.in.www1.artemis.domain.participation.*;
+import de.tum.in.www1.artemis.domain.participation.Participant;
+import de.tum.in.www1.artemis.domain.participation.Participation;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
+import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.exception.ContinuousIntegrationException;
@@ -65,11 +68,14 @@ public class ParticipationService {
 
     private final TeamRepository teamRepository;
 
+    private final ParticipantScoreRepository participantScoreRepository;
+
     public ParticipationService(UrlService urlService, ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository,
             StudentParticipationRepository studentParticipationRepository, ExerciseRepository exerciseRepository, ResultRepository resultRepository,
             SubmissionRepository submissionRepository, ComplaintResponseRepository complaintResponseRepository, ComplaintRepository complaintRepository,
             TeamRepository teamRepository, GitService gitService, QuizScheduleService quizScheduleService, ParticipationRepository participationRepository,
-            Optional<ContinuousIntegrationService> continuousIntegrationService, Optional<VersionControlService> versionControlService, RatingRepository ratingRepository) {
+            Optional<ContinuousIntegrationService> continuousIntegrationService, Optional<VersionControlService> versionControlService, RatingRepository ratingRepository,
+            ParticipantScoreRepository participantScoreRepository) {
         this.participationRepository = participationRepository;
         this.programmingExerciseStudentParticipationRepository = programmingExerciseStudentParticipationRepository;
         this.studentParticipationRepository = studentParticipationRepository;
@@ -85,6 +91,7 @@ public class ParticipationService {
         this.quizScheduleService = quizScheduleService;
         this.ratingRepository = ratingRepository;
         this.urlService = urlService;
+        this.participantScoreRepository = participantScoreRepository;
     }
 
     /**
@@ -606,8 +613,8 @@ public class ParticipationService {
     @Transactional // ok
     public Participation deleteResultsAndSubmissionsOfParticipation(Long participationId) {
         log.info("Request to delete all results and submissions of participation with id : {}", participationId);
-
         Participation participation = participationRepository.getOneWithEagerSubmissionsAndResults(participationId);
+        participantScoreRepository.deleteAllByParticipationIdTransactional(participationId, participation.getExercise().getId());
         Set<Submission> submissions = participation.getSubmissions();
         List<Result> resultsToBeDeleted = new ArrayList<>();
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/SubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/SubmissionResource.java
@@ -16,7 +16,9 @@ import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.ResultService;
+import de.tum.in.www1.artemis.service.SubmissionService;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
@@ -79,9 +81,8 @@ public class SubmissionResource {
         }
 
         checkAccessPermissionAtInstructor(submission.get());
-
-        Result result = submission.get().getLatestResult();
-        if (result != null) {
+        List<Result> results = submission.get().getResults();
+        for (Result result : results) {
             resultService.deleteResultWithComplaint(result.getId());
         }
         submissionRepository.deleteById(id);

--- a/src/test/java/de/tum/in/www1/artemis/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ParticipantScoreIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.lecture.ExerciseUnit;
+import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.ParticipationService;
 import de.tum.in.www1.artemis.util.ModelFactory;
@@ -73,6 +74,9 @@ public class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationBa
 
     @Autowired
     LectureUnitRepository lectureUnitRepository;
+
+    @Autowired
+    StudentParticipationRepository studentParticipationRepository;
 
     @AfterEach
     public void resetDatabase() {
@@ -147,6 +151,18 @@ public class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationBa
     @WithMockUser(username = "student1", roles = "USER")
     public void testAll_asStudent() throws Exception {
         this.testAllPreAuthorize();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void deleteParticipation_asInstructorOfCourse_shouldDeleteParticipation() throws Exception {
+        List<StudentParticipation> participations = studentParticipationRepository.findByExerciseIdAndStudentId(idOfIndividualTextExercise, idOfStudent1);
+        assertThat(participations).isNotEmpty();
+        for (StudentParticipation studentParticipation : participations) {
+            request.delete("/api/participations/" + studentParticipation.getId(), HttpStatus.OK);
+        }
+        participations = studentParticipationRepository.findByExerciseIdAndStudentId(idOfIndividualTextExercise, idOfStudent1);
+        assertThat(participations).isEmpty();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/ParticipantScoreIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ParticipantScoreIntegrationTest.java
@@ -159,6 +159,11 @@ public class ParticipantScoreIntegrationTest extends AbstractSpringIntegrationBa
         List<StudentParticipation> participations = studentParticipationRepository.findByExerciseIdAndStudentId(idOfIndividualTextExercise, idOfStudent1);
         assertThat(participations).isNotEmpty();
         for (StudentParticipation studentParticipation : participations) {
+            database.createSubmissionAndResult(studentParticipation, 30, false);
+        }
+        participations = studentParticipationRepository.findByExerciseIdAndStudentId(idOfIndividualTextExercise, idOfStudent1);
+        assertThat(participations).isNotEmpty();
+        for (StudentParticipation studentParticipation : participations) {
             request.delete("/api/participations/" + studentParticipation.getId(), HttpStatus.OK);
         }
         participations = studentParticipationRepository.findByExerciseIdAndStudentId(idOfIndividualTextExercise, idOfStudent1);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Deletion of participation was not possible. The reason was that the participation deletion happened in a transaction and this caused a conflict with the result entity listener.

### Description
<!-- Describe your changes in detail -->
Delete all participant scores related to the participation in a separate transaction before the results are deleted. I also added a test case for this issue

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

 Delete a Participation in Artemis that has submissions and results.