### PR TITLE
Show User Management Links only for Admins

### DIFF
--- a/src/main/webapp/app/course/manage/course-group.component.html
+++ b/src/main/webapp/app/course/manage/course-group.component.html
@@ -46,7 +46,10 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
-                        <a routerLink="/admin/user-management/{{ value?.login }}"> {{ value.id }} </a>
+                        <a *ngIf="isAdmin; else showId" routerLink="/admin/user-management/{{ value?.login }}"> {{ value.id }} </a>
+                        <ng-template #showId>
+                            {{ value?.id }}
+                        </ng-template>
                     </ng-template>
                 </ngx-datatable-column>
 

--- a/src/main/webapp/app/course/manage/course-group.component.ts
+++ b/src/main/webapp/app/course/manage/course-group.component.ts
@@ -15,6 +15,7 @@ import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { UserService } from 'app/core/user/user.service';
 import { DataTableComponent } from 'app/shared/data-table/data-table.component';
 import { iconsAsHTML } from 'app/utils/icons.utils';
+import { AccountService } from 'app/core/auth/account.service';
 
 const cssClasses = {
     alreadyMember: 'already-member',
@@ -42,6 +43,8 @@ export class CourseGroupComponent implements OnInit, OnDestroy {
     private dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
 
+    isAdmin = false;
+
     isLoading = false;
     isSearching = false;
     searchFailed = false;
@@ -56,6 +59,7 @@ export class CourseGroupComponent implements OnInit, OnDestroy {
         private eventManager: JhiEventManager,
         private courseService: CourseManagementService,
         private userService: UserService,
+        private accountService: AccountService,
     ) {}
 
     /**
@@ -78,6 +82,7 @@ export class CourseGroupComponent implements OnInit, OnDestroy {
      */
     loadAll() {
         this.isLoading = true;
+        this.isAdmin = this.accountService.isAdmin();
         this.route.parent!.data.subscribe(({ course }) => {
             this.course = course;
             this.paramSub = this.route.params.subscribe((params) => {

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
@@ -150,7 +150,10 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
-                        <a routerLink="/admin/user-management/{{ value?.login }}">{{ value?.name }}</a>
+                        <a *ngIf="isAdmin; else showName" routerLink="/admin/user-management/{{ value?.login }}">{{ value?.name }}</a>
+                        <ng-template #showName>
+                            {{ value?.name }}
+                        </ng-template>
                     </ng-template>
                 </ngx-datatable-column>
 

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.ts
@@ -17,6 +17,7 @@ import { TranslateService } from '@ngx-translate/core';
 import * as moment from 'moment';
 import { Moment } from 'moment';
 import { defaultLongDateTimeFormat } from 'app/shared/pipes/artemis-date.pipe';
+import { AccountService } from 'app/core/auth/account.service';
 
 @Component({
     selector: 'jhi-student-exams',
@@ -37,6 +38,7 @@ export class StudentExamsComponent implements OnInit {
     isExamStarted = false;
     isExamOver = false;
     longestWorkingTime: number;
+    isAdmin = false;
 
     constructor(
         private route: ActivatedRoute,
@@ -46,6 +48,7 @@ export class StudentExamsComponent implements OnInit {
         private jhiAlertService: JhiAlertService,
         private modalService: NgbModal,
         private translateService: TranslateService,
+        private accountService: AccountService,
     ) {}
 
     /**
@@ -60,6 +63,7 @@ export class StudentExamsComponent implements OnInit {
 
     private loadAll() {
         this.paramSub = this.route.params.subscribe(() => {
+            this.isAdmin = this.accountService.isAdmin();
             this.courseService.find(this.courseId).subscribe((courseResponse) => {
                 this.course = courseResponse.body!;
             });

--- a/src/main/webapp/app/exam/manage/students/exam-students.component.html
+++ b/src/main/webapp/app/exam/manage/students/exam-students.component.html
@@ -86,7 +86,10 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
-                        <a routerLink="/admin/user-management/{{ value?.login }}">{{ value.id }}</a>
+                        <a *ngIf="isAdmin; else showId" routerLink="/admin/user-management/{{ value?.login }}">{{ value?.id }}</a>
+                        <ng-template #showId>
+                            {{ value?.id }}
+                        </ng-template>
                     </ng-template>
                 </ngx-datatable-column>
 
@@ -98,7 +101,10 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
-                        <a routerLink="/admin/user-management/{{ value?.login }}">{{ value.login }}</a>
+                        <a *ngIf="isAdmin; else showLogin" routerLink="/admin/user-management/{{ value?.login }}">{{ value?.login }}</a>
+                        <ng-template #showLogin>
+                            {{ value?.login }}
+                        </ng-template>
                     </ng-template>
                 </ngx-datatable-column>
 

--- a/src/main/webapp/app/exam/manage/students/exam-students.component.ts
+++ b/src/main/webapp/app/exam/manage/students/exam-students.component.ts
@@ -13,6 +13,7 @@ import { iconsAsHTML } from 'app/utils/icons.utils';
 import { Exam } from 'app/entities/exam.model';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
 import { ButtonSize, ButtonType } from 'app/shared/components/button.component';
+import { AccountService } from 'app/core/auth/account.service';
 
 const cssClasses = {
     alreadyRegistered: 'already-registered',
@@ -48,6 +49,8 @@ export class ExamStudentsComponent implements OnInit, OnDestroy {
     isTransitioning = false;
     rowClass: string | undefined = undefined;
 
+    isAdmin = false;
+
     constructor(
         private router: Router,
         private route: ActivatedRoute,
@@ -55,11 +58,13 @@ export class ExamStudentsComponent implements OnInit, OnDestroy {
         private eventManager: JhiEventManager,
         private examManagementService: ExamManagementService,
         private userService: UserService,
+        private accountService: AccountService,
     ) {}
 
     ngOnInit() {
         this.isLoading = true;
         this.courseId = Number(this.route.snapshot.paramMap.get('courseId'));
+        this.isAdmin = this.accountService.isAdmin();
         this.route.data.subscribe(({ exam }: { exam: Exam }) => {
             this.exam = exam;
             this.allRegisteredUsers = exam.registeredUsers! || [];

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -168,9 +168,12 @@
                             {{ value.team.shortName }}
                         </a>
                         <ng-template #defaultMode>
-                            <a [routerLink]="['/admin', 'user-management', value.student.login]">
+                            <a *ngIf="isAdmin; else showLogin" [routerLink]="['/admin', 'user-management', value.student.login]">
                                 {{ value.student.login }}
                             </a>
+                            <ng-template #showLogin>
+                                {{ value.student.login }}
+                            </ng-template>
                         </ng-template>
                     </ng-template>
                 </ngx-datatable-column>

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.ts
@@ -72,6 +72,8 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
 
     isLoading: boolean;
 
+    isAdmin = false;
+
     constructor(
         private route: ActivatedRoute,
         private momentDiff: DifferencePipe,
@@ -108,6 +110,7 @@ export class ExerciseScoresComponent implements OnInit, OnDestroy {
                 this.exercise.isAtLeastTutor = this.accountService.isAtLeastTutorInCourse(this.course || this.exercise.exerciseGroup!.exam!.course);
                 this.exercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.course || this.exercise.exerciseGroup!.exam!.course);
                 this.newManualResultAllowed = areManualResultsAllowed(this.exercise);
+                this.isAdmin = this.accountService.isAdmin();
             });
         });
     }

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.html
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.html
@@ -166,7 +166,10 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value">
-                        <a routerLink="/admin/user-management/{{ value?.login }}">{{ value?.name }}</a>
+                        <a *ngIf="isAdmin; else showName" routerLink="/admin/user-management/{{ value?.login }}">{{ value?.name }}</a>
+                        <ng-template #showName>
+                            {{ value?.name }}
+                        </ng-template>
                     </ng-template>
                 </ngx-datatable-column>
 

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.ts
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.ts
@@ -57,6 +57,8 @@ export class ParticipationComponent implements OnInit, OnDestroy {
 
     exerciseSubmissionState: ExerciseSubmissionState;
 
+    isAdmin = false;
+
     isLoading: boolean;
 
     constructor(
@@ -128,6 +130,7 @@ export class ParticipationComponent implements OnInit, OnDestroy {
         } else if (this.exercise.exerciseGroup) {
             this.exercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.exerciseGroup.exam?.course!);
         }
+        this.isAdmin = this.accountService.isAdmin();
     }
 
     updateParticipationFilter(newValue: FilterProp) {

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exams.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exams.component.spec.ts
@@ -30,6 +30,8 @@ import * as moment from 'moment';
 import { By } from '@angular/platform-browser';
 import { NgbModal, NgbModule, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe.ts';
+import { AccountService } from 'app/core/auth/account.service';
+import { MockAccountService } from '../../../../helpers/mocks/service/mock-account.service';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -198,6 +200,7 @@ describe('StudentExamsComponent', () => {
                         },
                     },
                 },
+                { provide: AccountService, useClass: MockAccountService },
             ],
         })
             .compileComponents()


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) ~~on the test server https://artemistest.ase.in.tum.de~~ locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
The User Management is only accessible for administrators, but links to these pages are displayed at multiple places. Clicking them as non-administrator hast simply no effect at all. This PR removes this links and only displays them if the current user has administrator rights.

### Steps for Testing

Check the following pages once as administrator and once as admin. Make sure that the instructor can only see the value (in most cases the student's name or login) while the administrator sees a clickable link.

- Course Management -> Exams -> Students
- Course Management -> Exams -> Student exams
- Course Management -> Exercises -> Participations
- Course Management -> Exercises -> Scores
- Course Management -> Course (click on title) -> Any user group