### PR TITLE
Fixed bug in assessment-locks.component.html (found by Sentry)

### DIFF
--- a/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
+++ b/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
@@ -34,7 +34,7 @@
                         ></fa-icon>
                     </td>
                     <td>{{ submission.participation!.exercise!.title || '' }}</td>
-                    <td>{{ submission.submissionDate?.date() | artemisDate: 'long-date' }}</td>
+                    <td>{{ submission.submissionDate | artemisDate: 'long-date' }}</td>
                     <td>{{ submission.participation!.submissions ? submission.participation!.submissions.length : 0 }}</td>
                     <td>
                         <span *ngIf="submission.latestResult?.score != undefined">{{ submission.latestResult!.score }}%</span>


### PR DESCRIPTION
### Checklist
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
(I was assigned to an issue that was discovered in Sentry : ISSUE # ARTEMIS-HN)
A TypeError Exception is thrown in the class **assessment-locks.component.html** in the following line:
`<td>{{ submission.submissionDate?.date() | artemisDate: 'long-date' }}</td>`

### Description
<!-- Describe your changes in detail -->
I removed the "?.date()" part, so the code line looks now as follows : 
`<td>{{ submission.submissionDate | artemisDate: 'long-date' }}</td>`

How did I come up with this solution: (Please correct me if I am wrong!)
- **submissionDate** is of type **Moment** which is just a renamed instance of moment() from the [Moment.js](https://momentjs.com/) library. 
![image](https://user-images.githubusercontent.com/65814168/117717294-ed784080-b1da-11eb-8d38-98a698546d2b.png)
- Based on the [Docs](https://momentjs.com/docs/#/get-set/date/) the **.date()** method returns one number (month or day of the month) but not a full date.
- Looking at the context
  - the surrounding lines of code indicate the date to be a full date and not just one number (day/month)
    `<td>{{ submission.participation!.exercise!.title || '' }}</td>`
`    <td>{{ submission.submissionDate?.date() | artemisDate: 'long-date' }}</td>`
    `<td>{{ submission.participation!.submissions ?submission.participation!.submissions.length : 0 }}</td>`
  - the method **.date()** is (almost) never used anywhere else -> Indicator that this is an error
![image](https://user-images.githubusercontent.com/65814168/117719992-63ca7200-b1de-11eb-8694-e45b9b3dce89.png)
  - looking up instances of the pipe to artemisDate shows a very similar case with **studentExam.submissionDate** where submissionDate is again of type **Moment** and has no prefix "**?.date()**".
![image](https://user-images.githubusercontent.com/65814168/117720341-dcc9c980-b1de-11eb-9d97-975463c059f9.png)
- Why did I remove "**?**"
  - the **transform** method inside artemisDate should handle any edge case already
![image](https://user-images.githubusercontent.com/65814168/117721935-c290eb00-b1e0-11eb-8ef2-a5ec08ab38db.png)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
All tests inside the corresponding **spec.ts** file still work.

But I do not know how to test this fix in any other way? **If you do please tell me.** 

Especially considering the fact that this issue concerns assessments but only 13 individuals experienced any issues tells me that forcing this error to appear might be quite a rare edge case?

<!--### Test Coverage -->
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

