### PR TITLE
[Bugfix] Quiz DnD Questions invalid input update

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
@@ -587,6 +587,8 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Quiz
             this.question.correctMappings = [];
         }
         this.question.correctMappings = this.question.correctMappings.filter((mapping) => !this.dragAndDropQuestionUtil.isSameDropLocation(mapping.dropLocation!, dropLocation));
+        // Notify parent of changes
+        this.questionUpdated.emit();
     }
 
     /**
@@ -598,6 +600,8 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Quiz
             this.question.correctMappings = [];
         }
         this.question.correctMappings = this.question.correctMappings.filter((mapping) => !this.dragAndDropQuestionUtil.isSameDragItem(mapping.dragItem!, dragItem));
+        // Notify parent of changes
+        this.questionUpdated.emit();
     }
 
     /**
@@ -609,6 +613,8 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Quiz
             this.question.correctMappings = [];
         }
         this.question.correctMappings = this.question.correctMappings.filter((mapping) => mapping !== mappingToDelete);
+        // Notify parent of changes
+        this.questionUpdated.emit();
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) locally

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes a bug where the invalid input batch of a DnD question did not update when invalid mappings of drag items and drop locations was removed, instead of  the batch showing `invalid input (0)` with empty tooltip in the footer of the question, the batch should not be shown at all after removing invalid mappings.

Fixes #3371 

### Description
I added the `this.questionUpdated.emit();` in the functions where mappings are deleted from drag items or drop locations as the mapping can be removed on either on of them.
This call triggers, that the question in updated including the re-evaluation of the question validity which determines, was it shown in the invalid input batch.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. As instructor, create a new Quiz Exercise -> invalid input is (2) (title is missing, missing question)
2. Add a quiz title -> invalid input is (1) (missing question)
3. Add a new drag and drop question -> invalid input should be (2) (question title is missing, no correct mapping)
4. Add a question title -> invalid input should be (1) (no correct mapping)
5. Upload an image
6. Create drop locations in this image
7. Create two drag items
8. Create a valid mapping (i.e. each item to _one_ location) -> invalid input should be not be visible, only unsaved changes
9. Create an invalid mapping, i.e. by mapping _one_ drag item to _two_ locations
9. Check if the invalid input batch indicates the wrong mapping > invalid input should be (1) (incorrect mapping)
9. Delete one of the mapping (by either click on the mapping number at the drag item or the drop location)
10. Check if the invalid input batch disappears (and is exchanged by the grey 'unsaved changes' batch) -> invalid input should be not be visible, only unsaved changes

In general: Please try to trigger any invalid mappings or inputs, revert them and see if the batch is updated correctly

The behavior that should be fixed is presented in a screencast of the respective issue #3371 (for comparison)


### Screenshots
This is how it should look like now:
![drag-and-drop-solved](https://user-images.githubusercontent.com/41366522/117287301-7e14f080-ae6a-11eb-9591-6b93ff525a7a.gif)

