### PR TITLE
Automatically combine template on release of programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -9,6 +9,10 @@ public final class Constants {
 
     public static int COMPLAINT_LOCK_DURATION_IN_MINUTES = 1440; // 24h
 
+    public static int SECONDS_BEFORE_RELEASE_DATE_FOR_COMBINING_TEMPLATE_COMMITS = 60;
+
+    public static int SECONDS_AFTER_RELEASE_DATE_FOR_UNLOCKING_STUDENT_EXAM_REPOS = 5;
+
     // Regex for acceptable logins
     public static final String LOGIN_REGEX = "^[_'.@A-Za-z0-9-]*$";
 

--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -100,6 +100,8 @@ public final class Constants {
 
     public static final String PROGRAMMING_EXERCISE_SUCCESSFUL_UNLOCK_OPERATION_NOTIFICATION = "The student repositories for this programming exercise were unlocked successfully.";
 
+    public static final String PROGRAMMING_EXERCISE_SUCCESSFUL_COMBINE_OF_TEMPLATE_COMMITS = "The template commits for this programming exercise were combined successfully.";
+
     public static final int FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS = 5000;
 
     public static final String ASSIGNMENT_CHECKOUT_PATH = "assignment";

--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -57,6 +57,16 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
     @Query("select distinct pe from ProgrammingExercise pe left join fetch pe.studentParticipations")
     List<ProgrammingExercise> findAllWithEagerParticipations();
 
+
+    // Get all programming exercises that need to be scheduled: Those must satisfy one of the following requirements:
+    // 1. The release date is in the future --> Schedule combine template commits
+    // 2. The build and test student submissions after deadline date is in the future
+    // 3. Manual assessment is enabled and the due date is in the future
+    @Query("select distinct pe from ProgrammingExercise pe where pe.releaseDate > :#{#now} or " +
+        "pe.buildAndTestStudentSubmissionsAfterDueDate > :#{#now} or " +
+        "pe.assessmentType <> 'AUTOMATIC' and pe.dueDate > :#{#now}")
+    List<ProgrammingExercise> findAllToBeScheduled(@Param("now") ZonedDateTime now);
+
     @Query("select distinct pe from ProgrammingExercise pe where pe.course.endDate between :#{#endDate1} and :#{#endDate2}")
     List<ProgrammingExercise> findAllByRecentCourseEndDate(@Param("endDate1") ZonedDateTime endDate1, @Param("endDate2") ZonedDateTime endDate2);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -405,6 +405,18 @@ public class GitService {
         }
     }
 
+    /**
+     * Combine all commits of the given repository into one.
+     *
+     * @param repoUrl of the repository to combine.
+     * @throws InterruptedException If the checkout fails
+     * @throws GitAPIException      If the checkout fails
+     */
+    public void combineAllCommitsOfRepositoryIntoOne(VcsRepositoryUrl repoUrl) throws InterruptedException, GitAPIException {
+        Repository exerciseRepository = getOrCheckoutRepository(repoUrl, true);
+        combineAllCommitsIntoInitialCommit(exerciseRepository);
+    }
+
     public Path getDefaultLocalPathOfRepo(VcsRepositoryUrl targetUrl) {
         return getLocalPathOfRepo(repoClonePath, targetUrl);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -818,15 +818,23 @@ public class ExamService {
         return submissions;
     }
 
-    public void squashTemplates(Exam exam) {
+    /**
+     * Combines the template commits of all programming exercises in the exam.
+     * This is executed before the individual student exams are generated.
+     *
+     * @param exam - the exam which template commits should be combined
+     */
+    public void combineTemplateCommitsOfAllProgrammingExercisesInExam(Exam exam) {
         exam.getExerciseGroups().forEach(group -> group.getExercises().stream().filter(exercise -> exercise instanceof ProgrammingExercise)
                 .map(exercise -> (ProgrammingExercise) exercise).forEach(exercise -> {
                     try {
-                        gitService.combineAllCommitsOfRepositoryIntoOne(exercise.getVcsTemplateRepositoryUrl());
+                        ProgrammingExercise programmingExerciseWithTemplateParticipation = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(exercise.getId());
+                        gitService.combineAllCommitsOfRepositoryIntoOne(programmingExerciseWithTemplateParticipation.getTemplateParticipation().getVcsRepositoryUrl());
+                        log.debug("Finished combination of template commits for programming exercise " + programmingExerciseWithTemplateParticipation.toString());
+                    } catch (InterruptedException | GitAPIException e) {
+                        log.error("An error occurred when trying to combine template commits for exam " + exam.getId() + ".", e);
                     }
-                    catch (InterruptedException | GitAPIException e) {
-                        e.printStackTrace();
-                    }
-                }));
+            })
+        );
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -579,18 +579,6 @@ public class ProgrammingExerciseService {
     }
 
     /**
-     * Combine all commits of the given repository into one.
-     *
-     * @param repoUrl of the repository to combine.
-     * @throws InterruptedException If the checkout fails
-     * @throws GitAPIException      If the checkout fails
-     */
-    public void combineAllCommitsOfRepositoryIntoOne(VcsRepositoryUrl repoUrl) throws InterruptedException, GitAPIException {
-        Repository exerciseRepository = gitService.getOrCheckoutRepository(repoUrl, true);
-        gitService.combineAllCommitsIntoInitialCommit(exerciseRepository);
-    }
-
-    /**
      * Updates the timeline attributes of the given programming exercise
      * @param updatedProgrammingExercise containing the changes that have to be saved
      * @param notificationText optional text for a notification to all students about the update

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ProgrammingExerciseScheduleService.java
@@ -154,7 +154,7 @@ public class ProgrammingExerciseScheduleService implements IExerciseScheduleServ
         if (exercise.getReleaseDate() != null && ZonedDateTime.now().isBefore(exercise.getReleaseDate())) {
             scheduleService.scheduleTask(exercise, ExerciseLifecycle.RELEASE, () -> {
                 try {
-                    gitService.combineAllCommitsOfRepositoryIntoOne(exercise.getRepositoryURL(RepositoryType.TEMPLATE));
+                    gitService.combineAllCommitsOfRepositoryIntoOne(exercise.getVcsTemplateRepositoryUrl());
                 } catch (InterruptedException e) {
                     log.error("Failed to schedule combining of template commits of exercise " + exercise.getId(), e);
                 } catch (GitAPIException e) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -494,7 +494,9 @@ public class ExamResource {
     public ResponseEntity<List<StudentExam>> generateStudentExams(@PathVariable Long courseId, @PathVariable Long examId) {
         long start = System.nanoTime();
         log.info("REST request to generate student exams for exam {}", examId);
-        final var exam = examRepository.findByIdWithRegisteredUsersExerciseGroupsAndExercisesElseThrow(examId);
+        final Exam exam = examRepository.findByIdWithRegisteredUsersExerciseGroupsAndExercisesElseThrow(examId);
+
+        exam.getExerciseGroups().forEach(e -> e.getExercises().forEach(System.out::println));
 
         Optional<ResponseEntity<List<StudentExam>>> courseAndExamAccessFailure = examAccessService.checkCourseAndExamAccessForInstructor(courseId, exam);
         if (courseAndExamAccessFailure.isPresent()) {
@@ -503,6 +505,8 @@ public class ExamResource {
 
         // Validate settings of the exam
         examService.validateForStudentExamGeneration(exam);
+
+        examService.squashTemplates(exam);
 
         List<StudentExam> studentExams = examService.generateStudentExams(exam);
 
@@ -530,7 +534,7 @@ public class ExamResource {
     public ResponseEntity<List<StudentExam>> generateMissingStudentExams(@PathVariable Long courseId, @PathVariable Long examId) {
         log.info("REST request to generate missing student exams for exam {}", examId);
 
-        final var exam = examRepository.findByIdWithRegisteredUsersExerciseGroupsAndExercisesElseThrow(examId);
+        final Exam exam = examRepository.findByIdWithRegisteredUsersExerciseGroupsAndExercisesElseThrow(examId);
 
         Optional<ResponseEntity<List<StudentExam>>> courseAndExamAccessFailure = examAccessService.checkCourseAndExamAccessForInstructor(courseId, examId);
         if (courseAndExamAccessFailure.isPresent()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -506,7 +506,7 @@ public class ExamResource {
         // Validate settings of the exam
         examService.validateForStudentExamGeneration(exam);
 
-        examService.squashTemplates(exam);
+        examService.combineTemplateCommitsOfAllProgrammingExercisesInExam(exam);
 
         List<StudentExam> studentExams = examService.generateStudentExams(exam);
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
+import de.tum.in.www1.artemis.service.connectors.GitService;
 import jplag.ExitException;
 
 import org.apache.http.HttpException;
@@ -110,6 +111,8 @@ public class ProgrammingExerciseResource {
 
     private final CourseRepository courseRepository;
 
+    private final GitService gitService;
+
     /**
      * Java package name Regex according to Java 14 JLS (https://docs.oracle.com/javase/specs/jls/se14/html/jls-7.html#jls-7.4.1),
      * with the restriction to a-z,A-Z,_ as "Java letter" and 0-9 as digits due to JavaScript/Browser Unicode character class limitations
@@ -131,7 +134,8 @@ public class ProgrammingExerciseResource {
             ExerciseService exerciseService, ProgrammingExerciseService programmingExerciseService, StudentParticipationRepository studentParticipationRepository,
             ProgrammingExerciseImportService programmingExerciseImportService, ProgrammingExerciseExportService programmingExerciseExportService,
             ExerciseGroupService exerciseGroupService, StaticCodeAnalysisService staticCodeAnalysisService, GradingCriterionService gradingCriterionService,
-            ProgrammingLanguageFeatureService programmingLanguageFeatureService, TemplateUpgradePolicy templateUpgradePolicy, CourseRepository courseRepository) {
+            ProgrammingLanguageFeatureService programmingLanguageFeatureService, TemplateUpgradePolicy templateUpgradePolicy, CourseRepository courseRepository,
+            GitService gitService) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.userRepository = userRepository;
         this.courseService = courseService;
@@ -149,6 +153,7 @@ public class ProgrammingExerciseResource {
         this.programmingLanguageFeatureService = programmingLanguageFeatureService;
         this.templateUpgradePolicy = templateUpgradePolicy;
         this.courseRepository = courseRepository;
+        this.gitService = gitService;
     }
 
     /**
@@ -950,7 +955,7 @@ public class ProgrammingExerciseResource {
 
         try {
             var exerciseRepoURL = programmingExercise.getVcsTemplateRepositoryUrl();
-            programmingExerciseService.combineAllCommitsOfRepositoryIntoOne(exerciseRepoURL);
+            gitService.combineAllCommitsOfRepositoryIntoOne(exerciseRepoURL);
             return new ResponseEntity<>(HttpStatus.OK);
         }
         catch (IllegalStateException | InterruptedException | GitAPIException ex) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [ ] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
Instructors forgot to combine template commits of programming exercises before the release date and exam exercise preparation in some instances. Therefore we want to change the current system to combine template commits shortly before the release and before exam exercise preparation automatically.
Closes [#2771](https://github.com/ls1intum/Artemis/issues/2771)

### Description
The combination of template commits is now scheduled exactly one minute before the set release date of the exercise. The combination behaviour is not different from pressing the "_Combine Template Commits_" button in the exercise overview. In the case of an exam, the template commits of all programming exercises in all exercise groups are combined once an instructor presses the "_Generate individual exams_" button in the _student exams_ overview.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites: 1x instructor account, 1x test course and 1x exam with at least one registered student and one exercise group

**Regular Programming Exercises**
1. Generate new programming exercises with the following properties:
        - Release Date in the future, but no Due Date
        - Release Date in the future, Due Date in the future, but no "Run Tests after Due Date"
        - Release Date in the future, Due Date in the future, "Run Tests after Due Date" in the future, but no manual assessment
        - Release Date in the future, Due Date in the future, "Run Tests after Due Date" in the future and manual assessment 
          enabled
2. Generate some commits in the template repository for each created exercise finishing at least 1 minute before the release date
3. Ensure that the template commits for each created programming exercise are combined one minute before the release date of the individual exam
4. Ensure that every other expected action still works as intended (e.g. run tests after the due date, manual assessment)

**Exam Programming Exercises**
1. Generate a new programming exercise in the prepared exercise group
2. Generate some commits in the template repository of the created exercise group
3. Navigate to the _Student Exams_ overview
4. Press the "_Generate individual exams_" button
5. Navigate back to your created exercise
6. Ensure that the template commits have been combined

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
