### PR TITLE
Don't lock modeling submissions when checking for plagiarism

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -227,11 +227,10 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
         studentParticipation.setExercise(modelingExercise);
         modelingSubmission.getParticipation().getExercise().setGradingCriteria(gradingCriteria);
 
-        if (!withoutResults) {
-            // prepare modelingSubmission for response
-            modelingSubmissionService.hideDetails(modelingSubmission, user);
-            modelingSubmission.removeNotNeededResults(correctionRound, resultId);
-        }
+        // prepare modelingSubmission for response
+        modelingSubmissionService.hideDetails(modelingSubmission, user);
+        modelingSubmission.removeNotNeededResults(correctionRound, resultId);
+
         return ResponseEntity.ok(modelingSubmission);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -229,7 +229,10 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
 
         // prepare modelingSubmission for response
         modelingSubmissionService.hideDetails(modelingSubmission, user);
-        modelingSubmission.removeNotNeededResults(correctionRound, resultId);
+        // Don't remove results when they were not requested in the first place
+        if (!withoutResults) {
+            modelingSubmission.removeNotNeededResults(correctionRound, resultId);
+        }
 
         return ResponseEntity.ok(modelingSubmission);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.badRequest;
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
 
 import java.security.Principal;
 import java.util.*;
@@ -16,7 +17,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.GradingCriterion;
+import de.tum.in.www1.artemis.domain.Result;
+import de.tum.in.www1.artemis.domain.Submission;
+import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
@@ -178,13 +182,15 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
      * @param submissionId the id of the modelingSubmission to retrieve
      * @param correctionRound correction round for which we prepare the submission
      * @param resultId the resultId for which we want do get the submission
+     * @param withoutResults No result will be created or loaded and the exercise won't be locked when this is set so plagiarism detection doesn't lock results
      * @return the ResponseEntity with status 200 (OK) and with body the modelingSubmission for the given id, or with status 404 (Not Found) if the modelingSubmission could not be
      *         found
      */
     @GetMapping("/modeling-submissions/{submissionId}")
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<ModelingSubmission> getModelingSubmission(@PathVariable Long submissionId,
-            @RequestParam(value = "correction-round", defaultValue = "0") int correctionRound, @RequestParam(value = "resultId", required = false) Long resultId) {
+            @RequestParam(value = "correction-round", defaultValue = "0") int correctionRound, @RequestParam(value = "resultId", required = false) Long resultId,
+            @RequestParam(value = "withoutResults", defaultValue = "false") boolean withoutResults) {
         log.debug("REST request to get ModelingSubmission with id: {}", submissionId);
         // TODO CZ: include exerciseId in path to get exercise for auth check more easily?
         var modelingSubmission = modelingSubmissionRepository.findOne(submissionId);
@@ -198,29 +204,34 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
             return forbidden();
         }
 
