### PR TITLE
Display repository and build plan urls only if they exist

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores.component.html
@@ -253,11 +253,11 @@
                     [width]="470"
                 >
                     <ng-template ngx-datatable-cell-template let-value="value">
-                        <a class="btn btn-primary btn-sm mr-1" href="{{ getRepositoryLink(value) }}">
+                        <a *ngIf="getRepositoryLink(value)" class="btn btn-primary btn-sm mr-1" href="{{ getRepositoryLink(value) }}">
                             <fa-icon [icon]="'code-branch'" class="mr-1"></fa-icon>
                             Repository
                         </a>
-                        <button class="btn btn-primary btn-sm mr-1" jhiBuildPlanButton [projectKey]="projectKey()" [buildPlanId]="buildPlanId(value)!">
+                        <button *ngIf="buildPlanId(value)" class="btn btn-primary btn-sm mr-1" jhiBuildPlanButton [projectKey]="projectKey()" [buildPlanId]="buildPlanId(value)!">
                             <fa-icon class="mr-1" [icon]="['far', 'file-code']"></fa-icon>
                             Build plan
                         </button>

--- a/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
+++ b/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.html
@@ -81,8 +81,9 @@
                 <span jhiTranslate="artemisApp.programmingSubmission.commitHash"></span>
             </ng-template>
             <ng-template ngx-datatable-cell-template let-row="row" let-value="value">
-                <div *ngIf="value != undefined; else displayNa">
-                    <a href="{{ getCommitUrl(row) }}" target="_blank" rel="noopener noreferrer">{{ value.substr(0, 11) }}</a>
+                <div *ngIf="value; else displayNa">
+                    <a *ngIf="getCommitUrl(row); else commitWithoutLink" href="{{ getCommitUrl(row) }}" target="_blank" rel="noopener noreferrer">{{ value.substr(0, 11) }}</a>
+                    <ng-template #commitWithoutLink>{{ value.substr(0, 11) }}</ng-template>
                 </div>
                 <ng-template #displayNa>
                     {{ 'n.a' }}

--- a/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.ts
+++ b/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { SubmissionService } from 'app/exercises/shared/submission/submission.service';
 import { JhiEventManager } from 'ng-jhipster';
 import { Subscription } from 'rxjs/Subscription';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, take, tap } from 'rxjs/operators';
 import { combineLatest, of } from 'rxjs';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
 import { Submission, SubmissionType } from 'app/entities/submission.model';
@@ -19,7 +19,6 @@ import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { TranslateService } from '@ngx-translate/core';
 import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
