### PR TITLE
[ Fix ] - Docker-compose improvements to run latest Artemis version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ version: '3'
 
 services:
   artemis-server:
-    command: sh -c "./gradlew buildJarForDocker && java -jar build/libs/Artemis-*.jar"
+    command: sh -c "(apt update && apt install -y fontconfig ttf-dejavu graphviz || true) && ./gradlew buildJarForDocker && java -jar --add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED build/libs/Artemis-*.jar"
     depends_on:
       - artemis-mysql
-    image: openjdk:16-jdk-alpine
+    image: openjdk:16-jdk-buster
     environment:
       - SPRING_DATASOURCE_URL=jdbc:mysql://artemis-mysql:3306/Artemis?createDatabaseIfNotExist=true&allowPublicKeyRetrieval=true&useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&serverTimezone=UTC
       - SPRING_PROFILES_ACTIVE=dev,bamboo,bitbucket,jira,artemis,scheduling
@@ -37,8 +37,8 @@ services:
   artemis-mysql:
     command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8mb4 --explicit_defaults_for_timestamp
     environment:
-      - MYSQL_USER=root
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+      - MYSQL_ROOT_PASSWORD=
       - MYSQL_DATABASE=Artemis
     image: mysql:8.0.23
     networks:


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During the upgrade to Artemis 4.11.8 I had some struggles to deploy it using the provided `docker-compose.yml` file. I'm adding here the changes I used to overcome some errors and JVM crashes.

### Description
<!-- Describe your changes in detail -->
* Changed the base image to `openjdk:16-jdk-buster`: avoiding JVM crashes at compilation time
* Added `--add-exports java.naming/com.sun.jndi.ldap=ALL-UNNAMED`: to overcome `com.sun.jndi.ldap.LdapCtxFactory` module export error (already documented here https://artemis-platform.readthedocs.io/en/latest/dev/setup/?highlight=jndi#run-the-server-via-a-service-configuration)
* Added `apt update && apt install -y fontconfig ttf-dejavu graphviz`: to avoid `java.io.IOException: Cannot run program "/usr/bin/dot": error=2, No such file or directory` and `Error loading shared library libfreetype.so.6: No such file or directory` during exercise creation
* Removed `MYSQL_USER=root`: as for mysql:8.0.23 this is not nedded (and causes an error)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
