### PR TITLE
Improve code coverage of JenkinsAuthorizationInterceptor

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsAuthorizationInterceptor.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsAuthorizationInterceptor.java
@@ -5,6 +5,9 @@ import java.net.URL;
 
 import javax.validation.constraints.NotNull;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.*;
@@ -12,6 +15,7 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -19,6 +23,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 @Profile("jenkins")
 @Component
 public class JenkinsAuthorizationInterceptor implements ClientHttpRequestInterceptor {
+
+    private final Logger log = LoggerFactory.getLogger(JenkinsAuthorizationInterceptor.class);
 
     @Value("${artemis.continuous-integration.user}")
     private String username;
@@ -31,6 +37,9 @@ public class JenkinsAuthorizationInterceptor implements ClientHttpRequestInterce
 
     @Value("${jenkins.use-crumb:#{true}}")
     private boolean useCrumb;
+
+    @Autowired
+    private RestTemplate restTemplate;
 
     @NotNull
     @Override
@@ -47,9 +56,14 @@ public class JenkinsAuthorizationInterceptor implements ClientHttpRequestInterce
         headers.setBasicAuth(username, password);
         final var entity = new HttpEntity<>(headers);
 
-        final var response = new RestTemplate().exchange(jenkinsURL.toString() + "/crumbIssuer/api/json", HttpMethod.GET, entity, JsonNode.class);
-        final var sessionId = response.getHeaders().get("Set-Cookie").get(0);
-        headersToAuthenticate.add("Jenkins-Crumb", response.getBody().get("crumb").asText());
-        headersToAuthenticate.add("Cookie", sessionId);
+        try {
+            final var response = restTemplate.exchange(jenkinsURL.toString() + "/crumbIssuer/api/json", HttpMethod.GET, entity, JsonNode.class);
+            final var sessionId = response.getHeaders().get("Set-Cookie").get(0);
+            headersToAuthenticate.add("Jenkins-Crumb", response.getBody().get("crumb").asText());
+            headersToAuthenticate.add("Cookie", sessionId);
+        }
+        catch (RestClientException e) {
+            log.error("Cannot get Jenkins crumb from crumb issuer: {}", e.getMessage());
+        }
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/JenkinsAuthorizationInterceptorTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/JenkinsAuthorizationInterceptorTest.java
@@ -1,0 +1,134 @@
+package de.tum.in.www1.artemis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
+import de.tum.in.www1.artemis.service.connectors.jenkins.JenkinsAuthorizationInterceptor;
+
+public class JenkinsAuthorizationInterceptorTest extends AbstractSpringIntegrationJenkinsGitlabTest {
+
+    @Value("${artemis.continuous-integration.url}")
+    private URL jenkinsServerUrl;
+
+    @Autowired
+    JenkinsAuthorizationInterceptor jenkinsAuthorizationInterceptor;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    private MockRestServiceServer mockRestServiceServer;
+
+    /**
+     * This method initializes the test case by setting up a local repo
+     */
+    @BeforeEach
+    public void initTestCase() throws Exception {
+        jenkinsRequestMockProvider.enableMockingOfRequests(jenkinsServer);
+        gitlabRequestMockProvider.enableMockingOfRequests();
+        mockRestServiceServer = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).bufferContent().build();
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        gitlabRequestMockProvider.reset();
+        jenkinsRequestMockProvider.reset();
+        mockRestServiceServer.reset();
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR", username = "instructor1")
+    public void testAuthorizationInterceptorSetCrumbCorrectly() throws Exception {
+        // Create a mocked request with a header which shouldn't be erased after the request is intercepted.
+        var request = mockHttpRequestWithHeaders();
+
+        // Create the json returned by the response
+        var objectMapper = new ObjectMapper();
+        ObjectNode crumbJson = objectMapper.createObjectNode();
+        crumbJson.put("crumb", "some-crumb");
+        var responseBody = objectMapper.writeValueAsString(crumbJson);
+
+        mockGetCrumb(responseBody, HttpStatus.OK);
+        jenkinsAuthorizationInterceptor.intercept(request, new byte[] {}, mock(ClientHttpRequestExecution.class));
+
+        assertThat(request.getHeaders().keySet()).contains("some-header", "Jenkins-Crumb", "Cookie");
+        assertThat(request.getHeaders().get("some-header")).contains("true");
+        assertThat(request.getHeaders().get("Jenkins-Crumb")).contains("some-crumb");
+        assertThat(request.getHeaders().get("Cookie")).contains("some-session");
+
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR", username = "instructor1")
+    public void testAuthorizationInterceptorCrumbNotSet() throws Exception {
+        // Create a mocked request with a header which shouldn't be erased after the request is intercepted.
+        var request = mockHttpRequestWithHeaders();
+
+        ReflectionTestUtils.setField(jenkinsAuthorizationInterceptor, "useCrumb", false);
+        jenkinsAuthorizationInterceptor.intercept(request, new byte[] {}, mock(ClientHttpRequestExecution.class));
+        ReflectionTestUtils.setField(jenkinsAuthorizationInterceptor, "useCrumb", true);
+
+        assertThat(request.getHeaders().keySet()).contains("some-header");
+        assertThat(request.getHeaders().get("some-header")).contains("true");
+
+        assertThat(request.getHeaders().containsKey("Jenkins-Crumb")).isFalse();
+        assertThat(request.getHeaders().containsKey("Cookie")).isFalse();
+    }
+
+    @Test
+    @WithMockUser(roles = "INSTRUCTOR", username = "instructor1")
+    public void testAuthorizationInterceptorCrumbException() throws Exception {
+        // Create a mocked request with a header which shouldn't be erased after the request is intercepted.
+        var request = mockHttpRequestWithHeaders();
+
+        mockGetCrumb("", HttpStatus.NOT_FOUND);
+        jenkinsAuthorizationInterceptor.intercept(request, new byte[] {}, mock(ClientHttpRequestExecution.class));
+
+        assertThat(request.getHeaders().keySet()).contains("some-header");
+        assertThat(request.getHeaders().get("some-header")).contains("true");
+
+        assertThat(request.getHeaders().containsKey("Jenkins-Crumb")).isFalse();
+        assertThat(request.getHeaders().containsKey("Cookie")).isFalse();
+
+    }
+
+    private HttpRequest mockHttpRequestWithHeaders() {
+        var httpRequest = mock(HttpRequest.class);
+        var httpHeaders = new HttpHeaders();
+        httpHeaders.add("some-header", "true");
+        doReturn(httpHeaders).when(httpRequest).getHeaders();
+        return httpRequest;
+    }
+
+    private void mockGetCrumb(String expectedBody, HttpStatus expectedStatus) throws URISyntaxException {
+        final var uri = UriComponentsBuilder.fromUri(jenkinsServerUrl.toURI()).pathSegment("crumbIssuer/api/json").build().toUri();
+        var headers = new HttpHeaders();
+        headers.add("Set-Cookie", "some-session");
+        mockRestServiceServer.expect(requestTo(uri)).andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(expectedStatus).contentType(MediaType.APPLICATION_JSON).headers(headers).body(expectedBody));
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The `JenkinsAuthorizationInterceptor` class wasn't tested at all.

### Description
<!-- Describe your changes in detail -->
This PR adds tests and also improves the coverage to 100%. It also includes additional exception handling so that it doesn't throw an exception if the server cannot get a Jenkins crumb.

### Test Coverage 
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
JenkinsAuthorizationInterceptor.java 100%
