### PR TITLE
[Bugfix] student exams : 0 scores not showing

### DIFF
--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
@@ -221,7 +221,7 @@
                         <td>{{ studentResult.eMail ? studentResult.eMail : '-' }}</td>
                         <td>{{ studentResult.registrationNumber ? studentResult.registrationNumber : '-' }}</td>
                         <ng-container *ngFor="let exerciseGroup of examScoreDTO.exerciseGroups">
-                            <td *ngIf="studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id]; else empty">
+                            <td *ngIf="studentResult.exerciseGroupIdToExerciseResult && studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id]; else empty">
                                 {{ studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id].title }}
                                 :
                                 {{ roundAndPerformLocalConversion(studentResult.exerciseGroupIdToExerciseResult[exerciseGroup.id].achievedPoints, 1) }}

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.ts
@@ -263,8 +263,12 @@ export class ExamScoresComponent implements OnInit, OnDestroy {
                 histogramIndex = 100 / this.binWidth - 1;
             }
             this.histogramData[histogramIndex]++;
+            if (!studentResult.exerciseGroupIdToExerciseResult) {
+                continue;
+            }
+            const entries = Object.entries(studentResult.exerciseGroupIdToExerciseResult);
 
-            for (const [exGroupId, studentExerciseResult] of Object.entries(studentResult.exerciseGroupIdToExerciseResult)) {
+            for (const [exGroupId, studentExerciseResult] of entries) {
                 // Ignore exercise results with only empty submission if the option was set
                 if (!studentExerciseResult.hasNonEmptySubmission && this.filterForNonEmptySubmissions) {
                     continue;

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.html
@@ -8,9 +8,12 @@
     {{ exercise?.title }}
 </td>
 <td class="align-middle">
-    <ng-container *ngIf="result && result.score != undefined && exercise && exercise.maxPoints">
+    <ng-container class="score" *ngIf="result && result.score != undefined && exercise && exercise.maxPoints; else scoreNotDefined">
         {{ rounding((result.score * exercise.maxPoints) / 100) }}
     </ng-container>
+    <ng-template #scoreNotDefined>
+        {{ 'N/A' }}
+    </ng-template>
 </td>
 <td class="align-middle">
     {{ exercise?.maxPoints }}

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail-table-row/student-exam-detail-table-row.component.html
@@ -8,7 +8,7 @@
     {{ exercise?.title }}
 </td>
 <td class="align-middle">
-    <ng-container *ngIf="result && result.score && exercise && exercise.maxPoints">
+    <ng-container *ngIf="result && result.score != undefined && exercise && exercise.maxPoints">
         {{ rounding((result.score * exercise.maxPoints) / 100) }}
     </ng-container>
 </td>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de)
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
When the score of an exercise was 0 this was not displayed in the student exam detail view, as 0 was interpreted as false by angular.

This PR also fixes a bug where the exam scores could not be shown if there were any studentexams which had any unsubmitted exercises.

### Steps for Testing student exam detail page
<!-- Please describe in detail how the reviewer can test your changes. -->

1. go to an exam with student exams
2. view one of the exams and check if you can see the score if the exercise was assessed. (you should be able to see a score of 0 now)

after fix:
![image](https://user-images.githubusercontent.com/33342534/114152979-25ac0b00-991f-11eb-8caf-574763e71460.png)
before fix:
![image](https://user-images.githubusercontent.com/33342534/114153087-42e0d980-991f-11eb-8e81-15b965f3eadd.png)

Tests for the html parts of the component will come in a followup

### Steps for Testing exam score page

1. Go to the exam management page and go to score for any exam that has at least one student exam, which contains not submissions.
2. Check if the page is shown correctly.
after fix:
![image](https://user-images.githubusercontent.com/33342534/114166037-880c0800-992d-11eb-9342-332e65c1bf8e.png)

before the fix:
![image](https://user-images.githubusercontent.com/33342534/114165992-7b87af80-992d-11eb-8639-39786df6557f.png)
