### PR TITLE
Fix Documentation for Gitlab/Jenkins Local Docker Setup

### DIFF
--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -1180,7 +1180,7 @@ Preparation
 ~~~~~~~~~~~
 
 1. Create a Docker network named “artemis” with
-   ``docker network create artemis``
+   ``docker network create artemis``.
 
 .. _gitlab-1:
 
@@ -1188,11 +1188,11 @@ Gitlab
 ~~~~~~
 
 1. Add the Gitlab container to the created network with
-   ``docker network connect artemis gitlab``
+   ``docker network connect artemis gitlab``.
 2. Get the URL of the Gitlab container with the first IP returned by
-   ``docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' gitlab``
+   ``docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' gitlab``.
 3. Use this IP in the ``application-artemis.yml`` file at
-   ``artemis.version-control.url``
+   ``artemis.version-control.url``.
 
 .. _jenkins-2:
 
@@ -1200,18 +1200,18 @@ Jenkins
 ~~~~~~~
 
 1. Add the Jenkins container to the created network with
-   ``docker network connect artemis jenkins``
+   ``docker network connect artemis jenkins``.
 2. Get the URL of the Gitlab container with the first IP returned by
-   ``docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' jenkins``
+   ``docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' jenkins``.
 3. Use this IP in the ``application-artemis.yml`` file at
-   ``artemis.continuous-integration.url``
+   ``artemis.continuous-integration.url``.
 
 .. _artemis-1:
 
 Artemis
 ~~~~~~~
 
-1. In ``docker-compose.yml``
+1. In ``docker-compose.yml``:
 
    1. Make sure to use unique ports, e.g. 8080 for Artemis, 8081 for Gitlab and 8082 for Jenkins.
    2. Change the ``SPRING_PROFILES_ACTIVE`` environment variable to ``dev,jenkins,gitlab,artemis,scheduling``.

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -1171,12 +1171,13 @@ If you haven’t done so, generate the DH param file:
    resolver <if you have any, specify them here> valid=300s;
    resolver_timeout 5s;
 
-#Deployment Artemis / GitLab / Jenkins using Docker on Local machine
+Deployment Artemis / GitLab / Jenkins using Docker on Local machine
+-------------------------------------------------------------------
 
 Execute the following steps in addition to the ones described above:
 
 Preparation
------------
+~~~~~~~~~~~
 
 1. Create a Docker network named “artemis” with
    ``docker network create artemis``
@@ -1184,7 +1185,7 @@ Preparation
 .. _gitlab-1:
 
 Gitlab
-------
+~~~~~~
 
 1. Add the Gitlab container to the created network with
    ``docker network connect artemis gitlab``
@@ -1196,7 +1197,7 @@ Gitlab
 .. _jenkins-2:
 
 Jenkins
--------
+~~~~~~~
 
 1. Add the Jenkins container to the created network with
    ``docker network connect artemis jenkins``
@@ -1208,7 +1209,7 @@ Jenkins
 .. _artemis-1:
 
 Artemis
--------
+~~~~~~~
 
 1. In ``docker-compose.yml``
 

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -1213,10 +1213,10 @@ Artemis
 
 1. In ``docker-compose.yml``
 
-   1. Make sure to use unique ports, e.g. 8080 for Artemis, 8081 for Gitlab and 8082 for Jenkins
+   1. Make sure to use unique ports, e.g. 8080 for Artemis, 8081 for Gitlab and 8082 for Jenkins.
    2. Change the ``SPRING_PROFILES_ACTIVE`` environment variable to ``dev,jenkins,gitlab,artemis,scheduling``.
 
-2. In ``src/main/resources/config/application-dev.yml`` at ``server:`` use port 8080 for Artemis.
+2. In ``src/main/resources/config/application-dev.yml`` at ``server:`` use ``port: 8080`` for Artemis.
 
 3. Run ``docker-compose up``.
 

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -1214,23 +1214,18 @@ Artemis
 1. In ``docker-compose.yml``
 
    1. Make sure to use unique ports, e.g. 8080 for Artemis, 8081 for Gitlab and 8082 for Jenkins
-   2. Change the SPRING_PROFILES_ACTIVE to dev,jenkins,gitlab,artemis
+   2. Change the ``SPRING_PROFILES_ACTIVE`` environment variable to ``dev,jenkins,gitlab,artemis,scheduling``.
 
-2. In ``src/main/resources/config/application-dev.yml``
+2. In ``src/main/resources/config/application-dev.yml`` at ``server:`` use port 8080 for Artemis.
 
-   1. At ``spring.profiles.active:`` add ``& gitlab & jenkins``
-   2. At ``spring.liquibase:`` add the new property
-      ``change-log: classpath:config/liquibase/master.xml``
-   3. At ``server:`` use port 8080 for Artemis
-
-3. Run ``docker-compose up``
+3. Run ``docker-compose up``.
 
 4. After the container has been deployed run
-   ``docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' artemis_artemis-server``
+   ``docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' artemis_artemis-server``
    and copy the first resulting IP.
 
 5. In ``src/main/resources/config/application-dev.yml`` at ``server:``
-   at ``url:`` paste the copied IP
+   at ``url:`` paste the copied IP with the port number, e.g. ``url: http://172.33.0.1:8080``.
 
 6. Stop the Artemis docker container with Control-C and re-run
-   ``docker-compose up``
+   ``docker-compose up``.


### PR DESCRIPTION
### Description
This fixes the heading styles in the sections following https://artemis-platform.readthedocs.io/en/latest/dev/setup/jenkins-gitlab/#etc-nginx-common-common-ssl-conf

### Screenshots
Before:
![Screenshot_20210413_205023](https://user-images.githubusercontent.com/64250573/114605131-0b18bf80-9c9a-11eb-97e2-41629580c621.png)
After:
![Screenshot_20210413_225934](https://user-images.githubusercontent.com/64250573/114620609-09f08e00-9cac-11eb-9c04-661b2039b701.png)

