### PR TITLE
Update versions of SCA in pom.xml templates

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
@@ -287,7 +287,7 @@ public interface ContinuousIntegrationService {
      */
     static String getDockerImageName(ProgrammingLanguage language) {
         return switch (language) {
-            case JAVA, KOTLIN -> "ls1tum/artemis-maven-template:java16-1";
+            case JAVA, KOTLIN -> "ls1tum/artemis-maven-template:java16-2";
             case PYTHON -> "ls1tum/artemis-python-docker:latest";
             case C -> "ls1tum/artemis-c-docker:latest";
             case HASKELL -> "tumfpv/fpv-stack:8.8.4";

--- a/src/main/resources/templates/java/maven/test/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/maven/test/projectTemplate/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.1.4</version>
+                <version>4.2.3</version>
                 <configuration>
                     <!-- Do not analyze the files in the test directory -->
                     <includeTests>${analyzeTests}</includeTests>
@@ -78,12 +78,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.2</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.36.2</version>
+                        <version>8.41.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>
@@ -105,12 +105,12 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>6.29.0</version>
+                        <version>6.33.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>6.29.0</version>
+                        <version>6.33.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/main/resources/templates/java/test/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/test/projectTemplate/pom.xml
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.1.4</version>
+                <version>4.2.3</version>
                 <configuration>
                     <!-- Do not analyze the files in the test directory -->
                     <includeTests>${analyzeTests}</includeTests>
@@ -73,12 +73,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.2</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.36.2</version>
+                        <version>8.41.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>
@@ -100,12 +100,12 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>6.29.0</version>
+                        <version>6.33.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>6.29.0</version>
+                        <version>6.33.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes in 8 exercises in the course "Grundlagen: Algorithmen und Datenstrukturen"

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Java 16 has some new features that weren't previously supported by the SCA dependencies in programming exercises.
See for example this fixed issue of Spotbugs: https://github.com/spotbugs/spotbugs/pull/1503

### Description
<!-- Describe your changes in detail -->
A simple update of dependencies in the pom.xml template for java tests in programming exercises.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a new programming exercise with SCA
2. Submit a solution without any mistakes. It should have no reported SCA problems
3. Submit a solution with some SCA-mistakes. They should get reported in Artemis in the score as well.