### PR TITLE
[Bugfix] use artemisTimeAgo pipe for exam release date badge

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
@@ -16,7 +16,7 @@
                 <h4 *ngIf="!isTestRun">
                     <span class="mr-2"> {{ 'artemisApp.exam.publishResultsDate' | artemisTranslate }} : {{ exam?.publishResultsDate | artemisDate }} </span>
                     <span *ngIf="exam?.publishResultsDate" [ngClass]="exerciseStatusBadge" class="badge">
-                        {{ exam?.publishResultsDate | artemisDate }}
+                        {{ exam?.publishResultsDate | artemisTimeAgo }}
                     </span>
                 </h4>
             </ng-template>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) ~~on the test server https://artemistest.ase.in.tum.de~~ locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
The badge next to the Exam Release Date of Results just showed the same date again because the wrong pipe was used.

### Description
Use artemisTimeAgo-pipe

### Steps for Testing
1. You need an exam with a specified release date of results
2. Go to the assessment dashboard of any exam exercise
3. Check that the bade next to the release date shows the time until / ago.

### Screenshots
old:
![grafik](https://user-images.githubusercontent.com/26540346/113709254-92869180-96e2-11eb-82cb-df9b87fbc2bf.png)

new:
![grafik](https://user-images.githubusercontent.com/26540346/113709275-974b4580-96e2-11eb-82a8-b66b7c0c1f6a.png)

