### PR TITLE
Explicitly check for undefined/null before displaying breadcrumbs

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -218,12 +218,22 @@
     <div *ngIf="breadcrumbs && breadcrumbs.length > 0">
         <ol class="breadcrumb" *jhiHasAnyAuthority="['ROLE_TA', 'ROLE_EDITOR', 'ROLE_INSTRUCTOR', 'ROLE_ADMIN']">
             <li *ngFor="let breadcrumb of breadcrumbs" class="breadcrumb-item">
-                <a class="breadcrumb-link" [routerLink]="breadcrumb.uri" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" *ngIf="breadcrumb.translate">{{
-                    breadcrumb.label | artemisTranslate
-                }}</a>
-                <a class="breadcrumb-link" [routerLink]="breadcrumb.uri" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" *ngIf="!breadcrumb.translate">{{
-                    breadcrumb.label
-                }}</a>
+                <a
+                    class="breadcrumb-link"
+                    [routerLink]="breadcrumb.uri"
+                    routerLinkActive="active"
+                    [routerLinkActiveOptions]="{ exact: true }"
+                    *ngIf="breadcrumb && breadcrumb.translate"
+                    >{{ breadcrumb.label | artemisTranslate }}</a
+                >
+                <a
+                    class="breadcrumb-link"
+                    [routerLink]="breadcrumb.uri"
+                    routerLinkActive="active"
+                    [routerLinkActiveOptions]="{ exact: true }"
+                    *ngIf="breadcrumb && !breadcrumb.translate"
+                    >{{ breadcrumb.label }}</a
+                >
             </li>
         </ol>
     </div>


### PR DESCRIPTION
### Motivation and Context

Fixes https://sentry.ase.in.tum.de/organizations/artemis/issues/3892/events/6e17cbe1f8404d1383fed74337884b4d/ .

### Description

I don't know how an entry in that array can ever be null or undefined, so another error must have occurred beforehand. Nonetheless we can still make sure we don't cause a second error. The formatting changes are because of prettier, I just added `breadcrumb &&` to both `*ngIf`s to filter null/undefined.

