### PR TITLE
[bugfix] Add back URL to "go to repository" button

### DIFF
--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -40,6 +40,7 @@ import { getExerciseDashboardLink, getLinkToSubmissionAssessment } from 'app/uti
 import { Observable } from 'rxjs';
 import { getLatestSubmissionResult } from 'app/entities/submission.model';
 import { SubmissionType } from 'app/entities/submission.model';
+import { addUserIndependentRepositoryUrl } from 'app/overview/participation-utils';
 
 @Component({
     selector: 'jhi-code-editor-tutor-assessment',
@@ -210,6 +211,7 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
         this.submission = submission;
         this.manualResult = getLatestSubmissionResult(this.submission);
         this.participation = submission.participation!;
+        addUserIndependentRepositoryUrl(this.participation);
         this.exercise = this.participation.exercise as ProgrammingExercise;
         this.hasAssessmentDueDatePassed = !!this.exercise!.assessmentDueDate && moment(this.exercise!.assessmentDueDate).isBefore(now());
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on test server 3
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
Fixes #3375 

### Description
Adds back the call to addUserIndependentRepositoryUrl that got lost during a previous refactoring as suggested in the issue

### Steps for Testing
1. Recreate the bug
   1. Create a programming exercise with manual correction
   2. Assess it as a tutor
   3. Klick on "Go to repository" in the assessment overview of one specific submission
2. The button should now lead to the repository
3. Verify its the correct respository


### Screenshots
See linked issue
