### PR TITLE
[ GitLab ] - Internal Server Error when creating repo for user with dots in the login

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
@@ -353,8 +353,8 @@ public class GitLabService extends AbstractVersionControlService {
     public void createRepository(String projectKey, String repoName, String parentProjectKey) throws VersionControlException {
         try {
             final var groupId = gitlab.getGroupApi().getGroup(projectKey).getId();
-            final var project = new Project().withName(repoName.toLowerCase()).withNamespaceId(groupId).withVisibility(Visibility.PRIVATE).withJobsEnabled(false)
-                    .withSharedRunnersEnabled(false).withContainerRegistryEnabled(false);
+            final var project = new Project().withPath(repoName.toLowerCase()).withName(repoName.toLowerCase()).withNamespaceId(groupId).withVisibility(Visibility.PRIVATE)
+                    .withJobsEnabled(false).withSharedRunnersEnabled(false).withContainerRegistryEnabled(false);
             gitlab.getProjectApi().createProject(project);
         }
         catch (GitLabApiException e) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With ArTEMiS 4.10 the forking of the template repository to the students' repositories, has been replaced with copying.

Some problems occurred when users/students with a dot in the login (ex. student.4321) tried to start/participate to new programming exercises. An **internal server error - 500** would appear and the new repository remains empty in GitLab.

### Description
<!-- Describe your changes in detail -->
It appears that GitLab replaces the dots in ProjectNames with hypens in their URL's, which caused the error as the repository couldn't be found anymore during the copy.

By adding `withPath()` to the Project object it can be ensured that this replacement does not occur.

See https://gitlab.com/gitlab-org/gitlab/-/issues/18292#note_214998981

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

(On TS2 only)
1. Log in to Artemis
2. Create a user with a dot in the login
3. Log in using this new user
4. Try to start a new Programming Exercise

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
