### PR TITLE
[Bugfix] Reconnect submissions to results for template/solution participation

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -69,7 +69,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
 
             if (this.programmingExercise.templateParticipation) {
                 this.programmingExercise.templateParticipation.programmingExercise = this.programmingExercise;
-                this.loadLatestResultWithFeedback(this.programmingExercise.templateParticipation.id!).subscribe((results) => {
+                this.loadLatestResultWithFeedbackAndSubmission(this.programmingExercise.templateParticipation.id!).subscribe((results) => {
                     this.programmingExercise.templateParticipation!.results = results;
                     this.loadingTemplateParticipationResults = false;
                 });
@@ -78,7 +78,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
             if (this.programmingExercise.solutionParticipation) {
                 this.programmingExercise.solutionParticipation.programmingExercise = this.programmingExercise;
 
-                this.loadLatestResultWithFeedback(this.programmingExercise.solutionParticipation.id!).subscribe((results) => {
+                this.loadLatestResultWithFeedbackAndSubmission(this.programmingExercise.solutionParticipation.id!).subscribe((results) => {
                     this.programmingExercise.solutionParticipation!.results = results;
                     this.loadingSolutionParticipationResults = false;
                 });
@@ -95,8 +95,8 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
      * @param participationId of the given participation.
      * @return an empty array if there is no result or an array with the single latest result.
      */
-    private loadLatestResultWithFeedback(participationId: number): Observable<Result[]> {
-        return this.programmingExerciseParticipationService.getLatestResultWithFeedback(participationId).pipe(
+    private loadLatestResultWithFeedbackAndSubmission(participationId: number): Observable<Result[]> {
+        return this.programmingExerciseParticipationService.getLatestResultWithFeedback(participationId, true).pipe(
             catchError(() => of(null)),
             map((result: Result | null) => {
                 return result ? [result] : [];

--- a/src/main/webapp/app/exercises/programming/manage/services/programming-exercise.service.ts
+++ b/src/main/webapp/app/exercises/programming/manage/services/programming-exercise.service.ts
@@ -14,6 +14,7 @@ import { TemplateProgrammingExerciseParticipation } from 'app/entities/participa
 import { SolutionProgrammingExerciseParticipation } from 'app/entities/participation/solution-programming-exercise-participation.model';
 import { TextPlagiarismResult } from 'app/exercises/shared/plagiarism/types/text/TextPlagiarismResult';
 import { PlagiarismOptions } from 'app/exercises/shared/plagiarism/types/PlagiarismOptions';
+import { Submission } from 'app/entities/submission.model';
 
 export type EntityResponseType = HttpResponse<ProgrammingExercise>;
 export type EntityArrayResponseType = HttpResponse<ProgrammingExercise[]>;
@@ -178,13 +179,43 @@ export class ProgrammingExerciseService {
     /**
      * Finds the programming exercise for the given exerciseId with the template and solution participation
      * @param programmingExerciseId of the programming exercise to retrieve
+     * @param withSubmissionResults get results attached to submissions
      */
     findWithTemplateAndSolutionParticipation(programmingExerciseId: number, withSubmissionResults = false): Observable<EntityResponseType> {
         let params = new HttpParams();
         params = params.set('withSubmissionResults', withSubmissionResults.toString());
         return this.http
             .get<ProgrammingExercise>(`${this.resourceUrl}/${programmingExerciseId}/with-template-and-solution-participation`, { params, observe: 'response' })
-            .pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)));
+            .pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)))
+            .pipe(
+                map((res: EntityResponseType) => {
+                    if (res.body && withSubmissionResults) {
+                        // We need to reconnect the submissions with the results. They got removed because of the circular dependency
+                        const templateSubmissions = res.body.templateParticipation?.submissions;
+                        this.reconnectSubmissionAndResult(templateSubmissions);
+                        const solutionSubmissions = res.body.solutionParticipation?.submissions;
+                        this.reconnectSubmissionAndResult(solutionSubmissions);
+                    }
+                    return res;
+                }),
+            );
+    }
+
+    /**
+     * Reconnecting the missing submission of a submission's result
+     *
+     * @param submissions where the results have no reference to its submission
+     */
+    private reconnectSubmissionAndResult(submissions: Submission[] | undefined) {
+        if (submissions) {
+            submissions.forEach((submission) => {
+                if (submission.results) {
+                    submission.results.forEach((result) => {
+                        result.submission = submission;
+                    });
+                }
+            });
+        }
     }
 
     /**

--- a/src/test/javascript/spec/service/programming-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise.service.spec.ts
@@ -15,6 +15,9 @@ import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { ArtemisSharedComponentModule } from 'app/shared/components/shared-component.module';
 import { ArtemisProgrammingExerciseManagementModule } from 'app/exercises/programming/manage/programming-exercise-management.module';
 import * as moment from 'moment';
+import { TemplateProgrammingExerciseParticipation } from 'app/entities/participation/template-programming-exercise-participation.model';
+import { ProgrammingSubmission } from 'app/entities/programming-submission.model';
+import { Result } from 'app/entities/result.model';
 
 describe('ProgrammingExercise Service', () => {
     let injector: TestBed;
@@ -71,6 +74,23 @@ describe('ProgrammingExercise Service', () => {
                 .subscribe((resp) => expect(resp).toMatchObject({ body: expected }));
             const req = httpMock.expectOne({ method: 'POST' });
             req.flush(JSON.stringify(returnedFromService));
+        });
+
+        it('should reconnect template submission with result', async () => {
+            const templateParticipation = new TemplateProgrammingExerciseParticipation();
+            const tempSubmission = new ProgrammingSubmission();
+            const tempResult = new Result();
+            tempResult.id = 2;
+            tempSubmission.results = [tempResult];
+            templateParticipation.submissions = [tempSubmission];
+            const returnedFromService = Object.assign({ id: 0 }, { ...elemDefault, templateParticipation });
+            const expected = Object.assign({}, returnedFromService);
+            service
+                .findWithTemplateAndSolutionParticipation(expected.id, true)
+                .pipe(take(1))
+                .subscribe((resp) => expect(resp).toMatchObject({ body: expected }));
+            const req = httpMock.expectOne({ method: 'GET' });
+            req.flush(returnedFromService);
         });
 
         it('should update a ProgrammingExercise', async () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The failed build result for template and solution submissions are not accessible via the programming exercise detail and submission view.

### Description
<!-- Describe your changes in detail -->
Submissions of template and solution participations do not have their result connected to the submission. The structure is in these views the following:
Participation->submissions->result->submission missing!
But the result component can only fetch the submission via the provided result. 
This lead to a not clickable build failed result iff the build had failed and there are no feedbacks.

This PR reconnects the result with its submission directly after the REST call. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a programming exercise
4. Cause a build failed in the solution and/or the template
5. Now verify that the result in the exercise detail view and submission view is clickable and shows the message `Build failed` instead of `No tests found`.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
programming-exercise.service.ts: 76%

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
#### Current error on development: 
Not clickable and wrong message in Exercise Details:
![image](https://user-images.githubusercontent.com/33484318/111745972-a716fd00-888d-11eb-9b32-71f67bc0f521.png)
and in Submission view:
![image](https://user-images.githubusercontent.com/33484318/111746079-cf9ef700-888d-11eb-8363-41584f21c7a5.png)


#### Solution -> Programming Exercise Details: the shown message should be `Build failed` and clickable: 
![image](https://user-images.githubusercontent.com/33484318/111745894-8babf200-888d-11eb-8924-5a438d750303.png)
And in the Submission View:
![image](https://user-images.githubusercontent.com/33484318/111747085-26590080-888f-11eb-9e1d-ac35fc0d4b41.png)
