### PR TITLE
Fix the client tests of the non-programming-exercise-detail-common-actions

### DIFF
--- a/src/test/javascript/spec/component/course/course-update.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-update.component.spec.ts
@@ -27,7 +27,7 @@ import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.s
 import { ArtemisTestModule } from '../../test.module';
 import { RemoveKeysPipe } from 'app/shared/pipes/remove-keys.pipe';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
-import { stub } from 'sinon';
+import {SinonStub, stub } from 'sinon';
 import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 import { OrganizationManagementService } from 'app/admin/organization-management/organization-management.service';
 import { Organization } from 'app/entities/organization.model';
@@ -53,6 +53,7 @@ describe('Course Management Update Component', () => {
     let organizationService: OrganizationManagementService;
     let course: Course;
     let fileUploaderService: FileUploaderService;
+    let uploadStub: SinonStub;
 
     beforeEach(() => {
         course = new Course();
@@ -115,6 +116,8 @@ describe('Course Management Update Component', () => {
         profileService = fixture.debugElement.injector.get(ProfileService);
         organizationService = fixture.debugElement.injector.get(OrganizationManagementService);
         fileUploaderService = fixture.debugElement.injector.get(FileUploaderService);
+        uploadStub = stub(fileUploaderService, 'uploadFile');
+
     });
 
     afterEach(() => {
@@ -265,17 +268,15 @@ describe('Course Management Update Component', () => {
 
     describe('uploadCourseImage', () => {
         let croppedImage: string;
-        let uploadStub: sinon.SinonStub;
         beforeEach(() => {
             croppedImage = 'testCroppedImage';
             comp.croppedImage = 'data:image/png;base64,' + comp.croppedImage;
             comp.courseImageFileName = 'testFilename';
             comp.showCropper = true;
-            fixture.detectChanges();
-            uploadStub = stub(fileUploaderService, 'uploadFile');
+            comp.ngOnInit();
         });
         it('should upload new image and update form', () => {
-            uploadStub.returns(Promise.resolve({ path: 'testPath' } as FileUploadResponse));
+            uploadStub.resolves({ path: 'testPath' } as FileUploadResponse);
             comp.uploadCourseImage();
             const file = base64StringToBlob(croppedImage, 'image/*');
             file['name'] = comp.courseImageFileName;
@@ -283,7 +284,7 @@ describe('Course Management Update Component', () => {
             expect(comp.showCropper).to.equal(false);
         });
         it('should set image name to course icon if upload fails', () => {
-            uploadStub.returns(Promise.reject({} as FileUploadResponse));
+            uploadStub.rejects({} as FileUploadResponse);
             comp.course = new Course();
             comp.course.courseIcon = 'testCourseIcon';
             comp.uploadCourseImage();

--- a/src/test/javascript/spec/component/course/course-update.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-update.component.spec.ts
@@ -27,7 +27,7 @@ import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.s
 import { ArtemisTestModule } from '../../test.module';
 import { RemoveKeysPipe } from 'app/shared/pipes/remove-keys.pipe';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
-import {SinonStub, stub } from 'sinon';
+import { SinonStub, stub } from 'sinon';
 import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
 import { OrganizationManagementService } from 'app/admin/organization-management/organization-management.service';
 import { Organization } from 'app/entities/organization.model';

--- a/src/test/javascript/spec/component/non-programming-exercise-detail-common-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/non-programming-exercise-detail-common-actions.component.spec.ts
@@ -26,6 +26,7 @@ import { HttpResponse } from '@angular/common/http';
 import * as sinon from 'sinon';
 import { ModelingExerciseService } from 'app/exercises/modeling/manage/modeling-exercise.service';
 import { ExternalSubmissionButtonComponent } from 'app/exercises/shared/external-submission/external-submission-button.component';
+import { ExerciseType } from 'app/entities/exercise.model';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -52,6 +53,7 @@ describe('Exercise detail common actions Component', () => {
     });
 
     it('Should be ok', () => {
+        comp.exercise = { type: ExerciseType.TEXT, id: 1 } as TextExercise;
         fixture.detectChanges();
         expect(comp).to.be.ok;
     });
@@ -63,19 +65,22 @@ describe('Exercise detail common actions Component', () => {
 
         comp.exercise = textExercise;
         comp.courseId = course.id!;
-        expect(comp.getEditRoute().join('/')).to.equal('/course-management/123/text-exercises/123/edit');
+        comp.ngOnInit();
+        expect(comp.baseResource).to.equal('/course-management/123/text-exercises/123/');
 
         const fileUploadExercise: FileUploadExercise = new FileUploadExercise(course, undefined);
         fileUploadExercise.id = 123;
 
         comp.exercise = fileUploadExercise;
-        expect(comp.getEditRoute().join('/')).to.equal('/course-management/123/file-upload-exercises/123/edit');
+        comp.ngOnInit();
+        expect(comp.baseResource).to.equal('/course-management/123/file-upload-exercises/123/');
 
         const modelingExercise: ModelingExercise = new ModelingExercise(UMLDiagramType.ClassDiagram, course, undefined);
         modelingExercise.id = 123;
 
         comp.exercise = modelingExercise;
-        expect(comp.getEditRoute().join('/')).to.equal('/course-management/123/modeling-exercises/123/edit');
+        comp.ngOnInit();
+        expect(comp.baseResource).to.equal('/course-management/123/modeling-exercises/123/');
     });
 
     it('should get the correct edit routes for exam exercise', () => {
@@ -88,19 +93,22 @@ describe('Exercise detail common actions Component', () => {
         comp.isExamExercise = true;
         comp.exercise = textExercise;
         comp.courseId = course.id!;
-        expect(comp.getEditRoute().join('/')).to.equal('/course-management/1/exams/2/exercise-groups/3/text-exercises/4/edit');
+        comp.ngOnInit();
+        expect(comp.baseResource).to.equal('/course-management/1/exams/2/exercise-groups/3/text-exercises/4/');
 
         const fileUploadExercise: FileUploadExercise = new FileUploadExercise(course, exerciseGroup);
         fileUploadExercise.id = 5;
 
         comp.exercise = fileUploadExercise;
-        expect(comp.getEditRoute().join('/')).to.equal('/course-management/1/exams/2/exercise-groups/3/file-upload-exercises/5/edit');
+        comp.ngOnInit();
+        expect(comp.baseResource).to.equal('/course-management/1/exams/2/exercise-groups/3/file-upload-exercises/5/');
 
         const modelingExercise: ModelingExercise = new ModelingExercise(UMLDiagramType.ClassDiagram, course, exerciseGroup);
         modelingExercise.id = 6;
 
         comp.exercise = modelingExercise;
-        expect(comp.getEditRoute().join('/')).to.equal('/course-management/1/exams/2/exercise-groups/3/modeling-exercises/6/edit');
+        comp.ngOnInit();
+        expect(comp.baseResource).to.equal('/course-management/1/exams/2/exercise-groups/3/modeling-exercises/6/');
     });
 
     it('should call event manager on delete exercises', function () {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
@@ -16,6 +16,7 @@ import { ExerciseManagementStatisticsDto } from 'app/exercises/shared/statistics
 import { SinonStub } from 'sinon';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { MockProfileService } from '../../helpers/mocks/service/mock-profile.service';
+import { Exam } from 'app/entities/exam.model';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -86,7 +87,8 @@ describe('ProgrammingExercise Management Detail Component', () => {
     });
 
     describe('OnInit for exam exercise', () => {
-        const exerciseGroup = new ExerciseGroup();
+        const exam = { id: 4, course: {id: 6} as Course } as Exam;
+        const exerciseGroup = {id: 9, exam: exam}
         const programmingExercise = new ProgrammingExercise(undefined, undefined);
         programmingExercise.id = 123;
         programmingExercise.exerciseGroup = exerciseGroup;


### PR DESCRIPTION
### Description

Several of those tests fail on `develop`. There exists no `getEditRoute` method anymore, but `baseResource` is set in `ngOnInit`.
