### PR TITLE
Fix issues with example submissions for exercises with categories

### DIFF
--- a/src/main/webapp/app/exercises/shared/example-submission/example-submission.service.ts
+++ b/src/main/webapp/app/exercises/shared/example-submission/example-submission.service.ts
@@ -1,14 +1,14 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-
 import { ExampleSubmission } from 'app/entities/example-submission.model';
+import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 
 export type EntityResponseType = HttpResponse<ExampleSubmission>;
 
 @Injectable({ providedIn: 'root' })
 export class ExampleSubmissionService {
-    constructor(private http: HttpClient) {}
+    constructor(private http: HttpClient, private exerciseService: ExerciseService) {}
 
     /**
      * Creates an example submission
@@ -74,6 +74,12 @@ export class ExampleSubmissionService {
      * Convert a ExampleSubmission to a JSON which can be sent to the server.
      */
     private convert(exampleSubmission: ExampleSubmission): ExampleSubmission {
-        return Object.assign({}, exampleSubmission);
+        const jsonCopy = Object.assign({}, exampleSubmission);
+        if (jsonCopy.exercise) {
+            jsonCopy.exercise = this.exerciseService.convertDateFromClient(jsonCopy.exercise);
+            jsonCopy.exercise = this.exerciseService.setBonusPointsConstrainedByIncludedInOverallScore(jsonCopy.exercise!);
+            jsonCopy.exercise.categories = this.exerciseService.stringifyExerciseCategories(jsonCopy.exercise);
+        }
+        return jsonCopy;
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context

Closes #3300.

### Description

The modeling submission was sending an exercise alongside itself to the server, but didn't convert that exercise to a format the server expects. (Which is what we do now to fix the "Bad Request" errors.)

### Steps for Testing

1. Create or find a modeling exercise with categories
2. Create, update and delete example submissions
3. Also check if example solutions and example assessments for the example submissions still work

