### PR TITLE
Fix an error when importing text exercises with categories

### DIFF
--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -205,7 +205,13 @@
             <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
         </button>
 
-        <button type="submit" (click)="save()" class="btn btn-primary" id="submit-entity" [disabled]="editForm.form.invalid || isSaving">
+        <button
+            type="submit"
+            (click)="save()"
+            class="btn btn-primary"
+            id="submit-entity"
+            [disabled]="editForm.form.invalid || isSaving || textExercise.dueDateError || textExercise.assessmentDueDateError"
+        >
             <fa-icon [icon]="'save'"></fa-icon>
             <span *ngIf="isImport" jhiTranslate="artemisApp.textExercise.submitButton.import">Import</span>
             <span *ngIf="!isImport && textExercise.id" jhiTranslate="artemisApp.textExercise.submitButton.save">Save</span>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -205,7 +205,7 @@
             <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
         </button>
 
-        <button type="submit" (click)="save()" class="btn btn-primary" id="submit-entity">
+        <button type="submit" (click)="save()" class="btn btn-primary" id="submit-entity" [disabled]="editForm.form.invalid || isSaving">
             <fa-icon [icon]="'save'"></fa-icon>
             <span *ngIf="isImport" jhiTranslate="artemisApp.textExercise.submitButton.import">Import</span>
             <span *ngIf="!isImport && textExercise.id" jhiTranslate="artemisApp.textExercise.submitButton.save">Save</span>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.service.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.service.ts
@@ -44,8 +44,11 @@ export class TextExerciseService {
      * (like the old ID) will be handled by the server.
      */
     import(adaptedSourceTextExercise: TextExercise) {
+        let copy = this.exerciseService.convertDateFromClient(adaptedSourceTextExercise);
+        copy = this.exerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
+        copy.categories = this.exerciseService.stringifyExerciseCategories(copy);
         return this.http
-            .post<TextExercise>(`${this.resourceUrl}/import/${adaptedSourceTextExercise.id}`, adaptedSourceTextExercise, { observe: 'response' })
+            .post<TextExercise>(`${this.resourceUrl}/import/${adaptedSourceTextExercise.id}`, copy, { observe: 'response' })
             .pipe(
                 map((res: EntityResponseType) => this.exerciseService.convertDateFromServer(res)),
                 map((res: EntityResponseType) => this.exerciseService.convertExerciseCategoriesFromServer(res)),

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.service.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.service.ts
@@ -9,7 +9,6 @@ import { createRequestOption } from 'app/shared/util/request-util';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { TextPlagiarismResult } from 'app/exercises/shared/plagiarism/types/text/TextPlagiarismResult';
 import { PlagiarismOptions } from 'app/exercises/shared/plagiarism/types/PlagiarismOptions';
-import { ExerciseCategory } from 'app/entities/exercise-category.model';
 
 export type EntityResponseType = HttpResponse<TextExercise>;
 export type EntityArrayResponseType = HttpResponse<TextExercise[]>;
@@ -64,7 +63,7 @@ export class TextExerciseService {
         const options = createRequestOption(req);
         let copy = this.exerciseService.convertDateFromClient(textExercise);
         copy = this.exerciseService.setBonusPointsConstrainedByIncludedInOverallScore(copy);
-        copy.categories = textExercise.categories?.map((category) => JSON.stringify(category) as ExerciseCategory);
+        copy.categories = this.exerciseService.stringifyExerciseCategories(copy);
         return this.http
             .put<TextExercise>(this.resourceUrl, copy, { params: options, observe: 'response' })
             .pipe(


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context

Closes #3261.

### Description

The categories weren't serialized properly client side. We now re-use the same methods `create` and `update` use for importing text exercises, too. The commit messages describe the individual changes.

### Steps for Testing

- Create a text exercise with categories
- Update a text exercise with categories
- Import a text exercise with categories

