### PR TITLE
Fix example submission update bug

### DIFF
--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
@@ -178,18 +178,19 @@ export class ExampleModelingSubmissionComponent implements OnInit {
             this.createNewExampleModelingSubmission();
         }
         this.modelingSubmission.model = JSON.stringify(this.modelingEditor.getCurrentModel());
+
         this.modelingSubmission.explanationText = this.explanationText;
         this.modelingSubmission.exampleSubmission = true;
         if (this.result) {
             this.result.feedbacks = this.feedbacks;
             setLatestSubmissionResult(this.modelingSubmission, this.result);
+            delete this.result.submission;
         }
 
         const exampleSubmission = this.exampleSubmission;
         exampleSubmission.submission = this.modelingSubmission;
         exampleSubmission.exercise = this.exercise;
         exampleSubmission.usedForTutorial = this.usedForTutorial;
-
         this.exampleSubmissionService.update(exampleSubmission, this.exerciseId).subscribe(
             (exampleSubmissionResponse: HttpResponse<ExampleSubmission>) => {
                 this.exampleSubmission = exampleSubmissionResponse.body!;
@@ -366,8 +367,9 @@ export class ExampleModelingSubmissionComponent implements OnInit {
         }
 
         const exampleSubmission = Object.assign({}, this.exampleSubmission);
-
-        setLatestSubmissionResult(exampleSubmission.submission, new Result());
+        const result = new Result();
+        setLatestSubmissionResult(exampleSubmission.submission, result);
+        delete result.submission;
         getLatestSubmissionResult(exampleSubmission.submission)!.feedbacks = this.feedbacks;
 
         this.tutorParticipationService.assessExampleSubmission(exampleSubmission, this.exerciseId).subscribe(


### PR DESCRIPTION
Fixes #3222 

### Description
It was not possible to save example submission after assessing it.

### Steps for Testing
1. Go to 'Course Management'
2. Click on 'Create Modeling Exercise'
3. Create an Modeling Exercise
4. Create an Example submission for the modeling exercise
5. Assess this submission and save the assessment
6. Remove the assessed parts and save the assessment again
7. Try to change the underlying submission
8. Check the assessment got saved:

