### PR TITLE
Fix Submissions-Button beeing visible for tutors.

### DIFF
--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
@@ -177,7 +177,7 @@
                                     [(toggelingSecondCorrectionButton)]="toggelingSecondCorrectionButton"
                                 ></jhi-second-correction-enable-button>
                             </ng-container>
-                            <a class="btn btn-primary btn-sm" [routerLink]="getSubmissionsLinkForExercise(exercise)">
+                            <a class="btn btn-primary btn-sm" *ngIf="isAtLeastInstructor" [routerLink]="getSubmissionsLinkForExercise(exercise)">
                                 <span jhiTranslate="artemisApp.assessmentDashboard.submissions">Submissions</span>
                             </a>
                         </ng-container>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -214,7 +214,7 @@
                         <div class="btn-group flex-btn-group-container">
                             <div class="btn-group-vertical mr-1 mb-1">
                                 <a
-                                    *ngIf="programmingExercise.isAtLeastTutor"
+                                    *ngIf="programmingExercise.isAtLeastInstructor"
                                     [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id, 'assessment']"
                                     class="btn btn-success btn-sm mr-1 mb-1"
                                 >


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) ~~on the test server https://artemistest.ase.in.tum.de~~ locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
This fixed two places where tutors could see the submissions overview even though this page is only meant for instructors.

### Steps for Testing
1. Go to the Assessment-Dashboard and the programming exercises overview
2. Check that tutors cannot see the submissions button.

### Screenshots
old:
![grafik](https://user-images.githubusercontent.com/26540346/114030750-fcd23a00-987a-11eb-9381-540334ef49c0.png)
![grafik](https://user-images.githubusercontent.com/26540346/114030727-f80d8600-987a-11eb-8632-bddf18e052e8.png)

new:
![grafik](https://user-images.githubusercontent.com/26540346/114030708-f3e16880-987a-11eb-9151-5f8b929107a8.png)
![grafik](https://user-images.githubusercontent.com/26540346/114030682-ee841e00-987a-11eb-9b0b-5cffa6063fef.png)

