### PR TITLE
Add --illegal-access=warn to bootRun Gradle Task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,10 @@ springBoot {
     mainClass = "de.tum.in.www1.artemis.ArtemisApp"
 }
 
+bootRun {
+    jvmArgs = ["--illegal-access=warn"]
+}
+
 // Execute the test cases: ./gradlew executeTests
 
 test {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We should also add `--illegal-access=warn` to the `bootRun` task to make it work properly when Artemis is run from the command line interface.

### Steps for Testing
1. Run Artemis from the command line without the addition, it should fail at some point
2. Run Artemis with the change, it should work now

