### PR TITLE
User Documentation: Fix Feature Table Bamboo/Jenkins

### DIFF
--- a/docs/user/exercises/programming-exercise-setup.inc
+++ b/docs/user/exercises/programming-exercise-setup.inc
@@ -15,23 +15,23 @@ Instructors can still use those templates to generate programming exercises and 
   +----------------------+--------+---------+
   | Programming Language | Bamboo | Jenkins |
   +======================+========+=========+
-  | Java                 | yes   | yes      |
+  | Java                 | yes    | yes     |
   +----------------------+--------+---------+
-  | Python               | yes   | yes      |
+  | Python               | yes    | yes     |
   +----------------------+--------+---------+
-  | C                    | yes   | yes      |
+  | C                    | yes    | yes     |
   +----------------------+--------+---------+
-  | Haskell              | yes   | yes      |
+  | Haskell              | yes    | yes     |
   +----------------------+--------+---------+
-  | Kotlin               | yes   | no       |
+  | Kotlin               | yes    | no      |
   +----------------------+--------+---------+
-  | VHDL                 | yes   | no       |
+  | VHDL                 | yes    | no      |
   +----------------------+--------+---------+
-  | Assembler            | yes   | no       |
+  | Assembler            | yes    | no      |
   +----------------------+--------+---------+
-  | Swift                | yes   | no       |
+  | Swift                | yes    | no      |
   +----------------------+--------+---------+
-  | OCaml                | yes   | no       |
+  | OCaml                | yes    | no      |
   +----------------------+--------+---------+
 
 - Not all ``templates`` support the same feature set.


### PR DESCRIPTION
### Description
The table comparing programming language support in Bamboo/Jenkins in the user documentation https://docs.artemis.ase.in.tum.de/user/exercises/programming/#setup did not get shown correctly.

### Screenshots
Before:
![Screenshot_20210629_184430](https://user-images.githubusercontent.com/64250573/123837001-a40abe80-d90a-11eb-956f-d4ef48576842.png)

After:
![Screenshot_20210629_184438](https://user-images.githubusercontent.com/64250573/123837006-a4a35500-d90a-11eb-8673-df366bfdc0cb.png)
