### PR TITLE
Adding Editors to Atlassian Setup Script

### DIFF
--- a/docs/dev/setup/bamboo-bitbucket-jira.rst
+++ b/docs/dev/setup/bamboo-bitbucket-jira.rst
@@ -151,10 +151,10 @@ under ``localhost:7990``.
 
 5. The script has already created users and groups but you need to
    manually assign the users into their respective group in Jira. In our
-   test setup, users 1-5 are students, 6-10 are tutors and 11-15 are
-   instructors. The usernames are artemis_test_user_{1-15} and the
-   password is again the username. When you create a course in artemis
-   you have to manually choose the created groups(students, tutors,
+   test setup, users 1-5 are students, 6-10 are tutors, 11-15 are
+   editors and 16-20 are instructors. The usernames are artemis_test_user_{1-20}
+   and the password is again the username. When you create a course in artemis
+   you have to manually choose the created groups (students, tutors, editors
    instructors).
 
 6. Use the `user directories in

--- a/src/main/docker/atlassian-setup.sh
+++ b/src/main/docker/atlassian-setup.sh
@@ -50,7 +50,7 @@ fi
 
 # create groups
 
-declare -a group_names=("tutors" "instructors" "students")
+declare -a group_names=("tutors" "instructors" "students" "editors")
 
 jira_group_url="http://localhost:$jira_external_port/rest/api/latest/group"
 
@@ -73,13 +73,16 @@ base_user_name="artemis_test_user_"
 jira_user_url="http://localhost:$jira_external_port/rest/api/latest/user"
 jira_group_add_url="http://localhost:$jira_external_port/rest/api/2/group/user?groupname="
 
-for i in {1..15}; do
-    # User 1-5 are students, 6-10 are tutors, 11-15 are instructors
+for i in {1..20}; do
+    # User 1-5 are students, 6-10 are tutors, 11-15 are editors and 16-20 are instructors
     group="students"
     if ((i > 5)); then
       group="tutors"
     fi
     if ((i > 10)); then
+      group="editors"
+    fi
+    if ((i > 15)); then
       group="instructors"
     fi
 


### PR DESCRIPTION
### Motivation and Context
The new editor role is not mentioned in the local Atlassian setup documentation. Also, the atlassian-setup.sh script does not add the new editor role to Jira and does not create editor users automatically.

### Description
I have simply extended the current script so that it generates the new editor role and adds 5 more test users that can be used as editors. I have also updated the documentation accordingly.