### PR TITLE
Use Git Archive to Export Programming Exercise Repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,8 @@ dependencies {
     // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit
     implementation "org.eclipse.jgit:org.eclipse.jgit:5.11.0.202103091610-r"
     implementation "org.eclipse.jgit:org.eclipse.jgit.ssh.apache:5.11.0.202103091610-r"
+    // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit.archive
+    implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.archive', version: '5.11.0.202103091610-r'
     // https://mvnrepository.com/artifact/net.sourceforge.plantuml/plantuml
     implementation "net.sourceforge.plantuml:plantuml:8059"
     implementation "org.imsglobal:basiclti-util:1.2.0"

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
@@ -75,7 +75,7 @@ public class CourseExamExportService {
 
         var timestamp = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-Hmss"));
         var courseDirName = course.getShortName() + "-" + course.getTitle() + "-" + timestamp;
-        var cleanCourseDirName = fileService.removeIllegalCharacters(courseDirName);
+        String cleanCourseDirName = fileService.removeIllegalCharacters(courseDirName);
 
         // Create a temporary directory that will contain the files that will be zipped
         var courseDirPath = Path.of("./exports", cleanCourseDirName, cleanCourseDirName);

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
@@ -78,7 +78,7 @@ public class CourseExamExportService {
         String cleanCourseDirName = fileService.removeIllegalCharacters(courseDirName);
 
         // Create a temporary directory that will contain the files that will be zipped
-        var courseDirPath = Path.of("./exports", cleanCourseDirName, cleanCourseDirName);
+        Path courseDirPath = Path.of("./exports", cleanCourseDirName, cleanCourseDirName);
         try {
             Files.createDirectories(courseDirPath);
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
@@ -151,6 +151,8 @@ public class CourseExamExportService {
      * @param exportErrors List of failures that occurred during the export
      */
     private void exportCourseExercises(String notificationTopic, Course course, String outputDir, List<String> exportErrors) {
+        log.info("Exporting course exercises for course {} and title {}", course.getId(), course.getTitle());
+
         Path exercisesDir = Path.of(outputDir, "course-exercises");
         try {
             Files.createDirectory(exercisesDir);
@@ -170,6 +172,8 @@ public class CourseExamExportService {
      * @param exportErrors List of failures that occurred during the export
      */
     private void exportCourseExams(String notificationTopic, Course course, String outputDir, List<String> exportErrors) {
+        log.info("Export course exams for course {} and title {}", course.getId(), course.getTitle());
+
         Path examsDir = null;
         try {
             examsDir = Path.of(outputDir, "exams");
@@ -192,6 +196,8 @@ public class CourseExamExportService {
      * @param exportErrors List of failures that occurred during the export
      */
     private void exportExam(String notificationTopic, long examId, String outputDir, List<String> exportErrors) {
+        log.info("Export course exam {}", examId);
+
         Path examDir = null;
         try {
             // Create exam directory.
@@ -221,6 +227,8 @@ public class CourseExamExportService {
     private void exportExercises(String notificationTopic, Set<Exercise> exercises, String outputDir, List<String> exportErrors) {
         AtomicInteger exportedExercises = new AtomicInteger(0);
         exercises.forEach(exercise -> {
+            log.info("Exporting exercise {} with id {} ", exercise.getTitle(), exercise.getId());
+
             // Notify the user after the progress
             exportedExercises.addAndGet(1);
             notifyUserAboutExerciseExportState(notificationTopic, CourseExamExportState.RUNNING, List.of(exportedExercises + "/" + exercises.size() + " done"));

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
@@ -75,9 +75,10 @@ public class CourseExamExportService {
 
         var timestamp = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-Hmss"));
         var courseDirName = course.getShortName() + "-" + course.getTitle() + "-" + timestamp;
+        var cleanCourseDirName = fileService.removeIllegalCharacters(courseDirName);
 
         // Create a temporary directory that will contain the files that will be zipped
-        var courseDirPath = Path.of("./exports", courseDirName, courseDirName);
+        var courseDirPath = Path.of("./exports", cleanCourseDirName, cleanCourseDirName);
         try {
             Files.createDirectories(courseDirPath);
         }
@@ -116,9 +117,10 @@ public class CourseExamExportService {
 
         var timestamp = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-Hmss"));
         var examDirName = exam.getId() + "-" + exam.getTitle() + "-" + timestamp;
+        var cleanExamDirName = fileService.removeIllegalCharacters(examDirName);
 
         // Create a temporary directory that will contain the files that will be zipped
-        var examDirPath = Path.of("./exports", examDirName, examDirName);
+        var examDirPath = Path.of("./exports", cleanExamDirName, cleanExamDirName);
         try {
             Files.createDirectories(examDirPath);
         }
@@ -194,7 +196,8 @@ public class CourseExamExportService {
         try {
             // Create exam directory.
             var exam = examRepository.findByIdElseThrow(examId);
-            examDir = Path.of(outputDir, exam.getId() + "-" + exam.getTitle());
+            var cleanExamTitle = fileService.removeIllegalCharacters(exam.getId() + "-" + exam.getTitle());
+            examDir = Path.of(outputDir, cleanExamTitle);
             Files.createDirectory(examDir);
 
             // We retrieve every exercise from each exercise group and flatten the list.

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
@@ -120,7 +120,7 @@ public class CourseExamExportService {
         var cleanExamDirName = fileService.removeIllegalCharacters(examDirName);
 
         // Create a temporary directory that will contain the files that will be zipped
-        var examDirPath = Path.of("./exports", cleanExamDirName, cleanExamDirName);
+        Path examDirPath = Path.of("./exports", cleanExamDirName, cleanExamDirName);
         try {
             Files.createDirectories(examDirPath);
         }
@@ -202,7 +202,7 @@ public class CourseExamExportService {
         try {
             // Create exam directory.
             var exam = examRepository.findByIdElseThrow(examId);
-            var cleanExamTitle = fileService.removeIllegalCharacters(exam.getId() + "-" + exam.getTitle());
+            String cleanExamTitle = fileService.removeIllegalCharacters(exam.getId() + "-" + exam.getTitle());
             examDir = Path.of(outputDir, cleanExamTitle);
             Files.createDirectory(examDir);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -734,4 +734,13 @@ public class FileService implements DisposableBean {
         }
         return uniquePath;
     }
+
+    /**
+     * Removes illegal characters for filenames from the string.
+     * @param string the string with the characters
+     * @return stripped string
+     */
+    public String removeIllegalCharacters(String string) {
+        return string.replaceAll("/[/\\\\?%*:|\"<>]/g", "");
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
@@ -106,7 +106,9 @@ public abstract class SubmissionExportService {
         Course course = exercise.getCourseViaExerciseGroupOrCourseMember();
 
         String zipGroupName = course.getShortName() + "-" + exercise.getTitle() + "-" + exercise.getId();
-        String zipFileName = zipGroupName + "-" + ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-Hmss")) + ".zip";
+        var cleanZipGroupName = fileService.removeIllegalCharacters(zipGroupName);
+
+        String zipFileName = cleanZipGroupName + "-" + ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-Hmss")) + ".zip";
 
         Path submissionsFolderPath = Paths.get(submissionExportPath, "zippedSubmissions", zipGroupName);
         Path zipFilePath = Paths.get(submissionExportPath, "zippedSubmissions", zipFileName);

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
@@ -106,7 +106,7 @@ public abstract class SubmissionExportService {
         Course course = exercise.getCourseViaExerciseGroupOrCourseMember();
 
         String zipGroupName = course.getShortName() + "-" + exercise.getTitle() + "-" + exercise.getId();
-        var cleanZipGroupName = fileService.removeIllegalCharacters(zipGroupName);
+        String cleanZipGroupName = fileService.removeIllegalCharacters(zipGroupName);
 
         String zipFileName = cleanZipGroupName + "-" + ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-Hmss")) + ".zip";
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -49,7 +49,7 @@ import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipat
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.exception.GitException;
-import de.tum.in.www1.artemis.service.ZipFileService;
+import de.tum.in.www1.artemis.service.FileService;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 @Service
@@ -91,18 +91,18 @@ public class GitService {
 
     private final Map<Path, Path> cloneInProgressOperations = new ConcurrentHashMap<>();
 
-    private final ZipFileService zipFileService;
+    private final FileService fileService;
 
     private TransportConfigCallback sshCallback;
 
     private static final int JGIT_TIMEOUT_IN_SECONDS = 5;
 
-    public GitService(ZipFileService zipFileService) {
+    public GitService(FileService fileService) {
         log.info("file.encoding={}", System.getProperty("file.encoding"));
         log.info("sun.jnu.encoding={}", System.getProperty("sun.jnu.encoding"));
         log.info("Default Charset={}", Charset.defaultCharset());
         log.info("Default Charset in Use={}", new OutputStreamWriter(new ByteArrayOutputStream()).getEncoding());
-        this.zipFileService = zipFileService;
+        this.fileService = fileService;
     }
 
     /**
@@ -979,7 +979,7 @@ public class GitService {
             studentTeamOrDefault = participation.getTeam().get().getName();
         }
 
-        String zipRepoName = courseShortName + "-" + exercise.getTitle();
+        String zipRepoName = fileService.removeIllegalCharacters(courseShortName + "-" + exercise.getTitle());
         if (hideStudentName) {
             zipRepoName += "-student-submission.git.zip";
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -965,7 +965,7 @@ public class GitService {
      * @return path to zip file.
      * @throws IOException if the zipping process failed.
      */
-    public Path zipRepositoryWithParticipation(Repository repo, String targetPath, boolean hideStudentName) throws IOException {
+    public Path zipRepositoryWithParticipation(Repository repo, String targetPath, boolean hideStudentName) throws IOException, UncheckedIOException {
         var exercise = repo.getParticipation().getProgrammingExercise();
         var courseShortName = exercise.getCourseViaExerciseGroupOrCourseMember().getShortName();
         var participation = (ProgrammingExerciseStudentParticipation) repo.getParticipation();
@@ -998,7 +998,7 @@ public class GitService {
      * @return path to the zip file
      * @throws IOException if the zipping process failed.
      */
-    public Path zipRepository(Repository repository, String zipFilename, String targetPath) throws IOException {
+    public Path zipRepository(Repository repository, String zipFilename, String targetPath) throws IOException, UncheckedIOException {
         // Strip slashes from name
         var zipFilenameWithoutSlash = zipFilename.replaceAll("\\s", "");
 
@@ -1020,7 +1020,7 @@ public class GitService {
      * @param outputFile The filename of the zip file that will be created.
      * @throws IOException If the outFile is a directory or if git archive command failed.
      */
-    private Path archiveRepository(Repository repository, String outputFile) throws IOException {
+    private Path archiveRepository(Repository repository, String outputFile) throws IOException, UncheckedIOException {
         try {
             ArchiveCommand.registerFormat("zip", new ZipFormat());
             try (OutputStream out = new FileOutputStream(outputFile)) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -1025,7 +1025,7 @@ public class GitService {
             ArchiveCommand.registerFormat("zip", new ZipFormat());
             try (OutputStream out = new FileOutputStream(outputFile)) {
                 try (Git git = new Git(repository)) {
-                    var objectId = repository.resolve("HEAD");
+                    ObjectId objectId = repository.resolve("HEAD");
                     if (objectId != null) {
                         git.archive().setTree(objectId).setOutputStream(out).setFilename(outputFile).call();
                         return Path.of(outputFile);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -1013,7 +1013,7 @@ public class GitService {
             ArchiveCommand.registerFormat("zip", new ZipFormat());
             try (OutputStream out = new FileOutputStream(String.valueOf(zipFilePath))) {
                 try (Git git = new Git(repository)) {
-                    git.archive().setTree(repository.resolve("master")).setOutputStream(out).setFilename(zipFilePath.toString()).call();
+                    git.archive().setTree(repository.resolve("origin/master")).setOutputStream(out).setFilename(zipFilePath.toString()).call();
                 }
             }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -275,7 +275,7 @@ public class ProgrammingExerciseExportService {
             gitService.resetToOriginMaster(repository);
 
             // Zip it and return the path to the file
-            return gitService.zipRepository(repository.getLocalPath(), zipFilename, repoProjectPath);
+            return gitService.zipRepository(repository, zipFilename, repoProjectPath);
         }
         finally {
             deleteTempLocalRepository(repository);

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -129,7 +129,8 @@ public class ProgrammingExerciseExportService {
             // Zip the student and instructor repos together.
             var timestamp = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-Hmss"));
             var filename = exercise.getCourseViaExerciseGroupOrCourseMember().getShortName() + "-" + exercise.getTitle() + "-" + exercise.getId() + "-" + timestamp + ".zip";
-            var pathToZippedExercise = Path.of(pathToStoreZipFile, filename);
+            var cleanFilename = fileService.removeIllegalCharacters(filename);
+            var pathToZippedExercise = Path.of(pathToStoreZipFile, cleanFilename);
             zipFileService.createZipFile(pathToZippedExercise, zipFilePathsNonNull, false);
             return pathToZippedExercise;
         }
@@ -168,7 +169,7 @@ public class ProgrammingExerciseExportService {
 
         // Construct the name of the zip file
         String courseShortName = exercise.getCourseViaExerciseGroupOrCourseMember().getShortName();
-        String zippedRepoName = courseShortName + "-" + exercise.getTitle() + "-" + repositoryType.getName();
+        String zippedRepoName = fileService.removeIllegalCharacters(courseShortName + "-" + exercise.getTitle() + "-" + repositoryType.getName());
 
         try {
             // Get the url to the repository and zip it.

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.service.programming;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -188,7 +189,7 @@ public class ProgrammingExerciseExportService {
                 return new File(zippedRepo.toString());
             }
         }
-        catch (IOException | GitAPIException | GitException | InterruptedException ex) {
+        catch (IOException | UncheckedIOException | GitAPIException | GitException | InterruptedException ex) {
             var error = "Failed to export instructor repository " + repositoryType + " for programming exercise '" + exercise.getTitle() + "' (id: " + exercise.getId() + ")";
             log.info(error);
             exportErrors.add(error);
@@ -247,7 +248,7 @@ public class ProgrammingExerciseExportService {
                     zippedRepos.add(zippedRepo);
                 }
             }
-            catch (IOException e) {
+            catch (IOException | UncheckedIOException e) {
                 var error = "Failed to export the student repository with participation: " + participation.getId() + " for programming exercise '" + programmingExercise.getTitle()
                         + "' (id: " + programmingExercise.getId() + ") because the repository couldn't be downloaded. ";
                 exportErrors.add(error);
@@ -266,7 +267,8 @@ public class ProgrammingExerciseExportService {
      * @throws GitAPIException if the repo couldn't get checked out
      * @throws InterruptedException if the repo couldn't get checked out
      */
-    private Path createZipForRepository(VcsRepositoryUrl repositoryUrl, String zipFilename) throws IOException, GitAPIException, GitException, InterruptedException {
+    private Path createZipForRepository(VcsRepositoryUrl repositoryUrl, String zipFilename)
+            throws IOException, GitAPIException, GitException, InterruptedException, UncheckedIOException {
         var repoProjectPath = fileService.getUniquePathString(repoDownloadClonePath);
         Repository repository = null;
 
@@ -328,7 +330,7 @@ public class ProgrammingExerciseExportService {
      * @throws IOException if zip file creation failed
      */
     private Path createZipForRepositoryWithParticipation(final ProgrammingExercise programmingExercise, final ProgrammingExerciseStudentParticipation participation,
-            final RepositoryExportOptionsDTO repositoryExportOptions) throws IOException {
+            final RepositoryExportOptionsDTO repositoryExportOptions) throws IOException, UncheckedIOException {
         if (participation.getVcsRepositoryUrl() == null) {
             log.warn("Ignore participation {} for export, because its repository URL is null", participation.getId());
             return null;

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -131,8 +131,8 @@ public class ProgrammingExerciseExportService {
             // Zip the student and instructor repos together.
             var timestamp = ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-Hmss"));
             var filename = exercise.getCourseViaExerciseGroupOrCourseMember().getShortName() + "-" + exercise.getTitle() + "-" + exercise.getId() + "-" + timestamp + ".zip";
-            var cleanFilename = fileService.removeIllegalCharacters(filename);
-            var pathToZippedExercise = Path.of(pathToStoreZipFile, cleanFilename);
+            String cleanFilename = fileService.removeIllegalCharacters(filename);
+            Path pathToZippedExercise = Path.of(pathToStoreZipFile, cleanFilename);
             zipFileService.createZipFile(pathToZippedExercise, zipFilePathsNonNull, false);
             return pathToZippedExercise;
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -102,6 +102,7 @@ public class ProgrammingExerciseExportService {
      * @return the path to the zip file
      */
     public Path exportProgrammingExercise(ProgrammingExercise exercise, String pathToStoreZipFile, List<String> exportErrors) {
+        log.info("Exporting programming exercise {} with title {}", exercise.getId(), exercise.getTitle());
         // Will contain the zipped files. Note that there can be null elements
         // because e.g exportStudentRepositories returns null if student repositories don't
         // exist.

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -340,7 +340,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
     @WithMockUser(value = "student1", roles = "USER")
     public void getDataForTextEditorForNonTextExercise_badRequest() throws Exception {
         FileUploadExercise fileUploadExercise = ModelFactory.generateFileUploadExercise(ZonedDateTime.now().minusDays(1), ZonedDateTime.now().plusDays(1),
-            ZonedDateTime.now().plusDays(2), "png,pdf", textExercise.getCourseViaExerciseGroupOrCourseMember());
+                ZonedDateTime.now().plusDays(2), "png,pdf", textExercise.getCourseViaExerciseGroupOrCourseMember());
         exerciseRepo.save(fileUploadExercise);
 
         FileUploadSubmission fileUploadSubmission = ModelFactory.generateFileUploadSubmission(true);

--- a/src/test/java/de/tum/in/www1/artemis/TextExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextExerciseIntegrationTest.java
@@ -505,7 +505,7 @@ public class TextExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         course.setTeachingAssistantGroupName("test");
         courseRepository.save(course);
 
-       request.getList("/api/courses/" + course.getId() + "/text-exercises/", HttpStatus.FORBIDDEN, TextExercise.class);
+        request.getList("/api/courses/" + course.getId() + "/text-exercises/", HttpStatus.FORBIDDEN, TextExercise.class);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -834,7 +834,7 @@ public class ProgrammingExerciseTestService {
         doReturn(templateRepository).when(gitService).getOrCheckoutRepository(eq(exercise.getRepositoryURL(RepositoryType.TEMPLATE)), anyString(), anyBoolean());
 
         // Mock solution repo
-        var solutionRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(solutionRepo.localRepoFile.toPath(), null);
+        Repository solutionRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(solutionRepo.localRepoFile.toPath(), null);
         createAndCommitDummyFileInLocalRepository(solutionRepo, "Solution.java");
         doReturn(solutionRepository).when(gitService).getOrCheckoutRepository(eq(exercise.getRepositoryURL(RepositoryType.SOLUTION)), anyString(), anyBoolean());
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -798,7 +798,7 @@ public class ProgrammingExerciseTestService {
         exercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationById(exercise.getId()).get();
 
         var vcsUrl = exercise.getRepositoryURL(RepositoryType.valueOf(repositoryType));
-        var repository = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepository.localRepoFile.toPath(), null);
+        Repository repository = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepository.localRepoFile.toPath(), null);
         createAndCommitDummyFileInLocalRepository(localRepository, "some-file.java");
         doReturn(repository).when(gitService).getOrCheckoutRepository(eq(vcsUrl), anyString(), anyBoolean());
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -773,7 +773,7 @@ public class ProgrammingExerciseTestService {
 
     // Test
     public void exportInstructorRepositories_shouldReturnFile() throws Exception {
-        var zip = exportInstructorRepository("TEMPLATE", exerciseRepo, HttpStatus.OK);
+        String zip = exportInstructorRepository("TEMPLATE", exerciseRepo, HttpStatus.OK);
         assertThat(zip).isNotNull();
 
         zip = exportInstructorRepository("SOLUTION", solutionRepo, HttpStatus.OK);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 import org.awaitility.Awaitility;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.Repository;
@@ -772,36 +773,36 @@ public class ProgrammingExerciseTestService {
 
     // Test
     public void exportInstructorRepositories_shouldReturnFile() throws Exception {
-        var zip = exportInstructorRepository("TEMPLATE", sourceExerciseRepo.localRepoFile.toPath(), HttpStatus.OK);
+        var zip = exportInstructorRepository("TEMPLATE", exerciseRepo, HttpStatus.OK);
         assertThat(zip).isNotNull();
 
-        zip = exportInstructorRepository("SOLUTION", sourceSolutionRepo.localRepoFile.toPath(), HttpStatus.OK);
+        zip = exportInstructorRepository("SOLUTION", solutionRepo, HttpStatus.OK);
         assertThat(zip).isNotNull();
 
-        zip = exportInstructorRepository("TESTS", sourceTestRepo.localRepoFile.toPath(), HttpStatus.OK);
+        zip = exportInstructorRepository("TESTS", testRepo, HttpStatus.OK);
         assertThat(zip).isNotNull();
 
     }
 
     // Test
     public void exportInstructorRepositories_forbidden() throws Exception {
-        exportInstructorRepository("TEMPLATE", sourceExerciseRepo.localRepoFile.toPath(), HttpStatus.FORBIDDEN);
-        exportInstructorRepository("SOLUTION", sourceSolutionRepo.localRepoFile.toPath(), HttpStatus.FORBIDDEN);
-        exportInstructorRepository("TESTS", sourceTestRepo.localRepoFile.toPath(), HttpStatus.FORBIDDEN);
+        exportInstructorRepository("TEMPLATE", exerciseRepo, HttpStatus.FORBIDDEN);
+        exportInstructorRepository("SOLUTION", solutionRepo, HttpStatus.FORBIDDEN);
+        exportInstructorRepository("TESTS", testRepo, HttpStatus.FORBIDDEN);
     }
 
-    private String exportInstructorRepository(String repositoryType, Path localPathToRepository, HttpStatus expectedStatus) throws Exception {
+    private String exportInstructorRepository(String repositoryType, LocalRepository localRepository, HttpStatus expectedStatus) throws Exception {
         exercise = programmingExerciseRepository.save(exercise);
         exercise = database.addTemplateParticipationForProgrammingExercise(exercise);
         exercise = database.addSolutionParticipationForProgrammingExercise(exercise);
         exercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationById(exercise.getId()).get();
 
         var vcsUrl = exercise.getRepositoryURL(RepositoryType.valueOf(repositoryType));
-        var repository = gitService.getExistingCheckedOutRepositoryByLocalPath(localPathToRepository, null);
+        var repository = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepository.localRepoFile.toPath(), null);
+        createAndCommitDummyFileInLocalRepository(localRepository, "some-file.java");
         doReturn(repository).when(gitService).getOrCheckoutRepository(eq(vcsUrl), anyString(), anyBoolean());
 
         var url = "/api/programming-exercises/" + exercise.getId() + "/export-instructor-repository/" + repositoryType;
-        // return request.postWithResponseBodyFile(url, null, expectedStatus);
         return request.get(url, expectedStatus, String.class);
     }
 
@@ -812,32 +813,34 @@ public class ProgrammingExerciseTestService {
         course.setExercises(Set.of(exercise));
         courseRepository.save(course);
 
+        // Createa a programming exercise with solution, template, and tests participations
         exercise = programmingExerciseRepository.save(exercise);
         exercise = database.addTemplateParticipationForProgrammingExercise(exercise);
         exercise = database.addSolutionParticipationForProgrammingExercise(exercise);
         database.addTestCasesToProgrammingExercise(exercise);
 
+        // Add student participation
         exercise = programmingExerciseRepository.findWithTemplateAndSolutionParticipationById(exercise.getId()).get();
         var participation = database.addStudentParticipationForProgrammingExercise(exercise, studentLogin);
 
         // Mock student repo
         var studentRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepo.localRepoFile.toPath(), null);
-        createDummyFileInLocalRepository(studentRepo, "HelloWorld.java");
+        createAndCommitDummyFileInLocalRepository(studentRepo, "HelloWorld.java");
         doReturn(studentRepository).when(gitService).getOrCheckoutRepository(eq(participation.getVcsRepositoryUrl()), anyString(), anyBoolean());
 
         // Mock template repo
-        var templateRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(sourceExerciseRepo.localRepoFile.toPath(), null);
-        createDummyFileInLocalRepository(studentRepo, "Template.java");
+        var templateRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(exerciseRepo.localRepoFile.toPath(), null);
+        createAndCommitDummyFileInLocalRepository(exerciseRepo, "Template.java");
         doReturn(templateRepository).when(gitService).getOrCheckoutRepository(eq(exercise.getRepositoryURL(RepositoryType.TEMPLATE)), anyString(), anyBoolean());
 
         // Mock solution repo
-        var solutionRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(sourceSolutionRepo.localRepoFile.toPath(), null);
-        createDummyFileInLocalRepository(studentRepo, "Solution.java");
+        var solutionRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(solutionRepo.localRepoFile.toPath(), null);
+        createAndCommitDummyFileInLocalRepository(solutionRepo, "Solution.java");
         doReturn(solutionRepository).when(gitService).getOrCheckoutRepository(eq(exercise.getRepositoryURL(RepositoryType.SOLUTION)), anyString(), anyBoolean());
 
         // Mock tests repo
-        var testsRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(sourceTestRepo.localRepoFile.toPath(), null);
-        createDummyFileInLocalRepository(studentRepo, "Tests.java");
+        var testsRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(testRepo.localRepoFile.toPath(), null);
+        createAndCommitDummyFileInLocalRepository(testRepo, "Tests.java");
         doReturn(testsRepository).when(gitService).getOrCheckoutRepository(eq(exercise.getRepositoryURL(RepositoryType.TESTS)), anyString(), anyBoolean());
 
         request.put("/api/courses/" + course.getId() + "/archive", null, HttpStatus.OK);
@@ -845,13 +848,25 @@ public class ProgrammingExerciseTestService {
 
         var updatedCourse = courseRepository.findByIdElseThrow(course.getId());
         assertThat(updatedCourse.getCourseArchivePath()).isNotEmpty();
+
     }
 
-    public void createDummyFileInLocalRepository(LocalRepository localRepository, String filename) throws IOException {
+    /**
+     * Creates a dummy file in the repository and commits it locally
+     * without pushing it.
+     *
+     * @param localRepository the repository
+     * @param filename the file to create
+     * @throws IOException when the file cannot be created
+     * @throws GitAPIException when git can't add or commit the file
+     */
+    public void createAndCommitDummyFileInLocalRepository(LocalRepository localRepository, String filename) throws IOException, GitAPIException {
         var file = Path.of(localRepository.localRepoFile.toPath().toString(), filename);
         if (!Files.exists(file)) {
             Files.createFile(file);
         }
+        localRepository.localGit.add().addFilepattern(file.getFileName().toString()).call();
+        localRepository.localGit.commit().setMessage("Added testfile").call();
     }
 
     // Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -813,7 +813,7 @@ public class ProgrammingExerciseTestService {
         course.setExercises(Set.of(exercise));
         courseRepository.save(course);
 
-        // Createa a programming exercise with solution, template, and tests participations
+        // Create a programming exercise with solution, template, and tests participations
         exercise = programmingExerciseRepository.save(exercise);
         exercise = database.addTemplateParticipationForProgrammingExercise(exercise);
         exercise = database.addSolutionParticipationForProgrammingExercise(exercise);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -839,7 +839,7 @@ public class ProgrammingExerciseTestService {
         doReturn(solutionRepository).when(gitService).getOrCheckoutRepository(eq(exercise.getRepositoryURL(RepositoryType.SOLUTION)), anyString(), anyBoolean());
 
         // Mock tests repo
-        var testsRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(testRepo.localRepoFile.toPath(), null);
+        Repository testsRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(testRepo.localRepoFile.toPath(), null);
         createAndCommitDummyFileInLocalRepository(testRepo, "Tests.java");
         doReturn(testsRepository).when(gitService).getOrCheckoutRepository(eq(exercise.getRepositoryURL(RepositoryType.TESTS)), anyString(), anyBoolean());
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -829,7 +829,7 @@ public class ProgrammingExerciseTestService {
         doReturn(studentRepository).when(gitService).getOrCheckoutRepository(eq(participation.getVcsRepositoryUrl()), anyString(), anyBoolean());
 
         // Mock template repo
-        var templateRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(exerciseRepo.localRepoFile.toPath(), null);
+        Repository templateRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(exerciseRepo.localRepoFile.toPath(), null);
         createAndCommitDummyFileInLocalRepository(exerciseRepo, "Template.java");
         doReturn(templateRepository).when(gitService).getOrCheckoutRepository(eq(exercise.getRepositoryURL(RepositoryType.TEMPLATE)), anyString(), anyBoolean());
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The fix implemented in PR #3257 doesn't fix the issue that occurs when exporting programming exercises during the course archival. For some reason, the garbage collection from JGit kicks in during the export of programming exercises which leads to the `java.nio.file.NoSuchFileException` being thrown on `gc.log.lock`. 

### Description
<!-- Describe your changes in detail -->
This PR fixes the issue by implementing a new way of exporting/archiving code repositories. It takes advantage of the native `git archive` command to generate a zip archive of the repository. Since we don't export repositories manually anymore and let JGit do the heavy-lifting, we hope that it will fix the issue mentioned above.

This PR also adds some small fixes:

1. It strips illegal characters from all the filenames used for the zip files in order to prevent problems with the OS
2. It adds more log messages during the archival process
3. It catches the `UncaughtIOException` which may occur during a JGit operation

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
4. Generate one (or more) exercise of each type
5. Participate in each exercise
6. Generate an exam with exercises of each type
7. Participate in the exam
8. Edit the course and change the end date so that it's in the past
9. Navigate to the course detail page and click on "archive course"
10. Once archiving is complete, you should be able to download the course archive
11. Download the archive. You should be able to see the submissions in the zip file


### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
CourseExamExportService.java 85%
FileService.java 83%
SubmissionExportService.java 87%
GitService.java 75%
ProgrammingExerciseExportService.java 72%
