### PR TITLE
Performance improvements for assessment dashboards

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/assessment/dashboard/RatedCount.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/assessment/dashboard/RatedCount.java
@@ -1,0 +1,7 @@
+package de.tum.in.www1.artemis.domain.assessment.dashboard;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record RatedCount(boolean rated, long count) {
+}

--- a/src/main/java/de/tum/in/www1/artemis/domain/assessment/dashboard/ResultCount.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/assessment/dashboard/ResultCount.java
@@ -3,5 +3,6 @@ package de.tum.in.www1.artemis.domain.assessment.dashboard;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public record RatedCount(boolean rated, long count) {
+// we have to use upper case Boolean here, because in Result.rated can also take the value null
+public record ResultCount(Boolean rated, long count) {
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ComplaintRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ComplaintRepository.java
@@ -226,85 +226,78 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     /**
      * Get the number of Complaints for all tutors of a course
      *
-     * @param groupName - name of the tutorgroup
      * @param courseId  - id of the course
      * @return list of TutorLeaderboardComplaints
      */
     @Query("""
             SELECT
             new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaints(
-                a.id,
+                r.assessor.id,
                 count(c),
                 sum( CASE WHEN (c.accepted = true) THEN 1L ELSE 0L END),
                 sum( CASE WHEN (c.accepted = true) THEN e.maxPoints ELSE 0.0 END)
             )
             FROM
-                Complaint c join c.result r join r.participation p join p.exercise e join e.course co join r.assessor a
+                Complaint c join c.result r join r.participation p join p.exercise e
             WHERE
-                 :#{#groupName} member of a.groups
-                and c.complaintType = 'COMPLAINT'
-                and co.id = :courseId
+                    c.complaintType = 'COMPLAINT'
+                and e.course.id = :courseId
                 and r.completionDate IS NOT NULL
-            GROUP BY a.id
+            GROUP BY r.assessor.id
             """)
-    List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByCourseId(@Param("groupName") String groupName, @Param("courseId") long courseId);
+    List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByCourseId(@Param("courseId") long courseId);
 
     /**
      * Get the number of Complaints for all tutors of an exercise
      *
-     * @param groupName  - name of the tutorgroup
      * @param exerciseId - id of the exercise
      * @return list of TutorLeaderboardComplaints
      */
     @Query("""
             SELECT
             new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaints(
-                c.result.assessor.id,
+                r.assessor.id,
                 count(c),
                 sum( CASE WHEN (c.accepted = true ) THEN 1L ELSE 0L END),
                 sum( CASE WHEN (c.accepted = true) THEN e.maxPoints ELSE 0.0 END)
             )
             FROM
-                Complaint c join c.result r join r.participation p join p.exercise e join r.assessor a
+                Complaint c join c.result r join r.participation p join p.exercise e
             WHERE
-                 :#{#groupName} member of a.groups
-                and c.complaintType = 'COMPLAINT'
+                    c.complaintType = 'COMPLAINT'
                 and e.id = :#{#exerciseId}
                 and r.completionDate IS NOT NULL
-            GROUP BY a.id
+            GROUP BY r.assessor.id
             """)
-    List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByExerciseId(@Param("groupName") String groupName, @Param("exerciseId") long exerciseId);
+    List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByExerciseId(@Param("exerciseId") long exerciseId);
 
     /**
      * Get the number of Complaints for all tutors of an exam
      *
-     * @param groupName  - name of the tutorgroup
      * @param examId     - id of the exercise
      * @return list of TutorLeaderboardComplaints
      */
     @Query("""
             SELECT
             new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardComplaints(
-                c.result.assessor.id,
+                r.assessor.id,
                 count(c),
                 sum( CASE WHEN (c.accepted = true ) THEN 1L ELSE 0L END),
                 sum( CASE WHEN (c.accepted = true) THEN e.maxPoints ELSE 0.0 END)
             )
             FROM
-                Complaint c join c.result r join r.participation p join p.exercise e join e.exerciseGroup eg join eg.exam ex join r.assessor a
+                Complaint c join c.result r join r.participation p join p.exercise e join e.exerciseGroup eg
             WHERE
-                 :#{#groupName} member of a.groups
-                and c.complaintType = 'COMPLAINT'
-                and ex.id = :#{#examId}
+                    c.complaintType = 'COMPLAINT'
+                and eg.exam.id = :#{#examId}
                 and r.completionDate IS NOT NULL
-            GROUP BY a.id
+            GROUP BY r.assessor.id
             """)
-    List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByExamId(@Param("groupName") String groupName, @Param("examId") long examId);
+    List<TutorLeaderboardComplaints> findTutorLeaderboardComplaintsByExamId(@Param("examId") long examId);
 
     /**
      * Get the number of complaintResponses for all tutors assessments of a course
      *
-     * @param groupName  - name of the tutorgroup
      * @param courseId   - id of the exercise
      * @return list of TutorLeaderboardComplaintResponses
      */
@@ -316,21 +309,19 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
                 sum(e.maxPoints)
             )
             FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e join e.course co join r.assessor a
+                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e
             WHERE
                 c.complaintType = 'COMPLAINT'
-                and :#{#groupName} member of a.groups
-                and co.id = :courseId
+                and e.course.id = :courseId
                 and r.completionDate IS NOT NULL
                 and c.accepted IS NOT NULL
             GROUP BY cr.reviewer.id
             """)
-    List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByCourseId(@Param("groupName") String groupName, @Param("courseId") long courseId);
+    List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByCourseId(@Param("courseId") long courseId);
 
     /**
      * Get the number of complaintResponses for all tutors assessments of an exercise
      *
-     * @param groupName  - name of the tutorgroup
      * @param exerciseId - id of the exercise
      * @return list of TutorLeaderboardComplaintResponses
      */
@@ -342,21 +333,19 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
                  sum(e.maxPoints)
              )
              FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e join r.assessor a
+                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e
              WHERE
                  c.complaintType = 'COMPLAINT'
-                 and :#{#groupName} member of a.groups
                  and e.id = :exerciseId
                  and r.completionDate IS NOT NULL
                  and c.accepted IS NOT NULL
              GROUP BY cr.reviewer.id
              """)
-    List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByExerciseId(@Param("groupName") String groupName, @Param("exerciseId") long exerciseId);
+    List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByExerciseId(@Param("exerciseId") long exerciseId);
 
     /**
      * Get the number of complaintResponses for all tutors assessments of an exam
      *
-     * @param groupName  - name of the tutorgroup
      * @param examId     - id of the exam
      * @return list of TutorLeaderboardComplaintResponses
      */
@@ -368,100 +357,91 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
                  sum(e.maxPoints)
              )
              FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e join e.exerciseGroup eg join eg.exam ex  join r.assessor a
