### PR TITLE
Improve sorting of exercises for students

### DIFF
--- a/src/main/webapp/app/overview/course-exercises/course-exercises.component.ts
+++ b/src/main/webapp/app/overview/course-exercises/course-exercises.component.ts
@@ -271,7 +271,8 @@ export class CourseExercisesComponent implements OnInit, OnChanges, OnDestroy {
             const sortingAttributeB = byAttribute(b);
             const aValue = sortingAttributeA ? sortingAttributeA.seconds(0).milliseconds(0).valueOf() : moment().valueOf();
             const bValue = sortingAttributeB ? sortingAttributeB.seconds(0).milliseconds(0).valueOf() : moment().valueOf();
-            return this.sortingOrder.valueOf() * (aValue - bValue === 0 ? a.title!.localeCompare(b.title!) : aValue - bValue);
+            const titleSortValue = a.title && b.title ? a.title.localeCompare(b.title) : 0;
+            return this.sortingOrder.valueOf() * (aValue - bValue === 0 ? titleSortValue : aValue - bValue);
         });
     }
 }

--- a/src/main/webapp/app/overview/course-exercises/course-exercises.component.ts
+++ b/src/main/webapp/app/overview/course-exercises/course-exercises.component.ts
@@ -269,9 +269,9 @@ export class CourseExercisesComponent implements OnInit, OnChanges, OnDestroy {
         return exercises?.sort((a, b) => {
             const sortingAttributeA = byAttribute(a);
             const sortingAttributeB = byAttribute(b);
-            const aValue = sortingAttributeA ? sortingAttributeA.valueOf() : moment().valueOf();
-            const bValue = sortingAttributeB ? sortingAttributeB.valueOf() : moment().valueOf();
-            return this.sortingOrder.valueOf() * (aValue - bValue);
+            const aValue = sortingAttributeA ? sortingAttributeA.seconds(0).milliseconds(0).valueOf() : moment().valueOf();
+            const bValue = sortingAttributeB ? sortingAttributeB.seconds(0).milliseconds(0).valueOf() : moment().valueOf();
+            return this.sortingOrder.valueOf() * (aValue - bValue === 0 ? a.title!.localeCompare(b.title!) : aValue - bValue);
         });
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
From https://sharing-codeability.uibk.ac.at/sharing/artemis-user-documentation/-/issues/29

Currently exercises will get sorted by due date (https://github.com/ls1intum/Artemis/issues/1061#issuecomment-555739659). After that is is seemingly random. It's not sorted by id, name, creationTime, ...
We have created 10-ish exercises per week, which should go live at the same time and stay online for the same time (1st Oct 12:00 - 8th Oct 12:00), I can not figure out, how they are sorted after due date.

Expected Behaviour:
**Exercises are sorted by a second key (we would prefer sorting by name)**

### Description
<!-- Describe your changes in detail -->
Added sorting by exercise title if due/release date is the same.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create or use an existing course with multiple exercises with the same due or release date
4. Navigate to the Course overview of the course
5. Check if the exercises are sorted by title 

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
#### Before
![Screenshot from 2021-03-22 10-31-21](https://user-images.githubusercontent.com/45761921/111968823-dfbb0e80-8af9-11eb-95d7-92f0e94b7bcf.png)

#### After
![Screenshot from 2021-03-22 10-31-59](https://user-images.githubusercontent.com/45761921/111968836-e34e9580-8af9-11eb-8e3d-166aa0e1cc70.png)
