### PR TITLE
Fix plagiarism issues on text exercises with special characters

### DIFF
--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/plagiarism-split-view.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/plagiarism-split-view.component.ts
@@ -91,6 +91,7 @@ export class PlagiarismSplitViewComponent implements AfterViewInit, OnChanges, O
         const filesToMatchedElements = new Map();
 
         matches.forEach(({ start, length }) => {
+            // skip empty jplag (whitespace) matches
             if (length === 0) {
                 return;
             }

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/plagiarism-split-view.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/plagiarism-split-view.component.ts
@@ -91,6 +91,9 @@ export class PlagiarismSplitViewComponent implements AfterViewInit, OnChanges, O
         const filesToMatchedElements = new Map();
 
         matches.forEach(({ start, length }) => {
+            if (length === 0) {
+                return;
+            }
             const file = submission.elements[start].file || 'none';
 
             if (!filesToMatchedElements.has(file)) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and context:
Fixes https://sentry.ase.in.tum.de/organizations/artemis/issues/452/

### Description
<!-- Describe your changes in detail -->
Well this was painful to figure out :smile: 
Jplag sometimes reports matches with a length of 0 (when there are characters like tabs in a text submission?). These "empty" matches break the comparison view. My changes simply skip these matches when rendering them. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Review code, the issue is hard to reproduce but you can try checking plagiarism on ts1 -> Joscha Henningsens Test Course -> Test Text Exercise. This should display two submissions next to each other.


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

before | after 
--- | ---
![Screenshot_20210515_122129](https://user-images.githubusercontent.com/44805696/118357193-27e63280-b579-11eb-9859-aa62c11f4e14.png) | ![Screenshot_20210515_122156](https://user-images.githubusercontent.com/44805696/118357205-2d437d00-b579-11eb-8d14-453653cb783d.png)