+                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e join e.exerciseGroup eg
              WHERE
                  c.complaintType = 'COMPLAINT'
-                 and :#{#groupName} member of a.groups
-                 and ex.id = :examId
+                 and eg.exam.id = :examId
                  and r.completionDate IS NOT NULL
                  and c.accepted IS NOT NULL
              GROUP BY cr.reviewer.id
              """)
-    List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByExamId(@Param("groupName") String groupName, @Param("examId") long examId);
+    List<TutorLeaderboardComplaintResponses> findTutorLeaderboardComplaintResponsesByExamId(@Param("examId") long examId);
 
     /**
      * Get the number of Feedback Requests for all tutors assessments of a course
      *
-     * @param groupName  - name of the tutorgroup
      * @param courseId   - id of the exercise
      * @return list of TutorLeaderboardMoreFeedbackRequests
      */
     @Query("""
             SELECT
              new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardMoreFeedbackRequests(
-                 a.id,
+                 r.assessor.id,
                  count(c),
                  sum( CASE WHEN (c.accepted IS NULL) THEN 1L ELSE 0L END),
                  sum( CASE WHEN (c.accepted IS NULL) THEN e.maxPoints ELSE 0.0 END)
              )
              FROM
-                Complaint c join c.result r join r.participation p join p.exercise e join e.course co join r.assessor a
+                Complaint c join c.result r join r.participation p join p.exercise e
              WHERE
                  c.complaintType = 'MORE_FEEDBACK'
-                 and :#{#groupName} member of a.groups
-                 and co.id = :courseId
+                 and e.course.id = :courseId
                  and r.completionDate IS NOT NULL
-             GROUP BY a.id
+             GROUP BY r.assessor.id
              """)
-    List<TutorLeaderboardMoreFeedbackRequests> findTutorLeaderboardMoreFeedbackRequestsByCourseId(@Param("groupName") String groupName, @Param("courseId") long courseId);
+    List<TutorLeaderboardMoreFeedbackRequests> findTutorLeaderboardMoreFeedbackRequestsByCourseId(@Param("courseId") long courseId);
 
     /**
      * Get the number of Feedback Requests for all tutors assessments of an exercise
      *
-     * @param groupName  - name of the tutorgroup
      * @param exerciseId - id of the exercise
      * @return list of TutorLeaderboardMoreFeedbackRequests
      */
     @Query("""
             SELECT
             new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardMoreFeedbackRequests(
-               a.id,
+                r.assessor.id,
                 count(c),
                 sum( CASE WHEN (c.accepted IS NULL) THEN 1L ELSE 0L END),
                 sum( CASE WHEN (c.accepted IS NULL) THEN e.maxPoints ELSE 0.0 END)
             )
             FROM
-                Complaint c join c.result r join r.participation p join p.exercise e join r.assessor a
+                Complaint c join c.result r join r.participation p join p.exercise e
             WHERE
                 c.complaintType = 'MORE_FEEDBACK'
-                and :#{#groupName} member of a.groups
                 and e.id = :exerciseId
                 and r.completionDate IS NOT NULL
-            GROUP BY a.id
+            GROUP BY r.assessor.id
             """)
-    List<TutorLeaderboardMoreFeedbackRequests> findTutorLeaderboardMoreFeedbackRequestsByExerciseId(@Param("groupName") String groupName, @Param("exerciseId") long exerciseId);
+    List<TutorLeaderboardMoreFeedbackRequests> findTutorLeaderboardMoreFeedbackRequestsByExerciseId(@Param("exerciseId") long exerciseId);
 
     /**
      * Get the number of Feedback Request Responses for all tutors assessments of a course
      *
-     * @param groupName  - name of the tutorgroup
      * @param courseId   - id of the course
      * @return list of TutorLeaderboardAnsweredMoreFeedbackRequests
      */
     @Query("""
             SELECT
             new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardAnsweredMoreFeedbackRequests(
-                 cr.reviewer.id,
+                cr.reviewer.id,
                 count(c),
                 sum(e.maxPoints)
             )
             FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e join e.course co join r.assessor a
+                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e
             WHERE
                 c.complaintType = 'MORE_FEEDBACK'
-                and :#{#groupName} member of a.groups
-                and co.id = :courseId
+                and e.course.id = :courseId
                 and r.completionDate IS NOT NULL
                 and c.accepted = true
             GROUP BY cr.reviewer.id
             """)
-    List<TutorLeaderboardAnsweredMoreFeedbackRequests> findTutorLeaderboardAnsweredMoreFeedbackRequestsByCourseId(@Param("groupName") String groupName,
-            @Param("courseId") long courseId);
+    List<TutorLeaderboardAnsweredMoreFeedbackRequests> findTutorLeaderboardAnsweredMoreFeedbackRequestsByCourseId(@Param("courseId") long courseId);
 
     /**
      * Get the number of Feedback Request Responses for all tutors assessments of an exercise
      *
-     * @param groupName  - name of the tutorgroup
      * @param exerciseId - id of the exercise
      * @return list of TutorLeaderboardAnsweredMoreFeedbackRequests
      */
@@ -470,18 +450,16 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
             new de.tum.in.www1.artemis.domain.leaderboard.tutor.TutorLeaderboardAnsweredMoreFeedbackRequests(
                 cr.reviewer.id,
                 count(c),
-                sum(c.result.participation.exercise.maxPoints)
+                sum(e.maxPoints)
                 )
             FROM
-                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e join r.assessor a
+                Complaint c join c.complaintResponse cr join c.result r join r.participation p join p.exercise e
             WHERE
                 c.complaintType = 'MORE_FEEDBACK'
-                and :#{#groupName} member of a.groups
                 and e.id = :exerciseId
                 and r.completionDate IS NOT NULL
                 and c.accepted = true
             GROUP BY cr.reviewer.id
             """)
