### PR TITLE
[Bug] Fix release date tag in Course Overview and Exercise Details

### DIFF
--- a/src/main/webapp/app/shared/components/not-released-tag.component.html
+++ b/src/main/webapp/app/shared/components/not-released-tag.component.html
@@ -1,11 +1,8 @@
 <span
     class="ml-1 badge badge-warning"
-    *ngIf="exercise.releaseDate != undefined && !moment(exercise.releaseDate).isBefore(moment())"
+    *ngIf="exercise.isAtLeastTutor && exercise.releaseDate != undefined && !moment(exercise.releaseDate).isBefore(moment())"
     placement="right"
     ngbTooltip="Only visible to teaching assistants and instructors. Release date: {{ exercise.releaseDate | artemisDate }}"
 >
     {{ 'artemisApp.courseOverview.exerciseList.notReleased' | artemisTranslate }}
-</span>
-<span [ngClass]="exerciseStatusBadge" class="badge">
-    {{ exercise.releaseDate | artemisTimeAgo }}
 </span>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The course overview page now displays a green tag that shows the release date of an exercise.
This tag is displayed to students and instructors.
Fixes #3501 

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Open/Create an Exercise with Release date **in the past**
3. Open/Create an Exercise with Release date **in the future**

**As a student:** 
1. Log in to Artemis as a **Student**
2. Open _Course Overview_ and look for the exercise you created with release date **in the past**
3. You should **not** be able to see the release tag anymore, ex.: "a month ago" in the **Course Overview** page
4. You should **not** be able to see the release tag anymore, ex.: "a month ago" in the **Exercise Detail** page
5. The exercise with release date in the future is not shown at all as usual.

**As at _least_ a tutor:** 
1. Log in to Artemis as a **Tutor/Instructor**
2. Open _Course Overview_ and look for the exercise you created with release date **in the past**
3. You should **not** be able to see the release date tag anymore, ex.: "a month ago" either in Course Overview or Exercise Detail page 
4. Open _Course Overview_ and look for the exercise you created with release date **in the future**. You should **only** be able to see the **Unreleased** tag.


### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

STUDENT:
![student_before_after](https://user-images.githubusercontent.com/18335489/119827853-e307b780-bef9-11eb-95a3-a30317ed1c1a.PNG)


TUTOR:
![tutor_before_after](https://user-images.githubusercontent.com/18335489/119827809-d6835f00-bef9-11eb-9fe2-62f891b28e48.PNG)

