### PR TITLE
[Bugfix] import of text-/modeling exercises fix

### DIFF
--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.ts
@@ -55,8 +55,6 @@ export class ModelingExerciseUpdateComponent implements OnInit {
     isExamMode: boolean;
     semiAutomaticAssessmentAvailable = true;
 
-    saveCommand: SaveExerciseCommand<ModelingExercise>;
-
     constructor(
         private jhiAlertService: JhiAlertService,
         private modelingExerciseService: ModelingExerciseService,
@@ -66,7 +64,6 @@ export class ModelingExerciseUpdateComponent implements OnInit {
         private exerciseService: ExerciseService,
         private exerciseGroupService: ExerciseGroupService,
         private eventManager: JhiEventManager,
-        private exampleSubmissionService: ExampleSubmissionService,
         private activatedRoute: ActivatedRoute,
         private router: Router,
         private navigationUtilService: ArtemisNavigationUtilService,
@@ -100,8 +97,6 @@ export class ModelingExerciseUpdateComponent implements OnInit {
 
             this.backupExercise = cloneDeep(this.modelingExercise);
             this.examCourseId = this.modelingExercise.course?.id || this.modelingExercise.exerciseGroup?.exam?.course?.id;
-
-            this.saveCommand = new SaveExerciseCommand(this.modalService, this.popupService, this.modelingExerciseService, this.backupExercise, this.editType);
         });
 
         this.activatedRoute.url
@@ -185,13 +180,15 @@ export class ModelingExerciseUpdateComponent implements OnInit {
         this.modelingExercise.sampleSolutionModel = JSON.stringify(this.modelingEditor?.getCurrentModel());
         this.isSaving = true;
 
-        this.saveCommand.save(this.modelingExercise, this.notificationText).subscribe(
-            (exercise: ModelingExercise) => this.onSaveSuccess(exercise.id!),
-            (error: HttpErrorResponse) => this.onSaveError(error),
-            () => {
-                this.isSaving = false;
-            },
-        );
+        new SaveExerciseCommand(this.modalService, this.popupService, this.modelingExerciseService, this.backupExercise, this.editType)
+            .save(this.modelingExercise, this.notificationText)
+            .subscribe(
+                (exercise: ModelingExercise) => this.onSaveSuccess(exercise.id!),
+                (error: HttpErrorResponse) => this.onSaveError(error),
+                () => {
+                    this.isSaving = false;
+                },
+            );
     }
 
     /**

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.ts
@@ -5,7 +5,6 @@ import { JhiAlertService, JhiEventManager } from 'ng-jhipster';
 import { ModelingExercise, UMLDiagramType } from 'app/entities/modeling-exercise.model';
 import { ModelingExerciseService } from './modeling-exercise.service';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
-import { ExampleSubmissionService } from 'app/exercises/shared/example-submission/example-submission.service';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { ExerciseMode, IncludedInOverallScore } from 'app/entities/exercise.model';
 import { EditorMode } from 'app/shared/markdown-editor/markdown-editor.component';

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
@@ -5,7 +5,6 @@ import { JhiAlertService, JhiEventManager } from 'ng-jhipster';
 import { TextExercise } from 'app/entities/text-exercise.model';
 import { TextExerciseService } from './text-exercise.service';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
-import { ExampleSubmissionService } from 'app/exercises/shared/example-submission/example-submission.service';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { AssessmentType } from 'app/entities/assessment-type.model';
 import { ExerciseMode, IncludedInOverallScore } from 'app/entities/exercise.model';

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise-update.component.ts
@@ -50,8 +50,6 @@ export class TextExerciseUpdateComponent implements OnInit {
     domainCommandsSampleSolution = [new KatexCommand()];
     domainCommandsGradingInstructions = [new KatexCommand()];
 
-    saveCommand: SaveExerciseCommand<TextExercise>;
-
     constructor(
         private jhiAlertService: JhiAlertService,
         private textExerciseService: TextExerciseService,
@@ -61,7 +59,6 @@ export class TextExerciseUpdateComponent implements OnInit {
         private exerciseGroupService: ExerciseGroupService,
         private courseService: CourseManagementService,
         private eventManager: JhiEventManager,
-        private exampleSubmissionService: ExampleSubmissionService,
         private activatedRoute: ActivatedRoute,
         private router: Router,
         private navigationUtilService: ArtemisNavigationUtilService,
@@ -90,8 +87,6 @@ export class TextExerciseUpdateComponent implements OnInit {
             this.textExercise = textExercise;
             this.backupExercise = cloneDeep(this.textExercise);
             this.examCourseId = this.textExercise.course?.id || this.textExercise.exerciseGroup?.exam?.course?.id;
-
-            this.saveCommand = new SaveExerciseCommand(this.modalService, this.popupService, this.textExerciseService, this.backupExercise, this.editType);
         });
 
         this.activatedRoute.url
@@ -172,13 +167,15 @@ export class TextExerciseUpdateComponent implements OnInit {
     save() {
         this.isSaving = true;
 
-        this.saveCommand.save(this.textExercise, this.notificationText).subscribe(
-            (exercise: TextExercise) => this.onSaveSuccess(exercise.id!),
-            (error: HttpErrorResponse) => this.onSaveError(error),
-            () => {
-                this.isSaving = false;
-            },
-        );
+        new SaveExerciseCommand(this.modalService, this.popupService, this.textExerciseService, this.backupExercise, this.editType)
+            .save(this.textExercise, this.notificationText)
+            .subscribe(
+                (exercise: TextExercise) => this.onSaveSuccess(exercise.id!),
+                (error: HttpErrorResponse) => this.onSaveError(error),
+                () => {
+                    this.isSaving = false;
+                },
+            );
     }
 
     private onSaveSuccess(exerciseId: number) {

--- a/src/test/javascript/spec/component/text-exercise/text-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/text-exercise-update.component.spec.ts
@@ -109,8 +109,8 @@ describe('TextExercise Management Update Component', () => {
 
             it('Should call import service on save for new entity', fakeAsync(() => {
                 // GIVEN
-                comp.isImport = true;
                 comp.ngOnInit();
+                comp.isImport = true;
 
                 const entity = { ...textExercise };
                 spyOn(service, 'import').and.returnValue(of(new HttpResponse({ body: entity })));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
After refactoring the save process in https://github.com/ls1intum/Artemis/pull/3574 there appeared issues with importing the exercise. This PR is about to fix this. 

### Description
Problem is that we introduced a new enum `EditType` that specifies whether we are about to `IMPORT`/`CREATE`/`UPDATE` the exercise. However, due to asynchronous code, the editType was not setup properly to `IMPORT` (which is later used by the save function).

This is now fixed by creating the `SaveCommand` upon the button press, which guarantees that all the "dependencies" are provided for successful save of the exercise and editType is set accordingly.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Management
3. Pick a course
4. Successfully Import new text-/modeling-/ exercises
5. You should be redirected to the example submissions dashboard