### PR TITLE
[Docu] Missing export statement in JVM args

### DIFF
--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -181,6 +181,7 @@ This is a service file that works on Debian/Ubuntu (using systemd):
      -Xmx2048m \
      --add-modules java.se \
      --add-exports java.base/jdk.internal.ref=ALL-UNNAMED \
+     --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED \
      --add-opens java.base/java.lang=ALL-UNNAMED \
      --add-opens java.base/java.nio=ALL-UNNAMED \
      --add-opens java.base/sun.nio.ch=ALL-UNNAMED \


### PR DESCRIPTION
## Motivation and Context
On startup I've got an error regarding illegal access:

```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'ldapContextSource' defined in class path resource [org/springframework/boot/autoconfigure/ldap/LdapAutoConfiguration.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.ldap.core.support.LdapContextSource]: Factory method 'ldapContextSource' threw exception; nested exception is java.lang.IllegalAccessError: class org.springframework.ldap.core.support.AbstractContextSource (in unnamed module @0x1ff8b8f) cannot access class com.sun.jndi.ldap.LdapCtxFactory (in module java.naming) because module java.naming does not export com.sun.jndi.ldap to unnamed module
```

Therefore, I've updated the VM args to solve this issue.

See also https://github.com/spring-projects/spring-ldap/issues/570 (I'm actually using the workaround mentioned here)