### PR TITLE
Fix two editor in modeling submissions

### DIFF
--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.html
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.html
@@ -5,7 +5,7 @@
     <jhi-button
         submitbutton
         class="guided-tour submission-button"
-        [disabled]="(!isActive && !isLate) || !submission || !!result"
+        [disabled]="(!isActive && !isLate) || !submission || !!result || (isLate && submission.submitted)"
         [title]="!isLate ? 'entity.action.submit' : 'entity.action.submitDeadlineMissed'"
         (onClick)="submit()"
         [isLoading]="isSaving"
@@ -32,7 +32,7 @@
 
         <jhi-fullscreen>
             <div class="row flex-grow-1">
-                <div *ngIf="submission && (isActive || isLate) && !result" class="col-12 editor-large">
+                <div *ngIf="submission && (isActive || isLate) && !result && (!isLate || !submission.submitted)" class="col-12 editor-large">
                     <jhi-modeling-editor
                         [umlModel]="umlModel"
                         [diagramType]="modelingExercise.diagramType"
@@ -47,7 +47,7 @@
                         (receiveSubmission)="onReceiveSubmissionFromTeam($event)"
                     ></jhi-team-submission-sync>
                 </div>
-                <div *ngIf="(!isActive || result) && modelingExercise" class="col-9">
+                <div *ngIf="(!isActive || result) && modelingExercise && (!isLate || submission.submitted)" class="col-9">
                     <div class="flex flex-column h-100">
                         <jhi-modeling-assessment
                             [model]="umlModel"

--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
@@ -317,6 +317,10 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
             this.modelingSubmissionService.update(this.submission, this.modelingExercise.id!).subscribe(
                 (response) => {
                     this.submission = response.body!;
+                    if (this.submission.model) {
+                        this.umlModel = JSON.parse(this.submission.model);
+                        this.hasElements = this.umlModel.elements && this.umlModel.elements.length !== 0;
+                    }
                     this.submissionChange.next(this.submission);
                     this.participation = this.submission.participation as StudentParticipation;
                     this.participation.exercise = this.modelingExercise;

--- a/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
@@ -151,9 +151,10 @@ describe('Component Tests', () => {
             expect(submitButton.attributes['ng-reflect-disabled']).to.be.equal('true');
         });
 
-        it('should allow to submit after the deadline if the initialization date is after the due date', () => {
+        it('should allow to submit after the deadline if the initialization date is after the due date and not submitted', () => {
             submission.participation!.initializationDate = moment().add(1, 'days');
             (<StudentParticipation>submission.participation).exercise!.dueDate = moment();
+            submission.submitted = false;
             sinon.replace(service, 'getLatestSubmissionForModelingEditor', sinon.fake.returns(of(submission)));
 
             fixture.detectChanges();
@@ -162,6 +163,7 @@ describe('Component Tests', () => {
             const submitButton = debugElement.query(By.css('jhi-button'));
             expect(submitButton).to.exist;
             expect(submitButton.attributes['ng-reflect-disabled']).to.be.equal('false');
+            submission.submitted = true;
         });
 
         it('should not allow to submit if there is a result and no due date', () => {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
When user starts working on the exercise after the due date, user was seeing two editors instead of one.

### Description
PR allows user to submit only once if the user is late. After his/her submission user can only see assessments if there is any.

Issue before solved
![image](https://user-images.githubusercontent.com/16825065/114930283-1b18d680-9e35-11eb-9e6d-4aa8a4709544.png)
