### PR TITLE
Fix bogus undefined/null checks in the drag and drop util service

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/drag-and-drop-question-util.service.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/drag-and-drop-question-util.service.ts
@@ -208,7 +208,7 @@ export class DragAndDropQuestionUtil {
      * @return {boolean}
      */
     isSameDropLocation(a?: DropLocation, b?: DropLocation): boolean {
-        return a === b || (a !== undefined && b !== undefined && ((a.id && b.id && a.id === b.id) || (a.tempID != undefined && b.tempID != undefined && a.tempID === b.tempID)));
+        return a === b || (a != undefined && b != undefined && ((a.id && b.id && a.id === b.id) || (a.tempID != undefined && b.tempID != undefined && a.tempID === b.tempID)));
     }
 
     /**
@@ -219,6 +219,6 @@ export class DragAndDropQuestionUtil {
      * @return {boolean}
      */
     isSameDragItem(a?: DragItem, b?: DragItem): boolean {
-        return a === b || (a !== undefined && b !== undefined && ((a.id && b.id && a.id === b.id) || (a.tempID != undefined && b.tempID != undefined && a.tempID === b.tempID)));
+        return a === b || (a != undefined && b != undefined && ((a.id && b.id && a.id === b.id) || (a.tempID != undefined && b.tempID != undefined && a.tempID === b.tempID)));
     }
 }


### PR DESCRIPTION
### Motivation and Context

There are several `null is not an object` errors on Sentry.

### Description

Using `!== undefined` only checks for `undefined` but *not* for `null`, so we have to change the check to `!= undefined` to account for both possibilities. (See https://www.tektutorialshub.com/typescript/typescript-null-undefined-strict-null-checks/)
