### PR TITLE
[bugfix] unchecked call to code editor

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-base-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/code-editor/code-editor-instructor-base-container.component.ts
@@ -86,7 +86,8 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
         private participationService: ParticipationService,
         protected route: ActivatedRoute,
         private jhiAlertService: JhiAlertService,
-    ) {}
+    ) {
+    }
 
     /**
      * Initialize the route params subscription.
@@ -317,7 +318,8 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
                 }),
             )
             .subscribe(
-                () => {},
+                () => {
+                },
                 (err) => this.onError(err),
             );
     }
@@ -341,7 +343,8 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
                 }),
             )
             .subscribe(
-                () => {},
+                () => {
+                },
                 (err) => this.onError(err),
             );
     }
@@ -355,7 +358,11 @@ export abstract class CodeEditorInstructorBaseContainerComponent implements OnIn
         this.jhiAlertService.error(`artemisApp.editor.errors.${error}`);
     }
 
+    /**
+     * Returns whether the component can be left. Returns false if the code editor has unsaved changes
+     * or true if not or if there is no code editor
+     */
     canDeactivate() {
-        return this.codeEditorContainer.canDeactivate();
+        return this.codeEditorContainer?.canDeactivate() ?? true;
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
Solves Orion's [#49](https://github.com/ls1intum/Orion/issues/49)

### Description
Before leaving the code editor view it is ensured the editor does not have unsaved changes. The Orion variation of that view does not have a code editor, crashing the check and causing the mentioned issue

### Steps for Testing
Either alternative suffices!

#### With a browser:
1. Log in to Artemis as Editor or above
2. Locate or create a programming exercise
3. Click on "Edit in Editor"
4. Adapt the URL ending with /code-editor/_id_ to /code-editor/ide/_id_ to access Orion's view
5. "Course Management", "Course Overview" and the breadcrumbs should work as expected with no errors thrown
6. The selector and the Orion buttons won't work (your browser is no Orion) but should fail with "l().orionVCSConnector is undefined" and not the previous error

#### With Orion
1. Make sure not to use ts3 since ts3's vcs does not work
2. Run Orion
3. Adapt Intellij Settings -> Tools -> Orion -> Artemis URL to point to the test server you're using
4. Log in as instructor
5. Locate or create a programming exercise
6. Click on "Edit with Orion" from the instructor's exercise view (right side of the table, might require scrolling)
7. Load the exercise as Instructor
8. The selector and submit button should work, test locally is currently broken, that's adressed in Orion's [#46](https://github.com/ls1intum/Orion/pull/46)
9. The other buttons should also work, be aware though there is currently no way to navigate back, that will be adressed in Orion's [#45](https://github.com/ls1intum/Orion/pull/45)

### Test Coverage
Unchanged

### Screenshots
Refer to the linked issue
