### PR TITLE
[Bugfix] Fix Export Statistics for Participations without Submission

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
@@ -214,7 +214,7 @@ public class CourseExamExportService {
         exportedFiles.addAll(new ArrayList<>(exportedExercises));
 
         // Add total to report
-        reportData.add(new ArchivalReportEntry(-1, "Total Exercises", totalExercises, exportedFiles.size(), 0));
+        reportData.add(new ArchivalReportEntry(null, "Total Exercises", totalExercises, exportedFiles.size(), 0));
 
         return exportedFiles;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
@@ -214,7 +214,7 @@ public class CourseExamExportService {
         exportedFiles.addAll(new ArrayList<>(exportedExercises));
 
         // Add total to report
-        reportData.add(new ArchivalReportEntry(-1, "Total Exercises", totalExercises, exportedFiles.size()));
+        reportData.add(new ArchivalReportEntry(-1, "Total Exercises", totalExercises, exportedFiles.size(), 0));
 
         return exportedFiles;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
@@ -226,7 +226,7 @@ public abstract class SubmissionExportService {
         }).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
 
         // Add report entry
-        reportData.add(new ArchivalReportEntry(exercise.getId(), fileService.removeIllegalCharacters(exercise.getTitle()), participations.size(), submissionFilePaths.size(),
+        reportData.add(new ArchivalReportEntry(exercise, fileService.removeIllegalCharacters(exercise.getTitle()), participations.size(), submissionFilePaths.size(),
                 skippedEntries.intValue()));
 
         if (submissionFilePaths.isEmpty()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang.mutable.MutableInt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -178,6 +179,9 @@ public abstract class SubmissionExportService {
             return Optional.empty();
         }
 
+        // Create counter for log entry
+        MutableInt skippedEntries = new MutableInt();
+
         // Save all Submissions
         List<Path> submissionFilePaths = participations.stream().map((participation) -> {
 
@@ -198,6 +202,7 @@ public abstract class SubmissionExportService {
             }
 
             if (latestSubmission == null) {
+                skippedEntries.increment();
                 return Optional.<Path>empty();
             }
 
@@ -221,7 +226,8 @@ public abstract class SubmissionExportService {
         }).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
 
         // Add report entry
-        reportData.add(new ArchivalReportEntry(exercise.getId(), fileService.removeIllegalCharacters(exercise.getTitle()), participations.size(), submissionFilePaths.size()));
+        reportData.add(new ArchivalReportEntry(exercise.getId(), fileService.removeIllegalCharacters(exercise.getTitle()), participations.size(), submissionFilePaths.size(),
+                skippedEntries.intValue()));
 
         if (submissionFilePaths.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/de/tum/in/www1/artemis/service/archival/ArchivalReportEntry.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/archival/ArchivalReportEntry.java
@@ -12,26 +12,30 @@ public class ArchivalReportEntry {
 
     private final int successfulEntries;
 
+    private final int skippedEntries;
+
     private final int failedEntries;
 
     /**
      * Generates a new entry with the given data
      *
      * @param exerciseId the id or a negative number if no id is applicable
+     * @param skippedEntries Entries that did not get exported but did not fail either, e.g. because a participation did not have any submission
      */
-    public ArchivalReportEntry(long exerciseId, String exerciseName, int totalEntries, int successfulEntries, int failedEntries) {
+    public ArchivalReportEntry(long exerciseId, String exerciseName, int totalEntries, int successfulEntries, int skippedEntries, int failedEntries) {
         this.exerciseId = exerciseId >= 0 ? OptionalLong.of(exerciseId) : OptionalLong.empty();
         this.exerciseName = exerciseName;
         this.totalEntries = totalEntries;
         this.successfulEntries = successfulEntries;
+        this.skippedEntries = skippedEntries;
         this.failedEntries = failedEntries;
     }
 
     /**
      * Shortcut for {@link ArchivalReportEntry} but calculates the missing value
      */
-    public ArchivalReportEntry(long exerciseId, String exerciseName, int totalEntries, int successfulEntries) {
-        this(exerciseId, exerciseName, totalEntries, successfulEntries, totalEntries - successfulEntries);
+    public ArchivalReportEntry(long exerciseId, String exerciseName, int totalEntries, int successfulEntries, int skippedEntries) {
+        this(exerciseId, exerciseName, totalEntries, successfulEntries, skippedEntries, totalEntries - successfulEntries - skippedEntries);
     }
 
     /**
@@ -39,13 +43,14 @@ public class ArchivalReportEntry {
      */
     @Override
     public String toString() {
-        return (exerciseId.isPresent() ? exerciseId.getAsLong() : "") + "," + exerciseName + "," + totalEntries + "," + successfulEntries + "," + failedEntries;
+        return (exerciseId.isPresent() ? exerciseId.getAsLong() : "") + "," + exerciseName + "," + totalEntries + "," + successfulEntries + "," + skippedEntries + ","
+                + failedEntries;
     }
 
     /**
      * @return the headline of a csv file containing entries of this class
      */
     public static String getHeadline() {
-        return "exerciseId,exerciseName,totalEntries,successfulEntries,failedEntries";
+        return "exerciseId,exerciseName,totalEntries,successfulEntries,skippedEntries,failedEntries";
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/archival/ArchivalReportEntry.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/archival/ArchivalReportEntry.java
@@ -1,41 +1,41 @@
 package de.tum.in.www1.artemis.service.archival;
 
-import java.util.OptionalLong;
+import javax.annotation.Nullable;
+
+import de.tum.in.www1.artemis.domain.Exercise;
 
 public class ArchivalReportEntry {
 
-    private final OptionalLong exerciseId;
+    @Nullable
+    private final Exercise exercise;
 
     private final String exerciseName;
 
-    private final int totalEntries;
+    private final int participants;
 
-    private final int successfulEntries;
+    private final int successfulExports;
 
-    private final int skippedEntries;
+    private final int participantsWithoutSubmission;
 
-    private final int failedEntries;
+    private final int failedExports;
 
     /**
      * Generates a new entry with the given data
-     *
-     * @param exerciseId the id or a negative number if no id is applicable
-     * @param skippedEntries Entries that did not get exported but did not fail either, e.g. because a participation did not have any submission
      */
-    public ArchivalReportEntry(long exerciseId, String exerciseName, int totalEntries, int successfulEntries, int skippedEntries, int failedEntries) {
-        this.exerciseId = exerciseId >= 0 ? OptionalLong.of(exerciseId) : OptionalLong.empty();
+    public ArchivalReportEntry(@Nullable Exercise exercise, String exerciseName, int participants, int successfulExports, int participantsWithoutSubmission, int failedExports) {
+        this.exercise = exercise;
         this.exerciseName = exerciseName;
-        this.totalEntries = totalEntries;
-        this.successfulEntries = successfulEntries;
-        this.skippedEntries = skippedEntries;
-        this.failedEntries = failedEntries;
+        this.participants = participants;
+        this.successfulExports = successfulExports;
+        this.participantsWithoutSubmission = participantsWithoutSubmission;
+        this.failedExports = failedExports;
     }
 
     /**
-     * Shortcut for {@link ArchivalReportEntry} but calculates the missing value
+     * Shortcut for {@link ArchivalReportEntry} but calculates the amount of fails
      */
-    public ArchivalReportEntry(long exerciseId, String exerciseName, int totalEntries, int successfulEntries, int skippedEntries) {
-        this(exerciseId, exerciseName, totalEntries, successfulEntries, skippedEntries, totalEntries - successfulEntries - skippedEntries);
+    public ArchivalReportEntry(Exercise exercise, String exerciseName, int participants, int successfulExports, int participantsWithoutSubmission) {
+        this(exercise, exerciseName, participants, successfulExports, participantsWithoutSubmission, participants - successfulExports - participantsWithoutSubmission);
     }
 
     /**
@@ -43,14 +43,14 @@ public class ArchivalReportEntry {
      */
     @Override
     public String toString() {
-        return (exerciseId.isPresent() ? exerciseId.getAsLong() : "") + "," + exerciseName + "," + totalEntries + "," + successfulEntries + "," + skippedEntries + ","
-                + failedEntries;
+        return (exercise != null ? exercise.getId() + "," + exercise.getClass().getSimpleName() : ",") + "," + exerciseName + "," + participants + "," + successfulExports + ","
+                + participantsWithoutSubmission + "," + failedExports;
     }
 
     /**
      * @return the headline of a csv file containing entries of this class
      */
     public static String getHeadline() {
-        return "exerciseId,exerciseName,totalEntries,successfulEntries,skippedEntries,failedEntries";
+        return "id,type,name,participants,successful exports,participants without submission,failed exports";
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -208,7 +208,7 @@ public class ProgrammingExerciseExportService {
 
         String cleanProjectName = fileService.removeIllegalCharacters(exercise.getProjectName());
         // Add report entry, programming repositories cannot be skipped
-        reportData.add(new ArchivalReportEntry(exercise.getId(), cleanProjectName, pathsToBeZipped.size(), includedFilePathsNotNull.size(), 0));
+        reportData.add(new ArchivalReportEntry(exercise, cleanProjectName, pathsToBeZipped.size(), includedFilePathsNotNull.size(), 0));
 
         try {
             // Only create zip file if there's files to zip

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -207,7 +207,8 @@ public class ProgrammingExerciseExportService {
         List<Path> includedFilePathsNotNull = pathsToBeZipped.stream().filter(Objects::nonNull).collect(Collectors.toList());
 
         String cleanProjectName = fileService.removeIllegalCharacters(exercise.getProjectName());
-        reportData.add(new ArchivalReportEntry(exercise.getId(), cleanProjectName, pathsToBeZipped.size(), includedFilePathsNotNull.size()));
+        // Add report entry, programming repositories cannot be skipped
+        reportData.add(new ArchivalReportEntry(exercise.getId(), cleanProjectName, pathsToBeZipped.size(), includedFilePathsNotNull.size(), 0));
 
         try {
             // Only create zip file if there's files to zip


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context and Description
The export report file now distinguishes between failed exports and skipped exports, that is participations without submissions that cannot be exported. Also adds the exercise type to the report.

### Steps for Testing

1. Log in to Artemis
2. Create/Locate a course with various exercises
3. Create participation(s) without submissions by starting a file-upload, modelling or text exercise, but not uploading/submitting anything
4. Set the courses end date to the past
5. Archive the course
6. The resulting zip file contains a file called report.csv
7. This report should correctly count skipped participations (you can check the amount by subtracting the number of submissions from the number of participations from the corresponding menus)
8. The exercise types should be correct

### Test Coverage
Not notably changed
