### PR TITLE
Add date and time column to list of complaints and list of more feedback requests

### DIFF
--- a/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
+++ b/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
@@ -109,7 +109,7 @@
                     </td>
 
                     <td>
-                        <span>{{ complaint.submittedTime }}</span>
+                        <span>{{ complaint.submittedTime?.moment().format("lll") }}</span>
                     </td>
 
                     <td>

--- a/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
+++ b/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
@@ -109,7 +109,7 @@
                     </td>
 
                     <td>
-                        <span>{{ complaint.submittedTime.format('MMM, Do YYYY, hh:mm') }}</span>
+                        <span>{{ complaint.submittedTime }}</span>
                     </td>
 
                     <td>

--- a/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
+++ b/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
@@ -109,7 +109,7 @@
                     </td>
 
                     <td>
-                        <span>{{ 'complaint.submittedTime' | artemisDate }}</span>
+                        <span>{{ 'complaint.submittedTime?' | artemisDate }}</span>
                     </td>
 
                     <td>

--- a/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
+++ b/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
@@ -109,7 +109,7 @@
                     </td>
 
                     <td>
-                        <span>{{ complaint.submittedTime? | artemisDate }}</span>
+                        <span>{{ 'complaint.submittedTime' | artemisDate }}</span>
                     </td>
 
                     <td>

--- a/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
+++ b/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
@@ -109,7 +109,7 @@
                     </td>
 
                     <td>
-                        <span>{{ complaint.submittedTime?.moment().format("lll") }}</span>
+                        <span>{{ complaint.submittedTime? | artemisDate }}</span>
                     </td>
 
                     <td>

--- a/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
+++ b/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
@@ -63,6 +63,10 @@
                         <a class="th-link">{{ 'artemisApp.complaint.listOfComplaints.studentName' | artemisTranslate }}</a>
                         <fa-icon [icon]="'sort'"></fa-icon>
                     </th>
+                    <th jhiSortBy="submittedTime">
+                        <a class="th-link">{{ 'artemisApp.complaint.listOfComplaints.dateAndTime' | artemisTranslate }}</a>
+                        <fa-icon [icon]="'sort'"></fa-icon>
+                    </th>
                     <th jhiSortBy="accepted">
                         <a class="th-link">{{ 'artemisApp.complaint.listOfComplaints.status' | artemisTranslate }}</a>
                         <fa-icon [icon]="'sort'"></fa-icon>
@@ -102,6 +106,10 @@
 
                     <td *ngIf="hasStudentInformation">
                         <span>{{ complaint.student?.name }}</span>
+                    </td>
+
+                    <td>
+                        <span>{{ complaint.submittedTime }}</span>
                     </td>
 
                     <td>

--- a/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
+++ b/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
@@ -109,7 +109,7 @@
                     </td>
 
                     <td>
-                        <span>{{ complaint.submittedTime }}</span>
+                        <span>{{ complaint.submittedTime.format('MMM, Do YYYY, hh:mm') }}</span>
                     </td>
 
                     <td>

--- a/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
+++ b/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.html
@@ -109,7 +109,7 @@
                     </td>
 
                     <td>
-                        <span>{{ 'complaint.submittedTime?' | artemisDate }}</span>
+                        <span>{{ complaint.submittedTime | artemisDate }}</span>
                     </td>
 
                     <td>

--- a/src/main/webapp/i18n/de/complaint.json
+++ b/src/main/webapp/i18n/de/complaint.json
@@ -36,6 +36,7 @@
                 "studentName": "Name",
                 "actions": "Aktionen",
                 "title": "Liste der Beschwerden",
+                "dateAndTime": "Datum und Uhrzeit",
                 "status": "Status",
                 "noReply": "Noch keine Antwort",
                 "accepted": "Angenommen",

--- a/src/main/webapp/i18n/en/complaint.json
+++ b/src/main/webapp/i18n/en/complaint.json
@@ -41,7 +41,8 @@
                 "accepted": "Accepted",
                 "rejected": "Rejected",
                 "showAddressedComplaints": "Show addressed complaints",
-                "noComplaintsToShow": "There are no complaints to show at the moment"
+                "noComplaintsToShow": "There are no complaints to show at the moment",
+                "dateAndTime": "Date and Time",
             },
             "review": "Review Complaint"
         },

--- a/src/main/webapp/i18n/en/complaint.json
+++ b/src/main/webapp/i18n/en/complaint.json
@@ -36,13 +36,13 @@
                 "studentName": "Student's Name",
                 "actions": "Actions",
                 "title": "List of complaints",
+                "dateAndTime": "Date and Time",
                 "status": "Status",
                 "noReply": "No reply yet",
                 "accepted": "Accepted",
                 "rejected": "Rejected",
                 "showAddressedComplaints": "Show addressed complaints",
-                "noComplaintsToShow": "There are no complaints to show at the moment",
-                "dateAndTime": "Date and Time",
+                "noComplaintsToShow": "There are no complaints to show at the moment"
             },
             "review": "Review Complaint"
         },


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all the newly inserted strings into German and English

### Motivation and Context
Fixes #3488 

### Description
<!-- Describe your changes in detail -->
I added a column to the list of complaints and list of more feedback requests displaying the date and time of the corresponding entry.

### Steps for Testing
1. Log in to Artemis as an instructor
2. Navigate to Course Administration
3. Create an arbitrary exercise or use an existing one
4. Participate as a student
5. Assess the just created submission as instructor
6. Check the assessment and request more feedback or add a complaint as the same student
7. As instructor go to the instructor course dashboard and click on more feedback requests respectively complaints (depending on what you did at step 6)
8. Check the table for a date and time column

### Screenshots
<img width="1424" alt="List" src="https://user-images.githubusercontent.com/82283581/121727338-10ed1e80-caec-11eb-88c3-b9de38feb5da.png">