### PR TITLE
Fix an error when an participation does not exist

### DIFF
--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts
@@ -573,7 +573,7 @@ export class QuizParticipationComponent implements OnInit, OnDestroy {
         }
 
         // apply submission if it exists
-        if (participation.results?.length) {
+        if (participation?.results?.length) {
             this.submission = participation.results[0].submission as QuizSubmission;
 
             // update submission time


### PR DESCRIPTION
Description
We now check if the participation exists first

Sentry Issue: [ARTEMIS-96](https://sentry.ase.in.tum.de/organizations/artemis/issues/295/?referrer=github_integration)

```
TypeError: Cannot read property 'exercise' of null
  at updateParticipationFromServer (./src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts:571:42)
  at call (./src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts:231:22)
...
(29 additional frame(s) were not displayed)
```
