### PR TITLE
[chore] fix fakeAsync in student-question- and -answer-service

### DIFF
--- a/src/test/javascript/spec/service/student-question-answer.service.spec.ts
+++ b/src/test/javascript/spec/service/student-question-answer.service.spec.ts
@@ -1,6 +1,5 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
 import * as chai from 'chai';
 import { take } from 'rxjs/operators';
 import { StudentQuestionAnswerService } from 'app/overview/student-questions/student-question-answer/student-question-answer.service';
@@ -13,13 +12,11 @@ describe('StudentQuestionAnswer Service', () => {
     let service: StudentQuestionAnswerService;
     let httpMock: HttpTestingController;
     let elemDefault: StudentQuestionAnswer;
-    let expectedResult: any;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
         });
-        expectedResult = {} as HttpResponse<StudentQuestionAnswer>;
         injector = getTestBed();
         service = injector.get(StudentQuestionAnswerService);
         httpMock = injector.get(HttpTestingController);
@@ -31,49 +28,49 @@ describe('StudentQuestionAnswer Service', () => {
     });
 
     describe('Service methods', () => {
-        it('should create a StudentQuestionAnswer', async () => {
+        it('should create a StudentQuestionAnswer', fakeAsync(() => {
             const returnedFromService = { ...elemDefault, id: 0 };
             const expected = { ...returnedFromService };
             service
                 .create(1, new StudentQuestionAnswer())
                 .pipe(take(1))
-                .subscribe((resp) => (expectedResult = resp));
+                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
             const req = httpMock.expectOne({ method: 'POST' });
             req.flush(returnedFromService);
-            expect(expectedResult.body).to.deep.equal(expected);
-        });
+            tick();
+        }));
 
-        it('should update a StudentQuestionAnswer text field', async () => {
+        it('should update a StudentQuestionAnswer text field', fakeAsync(() => {
             const returnedFromService = { ...elemDefault, answerText: 'This is another test answer' };
             const expected = { ...returnedFromService };
             service
                 .update(1, expected)
                 .pipe(take(1))
-                .subscribe((resp) => (expectedResult = resp));
+                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
             const req = httpMock.expectOne({ method: 'PUT' });
             req.flush(returnedFromService);
-            expect(expectedResult.body).to.deep.equal(expected);
-        });
+            tick();
+        }));
 
-        it('should update a StudentQuestionAnswer tutorApproved field', async () => {
+        it('should update a StudentQuestionAnswer tutorApproved field', fakeAsync(() => {
             const returnedFromService = { ...elemDefault, tutorApproved: true };
             const expected = { ...returnedFromService };
             service
                 .update(1, expected)
                 .pipe(take(1))
-                .subscribe((resp) => (expectedResult = resp));
+                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
             const req = httpMock.expectOne({ method: 'PUT' });
             req.flush(returnedFromService);
-            expect(expectedResult.body).to.deep.equal(expected);
-        });
+            tick();
+        }));
 
-        it('should delete a StudentQuestionAnswer', async () => {
-            service.delete(1, 123).subscribe((resp) => (expectedResult = resp.ok));
+        it('should delete a StudentQuestionAnswer', fakeAsync(() => {
+            service.delete(1, 123).subscribe((resp) => expect(resp.ok).to.be.true);
 
             const req = httpMock.expectOne({ method: 'DELETE' });
             req.flush({ status: 200 });
-            expect(expectedResult).to.be.true;
-        });
+            tick();
+        }));
     });
 
     afterEach(() => {

--- a/src/test/javascript/spec/service/student-question.service.spec.ts
+++ b/src/test/javascript/spec/service/student-question.service.spec.ts
@@ -1,6 +1,5 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
 import * as chai from 'chai';
 import { take } from 'rxjs/operators';
 import { StudentQuestionService } from 'app/overview/student-questions/student-question/student-question.service';
@@ -21,13 +20,11 @@ describe('StudentQuestion Service', () => {
     let exerciseDefault: TextExercise;
     let lectureDefault: Lecture;
     let studentQuestionList: StudentQuestion[];
-    let expectedResult: any;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
         });
-        expectedResult = {} as HttpResponse<StudentQuestion>;
         injector = getTestBed();
         service = injector.get(StudentQuestionService);
         httpMock = injector.get(HttpTestingController);
@@ -60,64 +57,64 @@ describe('StudentQuestion Service', () => {
     });
 
     describe('Service methods', () => {
-        it('should create a StudentQuestion', async () => {
+        it('should create a StudentQuestion', fakeAsync(() => {
             const returnedFromService = { ...elemDefault, id: 0 };
             const expected = { ...returnedFromService };
             service
                 .create(1, new StudentQuestion())
                 .pipe(take(1))
-                .subscribe((resp) => (expectedResult = resp));
+                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
             const req = httpMock.expectOne({ method: 'POST' });
             req.flush(returnedFromService);
-            expect(expectedResult.body).to.deep.equal(expected);
-        });
+            tick();
+        }));
 
-        it('should update a StudentQuestion', async () => {
+        it('should update a StudentQuestion', fakeAsync(() => {
             const returnedFromService = { ...elemDefault, questionText: 'This is another test question' };
 
             const expected = { ...returnedFromService };
             service
                 .update(1, expected)
                 .pipe(take(1))
-                .subscribe((resp) => (expectedResult = resp));
+                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
             const req = httpMock.expectOne({ method: 'PUT' });
             req.flush(returnedFromService);
-            expect(expectedResult.body).to.deep.equal(expected);
-        });
+            tick();
+        }));
 
-        it('should delete a StudentQuestion', async () => {
-            service.delete(1, 123).subscribe((resp) => (expectedResult = resp.ok));
+        it('should delete a StudentQuestion', fakeAsync(() => {
+            service.delete(1, 123).subscribe((resp) => expect(resp.ok).to.be.true);
 
             const req = httpMock.expectOne({ method: 'DELETE' });
             req.flush({ status: 200 });
-            expect(expectedResult).to.be.true;
-        });
+            tick();
+        }));
 
-        it('should update the votes of a StudentQuestion', async () => {
+        it('should update the votes of a StudentQuestion', fakeAsync(() => {
             const returnedFromService = { ...elemDefault, votes: 42 };
 
             const expected = { ...returnedFromService };
             service
                 .updateVotes(1, expected.id!, 0)
                 .pipe(take(1))
-                .subscribe((resp) => (expectedResult = resp));
+                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
             const req = httpMock.expectOne({ method: 'PUT' });
             req.flush(returnedFromService);
-            expect(expectedResult.body).to.deep.equal(expected);
-        });
+            tick();
+        }));
 
-        it('should return all student questions for a course', async () => {
+        it('should return all student questions for a course', fakeAsync(() => {
             const returnedFromService = [...studentQuestionList];
 
             const expected = [...studentQuestionList];
             service
                 .findQuestionsForCourse(courseDefault.id!)
                 .pipe(take(2))
-                .subscribe((resp) => (expectedResult = resp));
+                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
             const req = httpMock.expectOne({ method: 'GET' });
             req.flush(returnedFromService);
-            expect(expectedResult.body).to.deep.equal(expected);
-        });
+            tick();
+        }));
     });
 
     afterEach(() => {


### PR DESCRIPTION
### Checklist
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Description
Replaces async with fakeAsync in student-question-service and student-question-answer-server and refactors the assertments to be in line with the example

### Steps for Testing
Review Code

### Test Coverage
unchanged