### PR TITLE
Update artemis-java-test-sandbox to Version 1.5.0

### DIFF
--- a/src/main/resources/templates/java/maven/test/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/maven/test/projectTemplate/pom.xml
@@ -18,7 +18,7 @@
             <!-- Comes with JUnit 5, AssertJ and Hamcrest. JUnit 4 (JUnit 5 Vintage) or jqwik need to be added explicitly -->
             <groupId>de.tum.in.ase</groupId>
             <artifactId>artemis-java-test-sandbox</artifactId>
-            <version>1.4.6</version>
+            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/resources/templates/java/test/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/test/projectTemplate/pom.xml
@@ -18,7 +18,7 @@
             <!-- Comes with JUnit 5, AssertJ and Hamcrest. JUnit 4 (JUnit 5 Vintage) or jqwik need to be added explicitly -->
             <groupId>de.tum.in.ase</groupId>
             <artifactId>artemis-java-test-sandbox</artifactId>
-            <version>1.4.6</version>
+            <version>1.5.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/resources/templates/kotlin/test/projectTemplate/pom.xml
+++ b/src/main/resources/templates/kotlin/test/projectTemplate/pom.xml
@@ -20,7 +20,7 @@
             <!-- Comes with JUnit 5, AssertJ and Hamcrest. JUnit 4 (JUnit 5 Vintage) or jqwik need to be added explicitly -->
             <groupId>de.tum.in.ase</groupId>
             <artifactId>artemis-java-test-sandbox</artifactId>
-            <version>1.4.6</version>
+            <version>1.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
Just a dependency update of `artemis-java-test-sandbox`. This mainly adds support for Java 16 for artemis-java-test-sandbox.

For details, see https://github.com/ls1intum/artemis-java-test-sandbox/compare/1.4.6...1.5.0

See also the update PRs in
 - https://github.com/ls1intum/artemis-maven-docker/pull/6