### PR TITLE
Update artemis-maven-template Docker Image to java16-3

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java
@@ -294,7 +294,7 @@ public interface ContinuousIntegrationService {
      */
     static String getDockerImageName(ProgrammingLanguage language) {
         return switch (language) {
-            case JAVA, KOTLIN, EMPTY -> "ls1tum/artemis-maven-template:java16-2";
+            case JAVA, KOTLIN, EMPTY -> "ls1tum/artemis-maven-template:java16-3";
             case PYTHON -> "ls1tum/artemis-python-docker:latest";
             case C -> "ls1tum/artemis-c-docker:latest";
             case HASKELL -> "tumfpv/fpv-stack:8.8.4";


### PR DESCRIPTION
Just an update for the `artemis-maven-template`, see https://hub.docker.com/layers/ls1tum/artemis-maven-template/java16-3/images/sha256-49e1b33062a1adf4bc739637a4fd5a560a53af354a2429e32f4c693e8abcd107?context=explore