-import { take, tap } from 'rxjs/operators';
 
 @Component({
     selector: 'jhi-participation-submission',
@@ -149,9 +148,12 @@ export class ParticipationSubmissionComponent implements OnInit {
 
     getCommitUrl(submission: ProgrammingSubmission): string | undefined {
         const projectKey = (this.exercise as ProgrammingExercise)?.projectKey!.toLowerCase();
-        let repoSlug;
+        let repoSlug: string | undefined = undefined;
         if (this.participation?.type === ParticipationType.PROGRAMMING) {
-            repoSlug = projectKey + '-' + (this.participation as ProgrammingExerciseStudentParticipation).participantIdentifier;
+            const studentParticipation = this.participation as ProgrammingExerciseStudentParticipation;
+            if (studentParticipation.repositoryUrl) {
+                repoSlug = projectKey + '-' + studentParticipation.participantIdentifier;
+            }
         } else if (this.participation?.type === ParticipationType.TEMPLATE) {
             // In case of a test submisson, we need to use the test repository
             repoSlug = projectKey + (submission?.type === SubmissionType.TEST ? '-tests' : '-exercise');

--- a/src/main/webapp/app/exercises/shared/participation/participation.component.html
+++ b/src/main/webapp/app/exercises/shared/participation/participation.component.html
@@ -88,7 +88,7 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                        <span *ngIf="value !== null">
+                        <span *ngIf="value">
                             <a href="{{ getRepositoryLink(row, value) }}" target="_blank" rel="noreferrer noopener">Repository Link</a>
                         </span>
                     </ng-template>
@@ -102,7 +102,7 @@
                         </span>
                     </ng-template>
                     <ng-template ngx-datatable-cell-template let-value="row">
-                        <span *ngIf="value.buildPlanId !== null">
+                        <span *ngIf="value">
                             <a jhiBuildPlanLink [buildPlanId]="value.buildPlanId" [projectKey]="value.exercise.projectKey">
                                 {{ value.buildPlanId }}
                             </a>

--- a/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
@@ -4,14 +4,14 @@ import { AccountService } from 'app/core/auth/account.service';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as moment from 'moment';
-import { SinonStub, stub, restore } from 'sinon';
+import { restore, SinonStub, stub } from 'sinon';
 import { ArtemisTestModule } from '../../test.module';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockComponent } from 'ng-mocks';
 import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { MomentModule } from 'ngx-moment';
 import { ActivatedRoute, Router } from '@angular/router';
-import { of, BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { AssessmentDetailComponent } from 'app/assessment/assessment-detail/assessment-detail.component';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
@@ -41,6 +41,8 @@ import { SolutionProgrammingExerciseParticipation } from 'app/entities/participa
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
+import { ProgrammingExerciseStudentParticipation } from 'app/entities/participation/programming-exercise-student-participation.model';
+import { ParticipationType } from 'app/entities/participation/participation.model';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -103,6 +105,29 @@ describe('ParticipationSubmissionComponent', () => {
     afterEach(() => {
         restore();
     });
+
+    it('Should return empty commit url if participation has no repository url', fakeAsync(() => {
+        const exercise: ProgrammingExercise = {
+            numberOfAssessmentsOfCorrectionRounds: [],
+            secondCorrectionEnabled: false,
+            studentAssignedTeamIdComputed: false,
+            projectKey: 'project-key',
+        };
+
+        const participation: ProgrammingExerciseStudentParticipation = { id: 1, type: ParticipationType.PROGRAMMING, participantIdentifier: 'identifier' };
+        const submission: ProgrammingSubmission = {
+            submissionExerciseType: SubmissionExerciseType.PROGRAMMING,
+            id: 3,
+            submitted: true,
+            type: SubmissionType.MANUAL,
+            submissionDate: moment('2019-07-09T10:47:33.244Z'),
+            commitHash: '123456789',
+            participation,
+        };
+        comp.participation = participation;
+        comp.exercise = exercise;
+        expect(comp.getCommitUrl(submission)).to.be.empty;
+    }));
 
     it('Submissions are correctly loaded from server', fakeAsync(() => {
         // set all attributes for comp

--- a/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
@@ -106,7 +106,7 @@ describe('ParticipationSubmissionComponent', () => {
         restore();
     });
 
-    it('Should return empty commit url if participation has no repository url', fakeAsync(() => {
+    it('Should return empty commit url if participation has no repository url', () => {
         const exercise: ProgrammingExercise = {
             numberOfAssessmentsOfCorrectionRounds: [],
             secondCorrectionEnabled: false,
@@ -127,7 +127,7 @@ describe('ParticipationSubmissionComponent', () => {
         comp.participation = participation;
         comp.exercise = exercise;
         expect(comp.getCommitUrl(submission)).to.be.empty;
-    }));
+    });
 
     it('Submissions are correctly loaded from server', fakeAsync(() => {
         // set all attributes for comp


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The repository and build plan URLs are displayed in the participation and exercise tables even if the URL is not available. This leads to confusion because if there's no link, the user is redirected to the  Artemis home page.

### Description
<!-- Describe your changes in detail -->
This PR displays the repository and build plans URLs only if it's available. This affects the exercise scores and particpation pages. The submission page is also modified, there the commit will be displayed without a hyperlink in case the repository isn't available.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Generate a programming exercise
4. Participate once in it to generate a submission and a participation
5. Navigate to Exercises -> participation page: make sure the repo and build plan URLs are visible
6. Navigate to Exercises -> Scores page: make sure the repo and build plan buttons are displayed
7. Click on the submission count and check that the commit URL is displayed with a hyperlink
5. Navigate to the exercise detail page and click on clean up. Make sure to click on the  checkbox.
7. Go back to the Participation and Scores page and make sure that the URLs and Buttons are not visible anymore
8. Go back to the submission page and make sure that the commit is visible without a hyperlink

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
participation-submission.component.ts 93.26%

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Since the submission produces a commit, but the repository URL isn't available, the commit isn't wrapped with a hyperlink:
![image](https://user-images.githubusercontent.com/11298674/116359669-5afd9780-a7ff-11eb-89e6-573a4bba9c2c.png)

In this case the repository url is available so a hyperlink is displayed:
![image](https://user-images.githubusercontent.com/11298674/116359975-b9c31100-a7ff-11eb-94ce-44589f84df1c.png)

Exercise scores: The first case doesn't have a repository nor a build plan URL so the buttons aren't displayed:
![image](https://user-images.githubusercontent.com/11298674/116360161-ec6d0980-a7ff-11eb-94da-88a839e1f5f5.png)

Participation page: We only display the URLs if they are available:
![image](https://user-images.githubusercontent.com/11298674/116360316-13c3d680-a800-11eb-9066-caec8c49393e.png)

