### PR TITLE
Fix text overlaps in the management overview

### DIFF
--- a/src/main/webapp/app/course/manage/overview/course-management-card.scss
+++ b/src/main/webapp/app/course/manage/overview/course-management-card.scss
@@ -140,7 +140,7 @@
     }
 }
 
-@media screen and (max-width: 1200px) {
+@media screen and (max-width: 1250px) {
     .card {
         .card-heading {
             .card-description {

--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col row details-container">
                 <a class="stretched-link" [routerLink]="['/course-management', course.id, details.type + '-exercises', details.id]"></a>
-                <div class="col-5 row-flex exercise-details-container">
+                <div class="col-6 row-flex exercise-details-container">
                     <div class="ml-2 mr-1 exercise-details-item" *ngIf="hasLeftoverAssessments">
                         <fa-icon [icon]="'exclamation-triangle'" class="text-warning" placement="right" [ngbTooltip]="iconTooltip | artemisTranslate" container="body"></fa-icon>
                     </div>
@@ -16,7 +16,7 @@
                     <div class="item-title-container">
                         <span class="item-title">{{ details.title }}</span>
                     </div>
-                    <div class="item-category d-flex hide-categories" *ngIf="(details.categories?.length || 0) > 0 && (details.title?.length || 0) < 40">
+                    <div class="item-category d-flex hide-categories" *ngIf="(details.categories?.length || 0) > 0 && (details.title?.length || 0) < 60">
                         <!-- We only support two categories -->
                         <h4 *ngFor="let category of details.categories">
                             <span class="badge text-white mr-1" [ngStyle]="{ backgroundColor: category.color }">{{ category.category }}</span>
@@ -24,7 +24,7 @@
                     </div>
                 </div>
 
-                <div class="col-4 row-flex exercise-date-container">
+                <div class="col-3 row-flex exercise-date-container">
                     <div [ngClass]="!!details.releaseDate ? 'exercise-date' : 'exercise-date exercise-no-date'">
                         <div class="exercise-date-timeline"></div>
                         <span>{{ 'artemisApp.course.releaseDate' | artemisTranslate }}</span>

--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.scss
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.scss
@@ -9,10 +9,6 @@
     align-content: center;
     height: 60px;
 
-    .exercise-details-container {
-        max-width: 55ch;
-    }
-
     .item-title-container {
         display: flex;
         align-items: center;
@@ -25,7 +21,7 @@
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        max-width: 50ch;
+        max-width: 60ch;
         display: block;
     }
 
@@ -42,7 +38,7 @@
             font-size: 1rem;
 
             .badge {
-                max-width: 150px;
+                max-width: 130px;
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
@@ -164,34 +160,38 @@
     }
 }
 
-@media screen and (max-width: 1900px) {
+@media screen and (max-width: 1925px) {
     .hide-categories {
         display: none !important;
     }
 
     .course-item {
         .exercise-details-container {
-            max-width: 43ch;
+            max-width: 53ch;
         }
 
         .item-title {
-            max-width: 40ch;
+            max-width: 47ch;
         }
 
         .exercise-date-container {
             margin-right: unset !important;
         }
+
+        .exercise-score-container {
+            margin: 0 10px 0 10px;
+        }
     }
 }
 
-@media screen and (max-width: 1680px) {
+@media screen and (max-width: 1700px) {
     .course-item {
         .exercise-details-container {
-            max-width: 33ch;
+            max-width: 40ch;
         }
 
         .item-title {
-            max-width: 30ch;
+            max-width: 34ch;
         }
 
         .exercise-score {
@@ -202,7 +202,7 @@
     }
 }
 
-@media screen and (max-width: 1400px) {
+@media screen and (max-width: 1500px) {
     .course-item {
         .exercise-details-container {
             max-width: 23ch;
@@ -246,7 +246,7 @@
     }
 }
 
-@media screen and (max-width: 675px) {
+@media screen and (max-width: 725px) {
     .details-container {
         max-width: 70% !important;
     }

--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.scss
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.scss
@@ -217,7 +217,7 @@
 @media screen and (max-width: 1250px) {
     .course-item {
         .exercise-details-container {
-            max-width: 18ch;
+            max-width: 15ch;
         }
 
         .item-title {

--- a/src/main/webapp/i18n/de/course.json
+++ b/src/main/webapp/i18n/de/course.json
@@ -129,9 +129,9 @@
             "pastExercises": "Vergangene Übungen ({{ amount }} von {{ total }})",
             "noExercises": "Keine aktiven Übungen vorhanden",
             "assessmentProgress": "Bewertungen",
-            "releaseDate": "Veröffentlichung",
-            "dueDate": "Einreichungsfrist",
-            "assessmentDueDate": "Bewertungsfrist",
+            "releaseDate": "Freigabe",
+            "dueDate": "Einreichung",
+            "assessmentDueDate": "Bewertung",
             "cleanup": {
                 "title": "Aufräumen",
                 "question": "Möchtest du den Kurs <strong>{{title}}</strong> wirklich bereinigen? Dadurch werden alle Studenten-Repositories für <strong>Übungen</strong> und <strong>Prüfungen</strong> gelöscht. Diese Aktion kann <strong class='text-danger'>NICHT</strong> rückgängig gemacht werden!"


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context

#3326 caused a small regression with exercises with very long titles which then sometimes overlap:
![grafik](https://user-images.githubusercontent.com/72132281/116872492-4150bb80-ac16-11eb-85ac-471bc5a318b6.png)

### Description

We shorten the titles a bit earlier and decrease the whitespace between elements:

![grafik](https://user-images.githubusercontent.com/72132281/116872509-4b72ba00-ac16-11eb-98db-1bf7204ceb52.png)

![grafik](https://user-images.githubusercontent.com/72132281/116872540-575e7c00-ac16-11eb-8d6d-0ef2282e97ee.png)

![grafik](https://user-images.githubusercontent.com/72132281/116872543-59283f80-ac16-11eb-9e37-eb94b094a8ee.png)

### Steps for Testing

1. Find or create an exercise with a long title (> 60 characters)
2. Navigate to the management overview and check that there are big no overlaps with the date timelines
3. If you want you can also create an exercise with categories and a title < 60 characters and check that the categories are displayed on large screens (see first screenshot)
