### PR TITLE
Change client service test documentation

### DIFF
--- a/docs/dev/guidelines/client.rst
+++ b/docs/dev/guidelines/client.rst
@@ -178,15 +178,16 @@ Some guidelines:
               httpMock.verify();
           });
 
-          it('should make get request', async () => {
+          it('should make get request', fakeAsync( () => {
               const returnedFromApi = {some: 'data'};
 
               component.callServiceMethod()
-                  .subscribe((data) => expect(data).toMatchObject({body: returnedFromApi}));
+                  .subscribe((data) => expect(data.body).toEqual(returnedFromApi));
 
-              const req = httpMock.expectOne({ method: 'GET' });
-              req.flush(JSON.stringify(returnedFromApi));
-          });
+              const req = httpMock.expectOne({ method: 'GET', url: 'urlThatMethodCalls' });
+              req.flush(returnedFromApi);
+              tick();
+          }));
         });
 
 


### PR DESCRIPTION
### Motivation and Context
Expect statement inside subscribe method does not work if you write service tests according to documentation.

