### PR TITLE
[Bugfix] TypeError whenever a grading sclale gets deleted

### DIFF
--- a/src/main/webapp/app/entities/grading-scale.model.ts
+++ b/src/main/webapp/app/entities/grading-scale.model.ts
@@ -5,6 +5,11 @@ export class GradingScale implements BaseEntity {
     public id?: number;
     public gradeType: GradeType = GradeType.NONE;
     public gradeSteps: GradeStep[];
+
+    constructor(gradeType: GradeType = GradeType.GRADE, gradeSteps: GradeStep[] = []) {
+        this.gradeType = gradeType;
+        this.gradeSteps = gradeSteps;
+    }
 }
 
 export enum GradeType {

--- a/src/main/webapp/app/grading-system/grading-system.component.ts
+++ b/src/main/webapp/app/grading-system/grading-system.component.ts
@@ -14,10 +14,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 })
 export class GradingSystemComponent implements OnInit {
     ButtonSize = ButtonSize;
-    gradingScale: GradingScale = {
-        gradeSteps: [],
-        gradeType: GradeType.GRADE,
-    };
+    gradingScale = new GradingScale();
     lowerBoundInclusivity = true;
     existingGradingScale = false;
     firstPassingGrade: string;
@@ -152,10 +149,7 @@ export class GradingSystemComponent implements OnInit {
                 this.dialogErrorSource.next('');
             });
         }
-        this.gradingScale = {
-            gradeSteps: [],
-            gradeType: GradeType.GRADE,
-        };
+        this.gradingScale = new GradingScale();
     }
 
     /**

--- a/src/main/webapp/app/grading-system/grading-system.component.ts
+++ b/src/main/webapp/app/grading-system/grading-system.component.ts
@@ -152,8 +152,10 @@ export class GradingSystemComponent implements OnInit {
                 this.dialogErrorSource.next('');
             });
         }
-        this.gradingScale = new GradingScale();
-        this.gradingScale.gradeType = GradeType.GRADE;
+        this.gradingScale = {
+            gradeSteps: [],
+            gradeType: GradeType.GRADE,
+        };
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A TypeError used to occur whenever a grading scale gets deleted
[Sentry](https://sentry.ase.in.tum.de/organizations/artemis/issues/959/?project=2&referrer=AssignedActivityEmail)

### Description
<!-- Describe your changes in detail -->
Now whenever a grading scale gets deleted, the grade steps get set to an empty array

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis as an instructor
2. Navigate to Course Administration
3. Navigate to a specific course -> Grade key
4. Save a grading scale and open the console
5. Delete the grading scale and check that no TypeErrors get thrown

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
Unchanged