### PR TITLE
Remove sudo from C Jenkinsfile

### DIFF
--- a/src/main/resources/templates/jenkins/c/regularRuns/Jenkinsfile
+++ b/src/main/resources/templates/jenkins/c/regularRuns/Jenkinsfile
@@ -27,10 +27,10 @@ pipeline {
                         sh  '''
                             cd $WORKSPACE
                             # Updating assignment and test-reports ownership...
-                            sudo chown artemis_user:artemis_user assignment/ -R
-                            sudo rm -rf test-reports
-                            sudo mkdir test-reports
-                            sudo chown artemis_user:artemis_user test-reports/ -R
+                            chown artemis_user:artemis_user assignment/ -R
+                            rm -rf test-reports
+                            mkdir test-reports
+                            chown artemis_user:artemis_user test-reports/ -R
 
                             # assignment
                             cd tests


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #2778. 

### Description
<!-- Describe your changes in detail -->
We remove the use of `sudo` from the Jenkinsfile for C exercises because apparently it's not needed for the pipeline to run correctly (I tested this locally and on TS2 which uses a separate agent for running pipelines). 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Please use TS2 to test this PR:

1. Log in to Artemis
2. Navigate to Course Administration
3. Generate a C programming exercise
4. Click on "Edit in Editor", navigate to solutions and make sure all tests passed
5. Participate in the exercise. Here you should get build errors if you enter gibberish. If you enter the solution code, the tests should pass 
