### PR TITLE
delete BuildLogEntries when deleting submissions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/BuildLogEntryRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/BuildLogEntryRepository.java
@@ -15,10 +15,9 @@ import de.tum.in.www1.artemis.domain.BuildLogEntry;
 public interface BuildLogEntryRepository extends JpaRepository<BuildLogEntry, Long> {
 
     /**
-     * Returns the title of the hint with the given id
+     * deletes all BuildLogEntry s of a ProgrammingSubmission
      *
-     * @param hintId the id of the hint
-     * @return the name/title of the hint or null if the hint does not exist
+     * @param programmingSubmissionId the id of the submission
      */
     @Modifying
     @Query("""

--- a/src/main/java/de/tum/in/www1/artemis/repository/BuildLogEntryRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/BuildLogEntryRepository.java
@@ -1,6 +1,9 @@
 package de.tum.in.www1.artemis.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import de.tum.in.www1.artemis.domain.BuildLogEntry;
@@ -10,5 +13,19 @@ import de.tum.in.www1.artemis.domain.BuildLogEntry;
  */
 @Repository
 public interface BuildLogEntryRepository extends JpaRepository<BuildLogEntry, Long> {
+
+    /**
+     * Returns the title of the hint with the given id
+     *
+     * @param hintId the id of the hint
+     * @return the name/title of the hint or null if the hint does not exist
+     */
+    @Modifying
+    @Query("""
+            DELETE
+            FROM BuildLogEntry b
+            WHERE b.programmingSubmission.id = :programmingSubmissionId
+            """)
+    void deleteAllByProgrammingSubmissionId(@Param("programmingSubmissionId") Long programmingSubmissionId);
 
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -791,7 +791,6 @@ public class ProgrammingExerciseService {
          * chance to remove the Artemis-local repositories on the server. In summary, they should and can always be deleted.
          */
         if (programmingExercise.getTemplateRepositoryUrl() != null) {
-
             gitService.deleteLocalRepository(templateRepositoryUrlAsUrl);
         }
         if (programmingExercise.getSolutionRepositoryUrl() != null) {

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -791,6 +791,7 @@ public class ProgrammingExerciseService {
          * chance to remove the Artemis-local repositories on the server. In summary, they should and can always be deleted.
          */
         if (programmingExercise.getTemplateRepositoryUrl() != null) {
+
             gitService.deleteLocalRepository(templateRepositoryUrlAsUrl);
         }
         if (programmingExercise.getSolutionRepositoryUrl() != null) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Should fix https://sentry.ase.in.tum.de/organizations/artemis/issues/134/

### Description
<!-- Describe your changes in detail -->
Sometimes exercises can't be deleted because submissions for the exercise are referenced by Build Logs. This PR adds expllicit deletion of such rows.
@krusche I'm a little unsure, can such rows be safely deleted?

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Could not reliably reproduce the original issue found on sentry -> code review.
