### PR TITLE
Fix sentry issue for grading-instructions-details.component

### DIFF
--- a/src/main/webapp/app/exercises/shared/structured-grading-criterion/grading-instructions-details/grading-instructions-details.component.ts
+++ b/src/main/webapp/app/exercises/shared/structured-grading-criterion/grading-instructions-details/grading-instructions-details.component.ts
@@ -83,7 +83,7 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
 
     generateMarkdown(): string {
         let markdownText = '';
-        if (this.criteria === undefined || this.criteria.length === 0) {
+        if (this.criteria == undefined || this.criteria.length === 0) {
             this.criteria = [];
             const dummyCriterion = new GradingCriterion();
             const exampleCriterion = new GradingCriterion();
@@ -96,7 +96,7 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
             this.criteria.push(exampleCriterion);
         }
         for (const criterion of this.criteria) {
-            if (criterion.title === null || criterion.title === undefined) {
+            if (criterion.title == undefined) {
                 // if it is a dummy criterion, leave out the command identifier
                 markdownText += this.generateInstructionsMarkdown(criterion);
             } else {
@@ -112,7 +112,7 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
      */
     generateInstructionsMarkdown(criterion: GradingCriterion): string {
         let markdownText = '';
-        if (criterion.structuredGradingInstructions === undefined || criterion.structuredGradingInstructions.length === 0) {
+        if (criterion.structuredGradingInstructions == undefined || criterion.structuredGradingInstructions.length === 0) {
             this.instructions = [];
             const newInstruction = new GradingInstruction();
             this.instructions.push(newInstruction);
@@ -149,7 +149,7 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
     }
 
     generateCreditsText(instruction: GradingInstruction): string {
-        if (instruction.credits === undefined) {
+        if (instruction.credits == undefined) {
             instruction.credits = parseFloat(CreditsCommand.text);
             return CreditsCommand.identifier + ' ' + CreditsCommand.text;
         }
@@ -157,7 +157,7 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
     }
 
     generateGradingScaleText(instruction: GradingInstruction): string {
-        if (instruction.gradingScale === undefined) {
+        if (instruction.gradingScale == undefined) {
             instruction.gradingScale = GradingScaleCommand.text;
             return GradingScaleCommand.identifier + ' ' + GradingScaleCommand.text;
         }
@@ -165,7 +165,7 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
     }
 
     generateInstructionDescriptionText(instruction: GradingInstruction): string {
-        if (instruction.instructionDescription === undefined) {
+        if (instruction.instructionDescription == undefined) {
             instruction.instructionDescription = InstructionDescriptionCommand.text;
             return InstructionDescriptionCommand.identifier + ' ' + InstructionDescriptionCommand.text;
         }
@@ -173,7 +173,7 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
     }
 
     generateInstructionFeedback(instruction: GradingInstruction): string {
-        if (instruction.feedback === undefined) {
+        if (instruction.feedback == undefined) {
             instruction.feedback = FeedbackCommand.text;
             return FeedbackCommand.identifier + ' ' + FeedbackCommand.text;
         }
@@ -181,7 +181,7 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
     }
 
     generateUsageCount(instruction: GradingInstruction): string {
-        if (instruction.usageCount === undefined) {
+        if (instruction.usageCount == undefined) {
             instruction.usageCount = parseInt(UsageCountCommand.text, 10);
             return UsageCountCommand.identifier + ' ' + UsageCountCommand.text;
         }
@@ -259,7 +259,7 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
      */
     groupInstructionsToCriteria(domainCommands: [string, DomainCommand | null][]): void {
         const initialCriteriaCommands = domainCommands;
-        if (this.exercise.gradingCriteria === undefined) {
+        if (this.exercise.gradingCriteria == undefined) {
             this.exercise.gradingCriteria = [];
         }
         for (const [text, command] of domainCommands) {
@@ -298,6 +298,9 @@ export class GradingInstructionsDetailsComponent implements OnInit, AfterContent
     setInstructionParameters(domainCommands: [string, DomainCommand | null][]): void {
         let index = 0;
         for (const [text, command] of domainCommands) {
+            if (!this.instructions[index]) {
+                break;
+            }
             if (command instanceof CreditsCommand) {
                 this.instructions[index].credits = parseFloat(text);
             } else if (command instanceof GradingScaleCommand) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

PR aims to resolve the sentry issue which is labeled as #ARTEMIS-11Y.

### How to reproduce the error before deployment:
1. Log in to Artemis
2. Navigate to Course Administration
3. Create new exercise (could be any type of exercise) and enable `Structured Grading Instructions` button
4. In the end of the markdown editor, add one of the command like that `[credits] 0` or `[gradingScale] add instruction` without `[gradingInstruction]` tag at the beginning (see the screenshot below)
5. You should see the following error at the console: `Cannot set property 'credits' of undefined` or `Cannot set property 'gradingScale' of undefined` etc.

<img src="https://user-images.githubusercontent.com/23650630/122313025-c0275c80-cf15-11eb-8282-0f814e9366ea.jpg" width="450"/>

### Description
<!-- Describe your changes in detail -->

I added simple check before setting the corresponding command. The sub-command does not make sense if `[gradingInstruction]` tag is not available, it should not be set for undefined instruction. Also, I modified the `=== undefined` checks with `== undefined`. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

After deployment, follow the steps you used for reproducing. There should not be any errors related with that.
