### PR TITLE
Added new TSLint rule & fixed/refactored consequent errors

### DIFF
--- a/src/main/webapp/app/exercises/text/shared/text-select.directive.ts
+++ b/src/main/webapp/app/exercises/text/shared/text-select.directive.ts
@@ -186,10 +186,11 @@ export class TextSelectDirective implements OnInit, OnDestroy {
         // being performed within the host element. Let's walk from the range container
         // up to the host element and add any relevant scroll offsets to the calculated
         // local position.
-        do {
+        while (node !== host && node.parentNode != undefined) {
             localLeft += (<Element>node).scrollLeft;
             localTop += (<Element>node).scrollTop;
-        } while (node !== host && (node = node.parentNode!));
+            node = node.parentNode;
+        }
 
         return {
             left: localLeft,

--- a/src/main/webapp/app/shared/markdown-editor/domainCommands/domainCommand.ts
+++ b/src/main/webapp/app/shared/markdown-editor/domainCommands/domainCommand.ts
@@ -30,10 +30,12 @@ export abstract class DomainCommand extends Command {
             regex = this.getTagRegex('g');
 
         const indexes: Array<{ matchStart: number; matchEnd: number; innerTagContent: string }> = [];
-        let match;
+
         // A line can have multiple tags in it, so we need to check for multiple matches.
-        while ((match = regex.exec(line))) {
+        let match = regex.exec(line);
+        while (match != undefined) {
             indexes.push({ matchStart: match.index, matchEnd: match.index + match[0].length, innerTagContent: match[1] });
+            match = regex.exec(line);
         }
         const matchOnCursor = indexes.find(({ matchStart, matchEnd }) => column > matchStart && column <= matchEnd);
         return matchOnCursor || null;

--- a/tslint.json
+++ b/tslint.json
@@ -40,6 +40,7 @@
         "no-duplicate-variable": true,
         "no-empty": false,
         "no-eval": true,
+        "no-conditional-assignment": true,
         "no-inferrable-types": [true],
         "no-shadowed-variable": true,
         "no-string-literal": false,


### PR DESCRIPTION
### Checklist
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
[TSLint](https://palantir.github.io/tslint/) is a tool for static code analysis we use to catch bugs, typos, and other errors that we as developers have missed or have overlooked while coding or reviewing. 
This PR proposes to add one additional rule to our existing ruleset.

The rule : `"no-conditional-assignment": true`  _([link](https://palantir.github.io/tslint/rules/no-conditional-assignment/) for more information)_

This rule **prohibits** the use of any type of **assignment in conditionals** _(e.g. while, if, etc.)_.

**(Optional to read) Context**
In my last PR I had the following crucial typo  `if ((notification.title = 'Quiz started')) ` 
This should have been naturally `if ( notification.title === 'Quiz started')` 
or at least `if ( notification.title == 'Quiz started')` but definitely not an assignment with double brackets.

I did not notice it and 10+ other reviewers that approved of my PR did not either.
Only @jpbernius noticed it and pointed this mistake out.

This added rule should avoid such issues in the future.

### Description
<!-- Describe your changes in detail -->
I added the rule to `tslint.json`. (I paid attention to the order of the ruleset which seems to be alphabetically sorted.)

Afterwards, I executed the `yarn lint --fix` command.
TSLint noticed two new errors as a consequence of adding the new rule.

The first one was spotted in `domainCommand.ts` :
![image](https://user-images.githubusercontent.com/65814168/121531479-b88c2300-c9fe-11eb-9d0b-fa05d3cea8da.png)


The second one in `text-select.directive.ts` :
![image](https://user-images.githubusercontent.com/65814168/121531494-bc1faa00-c9fe-11eb-9bea-d5e4e01e22ac.png)


I tried to fix them both by refactoring them instead of using @Annotations.
I used `!= undefined` because I want to catch both cases of `undefined` and `null` but `!= null` does not work based on another rule. But `!= undefined` should catch both cases. See [explanation](https://www.tektutorialshub.com/typescript/typescript-null-undefined-strict-null-checks/).

![Untitled](https://user-images.githubusercontent.com/65814168/121532065-4bc55880-c9ff-11eb-8454-a897d6b224ad.png)


Please tell me if my refactoring works and the logic makes sense, i.e. I did not break anything.
There are sadly no test classes (that I am aware of) where I can check the functionality.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Look at the code and read my explanation carefully.