### PR TITLE
[Bugfix] Course deletion - The user remains on the course detail page after the course has been deleted

### DIFF
--- a/src/main/webapp/app/course/manage/course-detail.component.ts
+++ b/src/main/webapp/app/course/manage/course-detail.component.ts
@@ -98,5 +98,6 @@ export class CourseDetailComponent implements OnInit, OnDestroy {
             },
             (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
         );
+        this.router.navigate(['/course-management']);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The delete button in the course detail page didn't redirect the user back to the course management upon deletion. Instead, the user used to remain on the same page and got a 404 Not found error (because the course has been deleted)

### Description
<!-- Describe your changes in detail -->
I added a router link to the delete method, so the user gets redirected to the course management page upon successful deletion of the course.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a course
4. Go to the course detail page of the newly created course and delete that course
5. The user should get redirected back to the course management page
