### PR TITLE
[Tests bugfix]

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -294,7 +294,7 @@ public class StudentExamService {
                 // we want to set it to FINISHED as the exam was handed in.
                 if (studentParticipation.getInitializationState().equals(InitializationState.INITIALIZED)) {
                     studentParticipation.setInitializationState(InitializationState.FINISHED);
-                    studentParticipation = studentParticipationRepository.save(studentParticipation);
+                    studentParticipationRepository.save(studentParticipation);
                 }
                 final var latestSubmission = studentParticipation.findLatestSubmission();
                 if (latestSubmission.isPresent() && latestSubmission.get().isEmpty()) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When saving saving the participation I set it as the returnvalue. This had the effect that the submissions were not any more eagerly loaded for the participation, which led to an error when trying to access them.
Now the return value of the save is just not used anymore, as it is not needed anyway. 
(The participation is the same before and after the save, except the data which is not loaded anymore.)

### Description
<!-- Describe your changes in detail -->
Should fix:
`testAssessUnsubmittedStudentExamsForMultipleCorrectionRounds()`
`testAssessEmptyExamSubmissions()`