### PR TITLE
[Chore] Improving server test coverage: ProgrammingSubmisionResultSimulationResource

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/simulation/ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/simulation/ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest.java
@@ -68,7 +68,7 @@ public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest ext
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void shouldCreateSubmissionWithoutConnectionToVCSandCI() throws Exception {
         assertThat(submissionRepository.findAll()).hasSize(0);
-        final var returnedSubmission = request.postWithResponseBody(ROOT + SUBMISSIONS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null,
+        final ProgrammingSubmission returnedSubmission = request.postWithResponseBody(ROOT + SUBMISSIONS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null,
                 ProgrammingSubmission.class, HttpStatus.CREATED);
         assertThat(submissionRepository.findAll()).hasSize(1);
         ProgrammingSubmission submission = submissionRepository.findAll().get(0);
@@ -79,6 +79,13 @@ public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest ext
         assertThat(submission.isSubmitted()).isTrue();
     }
 
+    // The tutor has instructor rights, but does not have the permissions of the repository since the tutor is not part of the instructor group.
+    @Test
+    @WithMockUser(username = "tutor1", roles = "INSTRUCTOR")
+    void shouldCreateSubmissionWithoutConnectionToVCSandCI_forbidden() throws Exception {
+        request.post(ROOT + SUBMISSIONS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null, HttpStatus.FORBIDDEN);
+    }
+
     /**
      * This tests if the result is created for programming exercises without local setup
      */
@@ -86,7 +93,7 @@ public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest ext
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void shouldCreateResultWithoutConnectionToVCSandCI() throws Exception {
-        final var returnedSubmission = request.postWithResponseBody(ROOT + SUBMISSIONS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null,
+        final ProgrammingSubmission returnedSubmission = request.postWithResponseBody(ROOT + SUBMISSIONS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null,
                 ProgrammingSubmission.class, HttpStatus.CREATED);
         assertThat(resultRepository.findAll()).hasSize(0);
         Result returnedResult = request.postWithResponseBody(ROOT + RESULTS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null, Result.class, HttpStatus.CREATED);
@@ -96,5 +103,12 @@ public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest ext
         Result result = resultRepository.findAll().get(0);
         assertThat(returnedResult).isEqualTo(result);
         assertThat(result.getParticipation().getId()).isEqualTo(submission.getParticipation().getId());
+    }
+
+    // The tutor has instructor rights, but does not have the permissions of the repository since the tutor is not part of the instructor group.
+    @Test
+    @WithMockUser(username = "tutor1", roles = "INSTRUCTOR")
+    void shouldCreateResultWithoutConnectionToVCSandCI_forbidden() throws Exception {
+        request.post(ROOT + RESULTS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null, HttpStatus.FORBIDDEN);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)

### Description
<!-- Describe your changes in detail -->
Improving the test coverage for the ProgrammingSubmissionResultSimulationResource

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

