### PR TITLE
changes as described in chore/angular/strict-templates, only changes to confirm-icon.component.ts

### DIFF
--- a/src/main/webapp/app/shared/confirm-icon/confirm-icon.component.ts
+++ b/src/main/webapp/app/shared/confirm-icon/confirm-icon.component.ts
@@ -1,13 +1,14 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
     selector: 'jhi-confirm-icon',
     templateUrl: './confirm-icon.component.html',
 })
 export class ConfirmIconComponent implements OnInit {
-    @Input() initialIcon = 'trash';
+    @Input() initialIcon = <IconProp>'trash';
     @Input() initialTooltip: string;
-    @Input() confirmIcon = 'check';
+    @Input() confirmIcon = <IconProp>'check';
     @Input() confirmTooltip: string;
     @Output() confirmEvent = new EventEmitter();
     showConfirm = false;


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

changes to move angular strict templates forward

### Description
<!-- Describe your changes in detail -->

added Typecast from String to IconProp to make code compilable in this dir;
added import for IconProp;

### Steps for Testing
just code review
