### PR TITLE
Revert changes causing errors when creating a file-upload-exercise

### DIFF
--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
@@ -82,7 +82,7 @@
                                 [customMax]="9999"
                                 name="points"
                                 id="field_points"
-                                [(ngModel)]="fileUploadExercise.maxPoints!"
+                                [(ngModel)]="fileUploadExercise.maxPoints"
                                 #points="ngModel"
                             />
                             <div *ngIf="points?.invalid && (points?.dirty || points?.touched) && points?.errors" class="alert alert-danger">


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context

You currently cannot create file-upload exercises:
![grafik](https://user-images.githubusercontent.com/72132281/114281170-22a73c80-9a3d-11eb-8f62-72218fd74276.png)

Despite setting points you get an error message about having 0 points.

### Description

Reverts a change from #3132, "solving" the issue. It doesn't seem to be related to a strict template problem either, as no strict template issue does show up for me even after reverting this change.

### Steps for Testing

Create a file-upload exercise.


