### PR TITLE
Bugfix/programming exercise update/fix for checkout repository of sample solution

### DIFF
--- a/src/main/webapp/app/entities/programming-exercise.model.ts
+++ b/src/main/webapp/app/entities/programming-exercise.model.ts
@@ -65,7 +65,7 @@ export class ProgrammingExercise extends Exercise {
         this.allowOfflineIde = true; // default value
         this.programmingLanguage = ProgrammingLanguage.JAVA; // default value
         this.noVersionControlAndContinuousIntegrationAvailable = false; // default value
-        this.checkoutSolutionRepository = true; // default value
+        this.checkoutSolutionRepository = false; // default value
         this.projectType = ProjectType.ECLIPSE; // default value
         this.showTestNamesToStudents = false; // default value
     }

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -333,7 +333,6 @@
                                 name="checkoutSolutionRepository"
                                 id="field_checkoutSolutionRepository"
                                 [(ngModel)]="programmingExercise.checkoutSolutionRepository"
-                                checked
                             />
                             <span jhiTranslate="artemisApp.programmingExercise.checkoutSolutionRepository.title">Checkout Solution repository</span>
                             <jhi-help-icon placement="top" text="artemisApp.programmingExercise.checkoutSolutionRepository.description"></jhi-help-icon>

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -138,6 +138,14 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
             this.programmingExercise.staticCodeAnalysisEnabled = false;
             this.programmingExercise.maxStaticCodeAnalysisPenalty = undefined;
         }
+
+        // Automatically enable the checkout of the solution repository for Haskell exercises
+        if (this.checkoutSolutionRepositoryAllowed && language === ProgrammingLanguage.HASKELL) {
+            this.programmingExercise.checkoutSolutionRepository = true;
+        } else {
+            this.programmingExercise.checkoutSolutionRepository = false;
+        }
+
         // Don't override the problem statement with the template in edit mode.
         if (this.programmingExercise.id === undefined) {
             this.loadProgrammingLanguageTemplate(language, this.programmingExercise.projectType!);
@@ -375,11 +383,6 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
         // Select the correct pattern
         this.setPackageNamePattern(language);
         this.selectedProgrammingLanguage = language;
-        if (language === ProgrammingLanguage.HASKELL) {
-            this.programmingExercise.checkoutSolutionRepository = true;
-        } else {
-            this.programmingExercise.checkoutSolutionRepository = false;
-        }
         return language;
     }
 

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -375,6 +375,11 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
         // Select the correct pattern
         this.setPackageNamePattern(language);
         this.selectedProgrammingLanguage = language;
+        if (language === ProgrammingLanguage.HASKELL) {
+            this.programmingExercise.checkoutSolutionRepository = true;
+        } else {
+            this.programmingExercise.checkoutSolutionRepository = false;
+        }
         return language;
     }
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with the user instructor on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Only the programming language Haskell could be selected as language while creating a new programming exercise after the PR #3272. All other programming languages would generate a warning "Checking out the solution repository is only supported for Haskell exercises".
 
### Description
The variable 'checkoutSolutionRepository' in 'ProgrammingExerciseUpdateComponent.ts' will only be set to true if Haskell is the selected programming language.

### Steps for Testing

1. Log into Artemis
2. Navigate to Course Administration
3. Generate a new programming exercise
4. Fill in a title and short name for the exercise
5. Select Haskell as a programming language
6. The option "Checkout repository of sample solution" is checked.
7. Select any other programming language 
8. No warning can be seen above the title input field. 


### Screenshots
![image](https://user-images.githubusercontent.com/32565407/115965216-5a77af00-a528-11eb-893d-6301f40aafaa.png)
