### PR TITLE
Add an exercise list to the course details page

### DIFF
--- a/src/main/webapp/app/course/manage/detail/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.html
@@ -141,6 +141,84 @@
             ></jhi-course-detail-bar-chart>
         </div>
         <hr />
+        <table class="table table-striped" aria-describedby="course-exercises">
+            <thead>
+                <tr jhiSort>
+                    <th jhiSortBy="type"><span jhiTranslate="artemisApp.exercise.type">Type</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th jhiSortBy="title"><span jhiTranslate="artemisApp.exercise.detail.title">Title</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th jhiSortBy="releaseDate"><span jhiTranslate="artemisApp.course.releaseDate">Email</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th jhiSortBy="dueDate"><span jhiTranslate="artemisApp.course.dueDate">Name</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th jhiSortBy="assessmentDueDate"><span jhiTranslate="artemisApp.course.assessmentDueDate">Lang Key</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody *ngIf="course.exercises">
+                <tr *ngFor="let exercise of course.exercises; trackBy: trackExercise">
+                    <td>
+                        <ngb-highlight [result]="exercise.type" [term]="searchTermString"></ngb-highlight>
+                    </td>
+                    <td>
+                        <a [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id]">{{ exercise.title }}</a>
+                    </td>
+                    <td>
+                        <ngb-highlight [result]="exercise.releaseDate"></ngb-highlight>
+                    </td>
+                    <td>
+                        <ngb-highlight [result]="exercise.dueDate"></ngb-highlight>
+                    </td>
+                    <td>
+                        <ngb-highlight [result]="exercise.assessmentDueDate"></ngb-highlight>
+                    </td>
+                    <td>
+                        <!-- TODO: statistic -->
+                    </td>
+                    <td>
+                        <!-- TODO: reduce duplication -->
+                        <div class="row-flex button-row">
+                            <a
+                                *ngIf="course.isAtLeastEditor && exercise.type !== exerciseType.QUIZ"
+                                [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id, 'edit']"
+                                class="btn btn-warning mr-1 mb-1"
+                                [ngbTooltip]="'entity.action.edit' | artemisTranslate"
+                            ><fa-icon [icon]="'wrench'"></fa-icon
+                            ></a>
+                            <!-- if the quiz is past
+                            <a
+                                *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.QUIZ"
+                                [routerLink]="['/course-management', course.id, details.type + '-exercises', exercise.id, 're-evaluate']"
+                                class="btn btn-warning mr-1 mb-1"
+                                [ngbTooltip]="'entity.action.re-evaluate' | artemisTranslate"
+                            ><fa-icon [icon]="'wrench'"></fa-icon
+                            ></a>
+                            -->
+                            <a
+                                *ngIf="course.isAtLeastTutor"
+                                [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id, 'scores']"
+                                class="btn btn-info mr-1 mb-1"
+                                [ngbTooltip]="'entity.action.scores' | artemisTranslate"
+                            ><fa-icon [icon]="'table'"></fa-icon
+                            ></a>
+                            <a
+                                *ngIf="course.isAtLeastInstructor && exercise.type !== exerciseType.PROGRAMMING && exercise.type !== exerciseType.QUIZ"
+                                [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id, 'submissions']"
+                                class="btn btn-success mr-1 mb-1"
+                                [ngbTooltip]="'artemisApp.courseOverview.exerciseDetails.instructorActions.submissions' | artemisTranslate"
+                            ><fa-icon [icon]="'book'"></fa-icon
+                            ></a>
+                            <a
+                                *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.PROGRAMMING"
+                                [routerLink]="['/course-management', course.id, 'programming-exercises', exercise.id, 'grading', 'test-cases']"
+                                class="btn btn-info mr-1 mb-1"
+                                [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.shortTitle' | artemisTranslate"
+                            ><fa-icon class="grading-icon" [icon]="'file-signature'"></fa-icon
+                            ></a>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <hr />
         <div>
             <h2><span jhiTranslate="artemisApp.course.detail.title">Course Details:</span></h2>
         </div>

--- a/src/main/webapp/app/course/manage/detail/course-detail.component.ts
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.ts
@@ -13,6 +13,7 @@ import { ButtonSize } from 'app/shared/components/button.component';
 import { CourseManagementDetailViewDto } from 'app/course/manage/course-management-detail-view-dto.model';
 import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 import { onError } from 'app/shared/util/global.utils';
+import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 
 export enum DoughnutChartType {
     ASSESSMENT = 'ASSESSMENT',
@@ -43,6 +44,9 @@ export class CourseDetailComponent implements OnInit, OnDestroy {
     private dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
     paramSub: Subscription;
+
+    searchTermString = '';
+    exerciseType = ExerciseType;
 
     constructor(
         private eventManager: JhiEventManager,
@@ -118,5 +122,14 @@ export class CourseDetailComponent implements OnInit, OnDestroy {
             (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
         );
         this.router.navigate(['/course-management']);
+    }
+
+    /**
+     * Returns the unique identifier the exercises in the collection
+     * @param index of the exercise in the collection
+     * @param exercise current exercise
+     */
+    trackExercise(index: number, exercise: Exercise) {
+        return exercise.id;
     }
 }


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [ ] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [ ] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] Server: I documented the Java code using JavaDoc style.
- [ ] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [ ] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [ ] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] Client: I translated all the newly inserted strings into German and English

### Motivation, Context and Description

Extends the course detail page to include a list of exercises for quick navigation.

### Steps for Testing

Open the course details page of a course and check the exercises list. It should display all exercises, be sortable, searchable and show correct buttons.

<!--
### Test Coverage


### Screenshots
-->
