### PR TITLE
[Bugfix] Show Attachment Lecture Unit Release Date in Badge

### DIFF
--- a/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.html
@@ -7,7 +7,7 @@
                 *ngIf="!attachmentUnit?.visibleToStudents"
                 class="badge badge-warning ml-2"
                 placement="right"
-                ngbTooltip="{{ 'artemisApp.attachmentUnit.notReleasedTooltip' | artemisTranslate }} {{ attachmentUnit?.releaseDate | artemisDate }}"
+                ngbTooltip="{{ 'artemisApp.attachmentUnit.notReleasedTooltip' | artemisTranslate }} {{ attachmentUnit?.attachment?.releaseDate | artemisDate }}"
             >
                 {{ 'artemisApp.courseOverview.exerciseList.notReleased' | artemisTranslate }}</span
             >


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) ~~on the test server https://artemistest.ase.in.tum.de~~ locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
Fixes #3284

### Description
The release date of an attachment lecture unit is defined by the attachment itself, not by the lecture unit. This is now handled correctly for the not-released tooltip.

### Steps for Testing

1. Create a Lecture with a File-Lecture unit which will be released in the future
2. Check that the not-released-tooltip shows the correct release date.
