### PR TITLE
Fix an error when an exercise has no due date defined

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -263,7 +263,11 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
         this.participationUpdateListener = this.participationWebsocketService.subscribeForParticipationChanges().subscribe((changedParticipation: StudentParticipation) => {
             if (changedParticipation && this.exercise && changedParticipation.exercise?.id === this.exercise.id) {
                 // Notify student about late submission result
-                if (changedParticipation.exercise?.dueDate && changedParticipation.exercise!.dueDate!.isBefore(moment.now()) && changedParticipation.results?.length! > this.studentParticipation?.results?.length!) {
+                if (
+                    changedParticipation.exercise?.dueDate &&
+                    changedParticipation.exercise!.dueDate!.isBefore(moment.now()) &&
+                    changedParticipation.results?.length! > this.studentParticipation?.results?.length!
+                ) {
                     this.jhiAlertService.success('artemisApp.exercise.lateSubmissionResultReceived');
                 }
                 this.exercise.studentParticipations =

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -263,7 +263,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
         this.participationUpdateListener = this.participationWebsocketService.subscribeForParticipationChanges().subscribe((changedParticipation: StudentParticipation) => {
             if (changedParticipation && this.exercise && changedParticipation.exercise?.id === this.exercise.id) {
                 // Notify student about late submission result
-                if (changedParticipation.exercise?.dueDate?.isBefore(moment.now()) && changedParticipation.results?.length! > this.studentParticipation?.results?.length!) {
+                if (changedParticipation.exercise?.dueDate && changedParticipation.exercise!.dueDate!.isBefore(moment.now()) && changedParticipation.results?.length! > this.studentParticipation?.results?.length!) {
                     this.jhiAlertService.success('artemisApp.exercise.lateSubmissionResultReceived');
                 }
                 this.exercise.studentParticipations =

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -312,10 +312,6 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
         return result.rated ? 'badge-success' : 'badge-info';
     }
 
-    get exerciseIsOver(): boolean {
-        return this.exercise ? moment(this.exercise!.dueDate!).isBefore(moment()) : true;
-    }
-
     get hasMoreResults(): boolean {
         if (!this.studentParticipation || !this.studentParticipation.results) {
             return false;


### PR DESCRIPTION
### Motivation and Context

There are some TypeErrors like `o.isBefore is not a function. (In 'o.isBefore(z.now())', 'o.isBefore' is undefined)` on Sentry.

### Description

We now check if the due date is null/undefined before calling `isBefore` on it. From https://github.com/ls1intum/Artemis/pull/3394#issuecomment-837368116:
> I think the problem is that `date?.isBefore(xyz)` with `date == undefined` evaluates to `undefined?.isBefore(xyz)` and then `undefined(xyz)` (which obviously doesn't work). If I understand https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining correctly we would have to use `date?.isBefore?.(xyz)` instead (which I didn't know before and) which we don't use in the code base afaik?

### Steps for Testing

I actually don't know how to trigger this error, but the code changes alone should be indication enough that it is fixed. (Only other option I see is that we're trying to call `isBefore` on an object that isn't actually a date, but I don't know how that would happen.)
