### PR TITLE
[Test] increase test coverage in exam-management-component.

### DIFF
--- a/src/main/webapp/app/exam/manage/exam-management.component.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.component.ts
@@ -118,7 +118,7 @@ export class ExamManagementComponent implements OnInit, OnDestroy {
      * @param index {number}
      * @param item {Exam}
      */
-    trackId(index: number, item: Exam) {
+    trackId(index: number, item: Exam): number | undefined {
         return item.id;
     }
 

--- a/src/test/javascript/spec/component/exam/manage/exam-management.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-management.component.spec.ts
@@ -19,6 +19,10 @@ import { CourseManagementService } from 'app/course/manage/course-management.ser
 import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { RouterTestingModule } from '@angular/router/testing';
 import { examManagementRoute } from 'app/exam/manage/exam-management.route';
+import { SortService } from 'app/shared/service/sort.service';
+import { AccountService } from 'app/core/auth/account.service';
+import { ExamInformationDTO } from 'app/entities/exam-information.model';
+import { JhiEventManager } from 'ng-jhipster';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -33,6 +37,9 @@ describe('Exam Management Component', () => {
     let fixture: ComponentFixture<ExamManagementComponent>;
     let service: ExamManagementService;
     let courseManagementService: CourseManagementService;
+    let sortService: SortService;
+    let accountService: AccountService;
+    let eventManager: JhiEventManager;
 
     const route = ({ snapshot: { paramMap: convertToParamMap({ courseId: course.id }) }, url: new Observable<UrlSegment[]>() } as any) as ActivatedRoute;
 
@@ -45,6 +52,7 @@ describe('Exam Management Component', () => {
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: TranslateService, useClass: MockTranslateService },
                 { provide: ActivatedRoute, useValue: route },
+                JhiEventManager,
             ],
         })
             .overrideTemplate(ExamManagementComponent, '')
@@ -54,6 +62,9 @@ describe('Exam Management Component', () => {
         comp = fixture.componentInstance;
         service = TestBed.inject(ExamManagementService);
         courseManagementService = TestBed.inject(CourseManagementService);
+        sortService = TestBed.inject(SortService);
+        accountService = TestBed.inject(AccountService);
+        eventManager = TestBed.inject(JhiEventManager);
     });
 
     afterEach(function () {
@@ -61,19 +72,97 @@ describe('Exam Management Component', () => {
         sinon.restore();
     });
 
-    it('Should call findAllExamsForCourse on init', () => {
+    it('Should call courseService on init', () => {
         // GIVEN
-        const responseFakeExams = { body: [exam] } as HttpResponse<Exam[]>;
-        const responseFakeCourse = { body: { id: 456 } as Course } as HttpResponse<Course>;
+        const responseFakeCourse = { body: course as Course } as HttpResponse<Course>;
         sinon.replace(courseManagementService, 'find', sinon.fake.returns(of(responseFakeCourse)));
-        sinon.replace(service, 'findAllExamsForCourse', sinon.fake.returns(of(responseFakeExams)));
 
         // WHEN
         comp.ngOnInit();
 
         // THEN
+        expect(courseManagementService.find).to.have.been.calledOnce;
+        expect(comp.course).to.eq(course);
+    });
+
+    it('Should call loadAllExamsForCourse on init', () => {
+        // GIVEN
+        const responseFakeCourse = { body: course as Course } as HttpResponse<Course>;
+        sinon.replace(courseManagementService, 'find', sinon.fake.returns(of(responseFakeCourse)));
+        const responseFakeExams = { body: [exam] } as HttpResponse<Exam[]>;
+        sinon.replace(service, 'findAllExamsForCourse', sinon.fake.returns(of(responseFakeExams)));
+
+        //WHEN
+        comp.ngOnInit();
+
+        // THEN
         expect(service.findAllExamsForCourse).to.have.been.calledOnce;
-        expect(comp.exams[0]).to.eq(exam);
+        expect(comp.exams).to.deep.eq([exam]);
+    });
+
+    it('Should call isAtLeastInstructorInCourse on init', () => {
+        // GIVEN
+        const responseFakeCourse = { body: course as Course } as HttpResponse<Course>;
+        sinon.replace(courseManagementService, 'find', sinon.fake.returns(of(responseFakeCourse)));
+        const expectedAtLeastInstructor = true;
+        sinon.replace(accountService, 'isAtLeastInstructorInCourse', sinon.fake.returns(expectedAtLeastInstructor));
+
+        // WHEN
+        comp.ngOnInit();
+
+        // THEN
+        expect(accountService.isAtLeastInstructorInCourse).to.have.been.calledOnce;
+        expect(comp.isAtLeastInstructor).to.eq(expectedAtLeastInstructor);
+    });
+
+    it('Should call isAtLeastTutorInCourse on init', () => {
+        // GIVEN
+        const responseFakeCourse = { body: course as Course } as HttpResponse<Course>;
+        sinon.replace(courseManagementService, 'find', sinon.fake.returns(of(responseFakeCourse)));
+        const expectedAtLeastTutor = true;
+        sinon.replace(accountService, 'isAtLeastTutorInCourse', sinon.fake.returns(expectedAtLeastTutor));
+
+        // WHEN
+        comp.ngOnInit();
+
+        // THEN
+        expect(accountService.isAtLeastTutorInCourse).to.have.been.calledOnce;
+        expect(comp.isAtLeastTutor).to.eq(expectedAtLeastTutor);
+    });
+
+    it('Should call getLatestIndividualDate on init', () => {
+        // GIVEN
+        const responseFakeCourse = { body: course as Course } as HttpResponse<Course>;
+        sinon.replace(courseManagementService, 'find', sinon.fake.returns(of(responseFakeCourse)));
+        const responseFakeExams = { body: [exam] } as HttpResponse<Exam[]>;
+        sinon.replace(service, 'findAllExamsForCourse', sinon.fake.returns(of(responseFakeExams)));
+
+        let examInformationDTO = new ExamInformationDTO();
+        examInformationDTO.latestIndividualEndDate = moment();
+        const responseFakeLatestIndividualEndDateOfExam = { body: examInformationDTO } as HttpResponse<ExamInformationDTO>;
+        sinon.replace(service, 'getLatestIndividualEndDateOfExam', sinon.fake.returns(of(responseFakeLatestIndividualEndDateOfExam)));
+
+        // WHEN
+        comp.ngOnInit();
+
+        // THEN
+        expect(service.getLatestIndividualEndDateOfExam).to.have.been.calledOnce;
+        expect(comp.exams[0].latestIndividualEndDate).to.eq(examInformationDTO.latestIndividualEndDate);
+    });
+
+    it('Should call findAllExamsForCourse on examListModification event being fired after registering for exam changes ', () => {
+        // GIVEN
+        comp.course = course;
+        const responseFakeExams = { body: [exam] } as HttpResponse<Exam[]>;
+        sinon.replace(service, 'findAllExamsForCourse', sinon.fake.returns(of(responseFakeExams)));
+
+        // WHEN
+        comp.registerChangeInExams();
+        eventManager.broadcast({ name: 'examListModification', content: 'dummy' });
+
+        // THEN
+        expect(service.findAllExamsForCourse).to.have.been.calledOnce;
+        expect(comp.exams).to.deep.eq([exam]);
     });
 
     it('Should delete an exam when delete exam is called', () => {
@@ -90,20 +179,10 @@ describe('Exam Management Component', () => {
 
         // THEN
         expect(service.delete).to.have.been.calledOnce;
+        expect(comp.exams.length).to.eq(0);
     });
 
-    it('Should return true for examHasFinished when component has no exam information ', () => {
-        // GIVEN
-        exam.latestIndividualEndDate = undefined;
-
-        // WHEN
-        const examHasFinished = comp.examHasFinished(exam);
-
-        // THEN
-        expect(examHasFinished).to.be.false;
-    });
-
-    it('Should return true for examHasFinished when component has information of other exams', () => {
+    it('Should return false for examHasFinished when component has no exam information ', () => {
         // GIVEN
         exam.latestIndividualEndDate = undefined;
 
@@ -134,5 +213,24 @@ describe('Exam Management Component', () => {
 
         // THEN
         expect(examHasFinished).to.be.false;
+    });
+
+    it('Should return exam.id, when item in the exam table is being tracked ', () => {
+        // WHEN
+        const itemId = comp.trackId(0, exam);
+
+        // THEN
+        expect(itemId).to.eq(exam.id);
+    });
+
+    it('Should call sortService when sortRows is called ', () => {
+        // GIVEN
+        sinon.replace(sortService, 'sortByProperty', sinon.fake.returns([]));
+
+        // WHEN
+        comp.sortRows();
+
+        // THEN
+        expect(sortService.sortByProperty).to.have.been.calledOnce;
     });
 });

--- a/src/test/javascript/spec/component/exam/manage/exam-management.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-management.component.spec.ts
@@ -92,7 +92,7 @@ describe('Exam Management Component', () => {
         const responseFakeExams = { body: [exam] } as HttpResponse<Exam[]>;
         sinon.replace(service, 'findAllExamsForCourse', sinon.fake.returns(of(responseFakeExams)));
 
-        //WHEN
+        // WHEN
         comp.ngOnInit();
 
         // THEN
@@ -137,7 +137,7 @@ describe('Exam Management Component', () => {
         const responseFakeExams = { body: [exam] } as HttpResponse<Exam[]>;
         sinon.replace(service, 'findAllExamsForCourse', sinon.fake.returns(of(responseFakeExams)));
 
-        let examInformationDTO = new ExamInformationDTO();
+        const examInformationDTO = new ExamInformationDTO();
         examInformationDTO.latestIndividualEndDate = moment();
         const responseFakeLatestIndividualEndDateOfExam = { body: examInformationDTO } as HttpResponse<ExamInformationDTO>;
         sinon.replace(service, 'getLatestIndividualEndDateOfExam', sinon.fake.returns(of(responseFakeLatestIndividualEndDateOfExam)));


### PR DESCRIPTION
## Motivation and Context
Increase test coverage for Exam-management-component.
New Created Tests for the following methods:
- trackId
- sortRows
- registerChangeInExams

Enriching the existing Tests for the methods:
- init
- loadAllExamsForCourse
- deleteExam

## Test Coverage
Test coverage is increased from 85.45% to **92.73%**