### PR TITLE
[Bugfix] Fix re-evaluate bug for programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/SolutionProgrammingExerciseParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SolutionProgrammingExerciseParticipationRepository.java
@@ -26,8 +26,8 @@ public interface SolutionProgrammingExerciseParticipationRepository extends JpaR
     @EntityGraph(type = LOAD, attributePaths = { "results", "submissions", "submissions.results" })
     Optional<SolutionProgrammingExerciseParticipation> findWithEagerResultsAndSubmissionsByProgrammingExerciseId(Long exerciseId);
 
-    @EntityGraph(type = LOAD, attributePaths = { "results", "results.feedbacks" })
-    Optional<SolutionProgrammingExerciseParticipation> findWithEagerResultsAndFeedbacksByProgrammingExerciseId(Long exerciseId);
+    @EntityGraph(type = LOAD, attributePaths = { "results", "results.feedbacks", "submissions" })
+    Optional<SolutionProgrammingExerciseParticipation> findWithEagerResultsAndFeedbacksAndSubmissionsByProgrammingExerciseId(Long exerciseId);
 
     Optional<SolutionProgrammingExerciseParticipation> findByProgrammingExerciseId(Long programmingExerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/TemplateProgrammingExerciseParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TemplateProgrammingExerciseParticipationRepository.java
@@ -26,8 +26,8 @@ public interface TemplateProgrammingExerciseParticipationRepository extends JpaR
     @EntityGraph(type = LOAD, attributePaths = { "results", "submissions" })
     Optional<TemplateProgrammingExerciseParticipation> findWithEagerResultsAndSubmissionsByProgrammingExerciseId(Long exerciseId);
 
-    @EntityGraph(type = LOAD, attributePaths = { "results", "results.feedbacks" })
-    Optional<TemplateProgrammingExerciseParticipation> findWithEagerResultsAndFeedbacksByProgrammingExerciseId(Long exerciseId);
+    @EntityGraph(type = LOAD, attributePaths = { "results", "results.feedbacks", "submissions" })
+    Optional<TemplateProgrammingExerciseParticipation> findWithEagerResultsAndFeedbacksAndSubmissionsByProgrammingExerciseId(Long exerciseId);
 
     Optional<TemplateProgrammingExerciseParticipation> findByProgrammingExerciseId(Long programmingExerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -257,12 +257,12 @@ public class ProgrammingExerciseGradingService {
 
         ArrayList<Result> updatedResults = new ArrayList<>();
 
-        templateProgrammingExerciseParticipationRepository.findWithEagerResultsAndFeedbacksByProgrammingExerciseId(exercise.getId())
+        templateProgrammingExerciseParticipationRepository.findWithEagerResultsAndFeedbacksAndSubmissionsByProgrammingExerciseId(exercise.getId())
                 .flatMap(p -> Optional.ofNullable(p.findLatestResult())).ifPresent(result -> {
                     calculateScoreForResult(testCases, testCases, result, exercise);
                     updatedResults.add(result);
                 });
-        solutionProgrammingExerciseParticipationRepository.findWithEagerResultsAndFeedbacksByProgrammingExerciseId(exercise.getId())
+        solutionProgrammingExerciseParticipationRepository.findWithEagerResultsAndFeedbacksAndSubmissionsByProgrammingExerciseId(exercise.getId())
                 .flatMap(p -> Optional.ofNullable(p.findLatestResult())).ifPresent(result -> {
                     calculateScoreForResult(testCases, testCases, result, exercise);
                     updatedResults.add(result);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I implemented the changes with a good performance and prevented too many database calls

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #3203. 

The re-evaluate functionality for programming exercises required that submission are loaded in other to update the results. Submissions weren't loaded eagerly which resulted in a Hibernate exception.

### Description
<!-- Describe your changes in detail -->
This pr fixes the issue by loading the submissions. It also adds an extra check in `findLatestResult` to make sure that submissions are loaded before operating on them.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
This pr can only be tested on **TS2**

1. Create a Programming Exercise
2. In Grading: Set some test to "After Due Date"
3. Create a Submission (and wait for tests finished)
4. In Grading: Change "After Due Date" to "Never"
5. Click on Re-evaluate all -> Internal Server Error

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
ProgrammingExerciseGradingService 93%