### PR TITLE
[BugFix] Add missing slash to paths in JenkinsBuildPlanCreator

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
@@ -82,7 +82,7 @@ public class JenkinsBuildPlanCreator implements JenkinsXmlConfigBuilder {
 
     @PostConstruct
     public void init() {
-        this.artemisNotificationUrl = ARTEMIS_SERVER_URL + "/api/" + Constants.NEW_RESULT_RESOURCE_PATH;
+        this.artemisNotificationUrl = ARTEMIS_SERVER_URL + Constants.NEW_RESULT_RESOURCE_API_PATH;
     }
 
     public String getPipelineScript(ProgrammingLanguage programmingLanguage, VcsRepositoryUrl testRepositoryURL, VcsRepositoryUrl assignmentRepositoryURL,

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
@@ -82,7 +82,7 @@ public class JenkinsBuildPlanCreator implements JenkinsXmlConfigBuilder {
 
     @PostConstruct
     public void init() {
-        this.artemisNotificationUrl = ARTEMIS_SERVER_URL + "/api" + Constants.NEW_RESULT_RESOURCE_PATH;
+        this.artemisNotificationUrl = ARTEMIS_SERVER_URL + "/api/" + Constants.NEW_RESULT_RESOURCE_PATH;
     }
 
     public String getPipelineScript(ProgrammingLanguage programmingLanguage, VcsRepositoryUrl testRepositoryURL, VcsRepositoryUrl assignmentRepositoryURL,


### PR DESCRIPTION
Added missing slash

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
In 5.0.1 I've encountered the bug that Jenkins cannot send the results to Artemis for programming exercises.
![image](https://user-images.githubusercontent.com/22198798/123972274-fe635800-d9ba-11eb-8b7c-3bf02fca2ef5.png)

### Description
As far as I can see, the problem should be solved if I add a missing `/`

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Submit a change in a programming exercise in a GitLab/Jenkins deployment and wait for the response.
