### PR TITLE
Fix an error when initializing the apollon editor

### DIFF
--- a/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
@@ -91,17 +91,22 @@ export class ModelingEditorComponent implements AfterViewInit, OnDestroy, OnChan
             this.apollonEditor.unsubscribeFromModelChange(this.modelSubscription);
             this.apollonEditor.destroy();
         }
+
         // Apollon doesn't need assessments in Modeling mode
         this.removeAssessments(this.umlModel);
-        this.apollonEditor = new ApollonEditor(this.editorContainer.nativeElement, {
-            model: this.umlModel,
-            mode: ApollonMode.Modelling,
-            readonly: this.readOnly,
-            type: this.diagramType || UMLDiagramType.ClassDiagram,
-        });
-        this.modelSubscription = this.apollonEditor.subscribeToModelChange((model: UMLModel) => {
-            this.onModelChanged.emit(model);
-        });
+
+        if (this.editorContainer) {
+            this.apollonEditor = new ApollonEditor(this.editorContainer.nativeElement, {
+                model: this.umlModel,
+                mode: ApollonMode.Modelling,
+                readonly: this.readOnly,
+                type: this.diagramType || UMLDiagramType.ClassDiagram,
+            });
+
+            this.modelSubscription = this.apollonEditor.subscribeToModelChange((model: UMLModel) => {
+                this.onModelChanged.emit(model);
+            });
+        }
     }
 
     get isApollonEditorMounted(): boolean {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context

When creating or viewing a modeling exercise an error would often appear in the console:
`this.editorContainer is undefined` or `Cannot read property 'nativeElement' of undefined`

### Description

The `initializeApollonEditor` might get called before the element reference for `editorContainer` is set. We can just do nothing in that case because the `ngOnChanges` will trigger the initialisation again as soon as the reference is set.

### Steps for Testing

1. Go to an exam exercise group and create a new modeling exercise.
2. Check if there are no errors in the console.

