### PR TITLE
Fix sorting of tutor leaderboard on instructor exercise dashboard

### DIFF
--- a/src/main/webapp/app/exercises/shared/dashboards/instructor/instructor-exercise-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/instructor/instructor-exercise-dashboard.component.ts
@@ -86,8 +86,8 @@ export class InstructorExerciseDashboardComponent implements OnInit {
 
         this.exerciseService.getStatsForInstructors(exerciseId).subscribe(
             (res: HttpResponse<StatsForDashboard>) => {
-                this.sortService.sortByProperty(this.stats.tutorLeaderboardEntries, 'points', false);
                 this.stats = StatsForDashboard.from(Object.assign({}, this.stats, res.body));
+                this.sortService.sortByProperty(this.stats.tutorLeaderboardEntries, 'points', false);
                 this.setStatistics();
             },
             (response: string) => this.onError(response),


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) ~~on the test server https://artemistest.ase.in.tum.de~~ locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Artemis always sorts the tutor leaderboard by points per default. But for the Instructor Exercises Dashboard this was not the case, this PR fixes this and also sorts this table by points initially.  

### Description
Fixed a method call that was out of order (it was overwritten the line after)

### Steps for Testing
1. Navigate to the Instructor Exercises Dashboard
2. Check that the Tutor Leaderboard is correctly sorted by points initially. 

### Screenshots
old (not that the sorting arrow on the points is shown even though the data is not sorted):
![grafik](https://user-images.githubusercontent.com/26540346/115297811-ec646e00-a15c-11eb-96d5-6d8a41cf3f5d.png)

new:
![grafik](https://user-images.githubusercontent.com/26540346/115297793-e79fba00-a15c-11eb-8ebb-1b3e481a226c.png)

