### PR TITLE
[Bugfix] - Fix Button colors in exercise detail instructor actions

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -84,7 +84,7 @@
                     *ngIf="!QUIZ_ENDED_STATUS.includes(quizExerciseStatus)"
                     [class.disabled]="quizExerciseStatus === QuizStatus.ACTIVE"
                     [routerLink]="['/course-management', courseId, exercise.type + '-exercises', exercise.id, 'edit']"
-                    class="btn btn-primary btn-sm mr-1"
+                    class="btn btn-warning btn-sm mr-1"
                 >
                     <fa-icon [icon]="'wrench'"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
@@ -92,7 +92,7 @@
                 <a
                     *ngIf="QUIZ_ENDED_STATUS.includes(quizExerciseStatus) && exercise.isAtLeastInstructor"
                     [routerLink]="['/course-management', courseId, 'quiz-exercises', exercise.id, 're-evaluate']"
-                    class="btn btn-primary btn-sm mr-1"
+                    class="btn btn-warning btn-sm mr-1"
                 >
                     <fa-icon [icon]="'wrench'"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="entity.action.re-evaluate">Re-evaluate</span>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We show edit and re-evaluate buttons in yellow

### Description
<!-- Describe your changes in detail -->
Changed edit and re-evaluate button color to yellow (button-warning)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate into a exercise detail page as an instructor
3. Make sure the edit/re-evaluate button the the top right corner is yellow

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
![image](https://user-images.githubusercontent.com/44401560/118354440-5c52f200-b56b-11eb-8fee-0cf48a497a1c.png)

After:
![image](https://user-images.githubusercontent.com/44401560/118355205-1e57cd00-b56f-11eb-8420-da31622ef6d3.png)
![image](https://user-images.githubusercontent.com/44401560/118355210-23b51780-b56f-11eb-82bf-9c1ef662a40a.png)


