### PR TITLE
[Bugfix] Metis Postings Alignment & Translation

### DIFF
--- a/src/main/webapp/app/overview/postings/post-votes/post-votes.component.html
+++ b/src/main/webapp/app/overview/postings/post-votes/post-votes.component.html
@@ -1,4 +1,4 @@
-<div class="student-votes d-flex flex-column">
+<div class="d-flex flex-column">
     <div class="col-auto">
         <fa-icon class="clickable fa-2x vote" [class.vote-active]="userVote && userVote.isPositive" [icon]="'angle-up'" (click)="toggleUpVote()"></fa-icon>
     </div>

--- a/src/main/webapp/app/overview/postings/post-votes/post-votes.component.ts
+++ b/src/main/webapp/app/overview/postings/post-votes/post-votes.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, EventEmitter, Input, Output } from '@angular/core';
+import { Component, OnInit, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
 import { AccountService } from 'app/core/auth/account.service';
 import { LocalStorageService } from 'ngx-webstorage';
 import { User } from 'app/core/user/user.model';

--- a/src/main/webapp/app/overview/postings/post/post.component.html
+++ b/src/main/webapp/app/overview/postings/post/post.component.html
@@ -27,7 +27,7 @@
         </div>
     </div>
     <div class="row">
-        <jhi-post-votes [postId]="post.id!" [votes]="post.votes!" (interactVotes)="interactVotes($event)"></jhi-post-votes>
+        <jhi-post-votes class="col-auto" [postId]="post.id!" [votes]="post.votes!" (interactVotes)="interactVotes($event)"></jhi-post-votes>
         <div
             id="content"
             class="col posting-content markdown-preview"

--- a/src/main/webapp/app/overview/postings/postings.component.html
+++ b/src/main/webapp/app/overview/postings/postings.component.html
@@ -1,5 +1,5 @@
 <!-- uncollapsed posts -->
-<div *ngIf="!collapsed; else collapsedPosts" class="posts-container expanded-posts">
+<div *ngIf="!collapsed; else collapsedPosts" class="postings-container expanded-posts">
     <div class="draggable-left"><fa-icon [icon]="'grip-lines-vertical'"></fa-icon></div>
     <div class="card">
         <!-- header -->
@@ -72,7 +72,11 @@
 </div>
 <!-- collapsed posts -->
 <ng-template #collapsedPosts>
-    <div class="posts-container collapsed-posts text-white" (click)="collapsed = false" [ngbTooltip]="'artemisApp.courseOverview.exerciseDetails.faq.show' | artemisTranslate">
+    <div
+        class="postings-container collapsed-postings text-white"
+        (click)="collapsed = false"
+        [ngbTooltip]="'artemisApp.courseOverview.exerciseDetails.faq.show' | artemisTranslate"
+    >
         <fa-icon [icon]="'chevron-left'"></fa-icon>
         <span jhiTranslate="artemisApp.courseOverview.exerciseDetails.faq.header">Q & A</span>
         <fa-icon [icon]="'chevron-left'"></fa-icon>

--- a/src/main/webapp/app/overview/postings/postings.scss
+++ b/src/main/webapp/app/overview/postings/postings.scss
@@ -2,9 +2,10 @@
 
 $background-color: #353d47;
 
-.posts-container {
+.postings-container {
     display: flex;
     height: 100%;
+    margin-left: auto;
 }
 
 .expanded-posts {
@@ -42,12 +43,12 @@ $background-color: #353d47;
     }
 }
 
-.collapsed-posts {
+.collapsed-postings {
     width: 50px;
     justify-content: space-between;
     flex-flow: column nowrap;
     background-color: $background-color;
-    margin-left: 15px;
+    margin-left: auto;
     cursor: pointer;
 
     span {

--- a/src/main/webapp/i18n/de/post.json
+++ b/src/main/webapp/i18n/de/post.json
@@ -16,6 +16,11 @@
                 "showApproved": "Zeige Posts mit bestätigten Antworten an",
                 "hideApproved": "Verstecke Posts mit bestätigten Antworten"
             }
+        },
+        "answerPost": {
+            "created": "Antwort erfolgreich erstellt",
+            "updated": "Antwort erfolgreich aktualisiert",
+            "deleted": "Antwort erfolgreich gelöscht"
         }
     }
 }

