### PR TITLE
[Tests] fixed flaky test

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2001,13 +2001,14 @@ public class DatabaseUtilService {
 
     public Course addCourseWithThreeFileUploadExercise() {
         var fileUploadExercises = createFileUploadExercisesWithCourse();
+        assertThat(fileUploadExercises.size()).as("created three exercises").isEqualTo(3);
         exerciseRepo.saveAll(fileUploadExercises);
-        List<Course> courseRepoContent = courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now());
-        List<Exercise> exerciseRepoContent = exerciseRepo.findAll();
-        assertThat(exerciseRepoContent.size()).as("one exercise got stored").isEqualTo(3);
-        assertThat(courseRepoContent.size()).as("a course got stored").isEqualTo(1);
-        assertThat(courseRepoContent.get(0).getExercises()).as("course contains the exercises").containsExactlyInAnyOrder(exerciseRepoContent.toArray(new Exercise[] {}));
-        return courseRepoContent.get(0);
+        long courseId = fileUploadExercises.get(0).getCourseViaExerciseGroupOrCourseMember().getId();
+        Course course = courseRepo.findByIdWithEagerExercisesElseThrow(courseId);
+        List<Exercise> exercises = exerciseRepo.findAllExercisesByCourseId(courseId).stream().toList();
+        assertThat(exercises.size()).as("three exercises got stored").isEqualTo(3);
+        assertThat(course.getExercises()).as("course contains the exercises").containsExactlyInAnyOrder(exercises.toArray(new Exercise[] {}));
+        return course;
     }
 
     /** With this method we can generate a course. We can specify the number of exercises. To not only test one type, this method generates modeling, file-upload and text exercises in a cyclic manner.


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Inside the FileUploadSubmissionIntegrationTest is a flaky test `getSubmissionByID_asStudent()`: https://bamboo.ase.in.tum.de/build/result/viewBuildResults.action?buildKey=ARTEMIS-TESTS1983-JAVATEST&buildNumber=10
As it turns out not the test itself is flaky, but the `init` of all of the tests in the class.
The issue was that for some reason the `findAll` method of the `exerciseRepo` did not return the correct set of exercises, maybe because the database was in a faulty state due to other issues.

### Description
<!-- Describe your changes in detail -->
The way the `init` is configured, this flakyness **_should_** be fixed now.

