### PR TITLE
[Bugfix] Displaying programming exercise grading actions to instructors

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
@@ -5,7 +5,7 @@
     </div>
     <ng-container *ngIf="!isLoading">
         <div class="top-bar">
-            <div class="d-flex align-items-center" *ngIf="exercise.staticCodeAnalysisEnabled; else tabPlaceholder">
+            <div class="d-flex align-items-center" *ngIf="programmingExercise.staticCodeAnalysisEnabled; else tabPlaceholder">
                 <div class="tab-item test-cases" (click)="selectTab('test-cases')" [ngClass]="activeTab == 'test-cases' ? 'active' : ''">
                     <b>Test Cases</b>
                 </div>
@@ -22,8 +22,8 @@
                     [hasUpdatedGradingConfig]="hasUpdatedGradingConfig"
                 ></jhi-programming-exercise-configure-grading-status>
                 <jhi-programming-exercise-configure-grading-actions
-                    *ngIf="exercise.isAtLeastInstructor"
-                    [exercise]="exercise"
+                    *ngIf="programmingExercise.isAtLeastInstructor"
+                    [exercise]="programmingExercise"
                     [hasUpdatedGradingConfig]="hasUpdatedGradingConfig"
                     [isSaving]="isSaving"
                 ></jhi-programming-exercise-configure-grading-actions>
@@ -43,7 +43,7 @@
                                 </label>
                             </div>
                             <jhi-programming-exercise-grading-table-actions
-                                [exercise]="exercise"
+                                [exercise]="programmingExercise"
                                 [hasUnsavedChanges]="!!changedTestCaseIds.length"
                                 [isSaving]="isSaving"
                                 (onReset)="resetTestCases()"
@@ -204,20 +204,20 @@
                             [testCases]="filteredTestCases"
                             [testCaseStatsMap]="gradingStatistics?.testCaseStatsMap"
                             [totalParticipations]="gradingStatistics?.numParticipations"
-                            [exercise]="exercise"
+                            [exercise]="programmingExercise"
                             (testCaseColorsChange)="testCaseColors = $event"
                         ></jhi-test-case-distribution-chart>
                     </div>
                 </div>
             </div>
-            <div *ngIf="activeTab == 'code-analysis' && exercise.staticCodeAnalysisEnabled">
+            <div *ngIf="activeTab == 'code-analysis' && programmingExercise.staticCodeAnalysisEnabled">
                 <div class="grading-table-layout">
                     <div>
                         <div class="d-flex align-items-center justify-content-between mb-4">
                             <h2 jhiTranslate="artemisApp.programmingExercise.configureGrading.categories.title">Code Analysis Categories</h2>
                             <!-- TODO currently the reset button is permanently disabled -->
                             <jhi-programming-exercise-grading-table-actions
-                                [exercise]="exercise"
+                                [exercise]="programmingExercise"
                                 [hasUnsavedChanges]="!!changedCategoryIds.length"
                                 [isSaving]="isSaving"
                                 (onReset)="resetCategories()"
@@ -364,7 +364,7 @@
                         <jhi-sca-category-distribution-chart
                             [categories]="staticCodeAnalysisCategories"
                             [categoryIssuesMap]="gradingStatistics?.categoryIssuesMap"
-                            [exercise]="exercise"
+                            [exercise]="programmingExercise"
                             (categoryColorsChange)="categoryColors = $event"
                         ></jhi-sca-category-distribution-chart>
                     </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
ented too many database calls
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Description
<!-- Describe your changes in detail -->
The grading actions _Trigger All_ & _Re-evaluate_ for programming exercises were not displayed to instructors.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in as instructor
2. Open the grading page of a programming exercise
3. See that the buttons are displayed properly

Repeat the steps as editor
1. Log in as editor
2. Open the grading page of a programming exercise
3. See that the buttons are **not** displayed 

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
The buttons should be displayed for the instructor: 
![image](https://user-images.githubusercontent.com/63976129/118130964-3cea8680-b3fe-11eb-8495-b04643952830.png)

