### PR TITLE
[Notification System] live quiz notifications and popups redirect to the open quiz

### DIFF
--- a/src/main/webapp/app/shared/notification/notification-popup/notification-popup.component.ts
+++ b/src/main/webapp/app/shared/notification/notification-popup/notification-popup.component.ts
@@ -46,7 +46,12 @@ export class NotificationPopupComponent implements OnInit {
     private notificationTargetRoute(notification: Notification): UrlTree | string {
         if (notification.target) {
             const target = JSON.parse(notification.target);
-            return this.router.createUrlTree([target.mainPage, target.course, target.entity, target.id]);
+
+            if (notification.title === 'Quiz started' && target.status) {
+                return this.router.createUrlTree([target.mainPage, target.course, target.entity, target.id, target.status]);
+            } else {
+                return this.router.createUrlTree([target.mainPage, target.course, target.entity, target.id]);
+            }
         }
         return this.router.url;
     }
@@ -77,6 +82,7 @@ export class NotificationPopupComponent implements OnInit {
         if (notification.target) {
             const target = JSON.parse(notification.target);
             target.entity = 'quiz-exercises';
+            target.status = 'live';
             const notificationWithLiveQuizTarget = {
                 target: JSON.stringify(target),
             } as GroupNotification;
@@ -84,6 +90,7 @@ export class NotificationPopupComponent implements OnInit {
                 !this.router.isActive(this.notificationTargetRoute(notification), true) &&
                 !this.router.isActive(this.notificationTargetRoute(notificationWithLiveQuizTarget) + '/live', true)
             ) {
+                notification.target = notificationWithLiveQuizTarget.target;
                 this.notifications.unshift(notification);
             }
         }

--- a/src/main/webapp/app/shared/notification/notification.service.ts
+++ b/src/main/webapp/app/shared/notification/notification.service.ts
@@ -62,7 +62,12 @@ export class NotificationService {
         if (notification.target) {
             const target = JSON.parse(notification.target);
             const courseId = target.course || notification.course?.id;
-            this.router.navigate([target.mainPage, courseId, target.entity, target.id]);
+
+            if ((notification.title = 'Quiz Started')) {
+                this.router.navigate([target.mainPage, courseId, 'quiz-exercises', target.id, 'live']);
+            } else {
+                this.router.navigate([target.mainPage, courseId, target.entity, target.id]);
+            }
         }
     }
 

--- a/src/main/webapp/app/shared/notification/notification.service.ts
+++ b/src/main/webapp/app/shared/notification/notification.service.ts
@@ -63,7 +63,7 @@ export class NotificationService {
             const target = JSON.parse(notification.target);
             const courseId = target.course || notification.course?.id;
 
-            if ((notification.title = 'Quiz Started')) {
+            if (notification.title === 'Quiz started') {
                 this.router.navigate([target.mainPage, courseId, 'quiz-exercises', target.id, 'live']);
             } else {
                 this.router.navigate([target.mainPage, courseId, target.entity, target.id]);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Previously, when you clicked on a pop-up or notification inside the drop-down sidebar informing about a new live quiz you were redirected to the quiz exercise detailed page.

Now the notification redirects you to the actual open quiz exercise so you can start working immediately (no need to click the button "start quiz")

Visual Example :
![PopUp_Demo](https://user-images.githubusercontent.com/65814168/120079410-ecd51a80-c0b3-11eb-8dd9-b9e24a529a3f.gif)


<!-- If it fixes an open issue, please link to the issue here. -->
(This change was requested by @krusche)

### Description
<!-- Describe your changes in detail -->

I changed the following two files :
1.) `notification-popup.component`
2.) `notification.service`

Instead of navigating to the detailed page with e.g. the URL =  https://artemistest.ase.in.tum.de/courses/3/exercises/7
We want to to access the opened quiz directly , i.e.  URL = https://artemistest.ase.in.tum.de/courses/3/quiz-exercises/7/live
Prefix stays the same : https://artemistest.ase.in.tum.de/courses/3
What changes:  /exercises/7 → /quiz-exercises/7/live


Such an URL is created from the `target` property of a notification.
e.g. `notification.target = {"course":3,"mainPage":"courses","entity":"exercises","id":7}`

As you can see, we need to change the `entity` from `exercises` to `quiz-exercises` & append `/live`


Now, how do we get to the page we want?
There are two different ways that are at work here.

A) Notification Drop-Down Sidebar (that is showed when you click the Bell icon)
- You have the Sidebar opened and click on the quiz notification
- Inside `notification-sidebar.component` the method `startNotification(notification: Notification)` calls the method `interpretNotification` of the `notification.service`.
-  The (Angular) `router` will navigate to the destination described by the explicitly mentioned parts of `target`, e.g. `this.router.navigate([target.mainPage, courseId, target.entity, target.id])`
- But, there is no property for "live", so it will be cut away or simply ignored.
- To fix this I added an if-case that if there is a live quiz notification it will tell the router to jump to the opened quiz, i.e.  `this.router.navigate([target.mainPage, courseId, 'quiz-exercises', target.id, 'live']);`

B) Pop-Up Notifications ( `notification-popup.component`)
- The final traversal takes place in `navigateToTarget(notification: Notification)`.
- The router's navigation here is based on an URL :   `this.router.navigateByUrl(this.notificationTargetRoute(notification))`
- This URL is created by `notificationTargetRoute()` which is similar to A) due to it explicitly mentioning the individual parts of `target`.
- My adjustment here is similar to the one in A).

-  Initially, `addQuizNotification(notification: Notification)` is called. _(It handles specific cases of visibility to the user based on the current page the user sees)_
- Originally, this method passes on its inputted notification without any changes. I replace the `target` property _(with the 'live' one)_
because its new property `status: 'live'` is needed in `notificationTargetRoute`.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

E.g. just follow the steps shown in the .gif above.

**Written Steps :**
1. Log in to Artemis
2. Create a new Quiz or Reset->SetVisible->StartQuiz an old one.
3. Test if a pop-up notification appears (with the title "Quiz started").
4. Click on it and check if you are already inside the opened/started quiz and **not** on the detailed quiz-exercise page (i.e. you do **not** need to click the button "Start quiz"  to start working on the quiz.)
5. Leave the quiz. Best, just go back to the Course or Home page.
6. Click on the Bell icon (Test if the number inside increased from before activating the quiz) to open the notification side bar.
7. Click on the new quiz notification.
8. Same as with 4) , check if you are inside the open quiz and not on the detailed quiz page.
