### PR TITLE
Fix strict template issues in the exercise headers

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
@@ -50,7 +50,7 @@
                 <div class="col-6">
                     <h5>
                         {{ exercise.type | exerciseTypeLabel }}
-                        <fa-icon [icon]="getIcon(exercise.type)" placement="right"></fa-icon>
+                        <fa-icon *ngIf="icon" [icon]="icon" placement="right"></fa-icon>
                     </h5>
                 </div>
             </div>

--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.ts
@@ -3,6 +3,7 @@ import * as moment from 'moment';
 import { Exercise, ExerciseCategory, getIcon, IncludedInOverallScore } from 'app/entities/exercise.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { Exam } from 'app/entities/exam.model';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
     selector: 'jhi-header-exercise-page-with-details',
@@ -10,17 +11,19 @@ import { Exam } from 'app/entities/exam.model';
 })
 export class HeaderExercisePageWithDetailsComponent implements OnInit, OnChanges {
     readonly IncludedInOverallScore = IncludedInOverallScore;
+
     @Input() public exercise: Exercise;
     @Input() public onBackClick: () => void; // TODO: This can be removed once we are happy with the breadcrumb navigation
     @Input() public title: string;
     @Input() public exam: Exam | null;
     @Input() public isTestRun = false;
     @Input() public displayBackButton = true; // TODO: This can be removed once we are happy with the breadcrumb navigation
+
     public exerciseStatusBadge = 'badge-success';
     public exerciseCategories: ExerciseCategory[];
     public isExamMode = false;
 
-    getIcon = getIcon;
+    icon: IconProp;
 
     constructor(private exerciseService: ExerciseService) {}
 
@@ -30,6 +33,7 @@ export class HeaderExercisePageWithDetailsComponent implements OnInit, OnChanges
     ngOnInit(): void {
         this.setExerciseStatusBadge();
         this.exerciseCategories = this.exerciseService.convertExerciseCategoriesFromServer(this.exercise);
+        this.icon = getIcon(this.exercise?.type) as IconProp;
     }
 
     /**
@@ -38,6 +42,7 @@ export class HeaderExercisePageWithDetailsComponent implements OnInit, OnChanges
     ngOnChanges(): void {
         this.setExerciseStatusBadge();
         this.exerciseCategories = this.exerciseService.convertExerciseCategoriesFromServer(this.exercise);
+        this.icon = getIcon(this.exercise?.type) as IconProp;
 
         if (this.exam) {
             this.isExamMode = true;


### PR DESCRIPTION
### Checklist

- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Description

Removes strict template errors in the exercise headers. Also removes a method call from the template.

### Steps for Testing

Check that exercise icons are still correctly displayed for:
- the exercise assessment dashboard
- the instructor exercise assessment dashboard
- the student exercise details page

### Screenshots

The icon on the student page:
![grafik](https://user-images.githubusercontent.com/72132281/112984461-33170780-915f-11eb-83f7-8100bd8effad.png)

Instructor exercise dashboard:
![grafik](https://user-images.githubusercontent.com/72132281/112984547-4e821280-915f-11eb-9ff3-483361c7b54e.png)

Exercise assessment dashboard:
![grafik](https://user-images.githubusercontent.com/72132281/112984580-59d53e00-915f-11eb-9270-6f2a1dfbf3d5.png)

