### PR TITLE
[Small Fix] Removing Duplicated Warnings for Improper SCA Settings

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -337,8 +337,6 @@
                                 type="number"
                                 [pattern]="maxPenaltyPattern"
                                 class="form-control"
-                                min="0"
-                                max="100"
                                 name="maxPenalty"
                                 id="field_maxPenalty"
                                 [(ngModel)]="programmingExercise.maxStaticCodeAnalysisPenalty"


### PR DESCRIPTION
### Motivation and Context
Putting invalid input in the max static code analysis penalty input field leads to two different warnings, one of them without a translation. This should not be the case.

### Description
I removed the min and max constraints because those were already covered by the pattern that checks if the input is valid. Having min and max set together with a pattern triggers two validity checks. If both validity checks fail, two warnings will be displayed.

### Steps for Testing
1. Open the programming exercise creation view
2. Enable Static Code Analysis
3. Enter a negative number and one above 100
4. Ensure that only one warning is displayed (see screenshots)


### Screenshots
**Previously:**
![previously](https://user-images.githubusercontent.com/45300855/124470576-0f85dd80-dd9c-11eb-90ef-f177a74043a0.PNG)

**After:**
![afterfix](https://user-images.githubusercontent.com/45300855/124470551-04cb4880-dd9c-11eb-8956-02b247ac0630.PNG)