### PR TITLE
Change quiz export filename to quiz title

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.ts
@@ -168,7 +168,7 @@ export class QuizExerciseComponent extends ExerciseComponent {
     exportQuizById(quizExerciseId: number, exportAll: boolean) {
         this.quizExerciseService.find(quizExerciseId).subscribe((res: HttpResponse<QuizExercise>) => {
             const exercise = res.body!;
-            this.quizExerciseService.exportQuiz(exercise.quizQuestions, exportAll);
+            this.quizExerciseService.exportQuiz(exercise.quizQuestions, exportAll, exercise.title);
         });
     }
 

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.service.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.service.ts
@@ -37,7 +37,7 @@ export class QuizExerciseService {
     /**
      * Update the given quiz exercise
      * @param quizExercise the quiz exercise that should be updated
-     * @param req Additional parameters that should be pased to the server when updating the exercise
+     * @param req Additional parameters that should be passed to the server when updating the exercise
      */
     update(quizExercise: QuizExercise, req?: any): Observable<EntityResponseType> {
         const options = createRequestOption(req);
@@ -181,7 +181,7 @@ export class QuizExerciseService {
 
     /**
      * Reset a quiz exercise
-     * @param quizExerciseId the id of the quiz exercise that should be resetted
+     * @param quizExerciseId the id of the quiz exercise that should be reset
      */
     reset(quizExerciseId: number): Observable<HttpResponse<{}>> {
         return this.http.delete(`${SERVER_API_URL + 'api/exercises'}/${quizExerciseId}/reset`, { observe: 'response' });
@@ -191,8 +191,9 @@ export class QuizExerciseService {
      * Exports given quiz questions into json file
      * @param quizQuestions Quiz questions we want to export
      * @param exportAll If true exports all questions, else exports only those whose export flag is true
+     * @param fileName Name (without ending) of the resulting file, defaults to 'quiz'
      */
-    exportQuiz(quizQuestions?: QuizQuestion[], exportAll?: boolean) {
+    exportQuiz(quizQuestions?: QuizQuestion[], exportAll?: boolean, fileName?: String) {
         // Make list of questions which we need to export,
         const questions: QuizQuestion[] = [];
         quizQuestions!.forEach((question) => {
@@ -208,7 +209,7 @@ export class QuizExerciseService {
         // Make blob from the list of questions and download the file,
         const quizJson = JSON.stringify(questions);
         const blob = new Blob([quizJson], { type: 'application/json' });
-        downloadFile(blob, 'quiz.json');
+        downloadFile(blob, (fileName ?? 'quiz') + '.json');
     }
 
     /**

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.ts
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.ts
@@ -148,7 +148,7 @@ export class ExamExerciseRowButtonsComponent {
     exportQuizById(exportAll: boolean) {
         this.quizExerciseService.find(this.exercise.id!).subscribe((res: HttpResponse<QuizExercise>) => {
             const exercise = res.body!;
-            this.quizExerciseService.exportQuiz(exercise.quizQuestions, exportAll);
+            this.quizExerciseService.exportQuiz(exercise.quizQuestions, exportAll, exercise.title);
         });
     }
 }

--- a/src/test/javascript/spec/component/exam-exercise-row-buttons/exam-exercise-row-buttons.component.spec.ts
+++ b/src/test/javascript/spec/component/exam-exercise-row-buttons/exam-exercise-row-buttons.component.spec.ts
@@ -54,7 +54,7 @@ describe('ExamExerciseRowButtonsComponent', () => {
 
     let deleteTextExerciseStub: SinonStub;
     let deleteModelingExerciseStub: SinonStub;
-    let deleteQuizExercsieStub: SinonStub;
+    let deleteQuizExerciseStub: SinonStub;
     let deleteFileUploadExerciseStub: SinonStub;
     let deleteProgrammingExerciseStub: SinonStub;
     let quizExerciseServiceFindStub: SinonStub;
@@ -101,7 +101,7 @@ describe('ExamExerciseRowButtonsComponent', () => {
 
                 deleteTextExerciseStub = stub(textExerciseService, 'delete');
                 deleteModelingExerciseStub = stub(modelingExerciseService, 'delete');
-                deleteQuizExercsieStub = stub(quizExerciseService, 'delete');
+                deleteQuizExerciseStub = stub(quizExerciseService, 'delete');
                 deleteFileUploadExerciseStub = stub(fileUploadExerciseService, 'delete');
                 deleteProgrammingExerciseStub = stub(programmingExerciseService, 'delete');
                 quizExerciseServiceFindStub = stub(quizExerciseService, 'find');
@@ -145,7 +145,7 @@ describe('ExamExerciseRowButtonsComponent', () => {
                 expect(onDeleteExerciseEmitSpy).to.have.been.calledOnce;
             });
             it('should handle error for textexercise', () => {
-                const error = { message: 'error occured!' } as HttpErrorResponse;
+                const error = { message: 'error occurred!' } as HttpErrorResponse;
                 deleteTextExerciseStub.returns(throwError(error));
                 component.exercise = textExercise;
                 component.deleteExercise();
@@ -162,7 +162,7 @@ describe('ExamExerciseRowButtonsComponent', () => {
                 expect(onDeleteExerciseEmitSpy).to.have.been.calledOnce;
             });
             it('should handle error for modelingexercise', () => {
-                const error = { message: 'error occured!' } as HttpErrorResponse;
+                const error = { message: 'error occurred!' } as HttpErrorResponse;
                 deleteModelingExerciseStub.returns(throwError(error));
                 component.exercise = modelingExercise;
                 component.deleteExercise();
@@ -179,7 +179,7 @@ describe('ExamExerciseRowButtonsComponent', () => {
                 expect(onDeleteExerciseEmitSpy).to.have.been.calledOnce;
             });
             it('should handle error for fileupload exercise', () => {
-                const error = { message: 'error occured!' } as HttpErrorResponse;
+                const error = { message: 'error occurred!' } as HttpErrorResponse;
                 deleteFileUploadExerciseStub.returns(throwError(error));
                 component.exercise = fileUploadExercise;
                 component.deleteExercise();
@@ -189,18 +189,18 @@ describe('ExamExerciseRowButtonsComponent', () => {
         });
         describe('should deleteQuizExercise', () => {
             it('should deleteQuizExercise', () => {
-                deleteQuizExercsieStub.returns(of({}));
+                deleteQuizExerciseStub.returns(of({}));
                 component.exercise = quizExercise;
                 component.deleteExercise();
-                expect(deleteQuizExercsieStub).to.have.been.calledOnce;
+                expect(deleteQuizExerciseStub).to.have.been.calledOnce;
                 expect(onDeleteExerciseEmitSpy).to.have.been.calledOnce;
             });
             it('should handle error for quizexercise', () => {
-                const error = { message: 'error occured!' } as HttpErrorResponse;
-                deleteQuizExercsieStub.returns(throwError(error));
+                const error = { message: 'error occurred!' } as HttpErrorResponse;
+                deleteQuizExerciseStub.returns(throwError(error));
                 component.exercise = quizExercise;
                 component.deleteExercise();
-                expect(deleteQuizExercsieStub).to.have.been.calledOnce;
+                expect(deleteQuizExerciseStub).to.have.been.calledOnce;
                 expect(onDeleteExerciseEmitSpy).to.not.have.been.called;
             });
         });
@@ -214,7 +214,7 @@ describe('ExamExerciseRowButtonsComponent', () => {
             expect(onDeleteExerciseEmitSpy).to.have.been.calledOnce;
         });
         it('should handle error for programmingExercise', () => {
-            const error = { message: 'error occured!' } as HttpErrorResponse;
+            const error = { message: 'error occurred!' } as HttpErrorResponse;
             deleteProgrammingExerciseStub.returns(throwError(error));
             component.exercise = programmingExercise;
             component.deleteProgrammingExercise({});
@@ -228,14 +228,14 @@ describe('ExamExerciseRowButtonsComponent', () => {
             component.exercise = quizExercise;
             component.exportQuizById(true);
             expect(quizExerciseExportSpy).to.have.been.called;
-            expect(quizExerciseExportSpy).to.have.been.calledWith({}, true);
+            expect(quizExerciseExportSpy).to.have.been.calledWith({}, true, quizExercise.title);
         });
         it('should export Quiz, exportAll false', () => {
             quizExerciseServiceFindStub.returns(of(quizResponse));
             component.exercise = quizExercise;
             component.exportQuizById(false);
             expect(quizExerciseExportSpy).to.have.been.called;
-            expect(quizExerciseExportSpy).to.have.been.calledWith({}, false);
+            expect(quizExerciseExportSpy).to.have.been.calledWith({}, false, quizExercise.title);
         });
     });
 });


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
Resolves #3311.

### Description
When exporting a quiz, the name of the downloaded file is set to the quiz' title. If questions from multiple quizzes are downloaded the filename defaults to 'quiz' as before.

### Steps for Testing
1. Log in to Artemis.
2. Create/Locate a quiz.
3. Export the quiz. The filename should match the title of the quiz.
4. Repeat for quizzes in exams
5. Also try names for quizzes likely to crash the process

### Test Coverage and GUI
Unchanged
