### PR TITLE
Improve the course management overview for smaller displays

### DIFF
--- a/src/main/webapp/app/course/manage/overview/course-management-card.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-card.component.html
@@ -8,7 +8,9 @@
                 <div *ngIf="course.startDate && !course.endDate">
                     <span jhiTranslate="artemisApp.course.startDate">Start Date</span>: {{ course.startDate | artemisDate: 'long-date' }}
                 </div>
-                <div *ngIf="!course.startDate && course.endDate"><span jhiTranslate="artemisApp.course.endDate">End Date</span>: {{ course.endDate | artemisDate: 'long-date' }}</div>
+                <div *ngIf="!course.startDate && course.endDate">
+                    <span jhiTranslate="artemisApp.course.endDate">End Date</span>: {{ course.endDate | artemisDate: 'long-date' }}
+                </div>
             </div>
         </div>
 

--- a/src/main/webapp/app/course/manage/overview/course-management-card.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-card.component.html
@@ -1,13 +1,15 @@
 <div class="card">
     <div class="card-heading text-white" [ngStyle]="{ backgroundColor: course.color || ARTEMIS_DEFAULT_COLOR }">
         <a class="stretched-link" [routerLink]="['/course-management', course.id]"></a>
-        <jhi-secured-image class="header-item" *ngIf="course.courseIcon" [cachingStrategy]="CachingStrategy.LOCAL_STORAGE" [src]="course.courseIcon"></jhi-secured-image>
-        <div class="card-date">
-            <span *ngIf="course.startDate && course.endDate">{{ course.startDate | artemisDate: 'long-date' }} - {{ course.endDate | artemisDate: 'long-date' }}</span>
-            <span *ngIf="course.startDate && !course.endDate">
-                <span jhiTranslate="artemisApp.course.startDate">Start Date</span>: {{ course.startDate | artemisDate: 'long-date' }}
-            </span>
-            <span *ngIf="!course.startDate && course.endDate"><span jhiTranslate="artemisApp.course.endDate">End Date</span>: {{ course.endDate | artemisDate: 'long-date' }}</span>
+        <div class="card-header-left">
+            <jhi-secured-image class="header-item" *ngIf="course.courseIcon" [cachingStrategy]="CachingStrategy.LOCAL_STORAGE" [src]="course.courseIcon"></jhi-secured-image>
+            <div class="card-date">
+                <div *ngIf="course.startDate && course.endDate">{{ course.startDate | artemisDate: 'long-date' }} - {{ course.endDate | artemisDate: 'long-date' }}</div>
+                <div *ngIf="course.startDate && !course.endDate">
+                    <span jhiTranslate="artemisApp.course.startDate">Start Date</span>: {{ course.startDate | artemisDate: 'long-date' }}
+                </div>
+                <div *ngIf="!course.startDate && course.endDate"><span jhiTranslate="artemisApp.course.endDate">End Date</span>: {{ course.endDate | artemisDate: 'long-date' }}</div>
+            </div>
         </div>
 
         <div class="container container-padding" [routerLink]="['/course-management', course.id]">
@@ -162,7 +164,7 @@
             [ngbTooltip]="'entity.action.exercise' | artemisTranslate"
         >
             <fa-icon [icon]="'list-alt'"></fa-icon>
-            <span class="d-none d-md-inline">{{ 'entity.action.exercise' | artemisTranslate }}</span>
+            <span class="d-none d-xl-inline">{{ 'entity.action.exercise' | artemisTranslate }}</span>
         </a>
         <a
             *ngIf="course.isAtLeastTutor"
@@ -171,7 +173,7 @@
             [ngbTooltip]="'entity.action.exams' | artemisTranslate"
         >
             <fa-icon [icon]="'graduation-cap'"></fa-icon>
-            <span class="d-none d-md-inline">{{ 'entity.action.exams' | artemisTranslate }}</span>
+            <span class="d-none d-xl-inline">{{ 'entity.action.exams' | artemisTranslate }}</span>
         </a>
         <a
             *ngIf="course.isAtLeastInstructor"
@@ -180,7 +182,7 @@
             [ngbTooltip]="'entity.action.lecture' | artemisTranslate"
         >
             <fa-icon [icon]="'file-pdf'"></fa-icon>
-            <span class="d-none d-md-inline">{{ 'entity.action.lecture' | artemisTranslate }}</span>
+            <span class="d-none d-xl-inline">{{ 'entity.action.lecture' | artemisTranslate }}</span>
         </a>
         <a
             *ngIf="course.isAtLeastInstructor"
@@ -189,7 +191,7 @@
             [ngbTooltip]="'artemisApp.learningGoal.learningGoalButton' | artemisTranslate"
         >
             <fa-icon [icon]="'flag'"></fa-icon>
