### PR TITLE
Fix unordered exercise groups bug within exam checklist

### DIFF
--- a/src/main/webapp/app/exam/manage/exam-management.route.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.route.ts
@@ -60,8 +60,9 @@ export class ExamResolve implements Resolve<Exam> {
         const courseId = route.params['courseId'] ? route.params['courseId'] : undefined;
         const examId = route.params['examId'] ? route.params['examId'] : undefined;
         const withStudents = route.data['requestOptions'] ? route.data['requestOptions'].withStudents : false;
+        const withExerciseGroups = route.data['requestOptions'] ? route.data['requestOptions'].withExerciseGroups : false;
         if (courseId && examId) {
-            return this.examManagementService.find(courseId, examId, withStudents).pipe(
+            return this.examManagementService.find(courseId, examId, withStudents, withExerciseGroups).pipe(
                 filter((response: HttpResponse<Exam>) => response.ok),
                 map((exam: HttpResponse<Exam>) => exam.body!),
             );
@@ -161,6 +162,7 @@ export const examManagementRoute: Routes = [
             pageTitle: 'artemisApp.examManagement.title',
             requestOptions: {
                 withStudents: true,
+                withExerciseGroups: true,
             },
         },
         canActivate: [UserRouteAccessService],

--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Exam } from 'app/entities/exam.model';
-import { ExerciseGroup } from 'app/entities/exercise-group.model';
 import { HttpResponse } from '@angular/common/http';
 import { AccountService } from 'app/core/auth/account.service';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
@@ -28,18 +27,9 @@ export class ExamChecklistComponent implements OnInit {
     constructor(private accountService: AccountService, private examService: ExamManagementService, private exerciseGroupService: ExerciseGroupService) {}
 
     ngOnInit() {
-        this.exerciseGroupService
-            .findAllForExam(this.exam!.course!.id!, this.exam.id!)
-            .pipe(
-                filter((res) => !!res.body),
-                map((exerciseGroupArray: HttpResponse<ExerciseGroup[]>) => exerciseGroupArray.body!),
-            )
-            .subscribe((exGroups) => {
-                this.exam.exerciseGroups = exGroups;
-                this.checkPointsExercisesEqual();
-                this.checkTotalPointsMandatory();
-                this.checkAllGroupContainsExercise();
-            });
+        this.checkPointsExercisesEqual();
+        this.checkTotalPointsMandatory();
+        this.checkAllGroupContainsExercise();
         this.examService
             .getExamStatistics(this.exam.course!.id!, this.exam.id!)
             .pipe(

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
@@ -111,6 +111,7 @@ describe('ExamDetailComponent', () => {
         exam.title = 'Example Exam';
         exam.numberOfRegisteredUsers = 3;
         exam.maxPoints = 100;
+        exam.exerciseGroups = [];
         examDetailComponent.exam = exam;
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently exercise groups can lose their sorting when loaded within the exam checklist view. 
We fix this in this PR.
### Description
<!-- Describe your changes in detail -->
We removed a custom exercise groups call and used the existing exam call with an existing param that we set to retrieve the exercise groups attached to the exam. That ensures that they keep the correct order at all times.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration -> checklist 
3. check if the order is the same as on exams -> exam -> exercise groups
4. also change the order via the buttons on the left of the exercise groups -> check again on the exam checklist page

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
