### PR TITLE
Send less data for certain user calls to improve data privacy

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -73,6 +73,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select user from User user where :#{#groupName} member of user.groups")
     List<User> findAllInGroupWithAuthorities(@Param("groupName") String groupName);
 
+    @Query("select user from User user where :#{#groupName} member of user.groups")
+    List<User> findAllInGroup(@Param("groupName") String groupName);
+
     /**
      * Searches for users in a group by their login or full name.
      *
@@ -120,9 +123,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
      *
      * @param page        Pageable related info (e.g. for page size)
      * @param loginOrName Either a login (e.g. ga12abc) or name (e.g. Max Mustermann) by which to search
-     * @return list of found users that match the search criteria
+     * @return            list of found users that match the search criteria
      */
-    @EntityGraph(type = LOAD, attributePaths = { "groups", "authorities" })
     @Query("select user from User user where user.login like :#{#loginOrName}% or concat_ws(' ', user.firstName, user.lastName) like %:#{#loginOrName}%")
     Page<User> searchAllByLoginOrName(Pageable page, @Param("loginOrName") String loginOrName);
 
@@ -169,7 +171,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
      */
     default Page<UserDTO> searchAllUsersByLoginOrName(Pageable pageable, String loginOrName) {
         Page<User> users = searchAllByLoginOrName(pageable, loginOrName);
-        users.forEach(user -> user.setVisibleRegistrationNumber(user.getRegistrationNumber()));
         return users.map(UserDTO::new);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/StudentDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/StudentDTO.java
@@ -60,10 +60,12 @@ public class StudentDTO {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
+        if (this == o) {
             return true;
-        if (o == null || getClass() != o.getClass())
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
+        }
         StudentDTO that = (StudentDTO) o;
         return Objects.equals(registrationNumber, that.registrationNumber) || Objects.equals(login, that.login);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/UserDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/UserDTO.java
@@ -8,6 +8,8 @@ import java.util.stream.Collectors;
 
 import javax.validation.constraints.*;
 
+import org.hibernate.Hibernate;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.in.www1.artemis.config.Constants;
@@ -66,12 +68,11 @@ public class UserDTO extends AuditingEntityDTO {
     public UserDTO(User user) {
         this(user.getId(), user.getLogin(), user.getName(), user.getFirstName(), user.getLastName(), user.getEmail(), user.getVisibleRegistrationNumber(), user.getActivated(),
                 user.getImageUrl(), user.getLangKey(), user.getCreatedBy(), user.getCreatedDate(), user.getLastModifiedBy(), user.getLastModifiedDate(),
-                user.getLastNotificationRead(), user.getAuthorities().stream().map(Authority::getName).collect(Collectors.toSet()), user.getGroups(), user.getGuidedTourSettings(),
-                user.getOrganizations());
+                user.getLastNotificationRead(), user.getAuthorities(), user.getGroups(), user.getGuidedTourSettings(), user.getOrganizations());
     }
 
     public UserDTO(Long id, String login, String name, String firstName, String lastName, String email, String visibleRegistrationNumber, boolean activated, String imageUrl,
-            String langKey, String createdBy, Instant createdDate, String lastModifiedBy, Instant lastModifiedDate, ZonedDateTime lastNotificationRead, Set<String> authorities,
+            String langKey, String createdBy, Instant createdDate, String lastModifiedBy, Instant lastModifiedDate, ZonedDateTime lastNotificationRead, Set<Authority> authorities,
             Set<String> groups, Set<GuidedTourSetting> guidedTourSettings, Set<Organization> organizations) {
 
         this.id = id;
@@ -89,7 +90,9 @@ public class UserDTO extends AuditingEntityDTO {
         this.setLastModifiedBy(lastModifiedBy);
         this.setLastModifiedDate(lastModifiedDate);
         this.lastNotificationRead = lastNotificationRead;
-        this.authorities = authorities;
+        if (authorities != null && Hibernate.isInitialized(authorities)) {
+            this.authorities = authorities.stream().map(Authority::getName).collect(Collectors.toSet());
+        }
         this.groups = groups;
         this.guidedTourSettings = guidedTourSettings;
         this.organizations = organizations;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -1127,11 +1127,15 @@ public class CourseResource {
      */
     @NotNull
     public ResponseEntity<List<User>> getAllUsersInGroup(Course course, String groupName) {
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastInstructorInCourse(course, user)) {
-            return forbidden();
-        }
-        return ResponseEntity.ok().body(userRepository.findAllInGroupWithAuthorities(groupName));
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
+        var usersInGroup = userRepository.findAllInGroup(groupName);
+        usersInGroup.forEach(user -> {
+            // remove some values which are not needed in the client
+            user.setLastNotificationRead(null);
+            user.setActivationKey(null);
+            user.setLangKey(null);
+        });
+        return ResponseEntity.ok().body(usersInGroup);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
@@ -188,6 +188,11 @@ public class UserResource {
         }
         // limit search results to 25 users (larger result sizes would impact performance and are not useful for specific user searches)
         final Page<UserDTO> page = userRepository.searchAllUsersByLoginOrName(PageRequest.of(0, 25), loginOrName);
+        page.forEach(user -> {
+            // remove some values which are not needed in the client
+            user.setLangKey(null);
+            user.setLastNotificationRead(null);
+        });
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(ServletUriComponentsBuilder.fromCurrentRequest(), page);
         return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
     }

--- a/src/main/webapp/app/exam/manage/exam-management.service.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.service.ts
@@ -175,8 +175,8 @@ export class ExamManagementService {
      * @param examId The id of the exam to which to add the student
      * @param studentLogin Login of the student
      */
-    addStudentToExam(courseId: number, examId: number, studentLogin: string): Observable<HttpResponse<any>> {
-        return this.http.post<any>(`${this.resourceUrl}/${courseId}/exams/${examId}/students/${studentLogin}`, { observe: 'response' });
+    addStudentToExam(courseId: number, examId: number, studentLogin: string): Observable<HttpResponse<StudentDTO>> {
+        return this.http.post<StudentDTO>(`${this.resourceUrl}/${courseId}/exams/${examId}/students/${studentLogin}`, undefined, { observe: 'response' });
     }
 
     /**
@@ -187,7 +187,7 @@ export class ExamManagementService {
      * @return studentDtos of students that were not found in the system
      */
     addStudentsToExam(courseId: number, examId: number, studentDtos: StudentDTO[]): Observable<HttpResponse<StudentDTO[]>> {
-        return this.http.post<any>(`${this.resourceUrl}/${courseId}/exams/${examId}/students`, studentDtos, { observe: 'response' });
+        return this.http.post<StudentDTO[]>(`${this.resourceUrl}/${courseId}/exams/${examId}/students`, studentDtos, { observe: 'response' });
     }
 
     /**

--- a/src/main/webapp/app/exam/manage/students/exam-students.component.ts
+++ b/src/main/webapp/app/exam/manage/students/exam-students.component.ts
@@ -13,7 +13,6 @@ import { iconsAsHTML } from 'app/utils/icons.utils';
 import { Exam } from 'app/entities/exam.model';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
 import { ButtonSize, ButtonType } from 'app/shared/components/button.component';
-import { StudentDTO } from 'app/entities/student-dto.model';
 
 const cssClasses = {
     alreadyRegistered: 'already-registered',

--- a/src/main/webapp/app/exam/manage/students/exam-students.component.ts
+++ b/src/main/webapp/app/exam/manage/students/exam-students.component.ts
@@ -13,6 +13,7 @@ import { iconsAsHTML } from 'app/utils/icons.utils';
 import { Exam } from 'app/entities/exam.model';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
 import { ButtonSize, ButtonType } from 'app/shared/components/button.component';
+import { StudentDTO } from 'app/entities/student-dto.model';
 
 const cssClasses = {
     alreadyRegistered: 'already-registered',
@@ -139,8 +140,11 @@ export class ExamStudentsComponent implements OnInit, OnDestroy {
         if (!this.allRegisteredUsers.map((u) => u.id).includes(user.id) && user.login) {
             this.isTransitioning = true;
             this.examManagementService.addStudentToExam(this.courseId, this.exam.id!, user.login).subscribe(
-                () => {
+                (student) => {
                     this.isTransitioning = false;
+
+                    // make sure the registration number is set in the user object
+                    user.visibleRegistrationNumber = student.body!.registrationNumber;
 
                     // Add newly registered user to the list of all registered users for the exam
                     this.allRegisteredUsers.push(user);

--- a/src/main/webapp/app/shared/data-table/data-table.component.ts
+++ b/src/main/webapp/app/shared/data-table/data-table.component.ts
@@ -72,7 +72,7 @@ export class DataTableComponent implements OnInit, OnChanges {
      * @property searchNoResultsTranslation Translation string that has the variable {{ length }} in it (default: 'artemisApp.dataTable.search.noResults')
      * @property searchPlaceholderTranslation Translation string that is used for the placeholder in the search input field
      * @property searchFields Fields of entity whose values will be compared to the user's search string (allows nested attributes, e.g. ['student.login', 'student.name'])
-     * @property searchFiltersEntities Flag whether searching should cause a filtering of the entities (default: true)
+     * @property searchEntityFilterEnabled Flag whether searching should cause a filtering of the entities (default: true)
      * @function searchTextFromEntity Function that takes an entity and returns a text that is inserted into the search input field when clicking on an autocomplete suggestion
      * @function searchResultFormatter Function that takes an entity and returns the text for the autocomplete suggestion result row
      * @function onSearchWrapper Wrapper around the onSearch method that can be used to modify the items displayed in the autocomplete

--- a/src/test/javascript/spec/component/exam/manage/exam-students.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-students.component.spec.ts
@@ -24,6 +24,7 @@ import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import { MockTranslateService } from '../../../helpers/mocks/service/mock-translate.service';
 import { ArtemisTestModule } from '../../../test.module';
+import { StudentDTO } from 'app/entities/student-dto.model';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -94,9 +95,10 @@ describe('ExamStudentsComponent', () => {
 
     it('should handle auto-complete for unregistered user', () => {
         const user3 = { id: 3, login: 'user3' } as User;
+        const student3 = { login: 'user3', registrationNumber: '1234567' } as StudentDTO;
         const callbackSpy = sinon.spy();
         const flashSpy = sinon.spy(component, 'flashRowClass');
-        const examServiceStub = sinon.stub(examManagementService, 'addStudentToExam').returns(of(new HttpResponse()));
+        const examServiceStub = sinon.stub(examManagementService, 'addStudentToExam').returns(of(new HttpResponse({ body: student3 })));
         fixture.detectChanges();
 
         component.onAutocompleteSelect(user3, callbackSpy);


### PR DESCRIPTION
Some REST calls related to users (which are only possible for instructors) reveal more information than needed for the Artemis user interface. This PR tries to reduce the data.

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I updated multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Steps for Testing
1. Add / remove users in the different course groups (students, tutors, instructors)
2. Register single / multiple users for exams
3. Add users to organizations
4. Search for users in those two places

Checks:
* Inspect the REST responses in the chrome developer console and check if unnecessary data (not shown in the user interface, such as groups, authorities, etc.) are not included in the json body.
