### PR TITLE
Fix some additional Instructor buttons being visible for Tutors

### DIFF
--- a/src/main/webapp/app/exam/manage/exam-management.component.html
+++ b/src/main/webapp/app/exam/manage/exam-management.component.html
@@ -1,8 +1,8 @@
 <div>
     <div class="d-flex">
         <h4 id="course-page-heading" jhiTranslate="artemisApp.examManagement.title">Exams</h4>
-        <div class="ml-auto d-flex">
-            <a class="btn btn-primary jh-create-entity create-exam" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" [routerLink]="['new']">
+        <div class="ml-auto d-flex" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
+            <a class="btn btn-primary jh-create-entity create-exam" *ngIf="isAtLeastInstructor" [routerLink]="['new']">
                 <fa-icon [icon]="'plus'"></fa-icon>
                 <span class="hidden-sm-down"> Create new Exam </span>
             </a>

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-dashboard.component.html
@@ -15,9 +15,11 @@
                 <fa-icon [fixedWidth]="true" [icon]="'folder-open'"></fa-icon>&nbsp;Assess next submission
             </button>
             <button (click)="refresh()" [disabled]="busy" class="btn btn-primary btn-sm mr-1"><fa-icon [fixedWidth]="true" [icon]="'sync'"></fa-icon>&nbsp;Refresh</button>
-            <button (click)="resetOptimality()" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" [disabled]="busy" class="btn btn-primary btn-sm mr-1">
-                <fa-icon [fixedWidth]="true" [icon]="'sync'"></fa-icon>&nbsp;Reset assessment order
-            </button>
+            <ng-container *ngIf="course.isAtLeastInstructor">
+                <button (click)="resetOptimality()" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" [disabled]="busy" class="btn btn-primary btn-sm mr-1">
+                    <fa-icon [fixedWidth]="true" [icon]="'sync'"></fa-icon>&nbsp;Reset assessment order
+                </button>
+            </ng-container>
         </div>
     </div>
     <h4>
@@ -205,7 +207,7 @@
                     <td *ngFor="let item of [].constructor(numberOfCorrectionrounds); let correctionRound = index">
                         <span *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
                             <!-- exercise without exam-->
-                            <span *ngIf="exercise.type === ExerciseType.MODELING && submission && exercise.course">
+                            <span *ngIf="course.isAtLeastInstructor && exercise.type === ExerciseType.MODELING && submission && exercise.course">
                                 <a
                                     *ngIf="!submission.latestResult"
                                     [class.disabled]="busy"

--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
@@ -42,7 +42,7 @@
         <!--
         Only show download all checkbox for instructors & admins.
         -->
-        <ng-container *ngIf="!singleParticipantMode && !isRepoExportForMultipleExercises">
+        <ng-container *ngIf="exercise.isAtLeastInstructor && !singleParticipantMode && !isRepoExportForMultipleExercises">
             <div *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" class="checkbox">
                 <label class="control-label">
                     <input type="checkbox" name="allStudents" [(ngModel)]="repositoryExportOptions.exportAllParticipants" />

--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.html
@@ -42,7 +42,7 @@
         <!--
         Only show download all checkbox for instructors & admins.
         -->
-        <ng-container *ngIf="exercise.isAtLeastInstructor && !singleParticipantMode && !isRepoExportForMultipleExercises">
+        <ng-container *ngIf="isAtLeastInstructor && !singleParticipantMode && !isRepoExportForMultipleExercises">
             <div *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" class="checkbox">
                 <label class="control-label">
                     <input type="checkbox" name="allStudents" [(ngModel)]="repositoryExportOptions.exportAllParticipants" />

--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.ts
@@ -31,6 +31,7 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
     repositoryExportOptions: RepositoryExportOptions;
     isLoading = false;
     isRepoExportForMultipleExercises: boolean;
+    isAtLeastInstructor?: boolean;
 
     constructor(
         private exerciseService: ExerciseService,
@@ -57,6 +58,7 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
                 .pipe(
                     tap(({ body: exercise }) => {
                         this.exercise = exercise!;
+                        this.isAtLeastInstructor = this.exercise.isAtLeastInstructor;
                     }),
                     catchError((err) => {
                         this.jhiAlertService.error(err);
@@ -69,6 +71,7 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
                 });
         } else {
             this.isLoading = false;
+            this.isAtLeastInstructor = this.selectedProgrammingExercises.every((exercise: ProgrammingExercise) => exercise.isAtLeastInstructor);
         }
     }
 

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-list.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-list.component.html
@@ -38,14 +38,16 @@
                     <a class="btn btn-primary mr-1" [routerLink]="['/course-management', courseId, 'apollon-diagrams', apollonDiagram.id]" jhiTranslate="entity.action.open">
                         Open
                     </a>
-                    <button
-                        *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']"
-                        class="btn btn-danger mr-1"
-                        (click)="delete(apollonDiagram)"
-                        jhiTranslate="entity.action.delete"
-                    >
-                        Delete
-                    </button>
+                    <ng-container *ngIf="isAtLeastInstructor">
+                        <button
+                            *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']"
+                            class="btn btn-danger mr-1"
+                            (click)="delete(apollonDiagram)"
+                            jhiTranslate="entity.action.delete"
+                        >
+                            Delete
+                        </button>
+                    </ng-container>
                 </td>
             </tr>
         </tbody>

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-list.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { HttpResponse } from '@angular/common/http';
 import { ActivatedRoute } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { JhiAlertService } from 'ng-jhipster';
