### PR TITLE
Fix UI/UX of number inputs in Firefox in plagiarism-inspector

### DIFF
--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
@@ -38,17 +38,7 @@
                     [ngbTooltip]="'artemisApp.plagiarism.similarity-threshold-tooltip' | artemisTranslate"
                     container="body"
                 ></fa-icon>
-                <input
-                    required
-                    type="number"
-                    class="form-control"
-                    min="50"
-                    max="100"
-                    step="5"
-                    onkeydown="return false"
-                    id="plagiarism-similarity-threshold"
-                    [(ngModel)]="similarityThreshold"
-                />
+                <input required type="number" class="form-control pr-0" min="50" max="100" step="5" id="plagiarism-similarity-threshold" [(ngModel)]="similarityThreshold" />
             </div>
 
             <div class="plagiarism-option" [class.disabled]="!enableMinimumScore">
@@ -57,7 +47,16 @@
                     <div class="plagiarism-option-label" jhiTranslate="artemisApp.plagiarism.minimum-score">Minimum Score</div>
                 </label>
                 <fa-icon [icon]="'question-circle'" placement="bottom" [ngbTooltip]="'artemisApp.plagiarism.minimum-score-tooltip' | artemisTranslate" container="body"></fa-icon>
-                <input required type="number" [disabled]="!enableMinimumScore" class="form-control" min="0" max="100" id="plagiarism-minimum-score" [(ngModel)]="minimumScore" />
+                <input
+                    required
+                    type="number"
+                    [disabled]="!enableMinimumScore"
+                    class="form-control pr-0"
+                    min="0"
+                    max="100"
+                    id="plagiarism-minimum-score"
+                    [(ngModel)]="minimumScore"
+                />
             </div>
 
             <div class="plagiarism-option" *ngIf="!isProgrammingExercise()" [class.disabled]="!enableMinimumSize">

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
@@ -38,7 +38,7 @@
                     [ngbTooltip]="'artemisApp.plagiarism.similarity-threshold-tooltip' | artemisTranslate"
                     container="body"
                 ></fa-icon>
-                <input required type="number" class="form-control pr-0" min="50" max="100" step="5" id="plagiarism-similarity-threshold" [(ngModel)]="similarityThreshold" />
+                <input type="number" required class="form-control pr-0" min="50" max="100" step="5" id="plagiarism-similarity-threshold" [(ngModel)]="similarityThreshold" />
             </div>
 
             <div class="plagiarism-option" [class.disabled]="!enableMinimumScore">

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
@@ -38,7 +38,7 @@
                     [ngbTooltip]="'artemisApp.plagiarism.similarity-threshold-tooltip' | artemisTranslate"
                     container="body"
                 ></fa-icon>
-                <input type="number" required class="form-control pr-0" min="50" max="100" step="5" id="plagiarism-similarity-threshold" [(ngModel)]="similarityThreshold" />
+                <input type="number" required class="form-control" min="50" max="100" step="5" id="plagiarism-similarity-threshold" [(ngModel)]="similarityThreshold" />
             </div>
 
             <div class="plagiarism-option" [class.disabled]="!enableMinimumScore">
@@ -47,16 +47,7 @@
                     <div class="plagiarism-option-label" jhiTranslate="artemisApp.plagiarism.minimum-score">Minimum Score</div>
                 </label>
                 <fa-icon [icon]="'question-circle'" placement="bottom" [ngbTooltip]="'artemisApp.plagiarism.minimum-score-tooltip' | artemisTranslate" container="body"></fa-icon>
-                <input
-                    required
-                    type="number"
-                    [disabled]="!enableMinimumScore"
-                    class="form-control pr-0"
-                    min="0"
-                    max="100"
-                    id="plagiarism-minimum-score"
-                    [(ngModel)]="minimumScore"
-                />
+                <input required type="number" [disabled]="!enableMinimumScore" class="form-control" min="0" max="100" id="plagiarism-minimum-score" [(ngModel)]="minimumScore" />
             </div>
 
             <div class="plagiarism-option" *ngIf="!isProgrammingExercise()" [class.disabled]="!enableMinimumSize">

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.scss
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.scss
@@ -94,6 +94,10 @@ $footer-height: 31px;
                 #plagiarism-minimum-size {
                     margin-left: 1rem;
                 }
+
+                .form-control {
+                    padding-right: 0;
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
Plagiarism detection thresholds are not editable in Firefox (Fixes #3485)

### Description
<!-- Describe your changes in detail -->
Firefox doesn't do the best job at rendering number inputs with padding. Instead of doing some magic css I just removed the right padding on the inputs.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

0. Use Firefox
1. Log in to Artemis
2. Navigate to Plagiarism detection on a programming exercise
3. Test if inputs for thresholds are editable (by keyboard input and using the spinner buttons)


Please note that the weird inconsistent formatting changes have been applied by some pre commit hook and I'm lacking the energy to fight it. :smile: 