### PR TITLE
fix issue with plagiarism state updates on slow connections

### DIFF
--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.ts
@@ -43,8 +43,11 @@ export class PlagiarismHeaderComponent {
      * @param status the new status of the comparison
      */
     updatePlagiarismStatus(status: PlagiarismStatus) {
-        return this.http.put<void>(`${this.resourceUrl}/${this.comparison.id}/status`, { status }, { observe: 'response' }).subscribe(() => {
-            this.comparison.status = status;
+        // store id in variable in case comparison changes while request is made
+        const comparison = this.comparison;
+        const resourceUrl = this.resourceUrl;
+        return this.http.put<void>(`${resourceUrl}/${comparison.id}/status`, { status }, { observe: 'response' }).subscribe(() => {
+            comparison.status = status;
         });
     }
 

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.ts
@@ -43,10 +43,9 @@ export class PlagiarismHeaderComponent {
      * @param status the new status of the comparison
      */
     updatePlagiarismStatus(status: PlagiarismStatus) {
-        // store id in variable in case comparison changes while request is made
+        // store comparison in variable in case comparison changes while request is made
         const comparison = this.comparison;
-        const resourceUrl = this.resourceUrl;
-        return this.http.put<void>(`${resourceUrl}/${comparison.id}/status`, { status }, { observe: 'response' }).subscribe(() => {
+        return this.http.put<void>(`${this.resourceUrl}/${comparison.id}/status`, { status }, { observe: 'response' }).subscribe(() => {
             comparison.status = status;
         });
     }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
fixes #3321

### Description
With slow internet connection after clicking confirm or deny and then selecting another plagiarism comparison, the confirmation/deny get's applied to the now selected results. See:

https://user-images.githubusercontent.com/44805696/121356167-e86cf500-c930-11eb-9357-53c7579d6299.mp4

After my changes: 

https://user-images.githubusercontent.com/44805696/121356111-dc813300-c930-11eb-9dcb-67a993641ec6.mp4

Note: On the right I'm selecting network throttling, this was not picked up when recording :( 
 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Navigate to plagiarism detection and select a result
2. Using the dev tools simulate very slow network connection
3. Confirm or deny
4. Select another comparison and turn of throttling
5. Observe, that the update gets applied to the correct comparison.