-        // load submission with results either by resultId or by correctionRound
-        if (resultId != null) {
-            // load the submission with additional needed properties
-            modelingSubmission = (ModelingSubmission) submissionRepository.findOneWithEagerResultAndFeedback(submissionId);
-            // check if result exists
-            Result result = modelingSubmission.getManualResultsById(resultId);
-            if (result == null) {
-                return ResponseEntity.badRequest()
-                        .headers(HeaderUtil.createFailureAlert(applicationName, true, "ModelingSubmission", "ResultNotFound", "No Result was found for the given ID.")).body(null);
+        if (!withoutResults) {
+            // load submission with results either by resultId or by correctionRound
+            if (resultId != null) {
+                // load the submission with additional needed properties
+                modelingSubmission = (ModelingSubmission) submissionRepository.findOneWithEagerResultAndFeedback(submissionId);
+                // check if result exists
+                Result result = modelingSubmission.getManualResultsById(resultId);
+                if (result == null) {
+                    return ResponseEntity.badRequest()
+                            .headers(HeaderUtil.createFailureAlert(applicationName, true, "ModelingSubmission", "ResultNotFound", "No Result was found for the given ID."))
+                            .body(null);
+                }
             }
-        }
-        else {
-            // load and potentially lock the submission with additional needed properties by correctionRound
-            modelingSubmission = modelingSubmissionService.lockAndGetModelingSubmission(submissionId, modelingExercise, correctionRound);
+            else {
+                // load and potentially lock the submission with additional needed properties by correctionRound
+                modelingSubmission = modelingSubmissionService.lockAndGetModelingSubmission(submissionId, modelingExercise, correctionRound);
+            }
         }
 
         // Make sure the exercise is connected to the participation in the json response
         studentParticipation.setExercise(modelingExercise);
         modelingSubmission.getParticipation().getExercise().setGradingCriteria(gradingCriteria);
 
-        // prepare modelingSubmission for response
-        modelingSubmissionService.hideDetails(modelingSubmission, user);
-        modelingSubmission.removeNotNeededResults(correctionRound, resultId);
+        if (!withoutResults) {
+            // prepare modelingSubmission for response
+            modelingSubmissionService.hideDetails(modelingSubmission, user);
+            modelingSubmission.removeNotNeededResults(correctionRound, resultId);
+        }
         return ResponseEntity.ok(modelingSubmission);
     }
 

--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.service.ts
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.service.ts
@@ -104,6 +104,17 @@ export class ModelingSubmissionService {
     }
 
     /**
+     * Get a submission with given Id without locking it on artemis so plagiarism detection doesn't disrupt assessment
+     * @param {number} submissionId - Id of the submission
+     */
+    getSubmissionWithoutLock(submissionId: number): Observable<ModelingSubmission> {
+        const url = `api/modeling-submissions/${submissionId}`;
+        let params = new HttpParams();
+        params = params.set('withoutResults', 'true');
+        return this.http.get<ModelingSubmission>(url, { params });
+    }
+
+    /**
      * Get latest submission for a given participation
      * @param {number} participationId - Id of the participation
      */

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/modeling-submission-viewer/modeling-submission-viewer.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/modeling-submission-viewer/modeling-submission-viewer.component.ts
@@ -26,7 +26,7 @@ export class ModelingSubmissionViewerComponent implements OnChanges {
 
             const currentPlagiarismSubmission: PlagiarismSubmission<ModelingSubmissionElement> = changes.plagiarismSubmission.currentValue;
 
-            this.modelingSubmissionService.getSubmission(currentPlagiarismSubmission.submissionId).subscribe(
+            this.modelingSubmissionService.getSubmissionWithoutLock(currentPlagiarismSubmission.submissionId).subscribe(
                 (submission: ModelingSubmission) => {
                     this.loading = false;
                     this.submissionModel = JSON.parse(submission.model!) as UMLModel;

--- a/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
@@ -365,6 +365,17 @@ public class ModelingSubmissionIntegrationTest extends AbstractSpringIntegration
     }
 
     @Test
+    @WithMockUser(value = "tutor1", roles = "TA")
+    public void getModelSubmissionWithoutResults() throws Exception {
+        ModelingSubmission submission = ModelFactory.generateModelingSubmission(validModel, true);
+        submission = database.addModelingSubmission(classExercise, submission, "student1");
+
+        ModelingSubmission storedSubmission = request.get("/api/modeling-submissions/" + submission.getId() + "?withoutResults=true", HttpStatus.OK, ModelingSubmission.class);
+
+        assertThat(storedSubmission.getLatestResult()).as("result has not been set").isNull();
+    }
+
+    @Test
     @WithMockUser(value = "tutor2", roles = "TA")
     public void getModelSubmission_tutorNotInCourse() throws Exception {
         ModelingSubmission submission = ModelFactory.generateModelingSubmission(validModel, true);

--- a/src/test/javascript/spec/component/plagiarism/modeling-submission-viewer.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/modeling-submission-viewer.component.spec.ts
@@ -45,7 +45,7 @@ describe('Modeling Submission Viewer Component', () => {
     });
 
     it('should fetch the submission', () => {
-        spyOn(modelingSubmissionService, 'getSubmission').and.returnValue(of(modelingSubmission));
+        spyOn(modelingSubmissionService, 'getSubmissionWithoutLock').and.returnValue(of(modelingSubmission));
 
         comp.ngOnChanges({
             plagiarismSubmission: {
@@ -56,6 +56,6 @@ describe('Modeling Submission Viewer Component', () => {
             },
         });
 
-        expect(modelingSubmissionService.getSubmission).toHaveBeenCalledWith(1);
+        expect(modelingSubmissionService.getSubmissionWithoutLock).toHaveBeenCalledWith(1);
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
When checking modeling exercises for plagiarism the submissions are locked for the user clicking through the results without them being notified. Not 100% sure, but I considered this a bug because text and programming exercises are not locked.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Check a modeling exercise for plagiarism
2. Click a few comparisons on the left
3. Go to the exercises submissions overview and check that you don't have locks for any submissions

