### PR TITLE
Check for null and undefined when assessing modeling exercises

### DIFF
--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment.component.ts
@@ -250,7 +250,7 @@ export class ModelingAssessmentComponent implements AfterViewInit, OnDestroy, On
             newElements = new Map<string, string>();
         }
 
-        if (this.apollonEditor !== null) {
+        if (this.apollonEditor != null) {
             const model: UMLModel = this.apollonEditor!.model;
             for (const element of model.elements) {
                 element.highlight = newElements.get(element.id);

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment.component.ts
@@ -250,7 +250,7 @@ export class ModelingAssessmentComponent implements AfterViewInit, OnDestroy, On
             newElements = new Map<string, string>();
         }
 
-        if (this.apollonEditor != null) {
+        if (this.apollonEditor != undefined) {
             const model: UMLModel = this.apollonEditor!.model;
             for (const element of model.elements) {
                 element.highlight = newElements.get(element.id);


### PR DESCRIPTION
### Motivation and Context

Fixes https://sentry.ase.in.tum.de/organizations/artemis/issues/604/events/a408b0f877d541e3994bf71058ada874/.

### Description

`!== null` doesn't check for `undefined`, while using just `!=` fixes that. See https://www.tektutorialshub.com/typescript/typescript-null-undefined-strict-null-checks/ .

### Steps for Testing

The code changes are pretty straight forward, but if you still want to test something open the assessment of a modeling submission and check if there are any errors related to undefined/null objects in the console.

