### PR TITLE
Fix the "included in overall score" picker not working

### DIFF
--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
@@ -67,7 +67,7 @@
                 <div class="form-group">
                     <label class="form-control-label">{{ 'artemisApp.exercise.includedInOverallScoreLabel' | artemisTranslate }}</label>
                     <div>
-                        <jhi-included-in-overall-score-picker [(includedInOverallScore)]="fileUploadExercise.includedInOverallScore!"></jhi-included-in-overall-score-picker>
+                        <jhi-included-in-overall-score-picker [(includedInOverallScore)]="fileUploadExercise.includedInOverallScore"></jhi-included-in-overall-score-picker>
                     </div>
                 </div>
                 <div class="row">

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
@@ -64,7 +64,7 @@
         <div class="form-group">
             <label class="form-control-label">{{ 'artemisApp.exercise.includedInOverallScoreLabel' | artemisTranslate }}</label>
             <div>
-                <jhi-included-in-overall-score-picker [(includedInOverallScore)]="modelingExercise.includedInOverallScore!"></jhi-included-in-overall-score-picker>
+                <jhi-included-in-overall-score-picker [(includedInOverallScore)]="modelingExercise.includedInOverallScore"></jhi-included-in-overall-score-picker>
             </div>
         </div>
         <div class="row">

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -152,7 +152,7 @@
                 <div class="form-group">
                     <label class="form-control-label">{{ 'artemisApp.exercise.includedInOverallScoreLabel' | artemisTranslate }}</label>
                     <div>
-                        <jhi-included-in-overall-score-picker [(includedInOverallScore)]="programmingExercise.includedInOverallScore!"></jhi-included-in-overall-score-picker>
+                        <jhi-included-in-overall-score-picker [(includedInOverallScore)]="programmingExercise.includedInOverallScore"></jhi-included-in-overall-score-picker>
                     </div>
                 </div>
                 <div class="row">

--- a/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.ts
+++ b/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.ts
@@ -10,7 +10,7 @@ export class IncludedInOverallScorePickerComponent {
     readonly IncludedInOverallScore = IncludedInOverallScore;
 
     @Input()
-    includedInOverallScore: IncludedInOverallScore;
+    includedInOverallScore: IncludedInOverallScore | undefined;
     @Output()
     includedInOverallScoreChange = new EventEmitter();
 

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.html
@@ -63,7 +63,7 @@
         <div class="form-group">
             <label class="form-control-label">{{ 'artemisApp.exercise.includedInOverallScoreLabel' | artemisTranslate }}</label>
             <div>
-                <jhi-included-in-overall-score-picker [(includedInOverallScore)]="textExercise.includedInOverallScore!"></jhi-included-in-overall-score-picker>
+                <jhi-included-in-overall-score-picker [(includedInOverallScore)]="textExercise.includedInOverallScore"></jhi-included-in-overall-score-picker>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

See https://github.com/ls1intum/Artemis/pull/3248#pullrequestreview-641531184. The selector no longer works, and always resets to "Yes". You can also see that by the fact that the "Bonus" points field is no longer hidden when changing to "Bonus" or "No".

### Description

Fixes the issue which was introduced due to the strict template changes. I assume that using `!` there meant the change emitter couldn't write back to the original object, so we don't use that any more.

### Steps for Testing

For every exercise type except quiz exercises:
1. Create or edit an exercise and try changing the value for `Should this exercise be included in the course / exam score calculation?`
2. (Optional) Check that the change had an effect (e.g. inspect the JSON sent to the server, or set a breakpoint in the server code)
3. Look at the created exercise (e.g. go in "edit" mode again) and verify that the change persisted

### Screenshots

The default selection of "Yes":
![grafik](https://user-images.githubusercontent.com/72132281/115623200-29fdfe00-a2f9-11eb-863e-7b121c14c17b.png)

With this fix the "Bonus" field is hidden when another value than "Yes" is selected:
![grafik](https://user-images.githubusercontent.com/72132281/115623244-397d4700-a2f9-11eb-9744-56953e1190a3.png)
