### PR TITLE
Created assessment_knowledge table

### DIFF
--- a/.idea/runConfigurations/Artemis__Server__Athene_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Athene_.xml
@@ -5,7 +5,7 @@
     <option name="ACTIVE_PROFILES" value="dev,bamboo,bitbucket,jira,artemis,scheduling,athene,local" />
     <option name="VM_PARAMETERS" value="--illegal-access=warn" />
     <option name="ALTERNATIVE_JRE_PATH" />
-    <option name="SHORTEN_COMMAND_LINE" value="NONE" />
+    <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/src/main/java/de/tum/in/www1/artemis/domain/AssessmentKnowledge.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/AssessmentKnowledge.java
@@ -1,0 +1,64 @@
+package de.tum.in.www1.artemis.domain;
+
+import javax.persistence.*;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "assessment_knowledge")
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class AssessmentKnowledge extends DomainObject{
+
+    @OneToMany(mappedBy = "knowledge", fetch = FetchType.LAZY)
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @JsonIgnoreProperties("knowledge")
+    private Set<Exercise> exercises = new HashSet<>();
+
+    @OneToMany(mappedBy = "knowledge", fetch = FetchType.LAZY)
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @JsonIgnoreProperties("knowledge")
+    private Set<Feedback> feedbacks = new HashSet<>();
+
+    @OneToMany(mappedBy = "knowledge", fetch = FetchType.LAZY)
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
+    @JsonIgnoreProperties("knowledge")
+    private Set<TextBlock> textBlocks = new HashSet<>();
+
+    public Set<Exercise> getExercises() {
+        return exercises;
+    }
+
+    public AssessmentKnowledge addExercises(Exercise exercise) {
+        this.exercises.add(exercise);
+        exercise.setKnowledge(this);
+        return this;
+    }
+
+    public Set<Feedback> getFeedbacks() {
+        return feedbacks;
+    }
+
+    public AssessmentKnowledge addFeedbacks(Feedback feedback) {
+        this.feedbacks.add(feedback);
+        feedback.setKnowledge(this);
+        return this;
+    }
+
+    public Set<TextBlock> getTextBlocks() {
+        return textBlocks;
+    }
+
+    public AssessmentKnowledge addTextBlocks(TextBlock textBlock) {
+        this.textBlocks.add(textBlock);
+        textBlock.setKnowledge(this);
+        return this;
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -163,6 +163,10 @@ public abstract class Exercise extends DomainObject {
     @JsonIgnore
     private Set<ExerciseHint> exerciseHints = new HashSet<>();
 
+    @ManyToOne
+    @JsonIgnoreProperties("exercises")
+    private AssessmentKnowledge knowledge;
+
     // NOTE: Helpers variable names must be different from Getter name, so that Jackson ignores the @Transient annotation, but Hibernate still respects it
     @Transient
     private DueDateStat numberOfSubmissionsTransient;
@@ -915,6 +919,14 @@ public abstract class Exercise extends DomainObject {
         else {
             return 1;
         }
+    }
+
+    public AssessmentKnowledge getKnowledge() {
+        return knowledge;
+    }
+
+    public void setKnowledge(AssessmentKnowledge knowledge) {
+        this.knowledge = knowledge;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/Feedback.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Feedback.java
@@ -67,6 +67,10 @@ public class Feedback extends DomainObject {
     private Result result;
 
     @ManyToOne
+    @JsonIgnoreProperties("feedbacks")
+    private AssessmentKnowledge knowledge;
+
+    @ManyToOne
     private GradingInstruction gradingInstruction;
 
     // TODO: JP remove these two references as they are not really needed
@@ -336,5 +340,13 @@ public class Feedback extends DomainObject {
             totalScore += getCredits();
         }
         return totalScore;
+    }
+
+    public AssessmentKnowledge getKnowledge() {
+        return knowledge;
+    }
+
+    public void setKnowledge(AssessmentKnowledge knowledge) {
+        this.knowledge = knowledge;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/TextBlock.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/TextBlock.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import javax.persistence.*;
 import javax.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
@@ -66,6 +67,10 @@ public class TextBlock implements Serializable {
     @ManyToOne
     @JsonIgnore
     private TextSubmission submission;
+
+    @ManyToOne
+    @JsonIgnoreProperties("textBlocks")
+    private AssessmentKnowledge knowledge;
 
     @ManyToOne
     @JsonIgnore
@@ -225,5 +230,13 @@ public class TextBlock implements Serializable {
 
     public void setNumberOfAffectedSubmissions(int numberOfAffectedSubmissions) {
         this.numberOfAffectedSubmissions = numberOfAffectedSubmissions;
+    }
+
+    public AssessmentKnowledge getKnowledge() {
+        return knowledge;
+    }
+
+    public void setKnowledge(AssessmentKnowledge knowledge) {
+        this.knowledge = knowledge;
     }
 }

--- a/src/main/resources/config/liquibase/changelog/20212106192928_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20212106192928_changelog.xml
@@ -1,0 +1,10 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="argertboja" id="20212106192928">
+        <createTable tableName="assessment_knowledge">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints primaryKey="true" primaryKeyName="knowledgePK"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -123,6 +123,7 @@
     <include file="classpath:config/liquibase/changelog/20210528104100_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20210528163200_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20210605180002_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20212106192928_changelog.xml" relativeToChangelogFile="false"/>
 
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Server: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/server.html).
- [ ] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [ ] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] Server: I documented the Java code using JavaDoc style.
- [ ] Client: I followed the [coding and design guidelines](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/client.html).
- [ ] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [ ] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] Client: I translated all the newly inserted strings into English and German using neutral, gender-inclusive language

### Motivation and Context
See: #3441 
Currently, we do not store any connection between an imported exercise and the one from which it was imported. However, in order to be able to reuse the feedback of old assessments we need to establish such a connection between the parent and the imported exercises.

### Description
We have introduced a new table `assessment_knowledge` which will store only an id value. This value is used to connect to each other the tables `exercise`, `text_block`, and `feedback` by storing this knowledge_id in each specific table. 

Furthermore, as a text block can now be part of multiple clusters, we have introduced a new table `cluster_to_block` which will have an `id`, `exercise_id`, `cluser_id`, and `block_id` columns and hence enabling a `ManyToMany` relationship where each cluster can have multiple blocks and each block can belong to multiple clusters.

### Steps for Testing

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

