### PR TITLE
Code Quality: Use Java 16 Pattern Variables in More Places

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/MetricsBean.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/MetricsBean.java
@@ -84,18 +84,15 @@ public class MetricsBean {
         for (HealthContributor healthContributor : healthContributors) {
             // For most HealthContributors, there is only one HealthIndicator that can directly be published.
             // The health status gets mapped to a double value, as only doubles can be returned by a Gauge.
-            if (healthContributor instanceof HealthIndicator) {
-                HealthIndicator healthIndicator = (HealthIndicator) healthContributor;
+            if (healthContributor instanceof HealthIndicator healthIndicator) {
                 Gauge.builder(ARTEMIS_HEALTH_NAME, healthIndicator, h -> mapHealthToDouble(h.health())).strongReference(true).description(ARTEMIS_HEALTH_DESCRIPTION)
                         .tag(ARTEMIS_HEALTH_TAG, healthIndicator.getClass().getSimpleName().toLowerCase()).register(meterRegistry);
             }
 
             // The DiscoveryCompositeHealthContributor can consist of several HealthIndicators, so they must all be published
-            if (healthContributor instanceof DiscoveryCompositeHealthContributor) {
-                DiscoveryCompositeHealthContributor discoveryCompositeHealthContributor = (DiscoveryCompositeHealthContributor) healthContributor;
+            if (healthContributor instanceof DiscoveryCompositeHealthContributor discoveryCompositeHealthContributor) {
                 for (NamedContributor<HealthContributor> discoveryHealthContributor : discoveryCompositeHealthContributor) {
-                    if (discoveryHealthContributor.getContributor() instanceof HealthIndicator) {
-                        HealthIndicator healthIndicator = (HealthIndicator) discoveryHealthContributor.getContributor();
+                    if (discoveryHealthContributor.getContributor() instanceof HealthIndicator healthIndicator) {
                         Gauge.builder(ARTEMIS_HEALTH_NAME, healthIndicator, h -> mapHealthToDouble(h.health())).strongReference(true).description(ARTEMIS_HEALTH_DESCRIPTION)
                                 .tag(ARTEMIS_HEALTH_TAG, discoveryHealthContributor.getName().toLowerCase()).register(meterRegistry);
                     }
@@ -111,8 +108,7 @@ public class MetricsBean {
     }
 
     private static double extractWebsocketUserCount(WebSocketHandler webSocketHandler) {
-        if (webSocketHandler instanceof SubProtocolWebSocketHandler) {
-            SubProtocolWebSocketHandler subProtocolWebSocketHandler = (SubProtocolWebSocketHandler) webSocketHandler;
+        if (webSocketHandler instanceof SubProtocolWebSocketHandler subProtocolWebSocketHandler) {
             return subProtocolWebSocketHandler.getStats().getWebSocketSessions();
         }
         return -1;

--- a/src/main/java/de/tum/in/www1/artemis/config/WebConfigurer.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/WebConfigurer.java
@@ -62,20 +62,18 @@ public class WebConfigurer implements ServletContextInitializer, WebServerFactor
     }
 
     private void setMimeMappings(WebServerFactory server) {
-        if (server instanceof ConfigurableServletWebServerFactory) {
+        if (server instanceof ConfigurableServletWebServerFactory servletWebServer) {
             MimeMappings mappings = new MimeMappings(MimeMappings.DEFAULT);
             // IE issue, see https://github.com/jhipster/generator-jhipster/pull/711
             mappings.add("html", MediaType.TEXT_HTML_VALUE + ";charset=" + StandardCharsets.UTF_8.name().toLowerCase());
             // CloudFoundry issue, see https://github.com/cloudfoundry/gorouter/issues/64
             mappings.add("json", MediaType.TEXT_HTML_VALUE + ";charset=" + StandardCharsets.UTF_8.name().toLowerCase());
-            ConfigurableServletWebServerFactory servletWebServer = (ConfigurableServletWebServerFactory) server;
             servletWebServer.setMimeMappings(mappings);
         }
     }
 
     private void setLocationForStaticAssets(WebServerFactory server) {
-        if (server instanceof ConfigurableServletWebServerFactory) {
-            ConfigurableServletWebServerFactory servletWebServer = (ConfigurableServletWebServerFactory) server;
+        if (server instanceof ConfigurableServletWebServerFactory servletWebServer) {
             File root;
             String prefixPath = resolvePathPrefix();
             root = new File(prefixPath + "build/resources/main/static/");

--- a/src/main/java/de/tum/in/www1/artemis/config/audit/AuditEventConverter.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/audit/AuditEventConverter.java
@@ -74,13 +74,11 @@ public class AuditEventConverter {
                 Object object = entry.getValue();
 
                 // Extract the data that will be saved.
-                if (object instanceof WebAuthenticationDetails) {
-                    WebAuthenticationDetails authenticationDetails = (WebAuthenticationDetails) object;
+                if (object instanceof WebAuthenticationDetails authenticationDetails) {
                     results.put("remoteAddress", authenticationDetails.getRemoteAddress());
                     results.put("sessionId", authenticationDetails.getSessionId());
                 }
-                else if (object instanceof Pair) {
-                    Pair authenticationPair = (Pair) object;
+                else if (object instanceof Pair authenticationPair) {
                     results.put(authenticationPair.getFirst().toString(), authenticationPair.getSecond().toString());
                 }
                 else {

--- a/src/main/java/de/tum/in/www1/artemis/config/websocket/WebsocketConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/websocket/WebsocketConfiguration.java
@@ -179,8 +179,7 @@ public class WebsocketConfiguration extends DelegatingWebSocketMessageBrokerConf
             @Override
             public boolean beforeHandshake(@NotNull ServerHttpRequest request, @NotNull ServerHttpResponse response, @NotNull WebSocketHandler wsHandler,
                     @NotNull Map<String, Object> attributes) {
-                if (request instanceof ServletServerHttpRequest) {
-                    ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
+                if (request instanceof ServletServerHttpRequest servletRequest) {
                     attributes.put(IP_ADDRESS, servletRequest.getRemoteAddress());
                 }
                 return true;

--- a/src/main/java/de/tum/in/www1/artemis/domain/Result.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Result.java
@@ -453,8 +453,7 @@ public class Result extends DomainObject {
      * Updates the attributes "score" and "successful" by evaluating its submission
      */
     public void evaluateSubmission() {
-        if (submission instanceof QuizSubmission) {
-            QuizSubmission quizSubmission = (QuizSubmission) submission;
+        if (submission instanceof QuizSubmission quizSubmission) {
             // get the exercise this result belongs to
             StudentParticipation studentParticipation = (StudentParticipation) getParticipation();
             QuizExercise quizExercise = (QuizExercise) studentParticipation.getExercise();

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/DragAndDropQuestion.java
@@ -249,9 +249,7 @@ public class DragAndDropQuestion extends QuizQuestion {
      * @param originalQuizQuestion the original QuizQuestion-object, which will be compared with this question
      */
     public void undoUnallowedChanges(QuizQuestion originalQuizQuestion) {
-
-        if (originalQuizQuestion instanceof DragAndDropQuestion) {
-            DragAndDropQuestion dndOriginalQuestion = (DragAndDropQuestion) originalQuizQuestion;
+        if (originalQuizQuestion instanceof DragAndDropQuestion dndOriginalQuestion) {
             // undo unallowed dragItemChanges
             undoUnallowedDragItemChanges(dndOriginalQuestion);
             // undo unallowed dragItemChanges
@@ -328,8 +326,7 @@ public class DragAndDropQuestion extends QuizQuestion {
      * @return a boolean which is true if the dragItem and dropLocation-changes make an update necessary and false if not
      */
     public boolean isUpdateOfResultsAndStatisticsNecessary(QuizQuestion originalQuizQuestion) {
-        if (originalQuizQuestion instanceof DragAndDropQuestion) {
-            DragAndDropQuestion dndOriginalQuestion = (DragAndDropQuestion) originalQuizQuestion;
+        if (originalQuizQuestion instanceof DragAndDropQuestion dndOriginalQuestion) {
             return checkDragItemsIfRecalculationIsNecessary(dndOriginalQuestion) || checkDropLocationsIfRecalculationIsNecessary(dndOriginalQuestion)
                     || !getCorrectMappings().equals(dndOriginalQuestion.getCorrectMappings());
         }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/MultipleChoiceQuestion.java
@@ -64,9 +64,7 @@ public class MultipleChoiceQuestion extends QuizQuestion {
      * @param originalQuizQuestion the original QuizQuestion-object, which will be compared with this question
      */
     public void undoUnallowedChanges(QuizQuestion originalQuizQuestion) {
-
-        if (originalQuizQuestion instanceof MultipleChoiceQuestion) {
-            MultipleChoiceQuestion mcOriginalQuestion = (MultipleChoiceQuestion) originalQuizQuestion;
+        if (originalQuizQuestion instanceof MultipleChoiceQuestion mcOriginalQuestion) {
             undoUnallowedAnswerChanges(mcOriginalQuestion);
         }
     }
@@ -109,8 +107,7 @@ public class MultipleChoiceQuestion extends QuizQuestion {
      * @return a boolean which is true if the answer-changes make an update necessary and false if not
      */
     public boolean isUpdateOfResultsAndStatisticsNecessary(QuizQuestion originalQuizQuestion) {
-        if (originalQuizQuestion instanceof MultipleChoiceQuestion) {
-            MultipleChoiceQuestion mcOriginalQuestion = (MultipleChoiceQuestion) originalQuizQuestion;
+        if (originalQuizQuestion instanceof MultipleChoiceQuestion mcOriginalQuestion) {
             return checkAnswersIfRecalculationIsNecessary(mcOriginalQuestion);
         }
         return false;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
@@ -573,8 +573,7 @@ public class QuizExercise extends Exercise {
                     quizQuestion.getQuizQuestionStatistic().setQuizQuestion(quizQuestion);
                 }
                 // do the same for answerOptions (if quizQuestion is multiple choice)
-                if (quizQuestion instanceof MultipleChoiceQuestion) {
-                    MultipleChoiceQuestion mcQuestion = (MultipleChoiceQuestion) quizQuestion;
+                if (quizQuestion instanceof MultipleChoiceQuestion mcQuestion) {
                     MultipleChoiceQuestionStatistic mcStatistic = (MultipleChoiceQuestionStatistic) mcQuestion.getQuizQuestionStatistic();
                     // reconnect answerCounters
                     for (AnswerCounter answerCounter : mcStatistic.getAnswerCounters()) {
@@ -589,8 +588,7 @@ public class QuizExercise extends Exercise {
                         }
                     }
                 }
-                if (quizQuestion instanceof DragAndDropQuestion) {
-                    DragAndDropQuestion dragAndDropQuestion = (DragAndDropQuestion) quizQuestion;
+                if (quizQuestion instanceof DragAndDropQuestion dragAndDropQuestion) {
                     DragAndDropQuestionStatistic dragAndDropStatistic = (DragAndDropQuestionStatistic) dragAndDropQuestion.getQuizQuestionStatistic();
                     // reconnect dropLocations
                     for (DropLocation dropLocation : dragAndDropQuestion.getDropLocations()) {
@@ -618,8 +616,7 @@ public class QuizExercise extends Exercise {
                         }
                     }
                 }
-                if (quizQuestion instanceof ShortAnswerQuestion) {
-                    ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) quizQuestion;
+                if (quizQuestion instanceof ShortAnswerQuestion shortAnswerQuestion) {
                     ShortAnswerQuestionStatistic shortAnswerStatistic = (ShortAnswerQuestionStatistic) shortAnswerQuestion.getQuizQuestionStatistic();
                     // reconnect spots
                     for (ShortAnswerSpot spot : shortAnswerQuestion.getSpots()) {

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/ShortAnswerQuestion.java
@@ -193,8 +193,7 @@ public class ShortAnswerQuestion extends QuizQuestion {
      */
     @Override
     public void undoUnallowedChanges(QuizQuestion originalQuizQuestion) {
-        if (originalQuizQuestion instanceof ShortAnswerQuestion) {
-            ShortAnswerQuestion shortAnswerOriginalQuestion = (ShortAnswerQuestion) originalQuizQuestion;
+        if (originalQuizQuestion instanceof ShortAnswerQuestion shortAnswerOriginalQuestion) {
             undoUnallowedSpotChanges(shortAnswerOriginalQuestion);
             checkInvalidSolutions(shortAnswerOriginalQuestion);
         }
@@ -251,8 +250,7 @@ public class ShortAnswerQuestion extends QuizQuestion {
 
     @Override
     public boolean isUpdateOfResultsAndStatisticsNecessary(QuizQuestion originalQuizQuestion) {
-        if (originalQuizQuestion instanceof ShortAnswerQuestion) {
-            ShortAnswerQuestion shortAnswerOriginalQuestion = (ShortAnswerQuestion) originalQuizQuestion;
+        if (originalQuizQuestion instanceof ShortAnswerQuestion shortAnswerOriginalQuestion) {
             return checkSolutionsIfRecalculationIsNecessary(shortAnswerOriginalQuestion) || checkSpotsIfRecalculationIsNecessary(shortAnswerOriginalQuestion)
                     || !getCorrectMappings().equals(shortAnswerOriginalQuestion.getCorrectMappings());
         }

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyDragAndDropAllOrNothing.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyDragAndDropAllOrNothing.java
@@ -13,9 +13,7 @@ public class ScoringStrategyDragAndDropAllOrNothing implements ScoringStrategy {
         if (quizQuestion.isInvalid()) {
             return quizQuestion.getPoints();
         }
-        if (submittedAnswer instanceof DragAndDropSubmittedAnswer && quizQuestion instanceof DragAndDropQuestion) {
-            DragAndDropSubmittedAnswer dndAnswer = (DragAndDropSubmittedAnswer) submittedAnswer;
-            DragAndDropQuestion dndQuestion = (DragAndDropQuestion) quizQuestion;
+        if (submittedAnswer instanceof DragAndDropSubmittedAnswer dndAnswer && quizQuestion instanceof DragAndDropQuestion dndQuestion) {
             // iterate through each drop location and compare its correct mappings with the answer's mapping
             for (DropLocation dropLocation : dndQuestion.getDropLocations()) {
                 DragItem selectedDragItem = dndAnswer.getSelectedDragItemForDropLocation(dropLocation);

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyDragAndDropProportionalWithPenalty.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyDragAndDropProportionalWithPenalty.java
@@ -17,10 +17,7 @@ public class ScoringStrategyDragAndDropProportionalWithPenalty implements Scorin
             return quizQuestion.getPoints();
         }
 
-        if (submittedAnswer instanceof DragAndDropSubmittedAnswer && quizQuestion instanceof DragAndDropQuestion) {
-            DragAndDropSubmittedAnswer dndAnswer = (DragAndDropSubmittedAnswer) submittedAnswer;
-            DragAndDropQuestion dndQuestion = (DragAndDropQuestion) quizQuestion;
-
+        if (submittedAnswer instanceof DragAndDropSubmittedAnswer dndAnswer && quizQuestion instanceof DragAndDropQuestion dndQuestion) {
             double mappedDropLocations = 0;
             double correctMappings = 0;
             double incorrectMappings = 0;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyDragAndDropProportionalWithoutPenalty.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyDragAndDropProportionalWithoutPenalty.java
@@ -16,10 +16,7 @@ public class ScoringStrategyDragAndDropProportionalWithoutPenalty implements Sco
             return quizQuestion.getPoints();
         }
 
-        if (submittedAnswer instanceof DragAndDropSubmittedAnswer && quizQuestion instanceof DragAndDropQuestion) {
-            DragAndDropSubmittedAnswer dndAnswer = (DragAndDropSubmittedAnswer) submittedAnswer;
-            DragAndDropQuestion dndQuestion = (DragAndDropQuestion) quizQuestion;
-
+        if (submittedAnswer instanceof DragAndDropSubmittedAnswer dndAnswer && quizQuestion instanceof DragAndDropQuestion dndQuestion) {
             double mappedDropLocations = 0;
             double correctMappings = 0;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyMultipleChoiceAllOrNothing.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyMultipleChoiceAllOrNothing.java
@@ -14,9 +14,7 @@ public class ScoringStrategyMultipleChoiceAllOrNothing implements ScoringStrateg
             return quizQuestion.getPoints();
         }
 
-        if (submittedAnswer instanceof MultipleChoiceSubmittedAnswer && quizQuestion instanceof MultipleChoiceQuestion) {
-            MultipleChoiceSubmittedAnswer mcAnswer = (MultipleChoiceSubmittedAnswer) submittedAnswer;
-            MultipleChoiceQuestion mcQuestion = (MultipleChoiceQuestion) quizQuestion;
+        if (submittedAnswer instanceof MultipleChoiceSubmittedAnswer mcAnswer && quizQuestion instanceof MultipleChoiceQuestion mcQuestion) {
             // iterate through each answer option and compare its correctness with the answer's selection
             for (AnswerOption answerOption : mcQuestion.getAnswerOptions()) {
                 boolean isSelected = mcAnswer.isSelected(answerOption);

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyMultipleChoiceProportionalWithPenalty.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyMultipleChoiceProportionalWithPenalty.java
@@ -15,10 +15,7 @@ public class ScoringStrategyMultipleChoiceProportionalWithPenalty implements Sco
             return quizQuestion.getPoints();
         }
 
-        if (submittedAnswer instanceof MultipleChoiceSubmittedAnswer && quizQuestion instanceof MultipleChoiceQuestion) {
-            MultipleChoiceSubmittedAnswer mcAnswer = (MultipleChoiceSubmittedAnswer) submittedAnswer;
-            MultipleChoiceQuestion mcQuestion = (MultipleChoiceQuestion) quizQuestion;
-
+        if (submittedAnswer instanceof MultipleChoiceSubmittedAnswer mcAnswer && quizQuestion instanceof MultipleChoiceQuestion mcQuestion) {
             double totalOptions = mcQuestion.getAnswerOptions().size();
             double correctSelections = 0;
             double incorrectSelections = 0;

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyMultipleChoiceProportionalWithoutPenalty.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyMultipleChoiceProportionalWithoutPenalty.java
@@ -14,10 +14,7 @@ public class ScoringStrategyMultipleChoiceProportionalWithoutPenalty implements 
             return quizQuestion.getPoints();
         }
 
-        if (submittedAnswer instanceof MultipleChoiceSubmittedAnswer && quizQuestion instanceof MultipleChoiceQuestion) {
-            MultipleChoiceSubmittedAnswer mcAnswer = (MultipleChoiceSubmittedAnswer) submittedAnswer;
-            MultipleChoiceQuestion mcQuestion = (MultipleChoiceQuestion) quizQuestion;
-
+        if (submittedAnswer instanceof MultipleChoiceSubmittedAnswer mcAnswer && quizQuestion instanceof MultipleChoiceQuestion mcQuestion) {
             double totalOptions = mcQuestion.getAnswerOptions().size();
             double correctSelections = 0;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyShortAnswerAllOrNothing.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyShortAnswerAllOrNothing.java
@@ -13,10 +13,7 @@ public class ScoringStrategyShortAnswerAllOrNothing implements ScoringStrategy {
         if (quizQuestion.isInvalid()) {
             return quizQuestion.getPoints();
         }
-        if (submittedAnswer instanceof ShortAnswerSubmittedAnswer && quizQuestion instanceof ShortAnswerQuestion) {
-            ShortAnswerSubmittedAnswer shortAnswerAnswer = (ShortAnswerSubmittedAnswer) submittedAnswer;
-            ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) quizQuestion;
-
+        if (submittedAnswer instanceof ShortAnswerSubmittedAnswer shortAnswerAnswer && quizQuestion instanceof ShortAnswerQuestion shortAnswerQuestion) {
             int[] values = ScoringStrategyShortAnswerUtil.getCorrectAndIncorrectSolutionCount(shortAnswerQuestion, shortAnswerAnswer);
             int correctSolutionsCount = values[0];
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyShortAnswerProportionalWithPenalty.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyShortAnswerProportionalWithPenalty.java
@@ -15,9 +15,7 @@ public class ScoringStrategyShortAnswerProportionalWithPenalty implements Scorin
             return quizQuestion.getPoints();
         }
 
-        if (submittedAnswer instanceof ShortAnswerSubmittedAnswer && quizQuestion instanceof ShortAnswerQuestion) {
-            ShortAnswerSubmittedAnswer shortAnswerAnswer = (ShortAnswerSubmittedAnswer) submittedAnswer;
-            ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) quizQuestion;
+        if (submittedAnswer instanceof ShortAnswerSubmittedAnswer shortAnswerAnswer && quizQuestion instanceof ShortAnswerQuestion shortAnswerQuestion) {
             double totalSolutionsCount = shortAnswerQuestion.getSpots().size();
 
             int[] values = ScoringStrategyShortAnswerUtil.getCorrectAndIncorrectSolutionCount(shortAnswerQuestion, shortAnswerAnswer);

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyShortAnswerProportionalWithoutPenalty.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/scoring/ScoringStrategyShortAnswerProportionalWithoutPenalty.java
@@ -14,9 +14,7 @@ public class ScoringStrategyShortAnswerProportionalWithoutPenalty implements Sco
             return quizQuestion.getPoints();
         }
 
-        if (submittedAnswer instanceof ShortAnswerSubmittedAnswer && quizQuestion instanceof ShortAnswerQuestion) {
-            ShortAnswerSubmittedAnswer shortAnswerAnswer = (ShortAnswerSubmittedAnswer) submittedAnswer;
-            ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) quizQuestion;
+        if (submittedAnswer instanceof ShortAnswerSubmittedAnswer shortAnswerAnswer && quizQuestion instanceof ShortAnswerQuestion shortAnswerQuestion) {
             double totalSolutionsCount = shortAnswerQuestion.getSpots().size();
 
             int[] values = ScoringStrategyShortAnswerUtil.getCorrectAndIncorrectSolutionCount(shortAnswerQuestion, shortAnswerAnswer);

--- a/src/main/java/de/tum/in/www1/artemis/security/SecurityUtils.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/SecurityUtils.java
@@ -58,8 +58,7 @@ public final class SecurityUtils {
         if (authentication == null) {
             return null;
         }
-        else if (authentication.getPrincipal() instanceof UserDetails) {
-            UserDetails springSecurityUser = (UserDetails) authentication.getPrincipal();
+        else if (authentication.getPrincipal() instanceof UserDetails springSecurityUser) {
             return springSecurityUser.getUsername();
         }
         else if (authentication.getPrincipal() instanceof String) {

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -577,8 +577,7 @@ public class ParticipationService {
         StudentParticipation participation = studentParticipationRepository.findWithEagerLegalSubmissionsResultsFeedbacksById(participationId).get();
         log.info("Request to delete Participation : {}", participation);
 
-        if (participation instanceof ProgrammingExerciseStudentParticipation) {
-            ProgrammingExerciseStudentParticipation programmingExerciseParticipation = (ProgrammingExerciseStudentParticipation) participation;
+        if (participation instanceof ProgrammingExerciseStudentParticipation programmingExerciseParticipation) {
             var repositoryUrl = programmingExerciseParticipation.getVcsRepositoryUrl();
             String buildPlanId = programmingExerciseParticipation.getBuildPlanId();
 

--- a/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/QuizExerciseService.java
@@ -64,8 +64,7 @@ public class QuizExerciseService {
 
         // fix references in all questions (step 1/2)
         for (var quizQuestion : quizExercise.getQuizQuestions()) {
-            if (quizQuestion instanceof MultipleChoiceQuestion) {
-                var mcQuestion = (MultipleChoiceQuestion) quizQuestion;
+            if (quizQuestion instanceof MultipleChoiceQuestion mcQuestion) {
                 var quizQuestionStatistic = (MultipleChoiceQuestionStatistic) mcQuestion.getQuizQuestionStatistic();
                 if (quizQuestionStatistic == null) {
                     quizQuestionStatistic = new MultipleChoiceQuestionStatistic();
@@ -89,8 +88,7 @@ public class QuizExerciseService {
                 }
                 quizQuestionStatistic.getAnswerCounters().removeAll(answerCounterToDelete);
             }
-            else if (quizQuestion instanceof DragAndDropQuestion) {
-                var dndQuestion = (DragAndDropQuestion) quizQuestion;
+            else if (quizQuestion instanceof DragAndDropQuestion dndQuestion) {
                 var quizQuestionStatistic = (DragAndDropQuestionStatistic) dndQuestion.getQuizQuestionStatistic();
                 if (quizQuestionStatistic == null) {
                     quizQuestionStatistic = new DragAndDropQuestionStatistic();
@@ -117,8 +115,7 @@ public class QuizExerciseService {
                 // save references as index to prevent Hibernate Persistence problem
                 saveCorrectMappingsInIndices(dndQuestion);
             }
-            else if (quizQuestion instanceof ShortAnswerQuestion) {
-                var saQuestion = (ShortAnswerQuestion) quizQuestion;
+            else if (quizQuestion instanceof ShortAnswerQuestion saQuestion) {
                 var quizQuestionStatistic = (ShortAnswerQuestionStatistic) saQuestion.getQuizQuestionStatistic();
                 if (quizQuestionStatistic == null) {
                     quizQuestionStatistic = new ShortAnswerQuestionStatistic();
@@ -155,13 +152,11 @@ public class QuizExerciseService {
 
         // fix references in all drag and drop questions and short answer questions (step 2/2)
         for (QuizQuestion quizQuestion : quizExercise.getQuizQuestions()) {
-            if (quizQuestion instanceof DragAndDropQuestion) {
-                DragAndDropQuestion dragAndDropQuestion = (DragAndDropQuestion) quizQuestion;
+            if (quizQuestion instanceof DragAndDropQuestion dragAndDropQuestion) {
                 // restore references from index after save
                 restoreCorrectMappingsFromIndices(dragAndDropQuestion);
             }
-            else if (quizQuestion instanceof ShortAnswerQuestion) {
-                ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) quizQuestion;
+            else if (quizQuestion instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 // restore references from index after save
                 restoreCorrectMappingsFromIndicesShortAnswer(shortAnswerQuestion);
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionVersionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionVersionService.java
@@ -79,8 +79,7 @@ public class SubmissionVersionService {
     }
 
     private String getSubmissionContent(Submission submission) {
-        if (submission instanceof ModelingSubmission) {
-            ModelingSubmission modelingSubmission = (ModelingSubmission) submission;
+        if (submission instanceof ModelingSubmission modelingSubmission) {
             return ("Model: " + modelingSubmission.getModel() + "; Explanation: " + modelingSubmission.getExplanationText());
         }
         else if (submission instanceof TextSubmission) {

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLPackage.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/classdiagram/UMLPackage.java
@@ -23,8 +23,7 @@ public class UMLPackage extends UMLContainerElement implements Serializable {
     public double similarity(Similarity<UMLElement> reference) {
         double similarity = 0;
 
-        if (reference instanceof UMLPackage) {
-            UMLPackage referencePackage = (UMLPackage) reference;
+        if (reference instanceof UMLPackage referencePackage) {
             similarity += NameSimilarity.levenshteinSimilarity(getName(), referencePackage.getName());
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/usecase/UMLSystemBoundary.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/umlmodel/usecase/UMLSystemBoundary.java
@@ -20,8 +20,7 @@ public class UMLSystemBoundary extends UMLContainerElement {
     public double similarity(Similarity<UMLElement> reference) {
         double similarity = 0;
 
-        if (reference instanceof UMLSystemBoundary) {
-            UMLSystemBoundary referencePackage = (UMLSystemBoundary) reference;
+        if (reference instanceof UMLSystemBoundary referencePackage) {
             similarity += NameSimilarity.levenshteinSimilarity(getName(), referencePackage.getName());
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -222,8 +222,7 @@ public class GitService {
         }).setSshDirectory(new java.io.File(gitSshPrivateKeyPath.get())).setHomeDirectory(new java.io.File(System.getProperty("user.home"))).build(new JGitKeyCache());
 
         sshCallback = transport -> {
-            if (transport instanceof SshTransport) {
-                SshTransport sshTransport = (SshTransport) transport;
+            if (transport instanceof SshTransport sshTransport) {
                 transport.setTimeout(JGIT_TIMEOUT_IN_SECONDS);
                 sshTransport.setSshSessionFactory(sshSessionFactory);
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
@@ -560,8 +560,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
      * @param submission ProgrammingSubmission
      */
     public void notifyUserAboutSubmission(ProgrammingSubmission submission) {
-        if (submission.getParticipation() instanceof StudentParticipation) {
-            StudentParticipation studentParticipation = (StudentParticipation) submission.getParticipation();
+        if (submission.getParticipation() instanceof StudentParticipation studentParticipation) {
             // no need to send all exercise details here
             submission.getParticipation().setExercise(null);
             studentParticipation.getStudents().forEach(user -> messagingTemplate.convertAndSendToUser(user.getLogin(), NEW_SUBMISSION_TOPIC, submission));
@@ -574,8 +573,7 @@ public class ProgrammingSubmissionService extends SubmissionService {
     }
 
     private void notifyUserAboutSubmissionError(ProgrammingSubmission submission, BuildTriggerWebsocketError error) {
-        if (submission.getParticipation() instanceof StudentParticipation) {
-            StudentParticipation studentParticipation = (StudentParticipation) submission.getParticipation();
+        if (submission.getParticipation() instanceof StudentParticipation studentParticipation) {
             studentParticipation.getStudents().forEach(user -> messagingTemplate.convertAndSendToUser(user.getLogin(), NEW_SUBMISSION_TOPIC, error));
         }
 

--- a/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
@@ -532,18 +532,15 @@ public class AssessmentComplaintIntegrationTest extends AbstractSpringIntegratio
             assertThat(exercise.getStudentParticipations()).as("Exercise only contains title and ID").isNullOrEmpty();
             assertThat(exercise.getTutorParticipations()).as("Exercise only contains title and ID").isNullOrEmpty();
             // TODO check exercise type specific sensitive attributes
-            if (exercise instanceof ModelingExercise) {
-                ModelingExercise modelingExercise = (ModelingExercise) exercise;
+            if (exercise instanceof ModelingExercise modelingExercise) {
                 assertThat(modelingExercise.getSampleSolutionModel()).as("Exercise only contains title and ID").isNull();
                 assertThat(modelingExercise.getSampleSolutionExplanation()).as("Exercise only contains title and ID").isNull();
             }
-            if (exercise instanceof TextExercise) {
-                TextExercise textExercise = (TextExercise) exercise;
+            if (exercise instanceof TextExercise textExercise) {
                 assertThat(textExercise.getSampleSolution()).as("Exercise only contains title and ID").isNull();
                 assertThat(textExercise.getExampleSubmissions()).as("Exercise only contains title and ID").isNull();
             }
-            if (exercise instanceof ProgrammingExercise) {
-                ProgrammingExercise programmingExercise = (ProgrammingExercise) exercise;
+            if (exercise instanceof ProgrammingExercise programmingExercise) {
                 assertThat(programmingExercise.getProgrammingLanguage()).as("Exercise only contains title and ID").isNull();
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
@@ -536,11 +536,11 @@ public class AssessmentComplaintIntegrationTest extends AbstractSpringIntegratio
                 assertThat(modelingExercise.getSampleSolutionModel()).as("Exercise only contains title and ID").isNull();
                 assertThat(modelingExercise.getSampleSolutionExplanation()).as("Exercise only contains title and ID").isNull();
             }
-            if (exercise instanceof TextExercise textExercise) {
+            else if (exercise instanceof TextExercise textExercise) {
                 assertThat(textExercise.getSampleSolution()).as("Exercise only contains title and ID").isNull();
                 assertThat(textExercise.getExampleSubmissions()).as("Exercise only contains title and ID").isNull();
             }
-            if (exercise instanceof ProgrammingExercise programmingExercise) {
+            else if (exercise instanceof ProgrammingExercise programmingExercise) {
                 assertThat(programmingExercise.getProgrammingLanguage()).as("Exercise only contains title and ID").isNull();
             }
         }

--- a/src/test/java/de/tum/in/www1/artemis/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExerciseIntegrationTest.java
@@ -120,19 +120,16 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                 assertThat(exerciseServer.getExampleSubmissions().size()).as("Example submissions not included").isZero();
 
                 // Test presence and absence of exercise type specific properties
-                if (exerciseServer instanceof FileUploadExercise) {
-                    FileUploadExercise fileUploadExercise = (FileUploadExercise) exerciseServer;
+                if (exerciseServer instanceof FileUploadExercise fileUploadExercise) {
                     assertThat(fileUploadExercise.getFilePattern()).as("File pattern was set correctly").isEqualTo("png");
                     assertThat(fileUploadExercise.getSampleSolution()).as("Sample solution was set correctly").isNotNull();
                 }
-                if (exerciseServer instanceof ModelingExercise) {
-                    ModelingExercise modelingExercise = (ModelingExercise) exerciseServer;
+                if (exerciseServer instanceof ModelingExercise modelingExercise) {
                     assertThat(modelingExercise.getDiagramType()).as("Diagram type was set correctly").isEqualTo(DiagramType.ClassDiagram);
                     assertThat(modelingExercise.getSampleSolutionModel()).as("Sample solution model was filtered out").isNull();
                     assertThat(modelingExercise.getSampleSolutionExplanation()).as("Sample solution explanation was filtered out").isNull();
                 }
-                if (exerciseServer instanceof ProgrammingExercise) {
-                    ProgrammingExercise programmingExerciseExercise = (ProgrammingExercise) exerciseServer;
+                if (exerciseServer instanceof ProgrammingExercise programmingExerciseExercise) {
                     assertThat(programmingExerciseExercise.getProjectKey()).as("Project key was set").isNotNull();
                     assertThat(programmingExerciseExercise.getTemplateRepositoryUrl()).as("Template repository url was filtered out").isNull();
                     assertThat(programmingExerciseExercise.getSolutionRepositoryUrl()).as("Solution repository url was filtered out").isNull();
@@ -140,15 +137,13 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                     assertThat(programmingExerciseExercise.getTemplateBuildPlanId()).as("Template build plan was filtered out").isNull();
                     assertThat(programmingExerciseExercise.getSolutionBuildPlanId()).as("Solution build plan was filtered out").isNull();
                 }
-                if (exerciseServer instanceof QuizExercise) {
-                    QuizExercise quizExercise = (QuizExercise) exerciseServer;
+                if (exerciseServer instanceof QuizExercise quizExercise) {
                     assertThat(quizExercise.getDuration()).as("Duration was set correctly").isEqualTo(10);
                     assertThat(quizExercise.getAllowedNumberOfAttempts()).as("Allowed number of attempts was set correctly").isEqualTo(1);
                     assertThat(quizExercise.getQuizPointStatistic()).as("Quiz point statistic was filtered out").isNull();
                     assertThat(quizExercise.getQuizQuestions().size()).as("Quiz questions were filtered out").isZero();
                 }
-                if (exerciseServer instanceof TextExercise) {
-                    TextExercise textExercise = (TextExercise) exerciseServer;
+                if (exerciseServer instanceof TextExercise textExercise) {
                     assertThat(textExercise.getSampleSolution()).as("Sample solution was filtered out").isNull();
                 }
 
@@ -163,13 +158,11 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                         Submission submission = participation.getSubmissions().iterator().next();
                         if (submission != null) {
                             // Test that the correct text submission was filtered.
-                            if (submission instanceof TextSubmission) {
-                                TextSubmission textSubmission = (TextSubmission) submission;
+                            if (submission instanceof TextSubmission textSubmission) {
                                 assertThat(textSubmission.getText()).as("Correct text submission").isEqualTo("text");
                             }
                             // Test that the correct modeling submission was filtered.
-                            if (submission instanceof ModelingSubmission) {
-                                ModelingSubmission modelingSubmission = (ModelingSubmission) submission;
+                            if (submission instanceof ModelingSubmission modelingSubmission) {
                                 assertThat(modelingSubmission.getModel()).as("Correct modeling submission").isEqualTo("model2");
                             }
                         }
@@ -237,21 +230,18 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
             for (Exercise exercise : course.getExercises()) {
                 Exercise exerciseWithDetails = request.get("/api/exercises/" + exercise.getId() + "/details", HttpStatus.OK, Exercise.class);
 
-                if (exerciseWithDetails instanceof FileUploadExercise) {
-                    FileUploadExercise fileUploadExercise = (FileUploadExercise) exerciseWithDetails;
+                if (exerciseWithDetails instanceof FileUploadExercise fileUploadExercise) {
                     assertThat(fileUploadExercise.getFilePattern()).as("File pattern was set correctly").isEqualTo("png");
                     assertThat(fileUploadExercise.getSampleSolution()).as("Sample solution was set correctly").isNotNull();
                     assertThat(fileUploadExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(0);
                 }
-                if (exerciseWithDetails instanceof ModelingExercise) {
-                    ModelingExercise modelingExercise = (ModelingExercise) exerciseWithDetails;
+                if (exerciseWithDetails instanceof ModelingExercise modelingExercise) {
                     assertThat(modelingExercise.getDiagramType()).as("Diagram type was set correctly").isEqualTo(DiagramType.ClassDiagram);
                     assertThat(modelingExercise.getSampleSolutionModel()).as("Sample solution model was filtered out").isNull();
                     assertThat(modelingExercise.getSampleSolutionExplanation()).as("Sample solution explanation was filtered out").isNull();
                     assertThat(modelingExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(2);
                 }
-                if (exerciseWithDetails instanceof ProgrammingExercise) {
-                    ProgrammingExercise programmingExerciseExercise = (ProgrammingExercise) exerciseWithDetails;
+                if (exerciseWithDetails instanceof ProgrammingExercise programmingExerciseExercise) {
                     assertThat(programmingExerciseExercise.getProjectKey()).as("Project key was set").isNotNull();
                     assertThat(programmingExerciseExercise.getTemplateRepositoryUrl()).as("Template repository url was filtered out").isNull();
                     assertThat(programmingExerciseExercise.getSolutionRepositoryUrl()).as("Solution repository url was filtered out").isNull();
@@ -260,16 +250,14 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                     assertThat(programmingExerciseExercise.getSolutionBuildPlanId()).as("Solution build plan was filtered out").isNull();
                     assertThat(programmingExerciseExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(0);
                 }
-                if (exerciseWithDetails instanceof QuizExercise) {
-                    QuizExercise quizExercise = (QuizExercise) exerciseWithDetails;
+                if (exerciseWithDetails instanceof QuizExercise quizExercise) {
                     assertThat(quizExercise.getDuration()).as("Duration was set correctly").isEqualTo(10);
                     assertThat(quizExercise.getAllowedNumberOfAttempts()).as("Allowed number of attempts was set correctly").isEqualTo(1);
                     assertThat(quizExercise.getQuizPointStatistic()).as("Quiz point statistic was filtered out").isNull();
                     assertThat(quizExercise.getQuizQuestions().size()).as("Quiz questions were filtered out").isZero();
                     assertThat(quizExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(0);
                 }
-                if (exerciseWithDetails instanceof TextExercise) {
-                    TextExercise textExercise = (TextExercise) exerciseWithDetails;
+                if (exerciseWithDetails instanceof TextExercise textExercise) {
                     assertThat(textExercise.getSampleSolution()).as("Sample solution was filtered out").isNull();
                     assertThat(textExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(1);
                 }
@@ -403,20 +391,16 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                 assertThat(exerciseForAssessmentDashboard.getDifficulty()).as("Difficulty was set correctly").isEqualTo(DifficultyLevel.MEDIUM);
 
                 // Test presence of exercise type specific properties
-                if (exerciseForAssessmentDashboard instanceof FileUploadExercise) {
-                    FileUploadExercise fileUploadExercise = (FileUploadExercise) exerciseForAssessmentDashboard;
+                if (exerciseForAssessmentDashboard instanceof FileUploadExercise fileUploadExercise) {
                     assertThat(fileUploadExercise.getFilePattern()).as("File pattern was set correctly").isEqualTo("png");
                 }
-                if (exerciseForAssessmentDashboard instanceof ModelingExercise) {
-                    ModelingExercise modelingExercise = (ModelingExercise) exerciseForAssessmentDashboard;
+                if (exerciseForAssessmentDashboard instanceof ModelingExercise modelingExercise) {
                     assertThat(modelingExercise.getDiagramType()).as("Diagram type was set correctly").isEqualTo(DiagramType.ClassDiagram);
                 }
-                if (exerciseForAssessmentDashboard instanceof ProgrammingExercise) {
-                    ProgrammingExercise programmingExerciseExercise = (ProgrammingExercise) exerciseForAssessmentDashboard;
+                if (exerciseForAssessmentDashboard instanceof ProgrammingExercise programmingExerciseExercise) {
                     assertThat(programmingExerciseExercise.getProjectKey()).as("Project key was set").isNotNull();
                 }
-                if (exerciseForAssessmentDashboard instanceof QuizExercise) {
-                    QuizExercise quizExercise = (QuizExercise) exerciseForAssessmentDashboard;
+                if (exerciseForAssessmentDashboard instanceof QuizExercise quizExercise) {
                     assertThat(quizExercise.getDuration()).as("Duration was set correctly").isEqualTo(10);
                     assertThat(quizExercise.getAllowedNumberOfAttempts()).as("Allowed number of attempts was set correctly").isEqualTo(1);
                 }

--- a/src/test/java/de/tum/in/www1/artemis/ExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExerciseIntegrationTest.java
@@ -124,12 +124,12 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                     assertThat(fileUploadExercise.getFilePattern()).as("File pattern was set correctly").isEqualTo("png");
                     assertThat(fileUploadExercise.getSampleSolution()).as("Sample solution was set correctly").isNotNull();
                 }
-                if (exerciseServer instanceof ModelingExercise modelingExercise) {
+                else if (exerciseServer instanceof ModelingExercise modelingExercise) {
                     assertThat(modelingExercise.getDiagramType()).as("Diagram type was set correctly").isEqualTo(DiagramType.ClassDiagram);
                     assertThat(modelingExercise.getSampleSolutionModel()).as("Sample solution model was filtered out").isNull();
                     assertThat(modelingExercise.getSampleSolutionExplanation()).as("Sample solution explanation was filtered out").isNull();
                 }
-                if (exerciseServer instanceof ProgrammingExercise programmingExerciseExercise) {
+                else if (exerciseServer instanceof ProgrammingExercise programmingExerciseExercise) {
                     assertThat(programmingExerciseExercise.getProjectKey()).as("Project key was set").isNotNull();
                     assertThat(programmingExerciseExercise.getTemplateRepositoryUrl()).as("Template repository url was filtered out").isNull();
                     assertThat(programmingExerciseExercise.getSolutionRepositoryUrl()).as("Solution repository url was filtered out").isNull();
@@ -137,13 +137,13 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                     assertThat(programmingExerciseExercise.getTemplateBuildPlanId()).as("Template build plan was filtered out").isNull();
                     assertThat(programmingExerciseExercise.getSolutionBuildPlanId()).as("Solution build plan was filtered out").isNull();
                 }
-                if (exerciseServer instanceof QuizExercise quizExercise) {
+                else if (exerciseServer instanceof QuizExercise quizExercise) {
                     assertThat(quizExercise.getDuration()).as("Duration was set correctly").isEqualTo(10);
                     assertThat(quizExercise.getAllowedNumberOfAttempts()).as("Allowed number of attempts was set correctly").isEqualTo(1);
                     assertThat(quizExercise.getQuizPointStatistic()).as("Quiz point statistic was filtered out").isNull();
                     assertThat(quizExercise.getQuizQuestions().size()).as("Quiz questions were filtered out").isZero();
                 }
-                if (exerciseServer instanceof TextExercise textExercise) {
+                else if (exerciseServer instanceof TextExercise textExercise) {
                     assertThat(textExercise.getSampleSolution()).as("Sample solution was filtered out").isNull();
                 }
 
@@ -162,7 +162,7 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                                 assertThat(textSubmission.getText()).as("Correct text submission").isEqualTo("text");
                             }
                             // Test that the correct modeling submission was filtered.
-                            if (submission instanceof ModelingSubmission modelingSubmission) {
+                            else if (submission instanceof ModelingSubmission modelingSubmission) {
                                 assertThat(modelingSubmission.getModel()).as("Correct modeling submission").isEqualTo("model2");
                             }
                         }
@@ -235,13 +235,13 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                     assertThat(fileUploadExercise.getSampleSolution()).as("Sample solution was set correctly").isNotNull();
                     assertThat(fileUploadExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(0);
                 }
-                if (exerciseWithDetails instanceof ModelingExercise modelingExercise) {
+                else if (exerciseWithDetails instanceof ModelingExercise modelingExercise) {
                     assertThat(modelingExercise.getDiagramType()).as("Diagram type was set correctly").isEqualTo(DiagramType.ClassDiagram);
                     assertThat(modelingExercise.getSampleSolutionModel()).as("Sample solution model was filtered out").isNull();
                     assertThat(modelingExercise.getSampleSolutionExplanation()).as("Sample solution explanation was filtered out").isNull();
                     assertThat(modelingExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(2);
                 }
-                if (exerciseWithDetails instanceof ProgrammingExercise programmingExerciseExercise) {
+                else if (exerciseWithDetails instanceof ProgrammingExercise programmingExerciseExercise) {
                     assertThat(programmingExerciseExercise.getProjectKey()).as("Project key was set").isNotNull();
                     assertThat(programmingExerciseExercise.getTemplateRepositoryUrl()).as("Template repository url was filtered out").isNull();
                     assertThat(programmingExerciseExercise.getSolutionRepositoryUrl()).as("Solution repository url was filtered out").isNull();
@@ -250,14 +250,14 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                     assertThat(programmingExerciseExercise.getSolutionBuildPlanId()).as("Solution build plan was filtered out").isNull();
                     assertThat(programmingExerciseExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(0);
                 }
-                if (exerciseWithDetails instanceof QuizExercise quizExercise) {
+                else if (exerciseWithDetails instanceof QuizExercise quizExercise) {
                     assertThat(quizExercise.getDuration()).as("Duration was set correctly").isEqualTo(10);
                     assertThat(quizExercise.getAllowedNumberOfAttempts()).as("Allowed number of attempts was set correctly").isEqualTo(1);
                     assertThat(quizExercise.getQuizPointStatistic()).as("Quiz point statistic was filtered out").isNull();
                     assertThat(quizExercise.getQuizQuestions().size()).as("Quiz questions were filtered out").isZero();
                     assertThat(quizExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(0);
                 }
-                if (exerciseWithDetails instanceof TextExercise textExercise) {
+                else if (exerciseWithDetails instanceof TextExercise textExercise) {
                     assertThat(textExercise.getSampleSolution()).as("Sample solution was filtered out").isNull();
                     assertThat(textExercise.getStudentParticipations().size()).as("Number of participations is correct").isEqualTo(1);
                 }
@@ -394,13 +394,13 @@ public class ExerciseIntegrationTest extends AbstractSpringIntegrationBambooBitb
                 if (exerciseForAssessmentDashboard instanceof FileUploadExercise fileUploadExercise) {
                     assertThat(fileUploadExercise.getFilePattern()).as("File pattern was set correctly").isEqualTo("png");
                 }
-                if (exerciseForAssessmentDashboard instanceof ModelingExercise modelingExercise) {
+                else if (exerciseForAssessmentDashboard instanceof ModelingExercise modelingExercise) {
                     assertThat(modelingExercise.getDiagramType()).as("Diagram type was set correctly").isEqualTo(DiagramType.ClassDiagram);
                 }
-                if (exerciseForAssessmentDashboard instanceof ProgrammingExercise programmingExerciseExercise) {
+                else if (exerciseForAssessmentDashboard instanceof ProgrammingExercise programmingExerciseExercise) {
                     assertThat(programmingExerciseExercise.getProjectKey()).as("Project key was set").isNotNull();
                 }
-                if (exerciseForAssessmentDashboard instanceof QuizExercise quizExercise) {
+                else if (exerciseForAssessmentDashboard instanceof QuizExercise quizExercise) {
                     assertThat(quizExercise.getDuration()).as("Duration was set correctly").isEqualTo(10);
                     assertThat(quizExercise.getAllowedNumberOfAttempts()).as("Allowed number of attempts was set correctly").isEqualTo(1);
                 }

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -114,8 +114,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         // Quiz type specific assertions
         for (QuizQuestion question : quizExercise.getQuizQuestions()) {
-            if (question instanceof MultipleChoiceQuestion) {
-                MultipleChoiceQuestion multipleChoiceQuestion = (MultipleChoiceQuestion) question;
+            if (question instanceof MultipleChoiceQuestion multipleChoiceQuestion) {
                 assertThat(multipleChoiceQuestion.getAnswerOptions().size()).as("Multiple choice question answer options were saved").isEqualTo(2);
                 assertThat(multipleChoiceQuestion.getTitle()).as("Multiple choice question title is correct").isEqualTo("MC");
                 assertThat(multipleChoiceQuestion.getText()).as("Multiple choice question text is correct").isEqualTo("Q1");
@@ -131,8 +130,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(answerOptions.get(1).getExplanation()).as("Explanation for answer option is correct").isEqualTo("E2");
                 assertThat(answerOptions.get(1).isIsCorrect()).as("Is correct for answer option is correct").isFalse();
             }
-            if (question instanceof DragAndDropQuestion) {
-                DragAndDropQuestion dragAndDropQuestion = (DragAndDropQuestion) question;
+            if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
                 assertThat(dragAndDropQuestion.getDropLocations().size()).as("Drag and drop question drop locations were saved").isEqualTo(3);
                 assertThat(dragAndDropQuestion.getDragItems().size()).as("Drag and drop question drag items were saved").isEqualTo(3);
                 assertThat(dragAndDropQuestion.getTitle()).as("Drag and drop question title is correct").isEqualTo("DnD");
@@ -155,8 +153,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(dragItems.get(0).getText()).as("Text for drag item is correct").isEqualTo("D1");
                 assertThat(dragItems.get(1).getText()).as("Text for drag item is correct").isEqualTo("D2");
             }
-            if (question instanceof ShortAnswerQuestion) {
-                ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) question;
+            if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 assertThat(shortAnswerQuestion.getSpots().size()).as("Short answer question spots were saved").isEqualTo(2);
                 assertThat(shortAnswerQuestion.getSolutions().size()).as("Short answer question solutions were saved").isEqualTo(2);
                 assertThat(shortAnswerQuestion.getTitle()).as("Short answer question title is correct").isEqualTo("SA");
@@ -188,8 +185,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         // Quiz type specific assertions
         for (QuizQuestion question : quizExercise.getQuizQuestions()) {
-            if (question instanceof MultipleChoiceQuestion) {
-                MultipleChoiceQuestion multipleChoiceQuestion = (MultipleChoiceQuestion) question;
+            if (question instanceof MultipleChoiceQuestion multipleChoiceQuestion) {
                 assertThat(multipleChoiceQuestion.getAnswerOptions().size()).as("Multiple choice question answer options were saved").isEqualTo(2);
                 assertThat(multipleChoiceQuestion.getTitle()).as("Multiple choice question title is correct").isEqualTo("MC");
                 assertThat(multipleChoiceQuestion.getText()).as("Multiple choice question text is correct").isEqualTo("Q1");
@@ -206,8 +202,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(answerOptions.get(1).isIsCorrect()).as("Is correct for answer option is correct").isFalse();
                 answerOptions.get(1).getQuestion();
             }
-            if (question instanceof DragAndDropQuestion) {
-                DragAndDropQuestion dragAndDropQuestion = (DragAndDropQuestion) question;
+            if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
                 assertThat(dragAndDropQuestion.getDropLocations().size()).as("Drag and drop question drop locations were saved").isEqualTo(3);
                 assertThat(dragAndDropQuestion.getDragItems().size()).as("Drag and drop question drag items were saved").isEqualTo(3);
                 assertThat(dragAndDropQuestion.getTitle()).as("Drag and drop question title is correct").isEqualTo("DnD");
@@ -228,8 +223,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(dragItems.get(0).getText()).as("Text for drag item is correct").isEqualTo("D1");
                 assertThat(dragItems.get(1).getText()).as("Text for drag item is correct").isEqualTo("D2");
             }
-            if (question instanceof ShortAnswerQuestion) {
-                ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) question;
+            if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 assertThat(shortAnswerQuestion.getSpots().size()).as("Short answer question spots were saved").isEqualTo(2);
                 assertThat(shortAnswerQuestion.getSolutions().size()).as("Short answer question solutions were saved").isEqualTo(2);
                 assertThat(shortAnswerQuestion.getTitle()).as("Short answer question title is correct").isEqualTo("SA");
@@ -317,8 +311,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         // Quiz type specific assertions
         for (QuizQuestion question : quizExercise.getQuizQuestions()) {
-            if (question instanceof MultipleChoiceQuestion) {
-                MultipleChoiceQuestion multipleChoiceQuestion = (MultipleChoiceQuestion) question;
+            if (question instanceof MultipleChoiceQuestion multipleChoiceQuestion) {
                 assertThat(multipleChoiceQuestion.getAnswerOptions().size()).as("Multiple choice question answer options were saved").isEqualTo(3);
                 assertThat(multipleChoiceQuestion.getTitle()).as("Multiple choice question title is correct").isEqualTo("MC");
                 assertThat(multipleChoiceQuestion.getText()).as("Multiple choice question text is correct").isEqualTo("Q1");
@@ -338,8 +331,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(answerOptions.get(2).getExplanation()).as("Explanation for answer option is correct").isEqualTo("E4");
                 assertThat(answerOptions.get(2).isIsCorrect()).as("Is correct for answer option is correct").isTrue();
             }
-            if (question instanceof DragAndDropQuestion) {
-                DragAndDropQuestion dragAndDropQuestion = (DragAndDropQuestion) question;
+            if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
                 assertThat(dragAndDropQuestion.getDropLocations().size()).as("Drag and drop question drop locations were saved").isEqualTo(2);
                 assertThat(dragAndDropQuestion.getDragItems().size()).as("Drag and drop question drag items were saved").isEqualTo(2);
                 assertThat(dragAndDropQuestion.getTitle()).as("Drag and drop question title is correct").isEqualTo("DnD");
@@ -355,8 +347,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 List<DragItem> dragItems = dragAndDropQuestion.getDragItems();
                 assertThat(dragItems.get(0).getText()).as("Text for drag item is correct").isEqualTo("D2");
             }
-            if (question instanceof ShortAnswerQuestion) {
-                ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) question;
+            if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 assertThat(shortAnswerQuestion.getSpots().size()).as("Short answer question spots were saved").isEqualTo(1);
                 assertThat(shortAnswerQuestion.getSolutions().size()).as("Short answer question solutions were saved").isEqualTo(1);
                 assertThat(shortAnswerQuestion.getTitle()).as("Short answer question title is correct").isEqualTo("SA");
@@ -397,8 +388,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         // Quiz type specific assertions
         for (QuizQuestion question : quizExercise.getQuizQuestions()) {
-            if (question instanceof MultipleChoiceQuestion) {
-                MultipleChoiceQuestion multipleChoiceQuestion = (MultipleChoiceQuestion) question;
+            if (question instanceof MultipleChoiceQuestion multipleChoiceQuestion) {
                 assertThat(multipleChoiceQuestion.getAnswerOptions().size()).as("Multiple choice question answer options were saved").isEqualTo(3);
                 assertThat(multipleChoiceQuestion.getTitle()).as("Multiple choice question title is correct").isEqualTo("MC");
                 assertThat(multipleChoiceQuestion.getText()).as("Multiple choice question text is correct").isEqualTo("Q1");
@@ -418,8 +408,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(answerOptions.get(2).getExplanation()).as("Explanation for answer option is correct").isEqualTo("E4");
                 assertThat(answerOptions.get(2).isIsCorrect()).as("Is correct for answer option is correct").isTrue();
             }
-            if (question instanceof DragAndDropQuestion) {
-                DragAndDropQuestion dragAndDropQuestion = (DragAndDropQuestion) question;
+            if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
                 assertThat(dragAndDropQuestion.getDropLocations().size()).as("Drag and drop question drop locations were saved").isEqualTo(2);
                 assertThat(dragAndDropQuestion.getDragItems().size()).as("Drag and drop question drag items were saved").isEqualTo(2);
                 assertThat(dragAndDropQuestion.getTitle()).as("Drag and drop question title is correct").isEqualTo("DnD");
@@ -435,8 +424,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 List<DragItem> dragItems = dragAndDropQuestion.getDragItems();
                 assertThat(dragItems.get(0).getText()).as("Text for drag item is correct").isEqualTo("D2");
             }
-            if (question instanceof ShortAnswerQuestion) {
-                ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) question;
+            if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 assertThat(shortAnswerQuestion.getSpots().size()).as("Short answer question spots were saved").isEqualTo(1);
                 assertThat(shortAnswerQuestion.getSolutions().size()).as("Short answer question solutions were saved").isEqualTo(1);
                 assertThat(shortAnswerQuestion.getTitle()).as("Short answer question title is correct").isEqualTo("SA");
@@ -1027,9 +1015,8 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
     public void testReEvaluateQuizQuestionWithMoreSolutions() throws Exception {
         quizExercise = createQuizOnServer(ZonedDateTime.now().minusHours(5), ZonedDateTime.now().minusHours(2));
         QuizQuestion question = quizExercise.getQuizQuestions().get(2);
-        if (question instanceof ShortAnswerQuestion) {
-            ShortAnswerQuestion shortAnswerQuestion = (ShortAnswerQuestion) question;
 
+        if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
             // demonstrate that the initial shortAnswerQuestion has 2 correct mappings and 2 solutions
             assertThat(shortAnswerQuestion.getCorrectMappings().size()).isEqualTo(2);
             assertThat(shortAnswerQuestion.getCorrectMappings().size()).isEqualTo(2);
@@ -1386,24 +1373,21 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
 
         for (var quizQuestion : quizExercise.getQuizQuestions()) {
             var statistic = quizQuestion.getQuizQuestionStatistic();
-            if (statistic instanceof MultipleChoiceQuestionStatistic) {
-                var mcStatistic = (MultipleChoiceQuestionStatistic) statistic;
+            if (statistic instanceof MultipleChoiceQuestionStatistic mcStatistic) {
                 assertThat(mcStatistic.getAnswerCounters()).isNotEmpty();
                 for (var counter : mcStatistic.getAnswerCounters()) {
                     System.out.println("AnswerCounters: " + counter.toString());
                     System.out.println("MultipleChoiceQuestionStatistic: " + counter.getMultipleChoiceQuestionStatistic());
                 }
             }
-            if (statistic instanceof DragAndDropQuestionStatistic) {
-                var dndStatistic = (DragAndDropQuestionStatistic) statistic;
+            if (statistic instanceof DragAndDropQuestionStatistic dndStatistic) {
                 assertThat(dndStatistic.getDropLocationCounters()).isNotEmpty();
                 for (var counter : dndStatistic.getDropLocationCounters()) {
                     System.out.println("DropLocationCounters: " + counter.toString());
                     System.out.println("DragAndDropQuestionStatistic: " + counter.getDragAndDropQuestionStatistic());
                 }
             }
-            if (statistic instanceof ShortAnswerQuestionStatistic) {
-                var saStatistic = (ShortAnswerQuestionStatistic) statistic;
+            if (statistic instanceof ShortAnswerQuestionStatistic saStatistic) {
                 assertThat(saStatistic.getShortAnswerSpotCounters()).isNotEmpty();
                 for (var counter : saStatistic.getShortAnswerSpotCounters()) {
                     System.out.println("ShortAnswerSpotCounters: " + counter.toString());

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -130,7 +130,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(answerOptions.get(1).getExplanation()).as("Explanation for answer option is correct").isEqualTo("E2");
                 assertThat(answerOptions.get(1).isIsCorrect()).as("Is correct for answer option is correct").isFalse();
             }
-            if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
+            else if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
                 assertThat(dragAndDropQuestion.getDropLocations().size()).as("Drag and drop question drop locations were saved").isEqualTo(3);
                 assertThat(dragAndDropQuestion.getDragItems().size()).as("Drag and drop question drag items were saved").isEqualTo(3);
                 assertThat(dragAndDropQuestion.getTitle()).as("Drag and drop question title is correct").isEqualTo("DnD");
@@ -153,7 +153,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(dragItems.get(0).getText()).as("Text for drag item is correct").isEqualTo("D1");
                 assertThat(dragItems.get(1).getText()).as("Text for drag item is correct").isEqualTo("D2");
             }
-            if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
+            else if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 assertThat(shortAnswerQuestion.getSpots().size()).as("Short answer question spots were saved").isEqualTo(2);
                 assertThat(shortAnswerQuestion.getSolutions().size()).as("Short answer question solutions were saved").isEqualTo(2);
                 assertThat(shortAnswerQuestion.getTitle()).as("Short answer question title is correct").isEqualTo("SA");
@@ -202,7 +202,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(answerOptions.get(1).isIsCorrect()).as("Is correct for answer option is correct").isFalse();
                 answerOptions.get(1).getQuestion();
             }
-            if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
+            else if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
                 assertThat(dragAndDropQuestion.getDropLocations().size()).as("Drag and drop question drop locations were saved").isEqualTo(3);
                 assertThat(dragAndDropQuestion.getDragItems().size()).as("Drag and drop question drag items were saved").isEqualTo(3);
                 assertThat(dragAndDropQuestion.getTitle()).as("Drag and drop question title is correct").isEqualTo("DnD");
@@ -223,7 +223,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(dragItems.get(0).getText()).as("Text for drag item is correct").isEqualTo("D1");
                 assertThat(dragItems.get(1).getText()).as("Text for drag item is correct").isEqualTo("D2");
             }
-            if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
+            else if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 assertThat(shortAnswerQuestion.getSpots().size()).as("Short answer question spots were saved").isEqualTo(2);
                 assertThat(shortAnswerQuestion.getSolutions().size()).as("Short answer question solutions were saved").isEqualTo(2);
                 assertThat(shortAnswerQuestion.getTitle()).as("Short answer question title is correct").isEqualTo("SA");
@@ -331,7 +331,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(answerOptions.get(2).getExplanation()).as("Explanation for answer option is correct").isEqualTo("E4");
                 assertThat(answerOptions.get(2).isIsCorrect()).as("Is correct for answer option is correct").isTrue();
             }
-            if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
+            else if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
                 assertThat(dragAndDropQuestion.getDropLocations().size()).as("Drag and drop question drop locations were saved").isEqualTo(2);
                 assertThat(dragAndDropQuestion.getDragItems().size()).as("Drag and drop question drag items were saved").isEqualTo(2);
                 assertThat(dragAndDropQuestion.getTitle()).as("Drag and drop question title is correct").isEqualTo("DnD");
@@ -347,7 +347,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 List<DragItem> dragItems = dragAndDropQuestion.getDragItems();
                 assertThat(dragItems.get(0).getText()).as("Text for drag item is correct").isEqualTo("D2");
             }
-            if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
+            else if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 assertThat(shortAnswerQuestion.getSpots().size()).as("Short answer question spots were saved").isEqualTo(1);
                 assertThat(shortAnswerQuestion.getSolutions().size()).as("Short answer question solutions were saved").isEqualTo(1);
                 assertThat(shortAnswerQuestion.getTitle()).as("Short answer question title is correct").isEqualTo("SA");
@@ -408,7 +408,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 assertThat(answerOptions.get(2).getExplanation()).as("Explanation for answer option is correct").isEqualTo("E4");
                 assertThat(answerOptions.get(2).isIsCorrect()).as("Is correct for answer option is correct").isTrue();
             }
-            if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
+            else if (question instanceof DragAndDropQuestion dragAndDropQuestion) {
                 assertThat(dragAndDropQuestion.getDropLocations().size()).as("Drag and drop question drop locations were saved").isEqualTo(2);
                 assertThat(dragAndDropQuestion.getDragItems().size()).as("Drag and drop question drag items were saved").isEqualTo(2);
                 assertThat(dragAndDropQuestion.getTitle()).as("Drag and drop question title is correct").isEqualTo("DnD");
@@ -424,7 +424,7 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                 List<DragItem> dragItems = dragAndDropQuestion.getDragItems();
                 assertThat(dragItems.get(0).getText()).as("Text for drag item is correct").isEqualTo("D2");
             }
-            if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
+            else if (question instanceof ShortAnswerQuestion shortAnswerQuestion) {
                 assertThat(shortAnswerQuestion.getSpots().size()).as("Short answer question spots were saved").isEqualTo(1);
                 assertThat(shortAnswerQuestion.getSolutions().size()).as("Short answer question solutions were saved").isEqualTo(1);
                 assertThat(shortAnswerQuestion.getTitle()).as("Short answer question title is correct").isEqualTo("SA");
@@ -1380,14 +1380,14 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
                     System.out.println("MultipleChoiceQuestionStatistic: " + counter.getMultipleChoiceQuestionStatistic());
                 }
             }
-            if (statistic instanceof DragAndDropQuestionStatistic dndStatistic) {
+            else if (statistic instanceof DragAndDropQuestionStatistic dndStatistic) {
                 assertThat(dndStatistic.getDropLocationCounters()).isNotEmpty();
                 for (var counter : dndStatistic.getDropLocationCounters()) {
                     System.out.println("DropLocationCounters: " + counter.toString());
                     System.out.println("DragAndDropQuestionStatistic: " + counter.getDragAndDropQuestionStatistic());
                 }
             }
-            if (statistic instanceof ShortAnswerQuestionStatistic saStatistic) {
+            else if (statistic instanceof ShortAnswerQuestionStatistic saStatistic) {
                 assertThat(saStatistic.getShortAnswerSpotCounters()).isNotEmpty();
                 for (var counter : saStatistic.getShortAnswerSpotCounters()) {
                     System.out.println("ShortAnswerSpotCounters: " + counter.toString());

--- a/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StudentExamIntegrationTest.java
@@ -874,9 +874,8 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
 
         for (var exercise : studentExamResponse.getExercises()) {
             var participation = exercise.getStudentParticipations().iterator().next();
-            if (exercise instanceof ProgrammingExercise) {
+            if (exercise instanceof ProgrammingExercise programmingExercise) {
                 studentProgrammingParticipations.add((ProgrammingExerciseStudentParticipation) participation);
-                var programmingExercise = (ProgrammingExercise) exercise;
                 exercisesToBeLocked.add(programmingExercise);
                 final var repositorySlug = (programmingExercise.getProjectKey() + "-" + participation.getParticipantIdentifier()).toLowerCase();
                 bitbucketRequestMockProvider.mockSetRepositoryPermissionsToReadOnly(repositorySlug, programmingExercise.getProjectKey(), participation.getStudents());
@@ -1090,23 +1089,20 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
         assertThat(savedQuizSubmission.getSubmittedAnswers().size()).isGreaterThan(0);
         quizExercise.getQuizQuestions().forEach(quizQuestion -> {
             SubmittedAnswer submittedAnswer = savedQuizSubmission.getSubmittedAnswerForQuestion(quizQuestion);
-            if (submittedAnswer instanceof MultipleChoiceSubmittedAnswer) {
-                var answer = (MultipleChoiceSubmittedAnswer) submittedAnswer;
+            if (submittedAnswer instanceof MultipleChoiceSubmittedAnswer answer) {
                 assertThat(answer.getSelectedOptions()).isNotNull();
                 assertThat(answer.getSelectedOptions().size()).isGreaterThan(0);
                 assertThat(answer.getSelectedOptions().iterator().next()).isNotNull();
                 assertThat(answer.getSelectedOptions().iterator().next()).isEqualTo(((MultipleChoiceQuestion) quizQuestion).getAnswerOptions().get(mcSelectedOptionIndex));
             }
-            else if (submittedAnswer instanceof ShortAnswerSubmittedAnswer) {
-                var answer = (ShortAnswerSubmittedAnswer) submittedAnswer;
+            else if (submittedAnswer instanceof ShortAnswerSubmittedAnswer answer) {
                 assertThat(answer.getSubmittedTexts()).isNotNull();
                 assertThat(answer.getSubmittedTexts().size()).isGreaterThan(0);
                 assertThat(answer.getSubmittedTexts().iterator().next()).isNotNull();
                 assertThat(answer.getSubmittedTexts().iterator().next().getText()).isEqualTo(shortAnswerText);
                 assertThat(answer.getSubmittedTexts().iterator().next().getSpot()).isEqualTo(((ShortAnswerQuestion) quizQuestion).getSpots().get(saSpotIndex));
             }
-            else if (submittedAnswer instanceof DragAndDropSubmittedAnswer) {
-                var answer = (DragAndDropSubmittedAnswer) submittedAnswer;
+            else if (submittedAnswer instanceof DragAndDropSubmittedAnswer answer) {
                 assertThat(answer.getMappings()).isNotNull();
                 assertThat(answer.getMappings().size()).isGreaterThan(0);
                 assertThat(answer.getMappings().iterator().next()).isNotNull();
@@ -1124,8 +1120,7 @@ public class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooB
         if (submission instanceof TextSubmission) {
             assertThat(((TextSubmission) submission).getText()).isEqualTo(versionedSubmission.get().getContent());
         }
-        else if (submission instanceof ModelingSubmission) {
-            ModelingSubmission modelingSubmission = (ModelingSubmission) submission;
+        else if (submission instanceof ModelingSubmission modelingSubmission) {
             assertThat("Model: " + modelingSubmission.getModel() + "; Explanation: " + modelingSubmission.getExplanationText()).isEqualTo(versionedSubmission.get().getContent());
         }
         else if (submission instanceof FileUploadSubmission) {

--- a/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
@@ -321,8 +321,7 @@ public class CourseTestService {
                 mockDelegate.mockDeleteGroupInUserManagement(course.getInstructorGroupName());
             }
             for (Exercise exercise : course.getExercises()) {
-                if (exercise instanceof ProgrammingExercise) {
-                    final var programmingExercise = (ProgrammingExercise) exercise;
+                if (exercise instanceof final ProgrammingExercise programmingExercise) {
                     final String projectKey = programmingExercise.getProjectKey();
                     final var templateRepoName = programmingExercise.generateRepositoryName(RepositoryType.TEMPLATE);
                     final var solutionRepoName = programmingExercise.generateRepositoryName(RepositoryType.SOLUTION);
@@ -547,13 +546,11 @@ public class CourseTestService {
                     Submission submission = participation.getSubmissions().iterator().next();
                     if (submission != null) {
                         // Test that the correct text submission was filtered.
-                        if (submission instanceof TextSubmission) {
-                            TextSubmission textSubmission = (TextSubmission) submission;
+                        if (submission instanceof TextSubmission textSubmission) {
                             assertThat(textSubmission.getText()).as("Correct text submission").isEqualTo("text");
                         }
                         // Test that the correct modeling submission was filtered.
-                        if (submission instanceof ModelingSubmission) {
-                            ModelingSubmission modelingSubmission = (ModelingSubmission) submission;
+                        if (submission instanceof ModelingSubmission modelingSubmission) {
                             assertThat(modelingSubmission.getModel()).as("Correct modeling submission").isEqualTo("model1");
                         }
                     }
@@ -588,13 +585,11 @@ public class CourseTestService {
                     Submission submission = participation.getSubmissions().iterator().next();
                     if (submission != null) {
                         // Test that the correct text submission was filtered.
-                        if (submission instanceof TextSubmission) {
-                            TextSubmission textSubmission = (TextSubmission) submission;
+                        if (submission instanceof TextSubmission textSubmission) {
                             assertThat(textSubmission.getText()).as("Correct text submission").isEqualTo("text");
                         }
                         // Test that the correct modeling submission was filtered.
-                        if (submission instanceof ModelingSubmission) {
-                            ModelingSubmission modelingSubmission = (ModelingSubmission) submission;
+                        if (submission instanceof ModelingSubmission modelingSubmission) {
                             assertThat(modelingSubmission.getModel()).as("Correct modeling submission").isEqualTo("model1");
                         }
                     }

--- a/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
@@ -550,7 +550,7 @@ public class CourseTestService {
                             assertThat(textSubmission.getText()).as("Correct text submission").isEqualTo("text");
                         }
                         // Test that the correct modeling submission was filtered.
-                        if (submission instanceof ModelingSubmission modelingSubmission) {
+                        else if (submission instanceof ModelingSubmission modelingSubmission) {
                             assertThat(modelingSubmission.getModel()).as("Correct modeling submission").isEqualTo("model1");
                         }
                     }
@@ -589,7 +589,7 @@ public class CourseTestService {
                             assertThat(textSubmission.getText()).as("Correct text submission").isEqualTo("text");
                         }
                         // Test that the correct modeling submission was filtered.
-                        if (submission instanceof ModelingSubmission modelingSubmission) {
+                        else if (submission instanceof ModelingSubmission modelingSubmission) {
                             assertThat(modelingSubmission.getModel()).as("Correct modeling submission").isEqualTo("model1");
                         }
                     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->


### Checklist
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
Java 16 allows [pattern matching on `instanceof`](https://openjdk.java.net/jeps/394). Using this feature additional explicit typecasts can be avoided.
I ran the inspection for such cases in IntelliJ and applied them where it made sense to do so.


### Description

#### Feature Applied
The new feature allows reducing e.g.
```java
if (submission instanceof QuizSubmission) {
    QuizSubmission quizSubmission = (QuizSubmission) submission;
    quizSubmission.foo();
    …
}
```
to
```java
if (submission instanceof QuizSubmission quizSubmission) {
    quizSubmission.foo();
    …
}
```
In those cases where the variable is only used inside the `if`-block, I chose to convert it to the new pattern.

#### Feature Not Applied
The new feature would also allow converting e.g. (in `UMLClass.java`)
```java
if (!(reference instanceof UMLClass)) {
    return 0;
}

UMLClass referenceClass = (UMLClass) reference;
referenceClass.foo();
…
```
to 
```java
if (!(reference instanceof UMLClass referenceClass)) {
    return 0;
}

referenceClass.foo();
…
```

as the `if`-head is considered to be in the outer scope. Especially in cases like this one from `UserJWTController.java`

```java
if (authentication == null || !authentication.isAuthenticated()
    || !(authentication.getPrincipal() instanceof Saml2AuthenticatedPrincipal)) {

    return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
}

final Saml2AuthenticatedPrincipal principal = (Saml2AuthenticatedPrincipal) authentication.getPrincipal();
principal.foo();
…
```

the declaration of `principal` would be hidden deeply inside the `if`:

```java
if (authentication == null || !authentication.isAuthenticated()
    || !(authentication.getPrincipal() instanceof Saml2AuthenticatedPrincipal principal)) {

    return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
}

principal.foo();
…
```

Therefore, in such cases I chose to ***not*** convert it to the new pattern, as I think that then the declaration of the new variable is easily missed as it is very hidden inside the `if`-head and therefore does not make the code easier to read/understand.


### Steps for Testing
Only code review needed.


### Test Coverage
unchanged