-    List<TutorLeaderboardAnsweredMoreFeedbackRequests> findTutorLeaderboardAnsweredMoreFeedbackRequestsByExerciseId(@Param("groupName") String groupName,
-            @Param("exerciseId") long exerciseId);
+    List<TutorLeaderboardAnsweredMoreFeedbackRequests> findTutorLeaderboardAnsweredMoreFeedbackRequestsByExerciseId(@Param("exerciseId") long exerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -121,7 +121,7 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
      * counts the number of assessments of a course, which are either rated or not rated
      *
      * @param exerciseIds - the exercises of the course
-     * @return an array with 2 elements: count of rated (in time) and unrated (late) assessments of a course
+     * @return a list with 3 elements: count of rated (in time) and unrated (late) assessments of a course and count of assessments without rating (null)
      */
     @Query("""
             SELECT new de.tum.in.www1.artemis.domain.assessment.dashboard.ResultCount(r.rated, count(r))

--- a/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/SubmissionRepository.java
@@ -215,9 +215,9 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the number of submissions belonging to the course id, which have the submitted flag set to true and the submission date after the exercise due date
      */
     @Query("""
-            SELECT COUNT (DISTINCT s) FROM Submission s join s.participation p join p.exercise e join e.course c
+            SELECT COUNT (DISTINCT s) FROM Submission s join s.participation p join p.exercise e
             WHERE TYPE(s) IN (ModelingSubmission, TextSubmission, FileUploadSubmission)
-                AND c.id = :#{#courseId}
+                AND e.course.id = :#{#courseId}
                 AND s.submitted = TRUE
                 AND e.dueDate IS NOT NULL
                 AND s.submissionDate > e.dueDate
@@ -227,7 +227,7 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     /**
      * Count number of late submissions for course. Only submissions for Text, Modeling and File Upload exercises are included.
      *
-     * @param exerciseIds the ids of the exercises bolonging to the course we are interested in
+     * @param exerciseIds the ids of the exercises belonging to the course we are interested in
      * @return the number of submissions belonging to the course, which have the submitted flag set to true and the submission date after the exercise due date
      */
     @Query("""
@@ -246,12 +246,12 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      *         exercise due date at all
      */
     @Query("""
-            SELECT COUNT (DISTINCT p) FROM StudentParticipation p
+            SELECT COUNT (DISTINCT p) FROM StudentParticipation p join p.exercise e
             JOIN p.submissions s
-                WHERE p.exercise.id = :#{#exerciseId}
+                WHERE e.id = :#{#exerciseId}
                 AND s.submitted = TRUE
                 AND (s.type <> 'ILLEGAL' OR s.type IS NULL)
-                AND (p.exercise.dueDate IS NULL OR s.submissionDate <= p.exercise.dueDate)
+                AND (e.dueDate IS NULL OR s.submissionDate <= e.dueDate)
             """)
     long countByExerciseIdSubmittedBeforeDueDate(@Param("exerciseId") long exerciseId);
 
@@ -261,16 +261,16 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      *         exercise due date at all
      */
     @Query("""
-             SELECT
-                 new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
-                     p.exercise.id,
-                     count(DISTINCT p)
-                 )
-            FROM StudentParticipation p JOIN p.submissions s
-             WHERE p.exercise.id IN :exerciseIds
-                 AND s.submitted = TRUE
-                 AND (p.exercise.dueDate IS NULL OR s.submissionDate <= p.exercise.dueDate)
-             GROUP BY  p.exercise.id
+            SELECT
+                new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
+                    p.exercise.id,
+                    count(DISTINCT p)
+                )
+            FROM StudentParticipation p JOIN p.submissions s JOIN p.exercise e
+            WHERE e.id IN :exerciseIds
+                AND s.submitted = TRUE
+                AND (e.dueDate IS NULL OR s.submissionDate <= e.dueDate)
+            GROUP BY e.id
              """)
     List<ExerciseMapEntry> countByExerciseIdsSubmittedBeforeDueDate(@Param("exerciseIds") Set<Long> exerciseIds);
 
@@ -293,12 +293,12 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      *         exercise due date at all
      */
     @Query("""
-            SELECT COUNT (DISTINCT p) FROM StudentParticipation p join  p.submissions s
-            WHERE p.exercise.id = :#{#exerciseId}
+            SELECT COUNT (DISTINCT p) FROM StudentParticipation p JOIN p.submissions s JOIN p.exercise e
+            WHERE e.id = :#{#exerciseId}
             AND p.testRun = FALSE
             AND s.submitted = TRUE
             AND (s.type <> 'ILLEGAL' or s.type is null)
-            AND (p.exercise.dueDate IS NULL OR s.submissionDate <= p.exercise.dueDate)
+            AND (e.dueDate IS NULL OR s.submissionDate <= e.dueDate)
             """)
     long countByExerciseIdSubmittedBeforeDueDateIgnoreTestRuns(@Param("exerciseId") long exerciseId);
 
@@ -314,12 +314,12 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
                     p.exercise.id,
                     count(DISTINCT p)
                 )
-            FROM StudentParticipation p JOIN  p.submissions s
-            WHERE p.exercise.id IN :exerciseIds
+            FROM StudentParticipation p JOIN p.submissions s JOIN p.exercise e
+            WHERE e.id IN :exerciseIds
                 AND p.testRun = FALSE
                 AND s.submitted = TRUE
-                AND (p.exercise.dueDate IS NULL OR s.submissionDate <= p.exercise.dueDate)
-            GROUP BY p.exercise.id
+                AND (e.dueDate IS NULL OR s.submissionDate <= e.dueDate)
+            GROUP BY e.id
                 """)
     List<ExerciseMapEntry> countByExerciseIdsSubmittedBeforeDueDateIgnoreTestRuns(@Param("exerciseIds") Set<Long> exerciseIds);
 
@@ -329,12 +329,12 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the number of submissions belonging to the exercise id, which have the submitted flag set to true and the submission date after the exercise due date
      */
     @Query("""
-            SELECT COUNT (DISTINCT p) FROM StudentParticipation p
-            JOIN p.submissions s
-                WHERE p.exercise.id = :#{#exerciseId}
+            SELECT COUNT (DISTINCT p)
+            FROM StudentParticipation p JOIN p.submissions s JOIN p.exercise e
+                WHERE e.id = :#{#exerciseId}
                 AND s.submitted = TRUE
                 AND (s.type <> 'ILLEGAL' OR s.type IS NULL)
-                AND s.submissionDate > p.exercise.dueDate
+                AND s.submissionDate > e.dueDate
             """)
     long countByExerciseIdSubmittedAfterDueDate(@Param("exerciseId") long exerciseId);
 
@@ -344,8 +344,9 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the number of submissions belonging to the exercise id, which have the submitted flag set to true
      */
     @Query("""
-            SELECT COUNT (DISTINCT p) FROM StudentParticipation p join p.submissions s
-                WHERE p.exercise.id = :#{#exerciseId}
+            SELECT COUNT (DISTINCT p)
+            FROM StudentParticipation p JOIN p.submissions s
+            WHERE p.exercise.id = :#{#exerciseId}
                 AND s.submitted = TRUE
             """)
     long countByExerciseIdSubmitted(@Param("exerciseId") long exerciseId);
