### PR TITLE
fixed strict template changes for markdown-editor.component

### DIFF
--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -454,7 +454,8 @@ export class MarkdownEditorComponent implements AfterViewInit {
         });
     }
 
-    markdownTextChange(value: {}) {
+    markdownTextChange(value: any) {
         this.markdownChange.emit(value as string);
+        this.markdown = value;
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
After some changes for strict templates, the grading instructions can not be edited. This has been solved with this PR.

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create an exercise
3. Change Structured Grading Instructions without example submission/any participation.
4. Check preview, see if the changes are saved.
5. Save the exercise, then check exercise details, see if the changes are saved.

![image](https://user-images.githubusercontent.com/33342534/115263407-b2cc3c80-a135-11eb-88f2-a35cd2faa5a2.png)
![image](https://user-images.githubusercontent.com/33342534/115263483-c24b8580-a135-11eb-8648-222c6390bf9e.png)
