### PR TITLE
[Test] Added Integration test for ComplaintResource

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
@@ -304,6 +304,25 @@ public class AssessmentComplaintIntegrationTest extends AbstractSpringIntegratio
     }
 
     @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void getComplaintsForAssessmentDashboard_testRun() throws Exception {
+        complaint.setParticipant(database.getUserByLogin("instructor1"));
+        complaintRepo.save(complaint);
+
+        final var params = new LinkedMultiValueMap<String, String>();
+        params.add("complaintType", ComplaintType.COMPLAINT.name());
+        final var complaints = request.getList("/api/exercises/" + modelingExercise.getId() + "/complaints-for-test-run-dashboard", HttpStatus.OK, Complaint.class, params);
+
+        complaints.forEach(compl -> {
+            final var participation = (StudentParticipation) compl.getResult().getParticipation();
+            assertThat(participation.getStudent()).as("No student information").isNull();
+            assertThat(compl.getParticipant()).as("No student information").isNull();
+            assertThat(participation.getExercise()).as("No additional exercise information").isNull();
+            assertThat(compl.getResultBeforeComplaint()).as("No old result information").isNull();
+        });
+    }
+
+    @Test
     @WithMockUser(username = "student1")
     public void getComplaintResponseByComplaintId_reviewerHiddenForStudent() throws Exception {
         complaint.setParticipant(database.getUserByLogin("student1"));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Server: I added an integration test 

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The `getMoreFeedbackRequestsForAssessmentDashboard` REST endpoint was not yet tested. With this PR we add a test to do so.

### Description
<!-- Describe your changes in detail -->
Previous coverage:
![image](https://user-images.githubusercontent.com/33342534/113145551-d6831d80-922e-11eb-8ace-62e9f715b373.png)
Coverage now (seen on the very left):
![image](https://user-images.githubusercontent.com/33342534/113145719-12b67e00-922f-11eb-969f-fae65ca4f903.png)