### PR TITLE
Don't crash if the result has no result string

### DIFF
--- a/src/main/webapp/app/exercises/shared/result/result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.component.ts
@@ -236,7 +236,8 @@ export class ResultComponent implements OnInit, OnChanges {
             // Only show the 'preliminary' string for programming student participation results and if the buildAndTestAfterDueDate has not passed.
         }
 
-        const resultStringCompiledMessage = this.result!.resultString!.replace('0 of 0 passed', this.translate.instant('artemisApp.editor.buildSuccessful'));
+        const buildSuccessful = this.translate.instant('artemisApp.editor.buildSuccessful');
+        const resultStringCompiledMessage = this.result!.resultString?.replace('0 of 0 passed', buildSuccessful) ?? buildSuccessful;
 
         if (
             this.participation &&


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
Closes #3664.

### Description

Some results have no `resultString`. In that case it makes sense to only use build failed or completed. (This is currently not displayed anyway as it seems.) 

### Steps for Testing

Go to https://artemistest.ase.in.tum.de/course-management/307/text-exercises/9554/submissions and check if there are errors in the console. Also check if the result strings look correct compared to that page on develop.

