### PR TITLE
Change the 'assessment' route to 'submissions'

### DIFF
--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
@@ -147,7 +147,7 @@
                 ></a>
                 <a
                     *ngIf="course.isAtLeastInstructor && details.type !== exerciseType.PROGRAMMING && details.type !== exerciseType.QUIZ"
-                    [routerLink]="['/course-management', course.id, details.type + '-exercises', details.id, 'assessment']"
+                    [routerLink]="['/course-management', course.id, details.type + '-exercises', details.id, 'submissions']"
                     class="btn btn-success mr-1 mb-1"
                     [ngbTooltip]="'artemisApp.courseOverview.exerciseDetails.instructorActions.submissions' | artemisTranslate"
                     ><fa-icon [icon]="'book'"></fa-icon

--- a/src/main/webapp/app/exam/manage/exam-management.route.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.route.ts
@@ -646,7 +646,7 @@ export const examManagementRoute: Routes = [
         canActivate: [UserRouteAccessService],
     },
     {
-        path: ':examId/exercise-groups/:exerciseGroupId/file-upload-exercises/:exerciseId/assessment',
+        path: ':examId/exercise-groups/:exerciseGroupId/file-upload-exercises/:exerciseId/submissions',
         component: FileUploadAssessmentDashboardComponent,
         data: {
             authorities: [Authority.ADMIN, Authority.INSTRUCTOR, Authority.EDITOR, Authority.TA],
@@ -655,7 +655,7 @@ export const examManagementRoute: Routes = [
         canActivate: [UserRouteAccessService],
     },
     {
-        path: ':examId/exercise-groups/:exerciseGroupId/text-exercises/:exerciseId/assessment',
+        path: ':examId/exercise-groups/:exerciseGroupId/text-exercises/:exerciseId/submissions',
         component: TextAssessmentDashboardComponent,
         data: {
             authorities: [Authority.ADMIN, Authority.INSTRUCTOR, Authority.EDITOR, Authority.TA],
@@ -676,7 +676,7 @@ export const examManagementRoute: Routes = [
         loadChildren: () => import('../../exercises/text/manage/example-text-submission/example-text-submission.module').then((m) => m.ArtemisExampleTextSubmissionModule),
     },
     {
-        path: ':examId/exercise-groups/:exerciseGroupId/modeling-exercises/:exerciseId/assessment',
+        path: ':examId/exercise-groups/:exerciseGroupId/modeling-exercises/:exerciseId/submissions',
         component: ModelingAssessmentDashboardComponent,
         data: {
             authorities: [Authority.ADMIN, Authority.INSTRUCTOR, Authority.EDITOR, Authority.TA],
@@ -694,7 +694,7 @@ export const examManagementRoute: Routes = [
         canActivate: [UserRouteAccessService],
     },
     {
-        path: ':examId/exercise-groups/:exerciseGroupId/programming-exercises/:exerciseId/assessment',
+        path: ':examId/exercise-groups/:exerciseGroupId/programming-exercises/:exerciseId/submissions',
         component: ProgrammingAssessmentDashboardComponent,
         data: {
             authorities: [Authority.ADMIN, Authority.INSTRUCTOR, Authority.EDITOR, Authority.TA],

--- a/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.route.ts
+++ b/src/main/webapp/app/exercises/file-upload/assess/file-upload-assessment.route.ts
@@ -25,7 +25,7 @@ export const routes: Routes = [
         canActivate: [UserRouteAccessService],
     },
     {
-        path: ':courseId/file-upload-exercises/:exerciseId/assessment',
+        path: ':courseId/file-upload-exercises/:exerciseId/submissions',
         component: FileUploadAssessmentDashboardComponent,
         data: {
             authorities: [Authority.ADMIN, Authority.INSTRUCTOR, Authority.EDITOR, Authority.TA],

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
@@ -74,7 +74,7 @@
                             </a>
                             <a
                                 *ngIf="fileUploadExercise.isAtLeastInstructor"
-                                [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id, 'assessment']"
+                                [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id, 'submissions']"
                                 class="btn btn-success btn-sm mr-1"
                             >
                                 <fa-icon [icon]="'book'"></fa-icon>

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.route.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.route.ts
@@ -27,7 +27,7 @@ export const routes: Routes = [
     },
 
     {
-        path: ':courseId/modeling-exercises/:exerciseId/assessment',
+        path: ':courseId/modeling-exercises/:exerciseId/submissions',
         component: ModelingAssessmentDashboardComponent,
         data: {
             authorities: [Authority.ADMIN, Authority.INSTRUCTOR, Authority.EDITOR, Authority.TA],

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
@@ -83,7 +83,7 @@
                             </a>
                             <a
                                 *ngIf="modelingExercise.isAtLeastInstructor"
-                                [routerLink]="['/course-management', courseId, 'modeling-exercises', modelingExercise.id, 'assessment']"
+                                [routerLink]="['/course-management', courseId, 'modeling-exercises', modelingExercise.id, 'submissions']"
                                 class="btn btn-success btn-sm mr-1"
                             >
                                 <fa-icon [icon]="'book'"></fa-icon>

--- a/src/main/webapp/app/exercises/programming/assess/programming-assessment.route.ts
+++ b/src/main/webapp/app/exercises/programming/assess/programming-assessment.route.ts
@@ -7,7 +7,7 @@ import { ProgrammingAssessmentDashboardComponent } from 'app/exercises/programmi
 
 export const routes: Routes = [
     {
-        path: ':courseId/programming-exercises/:exerciseId/assessment',
+        path: ':courseId/programming-exercises/:exerciseId/submissions',
         component: ProgrammingAssessmentDashboardComponent,
         data: {
             authorities: [Authority.ADMIN, Authority.INSTRUCTOR, Authority.EDITOR, Authority.TA],

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -217,7 +217,7 @@
                             <div class="btn-group-vertical mr-1 mb-1">
                                 <a
                                     *ngIf="programmingExercise.isAtLeastInstructor"
-                                    [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id, 'assessment']"
+                                    [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id, 'submissions']"
                                     class="btn btn-success btn-sm mr-1 mb-1"
                                 >
                                     <fa-icon [icon]="'book'"></fa-icon>

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -28,7 +28,7 @@
 
     <a
         *ngIf="course.isAtLeastInstructor && exercise.type !== exerciseType.QUIZ"
-        [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, exercise.type + '-exercises', exercise.id, 'assessment']"
+        [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, exercise.type + '-exercises', exercise.id, 'submissions']"
         class="btn btn-success btn-sm mr-1"
     >
         <fa-icon [icon]="'book'"></fa-icon>

--- a/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
@@ -17,7 +17,7 @@
     <!--Submissions -->
     <a
         *ngIf="exercise.isAtLeastInstructor && exercise.course"
-        [routerLink]="['/course-management', courseId, exercise.type! + '-exercises', exercise.id!, 'assessment']"
+        [routerLink]="['/course-management', courseId, exercise.type! + '-exercises', exercise.id!, 'submissions']"
         class="btn btn-primary btn-sm mr-1"
     >
         <fa-icon [icon]="['far', 'list-alt']"></fa-icon>

--- a/src/main/webapp/app/exercises/text/assess/text-submission-assessment.route.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-submission-assessment.route.ts
@@ -77,7 +77,7 @@ export class FeedbackConflictResolver implements Resolve<TextSubmission[] | unde
 export const NEW_ASSESSMENT_PATH = 'submissions/new/assessment';
 export const textSubmissionAssessmentRoutes: Routes = [
     {
-        path: 'assessment',
+        path: 'submissions',
         component: TextAssessmentDashboardComponent,
         data: {
             authorities: [Authority.ADMIN, Authority.INSTRUCTOR, Authority.EDITOR, Authority.TA],

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-row-buttons.component.html
@@ -16,7 +16,7 @@
     <!-- Submissions -->
     <a
         *ngIf="exercise.isAtLeastInstructor"
-        [routerLink]="['/course-management', courseId, exercise.type + '-exercises', exercise.id, 'assessment']"
+        [routerLink]="['/course-management', courseId, exercise.type + '-exercises', exercise.id, 'submissions']"
         class="btn btn-success btn-sm mr-1"
     >
         <fa-icon [icon]="'book'"></fa-icon>

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -325,7 +325,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
 
     get exerciseRouterLink(): string | null {
         if (this.exercise && [ExerciseType.MODELING, ExerciseType.TEXT, ExerciseType.FILE_UPLOAD].includes(this.exercise.type!)) {
-            return `/course-management/${this.courseId}/${this.exercise.type}-exercises/${this.exercise!.id}/assessment`;
+            return `/course-management/${this.courseId}/${this.exercise.type}-exercises/${this.exercise!.id}/submissions`;
         }
 
         return null;

--- a/src/main/webapp/app/utils/navigation.utils.ts
+++ b/src/main/webapp/app/utils/navigation.utils.ts
@@ -82,9 +82,9 @@ export const getExerciseSubmissionsLink = (exerciseType: ExerciseType, courseId:
             exerciseGroupId.toString(),
             exerciseType + '-exercises',
             exerciseId.toString(),
-            'assessment',
+            'submissions',
         ];
     }
 
-    return ['/course-management', courseId.toString(), exerciseType + '-exercises', exerciseId.toString(), 'assessment'];
+    return ['/course-management', courseId.toString(), exerciseType + '-exercises', exerciseId.toString(), 'submissions'];
 };

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail-table-row.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail-table-row.component.spec.ts
@@ -102,7 +102,7 @@ describe('StudentExamDetailTableRowComponent', () => {
         };
         const route = studentExamDetailTableRowComponent.getAssessmentLink(programmingExercise);
         expect(getAssessmentLinkSpy).to.have.been.calledOnce;
-        expect(route).to.deep.equal(['/course-management', '23', 'exams', '1', 'exercise-groups', '13', 'programming-exercises', '12', 'assessment']);
+        expect(route).to.deep.equal(['/course-management', '23', 'exams', '1', 'exercise-groups', '13', 'programming-exercises', '12', 'submissions']);
     });
 
     it('should route to modeling submission', () => {

--- a/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -436,7 +436,7 @@ describe('ModelingAssessmentEditorComponent', () => {
             component.courseId = courseId;
             component.modelingExercise = { id: exerciseId } as Exercise;
             component.exerciseId = exerciseId;
-            const url = ['/course-management', courseId.toString(), 'modeling-exercises', exerciseId.toString(), 'submissions', modelingSubmission.id!.toString(), 'submissions'];
+            const url = ['/course-management', courseId.toString(), 'modeling-exercises', exerciseId.toString(), 'submissions', modelingSubmission.id!.toString(), 'assessment'];
             const queryParams = { queryParams: { 'correction-round': correctionRound } };
 
             tick(500);

--- a/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -436,7 +436,7 @@ describe('ModelingAssessmentEditorComponent', () => {
             component.courseId = courseId;
             component.modelingExercise = { id: exerciseId } as Exercise;
             component.exerciseId = exerciseId;
-            const url = ['/course-management', courseId.toString(), 'modeling-exercises', exerciseId.toString(), 'submissions', modelingSubmission.id!.toString(), 'assessment'];
+            const url = ['/course-management', courseId.toString(), 'modeling-exercises', exerciseId.toString(), 'submissions', modelingSubmission.id!.toString(), 'submissions'];
             const queryParams = { queryParams: { 'correction-round': correctionRound } };
 
             tick(500);

--- a/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
@@ -222,7 +222,7 @@ describe('CourseExerciseDetailsComponent', () => {
         expect(comp.exerciseRatedBadge(result)).to.equal('badge-info');
 
         // has correct router link
-        expect(comp.exerciseRouterLink).to.equal(`/course-management/1/text-exercises/42/assessment`);
+        expect(comp.exerciseRouterLink).to.equal(`/course-management/1/text-exercises/42/submissions`);
     }));
 
     it('should not allow to publish a build plan for text exercises', () => {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context

The route name was inconsistent with what the page actually does (and how the button to it is called): It shows the submissions of an exercise. This also caused the breadcrumbs to not work properly when inspecting an individual submission and trying to go back to "Submissions".

### Description

We change `/assessment` to `/submissions`.

### Steps for Testing

For both course and exam:
1. Check that you can access the "Submissions" page of every exercise type without error
2. Go to an individual submission ("Open Assessment") and navigate back to "Submissions" using the breadcrumbs

![grafik](https://user-images.githubusercontent.com/72132281/117727158-f4598000-b1e7-11eb-9ea7-99dfe8f080aa.png)

3. Also check that the "Submissions" button in the student's view for a single exercise still works (if you are an instructor viewing an exercise)