### PR TITLE
[Refactor] refactoring TextAssessmentResource 

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/FeedbackConflictRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/FeedbackConflictRepository.java
@@ -3,12 +3,15 @@ package de.tum.in.www1.artemis.repository;
 import java.util.List;
 import java.util.Optional;
 
+import javax.validation.constraints.NotNull;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import de.tum.in.www1.artemis.domain.FeedbackConflict;
+import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 
 /**
  * Spring Data JPA repository for the FeedbackConflict entity.
@@ -37,4 +40,10 @@ public interface FeedbackConflictRepository extends JpaRepository<FeedbackConfli
     @Query("select distinct conflict from FeedbackConflict conflict " + "left join fetch conflict.firstFeedback f1 left join fetch f1.result r1 left join fetch r1.assessor "
             + "left join fetch conflict.secondFeedback f2 left join fetch f2.result r2 left join fetch r2.assessor " + "where conflict.id = :feedbackConflictId")
     Optional<FeedbackConflict> findByFeedbackConflictId(@Param("feedbackConflictId") Long feedbackConflictId);
+
+    @NotNull
+    default FeedbackConflict findByFeedbackConflictIdElseThrow(long feedbackConflictId) {
+        return findByFeedbackConflictId(feedbackConflictId)
+                .orElseThrow(() -> new BadRequestAlertException("No FeedbackConflict found for given feedbackConflictId.", "feedbackConflict", "feedbackConflictNotFound"));
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TextSubmissionRepository.java
@@ -5,6 +5,8 @@ import static org.springframework.data.jpa.repository.EntityGraph.EntityGraphTyp
 import java.util.List;
 import java.util.Optional;
 
+import javax.validation.constraints.NotNull;
+
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -74,15 +76,23 @@ public interface TextSubmissionRepository extends JpaRepository<TextSubmission, 
         return findByParticipation_ExerciseIdAndSubmittedIsTrue(exerciseId);
     }
 
-    default TextSubmission getTextSubmissionWithResultAndTextBlocksAndFeedbackByResultId(long resultId) {
+    @NotNull
+    default TextSubmission getTextSubmissionWithResultAndTextBlocksAndFeedbackByResultIdElseThrow(long resultId) {
         return findWithEagerResultAndTextBlocksAndFeedbackByResults_Id(resultId)
                 .orElseThrow(() -> new BadRequestAlertException("No text submission found for the given result.", "textSubmission", "textSubmissionNotFound"));
+    }
+
+    @NotNull
+    default TextSubmission findByIdWithEagerParticipationExerciseResultAssessorElseThrow(long submissionId) {
+        return findByIdWithEagerParticipationExerciseResultAssessor(submissionId)
+                .orElseThrow(() -> new BadRequestAlertException("No text submission found for the given submission.", "textSubmission", "textSubmissionNotFound"));
     }
 
     default List<TextSubmission> getTextSubmissionsWithTextBlocksByExerciseIdAndLanguage(long exerciseId, Language language) {
         return findByParticipation_ExerciseIdAndSubmittedIsTrueAndLanguage(exerciseId, language);
     }
 
+    @NotNull
     default TextSubmission findByIdWithParticipationExerciseResultAssessorElseThrow(long submissionId) {
         return findByIdWithEagerParticipationExerciseResultAssessor(submissionId).orElseThrow(() -> new EntityNotFoundException("TextSubmission", submissionId));
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
@@ -12,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.*;
-import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AssessmentService;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.WebsocketMessagingService;
@@ -176,9 +175,11 @@ public abstract class AssessmentResource {
      * @param exercise the exercise for which the authorization should be checked
      * @throws BadRequestAlertException if no course is associated to the given exercise
      */
