### PR TITLE
Fix the coloring of quiz statistics

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/statistics/question-statistic.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/question-statistic.component.ts
@@ -219,7 +219,8 @@ export abstract class QuestionStatisticComponent implements DataSetProvider, OnI
         // if show Solution is true use the label, backgroundColor and Data, which show the solution
         if (this.showSolution) {
             // show Solution: use the backgroundColor which shows the solution
-            this.colors = this.backgroundSolutionColors.map((backgroundColor) => ({ backgroundColor }));
+            this.colors = [{ backgroundColor: this.backgroundSolutionColors }];
+
             if (this.rated) {
                 this.participants = this.questionStatistic.participantsRated!;
                 // if rated is true use the rated Data and add the rated CorrectCounter
@@ -237,7 +238,8 @@ export abstract class QuestionStatisticComponent implements DataSetProvider, OnI
             this.chartLabels = this.solutionLabels;
         } else {
             // don't show Solution: use the backgroundColor which doesn't show the solution
-            this.colors = this.backgroundColors.map((backgroundColor) => ({ backgroundColor }));
+            this.colors = [{ backgroundColor: this.backgroundColors }];
+
             // if rated is true use the rated Data
             if (this.rated) {
                 this.participants = this.questionStatistic.participantsRated!;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

#3152 changed how we pass colors to the canvas, which resulted in only a single color being used:
![grafik](https://user-images.githubusercontent.com/72132281/115869296-f7115280-a43d-11eb-9de2-00745ee1d164.png)

### Description

We now pass the colors as string array to a single color object as background colors:
![grafik](https://user-images.githubusercontent.com/72132281/115869360-101a0380-a43e-11eb-850e-9f2231dc331f.png)

### Steps for Testing

1. Create a new quiz and participate or find a quiz with participations
2. Check the quiz point statistics for a single question and view the solution
3. Correct colors should be green, incorrect red and the summary blueish (see the screenshot above)
