### PR TITLE
[Tests] Increased coverage of FileUploadExerciseResource to around 100%

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -118,11 +118,12 @@ public class FileUploadExerciseResource {
 
     private boolean isFilePatternValid(FileUploadExercise exercise) {
         // a file ending should consist of a comma separated list of 1-5 characters / digits
-        var filePattern = exercise.getFilePattern().toLowerCase().replaceAll("\\s+", "");
-        var allowedFileEndings = filePattern.split(",");
-        if (allowedFileEndings.length == 0) {
+        // when an empty string "" is passed in the exercise the file-pattern is null when it arrives in the rest endpoint
+        if (exercise.getFilePattern() == null) {
             return false;
         }
+        var filePattern = exercise.getFilePattern().toLowerCase().replaceAll("\\s+", "");
+        var allowedFileEndings = filePattern.split(",");
         var isValid = true;
         for (var allowedFileEnding : allowedFileEndings) {
             isValid = isValid && FILE_ENDING_PATTERN.matcher(allowedFileEnding).matches();

--- a/src/test/java/de/tum/in/www1/artemis/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadExerciseIntegrationTest.java
@@ -1,4 +1,4 @@
-    package de.tum.in.www1.artemis;
+package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/de/tum/in/www1/artemis/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadExerciseIntegrationTest.java
@@ -1,4 +1,4 @@
-package de.tum.in.www1.artemis;
+    package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,10 +59,51 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void createFileUploadExerciseFailsIfAlreadyCreated() throws Exception {
+        String filePattern = "Example file pattern";
+        FileUploadExercise fileUploadExercise = database.createFileUploadExercisesWithCourse().get(0);
+        fileUploadExercise.setFilePattern(filePattern);
+        fileUploadExercise = fileUploadExerciseRepository.save(fileUploadExercise);
+        request.postWithResponseBody("/api/file-upload-exercises", fileUploadExercise, FileUploadExercise.class, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createFileUploadExercise_InvalidMaxScore() throws Exception {
         FileUploadExercise fileUploadExercise = database.createFileUploadExercisesWithCourse().get(0);
         fileUploadExercise.setFilePattern(creationFilePattern);
         fileUploadExercise.setMaxPoints(0.0);
+        request.postWithResponseBody("/api/file-upload-exercises", fileUploadExercise, FileUploadExercise.class, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void createFileUploadExercise_InvalidInstructor() throws Exception {
+        FileUploadExercise fileUploadExercise = database.createFileUploadExercisesWithCourse().get(0);
+        // make sure the instructor is not instructor for this course anymore by changing the courses instructor group name
+        var course = fileUploadExercise.getCourseViaExerciseGroupOrCourseMember();
+        course.setInstructorGroupName("new-instructor-group-name");
+        courseRepo.save(course);
+        fileUploadExercise.setFilePattern(creationFilePattern);
+        gradingCriteria = database.addGradingInstructionsToExercise(fileUploadExercise);
+        request.postWithResponseBody("/api/file-upload-exercises", fileUploadExercise, FileUploadExercise.class, HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void createFileUploadExerciseFails_AlmostEmptyFilePattern() throws Exception {
+        FileUploadExercise fileUploadExercise = database.createFileUploadExercisesWithCourse().get(0);
+        fileUploadExercise.setFilePattern(" ");
+        gradingCriteria = database.addGradingInstructionsToExercise(fileUploadExercise);
+        request.postWithResponseBody("/api/file-upload-exercises", fileUploadExercise, FileUploadExercise.class, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void createFileUploadExerciseFails_EmptyFilePattern() throws Exception {
+        FileUploadExercise fileUploadExercise = database.createFileUploadExercisesWithCourse().get(0);
+        fileUploadExercise.setFilePattern("");
+        gradingCriteria = database.addGradingInstructionsToExercise(fileUploadExercise);
         request.postWithResponseBody("/api/file-upload-exercises", fileUploadExercise, FileUploadExercise.class, HttpStatus.BAD_REQUEST);
     }
 
@@ -192,6 +233,24 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
     }
 
     @Test
+    @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
+    public void getFileUploadExerciseFails_wrongId() throws Exception {
+        Course course = database.addCourseWithThreeFileUploadExercise();
+        request.get("/api/file-upload-exercises/" + 555555, HttpStatus.NOT_FOUND, FileUploadExercise.class);
+      }
+
+    @Test
+    @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
+    public void getExamFileUploadExercise_InstructorNotInGroup() throws Exception {
+        Course course = database.addCourseWithThreeFileUploadExercise();
+        course.setInstructorGroupName("new-instructor-group-name");
+        courseRepo.save(course);
+        for (var exercise : course.getExercises()) {
+           request.get("/api/file-upload-exercises/" + exercise.getId(), HttpStatus.FORBIDDEN, FileUploadExercise.class);
+        }
+    }
+
+    @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void deleteFileUploadExercise_asInstructor() throws Exception {
         Course course = database.addCourseWithThreeFileUploadExercise();
@@ -213,6 +272,25 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
     }
 
     @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void deleteFileUploadExerciseFails_WithWrongId() throws Exception {
+        Course course = database.addCourseWithThreeFileUploadExercise();
+        request.delete("/api/file-upload-exercises/" + 5555555, HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void deleteFileUploadExerciseFails_InstructorNotInGroup() throws Exception {
+        Course course = database.addCourseWithThreeFileUploadExercise();
+        course.setInstructorGroupName("new-instructor-group-name");
+        courseRepo.save(course);
+        for (var exercise : course.getExercises()) {
+            request.delete("/api/file-upload-exercises/" + exercise.getId(), HttpStatus.FORBIDDEN);
+        }
+        assertThat(exerciseRepo.findAll().size()).isEqualTo(3);
+    }
+
+    @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void deleteExamFileUploadExercise() throws Exception {
         FileUploadExercise fileUploadExercise = database.addCourseExamExerciseGroupWithOneFileUploadExercise();
@@ -228,12 +306,24 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
         FileUploadExercise fileUploadExercise = database.findFileUploadExerciseWithTitle(course.getExercises(), "released");
         fileUploadExercise.setDueDate(ZonedDateTime.now().plusDays(10));
 
-        FileUploadExercise receivedFileUploadExercise = request.putWithResponseBody("/api/file-upload-exercises/" + fileUploadExercise.getId(), fileUploadExercise,
+        FileUploadExercise receivedFileUploadExercise = request.putWithResponseBody("/api/file-upload-exercises/" + fileUploadExercise.getId() + "?notificationText=notification", fileUploadExercise,
                 FileUploadExercise.class, HttpStatus.OK);
         assertThat(receivedFileUploadExercise.getDueDate().equals(ZonedDateTime.now().plusDays(10)));
         assertThat(receivedFileUploadExercise.getCourseViaExerciseGroupOrCourseMember()).as("course was set for normal exercise").isNotNull();
         assertThat(receivedFileUploadExercise.getExerciseGroup()).as("exerciseGroup was not set for normal exercise").isNull();
         assertThat(receivedFileUploadExercise.getCourseViaExerciseGroupOrCourseMember().getId()).as("courseId was not updated").isEqualTo(course.getId());
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void updateFileUploadExerciseFails_InstructorNotInGroup() throws Exception {
+        Course course = database.addCourseWithThreeFileUploadExercise();
+        FileUploadExercise fileUploadExercise = database.findFileUploadExerciseWithTitle(course.getExercises(), "released");
+        fileUploadExercise.setDueDate(ZonedDateTime.now().plusDays(10));
+        course.setInstructorGroupName("new-instructor-group-name");
+        courseRepo.save(course);
+        FileUploadExercise receivedFileUploadExercise = request.putWithResponseBody("/api/file-upload-exercises/" + fileUploadExercise.getId(), fileUploadExercise,
+            FileUploadExercise.class, HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -296,6 +386,15 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
         database.changeUser("instructor1");
         assertThat(receivedFileUploadExercises.size() == courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now()).get(0).getExercises().size());
     }
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void getAllFileUploadExercisesForCourseFails_InstructorNotInGroup() throws Exception {
+        Course course = database.addCourseWithThreeFileUploadExercise();
+        course.setInstructorGroupName("new-instructor-group-name");
+        courseRepo.save(course);
+        long courseID = courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now()).get(0).getId();
+        request.getList("/api/courses/" + courseID + "/file-upload-exercises", HttpStatus.FORBIDDEN, FileUploadExercise.class);
+  }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -3218,4 +3218,8 @@ public class DatabaseUtilService {
         programmingExerciseStudentParticipationRepo.save(programmingExerciseStudentParticipation2);
         return course;
     }
+
+    public Course saveCourse(Course course) {
+        return courseRepo.save(course);
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I added Integration tests for the FileUploadExerciseResource. Now the coverage is at 100%. 
