### PR TITLE
[Bugfix] Show Page Title on Exercise Assesment Dashboard

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
@@ -1,8 +1,8 @@
 <div class="course-info-bar" *ngIf="exercise">
     <div class="row">
         <div class="col general-info">
-            <h3 *ngIf="displayBackButton">
-                <fa-icon [icon]="'arrow-left'" (click)="onBackClick()" class="back-button mr-2"></fa-icon>
+            <h3>
+                <fa-icon *ngIf="displayBackButton" [icon]="'arrow-left'" (click)="onBackClick()" class="back-button mr-2"></fa-icon>
                 <ng-content select="[pagetitle]"></ng-content>
             </h3>
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) ~~on the test server https://artemistest.ase.in.tum.de~~ locally.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
The exercise assessment dashboard does not show the page title which makes it unclear which exercise is currently viewed.

### Description
If no back button is shown the exercise head did not display the title either. This is now changed, the `displayBackButton`-attribute only toggles the visibility of the back button, the title will be shown anyways.

### Steps for Testing
1. Navigate to the Exercise Assessment Dashboard
2. Check that the title is displayed correctly

### Screenshots
old:
![grafik](https://user-images.githubusercontent.com/26540346/116895809-da41ff80-ac33-11eb-9fe3-10ae73f9a82d.png)

new:
![grafik](https://user-images.githubusercontent.com/26540346/116895839-e0d07700-ac33-11eb-8766-b7a716c81c0d.png)

