### PR TITLE
fixed wrong error message in password component

### DIFF
--- a/src/main/webapp/app/account/password/password.component.html
+++ b/src/main/webapp/app/account/password/password.component.html
@@ -30,7 +30,7 @@
                         <small
                             class="form-text text-danger"
                             *ngIf="passwordForm.get('currentPassword')?.errors?.required"
-                            jhiTranslate="global.messages.validate.newpassword.required"
+                            jhiTranslate="global.messages.validate.oldpassword.required"
                         >
                             Your password is required.
                         </small>

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -138,6 +138,9 @@
                 "dontmatch": "Das bestätigte Passwort entspricht nicht dem neuen Passwort!"
             },
             "validate": {
+                "oldpassword": {
+                    "required": "Bitte gib dein aktuelles Passwort ein."
+                },
                 "newpassword": {
                     "required": "Ein neues Passwort wird benötigt.",
                     "minlength": "Das neue Passwort muss mindestens 8 Zeichen lang sein",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -138,8 +138,11 @@
                 "dontmatch": "The password and its confirmation do not match!"
             },
             "validate": {
+                "oldpassword": {
+                    "required": "Please enter your current password."
+                },
                 "newpassword": {
-                    "required": "Your password is required.",
+                    "required": "Your new password is required.",
                     "minlength": "Your password is required to be at least 8 characters.",
                     "maxlength": "Your password cannot be longer than 100 characters.",
                     "strength": "Password strength:"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [ ] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [ ] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] Server: I documented the Java code using JavaDoc style.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [ ] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? --> Error message in password component was not describing the right thing. Now it does.
<!-- If it fixes an open issue, please link to the issue here. --> https://github.com/ls1intum/Artemis/issues/3110

### Description
<!-- Describe your changes in detail --> I added a new message 'global.message.validate.oldpassword.required' that describes the needed error better and used that one in the relevant component. I also changed the english error message under the 'New Password' field to include the word "new". 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. --> 
1. Log out of Artemis
2. Navigate to account/register
3. Click on 'New Password' field and then somewhere else to see new message
4. Log into Artemis
5. Navigate to account/password
6. Click on all three field to see new messages
7. repeat for en/de

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->



### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->

de new:
![de](https://user-images.githubusercontent.com/56715566/114281969-a3683780-9a41-11eb-997b-5b04c66af5f3.png)
en new:
![en_post](https://user-images.githubusercontent.com/56715566/114281972-a400ce00-9a41-11eb-8f50-0fb04039180b.png)
en old:
![en_pre](https://user-images.githubusercontent.com/56715566/114281973-a400ce00-9a41-11eb-92e0-579a93f343f3.png)

<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
