### PR TITLE
Fix editing programming exercises for exams not working properly

### DIFF
--- a/src/main/webapp/app/exam/manage/exam-management.route.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.route.ts
@@ -457,7 +457,7 @@ export const examManagementRoute: Routes = [
     },
     // Import programming exercise
     {
-        path: ':examId/exercise-groups/:exerciseGroupId/programming-exercises/import/:id',
+        path: ':examId/exercise-groups/:exerciseGroupId/programming-exercises/import/:exerciseId',
         component: ProgrammingExerciseUpdateComponent,
         resolve: {
             programmingExercise: ProgrammingExerciseResolve,
@@ -470,7 +470,7 @@ export const examManagementRoute: Routes = [
     },
     // Edit Programming Exercise
     {
-        path: ':examId/exercise-groups/:exerciseGroupId/programming-exercises/:id/edit',
+        path: ':examId/exercise-groups/:exerciseGroupId/programming-exercises/:exerciseId/edit',
         component: ProgrammingExerciseUpdateComponent,
         resolve: {
             programmingExercise: ProgrammingExerciseResolve,


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context

Closes #3329.

### Description

The site is not wrong, but the resolver does not fetch the programming exercise, since it looks for `exerciseId` not `id`. Changing that route parameter fixes the issue.

### Steps for Testing

1. Find or create an exam with a programming exercise
2. Edit the exercise

