### PR TITLE
[Bugfix] Fix wrong translation in programming assessment and issue with complaints

### DIFF
--- a/src/main/webapp/app/complaints/complaint-interactions.component.html
+++ b/src/main/webapp/app/complaints/complaint-interactions.component.html
@@ -25,11 +25,11 @@
 
     <div class="row" *ngIf="showComplaintForm || hasComplaint">
         <jhi-complaint-form
-            *ngIf="result && exam"
+            *ngIf="result"
             class="flex-grow-1"
             [exercise]="exercise"
             [resultId]="result.id!"
-            [examId]="exam.id!"
+            [examId]="exam?.id!"
             [allowedComplaints]="numberOfAllowedComplaints"
             [maxComplaintsPerCourse]="calculateMaxComplaints()"
             [complaintType]="ComplaintType.COMPLAINT"

--- a/src/main/webapp/app/complaints/complaint.service.ts
+++ b/src/main/webapp/app/complaints/complaint.service.ts
@@ -70,7 +70,7 @@ export class ComplaintService implements IComplaintService {
      * @param complaint
      * @param examId the Id of the exam
      */
-    create(complaint: Complaint, examId: number): Observable<EntityResponseType> {
+    create(complaint: Complaint, examId?: number): Observable<EntityResponseType> {
         const copy = this.convertDateFromClient(complaint);
         if (examId) {
             return this.http

--- a/src/main/webapp/app/complaints/complaints.component.ts
+++ b/src/main/webapp/app/complaints/complaints.component.ts
@@ -19,7 +19,7 @@ import { Exercise } from 'app/entities/exercise.model';
 export class ComplaintsComponent implements OnInit {
     @Input() exercise: Exercise;
     @Input() resultId: number;
-    @Input() examId: number;
+    @Input() examId?: number;
     @Input() allowedComplaints: number; // the number of complaints that a student can still submit in the course
     @Input() maxComplaintsPerCourse: number;
     @Input() complaintType: ComplaintType;

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
@@ -111,7 +111,7 @@
 
 <ng-template #noSubmission>
     <div *ngIf="!loadingInitialSubmission" class="alert alert-warning text-center mt-4" role="alert">
-        <p jhiTranslate="artemisApp.fileUploadAssessment.notFound">We haven't found any new submission without an assessment, please go back.</p>
+        <p jhiTranslate="artemisApp.programmingAssessment.notFound">We haven't found any new submission without an assessment, please go back.</p>
         <a [routerLink]="exerciseDashboardLink" class="btn btn-info btn-sm mr-1 mb-1 assessment-dashboard">
             <span class="d-none d-md-inline" jhiTranslate="entity.action.exerciseDashboard">Exercise dashboard</span>
         </a>

--- a/src/main/webapp/i18n/de/programmingAssessment.json
+++ b/src/main/webapp/i18n/de/programmingAssessment.json
@@ -4,7 +4,8 @@
             "dashboard": {
                 "heading": "Einreichungen und Bewertungen der Textaufgabe \"{{exerciseTitle}}\""
             },
-            "confirmCancel": "Bist du sicher, dass du die Bewertung abbrechen möchtest? Dein aktueller Bewertungsfortschritt wird gelöscht und die Abgabe steht anderen Tutoren wieder zur Verfügung."
+            "confirmCancel": "Bist du sicher, dass du die Bewertung abbrechen möchtest? Dein aktueller Bewertungsfortschritt wird gelöscht und die Abgabe steht anderen Tutoren wieder zur Verfügung.",
+            "notFound": "Wir haben keine neue Programmier Abgabe ohne Bewertung gefunden, bitte gehe zurück."
         }
     }
 }

--- a/src/main/webapp/i18n/en/programmingAssessment.json
+++ b/src/main/webapp/i18n/en/programmingAssessment.json
@@ -4,7 +4,8 @@
             "dashboard": {
                 "heading": "Submissions and assessments of programming exercise \"{{exerciseTitle}}\""
             },
-            "confirmCancel": "Are you sure you want to cancel the assessment? Your current assessment progress will be deleted and the submission will be available for assessment to other tutors again."
+            "confirmCancel": "Are you sure you want to cancel the assessment? Your current assessment progress will be deleted and the submission will be available for assessment to other tutors again.",
+            "notFound": "We haven't found any new programming submission without an assessment, please go back."
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #3214 and fixes a small translation issue.

### Description
<!-- Describe your changes in detail -->
- Fixed translation
- Removed exam check for complaint 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create an programming exercise, participate and assess 
3.1 After the last assessment, it should say now programming exercise instead of file upload.
4. Complain about assessment, you should be able to fill out the complain mask.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Nothing changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/33342534/114763776-7a0e1b00-9d63-11eb-91b1-7171a42e6fc5.png)
![image](https://user-images.githubusercontent.com/33342534/114764070-ce18ff80-9d63-11eb-9c83-16c7ec98912e.png)