-            <span [innerHTML]="'artemisApp.learningGoal.learningGoalButton' | artemisTranslate" class="d-none d-md-inline"></span>
+            <span [innerHTML]="'artemisApp.learningGoal.learningGoalButton' | artemisTranslate" class="d-none d-xl-inline"></span>
         </a>
         <a
             *ngIf="course.isAtLeastTutor"
@@ -200,7 +202,7 @@
             [class.guided-tour]="isGuidedTour"
         >
             <fa-icon [icon]="'user-check'"></fa-icon>
-            <span class="d-none d-md-inline">{{ 'entity.action.assessmentDashboard' | artemisTranslate }}</span>
+            <span class="d-none d-xl-inline">{{ 'entity.action.assessmentDashboard' | artemisTranslate }}</span>
         </a>
         <a
             *ngIf="course.isAtLeastInstructor"
@@ -209,7 +211,7 @@
             [ngbTooltip]="'artemisApp.course.instructorDashboard' | artemisTranslate"
         >
             <fa-icon [icon]="'chess-king'"></fa-icon>
-            <span class="d-none d-md-inline">{{ 'artemisApp.course.instructorDashboard' | artemisTranslate }}</span>
+            <span class="d-none d-xl-inline">{{ 'artemisApp.course.instructorDashboard' | artemisTranslate }}</span>
         </a>
         <a
             *ngIf="course.isAtLeastInstructor"
@@ -218,7 +220,7 @@
             [ngbTooltip]="'entity.action.scores' | artemisTranslate"
         >
             <fa-icon [icon]="'table'"></fa-icon>
-            <span class="d-none d-md-inline">{{ 'entity.action.scores' | artemisTranslate }}</span>
+            <span class="d-none d-xl-inline">{{ 'entity.action.scores' | artemisTranslate }}</span>
         </a>
         <a
             *ngIf="course.isAtLeastTutor"
@@ -227,7 +229,7 @@
             [ngbTooltip]="'artemisApp.courseStatistics.statistics' | artemisTranslate"
         >
             <fa-icon [icon]="'chart-bar'"></fa-icon>
-            <span class="d-none d-md-inline">{{ 'artemisApp.courseStatistics.statistics' | artemisTranslate }}</span>
+            <span class="d-none d-xl-inline">{{ 'artemisApp.courseStatistics.statistics' | artemisTranslate }}</span>
         </a>
     </div>
 </div>

--- a/src/main/webapp/app/course/manage/overview/course-management-card.scss
+++ b/src/main/webapp/app/course/manage/overview/course-management-card.scss
@@ -48,6 +48,11 @@
             }
         }
 
+        .card-header-left {
+            display: flex;
+            flex-direction: row;
+        }
+
         jhi-secured-image {
             padding: 5px 0 5px 5px;
 
@@ -143,7 +148,7 @@
     }
 }
 
