### PR TITLE
[Bugfix] Sentry Issue Nullpointer Exception for setRatedIfNotExceeded() on result object

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Result.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Result.java
@@ -250,7 +250,11 @@ public class Result extends DomainObject {
     }
 
     public void setRatedIfNotExceeded(@Nullable ZonedDateTime exerciseDueDate, ZonedDateTime submissionDate) {
-        this.rated = exerciseDueDate == null || submissionDate.isBefore(exerciseDueDate) || submissionDate.isEqual(exerciseDueDate);
+        // We perform a non-null check to avoid null pointer exceptions for (irregularly) missing submission dates,
+        // which seem to have occurred in the past due to database schema inconsistencies.
+        if (submissionDate != null) {
+            this.rated = exerciseDueDate == null || submissionDate.isBefore(exerciseDueDate) || submissionDate.isEqual(exerciseDueDate);
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR address an issue occurred on sentry [ARTEMIS-10Y ](https://sentry.ase.in.tum.de/organizations/artemis/issues/1068).

### Description
<!-- Describe your changes in detail -->
In the past, there were several occurrences of Null Pointer Exceptions because the method `setRatedIfNotExceeded()` method on a result object was called with a submission date that was null. The error occurred in the assessment of FileUploadExcercise.
The method actually checks if a calculated result after a manual assessment will be graded or not. This depends on the submission date. If the submission is equal or before the due date, or if there is no exercise due date, the assessed submission result will be graded (a batch "graded" appears), otherwise, it will not be graded ("not graded" batch).
Within the described checks, `submissionDate.isBefore(dueDate)` will fail, if the submission date is null.

I was not able to reproduce the exception, i.e. to assess a submission without a submission date being set. I guess this occurred due to some database inconsistencies and should not appear again.

As a prevention for the Null Pointer Exception, I suggest, that we do a non-null check before the checks. 
In the case of the submissionDate being null, the `result.rated` is not set to true and the batch "not graded" appears (similar to the case when the submission was made after the due date). 

With the induced situation of calling `setRatedIfNotExceeded()` with a `submissionDate` of null, this is the result:
![image](https://user-images.githubusercontent.com/41366522/118716685-6869d880-b825-11eb-8c98-f92dd3b59d65.png)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
As we cannot reproduce the situation causing the problem, we should ensure that the expected behavior is still working with the proposed changes.

1. Log in to Artemis
2. Navigate to Course Administration
3. Create/Search a FileUploadExcercise with due date set in the past
4. As a student of the respective course, make a submission for that exercise (you will be informed, that the submission is late and therefore not graded but you can submit anyways)
5. As an instructor, assess the submission
6. As a student, check if the feedback is the following and the course statistics do not change:

![image](https://user-images.githubusercontent.com/41366522/118717273-242b0800-b826-11eb-8b3a-d1e46f172a2e.png)

1. Log in to Artemis
2. Navigate to Course Administration
3. Create/Search a FileUploadExcercise with due date in the future
4. As a student of the respective course, make a submission for that exercise
5. (Optionally, set the due date of the exercise to a point in time after the submission and before "now" -> during assessment, the exercise was already finished) 
6. As an instructor, assess the submission
7. As a student, check if the feedback on the submission, there should not be a "not graded" batch, the feedback and the result should be visible (as in the screenshot) and the point should account for the overall course statistics.

![image](https://user-images.githubusercontent.com/41366522/118720200-9ea95700-b829-11eb-9501-e88b1b897d38.png)
