### PR TITLE
Add an exercise list to the course details page

### DIFF
--- a/src/main/webapp/app/course/manage/course-management.service.ts
+++ b/src/main/webapp/app/course/manage/course-management.service.ts
@@ -110,6 +110,7 @@ export class CourseManagementService {
     findWithExercises(courseId: number): Observable<EntityResponseType> {
         return this.http.get<Course>(`${this.resourceUrl}/${courseId}/with-exercises`, { observe: 'response' }).pipe(
             map((res: EntityResponseType) => this.convertDateFromServer(res)),
+            map((res: EntityResponseType) => this.checkAccessRightsCourse(res)),
             tap((res: EntityResponseType) => this.convertExerciseCategoriesFromServer(res)),
         );
     }

--- a/src/main/webapp/app/course/manage/detail/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.html
@@ -141,6 +141,74 @@
             ></jhi-course-detail-bar-chart>
         </div>
         <hr />
+        <table class="table table-striped" *ngIf="course.exercises && course.exercises.length > 0">
+            <thead>
+                <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="sortRows.bind(this)">
+                    <th jhiSortBy="type"><span jhiTranslate="artemisApp.exercise.type">Type</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th jhiSortBy="title"><span jhiTranslate="artemisApp.exercise.detail.title">Title</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th jhiSortBy="releaseDate"><span jhiTranslate="artemisApp.course.releaseDate">Email</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th jhiSortBy="dueDate"><span jhiTranslate="artemisApp.course.dueDate">Name</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th jhiSortBy="assessmentDueDate"><span jhiTranslate="artemisApp.course.assessmentDueDate">Lang Key</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let exercise of course.exercises; trackBy: trackExercise">
+                    <td>
+                        <fa-icon [icon]="icons[exercise.type!]" placement="right" [ngbTooltip]="iconTooltips[exercise.type!] | artemisTranslate"></fa-icon>
+                    </td>
+                    <td>
+                        <a [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id]">{{ exercise.title }}</a>
+                    </td>
+                    <td>{{ exercise.releaseDate | artemisDate }}</td>
+                    <td>{{ exercise.dueDate | artemisDate }}</td>
+                    <td>{{ exercise.assessmentDueDate | artemisDate }}</td>
+                    <td>
+                        <!-- TODO: reduce duplication -->
+                        <div class="row-flex button-row">
+                            <a
+                                *ngIf="course.isAtLeastEditor && exercise.type !== exerciseType.QUIZ"
+                                [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id, 'edit']"
+                                class="btn btn-warning mr-1 mb-1"
+                                [ngbTooltip]="'entity.action.edit' | artemisTranslate"
+                            ><fa-icon [icon]="'wrench'"></fa-icon
+                            ></a>
+                            <!-- if the quiz is past
+                            <a
+                                *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.QUIZ"
+                                [routerLink]="['/course-management', course.id, details.type + '-exercises', exercise.id, 're-evaluate']"
+                                class="btn btn-warning mr-1 mb-1"
+                                [ngbTooltip]="'entity.action.re-evaluate' | artemisTranslate"
+                            ><fa-icon [icon]="'wrench'"></fa-icon
+                            ></a>
+                            -->
+                            <a
+                                *ngIf="course.isAtLeastTutor"
+                                [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id, 'scores']"
+                                class="btn btn-info mr-1 mb-1"
+                                [ngbTooltip]="'entity.action.scores' | artemisTranslate"
+                            ><fa-icon [icon]="'table'"></fa-icon
+                            ></a>
+                            <a
+                                *ngIf="course.isAtLeastInstructor && exercise.type !== exerciseType.PROGRAMMING && exercise.type !== exerciseType.QUIZ"
+                                [routerLink]="['/course-management', course.id, exercise.type + '-exercises', exercise.id, 'submissions']"
+                                class="btn btn-success mr-1 mb-1"
+                                [ngbTooltip]="'artemisApp.courseOverview.exerciseDetails.instructorActions.submissions' | artemisTranslate"
+                            ><fa-icon [icon]="'book'"></fa-icon
+                            ></a>
+                            <a
+                                *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.PROGRAMMING"
+                                [routerLink]="['/course-management', course.id, 'programming-exercises', exercise.id, 'grading', 'test-cases']"
+                                class="btn btn-info mr-1 mb-1"
+                                [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.shortTitle' | artemisTranslate"
+                            ><fa-icon class="grading-icon" [icon]="'file-signature'"></fa-icon
+                            ></a>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <hr />
         <div>
             <h2><span jhiTranslate="artemisApp.course.detail.title">Course Details:</span></h2>
         </div>

--- a/src/main/webapp/app/course/manage/detail/course-detail.component.ts
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.ts
@@ -13,6 +13,8 @@ import { ButtonSize } from 'app/shared/components/button.component';
 import { CourseManagementDetailViewDto } from 'app/course/manage/course-management-detail-view-dto.model';
 import { ARTEMIS_DEFAULT_COLOR } from 'app/app.constants';
 import { onError } from 'app/shared/util/global.utils';
+import { Exercise, ExerciseType, icons, iconTooltips } from 'app/entities/exercise.model';
+import { SortService } from 'app/shared/service/sort.service';
 
 export enum DoughnutChartType {
     ASSESSMENT = 'ASSESSMENT',
@@ -47,12 +49,20 @@ export class CourseDetailComponent implements OnInit, OnDestroy {
     dialogError$ = this.dialogErrorSource.asObservable();
     paramSub: Subscription;
 
+    searchTermString = '';
+    exerciseType = ExerciseType;
+    predicate: string = 'id';
+    reverse: boolean = false;
+    icons = icons;
+    iconTooltips = iconTooltips;
+
     constructor(
         private eventManager: JhiEventManager,
         private courseService: CourseManagementService,
         private route: ActivatedRoute,
         private router: Router,
         private jhiAlertService: JhiAlertService,
+        private sortService: SortService,
     ) {}
 
     /**
@@ -92,7 +102,7 @@ export class CourseDetailComponent implements OnInit, OnDestroy {
             courseId = params['courseId'];
         });
         // Get course first for basic course information
-        this.courseService.find(courseId).subscribe((courseResponse) => {
+        this.courseService.findWithExercises(courseId).subscribe((courseResponse) => {
             this.course = courseResponse.body!;
         });
         // fetch statistics separately because it takes quite long for larger courses
@@ -122,4 +132,22 @@ export class CourseDetailComponent implements OnInit, OnDestroy {
         );
         this.router.navigate(['/course-management']);
     }
+
+    /**
+     * Returns the unique identifier the exercises in the collection
+     * @param index of the exercise in the collection
+     * @param exercise current exercise
+     */
+    trackExercise(index: number, exercise: Exercise) {
+        return exercise.id;
+    }
+
+    sortRows() {
+        this.sortService.sortByProperty(this.course.exercises!, this.predicate, this.reverse);
+    }
+
+    /**
+     * Used in the template for jhiSort
+     */
+    callback() {}
 }

--- a/src/main/webapp/app/entities/exercise.model.ts
+++ b/src/main/webapp/app/entities/exercise.model.ts
@@ -145,35 +145,36 @@ export abstract class Exercise implements BaseEntity {
     }
 }
 
+export const icons = {
+    [ExerciseType.PROGRAMMING]: 'keyboard' as IconProp,
+    [ExerciseType.MODELING]: 'project-diagram' as IconProp,
+    [ExerciseType.QUIZ]: 'check-double' as IconProp,
+    [ExerciseType.TEXT]: 'font' as IconProp,
+    [ExerciseType.FILE_UPLOAD]: 'file-upload' as IconProp,
+};
+
 export function getIcon(exerciseType?: ExerciseType): IconProp {
     if (!exerciseType) {
         return 'question' as IconProp;
     }
 
-    const icons = {
-        [ExerciseType.PROGRAMMING]: 'keyboard',
-        [ExerciseType.MODELING]: 'project-diagram',
-        [ExerciseType.QUIZ]: 'check-double',
-        [ExerciseType.TEXT]: 'font',
-        [ExerciseType.FILE_UPLOAD]: 'file-upload',
-    };
-
-    return icons[exerciseType] as IconProp;
+    return icons[exerciseType];
 }
+
+export const iconTooltips = {
+    [ExerciseType.PROGRAMMING]: 'artemisApp.exercise.isProgramming',
+    [ExerciseType.MODELING]: 'artemisApp.exercise.isModeling',
+    [ExerciseType.QUIZ]: 'artemisApp.exercise.isQuiz',
+    [ExerciseType.TEXT]: 'artemisApp.exercise.isText',
+    [ExerciseType.FILE_UPLOAD]: 'artemisApp.exercise.isFileUpload',
+};
 
 export function getIconTooltip(exerciseType?: ExerciseType): string {
     if (!exerciseType) {
         return '';
     }
-    const tooltips = {
-        [ExerciseType.PROGRAMMING]: 'artemisApp.exercise.isProgramming',
-        [ExerciseType.MODELING]: 'artemisApp.exercise.isModeling',
-        [ExerciseType.QUIZ]: 'artemisApp.exercise.isQuiz',
-        [ExerciseType.TEXT]: 'artemisApp.exercise.isText',
-        [ExerciseType.FILE_UPLOAD]: 'artemisApp.exercise.isFileUpload',
-    };
 
-    return tooltips[exerciseType];
+    return iconTooltips[exerciseType];
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [ ] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] Client: I translated all the newly inserted strings into English and German using neutral, gender-inclusive language

### Description

Extends the course detail page to include a list of exercises for quick navigation.

### Steps for Testing

Open the course details page of a course and check the exercises list. It should display all exercises, be sortable, and show correct buttons.

### Test Coverage


### Screenshots

![grafik](https://user-images.githubusercontent.com/72132281/122784856-2106ba00-d2b3-11eb-86f6-0623a44e3541.png)

