### PR TITLE
Bugfix/programming exercise update/checkout repository of sample solution

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise.model.ts
+++ b/src/main/webapp/app/entities/programming-exercise.model.ts
@@ -65,7 +65,7 @@ export class ProgrammingExercise extends Exercise {
         this.allowOfflineIde = true; // default value
         this.programmingLanguage = ProgrammingLanguage.JAVA; // default value
         this.noVersionControlAndContinuousIntegrationAvailable = false; // default value
-        this.checkoutSolutionRepository = false; // default value
+        this.checkoutSolutionRepository = true; // default value
         this.projectType = ProjectType.ECLIPSE; // default value
         this.showTestNamesToStudents = false; // default value
     }

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -333,6 +333,7 @@
                                 name="heckoutSolutionRepository"
                                 id="field_checkoutSolutionRepository"
                                 [(ngModel)]="programmingExercise.checkoutSolutionRepository"
+                                checked
                             />
                             <span jhiTranslate="artemisApp.programmingExercise.checkoutSolutionRepository.title">Checkout Solution repository</span>
                             <jhi-help-icon placement="top" text="artemisApp.programmingExercise.checkoutSolutionRepository.description"></jhi-help-icon>

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -330,7 +330,7 @@
                             <input
                                 class="form-check-input"
                                 type="checkbox"
-                                name="heckoutSolutionRepository"
+                                name="checkoutSolutionRepository"
                                 id="field_checkoutSolutionRepository"
                                 [(ngModel)]="programmingExercise.checkoutSolutionRepository"
                                 checked


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
When using the Haskell template for generating a programming exercise, the option "Checkout repository of sample solution" should be checked automatically since the Haskell testing framework relies on it. Issue: #3094


### Steps for Testing
1.	Generate a new programming exercise
2.	Select Haskell as a programming language
3.	The option "Checkout repository of sample solution" is checked.




### Screenshots
![image](https://user-images.githubusercontent.com/32565407/115766648-7eac8200-a3a8-11eb-81f6-89acee7f6b58.png)

