### PR TITLE
[Bugfix] Fix File Upload Editor showing Feedback before Assessment Due Date

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
@@ -327,14 +327,14 @@ public class FileUploadSubmissionResource extends AbstractSubmissionResource {
         participation.setResults(null);
 
         if (fileUploadSubmission.getLatestResult() != null) {
-            // do not send the result to the client
+            // do not send the feedback to the client
             // if the assessment is not finished
             boolean assessmentUnfinished = fileUploadSubmission.getLatestResult().getCompletionDate() == null || fileUploadSubmission.getLatestResult().getAssessor() == null;
             // or the assessment due date isn't over yet
             boolean assessmentDueDateNotOver = fileUploadExercise.getAssessmentDueDate() != null && fileUploadExercise.getAssessmentDueDate().isAfter(ZonedDateTime.now());
 
             if (assessmentUnfinished || assessmentDueDateNotOver) {
-                fileUploadSubmission.setResults(new ArrayList<>());
+                fileUploadSubmission.getLatestResult().setFeedbacks(new ArrayList<>());
             }
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
@@ -4,6 +4,7 @@ import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -325,10 +326,16 @@ public class FileUploadSubmissionResource extends AbstractSubmissionResource {
         participation.setSubmissions(null);
         participation.setResults(null);
 
-        // do not send the result to the client if the assessment is not finished
-        if (fileUploadSubmission.getLatestResult() != null
-                && (fileUploadSubmission.getLatestResult().getCompletionDate() == null || fileUploadSubmission.getLatestResult().getAssessor() == null)) {
-            fileUploadSubmission.setResults(new ArrayList<Result>());
+        if (fileUploadSubmission.getLatestResult() != null) {
+            // do not send the result to the client
+            // if the assessment is not finished
+            boolean assessmentUnfinished = fileUploadSubmission.getLatestResult().getCompletionDate() == null || fileUploadSubmission.getLatestResult().getAssessor() == null;
+            // or the assessment due date isn't over yet
+            boolean assessmentDueDateNotOver = fileUploadExercise.getAssessmentDueDate() != null && fileUploadExercise.getAssessmentDueDate().isAfter(ZonedDateTime.now());
+
+            if (assessmentUnfinished || assessmentDueDateNotOver) {
+                fileUploadSubmission.setResults(new ArrayList<>());
+            }
         }
 
         // do not send the assessor information to students

--- a/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.html
+++ b/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.html
@@ -65,7 +65,13 @@
                 <jhi-rating *ngIf="isOwnerOfParticipation" class="mt-2 alert alert-info" [result]="addParticipationToResult(result, participation)"></jhi-rating>
             </div>
         </div>
-        <jhi-complaint-interactions *ngIf="fileUploadExercise" [result]="result" [participation]="participation" [exercise]="fileUploadExercise"> </jhi-complaint-interactions>
+        <jhi-complaint-interactions
+            *ngIf="fileUploadExercise && result && participation && isAfterAssessmentDueDate"
+            [result]="result"
+            [participation]="participation"
+            [exercise]="fileUploadExercise"
+        >
+        </jhi-complaint-interactions>
     </div>
     <!--endregion-->
     <!--region Right Panel-->

--- a/src/test/java/de/tum/in/www1/artemis/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadSubmissionIntegrationTest.java
@@ -35,6 +35,8 @@ public class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrati
 
     private FileUploadExercise finishedFileUploadExercise;
 
+    private FileUploadExercise assessedFileUploadExercise;
+
     private FileUploadSubmission submittedFileUploadSubmission;
 
     private FileUploadSubmission notSubmittedFileUploadSubmission;
@@ -51,6 +53,7 @@ public class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrati
         Course course = database.addCourseWithThreeFileUploadExercise();
         releasedFileUploadExercise = database.findFileUploadExerciseWithTitle(course.getExercises(), "released");
         finishedFileUploadExercise = database.findFileUploadExerciseWithTitle(course.getExercises(), "finished");
+        assessedFileUploadExercise = database.findFileUploadExerciseWithTitle(course.getExercises(), "assessed");
         submittedFileUploadSubmission = ModelFactory.generateFileUploadSubmission(true);
         notSubmittedFileUploadSubmission = ModelFactory.generateFileUploadSubmission(false);
         lateFileUploadSubmission = ModelFactory.generateLateFileUploadSubmission();
@@ -323,6 +326,21 @@ public class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrati
         FileUploadSubmission submission = request.get("/api/participations/" + modelingExerciseParticipation.getId() + "/file-upload-editor", HttpStatus.BAD_REQUEST,
                 FileUploadSubmission.class);
         assertThat(submission).isNull();
+    }
+
+    @Test
+    @WithMockUser(value = "student1")
+    public void getDataForFileUpload_afterAssessmentDueDate_showsFeedback() throws Exception {
+        FileUploadSubmission fileUploadSubmission = ModelFactory.generateFileUploadSubmission(true);
+        List<Feedback> feedbacks = ModelFactory.generateFeedback();
+        fileUploadSubmission = database.saveFileUploadSubmissionWithResultAndAssessorFeedback(assessedFileUploadExercise, fileUploadSubmission, "student1", "tutor1", feedbacks);
+
+        FileUploadSubmission submission = request.get("/api/participations/" + fileUploadSubmission.getParticipation().getId() + "/file-upload-editor", HttpStatus.OK,
+                FileUploadSubmission.class);
+        assertThat(submission).isNotNull();
+        assertThat(submission.getLatestResult()).isNotNull();
+        assertThat(submission.isSubmitted()).isTrue();
+        assertThat(submission.getLatestResult().getFeedbacks()).isEqualTo(feedbacks);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadSubmissionIntegrationTest.java
@@ -297,7 +297,8 @@ public class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrati
 
         FileUploadSubmission submission = request.get("/api/participations/" + fileUploadSubmission.getParticipation().getId() + "/file-upload-editor", HttpStatus.OK,
                 FileUploadSubmission.class);
-        assertThat(submission.getLatestResult()).isNull();
+        assertThat(submission.getLatestResult()).isNotNull();
+        assertThat(submission.getLatestResult().getFeedbacks()).isEmpty();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2352,6 +2352,10 @@ public class DatabaseUtilService {
         }
         result.setFeedbacks(feedbacks);
         result = resultRepo.save(result);
+        for (Feedback feedback : feedbacks) {
+            feedback.setResult(result);
+        }
+        result = resultRepo.save(result);
         result.setSubmission(fileUploadSubmission);
         fileUploadSubmission.setParticipation(participation);
         fileUploadSubmission.addResult(result);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) ~~on the test server https://artemistest.ase.in.tum.de~~ locally.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)

### Motivation and Context
The file Upload Editor shows the feedback even if the assessment due date isn't over yet. This PR changes this, students should only see feedback after the assessment due date.

### Description
- In the file-upload-editor-API a check against the assessment due date was missing.
- Added an isAfterAssessmentDueDate-check to the complaint interactions checks.
- Fix Tests not saving the feedback correctly -> test `getDataForFileUpload()` was testing against nothing before, now the feedback is really removed by the api)
- Added one additional test (feedback is shown after assessment due date)

### Steps for Testing
1. Create a File-Upload-Exercises with an Assessment Due Date in the future
2. Participate in the exercises as a student
3. Assess the participation
4. Student: Click the View submission button to check the own submission
5. Before Assessment Due date: no Feedback is visible, there is no option to submit a complaint / feedback request
   After Assessment Due date: Feedback is visible, the student is able to complaint / request more feedback


### Screenshots
old:
![image](https://user-images.githubusercontent.com/26540346/117109403-e2f61b00-ad84-11eb-9d11-a38787d22a0a.png)

new:
![image](https://user-images.githubusercontent.com/26540346/117139696-d1c10480-adac-11eb-9629-1bf295c7359b.png)