@@ -355,16 +356,16 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the numbers of submissions belonging to each exercise id, which have the submitted flag set to true and the submission date after the exercise due date
      */
     @Query("""
-             SELECT
-                 new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
-                     p.exercise.id,
-                     count(DISTINCT p)
-                 )
-            FROM StudentParticipation p JOIN p.submissions s
-             WHERE p.exercise.id IN :exerciseIds
+            SELECT
+                new de.tum.in.www1.artemis.domain.assessment.dashboard.ExerciseMapEntry(
+                    p.exercise.id,
+                    count(DISTINCT p)
+                    )
+            FROM StudentParticipation p JOIN p.submissions s JOIN p.exercise e
+             WHERE e.id IN :exerciseIds
                  AND s.submitted = TRUE
-                 AND s.submissionDate > p.exercise.dueDate
-             GROUP BY  p.exercise.id
+                 AND s.submissionDate > e.dueDate
+             GROUP BY e.id
              """)
     List<ExerciseMapEntry> countByExerciseIdsSubmittedAfterDueDate(@Param("exerciseIds") Set<Long> exerciseIds);
 
@@ -379,8 +380,10 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
      * @return the submissions belonging to the exercise id, which have been assessed by the given assessor
      */
     @Query("""
-            SELECT DISTINCT submission FROM Submission submission LEFT JOIN FETCH submission.results r LEFT JOIN FETCH r.assessor a
-            WHERE submission.participation.exercise.id = :#{#exerciseId} AND :#{#assessor} = a
+            SELECT DISTINCT submission
+            FROM Submission submission LEFT JOIN FETCH submission.results r LEFT JOIN FETCH r.assessor a
+            WHERE submission.participation.exercise.id = :#{#exerciseId}
+                AND :#{#assessor} = a
             """)
     <T extends Submission> List<T> findAllByParticipationExerciseIdAndResultAssessor(@Param("exerciseId") Long exerciseId, @Param("assessor") User assessor);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/TutorLeaderboardService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TutorLeaderboardService.java
