### PR TITLE
[Tests] Fix Flaky Export Test

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
@@ -126,7 +126,8 @@ public class UserCreationService {
         try {
             Set<Organization> matchingOrganizations = organizationRepository.getAllMatchingOrganizationsByUserEmail(email);
             newUser.setOrganizations(matchingOrganizations);
-        } catch (InvalidDataAccessApiUsageException | PatternSyntaxException pse) {
+        }
+        catch (InvalidDataAccessApiUsageException | PatternSyntaxException pse) {
             log.warn("Could not retrieve matching organizations from pattern: {}", pse.getMessage());
         }
         saveUser(newUser);
@@ -169,7 +170,8 @@ public class UserCreationService {
         try {
             Set<Organization> matchingOrganizations = organizationRepository.getAllMatchingOrganizationsByUserEmail(userDTO.getEmail());
             user.setOrganizations(matchingOrganizations);
-        } catch (InvalidDataAccessApiUsageException | PatternSyntaxException pse) {
+        }
+        catch (InvalidDataAccessApiUsageException | PatternSyntaxException pse) {
             log.warn("Could not retrieve matching organizations from pattern: {}", pse.getMessage());
         }
         user.setGroups(userDTO.getGroups());

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
@@ -63,6 +63,12 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    void testExportSubmissionAnonymizationCombining() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportSubmissionAnonymizationCombining();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void textExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
         programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
@@ -75,6 +75,12 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    void testExportSubmissionAnonymizationCombining() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportSubmissionAnonymizationCombining();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void textExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
         programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
@@ -286,9 +286,10 @@ public class ProgrammingExerciseIntegrationServiceTest {
         Optional<Path> extractedRepo1 = entries.stream().filter(entry -> entry.toString().endsWith(Paths.get("student1", ".git").toString())).findFirst();
         assertThat(extractedRepo1).isPresent();
         try (Git downloadedGit = Git.open(extractedRepo1.get().toFile())) {
-            RevCommit latestCommit = downloadedGit.log().setMaxCount(1).call().iterator().next();
-            assertThat(latestCommit.getAuthorIdent().getName()).isEqualTo("student");
-            assertThat(latestCommit.getFullMessage()).isEqualTo("All student changes in one commit");
+            List<RevCommit> commits = new ArrayList<>();
+            downloadedGit.log().call().iterator().forEachRemaining(commits::add);
+            assertThat(commits.stream().anyMatch(commit -> commit.getAuthorIdent().getName().equals("student"))).isTrue();
+            assertThat(commits.stream().anyMatch(commit -> commit.getFullMessage().equals("All student changes in one commit"))).isTrue();
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
@@ -253,8 +253,8 @@ public class ProgrammingExerciseIntegrationServiceTest {
     }
 
     public void textExportSubmissionsByParticipationIds() throws Exception {
-        var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), new VcsRepositoryUrl("url1"));
-        var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), new VcsRepositoryUrl("url2"));
+        var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), new VcsRepositoryUrl("www.test1.com"));
+        var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), new VcsRepositoryUrl("www.test2.com"));
         doReturn(repository1).when(gitService).getOrCheckoutRepository(eq(participation1.getVcsRepositoryUrl()), anyString(), anyBoolean());
         doReturn(repository2).when(gitService).getOrCheckoutRepository(eq(participation2.getVcsRepositoryUrl()), anyString(), anyBoolean());
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
@@ -269,6 +269,9 @@ public class ProgrammingExerciseIntegrationServiceTest {
         localGit.add().addFilepattern(".").call();
         localGit.commit().setMessage("commit").setAuthor("user1", "email1").call();
 
+        System.out.println("Commits before anonymization: ");
+        localGit.log().call().iterator().forEachRemaining(commit -> System.out.println(commit.getCommitTime() + "," + commit.getFullMessage() + "," + commit.getAuthorIdent().getName()));
+
         var participationIds = programmingExerciseStudentParticipationRepository.findAll().stream().map(participation -> participation.getId().toString())
                 .collect(Collectors.toList());
         final var path = ROOT + EXPORT_SUBMISSIONS_BY_PARTICIPATIONS.replace("{exerciseId}", String.valueOf(programmingExercise.getId())).replace("{participationIds}",
@@ -286,6 +289,8 @@ public class ProgrammingExerciseIntegrationServiceTest {
         Optional<Path> extractedRepo1 = entries.stream().filter(entry -> entry.toString().endsWith(Paths.get("student1", ".git").toString())).findFirst();
         assertThat(extractedRepo1).isPresent();
         try (Git downloadedGit = Git.open(extractedRepo1.get().toFile())) {
+            System.out.println("Commits after anonymization: ");
+            downloadedGit.log().call().iterator().forEachRemaining(commit -> System.out.println(commit.getCommitTime() + "," + commit.getFullMessage() + "," + commit.getAuthorIdent().getName()));
             List<RevCommit> commits = new ArrayList<>();
             downloadedGit.log().call().iterator().forEachRemaining(commits::add);
             assertThat(commits.stream().anyMatch(commit -> commit.getAuthorIdent().getName().equals("student"))).isTrue();

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
@@ -295,10 +295,6 @@ public class ProgrammingExerciseIntegrationServiceTest {
         localGit.add().addFilepattern(".").call();
         localGit.commit().setMessage("commit").setAuthor("user1", "email1").call();
 
-        System.out.println("Commits before anonymization: ");
-        localGit.log().call().iterator()
-                .forEachRemaining(commit -> System.out.println(commit.getCommitTime() + "," + commit.getFullMessage() + "," + commit.getAuthorIdent().getName()));
-
         // Rest call
         final var path = ROOT + EXPORT_SUBMISSIONS_BY_PARTICIPATIONS.replace("{exerciseId}", String.valueOf(programmingExercise.getId())).replace("{participationIds}",
                 String.valueOf(participation1.getId()));
@@ -317,10 +313,6 @@ public class ProgrammingExerciseIntegrationServiceTest {
         Optional<Path> extractedRepo1 = entries.stream().filter(entry -> entry.toString().endsWith(Paths.get("student1", ".git").toString())).findFirst();
         assertThat(extractedRepo1).isPresent();
         try (Git downloadedGit = Git.open(extractedRepo1.get().toFile())) {
-            System.out.println("Commits after anonymization: ");
-            downloadedGit.log().call().iterator()
-                    .forEachRemaining(commit -> System.out.println(commit.getCommitTime() + "," + commit.getFullMessage() + "," + commit.getAuthorIdent().getName()));
-
             RevCommit commit = downloadedGit.log().setMaxCount(1).call().iterator().next();
             assertThat(commit.getAuthorIdent().getName().equals("student")).isTrue();
             assertThat(commit.getFullMessage().equals("All student changes in one commit")).isTrue();

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
@@ -253,8 +253,8 @@ public class ProgrammingExerciseIntegrationServiceTest {
     }
 
     public void textExportSubmissionsByParticipationIds() throws Exception {
-        var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), new VcsRepositoryUrl("www.test1.com"));
-        var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), new VcsRepositoryUrl("www.test2.com"));
+        var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), new VcsRepositoryUrl("https://artemistest.ase.in.tum.de/"));
+        var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), new VcsRepositoryUrl("https://artemistest2.ase.in.tum.de/"));
         doReturn(repository1).when(gitService).getOrCheckoutRepository(eq(participation1.getVcsRepositoryUrl()), anyString(), anyBoolean());
         doReturn(repository2).when(gitService).getOrCheckoutRepository(eq(participation2.getVcsRepositoryUrl()), anyString(), anyBoolean());
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
@@ -253,16 +253,17 @@ public class ProgrammingExerciseIntegrationServiceTest {
     }
 
     public void textExportSubmissionsByParticipationIds() throws Exception {
-        var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
-        var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), null);
+        var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), new VcsRepositoryUrl("url1"));
+        var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), new VcsRepositoryUrl("url2"));
         doReturn(repository1).when(gitService).getOrCheckoutRepository(eq(participation1.getVcsRepositoryUrl()), anyString(), anyBoolean());
         doReturn(repository2).when(gitService).getOrCheckoutRepository(eq(participation2.getVcsRepositoryUrl()), anyString(), anyBoolean());
 
         // Mock and pretend first commit is template commit
         ObjectId head1 = localGit.getRepository().findRef("HEAD").getObjectId();
         ObjectId head2 = localGit2.getRepository().findRef("HEAD").getObjectId();
-        // Each head has to be returned twice, once for combineStudentCommits and once for anonymizeStudentCommits
-        when(gitService.getLastCommitHash(any())).thenReturn(head1, head1, head2, head2).thenCallRealMethod();
+        // Return the corresponding head to mock the template
+        when(gitService.getLastCommitHash(repository1.getRemoteRepositoryUrl())).thenReturn(head1);
+        when(gitService.getLastCommitHash(repository2.getRemoteRepositoryUrl())).thenReturn(head2);
 
         // Add commit to anonymize
         assertThat(localRepoFile.toPath().resolve("Test.java").toFile().createNewFile()).isTrue();


### PR DESCRIPTION
### Motivation and Context
The changed tests sometimes failed because the author was "Artemis" and not "student".

### Description
The issue was caused because the export order of the students is not always the same, causing errors with the mock providing fake template repositories. Attempting to refine the mock to be independent of the order caused more problems than it solved, so I split the tests into two: One testing if exporting multiple repositories works, and one to test if anonymization and squashing works. That way a simple mock suffices.

### Steps for Testing
1. Review code

### Test Coverage
unchanged
