### PR TITLE
remove course update notification when clicking the archive button

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -1034,7 +1034,7 @@ public class CourseResource {
         // Note: Questions and answers are not part of the archive at the moment and will be included in a future version
         // 1) Get all questions and answers for exercises and lectures and store those in structured text files
 
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, course.getId().toString())).build();
+        return ResponseEntity.ok().build();
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -895,7 +895,7 @@ public class ExamResource {
         }
 
         examService.archiveExam(exam);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, examId.toString())).build();
+        return ResponseEntity.ok().build();
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html)

### Description
<!-- Describe your changes in detail -->
This pr removes a "This ... has been updated" notification that appears each time the "Archive Course" or "Archive Exam" button is pressed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to a course that is finished
4. Press the archive button
5. The notification displayed on the bottom shouldn't be displayed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

The redundant notification that is removed when archiving a course or exam:

![1](https://user-images.githubusercontent.com/11298674/117633261-2c2bdd80-b17e-11eb-978b-e021b35848ef.gif)