@@ -48,37 +48,33 @@ public class TutorLeaderboardService {
     public List<TutorLeaderboardDTO> getCourseLeaderboard(Course course, Set<Long> exerciseIdsOfCourse) {
 
         List<User> tutors = userRepository.getTutors(course);
-        String groupName = course.getTeachingAssistantGroupName();
 
         long start = System.currentTimeMillis();
         // 2.3s
-        List<TutorLeaderboardAssessments> tutorLeaderboardAssessments = resultRepository.findTutorLeaderboardAssessmentByCourseId(exerciseIdsOfCourse);
+        var tutorLeaderboardAssessments = resultRepository.findTutorLeaderboardAssessmentByCourseId(exerciseIdsOfCourse);
         long end = System.currentTimeMillis();
         log.info("Finished >>resultRepository.findTutorLeaderboardAssessmentByCourseId<< call for course {} in {}ms", course.getId(), end - start);
 
         start = System.currentTimeMillis();
         // 3.0s
-        List<TutorLeaderboardComplaints> tutorLeaderboardComplaints = complaintRepository.findTutorLeaderboardComplaintsByCourseId(groupName, course.getId());
+        var tutorLeaderboardComplaints = complaintRepository.findTutorLeaderboardComplaintsByCourseId(course.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardComplaintsByCourseId<< call for course {} in {}ms", course.getId(), end - start);
 
         start = System.currentTimeMillis();
         // 0.6s
-        List<TutorLeaderboardMoreFeedbackRequests> tutorLeaderboardMoreFeedbackRequests = complaintRepository.findTutorLeaderboardMoreFeedbackRequestsByCourseId(groupName,
-                course.getId());
+        var tutorLeaderboardMoreFeedbackRequests = complaintRepository.findTutorLeaderboardMoreFeedbackRequestsByCourseId(course.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardMoreFeedbackRequestsByCourseId<< call for course {} in {}ms", course.getId(), end - start);
 
         start = System.currentTimeMillis();
         // 2.3s
-        List<TutorLeaderboardComplaintResponses> tutorLeaderboardComplaintResponses = complaintRepository.findTutorLeaderboardComplaintResponsesByCourseId(groupName,
-                course.getId());
+        var tutorLeaderboardComplaintResponses = complaintRepository.findTutorLeaderboardComplaintResponsesByCourseId(course.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardComplaintResponsesByCourseId<< call for course {} in {}ms", course.getId(), end - start);
 
         start = System.currentTimeMillis();
-        List<TutorLeaderboardAnsweredMoreFeedbackRequests> tutorLeaderboardAnsweredMoreFeedbackRequests = complaintRepository
-                .findTutorLeaderboardAnsweredMoreFeedbackRequestsByCourseId(groupName, course.getId());
+        var tutorLeaderboardAnsweredMoreFeedbackRequests = complaintRepository.findTutorLeaderboardAnsweredMoreFeedbackRequestsByCourseId(course.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardAnsweredMoreFeedbackRequestsByCourseId<< call for course {} in {}ms", course.getId(), end - start);
 
@@ -95,19 +91,18 @@ public class TutorLeaderboardService {
      */
     public List<TutorLeaderboardDTO> getExamLeaderboard(Course course, Exam exam) {
 
-        List<User> tutors = userRepository.getTutors(course);
-        String groupName = course.getTeachingAssistantGroupName();
+        var tutors = userRepository.getTutors(course);
 
         long start = System.currentTimeMillis();
-        List<TutorLeaderboardAssessments> tutorLeaderboardAssessments = resultRepository.findTutorLeaderboardAssessmentByExamId(exam.getId());
+        var tutorLeaderboardAssessments = resultRepository.findTutorLeaderboardAssessmentByExamId(exam.getId());
         long end = System.currentTimeMillis();
         log.info("Finished >>resultRepository.findTutorLeaderboardAssessmentByExamId<< call for exercise {} in {}ms", exam.getId(), end - start);
         start = System.currentTimeMillis();
-        List<TutorLeaderboardComplaints> tutorLeaderboardComplaints = complaintRepository.findTutorLeaderboardComplaintsByExamId(groupName, exam.getId());
+        var tutorLeaderboardComplaints = complaintRepository.findTutorLeaderboardComplaintsByExamId(exam.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardComplaintsByExamId<< call for exercise {} in {}ms", exam.getId(), end - start);
         start = System.currentTimeMillis();
-        List<TutorLeaderboardComplaintResponses> tutorLeaderboardComplaintResponses = complaintRepository.findTutorLeaderboardComplaintResponsesByExamId(groupName, exam.getId());
+        var tutorLeaderboardComplaintResponses = complaintRepository.findTutorLeaderboardComplaintResponsesByExamId(exam.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardComplaintResponsesByExamId<< call for exercise {} in {}ms", exam.getId(), end - start);
 
@@ -123,29 +118,25 @@ public class TutorLeaderboardService {
      */
     public List<TutorLeaderboardDTO> getExerciseLeaderboard(Exercise exercise) {
 
-        List<User> tutors = userRepository.getTutors(exercise.getCourseViaExerciseGroupOrCourseMember());
-        String groupName = exercise.getCourseViaExerciseGroupOrCourseMember().getTeachingAssistantGroupName();
+        var tutors = userRepository.getTutors(exercise.getCourseViaExerciseGroupOrCourseMember());
         long start = System.currentTimeMillis();
-        List<TutorLeaderboardAssessments> tutorLeaderboardAssessments = resultRepository.findTutorLeaderboardAssessmentByExerciseId(exercise.getId());
+        var tutorLeaderboardAssessments = resultRepository.findTutorLeaderboardAssessmentByExerciseId(exercise.getId());
         long end = System.currentTimeMillis();
         log.info("Finished >>resultRepository.findTutorLeaderboardAssessmentByExerciseId<< call for exercise {} in {}ms", exercise.getId(), end - start);
         start = System.currentTimeMillis();
-        List<TutorLeaderboardComplaints> tutorLeaderboardComplaints = complaintRepository.findTutorLeaderboardComplaintsByExerciseId(groupName, exercise.getId());
+        var tutorLeaderboardComplaints = complaintRepository.findTutorLeaderboardComplaintsByExerciseId(exercise.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardComplaintsByExerciseId<< call for exercise {} in {}ms", exercise.getId(), end - start);
         start = System.currentTimeMillis();
-        List<TutorLeaderboardMoreFeedbackRequests> tutorLeaderboardMoreFeedbackRequests = complaintRepository.findTutorLeaderboardMoreFeedbackRequestsByExerciseId(groupName,
-                exercise.getId());
+        var tutorLeaderboardMoreFeedbackRequests = complaintRepository.findTutorLeaderboardMoreFeedbackRequestsByExerciseId(exercise.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardMoreFeedbackRequestsByExerciseId<< call for exercise {} in {}ms", exercise.getId(), end - start);
         start = System.currentTimeMillis();
-        List<TutorLeaderboardComplaintResponses> tutorLeaderboardComplaintResponses = complaintRepository.findTutorLeaderboardComplaintResponsesByExerciseId(groupName,
-                exercise.getId());
+        var tutorLeaderboardComplaintResponses = complaintRepository.findTutorLeaderboardComplaintResponsesByExerciseId(exercise.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardComplaintResponsesByExerciseId<< call for exercise {} in {}ms", exercise.getId(), end - start);
         start = System.currentTimeMillis();
-        List<TutorLeaderboardAnsweredMoreFeedbackRequests> tutorLeaderboardAnsweredMoreFeedbackRequests = complaintRepository
-                .findTutorLeaderboardAnsweredMoreFeedbackRequestsByExerciseId(groupName, exercise.getId());
+        var tutorLeaderboardAnsweredMoreFeedbackRequests = complaintRepository.findTutorLeaderboardAnsweredMoreFeedbackRequestsByExerciseId(exercise.getId());
         end = System.currentTimeMillis();
         log.info("Finished >>complaintRepository.findTutorLeaderboardAnsweredMoreFeedbackRequestsByExerciseId<< call for exercise {} in {}ms", exercise.getId(), end - start);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -477,7 +477,7 @@ public class ExamService {
                 if (totalNumberOfAssessmentsFinished[i] == null) {
                     totalNumberOfAssessmentsFinished[i] = 0L;
                 }
-                totalNumberOfAssessmentsFinished[i] += dateStats[i].getInTime();
+                totalNumberOfAssessmentsFinished[i] += dateStats[i].inTime();
             }
         }
         for (Long numberOfComplaints : numberOfComplaintsOpenByExercise) {

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/quiz/QuizScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/quiz/QuizScheduleService.java
@@ -372,7 +372,7 @@ public class QuizScheduleService {
      * 4. Send out new Statistics to instructors (WEBSOCKET SEND)
      */
     public void processCachedQuizSubmissions() {
-        log.info("Process cached quiz submissions");
+        log.debug("Process cached quiz submissions");
         // global try-catch for error logging
         try {
             for (QuizExerciseCache cachedQuiz : quizCache.getAllQuizExerciseCaches()) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -45,6 +45,7 @@ import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.*;
 import de.tum.in.www1.artemis.service.connectors.CIUserManagementService;
 import de.tum.in.www1.artemis.service.connectors.VcsUserManagementService;
+import de.tum.in.www1.artemis.service.util.TimeLogUtil;
 import de.tum.in.www1.artemis.web.rest.dto.*;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
@@ -606,6 +607,7 @@ public class CourseResource {
     @GetMapping("/courses/{courseId}/stats-for-assessment-dashboard")
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<StatsForDashboardDTO> getStatsForAssessmentDashboard(@PathVariable long courseId) {
+        long startRestCall = System.nanoTime();
         Course course = courseRepository.findByIdElseThrow(courseId);
 
         long start = System.currentTimeMillis();
@@ -679,6 +681,7 @@ public class CourseResource {
 
         stats.setTutorLeaderboardEntries(leaderboardEntries);
 
+        log.error("Finished > getStatsForAssessmentDashboard < call for course {} in {}", course.getId(), TimeLogUtil.formatDurationFrom(startRestCall));
         return ResponseEntity.ok(stats);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -681,7 +681,7 @@ public class CourseResource {
 
         stats.setTutorLeaderboardEntries(leaderboardEntries);
 
-        log.error("Finished > getStatsForAssessmentDashboard < call for course {} in {}", course.getId(), TimeLogUtil.formatDurationFrom(startRestCall));
+        log.info("Finished > getStatsForAssessmentDashboard < call for course {} in {}", course.getId(), TimeLogUtil.formatDurationFrom(startRestCall));
         return ResponseEntity.ok(stats);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/DueDateStat.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/DueDateStat.java
@@ -7,36 +7,5 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * depending on the due-date of an exercise.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class DueDateStat {
-
-    // The statistic component before the due-date
-    private long inTime;
-
-    // The statistic component after the due-date
-    private long late;
-
-    public DueDateStat() {
-        // default constructor for our beloved Jackson serializer :-*
-    }
-
-    public DueDateStat(long inTime, long late) {
-        this.inTime = inTime;
-        this.late = late;
-    }
-
-    public long getInTime() {
-        return inTime;
-    }
-
-    public void setInTime(long inTime) {
-        this.inTime = inTime;
-    }
-
-    public long getLate() {
-        return late;
-    }
-
-    public void setLate(long late) {
-        this.late = late;
-    }
+public record DueDateStat(long inTime, long late) {
 }

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -1874,8 +1874,8 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         assertThat(stats.getTutorLeaderboardEntries()).isInstanceOf(List.class);
         assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()).isInstanceOf(DueDateStat[].class);
         assertThat(stats.getNumberOfAssessmentLocks()).isEqualTo(0L);
-        assertThat(stats.getNumberOfSubmissions().getInTime()).isEqualTo(0L);
-        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(0L);
+        assertThat(stats.getNumberOfSubmissions().inTime()).isEqualTo(0L);
+        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(0L);
         assertThat(stats.getTotalNumberOfAssessmentLocks()).isEqualTo(0L);
 
         var lockedSubmissions = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/lockedSubmissions", HttpStatus.OK, List.class);
@@ -1930,8 +1930,8 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         stats = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/stats-for-exam-assessment-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
         assertThat(stats.getNumberOfAssessmentLocks()).isEqualTo(0L);
         // 75 = (15 users * 5 exercises); quiz submissions are not counted
-        assertThat(stats.getNumberOfSubmissions().getInTime()).isEqualTo(75L);
-        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(0L);
+        assertThat(stats.getNumberOfSubmissions().inTime()).isEqualTo(75L);
+        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(0L);
         assertThat(stats.getNumberOfComplaints()).isEqualTo(0L);
         assertThat(stats.getTotalNumberOfAssessmentLocks()).isEqualTo(0L);
 
@@ -1964,9 +1964,9 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         stats = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/stats-for-exam-assessment-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
         assertThat(stats.getNumberOfAssessmentLocks()).isEqualTo(75L);
         // 75 = (15 users * 5 exercises); quiz submissions are not counted
-        assertThat(stats.getNumberOfSubmissions().getInTime()).isEqualTo(75L);
+        assertThat(stats.getNumberOfSubmissions().inTime()).isEqualTo(75L);
         // the 15 quiz submissions are already assessed
-        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(15L);
+        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(15L);
         assertThat(stats.getNumberOfComplaints()).isEqualTo(0L);
         assertThat(stats.getTotalNumberOfAssessmentLocks()).isEqualTo(75L);
 
@@ -1975,7 +1975,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         exam.getExerciseGroups().forEach(group -> {
             var locks = group.getExercises().stream().map(
                     exercise -> resultRepository.countNumberOfLockedAssessmentsByOtherTutorsForExamExerciseForCorrectionRounds(exercise, numberOfCorrectionRounds, examTutor2)[0]
-                            .getInTime())
+                            .inTime())
                     .reduce(Long::sum).get();
             if (group.getExercises().stream().anyMatch(exercise -> !(exercise instanceof QuizExercise)))
                 assertThat(locks).isEqualTo(15L);
@@ -2001,9 +2001,9 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         stats = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/stats-for-exam-assessment-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
         assertThat(stats.getNumberOfAssessmentLocks()).isEqualTo(0L);
         // 75 = (15 users * 5 exercises); quiz submissions are not counted
-        assertThat(stats.getNumberOfSubmissions().getInTime()).isEqualTo(75L);
+        assertThat(stats.getNumberOfSubmissions().inTime()).isEqualTo(75L);
         // 75 + the 15 quiz submissions
-        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(90L);
+        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(90L);
         assertThat(stats.getNumberOfComplaints()).isEqualTo(0L);
         assertThat(stats.getTotalNumberOfAssessmentLocks()).isEqualTo(0L);
 
@@ -2043,10 +2043,10 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         var stats = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/stats-for-exam-assessment-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
         assertThat(stats.getNumberOfAssessmentLocks()).isEqualTo(75L);
         // 75 = (15 users * 5 exercises); quiz submissions are not counted
-        assertThat(stats.getNumberOfSubmissions().getInTime()).isEqualTo(75L);
+        assertThat(stats.getNumberOfSubmissions().inTime()).isEqualTo(75L);
         // the 15 quiz submissions are already assessed - and all are assessed in the first correctionRound
-        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(90L);
-        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[1].getInTime()).isEqualTo(15L);
+        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(90L);
+        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[1].inTime()).isEqualTo(15L);
         assertThat(stats.getNumberOfComplaints()).isEqualTo(0L);
         assertThat(stats.getTotalNumberOfAssessmentLocks()).isEqualTo(75L);
 
@@ -2055,14 +2055,14 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         exam.getExerciseGroups().forEach(group -> {
             var locksRound1 = group.getExercises().stream().map(
                     exercise -> resultRepository.countNumberOfLockedAssessmentsByOtherTutorsForExamExerciseForCorrectionRounds(exercise, numberOfCorrectionRounds, examTutor2)[0]
-                            .getInTime())
+                            .inTime())
                     .reduce(Long::sum).get();
             if (group.getExercises().stream().anyMatch(exercise -> !(exercise instanceof QuizExercise)))
                 assertThat(locksRound1).isEqualTo(0L);
 
             var locksRound2 = group.getExercises().stream().map(
                     exercise -> resultRepository.countNumberOfLockedAssessmentsByOtherTutorsForExamExerciseForCorrectionRounds(exercise, numberOfCorrectionRounds, examTutor2)[1]
-                            .getInTime())
+                            .inTime())
                     .reduce(Long::sum).get();
             if (group.getExercises().stream().anyMatch(exercise -> !(exercise instanceof QuizExercise)))
                 assertThat(locksRound2).isEqualTo(15L);
@@ -2088,9 +2088,9 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         stats = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/stats-for-exam-assessment-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
         assertThat(stats.getNumberOfAssessmentLocks()).isEqualTo(0L);
         // 75 = (15 users * 5 exercises); quiz submissions are not counted
-        assertThat(stats.getNumberOfSubmissions().getInTime()).isEqualTo(75L);
+        assertThat(stats.getNumberOfSubmissions().inTime()).isEqualTo(75L);
         // 75 + the 15 quiz submissions
-        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(90L);
+        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(90L);
         assertThat(stats.getNumberOfComplaints()).isEqualTo(0L);
         assertThat(stats.getTotalNumberOfAssessmentLocks()).isEqualTo(0L);
 

--- a/src/test/java/de/tum/in/www1/artemis/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExerciseIntegrationTest.java
@@ -89,9 +89,9 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
         }
         StatsForDashboardDTO statsForDashboardDTO = request.get("/api/exercises/" + textExercise.getId() + "/stats-for-assessment-dashboard", HttpStatus.OK,
                 StatsForDashboardDTO.class);
-        assertThat(statsForDashboardDTO.getNumberOfSubmissions().getInTime()).isEqualTo(submissions.size() + 1);
-        assertThat(statsForDashboardDTO.getTotalNumberOfAssessments().getInTime()).isEqualTo(3);
-        assertThat(statsForDashboardDTO.getNumberOfAutomaticAssistedAssessments().getInTime()).isEqualTo(1);
+        assertThat(statsForDashboardDTO.getNumberOfSubmissions().inTime()).isEqualTo(submissions.size() + 1);
+        assertThat(statsForDashboardDTO.getTotalNumberOfAssessments().inTime()).isEqualTo(3);
+        assertThat(statsForDashboardDTO.getNumberOfAutomaticAssistedAssessments().inTime()).isEqualTo(1);
 
         for (Exercise exercise : course.getExercises()) {
             StatsForDashboardDTO stats = request.get("/api/exercises/" + exercise.getId() + "/stats-for-assessment-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
@@ -481,8 +481,8 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
             var tutors = findTutors(course);
             for (Exercise exercise : course.getExercises()) {
                 StatsForDashboardDTO stats = request.get("/api/exercises/" + exercise.getId() + "/stats-for-assessment-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
-                assertThat(stats.getTotalNumberOfAssessments().getInTime()).as("Number of in-time assessments is correct").isEqualTo(0);
-                assertThat(stats.getTotalNumberOfAssessments().getLate()).as("Number of late assessments is correct").isEqualTo(0);
+                assertThat(stats.getTotalNumberOfAssessments().inTime()).as("Number of in-time assessments is correct").isEqualTo(0);
+                assertThat(stats.getTotalNumberOfAssessments().late()).as("Number of late assessments is correct").isEqualTo(0);
 
                 assertThat(stats.getTutorLeaderboardEntries().size()).as("Number of tutor leaderboard entries is correct").isEqualTo(tutors.size());
                 assertThat(stats.getNumberOfOpenComplaints()).as("Number of open complaints should be available to tutor").isNotNull();
@@ -490,22 +490,22 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                 assertThat(stats.getNumberOfAssessmentLocks()).as("Number of assessment locks are not available for exercises").isNull();
 
                 if (exercise instanceof FileUploadExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for file upload exercise is correct").isEqualTo(0);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for file upload exercise is correct").isEqualTo(0);
                 }
                 if (exercise instanceof ModelingExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for modeling exercise is correct").isEqualTo(2);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for modeling exercise is correct").isEqualTo(2);
                 }
                 if (exercise instanceof ProgrammingExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for programming exercise is correct").isEqualTo(0);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for programming exercise is correct").isEqualTo(0);
                 }
                 if (exercise instanceof QuizExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for quiz exercise is correct").isEqualTo(0);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for quiz exercise is correct").isEqualTo(0);
                 }
                 if (exercise instanceof TextExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for text exercise is correct").isEqualTo(1);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for text exercise is correct").isEqualTo(1);
                 }
 
-                assertThat(stats.getNumberOfSubmissions().getLate()).as("Number of late submissions for exercise is correct").isEqualTo(0);
+                assertThat(stats.getNumberOfSubmissions().late()).as("Number of late submissions for exercise is correct").isEqualTo(0);
             }
         }
     }
@@ -525,30 +525,30 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
             var tutors = findTutors(course);
             for (Exercise exercise : course.getExercises()) {
                 StatsForDashboardDTO stats = request.get("/api/exercises/" + exercise.getId() + "/stats-for-instructor-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
-                assertThat(stats.getTotalNumberOfAssessments().getInTime()).as("Number of in-time assessments is correct").isEqualTo(0);
-                assertThat(stats.getTotalNumberOfAssessments().getLate()).as("Number of late assessments is correct").isEqualTo(0);
+                assertThat(stats.getTotalNumberOfAssessments().inTime()).as("Number of in-time assessments is correct").isEqualTo(0);
+                assertThat(stats.getTotalNumberOfAssessments().late()).as("Number of late assessments is correct").isEqualTo(0);
                 assertThat(stats.getTutorLeaderboardEntries().size()).as("Number of tutor leaderboard entries is correct").isEqualTo(tutors.size());
                 assertThat(stats.getNumberOfOpenComplaints()).as("Number of open complaints is zero").isZero();
                 assertThat(stats.getNumberOfOpenMoreFeedbackRequests()).as("Number of open more feedback requests is zero").isZero();
                 assertThat(stats.getNumberOfAssessmentLocks()).as("Number of assessment locks are not available for exercises").isNull();
 
                 if (exercise instanceof FileUploadExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for file upload exercise is correct").isEqualTo(0);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for file upload exercise is correct").isEqualTo(0);
                 }
                 if (exercise instanceof ModelingExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for modeling exercise is correct").isEqualTo(2);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for modeling exercise is correct").isEqualTo(2);
                 }
                 if (exercise instanceof ProgrammingExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for programming exercise is correct").isEqualTo(0);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for programming exercise is correct").isEqualTo(0);
                 }
                 if (exercise instanceof QuizExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for quiz exercise is correct").isEqualTo(0);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for quiz exercise is correct").isEqualTo(0);
                 }
                 if (exercise instanceof TextExercise) {
-                    assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions for text exercise is correct").isEqualTo(1);
+                    assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions for text exercise is correct").isEqualTo(1);
                 }
 
-                assertThat(stats.getNumberOfSubmissions().getLate()).as("Number of late submissions for exercise is correct").isEqualTo(0);
+                assertThat(stats.getNumberOfSubmissions().late()).as("Number of late submissions for exercise is correct").isEqualTo(0);
             }
         }
     }

--- a/src/test/java/de/tum/in/www1/artemis/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadAssessmentIntegrationTest.java
@@ -97,7 +97,7 @@ public class FileUploadAssessmentIntegrationTest extends AbstractSpringIntegrati
                 Course.class);
         Exercise exercise = database.findFileUploadExerciseWithTitle(course.getExercises(), "released");
         assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds().length).isEqualTo(1L);
-        assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(1L);
+        assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingAssessmentIntegrationTest.java
@@ -229,7 +229,7 @@ public class ModelingAssessmentIntegrationTest extends AbstractSpringIntegration
         Course course = request.get("/api/courses/" + this.course.getId() + "/for-assessment-dashboard", HttpStatus.OK, Course.class);
         Exercise exercise = database.findModelingExerciseWithTitle(course.getExercises(), "ClassDiagram");
         assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds().length).isEqualTo(1L);
-        assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(1L);
+        assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
@@ -658,8 +658,8 @@ public class ResultServiceIntegrationTest extends AbstractSpringIntegrationBambo
         submissionRepository.save(textSubmission);
 
         var assessments = resultRepository.countNumberOfFinishedAssessmentsForExamExerciseForCorrectionRounds(textExercise, 2);
-        assertThat(assessments[0].getInTime()).isEqualTo(1);    // correction round 1
-        assertThat(assessments[1].getInTime()).isEqualTo(1);    // correction round 2
+        assertThat(assessments[0].inTime()).isEqualTo(1);    // correction round 1
+        assertThat(assessments[1].inTime()).isEqualTo(1);    // correction round 2
     }
 
     @Test
@@ -704,7 +704,7 @@ public class ResultServiceIntegrationTest extends AbstractSpringIntegrationBambo
         submissionRepository.save(programmingSubmission);
 
         var assessments = resultRepository.countNumberOfFinishedAssessmentsForExamExerciseForCorrectionRounds(programmingExercise, 2);
-        assertThat(assessments[0].getInTime()).isEqualTo(1);    // correction round 1
-        assertThat(assessments[1].getInTime()).isEqualTo(1);    // correction round 2
+        assertThat(assessments[0].inTime()).isEqualTo(1);    // correction round 1
+        assertThat(assessments[1].inTime()).isEqualTo(1);    // correction round 2
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -594,7 +594,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         Course course = request.get("/api/courses/" + textExercise.getCourseViaExerciseGroupOrCourseMember().getId() + "/for-assessment-dashboard", HttpStatus.OK, Course.class);
         Exercise exercise = (Exercise) course.getExercises().toArray()[0];
         assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds().length).isEqualTo(1L);
-        assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(1L);
+        assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingAssessmentIntegrationTest.java
@@ -301,7 +301,7 @@ public class ProgrammingAssessmentIntegrationTest extends AbstractSpringIntegrat
                 Course.class);
         Exercise exercise = (Exercise) course.getExercises().toArray()[0];
         assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds().length).isEqualTo(1L);
-        assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(1L);
+        assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(1L);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
@@ -606,25 +606,25 @@ public class CourseTestService {
         for (Course testCourse : testCourses) {
             Course course = request.get("/api/courses/" + testCourse.getId() + "/for-assessment-dashboard", HttpStatus.OK, Course.class);
             for (Exercise exercise : course.getExercises()) {
-                assertThat(exercise.getTotalNumberOfAssessments().getInTime()).as("Number of in-time assessments is correct").isZero();
-                assertThat(exercise.getTotalNumberOfAssessments().getLate()).as("Number of late assessments is correct").isZero();
+                assertThat(exercise.getTotalNumberOfAssessments().inTime()).as("Number of in-time assessments is correct").isZero();
+                assertThat(exercise.getTotalNumberOfAssessments().late()).as("Number of late assessments is correct").isZero();
                 assertThat(exercise.getTutorParticipations().size()).as("Tutor participation was created").isEqualTo(1);
                 // Mock data contains exactly two submissions for the modeling exercise
                 if (exercise instanceof ModelingExercise) {
-                    assertThat(exercise.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions is correct").isEqualTo(2);
+                    assertThat(exercise.getNumberOfSubmissions().inTime()).as("Number of in-time submissions is correct").isEqualTo(2);
                 }
                 // Mock data contains exactly one submission for the text exercise
                 if (exercise instanceof TextExercise) {
-                    assertThat(exercise.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions is correct").isEqualTo(1);
+                    assertThat(exercise.getNumberOfSubmissions().inTime()).as("Number of in-time submissions is correct").isEqualTo(1);
                 }
                 // Mock data contains no submissions for the file upload and programming exercise
                 if (exercise instanceof FileUploadExercise || exercise instanceof ProgrammingExercise) {
-                    assertThat(exercise.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions is correct").isEqualTo(0);
+                    assertThat(exercise.getNumberOfSubmissions().inTime()).as("Number of in-time submissions is correct").isEqualTo(0);
                 }
 
-                assertThat(exercise.getNumberOfSubmissions().getLate()).as("Number of late submissions is correct").isEqualTo(0);
+                assertThat(exercise.getNumberOfSubmissions().late()).as("Number of late submissions is correct").isEqualTo(0);
                 assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds().length).isEqualTo(1L);
-                assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(0L);
+                assertThat(exercise.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(0L);
                 // Check tutor participation
                 if (exercise.getTutorParticipations().size() > 0) {
                     TutorParticipation tutorParticipation = exercise.getTutorParticipations().iterator().next();
@@ -634,12 +634,12 @@ public class CourseTestService {
 
             StatsForDashboardDTO stats = request.get("/api/courses/" + testCourse.getId() + "/stats-for-assessment-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
             long numberOfInTimeSubmissions = course.getId().equals(testCourses.get(0).getId()) ? 3 : 0; // course 1 has 3 submissions, course 2 has 0 submissions
-            assertThat(stats.getNumberOfSubmissions().getInTime()).as("Number of in-time submissions is correct").isEqualTo(numberOfInTimeSubmissions);
-            assertThat(stats.getNumberOfSubmissions().getLate()).as("Number of latte submissions is correct").isEqualTo(0);
-            assertThat(stats.getTotalNumberOfAssessments().getInTime()).as("Number of in-time assessments is correct").isEqualTo(0);
-            assertThat(stats.getTotalNumberOfAssessments().getLate()).as("Number of late assessments is correct").isEqualTo(0);
+            assertThat(stats.getNumberOfSubmissions().inTime()).as("Number of in-time submissions is correct").isEqualTo(numberOfInTimeSubmissions);
+            assertThat(stats.getNumberOfSubmissions().late()).as("Number of latte submissions is correct").isEqualTo(0);
+            assertThat(stats.getTotalNumberOfAssessments().inTime()).as("Number of in-time assessments is correct").isEqualTo(0);
+            assertThat(stats.getTotalNumberOfAssessments().late()).as("Number of late assessments is correct").isEqualTo(0);
             assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds().length).isEqualTo(1L);
-            assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].getInTime()).isEqualTo(0L);
+            assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isEqualTo(0L);
             assertThat(stats.getTutorLeaderboardEntries().size()).as("Number of tutor leaderboard entries is correct").isEqualTo(5);
 
             StatsForDashboardDTO stats2 = request.get("/api/courses/" + testCourse.getId() + "/stats-for-instructor-dashboard", isInstructor ? HttpStatus.OK : HttpStatus.FORBIDDEN,


### PR DESCRIPTION
I optimized a few Hibernate queries for the assessment dashboards which should improve the performance. In my local tests, I was able to improve the performance of the `stats-for-assessment-dashboard` for courses in a medium course (Patterns in software engineering) from around 7,5s to 4,3s.

I mainly avoid unnecessary queries, e.g.: 
* Checking for the group name is not necessary, this will be filtered out afterwards anyway and typically non tutors do not assess
* Avoid queries that only check the course id / exam id / exercise id / assessor id. Those are not necessary because they can be access without a join, e.g. `exercise.course_id = <id>` instead of additional join with `course.id = <id>`. We only need to join objects in case we want to access other values (e.g. dueDate)

There are probably additional ways how to improve the performance and we should further investigate what we can do here.

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

1. Navigate into a course with many assessments, complaints, more feedback requests, complaint responses
2. Make sure the performance is good and the correct data is shown

In particular, code reviews would be appreciated.

Edit: we now have the first use of the fancy new Records in Java 16 which make data transport objects (DTOs) for SQL queries and REST communication much easier to use