### PR TITLE
Improve the student course overview cards

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
@@ -128,18 +128,34 @@ export class ExerciseService {
     }
 
     /**
-     * Return all exercises of input exercises that are due in delayInDays or 7 days if not specified
-     * @param { Exercise[] } exercises - Considered exercises
-     * @param { number} delayInDays - If set, amount of days that are considered
+     * Returns all exercises of the given exercises parameter which have no due date or a due date in the future within delayInDays days
+     * The returned exercises are sorted by due date, with the earliest due date being sorted first, and no due date sorted last
+     *
+     * @param { Exercise[] } exercises - The exercises to filter and sort
+     * @param { number } delayInDays - The amount of days an exercise can be due into the future, defaults to seven
      */
-    getNextExerciseForDays(exercises?: Exercise[], delayInDays = 7) {
-        if (!exercises) {
-            return undefined;
-        }
-        return exercises.find((exercise) => {
-            const dueDate = exercise.dueDate!;
-            return moment().isBefore(dueDate) && moment().add(delayInDays, 'day').isSameOrAfter(dueDate);
-        })!;
+    getNextExercisesForDays(exercises: Exercise[], delayInDays = 7): Exercise[] {
+        return exercises
+            .filter((exercise) => {
+                if (!exercise.dueDate) {
+                    return true;
+                }
+
+                const dueDate = exercise.dueDate!;
+                return moment().isBefore(dueDate) && moment().add(delayInDays, 'day').isSameOrAfter(dueDate);
+            })
+            .sort((exerciseA: Exercise, exerciseB: Exercise) => {
+                if (!exerciseA.dueDate) {
+                    // If A has no due date, sort B first
+                    return 1;
+                } else if (!exerciseB.dueDate) {
+                    // If B has no due date, sort A first
+                    return -1;
+                } else {
+                    // Sort the one with the next due date first
+                    return exerciseA.dueDate.isBefore(exerciseB.dueDate) ? -1 : 1;
+                }
+            });
     }
 
     /**

--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -32,7 +32,7 @@
         <div class="chart-container" *ngIf="exerciseCount > 0">
             <div class="chart-text">
                 <h2 class="text-center">{{ totalRelativeScore }}%</h2>
-                <h5 class="text-center">{{ totalAbsoluteScore }} / {{ totalReachableScore }} Pts</h5>
+                <h5 class="text-center points">{{ totalAbsoluteScore }} / {{ totalReachableScore }} Pts</h5>
             </div>
             <canvas
                 baseChart

--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -57,7 +57,7 @@
                 <div class="col-6 next-exercise-col">
                     <fa-icon [icon]="nextExerciseIcon" placement="right" [ngbTooltip]="nextExerciseTooltip | artemisTranslate" container="body" style="z-index: 1"></fa-icon>
                     <span>&nbsp;</span>
-                    <h5>{{ nextRelevantExercise.title }}</h5>
+                    <span class="next-exercise-title">{{ nextRelevantExercise.title }}</span>
                 </div>
                 <div class="col-3 next-exercise-col">
                     <div *ngIf="nextRelevantExercise.dueDate">

--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -1,20 +1,75 @@
 <div class="card" [class.guided-tour]="hasGuidedTour">
-    <div class="card-header text-white" routerLink="/courses/{{ course.id }}" [ngStyle]="{ backgroundColor: course.color || ARTEMIS_DEFAULT_COLOR }">
-        <h5 class="card-title text-center">
-            {{ course.title }}
-        </h5>
-    </div>
-    <div class="card-body" routerLink="/courses/{{ course.id }}">
-        <h4 jhiTranslate="artemisApp.studentDashboard.cardTitle">Your overall score:</h4>
-        <h2>{{ displayTotalRelativeScore() }}%</h2>
+    <div class="card-header text-white" [routerLink]="['/courses', course.id!]" [ngStyle]="{ backgroundColor: course.color || ARTEMIS_DEFAULT_COLOR }">
+        <a class="stretched-link" [routerLink]="['/courses', course.id!]"></a>
+        <div class="container">
+            <div class="row">
+                <div class="col image-col">
+                    <jhi-secured-image *ngIf="course.courseIcon" [cachingStrategy]="CachingStrategy.LOCAL_STORAGE" [src]="course.courseIcon"></jhi-secured-image>
+                </div>
+                <div class="col title-col">
+                    <h5 class="card-title text-center">
+                        {{ course.title }}
+                    </h5>
+                </div>
+                <div class="col course-info-col">
+                    <div class="course-info-amounts">
+                        <span *ngIf="exerciseCount === 0">Exercises: {{ exerciseCount }}</span>
+                        <a *ngIf="exerciseCount > 0" [routerLink]="['/courses', course.id!, 'exercises']">Exercises: {{ exerciseCount }}</a>
+
+                        <span *ngIf="lectureCount === 0">Lectures: {{ lectureCount }}</span>
+                        <a *ngIf="lectureCount > 0" [routerLink]="['/courses', course.id!, 'lectures']">Lectures: {{ lectureCount }}</a>
+
+                        <span *ngIf="examCount === 0">Exams: {{ examCount }}</span>
+                        <a *ngIf="examCount > 0" [routerLink]="['/courses', course.id!, 'exams']">Exams: {{ examCount }}</a>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
-    <div class="card-footer text-muted" *ngIf="nextRelevantExercise" (click)="startExercise(nextRelevantExercise)">
-        <h6 jhiTranslate="artemisApp.studentDashboard.cardExerciseLabel">Next exercise:</h6>
-        <h5>{{ nextRelevantExercise.title }}</h5>
-        <h6>{{ nextRelevantExercise.dueDate | artemisDate }}</h6>
+    <div class="card-body">
+        <a class="stretched-link" [routerLink]="['/courses', course.id!]"></a>
+        <div class="chart-container" *ngIf="exerciseCount > 0">
+            <div class="chart-text">
+                <h2 class="text-center">{{ totalRelativeScore }}%</h2>
+                <h5 class="text-center">{{ totalAbsoluteScore }} / {{ totalReachableScore }} Pts</h5>
+            </div>
+            <canvas
+                baseChart
+                id="score-chart"
+                [legend]="false"
+                [datasets]="doughnutChartData"
+                [options]="totalScoreOptions"
+                [colors]="doughnutChartColors"
+                [labels]="doughnutChartLabels"
+                [chartType]="'doughnut'"
+            ></canvas>
+        </div>
+    </div>
+
+    <div class="card-footer text-muted" *ngIf="nextRelevantExercise">
+        <a class="stretched-link" [routerLink]="['/courses', course.id!, 'exercises', nextRelevantExercise.id!]"></a>
+        <div class="container">
+            <div class="row">
+                <div class="col-3 next-exercise-col">
+                    <h6 jhiTranslate="artemisApp.studentDashboard.cardExerciseLabel">Next exercises:</h6>
+                </div>
+                <div class="col-6 next-exercise-col">
+                    <h5>{{ nextRelevantExercise.title }}</h5>
+                </div>
+                <div class="col-3 next-exercise-col">
+                    <div *ngIf="nextRelevantExercise.dueDate">
+                        <h6>{{ 'artemisApp.exercise.dueDate' | artemisTranslate }}:</h6>
+                        <h6>{{ nextRelevantExercise.dueDate | amTimeAgo }}</h6>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     <div class="card-footer text-muted" *ngIf="!nextRelevantExercise">
-        <h6 jhiTranslate="artemisApp.studentDashboard.cardNoExerciseLabel">No Exercise planned</h6>
+        <a class="stretched-link" [routerLink]="['/courses', course.id!]"></a>
+        <div class="col no-exercise">
+            <h6 jhiTranslate="artemisApp.studentDashboard.cardNoExerciseLabel">No Exercise planned</h6>
+        </div>
     </div>
 </div>

--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -55,7 +55,13 @@
                     <h6 jhiTranslate="artemisApp.studentDashboard.cardExerciseLabel">Next exercises:</h6>
                 </div>
                 <div class="col-6 next-exercise-col">
-                    <fa-icon class="next-exercise-icon" [icon]="nextExerciseIcon" placement="right" [ngbTooltip]="nextExerciseTooltip | artemisTranslate" container="body"></fa-icon>
+                    <fa-icon
+                        class="next-exercise-icon"
+                        [icon]="nextExerciseIcon"
+                        placement="right"
+                        [ngbTooltip]="nextExerciseTooltip | artemisTranslate"
+                        container="body"
+                    ></fa-icon>
                     <span class="next-exercise-title">{{ nextRelevantExercise.title }}</span>
                 </div>
                 <div class="col-3 next-exercise-col">

--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -55,6 +55,8 @@
                     <h6 jhiTranslate="artemisApp.studentDashboard.cardExerciseLabel">Next exercises:</h6>
                 </div>
                 <div class="col-6 next-exercise-col">
+                    <fa-icon [icon]="nextExerciseIcon" placement="right" [ngbTooltip]="nextExerciseTooltip | artemisTranslate" container="body" style="z-index: 1"></fa-icon>
+                    <span>&nbsp;</span>
                     <h5>{{ nextRelevantExercise.title }}</h5>
                 </div>
                 <div class="col-3 next-exercise-col">

--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -29,7 +29,7 @@
 
     <div class="card-body">
         <a class="stretched-link" [routerLink]="['/courses', course.id!]"></a>
-        <div class="chart-container" *ngIf="exerciseCount > 0">
+        <div class="chart-container" *ngIf="exerciseCount > 0 && totalReachableScore > 0">
             <div class="chart-text">
                 <h2 class="text-center">{{ totalRelativeScore }}%</h2>
                 <h5 class="text-center points">{{ totalAbsoluteScore }} / {{ totalReachableScore }} Pts</h5>
@@ -55,8 +55,7 @@
                     <h6 jhiTranslate="artemisApp.studentDashboard.cardExerciseLabel">Next exercises:</h6>
                 </div>
                 <div class="col-6 next-exercise-col">
-                    <fa-icon [icon]="nextExerciseIcon" placement="right" [ngbTooltip]="nextExerciseTooltip | artemisTranslate" container="body" style="z-index: 1"></fa-icon>
-                    <span>&nbsp;</span>
+                    <fa-icon class="next-exercise-icon" [icon]="nextExerciseIcon" placement="right" [ngbTooltip]="nextExerciseTooltip | artemisTranslate" container="body"></fa-icon>
                     <span class="next-exercise-title">{{ nextRelevantExercise.title }}</span>
                 </div>
                 <div class="col-3 next-exercise-col">

--- a/src/main/webapp/app/overview/course-card.component.ts
+++ b/src/main/webapp/app/overview/course-card.component.ts
@@ -60,10 +60,10 @@ export class CourseCardComponent implements OnChanges {
         if (this.course.exercises && this.course.exercises.length > 0) {
             this.exerciseCount = this.course.exercises.length;
             const nextExercises = this.exerciseService.getNextExercisesForDays(this.course.exercises);
-            if (nextExercises.length > 0) {
+            if (nextExercises.length > 0 && nextExercises[0]) {
                 this.nextRelevantExercise = nextExercises[0];
-                this.nextExerciseIcon = getIcon(this.nextRelevantExercise.type);
-                this.nextExerciseTooltip = getIconTooltip(this.nextRelevantExercise.type);
+                this.nextExerciseIcon = getIcon(this.nextRelevantExercise!.type);
+                this.nextExerciseTooltip = getIconTooltip(this.nextRelevantExercise!.type);
             }
 
             const scores = this.courseScoreCalculationService.calculateTotalScores(this.course.exercises);

--- a/src/main/webapp/app/overview/course-card.component.ts
+++ b/src/main/webapp/app/overview/course-card.component.ts
@@ -5,6 +5,8 @@ import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 import { CourseScoreCalculationService } from 'app/overview/course-score-calculation.service';
 import { Exercise } from 'app/entities/exercise.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
+import { CourseStatisticsDataSet } from 'app/overview/course-statistics/course-statistics.component';
+import { CachingStrategy } from 'app/shared/image/secured-image.component';
 
 @Component({
     selector: 'jhi-overview-course-card',
@@ -16,7 +18,33 @@ export class CourseCardComponent implements OnChanges {
     @Input() course: Course;
     @Input() hasGuidedTour: boolean;
 
+    CachingStrategy = CachingStrategy;
+
     nextRelevantExercise?: Exercise;
+    exerciseCount = 0;
+    lectureCount = 0;
+    examCount = 0;
+
+    totalRelativeScore: number;
+    totalReachableScore: number;
+    totalAbsoluteScore: number;
+
+    doughnutChartColors = ['limegreen', 'red'];
+    doughnutChartLabels: string[] = ['Achieved Points', 'Missing Points'];
+    doughnutChartData: CourseStatisticsDataSet[] = [
+        {
+            data: [0, 0],
+            backgroundColor: this.doughnutChartColors,
+        },
+    ];
+    totalScoreOptions: object = {
+        cutoutPercentage: 75,
+        scaleShowVerticalLines: false,
+        responsive: false,
+        tooltips: {
+            backgroundColor: 'rgba(0, 0, 0, 1)',
+        },
+    };
 
     constructor(
         private router: Router,
@@ -26,18 +54,26 @@ export class CourseCardComponent implements OnChanges {
     ) {}
 
     ngOnChanges() {
-        this.nextRelevantExercise = this.exerciseService.getNextExerciseForDays(this.course.exercises!);
-    }
-
-    displayTotalRelativeScore(): number {
         if (this.course.exercises && this.course.exercises.length > 0) {
-            return this.courseScoreCalculationService.calculateTotalScores(this.course.exercises).get('currentRelativeScore')!;
-        } else {
-            return 0;
-        }
-    }
+            this.exerciseCount = this.course.exercises.length;
+            const nextExercises = this.exerciseService.getNextExercisesForDays(this.course.exercises);
+            if (nextExercises.length > 0) {
+                this.nextRelevantExercise = nextExercises[0];
+            }
 
-    startExercise(exercise: Exercise): void {
-        this.router.navigate([this.course.id, 'exercises', exercise.id], { relativeTo: this.route });
+            const scores = this.courseScoreCalculationService.calculateTotalScores(this.course.exercises);
+            this.totalRelativeScore = scores.get('currentRelativeScore')!;
+            this.totalAbsoluteScore = scores.get('absoluteScore')!;
+            this.totalReachableScore = scores.get('reachableScore')!;
+            this.doughnutChartData[0].data = [this.totalAbsoluteScore, this.totalReachableScore - this.totalAbsoluteScore];
+        }
+
+        if (this.course.lectures) {
+            this.lectureCount = this.course.lectures.length;
+        }
+
+        if (this.course.exams) {
+            this.examCount = this.course.exams.length;
+        }
     }
 }

--- a/src/main/webapp/app/overview/course-card.component.ts
+++ b/src/main/webapp/app/overview/course-card.component.ts
@@ -3,10 +3,11 @@ import { Course } from 'app/entities/course.model';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 import { CourseScoreCalculationService } from 'app/overview/course-score-calculation.service';
-import { Exercise } from 'app/entities/exercise.model';
+import { Exercise, getIcon, getIconTooltip } from 'app/entities/exercise.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { CourseStatisticsDataSet } from 'app/overview/course-statistics/course-statistics.component';
 import { CachingStrategy } from 'app/shared/image/secured-image.component';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 @Component({
     selector: 'jhi-overview-course-card',
@@ -21,6 +22,8 @@ export class CourseCardComponent implements OnChanges {
     CachingStrategy = CachingStrategy;
 
     nextRelevantExercise?: Exercise;
+    nextExerciseIcon: IconProp;
+    nextExerciseTooltip: string;
     exerciseCount = 0;
     lectureCount = 0;
     examCount = 0;
@@ -59,6 +62,8 @@ export class CourseCardComponent implements OnChanges {
             const nextExercises = this.exerciseService.getNextExercisesForDays(this.course.exercises);
             if (nextExercises.length > 0) {
                 this.nextRelevantExercise = nextExercises[0];
+                this.nextExerciseIcon = getIcon(this.nextRelevantExercise.type);
+                this.nextExerciseTooltip = getIconTooltip(this.nextRelevantExercise.type);
             }
 
             const scores = this.courseScoreCalculationService.calculateTotalScores(this.course.exercises);

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -101,14 +101,15 @@
             justify-content: center;
             align-items: center;
 
-            h5 {
+            .next-exercise-title {
+                font-weight: bolder;
+                font-size: large;
                 margin-bottom: 0;
                 display: inline-block;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 max-width: 40ch;
-                min-height: 22px;
             }
 
             h6 {

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -101,6 +101,11 @@
             justify-content: center;
             align-items: center;
 
+            .next-exercise-icon {
+                z-index: 1;
+                font-size: large;
+            }
+
             .next-exercise-title {
                 font-weight: bolder;
                 font-size: large;
@@ -110,6 +115,7 @@
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 max-width: 40ch;
+                padding-left: 15px;
             }
 
             h6 {

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -108,6 +108,7 @@
                 text-overflow: ellipsis;
                 white-space: nowrap;
                 max-width: 40ch;
+                min-height: 22px;
             }
 
             h6 {

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -1,17 +1,128 @@
 .card {
-    height: 320px;
-    cursor: pointer;
+    min-height: 320px;
+
     .card-header {
-        min-height: 60px;
-        max-height: 100px;
+        position: relative;
+        padding: 0;
+        height: 80px;
         display: flex;
         justify-content: center;
         align-items: center;
+
+        .col {
+            height: 80px;
+            display: flex;
+            align-items: center;
+        }
+
+        .image-col {
+            justify-content: flex-start;
+        }
+
+        .title-col {
+            justify-content: center;
+        }
+
+        .course-info-col {
+            justify-content: flex-end;
+
+            .course-info-amounts {
+                display: flex;
+                flex-direction: column;
+                line-height: 20px;
+                white-space: nowrap;
+                z-index: 1;
+
+                a {
+                    color: white;
+                    font-weight: unset;
+                }
+            }
+        }
+
+        .container {
+            height: 80px;
+
+            .row {
+                height: 80px;
+                justify-content: space-between;
+            }
+        }
+
+        .card-title {
+            overflow: hidden;
+            padding-bottom: 1px;
+            max-height: 80px;
+        }
     }
+
     .card-body {
+        position: relative;
         display: flex;
         justify-content: center;
         align-items: center;
         flex-direction: column;
+
+        .chart-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            .chart-text {
+                position: absolute;
+            }
+        }
+
+        canvas {
+            z-index: 1;
+        }
+    }
+
+    .card-footer {
+        position: relative;
+        padding: 0;
+        height: 50px;
+
+        .container {
+            height: 50px;
+
+            .row {
+                height: 50px;
+            }
+        }
+
+        .next-exercise-col {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
+            h5 {
+                margin-bottom: 1px;
+                height: 1em;
+                overflow: hidden;
+            }
+
+            h6 {
+                margin-bottom: 0;
+            }
+        }
+
+        .no-exercise {
+            display: flex;
+            height: 50px;
+            align-items: center;
+
+            h6 {
+                margin-bottom: 0;
+            }
+        }
+    }
+}
+
+jhi-secured-image {
+    ::ng-deep img {
+        border-radius: 50%;
+        height: 65px;
+        width: auto;
     }
 }

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -73,6 +73,11 @@
             }
         }
 
+        .points {
+            display: block;
+            max-width: 11ch;
+        }
+
         canvas {
             z-index: 1;
         }
@@ -97,9 +102,12 @@
             align-items: center;
 
             h5 {
-                margin-bottom: 1px;
-                height: 1em;
+                margin-bottom: 0;
+                display: inline-block;
                 overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                max-width: 40ch;
             }
 
             h6 {

--- a/src/main/webapp/app/overview/courses.component.html
+++ b/src/main/webapp/app/overview/courses.component.html
@@ -40,11 +40,6 @@
     <jhi-course-registration-selector [courses]="courses" (courseRegistered)="loadAndFilterCourses()" class="col-12 col-sm-auto d-flex"></jhi-course-registration-selector>
 </div>
 <div class="row">
-    <jhi-overview-course-card
-        *ngFor="let course of courses"
-        class="col-12 col-lg-6 col-xl-4 pr-2 pl-2 mb-2"
-        [course]="course"
-        [hasGuidedTour]="course === courseForGuidedTour"
-    >
+    <jhi-overview-course-card *ngFor="let course of courses" class="col-12 col-lg-6 col-xl-4 pr-2 pl-2 mb-2" [course]="course" [hasGuidedTour]="course === courseForGuidedTour">
     </jhi-overview-course-card>
 </div>

--- a/src/main/webapp/app/overview/courses.component.html
+++ b/src/main/webapp/app/overview/courses.component.html
@@ -42,7 +42,7 @@
 <div class="row">
     <jhi-overview-course-card
         *ngFor="let course of courses"
-        class="col-12 col-md-6 col-lg-4 col-xl-3 pr-2 pl-2 mb-2"
+        class="col-12 col-lg-6 col-xl-4 pr-2 pl-2 mb-2"
         [course]="course"
         [hasGuidedTour]="course === courseForGuidedTour"
     >

--- a/src/main/webapp/app/overview/courses.component.scss
+++ b/src/main/webapp/app/overview/courses.component.scss
@@ -15,3 +15,10 @@
     display: block;
     opacity: 1;
 }
+
+@media screen and (min-width: 1900px) {
+    .col-xl-4 {
+        flex: 0 0 25;
+        max-width: 25%;
+    }
+}

--- a/src/test/javascript/spec/component/overview/course-card.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-card.component.spec.ts
@@ -1,0 +1,53 @@
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
+import { ArtemisTestModule } from '../../test.module';
+import { CourseCardComponent } from 'app/overview/course-card.component';
+import { Course } from 'app/entities/course.model';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { MockRouterLinkDirective } from '../lecture-unit/lecture-unit-management.component.spec';
+import { SecuredImageComponent } from 'app/shared/image/secured-image.component';
+import { Exercise } from 'app/entities/exercise.model';
+import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
+import { ChartsModule } from 'ng2-charts';
+import { TimeAgoPipe } from 'ngx-moment';
+import * as moment from 'moment';
+
+chai.use(sinonChai);
+const expect = chai.expect;
+
+describe('CourseCardComponent', () => {
+    let fixture: ComponentFixture<CourseCardComponent>;
+    let component: CourseCardComponent;
+
+    const pastExercise = { dueDate: moment().subtract(2, 'days') } as Exercise;
+    const nextExercise = { dueDate: moment().add(2, 'days') } as Exercise;
+    const secondNextExercise = { dueDate: moment().add(4, 'days') } as Exercise;
+    const course = { id: 1, exercises: [pastExercise, nextExercise, secondNextExercise], lectures: [], exams: [] } as Course;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule, ChartsModule],
+            declarations: [CourseCardComponent, MockPipe(ArtemisTranslatePipe), MockPipe(TimeAgoPipe), MockRouterLinkDirective, MockComponent(SecuredImageComponent)],
+            providers: [MockProvider(TranslateService)],
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(CourseCardComponent);
+                component = fixture.componentInstance;
+                component.course = course;
+            });
+    });
+
+    it('should initialize component', () => {
+        fixture.detectChanges();
+        expect(component).to.be.ok;
+    });
+
+    it('should display the next exercise', () => {
+        fixture.detectChanges();
+        component.ngOnChanges();
+        expect(component.nextRelevantExercise).to.equal(nextExercise);
+    });
+});

--- a/src/test/javascript/spec/component/overview/course-card.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-card.component.spec.ts
@@ -9,10 +9,11 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockRouterLinkDirective } from '../lecture-unit/lecture-unit-management.component.spec';
 import { SecuredImageComponent } from 'app/shared/image/secured-image.component';
 import { Exercise } from 'app/entities/exercise.model';
-import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
+import { MockComponent, MockPipe, MockProvider, MockDirective } from 'ng-mocks';
 import { ChartsModule } from 'ng2-charts';
 import { TimeAgoPipe } from 'ngx-moment';
 import * as moment from 'moment';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -29,7 +30,14 @@ describe('CourseCardComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, ChartsModule],
-            declarations: [CourseCardComponent, MockPipe(ArtemisTranslatePipe), MockPipe(TimeAgoPipe), MockRouterLinkDirective, MockComponent(SecuredImageComponent)],
+            declarations: [
+                CourseCardComponent,
+                MockPipe(ArtemisTranslatePipe),
+                MockPipe(TimeAgoPipe),
+                MockRouterLinkDirective,
+                MockComponent(SecuredImageComponent),
+                MockDirective(NgbTooltip),
+            ],
             providers: [MockProvider(TranslateService)],
         })
             .compileComponents()

--- a/src/test/javascript/spec/component/overview/overview.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/overview.component.spec.ts
@@ -109,7 +109,7 @@ describe('Overview Component', () => {
 
                     spyOn<any>(guidedTourComponent, 'subscribeToDotChanges').and.returnValue(of());
 
-                    spyOn(exerciseService, 'getNextExerciseForDays').and.returnValue(of());
+                    spyOn(exerciseService, 'getNextExercisesForDays').and.returnValue(of());
                     spyOn(guidedTourService, 'init').and.returnValue(of());
                     spyOn<any>(guidedTourService, 'updateGuidedTourSettings').and.returnValue(of());
 

--- a/src/test/javascript/spec/component/overview/overview.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/overview.component.spec.ts
@@ -102,7 +102,6 @@ describe('Overview Component', () => {
                     guidedTourService = TestBed.inject(GuidedTourService);
                     exerciseService = TestBed.inject(ExerciseService);
 
-                    spyOn(courseCardComponent, 'displayTotalRelativeScore').and.returnValue(of());
                     spyOn(navBarComponentFixture.componentInstance, 'ngOnInit').and.callFake(() => {
                         navBarComponent.currAccount = user;
                     });


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

We want to display more information (visually) for the first pages students see.

### Description

The course icon is now displayed, alongside numbers for exercises, lectures, and exams. Those can be clicked on if the number is greater than 0 and takes you to the corresponding sub-page. The score has a visual graph and the exercise displayed as next exercise is always the one with the closest due date.

### Steps for Testing

Basically just looking at the student courses view:
- Is the exercise with the closest due date (in the next 7 days) displayed?
- Are the numbers for exercises, lectures, and exams correct?
- Is the score graph correct?
- Do you see any visual glitches?

### Test Coverage

`course-card.component.ts`: 100% (and testing of the exercise service method)

### Screenshots

![grafik](https://user-images.githubusercontent.com/72132281/114281808-c8a87600-9a40-11eb-9d07-fddfa990130c.png)

<!--
![grafik](https://user-images.githubusercontent.com/72132281/114281786-af9fc500-9a40-11eb-9a11-55610f4c9513.png)

![grafik](https://user-images.githubusercontent.com/72132281/114279716-559a0200-9a36-11eb-895f-96eb2b06fea9.png)

If an exercise specifies a due date:
![grafik](https://user-images.githubusercontent.com/72132281/114279993-93e3f100-9a37-11eb-9f6c-3286d3d2637f.png)
-->
