### PR TITLE
Don't limit plagiarism similarity to 50%

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
@@ -184,8 +184,6 @@ public class ProgrammingPlagiarismDetectionService {
             options.setBaseCodeSubmissionName(templateRepoName);
         }
 
-        // Important: for large courses with more than 1000 students, we might get more than one million results and 10 million files in the file system due to many 0% results,
-        // therefore we limit the results to at least 50% or 0.5 similarity, the passed threshold is between 0 and 100%
         options.setSimilarityThreshold(similarityThreshold);
 
         log.info("Start JPlag programming comparison for programming exercise {}", programmingExerciseId);

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
@@ -38,7 +38,7 @@
                     [ngbTooltip]="'artemisApp.plagiarism.similarity-threshold-tooltip' | artemisTranslate"
                     container="body"
                 ></fa-icon>
-                <input type="number" required class="form-control" min="50" max="100" step="5" id="plagiarism-similarity-threshold" [(ngModel)]="similarityThreshold" />
+                <input type="number" required class="form-control" min="0" max="100" step="5" id="plagiarism-similarity-threshold" [(ngModel)]="similarityThreshold" />
             </div>
 
             <div class="plagiarism-option" [class.disabled]="!enableMinimumScore">


### PR DESCRIPTION
fixes #3601

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We limited the saved plagiarism results to 5000 which drastically improved performance, therefore there is no reason to limit the similarity threshold anymore. 
fixes #3601 

### Description
<!-- Describe your changes in detail -->
As far as I can see the only thing preventing users from entering numbers less than 50% is a html tag. I removed it. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. submit results with only a little overlap
2. run plagiarism detection with less than 50% similarity threshold
3. make sure such results <50% similarity are present.