-@media screen and (max-width: 960px) {
+@media screen and (max-width: 1060px) {
     .card {
         .statistics-card {
             display: none;
@@ -154,31 +159,42 @@
         }
 
         .card-heading {
-            flex-direction: column;
-            height: unset;
-
-            .card-date {
-                justify-content: center;
-            }
-
-            jhi-secured-image {
-                margin: auto;
-                display: flex;
+            .card-description {
+                display: none;
             }
         }
-
-        height: unset;
     }
 }
 
 @media screen and (max-width: 700px) {
     .card {
         .card-heading {
-            .card-description {
-                max-width: 40ch !important;
+            .card-title {
+                overflow: hidden;
+            }
+
+            .card-header-left {
+                flex-direction: column;
+                max-width: 110px;
+            }
+
+            .card-date {
+                padding-left: 10px;
+                width: 100px;
+                white-space: pre-wrap;
+                margin-top: auto;
+                margin-bottom: auto;
+            }
+
+            jhi-secured-image {
+                margin-left: auto;
+                margin-right: auto;
+                display: flex;
+                align-content: center;
             }
 
             height: unset;
+            max-height: 135px;
         }
 
         height: unset;

--- a/src/main/webapp/app/course/manage/overview/course-management-card.scss
+++ b/src/main/webapp/app/course/manage/overview/course-management-card.scss
@@ -10,10 +10,6 @@
         cursor: pointer;
         height: 75px;
 
-        .card-title {
-            margin-bottom: 0;
-        }
-
         .container-padding {
             padding: 10px;
         }
@@ -169,10 +165,6 @@
 @media screen and (max-width: 700px) {
     .card {
         .card-heading {
-            .card-title {
-                overflow: hidden;
-            }
-
             .card-header-left {
                 flex-direction: column;
                 max-width: 110px;

--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col row details-container">
                 <a class="stretched-link" [routerLink]="['/course-management', course.id, details.type + '-exercises', details.id]"></a>
-                <div class="col-5 row-flex">
+                <div class="col-5 row-flex exercise-details-container">
                     <div class="ml-2 mr-1 exercise-details-item" *ngIf="hasLeftoverAssessments">
                         <fa-icon [icon]="'exclamation-triangle'" class="text-warning" placement="right" [ngbTooltip]="iconTooltip | artemisTranslate" container="body"></fa-icon>
                     </div>
@@ -24,7 +24,7 @@
                     </div>
                 </div>
 
-                <div class="col-4 row-flex hide-1400 exercise-date-container">
+                <div class="col-4 row-flex exercise-date-container">
                     <div [ngClass]="!!details.releaseDate ? 'exercise-date' : 'exercise-date exercise-no-date'">
                         <div class="exercise-date-timeline"></div>
                         <span>{{ 'artemisApp.course.releaseDate' | artemisTranslate }}</span>
@@ -89,7 +89,7 @@
                     </div>
                 </div>
 
-                <div class="col-2 row-flex hide-1680 exercise-score-container">
+                <div class="col-2 row-flex exercise-score-container">
                     <div class="exercise-score" *ngIf="statistic && rowType == exerciseRowType.CURRENT">
                         <span>{{ 'artemisApp.course.participations' | artemisTranslate }}</span>
                         <jhi-progress-bar

--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.scss
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.scss
@@ -9,6 +9,10 @@
     align-content: center;
     height: 60px;
 
+    .exercise-details-container {
+        max-width: 55ch;
+    }
+
     .item-title-container {
         display: flex;
         align-items: center;
@@ -100,7 +104,7 @@
 
     .exercise-date-container {
         justify-content: center;
-        min-width: 340px;
+        min-width: 285px;
         max-width: max-content;
         padding: 0;
         margin: auto;
@@ -119,18 +123,21 @@
     }
 
     .exercise-score-container {
-        padding-left: 0;
+        padding: 0;
         margin: auto;
         z-index: 1;
     }
 
     .exercise-score {
-        padding-left: 15px;
         width: 250px;
         text-align: center;
         display: flex;
         flex-direction: column;
         justify-content: center;
+
+        span {
+            white-space: nowrap;
+        }
     }
 
     .pointer-row {
@@ -163,6 +170,10 @@
     }
 
     .course-item {
+        .exercise-details-container {
+            max-width: 43ch;
+        }
+
         .item-title {
             max-width: 40ch;
         }
@@ -174,22 +185,64 @@
 }
 
 @media screen and (max-width: 1680px) {
-    .hide-1680 {
-        display: none !important;
-    }
+    .course-item {
+        .exercise-details-container {
+            max-width: 33ch;
+        }
 
-    .pointer-row {
-        min-width: 45%;
+        .item-title {
+            max-width: 30ch;
+        }
+
+        .exercise-score {
+            span {
+                font-size: small;
+            }
+        }
     }
 }
 
-@media screen and (max-width: 1450px) {
-    .hide-1400 {
+@media screen and (max-width: 1400px) {
+    .course-item {
+        .exercise-details-container {
+            max-width: 23ch;
+        }
+
+        .item-title {
+            max-width: 15ch;
+        }
+    }
+}
+
+@media screen and (max-width: 1250px) {
+    .course-item {
+        .exercise-details-container {
+            max-width: 18ch;
+        }
+
+        .item-title {
+            max-width: 10ch;
+        }
+    }
+}
+
+@media screen and (max-width: 1150px) {
+    .exercise-score-container {
         display: none !important;
     }
 
-    .pointer-row {
-        min-width: 100%;
+    .exercise-date-container {
+        display: none !important;
+    }
+
+    .course-item {
+        .exercise-details-container {
+            max-width: 60ch;
+        }
+
+        .item-title {
+            max-width: 50ch;
+        }
     }
 }
 
@@ -199,6 +252,10 @@
     }
 
     .course-item {
+        .exercise-details-container {
+            max-width: 30ch;
+        }
+
         .item-title {
             max-width: 20ch;
         }
@@ -207,6 +264,10 @@
 
 @media screen and (max-width: 480px) {
     .course-item {
+        .exercise-details-container {
+            max-width: 40ch;
+        }
+
         .item-title {
             max-width: 15ch;
         }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

The exercise details and statistic bars were hidden on smaller displays.

### Description

We now make space (by e.g. shortening the title and using smaller fonts) to display those for 1200px displays as well.

### Steps for Testing

1. Look at courses in the course management overview with different "screen sizes" (resize your browser window) and check that there are no glitches

### Screenshots

1200px:
![grafik](https://user-images.githubusercontent.com/72132281/116700653-508dfa00-a9c7-11eb-91ca-e4fdaffec376.png)

Phone sized:
![grafik](https://user-images.githubusercontent.com/72132281/116700307-eaa17280-a9c6-11eb-9eac-df305706e1a5.png)

