### PR TITLE
[Feature] Hide Future Lectures

### DIFF
--- a/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
+++ b/src/main/webapp/app/overview/course-lectures/course-lectures.component.ts
@@ -87,7 +87,7 @@ export class CourseLecturesComponent implements OnInit, OnDestroy {
                     groupedLectures[dateIndex] = {
                         start: moment(dateValue).startOf('week'),
                         end: moment(dateValue).endOf('week'),
-                        isCollapsed: dateValue.isBefore(moment(), 'week'),
+                        isCollapsed: dateValue.isBefore(moment(), 'week') || dateValue.isAfter(moment(), 'week'),
                         isCurrentWeek: dateValue.isSame(moment(), 'week'),
                         lectures: [],
                     };


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some lecturers already create the lectures and upload the material at the start of the semester. This leads to the problem that the current week of the lecture is hidden below many unreleased lectures.

### Description
<!-- Describe your changes in detail -->
This PR changes the behavior of the lectures overview, so that only the current week is not collapsed when loading the lecture overview.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create three lectures. One that is at least one week old, one that is in the current week, one that is in some future week
3. Navigate to the lecture overview from the student's perspective
4. Make sure that only the current week is expanded. All previous and future weeks should be collapsed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Old standard view:
![Bildschirmfoto 2021-05-13 um 17 36 34](https://user-images.githubusercontent.com/38322605/118149406-cfe0ec00-b411-11eb-9c1f-4b8c4fef34bc.png)
New standard view:
![Bildschirmfoto 2021-05-13 um 17 36 47](https://user-images.githubusercontent.com/38322605/118149439-d96a5400-b411-11eb-94b0-5e731e424406.png)
