### PR TITLE
Fix errors when the exercise of the participation header is undefined

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnChanges, OnInit, ViewEncapsulation } from '@angular/core';
 import * as moment from 'moment';
 import { Exercise, getIcon, IncludedInOverallScore } from 'app/entities/exercise.model';
-import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { ButtonType } from 'app/shared/components/button.component';
 import { ExerciseCategory } from 'app/entities/exercise-category.model';
@@ -24,14 +23,14 @@ export class HeaderParticipationPageComponent implements OnInit, OnChanges {
 
     getIcon = getIcon;
 
-    constructor(private exerciseService: ExerciseService) {}
+    constructor() {}
 
     /**
      * Sets the status badge and categories of the exercise on init
      */
     ngOnInit(): void {
         this.setExerciseStatusBadge();
-        this.exerciseCategories = this.exercise.categories || [];
+        this.exerciseCategories = this.exercise?.categories || [];
     }
 
     /**
@@ -53,7 +52,7 @@ export class HeaderParticipationPageComponent implements OnInit, OnChanges {
      */
     ngOnChanges(): void {
         this.setExerciseStatusBadge();
-        this.exerciseCategories = this.exercise.categories || [];
+        this.exerciseCategories = this.exercise?.categories || [];
     }
 
     private setExerciseStatusBadge(): void {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context

Sentry reported several errors where `exercise` was null or undefined when we tried to access its categories.

### Description

We now account for `exercise` not being set. Also removes the exercise service as it was not used.

### Steps for Testing

1. Before deploying this branch, start participating in a text exercise. Open the console once you opened the text editor and you should see one or two errors:
![grafik](https://user-images.githubusercontent.com/72132281/116437496-ca9a7380-a84d-11eb-82b8-2ba722992948.png)
2. Deploy the fix and repeat the same thing. This time no such errors should be present.

You can test the same with modeling or file upload exercises.

I noticed that categories are not displayed at all, and that appears to happen because the server doesn't send them alongside the exercise. Not sure why is that (and is also not related to fixing these errors.)