### PR TITLE
[Docs] Information on GitLab User PW Reset Patch & Jenkins Docker Pipeline Plugin

### DIFF
--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -478,7 +478,7 @@ recommended ones that got installed during the setup process):
 
     **Note:** This is a suite of plugins that will install multiple plugins
 
-4. `Pipeline Maven <https://plugins.jenkins.io/pipeline-maven/>`__ to use maven within the pipelines.
+4. `Pipeline Maven <https://plugins.jenkins.io/pipeline-maven/>`__ to use maven within the pipelines. If you want to use docker for your build agents you may also need to install `Docker Pipeline <https://plugins.jenkins.io/docker-workflow/>`__ .
 
 5. `Matrix Authorization Strategy Plugin <https://plugins.jenkins.io/matrix-auth/>`__ for configuring permissions for users on a project and build plan level (Matrix Authorization Strategy might already be installed).
 

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -127,7 +127,21 @@ GitLab
 Gitlab Server Setup
 ~~~~~~~~~~~~~~~~~~~
 
-1. Pull the latest GitLab Docker image
+GitLab provides no possibility to set a users password via API without forcing the user to change it afterwards (see `Issue 19141 <https://gitlab.com/gitlab-org/gitlab/-/issues/19141>`__).
+Therefore, you may want to patch the official gitlab docker image.
+Thus, you can use the following Dockerfile:
+
+.. code:: dockerfile
+
+    FROM gitlab/gitlab-ce:latest
+    RUN sed -i '/^.*user_params\[:password_expires_at\] = Time.current if admin_making_changes_for_another_user.*$/s/^/#/' /opt/gitlab/embedded/service/gitlab-rails/lib/api/users.rb
+
+
+This dockerfile disables the mechanism that sets the password to expired state after changed via API.
+If you want to use this custom image, you have to build the image and replace all occurances of ``gitlab/gitlab-ce:latest`` in the following instructions by your chosen image name.
+
+
+1. Pull the latest GitLab Docker image (only if you don't use your custom gitlab image)
 
    ::
 


### PR DESCRIPTION
**Important: This PR operates on a mirror branch of [kit-sdq](https://github.com/kit-sdq/Artemis/tree/enhancement/gitlab-jenkins-docs). Do not modify this branch here, as changes may be overridden by mirroring!**

### Motivation, Context, and Description
I've encountered two issues in the documentation regarding the documentation resp. setup of the jenkins/gitlab server configuration:

1. The information that you might have to install the `Docker Pipeline Plugin` for Jenkins was not mentioned (so I added this information)
2. GitLab has the "Feature" that changes via REST API like password changes force the gitlab user to reset the password upon next login (see [here](https://gitlab.com/gitlab-org/gitlab/-/issues/19141)). This behavior can be disabled via a patch in the official docker file of gitlab. So I've added a description of the necessary steps to create a "repaired" version of gitlab.


If you have any questions to this PR, feel free to ask :) 

