### PR TITLE
Fix: Newlines Not Shown In Feedback

### DIFF
--- a/src/main/webapp/app/exercises/shared/result/feedback-collapse.component.html
+++ b/src/main/webapp/app/exercises/shared/result/feedback-collapse.component.html
@@ -1,4 +1,6 @@
-<p *ngIf="text.length < smallCharacterLimit; else longText">{{ text }}</p>
+<div class="feedback-text">
+    <p *ngIf="text.length < smallCharacterLimit; else longText">{{ text }}</p>
+</div>
 
 <ng-template #longText>
     <div *ngIf="isCollapsed; else opened">
@@ -6,9 +8,9 @@
         {{ text.substring(0, 100) }} ...
     </div>
     <ng-template #opened>
-        <div>
+        <div class="feedback-text">
             <fa-icon class="fa-angle" [icon]="'angle-down'" (click)="isCollapsed = !isCollapsed"></fa-icon>
-            {{ text }}
+            <p>{{ text }}</p>
         </div>
     </ng-template>
 </ng-template>

--- a/src/main/webapp/app/exercises/shared/result/result-detail.scss
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.scss
@@ -35,6 +35,14 @@
     }
 }
 
+.feedback-text {
+    p {
+        display: inline;
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+}
+
 .result-score-chart {
     margin-bottom: 1em;
 


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de. (tested locally)
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
See #3492. The feedback as part of the result component did not show any newlines that are part of the feedback text.

### Description
Closes #3492.

### Steps for Testing
1. Create a new exercise or re-use an existing one.
2. In the Tests-repository, edit a `fail(…)` message of a test to include newlines.
3. After the tests ran check that the feedback text for that test cases contains the newlines.

### Screenshots
Short feedback text with newlines:
![Screenshot_20210603_162716](https://user-images.githubusercontent.com/64250573/120662879-cb947580-c489-11eb-928f-d0530813c0a6.png)
Collapsed feedback text for long feedbacks, newlines not shown:
![Screenshot_20210603_162725](https://user-images.githubusercontent.com/64250573/120662882-cc2d0c00-c489-11eb-8de9-64fc971002ad.png)
Same feedback text, now expanded. Newlines are rendered:
![Screenshot_20210603_162740](https://user-images.githubusercontent.com/64250573/120662883-cc2d0c00-c489-11eb-8b6b-dcf182098913.png)

