### PR TITLE
[Bugfix] Fix Total Number of Complaints on Course Assessment Dashboard

### DIFF
--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard-information.component.html
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard-information.component.html
@@ -91,7 +91,7 @@
                     <!-- Complaints about all assessments: -->
                     <li *ngIf="!isExamMode && complaintsEnabled">
                         <a [routerLink]="['/course-management', courseId, 'complaints']">
-                            <strong> {{ 'artemisApp.assessmentDashboard.totalComplaints' | translate }}:</strong> {{ numberOfTutorComplaints }}
+                            <strong> {{ 'artemisApp.assessmentDashboard.totalComplaints' | translate }}:</strong> {{ numberOfComplaints }}
                         </a>
                     </li>
                     <li *ngIf="!isExamMode && feedbackRequestEnabled">


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) ~~on the test server https://artemistest.ase.in.tum.de~~ locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
The Course Assessment Dashboard shows the wrong number of complaints in the course overview section. Here the complaints against me are used, not the total number of complaints.

1. You need a course with at least one complaint
2. Navigate to Course Assessment Dashboard
3. Check that the number is correct

### Screenshots
old:
![grafik](https://user-images.githubusercontent.com/26540346/115695774-60239800-a362-11eb-9b80-c7fb912bf4c7.png)

new:
![grafik](https://user-images.githubusercontent.com/26540346/115695815-64e84c00-a362-11eb-85ef-8040ccbd269d.png)

