### PR TITLE
[Small Fix] Removing Whitespace on Student Exercise View

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
@@ -72,7 +72,7 @@
                 <div class="col-6">
                     <h5>
                         {{ exercise.maxPoints }}
-                        <span *ngIf="exercise.bonusPoints">({{ 'artemisApp.courseOverview.exerciseDetails.bonus' | artemisTranslate }} {{ exercise.bonusPoints }} )</span>
+                        <span *ngIf="exercise.bonusPoints">({{ 'artemisApp.courseOverview.exerciseDetails.bonus' | artemisTranslate }} {{ exercise.bonusPoints }})</span>
                     </h5>
                 </div>
             </div>


### PR DESCRIPTION
### Motivation and Context
When setting bonus points for exercises, the student exercise page view contains an additional whitespace character, that shouldn't be there.

### Description
I removed the whitespace

### Steps for Testing
1. Create an arbitrary exercise with an arbitrary amount of regular points and bonus points 
2. Go to the student exercise view and ensure that the additional whitespace is gone

### Screenshots
**Previously:**
![bad](https://user-images.githubusercontent.com/45300855/124446533-cecc9b00-dd80-11eb-8098-1e1edb3483b7.PNG)

**Now:**
![better](https://user-images.githubusercontent.com/45300855/124446539-cffdc800-dd80-11eb-9118-a507e992be69.PNG)

