### PR TITLE
Use bottom-end placement for the account dropdown

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -156,7 +156,7 @@
                 ngbDropdown
                 class="nav-item dropdown pointer"
                 display="dynamic"
-                placement="bottom-right"
+                placement="bottom-end"
                 routerLinkActive="active"
                 [routerLinkActiveOptions]="{ exact: true }"
                 [autoClose]="true"


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Currently the dropdown overflowed outside of the screen (you had to scroll right) for short names (like your university login).

### Description

The bootstrap changes from 4->5 included renaming `right` to `end` which was overlooked here.

### Screenshots
Before:
![grafik](https://user-images.githubusercontent.com/72132281/123511178-43685100-d680-11eb-9f80-fec648fd99a9.png)
After:
![grafik](https://user-images.githubusercontent.com/72132281/123511144-069c5a00-d680-11eb-9f75-5c07a0b812d0.png)