-    void checkAuthorization(Exercise exercise, User user) throws BadRequestAlertException {
+    void checkAuthorization(Exercise exercise, User user) {
         validateExercise(exercise);
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, exercise, user);
+        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user)) {
+            forbidden();
+        }
     }
 
     void validateExercise(Exercise exercise) throws BadRequestAlertException {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
@@ -180,7 +180,7 @@ public class TextAssessmentResource extends AssessmentResource {
      * @param textAssessment the assessments which should be submitted
      * @return 200 Ok if successful with the corresponding result as a body, but sensitive information are filtered out
      */
-    @PutMapping("/exercise/{exerciseId}/result/{resultId}/submit")
+    @PostMapping("/exercise/{exerciseId}/result/{resultId}/submit")
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<Result> submitTextAssessment(@PathVariable Long exerciseId, @PathVariable Long resultId, @RequestBody TextAssessmentDTO textAssessment) {
         final boolean hasAssessmentWithTooLongReference = textAssessment.getFeedbacks().stream().filter(Feedback::hasReference)
@@ -293,6 +293,7 @@ public class TextAssessmentResource extends AssessmentResource {
         else {
             // in case no resultId is set we get result by correctionRound
             result = textSubmission.getResultForCorrectionRound(correctionRound);
+
             if (result != null && !isAtLeastInstructorForExercise && result.getAssessor() != null && !result.getAssessor().getLogin().equals(user.getLogin())
                     && result.getCompletionDate() == null) {
                 // If we already have a result, we need to check if it is locked.

--- a/src/main/webapp/app/exercises/text/assess/text-assessment.service.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment.service.ts
@@ -93,7 +93,7 @@ export class TextAssessmentService {
      * @param submissionId id of corresponding submission of type {number}
      */
     public cancelAssessment(exerciseId: number, submissionId: number): Observable<void> {
-        return this.http.put<void>(`${this.resourceUrl}/exercise/${exerciseId}/submission/${submissionId}/cancel-assessment`, null);
+        return this.http.post<void>(`${this.resourceUrl}/exercise/${exerciseId}/submission/${submissionId}/cancel-assessment`, null);
     }
 
     /**
@@ -160,7 +160,7 @@ export class TextAssessmentService {
      * @param feedbackConflictId id of the feedback conflict to be solved
      */
     public solveFeedbackConflict(exerciseId: number, feedbackConflictId: number): Observable<FeedbackConflict> {
-        return this.http.get<FeedbackConflict>(`${this.resourceUrl}/exercise/${exerciseId}/feedbackConflict/${feedbackConflictId}/solve-feedback-conflict`);
+        return this.http.post<FeedbackConflict>(`${this.resourceUrl}/exercise/${exerciseId}/feedbackConflict/${feedbackConflictId}/solve-feedback-conflict`, null);
     }
 
     private static prepareFeedbacksAndTextblocksForRequest(feedbacks: Feedback[], textBlocks: TextBlock[]): TextAssessmentDTO {

--- a/src/main/webapp/app/exercises/text/assess/text-assessment.service.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment.service.ts
@@ -51,7 +51,7 @@ export class TextAssessmentService {
     public submit(exerciseId: number, resultId: number, feedbacks: Feedback[], textBlocks: TextBlock[]): Observable<EntityResponseType> {
         const body = TextAssessmentService.prepareFeedbacksAndTextblocksForRequest(feedbacks, textBlocks);
         return this.http
-            .put<Result>(`${this.resourceUrl}/exercise/${exerciseId}/result/${resultId}/submit`, body, { observe: 'response' })
+            .post<Result>(`${this.resourceUrl}/exercise/${exerciseId}/result/${resultId}/submit`, body, { observe: 'response' })
             .pipe(map((res: EntityResponseType) => TextAssessmentService.convertResponse(res)));
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -124,7 +124,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         Result result = textSubmission.getLatestResult();
         result.setCompletionDate(null); // assessment is still in progress for this test
         resultRepo.save(result);
-        StudentParticipation participation = request.get("/api/text-assessments/submission/" + textSubmission.getId(), HttpStatus.BAD_REQUEST, StudentParticipation.class);
+        StudentParticipation participation = request.get("/api/text-assessments/submission/" + textSubmission.getId(), HttpStatus.FORBIDDEN, StudentParticipation.class);
         assertThat(participation).as("participation is locked and should not be returned").isNull();
     }
 
@@ -1005,7 +1005,8 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
     @WithMockUser(value = "tutor1", roles = "TA")
     public void solveFeedbackConflict_forNonExistingConflict() throws Exception {
         prepareTextSubmissionsWithFeedbackAndConflicts();
-        FeedbackConflict feedbackConflict = solveFeedbackConflict(HttpStatus.BAD_REQUEST);
+        FeedbackConflict feedbackConflict = request.postWithResponseBody("/api/text-assessments/exercise/" + textExercise.getId() + "/feedbackConflict/2/solve-feedback-conflict",
+                null, FeedbackConflict.class, HttpStatus.BAD_REQUEST);
         assertThat(feedbackConflict).as("feedback conflict should not be found").isNull();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -462,7 +462,8 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         TextSubmission textSubmission = ModelFactory.generateTextSubmission("Some text", Language.ENGLISH, true);
         textSubmission = database.saveTextSubmissionWithResultAndAssessor(textExercise, textSubmission, "student1", "tutor1");
         database.addSampleFeedbackToResults(textSubmission.getLatestResult());
-        request.put("/api/text-assessments/exercise/" + textExercise.getId() + "/submission/" + textSubmission.getId() + "/cancel-assessment", null, expectedStatus);
+        request.postWithoutLocation("/api/text-assessments/exercise/" + textExercise.getId() + "/submission/" + textSubmission.getId() + "/cancel-assessment", null, expectedStatus,
+                null);
     }
 
     @Test
@@ -492,7 +493,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
     @Test
     @WithMockUser(value = "tutor1", roles = "TA")
     public void cancelAssessment_wrongSubmissionId() throws Exception {
-        request.put("/api/text-assessments/exercise/" + textExercise.getId() + "/submission/100/cancel-assessment", null, HttpStatus.NOT_FOUND);
+        request.post("/api/text-assessments/exercise/" + textExercise.getId() + "/submission/100/cancel-assessment", null, HttpStatus.NOT_FOUND);
     }
 
     @Test
@@ -1004,16 +1005,15 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
     @WithMockUser(value = "tutor1", roles = "TA")
     public void solveFeedbackConflict_forNonExistingConflict() throws Exception {
         prepareTextSubmissionsWithFeedbackAndConflicts();
-        FeedbackConflict feedbackConflict = request.get("/api/text-assessments/exercise/" + textExercise.getId() + "/feedbackConflict/2/solve-feedback-conflict",
-                HttpStatus.BAD_REQUEST, FeedbackConflict.class);
+        FeedbackConflict feedbackConflict = solveFeedbackConflict(HttpStatus.BAD_REQUEST);
         assertThat(feedbackConflict).as("feedback conflict should not be found").isNull();
     }
 
     private FeedbackConflict solveFeedbackConflict(HttpStatus expectedStatus) throws Exception {
         prepareTextSubmissionsWithFeedbackAndConflicts();
-        return request.get(
+        return request.postWithResponseBody(
                 "/api/text-assessments/exercise/" + textExercise.getId() + "/feedbackConflict/" + feedbackConflictRepository.findAll().get(0).getId() + "/solve-feedback-conflict",
-                expectedStatus, FeedbackConflict.class);
+                null, FeedbackConflict.class, expectedStatus);
     }
 
     @Test

--- a/src/test/javascript/spec/service/text-assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/text-assessment.service.spec.ts
@@ -165,7 +165,7 @@ describe('TextAssessment Service', () => {
 
         const req = httpMock.expectOne({
             url: `${SERVER_API_URL}api/text-assessments/exercise/${exerciseId}/feedbackConflict/${feedbackConflict.id}/solve-feedback-conflict`,
-            method: 'GET',
+            method: 'POST',
         });
         req.flush(JSON.stringify(returnedFromService));
     });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [ ] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Remote methods should be invoked by POST, making HTTPStatus Response codes more uniform

### Description
<!-- Describe your changes in detail -->
changed some remotely invoked methods calls (like  ".../cancel-assessment") to now be invoked by POST, made whole Resource more uniform and coherent to new Resource style.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Participate in a TextExercise
3. Assess your participation
4. Review the Assessment as Student who participated in the exercise

Check the Console while you do all this for failing Requests

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

tbd