### PR TITLE
Remove redundant tooltip from Student Q&A

### DIFF
--- a/src/main/webapp/app/overview/student-questions/student-questions.component.html
+++ b/src/main/webapp/app/overview/student-questions/student-questions.component.html
@@ -57,11 +57,7 @@
             <!-- new question button -->
             <div class="row" *ngIf="!isEditMode">
                 <div class="col-12">
-                    <button
-                        class="btn btn-sm btn-outline-secondary"
-                        [ngbTooltip]="'artemisApp.courseOverview.exerciseDetails.faq.addNewQuestion' | artemisTranslate"
-                        (click)="isEditMode = true"
-                    >
+                    <button class="btn btn-sm btn-outline-secondary" (click)="isEditMode = true">
                         <fa-icon [icon]="'plus'"></fa-icon>
                         <span class="d-none d-md-inline">{{ 'artemisApp.courseOverview.exerciseDetails.faq.addNewQuestion' | artemisTranslate }}</span>
                     </button>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Fixing #3043

### Description
The button "Add a new Question" doesn't show a redundant tooltip any more.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate into an exercise where Q&A is enabled in the course
3. Hover over "Add a new Question" and see no redundant tooltip (no tooltip should be shown at all)