### PR TITLE
[Bugfix] Fix Sentry issue: Type Error undefined is not an object

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.ts
@@ -220,7 +220,7 @@ export class DragAndDropQuestionComponent implements OnChanges {
             return (
                 !this.mappings?.some((mapping) => {
                     return this.dragAndDropQuestionUtil.isSameDragItem(mapping.dragItem!, dragItem);
-                }, this) ?? true
+                }, this) ?? false
             );
         }, this);
     }

--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.ts
@@ -217,9 +217,11 @@ export class DragAndDropQuestionComponent implements OnChanges {
      */
     getUnassignedDragItems() {
         return this.question.dragItems?.filter((dragItem) => {
-            return !this.mappings.some((mapping) => {
-                return this.dragAndDropQuestionUtil.isSameDragItem(mapping.dragItem!, dragItem);
-            }, this);
+            return (
+                !this.mappings?.some((mapping) => {
+                    return this.dragAndDropQuestionUtil.isSameDragItem(mapping.dragItem!, dragItem);
+                }, this) ?? false
+            );
         }, this);
     }
 

--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.ts
@@ -220,7 +220,7 @@ export class DragAndDropQuestionComponent implements OnChanges {
             return (
                 !this.mappings?.some((mapping) => {
                     return this.dragAndDropQuestionUtil.isSameDragItem(mapping.dragItem!, dragItem);
-                }, this) ?? false
+                }, this) ?? true
             );
         }, this);
     }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? --> DragAndDropQuestion.mappings is undefined in some cases which leads to a type error when trying to filter the array
<!-- If it fixes an open issue, please link to the issue here. --> <a href="https://sentry.ase.in.tum.de/organizations/artemis/issues/769/?project=2"> Sentry issue </a>

### Description
<!-- Describe your changes in detail --> I added a fallback value (true) in case the mappings is not yet defined and also added the '?' operator so some() is not called in this case.