### PR TITLE
[Bugfix] Code Editor Tutor Assessment Inline Feedback fix points

### DIFF
--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
@@ -23,11 +23,9 @@
             <button type="button" class="btn btn-secondary btn-sm" (click)="cancelFeedback()">
                 <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
             </button>
-            <div *ngIf="feedback.type === MANUAL">
-                <button type="submit" (click)="deleteFeedback()" class="btn btn-danger btn-sm me-1">
-                    <fa-icon [icon]="'trash-alt'"></fa-icon> <span jhiTranslate="entity.action.delete">Delete</span>
-                </button>
-            </div>
+            <button *ngIf="feedback.type === MANUAL" type="submit" (click)="deleteFeedback()" class="btn btn-danger btn-sm me-1">
+                <fa-icon [icon]="'trash-alt'"></fa-icon> <span jhiTranslate="entity.action.delete">Delete</span>
+            </button>
             <button type="submit" [disabled]="feedback.credits == null" class="btn btn-primary btn-sm" (click)="updateFeedback()">
                 <fa-icon [icon]="'save'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
             </button>

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
@@ -7,11 +7,11 @@
 >
     <div class="m-2">
         <div *ngIf="!viewOnly; else readOnlyFeedback" class="row align-items-start" (drop)="updateFeedbackOnDrop($event)" (dragover)="$event.preventDefault()">
-            <div class="form-group col-9" [style.max-width]="'500px'">
+            <div class="form-group col-8">
                 <label jhiTranslate="artemisApp.assessment.detail.feedback"></label>
                 <textarea class="form-control" rows="5" [(ngModel)]="feedback.detailText" [readOnly]="viewOnly"></textarea>
             </div>
-            <div class="form-group col-2" [style.max-width]="'100px'">
+            <div class="form-group col-2">
                 <label jhiTranslate="artemisApp.exercise.score"></label>
                 <input class="form-control" type="number" step="0.5" [(ngModel)]="feedback.credits" [readOnly]="viewOnly || disableEditScore" />
             </div>

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
@@ -7,18 +7,13 @@
 >
     <div class="m-2">
         <div *ngIf="!viewOnly; else readOnlyFeedback" class="row align-items-start" (drop)="updateFeedbackOnDrop($event)" (dragover)="$event.preventDefault()">
-            <div class="form-group col-8" [style.max-width]="'500px'">
+            <div class="form-group col-9" [style.max-width]="'500px'">
                 <label jhiTranslate="artemisApp.assessment.detail.feedback"></label>
                 <textarea class="form-control" rows="5" [(ngModel)]="feedback.detailText" [readOnly]="viewOnly"></textarea>
             </div>
-            <div class="form-group col-1" [style.max-width]="'100px'">
+            <div class="form-group col-2" [style.max-width]="'100px'">
                 <label jhiTranslate="artemisApp.exercise.score"></label>
                 <input class="form-control" type="number" step="0.5" [(ngModel)]="feedback.credits" [readOnly]="viewOnly || disableEditScore" />
-            </div>
-            <div *ngIf="feedback.type === MANUAL" class="form-group col-2">
-                <button type="submit" (click)="deleteFeedback()" class="btn btn-danger btn-sm me-1">
-                    <fa-icon [icon]="'trash-alt'"></fa-icon> <span jhiTranslate="entity.action.delete">Delete</span>
-                </button>
             </div>
             <div class="form-group col-1" *ngIf="feedback.gradingInstruction!">
                 <jhi-grading-instruction-link-icon [assessment]="feedback"></jhi-grading-instruction-link-icon>
@@ -28,6 +23,11 @@
             <button type="button" class="btn btn-secondary btn-sm" (click)="cancelFeedback()">
                 <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
             </button>
+            <div *ngIf="feedback.type === MANUAL">
+                <button type="submit" (click)="deleteFeedback()" class="btn btn-danger btn-sm me-1">
+                    <fa-icon [icon]="'trash-alt'"></fa-icon> <span jhiTranslate="entity.action.delete">Delete</span>
+                </button>
+            </div>
             <button type="submit" [disabled]="feedback.credits == null" class="btn btn-primary btn-sm" (click)="updateFeedback()">
                 <fa-icon [icon]="'save'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
             </button>

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
@@ -7,15 +7,15 @@
 >
     <div class="m-2">
         <div *ngIf="!viewOnly; else readOnlyFeedback" class="row align-items-start" (drop)="updateFeedbackOnDrop($event)" (dragover)="$event.preventDefault()">
-            <div class="form-group col-8">
+            <div class="form-group col-8 p-2">
                 <label jhiTranslate="artemisApp.assessment.detail.feedback"></label>
                 <textarea class="form-control" rows="5" [(ngModel)]="feedback.detailText" [readOnly]="viewOnly"></textarea>
             </div>
-            <div class="form-group col-2">
+            <div class="form-group col-3 p-2">
                 <label jhiTranslate="artemisApp.exercise.score"></label>
-                <input class="form-control" type="number" step="0.5" [(ngModel)]="feedback.credits" [readOnly]="viewOnly || disableEditScore" />
+                <input class="form-control px-1" type="number" step="0.5" [(ngModel)]="feedback.credits" [readOnly]="viewOnly || disableEditScore" />
             </div>
-            <div class="form-group col-1" *ngIf="feedback.gradingInstruction!">
+            <div class="form-group col-1 p-2" *ngIf="feedback.gradingInstruction!">
                 <jhi-grading-instruction-link-icon [assessment]="feedback"></jhi-grading-instruction-link-icon>
             </div>
         </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently, the points can not be used efficiently when the user wants to give inline feedback during programming exercise assessment. I just changed the column size for points and move the delete button into the bottom area for saving some space.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Create/Find a programming exercise
3. Set Manual Review and Enable online code editor
4. Participate to the exercise
5. As an instructor, start to assess this submission after due date
6. give an inline feedback on code editor
7. you should be able to see points properly
8. after save, click edit for this inline feedback
9. delete button should be placed at the bottom row

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
nothing's changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Before:** 

<img src="https://user-images.githubusercontent.com/23650630/123345018-6cd88e00-d555-11eb-9f94-3fed2ba26fa2.png" width="500" />
<img src="https://user-images.githubusercontent.com/23650630/123345038-79f57d00-d555-11eb-9cac-b2907c5ec16c.png" width="500" />

**After:**
<img src="https://user-images.githubusercontent.com/23650630/123349940-3f421380-d55a-11eb-8133-67b9094cab59.png" width="500" />
<img src="https://user-images.githubusercontent.com/23650630/123349924-35b8ab80-d55a-11eb-807c-1d947f295583.png" width="500" />
