### PR TITLE
[Bugfix] Repair Prettier for cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,8 +185,8 @@
     },
     "scripts": {
         "postinstall": "husky install",
-        "prettier:format": "prettier --write 'src/{main/webapp,test}/**/*.{json,ts,js,css,scss,html}'",
-        "prettier:check": "prettier --check 'src/{main/webapp,test}/**/*.{json,ts,js,css,scss,html}'",
+        "prettier:write": "prettier --write \"src/{main/webapp,test}/**/*.{json,ts,js,css,scss,html}\"",
+        "prettier:check": "prettier --check \"src/{main/webapp,test}/**/*.{json,ts,js,css,scss,html}\"",
         "lint": "eslint . --ext .ts",
         "lint:fix": "yarn run lint --fix",
         "lint:doc": "tslint --config tslint-doc.json --project tsconfig.json -e 'node_modules/**'",


### PR DESCRIPTION
### Motivation and Context
Running `yarn prettier:check` and `yarn prettier:format` yields the following error on windows with cmd as default terminal in IntelliJ:

![grafik](https://user-images.githubusercontent.com/61357727/123707690-63f3ff00-d86a-11eb-9050-8afd23d3937d.png)

### Description
Apparently cmd fails to correctly interpret the single ticks, replacing them with \\" solves the issue. Also renames prettier:format to prettier:write to match prettiers naming

### Steps for Testing

1. Check out the branch
2. Run `yarn prettier:check` and `yarn prettier:write`
3. Neither command should fail
4. Please add your terminal/operating system so we can be sure it works for everyone

### Test Coverage
Unchanged
