### PR TITLE
Fix Nullpointer in ProgrammingExerciseParticipationService

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -9,6 +9,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.hibernate.Hibernate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.*;
@@ -145,39 +146,39 @@ public class ProgrammingExerciseParticipationService {
      * @return true if the user can access the participation, false if not. Also returns false if the participation is not from a programming exercise.
      */
     public boolean canAccessParticipation(ProgrammingExerciseParticipation participation) {
-        if (participation instanceof ProgrammingExerciseStudentParticipation) {
-            return canAccessParticipation((ProgrammingExerciseStudentParticipation) participation);
+        User user = userRepository.getUserWithGroupsAndAuthorities();
+        if (participation instanceof ProgrammingExerciseStudentParticipation studentParticipation) {
+            // If the current user is owner of the participation, they are allowed to access it
+            if (studentParticipation.isOwnedBy(user)) {
+                return true;
+            }
+            return canAccessParticipation(studentParticipation, studentParticipationRepository, user);
         }
-        else if (participation instanceof SolutionProgrammingExerciseParticipation) {
-            return canAccessParticipation((SolutionProgrammingExerciseParticipation) participation);
+        else if (participation instanceof SolutionProgrammingExerciseParticipation solutionParticipation) {
+            return canAccessParticipation(solutionParticipation, solutionParticipationRepository, user);
         }
-        else if (participation instanceof TemplateProgrammingExerciseParticipation) {
-            return canAccessParticipation((TemplateProgrammingExerciseParticipation) participation);
+        else if (participation instanceof TemplateProgrammingExerciseParticipation templateParticipation) {
+            return canAccessParticipation(templateParticipation, templateParticipationRepository, user);
         }
         return false;
     }
 
-    private boolean canAccessParticipation(@NotNull ProgrammingExerciseStudentParticipation participation) {
-        var user = userRepository.getUserWithGroupsAndAuthorities();
-        return participation.isOwnedBy(user) || authCheckService.isAtLeastTeachingAssistantForExercise(participation.getExercise(), user);
-    }
-
-    private boolean canAccessParticipation(@NotNull SolutionProgrammingExerciseParticipation participation) {
+    /**
+     * Returns whether a user is allowed to access a given participation.
+     *
+     * @param <T>           The {@link ProgrammingExerciseParticipation} sub-class
+     * @param participation A participation of type <code>T</code>, must not be null
+     * @param repository    The database repository where participations of type <code>T</code> reside in
+     * @param user          The user, may be null, in which case the current user is fetched and used.
+     * @return <code>true</code> if the current user is allowed to access the given participation, <code>false</code> otherwise
+     */
+    private <T extends ProgrammingExerciseParticipation> boolean canAccessParticipation(@NotNull T participation, JpaRepository<T, Long> repository, User user) {
         // Note: if this participation was retrieved as Participation (abstract super class) from the database, the programming exercise might not be correctly initialized
-        // To prevent null pointer exceptions, we therefore retrieve it again as concrete solution programming exercise participation
+        // To prevent null pointer exceptions, we therefore retrieve it again as concrete sub-class instance by using the provided repository
         if (participation.getProgrammingExercise() == null || !Hibernate.isInitialized(participation.getProgrammingExercise())) {
-            participation.setProgrammingExercise(solutionParticipationRepository.findById(participation.getId()).get().getProgrammingExercise());
+            participation.setProgrammingExercise(repository.findById(participation.getId()).get().getProgrammingExercise());
         }
-        return authCheckService.isAtLeastTeachingAssistantForExercise(participation.getProgrammingExercise(), null);
-    }
-
-    private boolean canAccessParticipation(@NotNull TemplateProgrammingExerciseParticipation participation) {
-        // Note: if this participation was retrieved as Participation (abstract super class) from the database, the programming exercise might not be correctly initialized
-        // To prevent null pointer exceptions, we therefore retrieve it again as concrete template programming exercise participation
-        if (participation.getProgrammingExercise() == null || !Hibernate.isInitialized(participation.getProgrammingExercise())) {
-            participation.setProgrammingExercise(templateParticipationRepository.findById(participation.getId()).get().getProgrammingExercise());
-        }
-        return authCheckService.isAtLeastTeachingAssistantForExercise(participation.getProgrammingExercise(), null);
+        return authCheckService.isAtLeastTeachingAssistantForExercise(participation.getProgrammingExercise(), user);
     }
 
     /**
@@ -185,6 +186,8 @@ public class ProgrammingExerciseParticipationService {
      * The method will treat the participation types differently:
      * - ProgrammingExerciseStudentParticipations should only be accessible by its owner (student) and the courses instructor/tas.
      * - Template/SolutionParticipations should only be accessible by the courses instructor/tas.
+     *
+     * TODO: why is this different to {@link #canAccessParticipation(ProgrammingExerciseParticipation)}?
      *
      * @param participation to check permissions for.
      * @param principal object to check permissions of the user with.

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -168,7 +168,7 @@ public class ProgrammingExerciseParticipationService {
         if (participation.getProgrammingExercise() == null || !Hibernate.isInitialized(participation.getProgrammingExercise())) {
             participation.setProgrammingExercise(solutionParticipationRepository.findById(participation.getId()).get().getProgrammingExercise());
         }
-        return authCheckService.isAtLeastTeachingAssistantForExercise(participation.getExercise(), null);
+        return authCheckService.isAtLeastTeachingAssistantForExercise(participation.getProgrammingExercise(), null);
     }
 
     private boolean canAccessParticipation(@NotNull TemplateProgrammingExerciseParticipation participation) {
@@ -177,7 +177,7 @@ public class ProgrammingExerciseParticipationService {
         if (participation.getProgrammingExercise() == null || !Hibernate.isInitialized(participation.getProgrammingExercise())) {
             participation.setProgrammingExercise(templateParticipationRepository.findById(participation.getId()).get().getProgrammingExercise());
         }
-        return authCheckService.isAtLeastTeachingAssistantForExercise(participation.getExercise(), null);
+        return authCheckService.isAtLeastTeachingAssistantForExercise(participation.getProgrammingExercise(), null);
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/RepositoryIntegrationTest.java
@@ -42,7 +42,6 @@ import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
-import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseParticipationService;
 import de.tum.in.www1.artemis.util.GitUtilService;
@@ -93,7 +92,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
                     + "while parsing file C:\\Users\\Stefan\\bamboo-home\\xml-data\\build-dir\\STCTESTPLUGINSCA-SOLUTION-JOB1\\assignment\\"
                     + "src\\www\\testPluginSCA\\BubbleSort.java. expecting EOF, found '}' -> [Help 1]");
 
-    private StudentParticipation participation;
+    private ProgrammingExerciseStudentParticipation participation;
 
     private ListAppender<ILoggingEvent> listAppender;
 
@@ -123,7 +122,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
 
         var localRepoUrl = new GitUtilService.MockFileRepositoryUrl(studentRepository.localRepoFile);
         database.addStudentParticipationForProgrammingExerciseForLocalRepo(programmingExercise, "student1", localRepoUrl.getURL());
-        participation = studentParticipationRepository.findAll().get(0);
+        participation = (ProgrammingExerciseStudentParticipation) studentParticipationRepository.findAll().get(0);
         programmingExercise.setTestRepositoryUrl(localRepoUrl.toString());
 
         // Create template repo
@@ -158,8 +157,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
         doReturn(gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepository.localRepoFile.toPath(), null)).when(gitService)
                 .getOrCheckoutRepository(((ProgrammingExerciseParticipation) participation).getVcsRepositoryUrl(), false);
 
-        doReturn(gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepository.localRepoFile.toPath(), null)).when(gitService)
-                .getOrCheckoutRepository((ProgrammingExerciseParticipation) participation);
+        doReturn(gitService.getExistingCheckedOutRepositoryByLocalPath(studentRepository.localRepoFile.toPath(), null)).when(gitService).getOrCheckoutRepository(participation);
 
         bitbucketRequestMockProvider.enableMockingOfRequests(true);
         bitbucketRequestMockProvider.mockDefaultBranch("master", ((ProgrammingExerciseParticipation) participation).getVcsRepositoryUrl());
@@ -694,7 +692,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
     void testStashChangesInStudentRepositoryAfterDueDateHasPassed_beforeStateRepoConfigured() {
         participation.setInitializationState(InitializationState.REPO_COPIED);
         // Try to stash changes
-        programmingExerciseParticipationService.stashChangesInStudentRepositoryAfterDueDateHasPassed(programmingExercise, (ProgrammingExerciseStudentParticipation) participation);
+        programmingExerciseParticipationService.stashChangesInStudentRepositoryAfterDueDateHasPassed(programmingExercise, participation);
 
         // Check the logs
         List<ILoggingEvent> logsList = listAppender.list;
@@ -710,7 +708,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
         programmingExercise.setDueDate(ZonedDateTime.now().minusHours(1));
 
         // Stash changes using service
-        programmingExerciseParticipationService.stashChangesInStudentRepositoryAfterDueDateHasPassed(programmingExercise, (ProgrammingExerciseStudentParticipation) participation);
+        programmingExerciseParticipationService.stashChangesInStudentRepositoryAfterDueDateHasPassed(programmingExercise, participation);
         assertThat(FileUtils.readFileToString(studentFilePath.toFile(), Charset.defaultCharset())).isEqualTo("initial commit");
     }
 
@@ -718,7 +716,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
     @WithMockUser(username = "student1", roles = "USER")
     void testStashChangesInStudentRepositoryAfterDueDateHasPassed_throwError() {
         // Try to stash changes, but it will throw error as the HEAD is not initialized in the remote repo (this is done with the initial commit)
-        programmingExerciseParticipationService.stashChangesInStudentRepositoryAfterDueDateHasPassed(programmingExercise, (ProgrammingExerciseStudentParticipation) participation);
+        programmingExerciseParticipationService.stashChangesInStudentRepositoryAfterDueDateHasPassed(programmingExercise, participation);
 
         // Check the logs
         List<ILoggingEvent> logsList = listAppender.list;
@@ -733,7 +731,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
         database.addTemplateParticipationForProgrammingExercise(programmingExercise);
 
         // Check for canAccessParticipation(participation)
-        var response = programmingExerciseParticipationService.canAccessParticipation((ProgrammingExerciseParticipation) participation);
+        var response = programmingExerciseParticipationService.canAccessParticipation(participation);
         assertThat(response).isTrue();
 
         var responseSolution = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getSolutionParticipation());
@@ -749,7 +747,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
         final var username = "instructor1";
         final Principal principal = () -> username;
 
-        response = programmingExerciseParticipationService.canAccessParticipation((ProgrammingExerciseParticipation) participation, principal);
+        response = programmingExerciseParticipationService.canAccessParticipation(participation, principal);
         assertThat(response).isFalse();
 
         responseSolution = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getSolutionParticipation(), principal);
@@ -764,14 +762,58 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void testCanAccessParticipation_asInstructor_edgeCase_programmingExercise_null() {
+    void testCanAccessParticipation_asInstructor_edgeCase_exercise_null() {
         // Set solution and template participation
         database.addSolutionParticipationForProgrammingExercise(programmingExercise);
         database.addTemplateParticipationForProgrammingExercise(programmingExercise);
 
         // Check with exercise null
+        participation.setExercise(null);
+        programmingExercise.getSolutionParticipation().setExercise(null);
+        programmingExercise.getTemplateParticipation().setExercise(null);
+
+        var response1 = programmingExerciseParticipationService.canAccessParticipation(participation);
+        assertThat(response1).isTrue();
+
+        var responseSolution1 = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getSolutionParticipation());
+        assertThat(responseSolution1).isTrue();
+
+        var responseTemplate1 = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getTemplateParticipation());
+        assertThat(responseTemplate1).isTrue();
+
+        // Check with exercise and programmingExercise null (and set everything again)
+        participation.setExercise(null);
+        programmingExercise.getSolutionParticipation().setExercise(null);
+        programmingExercise.getTemplateParticipation().setExercise(null);
+        // Note that in the current implementation, setProgrammingExercise is equivalent to setExercise only for the ProgrammingExerciseStudentParticipation
+        participation.setProgrammingExercise(null);
         programmingExercise.getSolutionParticipation().setProgrammingExercise(null);
         programmingExercise.getTemplateParticipation().setProgrammingExercise(null);
+
+        var response2 = programmingExerciseParticipationService.canAccessParticipation(participation);
+        assertThat(response2).isTrue();
+
+        var responseSolution2 = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getSolutionParticipation());
+        assertThat(responseSolution2).isTrue();
+
+        var responseTemplate2 = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getTemplateParticipation());
+        assertThat(responseTemplate2).isTrue();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    void testCanAccessParticipation_asInstructor_edgeCase_programmingExercise_null() {
+        // Set solution and template participation
+        database.addSolutionParticipationForProgrammingExercise(programmingExercise);
+        database.addTemplateParticipationForProgrammingExercise(programmingExercise);
+
+        // Check with programmingExercise only null
+        participation.setProgrammingExercise(null);
+        programmingExercise.getSolutionParticipation().setProgrammingExercise(null);
+        programmingExercise.getTemplateParticipation().setProgrammingExercise(null);
+
+        var response = programmingExerciseParticipationService.canAccessParticipation(participation);
+        assertThat(response).isTrue();
 
         var responseSolution = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getSolutionParticipation());
         assertThat(responseSolution).isTrue();
@@ -788,7 +830,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
         database.addTemplateParticipationForProgrammingExercise(programmingExercise);
 
         // Check for canAccessParticipation(participation)
-        var response = programmingExerciseParticipationService.canAccessParticipation((ProgrammingExerciseParticipation) participation);
+        var response = programmingExerciseParticipationService.canAccessParticipation(participation);
         assertThat(response).isTrue();
 
         var responseSolution = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getSolutionParticipation());
@@ -803,7 +845,7 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
         // Check for canAccessParticipation(participation, principal)
         final var username = "student1";
         final Principal principal = () -> username;
-        response = programmingExerciseParticipationService.canAccessParticipation((ProgrammingExerciseParticipation) participation, principal);
+        response = programmingExerciseParticipationService.canAccessParticipation(participation, principal);
         assertThat(response).isTrue();
 
         responseSolution = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getSolutionParticipation(), principal);
@@ -833,17 +875,17 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
         }).when(versionControlService).configureRepository(programmingExercise, ((ProgrammingExerciseParticipation) participation).getVcsRepositoryUrl(),
                 participation.getStudents(), true);
 
-        programmingExerciseParticipationService.unlockStudentRepository(programmingExercise, (ProgrammingExerciseStudentParticipation) participation);
+        programmingExerciseParticipationService.unlockStudentRepository(programmingExercise, participation);
 
         assertThat(((ProgrammingExercise) participation.getExercise()).getBuildAndTestStudentSubmissionsAfterDueDate()).isNull();
-        assertThat(((ProgrammingExerciseStudentParticipation) participation).isLocked()).isFalse();
+        assertThat(participation.isLocked()).isFalse();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     void testUnlockStudentRepository_beforeStateRepoConfigured() {
         participation.setInitializationState(InitializationState.REPO_COPIED);
-        programmingExerciseParticipationService.unlockStudentRepository(programmingExercise, (ProgrammingExerciseStudentParticipation) participation);
+        programmingExerciseParticipationService.unlockStudentRepository(programmingExercise, participation);
 
         // Check the logs
         List<ILoggingEvent> logsList = listAppender.list;
@@ -860,15 +902,15 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
         }).when(versionControlService).setRepositoryPermissionsToReadOnly(((ProgrammingExerciseParticipation) participation).getVcsRepositoryUrl(),
                 programmingExercise.getProjectKey(), participation.getStudents());
 
-        programmingExerciseParticipationService.lockStudentRepository(programmingExercise, (ProgrammingExerciseStudentParticipation) participation);
-        assertThat(((ProgrammingExerciseStudentParticipation) participation).isLocked()).isTrue();
+        programmingExerciseParticipationService.lockStudentRepository(programmingExercise, participation);
+        assertThat(participation.isLocked()).isTrue();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     void testLockStudentRepository_beforeStateRepoConfigured() {
         participation.setInitializationState(InitializationState.REPO_COPIED);
-        programmingExerciseParticipationService.lockStudentRepository(programmingExercise, (ProgrammingExerciseStudentParticipation) participation);
+        programmingExerciseParticipationService.lockStudentRepository(programmingExercise, participation);
 
         // Check the logs
         List<ILoggingEvent> logsList = listAppender.list;

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/RepositoryIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/RepositoryIntegrationTest.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.programmingexercise;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.File;
@@ -759,6 +760,24 @@ public class RepositoryIntegrationTest extends AbstractSpringIntegrationBambooBi
 
         responseSolution = programmingExerciseParticipationService.canAccessParticipation(null, principal);
         assertThat(responseSolution).isFalse();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    void testCanAccessParticipation_asInstructor_edgeCase_programmingExercise_null() {
+        // Set solution and template participation
+        database.addSolutionParticipationForProgrammingExercise(programmingExercise);
+        database.addTemplateParticipationForProgrammingExercise(programmingExercise);
+
+        // Check with exercise null
+        programmingExercise.getSolutionParticipation().setProgrammingExercise(null);
+        programmingExercise.getTemplateParticipation().setProgrammingExercise(null);
+
+        var responseSolution = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getSolutionParticipation());
+        assertThat(responseSolution).isTrue();
+
+        var responseTemplate = programmingExerciseParticipationService.canAccessParticipation(programmingExercise.getTemplateParticipation());
+        assertThat(responseTemplate).isTrue();
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)

### Motivation and Context
Fix 
- https://sentry.ase.in.tum.de/organizations/artemis/issues/4073/?environment=prod&project=2&query=is%3Aunresolved
- https://sentry.ase.in.tum.de/organizations/artemis/issues/5293/?query=is%3Aunresolved

In summary: Occasionally, you did get an internal server error when viewing programming exercises and the solution result is not displayed.

### Description
- Switched to correct getter (from `getExercise()` to `getProgrammingExercise()`).
- Refactor `canAccessParticipation` to have less duplication and more type safety
- Added more tests that test access checks with null exercise attributes. We checked that our new tests failed without the fix.

### Steps for Testing
0. Review the code
1. Go to an Artemis programming exercise and take part as a student in the online editor. Check that you still get results and can see them everywhere.
2. Check that as an instructor, you can always see the results of the template and solution of programming exercises and especially that you do not get an internal server error anymore.
3. I would recommend to check multiple places where you can see results of programming exercises. The original error only happened occasionally.

### Test Coverage
![image](https://user-images.githubusercontent.com/11130248/123832487-acacc600-d905-11eb-8eb9-7da1b04a1991.png)

