### PR TITLE
Fixed sentry issue for exercise details overview

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -143,8 +143,8 @@ export class ExerciseDetailsStudentActionsComponent {
      * @return {assignedTeamId}
      */
     get assignedTeamId(): number | undefined {
-        const participation = this.exercise.studentParticipations;
-        return participation && participation?.length > 0 ? participation[0].team?.id : this.exercise.studentAssignedTeamId;
+        const participations = this.exercise.studentParticipations;
+        return participations && participations.length > 0 ? participations[0].team?.id : this.exercise.studentAssignedTeamId;
     }
 
     repositoryUrl(participation: Participation) {

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -143,8 +143,8 @@ export class ExerciseDetailsStudentActionsComponent {
      * @return {assignedTeamId}
      */
     get assignedTeamId(): number | undefined {
-        const participation = this.exercise.studentParticipations![0];
-        return participation ? participation.team?.id : this.exercise.studentAssignedTeamId;
+        const participation = this.exercise.studentParticipations;
+        return participation !== undefined && participation?.length > 0 ? participation[0].team?.id : this.exercise.studentAssignedTeamId;
     }
 
     repositoryUrl(participation: Participation) {

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.ts
@@ -144,7 +144,7 @@ export class ExerciseDetailsStudentActionsComponent {
      */
     get assignedTeamId(): number | undefined {
         const participation = this.exercise.studentParticipations;
-        return participation !== undefined && participation?.length > 0 ? participation[0].team?.id : this.exercise.studentAssignedTeamId;
+        return participation && participation?.length > 0 ? participation[0].team?.id : this.exercise.studentAssignedTeamId;
     }
 
     repositoryUrl(participation: Participation) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes ARTEMIS-5E sentry issue.  `assignedTeamId()` does not work properly when there is no participation for team exercise.

`TypeError: Cannot read property '0' of undefined`

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create new team exercise
3. Navigate to course management, go to 'Exercises' for selected course 
4. select 'Teams' for the exercise you created.
5. Crate new team, and add students into the team
6. login as a student who is added to the team
7. Navigate to course overview, select the course that includes the exercise you created at the previous step
8. Check the console, the error mentioned in description should not be displayed.


