### PR TITLE
[Sentry-issue] Fix null pointer for Example Submission

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/ExampleSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ExampleSubmission.java
@@ -40,7 +40,7 @@ public class ExampleSubmission extends DomainObject {
     @Column(name = "assessment_explanation")
     private String assessmentExplanation;
 
-    public Boolean isUsedForTutorial() {
+    public boolean isUsedForTutorial() {
         return Boolean.TRUE.equals(usedForTutorial);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/ExampleSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ExampleSubmission.java
@@ -41,7 +41,7 @@ public class ExampleSubmission extends DomainObject {
     private String assessmentExplanation;
 
     public Boolean isUsedForTutorial() {
-        return usedForTutorial;
+        return Boolean.TRUE.equals(usedForTutorial);
     }
 
     public void setUsedForTutorial(Boolean usedForTutorial) {


### PR DESCRIPTION
### Fix sentry issue [Artemis - 7](https://sentry.ase.in.tum.de/organizations/artemis/issues/8/?environment=prod&project=2#exception)

Error message:
> Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "de.tum.in.www1.artemis.domain.ExampleSubmission.isUsedForTutorial()" is null

It seems that the problem was that the `isUsedForTutorial` field was `null` when retrieved from the database. I am not sure why this is the case, but one possible fix is to treat the `null` case as being set to `false`.