### PR TITLE
Don't allow consecutive, trailing or preceding whitespaces in exercise titles

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -937,6 +937,14 @@ public abstract class Exercise extends DomainObject {
     }
 
     /**
+     * This Method removes douplicated whitespaces, tabs etc from exercise titles and replaces them with a single space.
+     */
+    public void validateTitle() {
+        // replace all consecutive whitespaces with a single space.
+        setTitle(getTitle().trim().replaceAll("\\s+", " "));
+    }
+
+    /**
      * This method is used to validate the dates of an exercise. A date is valid if there is no dueDateError or assessmentDueDateError
      * @throws BadRequestException if the dates are not valid
      */

--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -209,8 +209,14 @@ public abstract class Exercise extends DomainObject {
         return this;
     }
 
+    /**
+     * Sets the title of the exercise
+     * all consecutive, trailing or preceding whitespaces are replaced with a single space.
+     *
+     * @param title the new (unsanitized) title to be set
+     */
     public void setTitle(String title) {
-        this.title = title != null ? title.strip() : null;
+        this.title = title != null ? title.strip().replaceAll("\\s+", " ") : null;
     }
 
     public String getShortName() {
@@ -934,14 +940,6 @@ public abstract class Exercise extends DomainObject {
         public String getMappedColumnName() {
             return mappedColumnName;
         }
-    }
-
-    /**
-     * This Method removes douplicated whitespaces, tabs etc from exercise titles and replaces them with a single space.
-     */
-    public void validateTitle() {
-        // replace all consecutive whitespaces with a single space.
-        setTitle(getTitle().trim().replaceAll("\\s+", " "));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -774,7 +774,6 @@ public class ExerciseService {
 
     public void validateGeneralSettings(Exercise exercise) {
         validateScoreSettings(exercise);
-        exercise.validateTitle();
         exercise.validateDates();
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -774,6 +774,7 @@ public class ExerciseService {
 
     public void validateGeneralSettings(Exercise exercise) {
         validateScoreSettings(exercise);
+        exercise.validateTitle();
         exercise.validateDates();
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).(https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
fixes #3604 (for all future exercises)
 
### Description
Before creating exercises I trim consecutive, trailing or preceding whitespaces

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. create an exercise with weird whitespaces all over the place.
2. try deleting the exercise, type what the name of the exercise seems to be (without any odd spaces) or copy the name from the website.
3. verify that the exercise was deleted
