### PR TITLE
Fix modeling exercises not displaying categories in details or edit pages

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ModelingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ModelingExerciseRepository.java
@@ -61,6 +61,11 @@ public interface ModelingExerciseRepository extends JpaRepository<ModelingExerci
     }
 
     @NotNull
+    default ModelingExercise findWithEagerExampleSubmissionsByIdElseThrow(long exerciseId) {
+        return findWithEagerExampleSubmissionsById(exerciseId).orElseThrow(() -> new EntityNotFoundException("Modeling Exercise", exerciseId));
+    }
+
+    @NotNull
     default ModelingExercise findByIdWithExampleSubmissionsAndResultsElseThrow(long exerciseId) {
         return findByIdWithExampleSubmissionsAndResults(exerciseId).orElseThrow(() -> new EntityNotFoundException("Modeling Exercise", exerciseId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -250,7 +250,7 @@ public class ModelingExerciseResource {
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<ModelingExercise> getModelingExercise(@PathVariable Long exerciseId) {
         log.debug("REST request to get ModelingExercise : {}", exerciseId);
-        var modelingExercise = modelingExerciseRepository.findByIdWithExampleSubmissionsAndResultsElseThrow(exerciseId);
+        var modelingExercise = modelingExerciseRepository.findWithEagerExampleSubmissionsByIdElseThrow(exerciseId);
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, modelingExercise, null);
         List<GradingCriterion> gradingCriteria = gradingCriterionRepository.findByExerciseIdWithEagerGradingCriteria(exerciseId);
         modelingExercise.setGradingCriteria(gradingCriteria);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).

### Motivation and Context

#3175 accidentally(?) changed the get method for modeling exercises to fetch the results of the exercise, but not the categories.

### Description

We use the call from before now.

### Steps for Testing

1. View the details page of a modeling exercise and verify that its categories present
2. Update a modeling exercise and verify that its existing categories are listed and that you can change them