@@ -7,6 +8,9 @@ import { ApollonDiagramService } from 'app/exercises/quiz/manage/apollon-diagram
 import { ApollonDiagram } from 'app/entities/apollon-diagram.model';
 import { UMLDiagramType } from 'app/entities/modeling-exercise.model';
 import { SortService } from 'app/shared/service/sort.service';
+import { AccountService } from 'app/core/auth/account.service';
+import { CourseManagementService } from 'app/course/manage/course-management.service';
+import { Course } from 'app/entities/course.model';
 
 @Component({
     selector: 'jhi-apollon-diagram-list',
@@ -18,6 +22,7 @@ export class ApollonDiagramListComponent implements OnInit {
     predicate: string;
     reverse: boolean;
     courseId: number;
+    isAtLeastInstructor = false;
 
     constructor(
         private apollonDiagramsService: ApollonDiagramService,
@@ -25,6 +30,8 @@ export class ApollonDiagramListComponent implements OnInit {
         private modalService: NgbModal,
         private sortService: SortService,
         private route: ActivatedRoute,
+        private courseService: CourseManagementService,
+        private accountService: AccountService,
     ) {
         this.predicate = 'id';
         this.reverse = true;
@@ -35,6 +42,9 @@ export class ApollonDiagramListComponent implements OnInit {
      */
     ngOnInit() {
         this.courseId = Number(this.route.snapshot.paramMap.get('courseId'));
+        this.courseService.find(this.courseId).subscribe((courseResponse: HttpResponse<Course>) => {
+            this.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(courseResponse.body!);
+        });
         this.apollonDiagramsService.getDiagramsByCourse(this.courseId).subscribe(
             (response) => {
                 this.apollonDiagrams = response.body!;

--- a/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.html
+++ b/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.html
@@ -19,7 +19,7 @@
         <!--
         Only show download all checkbox for instructors & admins.
         -->
-        <ng-container>
+        <ng-container *ngIf="exercise.isAtLeastInstructor">
             <div *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']" class="checkbox">
                 <label class="control-label">
                     <input type="checkbox" name="allStudents" [(ngModel)]="submissionExportOptions.exportAllParticipants" />

--- a/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-list.component.spec.ts
+++ b/src/test/javascript/spec/component/apollon-diagrams/apollon-diagram-list.component.spec.ts
@@ -15,9 +15,12 @@ import { UMLDiagramType } from 'app/entities/modeling-exercise.model';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { HttpResponse } from '@angular/common/http';
 import * as _ from 'lodash';
+import { CourseManagementService } from 'app/course/manage/course-management.service';
+import { AccountService } from 'app/core/auth/account.service';
 
 describe('ApollonDiagramList Component', () => {
     let apollonDiagramService: ApollonDiagramService;
+    let courseService: CourseManagementService;
     let fixture: ComponentFixture<ApollonDiagramListComponent>;
     const sandbox = sinon.createSandbox();
     const course: Course = { id: 123 } as Course;
@@ -34,6 +37,8 @@ describe('ApollonDiagramList Component', () => {
                 MockProvider(SortService),
                 { provide: NgbModal, useClass: MockNgbModalService },
                 { provide: ActivatedRoute, useValue: route },
+                MockProvider(CourseManagementService),
+                MockProvider(AccountService),
             ],
             schemas: [],
         })
@@ -41,7 +46,9 @@ describe('ApollonDiagramList Component', () => {
             .compileComponents()
             .then(() => {
                 fixture = TestBed.createComponent(ApollonDiagramListComponent);
-                apollonDiagramService = fixture.debugElement.injector.get(ApollonDiagramService);
+                const injector = fixture.debugElement.injector;
+                apollonDiagramService = injector.get(ApollonDiagramService);
+                courseService = injector.get(CourseManagementService);
             });
     });
 
@@ -51,8 +58,11 @@ describe('ApollonDiagramList Component', () => {
 
     it('ngOnInit', () => {
         const apollonDiagrams: ApollonDiagram[] = [new ApollonDiagram(UMLDiagramType.ClassDiagram, course.id!), new ApollonDiagram(UMLDiagramType.ActivityDiagram, course.id!)];
-        const response: HttpResponse<ApollonDiagram[]> = new HttpResponse({ body: apollonDiagrams });
-        sandbox.stub(apollonDiagramService, 'getDiagramsByCourse').returns(of(response));
+        const diagramResponse: HttpResponse<ApollonDiagram[]> = new HttpResponse({ body: apollonDiagrams });
+        const courseResponse: HttpResponse<Course> = new HttpResponse({ body: course });
+
+        sandbox.stub(apollonDiagramService, 'getDiagramsByCourse').returns(of(diagramResponse));
+        sandbox.stub(courseService, 'find').returns(of(courseResponse));
 
         // test
         fixture.componentInstance.ngOnInit();


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) ~~on the test server https://artemistest.ase.in.tum.de~~ locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
I found some more buttons which are only meant for instructors but they are visible for tutors as well if they have instructor rights in other courses.

### Description
Just checking for `*jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']"` is not enough because this only checks for the global instructor role which is given to users who are instructors at any course. We need to check if the user is an Instructor in this specific course.

### Steps for Testing

Please test that the following buttons are not visible for tutors with instructor rights at other courses:

- Course Management -> Exams -> Create new Exam
- Course Management -> Exercises -> Tests this for modeling and programming exercises -> Scores -> Export Submissions -> Download all repositories

