### PR TITLE
Compare Feedback name with TestCase name ignoring case

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -387,7 +387,7 @@ public class ProgrammingExerciseGradingService {
     private void retainAutomaticFeedbacksWithTestCase(Result result, final Set<ProgrammingExerciseTestCase> testCases) {
         // Remove automatic feedbacks not associated with test cases
         result.getFeedbacks().removeIf(feedback -> feedback.getType() == FeedbackType.AUTOMATIC && !feedback.isStaticCodeAnalysisFeedback()
-                && testCases.stream().noneMatch(test -> test.getTestName().equals(feedback.getText())));
+                && testCases.stream().noneMatch(test -> test.getTestName().equalsIgnoreCase(feedback.getText())));
 
         // If there are no feedbacks left after filtering those not valid, also setHasFeedback to false.
         if (result.getFeedbacks().stream().noneMatch(feedback -> Boolean.FALSE.equals(feedback.isPositive())
@@ -403,7 +403,7 @@ public class ProgrammingExerciseGradingService {
      */
     private void setVisibilityForFeedbacksWithTestCase(Result result, final Set<ProgrammingExerciseTestCase> allTests) {
         for (Feedback feedback : result.getFeedbacks()) {
-            allTests.stream().filter(testCase -> testCase.getTestName().equals(feedback.getText())).findFirst()
+            allTests.stream().filter(testCase -> testCase.getTestName().equalsIgnoreCase(feedback.getText())).findFirst()
                     .ifPresent(testCase -> feedback.setVisibility(testCase.getVisibility()));
         }
     }


### PR DESCRIPTION
### Motivation and Context
Names of `ProgrammingExerciseTestCase`s are case independent: `ProgrammingExerciseTestCase.isSameTestCase()` https://github.com/ls1intum/Artemis/blob/53dc8b3f19dea869efb5aec35581c140f4cfc151/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java#L173
In `ProgrammingExerciseGradingService.java` on the check if `Feedback` has a corresponding test case the check was case dependent, leading to submissions not fulfilling test cases, even if they should have.

### Description
Changed the equality check of `TestCase.name` and `Feedback.name` to ignore casing in two missed locations when generating the feedback to students. In other locations the check already ignored the casing as intended.

### Steps for Testing
1. Create a programming exercise.
2. Change a letter of a unit test name from lowercase to uppercase.
3. Intended behaviour:
    - There are no inactive test cases on the grading page.
    - For the solution repository still all test cases are successful.

### Test Coverage
unchanged
