### PR TITLE
[Bugfix] Restore Back button in text-/modelling example submission components

### DIFF
--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
@@ -2,7 +2,7 @@
 <div *ngIf="exercise" class="row">
     <div class="col-6">
         <h2>
-            <fa-icon [icon]="'arrow-left'" (click)="back()" class="guided-tour-back back-button mr-2"></fa-icon>
+            <fa-icon [icon]="'arrow-left'" (click)="back()" class="guided-tour-back back-button mr-2 clickable"></fa-icon>
             {{ 'artemisApp.modelingExercise.exampleSubmissionForModelingExercise' | artemisTranslate }} {{ exercise?.title }}
         </h2>
         <p *ngIf="assessmentMode" jhiTranslate="artemisApp.exampleSubmission.assessmentInstruction">Double-click on a model element to view and edit the element's assessment.</p>

--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
@@ -1,12 +1,9 @@
 <jhi-alert></jhi-alert>
 <div *ngIf="exercise" class="row">
-    <div style="width: 50px">
-        <button class="btn btn-secondary" (click)="back()">&larr;</button>
-    </div>
-
-    <div class="col-12 col-lg-7 d-flex flex-column justify-content-between">
-        <h2 jhiTranslate="artemisApp.modelingExercise.exampleSubmissionForModelingExercise" [translateValues]="{ exerciseTitle: exercise?.title }">
-            Example Modeling Submission for Exercise {{ exercise?.title }}
+    <div class="col-6">
+        <h2>
+            <fa-icon [icon]="'arrow-left'" (click)="back()" class="guided-tour-back back-button mr-2"></fa-icon>
+            {{ 'artemisApp.modelingExercise.exampleSubmissionForModelingExercise' | artemisTranslate }} {{ exercise?.title }}
         </h2>
         <p *ngIf="assessmentMode" jhiTranslate="artemisApp.exampleSubmission.assessmentInstruction">Double-click on a model element to view and edit the element's assessment.</p>
     </div>

--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
@@ -1,5 +1,9 @@
 <jhi-alert></jhi-alert>
 <div *ngIf="exercise" class="row">
+    <div style="width: 50px">
+        <button class="btn btn-secondary" (click)="back()">&larr;</button>
+    </div>
+
     <div class="col-12 col-lg-7 d-flex flex-column justify-content-between">
         <h2 jhiTranslate="artemisApp.modelingExercise.exampleSubmissionForModelingExercise" [translateValues]="{ exerciseTitle: exercise?.title }">
             Example Modeling Submission for Exercise {{ exercise?.title }}

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
@@ -2,7 +2,7 @@
     <div class="row justify-content-between">
         <div class="col-6">
             <h2>
-                <fa-icon [icon]="'arrow-left'" (click)="back()" class="guided-tour-back back-button mr-2"></fa-icon>
+                <fa-icon [icon]="'arrow-left'" (click)="back()" class="guided-tour-back back-button mr-2 clickable"></fa-icon>
                 <span *ngIf="isNewSubmission">{{ 'artemisApp.exampleSubmission.createNew' | artemisTranslate }} </span
                 >{{ 'artemisApp.exampleSubmission.pageHeader' | artemisTranslate }}
                 {{ exercise?.title }}

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
@@ -2,6 +2,7 @@
     <div class="row justify-content-between">
         <div class="col-6">
             <h2>
+                <fa-icon [icon]="'arrow-left'" (click)="back()" class="guided-tour-back back-button mr-2"></fa-icon>
                 <span *ngIf="isNewSubmission">{{ 'artemisApp.exampleSubmission.createNew' | artemisTranslate }} </span
                 >{{ 'artemisApp.exampleSubmission.pageHeader' | artemisTranslate }}
                 {{ exercise?.title }}

--- a/src/main/webapp/i18n/de/modelingExercise.json
+++ b/src/main/webapp/i18n/de/modelingExercise.json
@@ -30,7 +30,7 @@
             "showExampleSubmission": "Abgabe anzeigen",
             "showExampleAssessment": "Bewertung anzeigen",
             "exampleSubmissionsRequireExercise": "Um eine Beispielabgabe zu erstellen, musst du zunächst die Erstellung der Modellierungsaufgabe abschließen. Du wirst automatisch weitergeleitet.",
-            "exampleSubmissionForModelingExercise": "Beispielabgabe für Modellierungsaufgabe {{ exerciseTitle }}",
+            "exampleSubmissionForModelingExercise": "Beispielabgabe für Modellierungsaufgabe",
             "usedForTutorial": "Für Tutorial",
             "apollonConversion": {
                 "error": "Apollon-Konvertierung ist nicht verfügbar"

--- a/src/main/webapp/i18n/en/modelingExercise.json
+++ b/src/main/webapp/i18n/en/modelingExercise.json
@@ -30,7 +30,7 @@
             "showExampleSubmission": "Show Submission",
             "showExampleAssessment": "Show Assessment",
             "exampleSubmissionsRequireExercise": "To create an example submission, you first need to finish creating the modelling exercise. You will be redirected automatically.",
-            "exampleSubmissionForModelingExercise": "Example Submission for Modelling Exercise {{ exerciseTitle }}",
+            "exampleSubmissionForModelingExercise": "Example Submission for Modelling Exercise",
             "usedForTutorial": "Used for Tutorial",
             "apollonConversion": {
                 "error": "Apollon conversion is not available"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test 

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The motivation is to restore the Back button in the text-/modelling submission component.

### Description
<!-- Describe your changes in detail -->
The back button was removed unintentionally because of the dependencies PR. 
This PR introduces it again.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Pick a course
4. Go to Exercises
5. Click on Example Submissions for a certain text or modelling exercise.
6. Create new Example Submission. 
7. You should be able to see the back button.


### Screenshots
Text Exercise
Before:
<img width="1261" alt="Screenshot 2021-07-05 at 3 34 36 PM" src="https://user-images.githubusercontent.com/51077603/124479392-83c57e80-dda6-11eb-9506-027ecfbdc847.png">

After:
<img width="1501" alt="after_text" src="https://user-images.githubusercontent.com/51077603/124479474-9cce2f80-dda6-11eb-8751-2543e6f416eb.png">

- - - - - - -- - - - 
Modelling Exercise:
Before:
<img width="1254" alt="before_modeling" src="https://user-images.githubusercontent.com/51077603/124480064-2b42b100-dda7-11eb-986d-7b998755f313.png">

After:
<img width="778" alt="Screenshot 2021-07-05 at 7 20 34 PM" src="https://user-images.githubusercontent.com/51077603/124503577-280aed80-ddc6-11eb-82e0-621169d21a80.png">

