### PR TITLE
[Bugfix] Removing quiz action buttons for editor

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
@@ -71,7 +71,7 @@
                     </td>
                     <td>{{ quizExercise.maxPoints }}</td>
                     <td>{{ exerciseService.isIncludedInScore(quizExercise) }}</td>
-                    <td class="text-right">
+                    <td class="text-right" *ngIf="quizExercise.isAtLeastEditor">
                         <div class="btn-group flex-btn-group-container">
                             <button
                                 type="submit"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Description
<!-- Describe your changes in detail -->
Tutors have been able to set quizzes visible - this was fixed server-sided recently - but the UI was forgotten. The buttons don't work for a tutor (403) so they are removed within this PR.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Prepare a quiz that is not visible
2. Prepare a quiz that is visible
3. Prepare a quiz that is started
4. Prepare a quiz that is over but not yet ready for practice
5. Check whether tutors do not see the buttons 
6. Check whether editors and tutors can see the buttons to change the state of the quiz

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
editor+ view:
![image](https://user-images.githubusercontent.com/63976129/118381190-b776fa00-b5e8-11eb-9142-6a26c3e4b3d0.png)

tutor view:
![image](https://user-images.githubusercontent.com/63976129/118381221-ee4d1000-b5e8-11eb-9e05-98aaf58f4983.png)

