### PR TITLE
Fix failing test on feedback editor close button css

### DIFF
--- a/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.html
+++ b/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.html
@@ -18,7 +18,7 @@
         <span [jhiTranslate]="'artemisApp.textAssessment.conflict.type.' + conflictType"></span>
     </span>
 
-    <div class="close-button" *ngIf="!readOnly">
+    <div class="close" *ngIf="!readOnly">
         <ng-container *ngIf="canDismiss; then closeButton; else trashButton"></ng-container>
         <ng-template #closeButton>
             <fa-icon icon="times" [ngbTooltip]="'artemisApp.textAssessment.feedbackEditor.dismissFeedback' | artemisTranslate" (click)="dismiss()"> </fa-icon>

--- a/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.scss
+++ b/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.scss
@@ -34,7 +34,7 @@ label {
     top: -25px;
 }
 
-.close-button {
+.close {
     display: inline;
     margin-top: -0.5vh;
     float: right;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes failing client test : _TextblockFeedbackEditorComponent should show delete button for empty feedback only_

### Description
<!-- Describe your changes in detail -->
A change in the css className led to a corresponding css query on the client test to fail. This PR resolves that by updating the class name to fit the one used in the test. Changed className from **close-button** back to **close**. 
[Test reference line](https://github.com/ls1intum/Artemis/blob/develop/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-editor.component.spec.ts#L59)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to a Text Exercise submission.
3. Check or click a text block
4. The X-button should show on the top right corner.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/18335489/122076332-13f15300-cdfb-11eb-8e82-a9c650f650ec.png)