--- a/src/main/webapp/i18n/de/student-dashboard.json
+++ b/src/main/webapp/i18n/de/student-dashboard.json
@@ -154,8 +154,8 @@
                 "practice": "Übung",
                 "faq": {
                     "header": "Postings",
-                    "show": "Antworten anzeigen",
-                    "hide": "Antworten einklappen",
+                    "show": "Postings anzeigen",
+                    "hide": "Postings einklappen",
                     "noPosts": "Es gibt keine Postings.",
                     "addNewPost": "Einen neuen Post erstellen",
                     "newPostLabel": "Neuer Post",

--- a/src/main/webapp/i18n/en/post.json
+++ b/src/main/webapp/i18n/en/post.json
@@ -16,6 +16,11 @@
                 "showApproved": "Show posts with approved replies",
                 "hideApproved": "Hide posts with approved replies"
             }
+        },
+        "answerPost": {
+            "created": "New reply successfully created",
+            "updated": "Reply successfully updated",
+            "deleted": "Reply successfully deleted"
         }
     }
 }

--- a/src/main/webapp/i18n/en/student-dashboard.json
+++ b/src/main/webapp/i18n/en/student-dashboard.json
@@ -156,8 +156,8 @@
                 "practice": "Practice",
                 "faq": {
                     "header": "Postings",
-                    "show": "Show replies",
-                    "hide": "Hide replies",
+                    "show": "Show postings",
+                    "hide": "Hide postings",
                     "noPosts": "There are no postings",
                     "addNewPost": "Add a new post",
                     "newPostLabel": "New post",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

After the merging #3470 (including a Bootstrap update), the Postings-Section of exercises/lectures was misplaced and not shown on the right-hand-side anymore. Additionally, the alignment of the up-/downvote section next to the post text was broken (was displayed on top of each other instead of side by side).

Besides the alignment issues, I recognized, that there were missing translations for adding, updating and deleting a reply (`AnswerPost`).

### Description
<!-- Describe your changes in detail -->
I fixed the mentioned css issues and added the missing translations (en, de).

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to a lecture or exercise -> check if the posting section is on the right-hand-side, collapsed as well as expanded
3. Use the Posting feature -> if posts/replies are added/edited/deleted, check the notification in english and german.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Broken - alignment:**
![image](https://user-images.githubusercontent.com/41366522/121391496-b79bb880-c94e-11eb-8f73-c4cd6a12cc97.png)
**Broken - translation:**
<img width="1256" alt="Bildschirmfoto 2021-06-09 um 18 17 55" src="https://user-images.githubusercontent.com/41366522/121392022-47d9fd80-c94f-11eb-8d4b-b1737f83aa2d.png">


**Fixed - correct alignment:**
<img width="1268" alt="Bildschirmfoto 2021-06-09 um 18 10 09" src="https://user-images.githubusercontent.com/41366522/121391522-c08c8a00-c94e-11eb-8cca-cc1d31c75e71.png">
<img width="1267" alt="Bildschirmfoto 2021-06-09 um 18 10 16" src="https://user-images.githubusercontent.com/41366522/121391540-c5e9d480-c94e-11eb-9b13-4e9ac3d0e2a3.png">

**Fixed - correct notification:**
<img width="1265" alt="Bildschirmfoto 2021-06-09 um 18 10 29" src="https://user-images.githubusercontent.com/41366522/121391626-e31ea300-c94e-11eb-969d-dc9d38843ab7.png">
<img width="1248" alt="Bildschirmfoto 2021-06-09 um 18 10 41" src="https://user-images.githubusercontent.com/41366522/121391633-e4e86680-c94e-11eb-80ea-39b26b54c0cb.png">

