### PR TITLE
Fix the solution labels of dnd and sa quiz questions being undefined

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/statistics/drag-and-drop-question-statistic/drag-and-drop-question-statistic.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/drag-and-drop-question-statistic/drag-and-drop-question-statistic.component.ts
@@ -66,6 +66,7 @@ export class DragAndDropQuestionStatisticComponent extends QuestionStatisticComp
         // set label and background color based on the dropLocations
         this.question.dropLocations!.forEach((dropLocation, i) => {
             this.labels.push(this.getLetter(i) + '.');
+            this.solutionLabels.push(this.getLetter(i) + '.');
             this.backgroundColors.push(blueColor);
             this.backgroundSolutionColors.push(greenColor);
         });

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/short-answer-question-statistic/short-answer-question-statistic.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/short-answer-question-statistic/short-answer-question-statistic.component.ts
@@ -94,6 +94,7 @@ export class ShortAnswerQuestionStatisticComponent extends QuestionStatisticComp
         // set label and backgroundcolor based on the spots
         this.question.spots!.forEach((spot, i) => {
             this.labels.push(this.getLetter(i) + '.');
+            this.solutionLabels.push(this.getLetter(i) + '.');
             this.backgroundColors.push(blueColor);
             this.backgroundSolutionColors.push(greenColor);
         });


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Currently when switching to the solution view for drag and drop or short answer quiz questions the labels for the questions change from `A.`, `B.`, etc. to `undefined`:
![grafik](https://user-images.githubusercontent.com/72132281/116208601-5ffc1180-a741-11eb-8594-a8a52abcbe2b.png)

### Description

Changed it to simply use the letters of the question in the solution view as well.

### Steps for Testing

1. Create or find a quiz with short answer and drag and drop questions
2. Participate and view the statistics afterwards
3. Toggle between the "Show Solution" and "Hide Solution" and check that everything displays correctly

