### PR TITLE
[bugfix] Fix re-compiling issue on develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
         "url-loader": "4.1.1",
         "uuid": "8.3.2",
         "weak-napi": "2.0.2",
-        "webpack": "5.42.0",
+        "webpack": "5.42.1",
         "webpack-bundle-analyzer": "4.4.2",
         "webpack-cli": "4.7.2",
         "webpack-dev-server": "3.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11969,10 +11969,10 @@ webpack-sources@^2.3.0:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
-webpack@5.42.0:
-  version "5.42.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.42.0.tgz#39aadbce84ad2cebf86cc5f88a2c53db65cbddfb"
-  integrity sha512-Ln8HL0F831t1x/yPB/qZEUVmZM4w9BnHZ1EQD/sAUHv8m22hthoPniWTXEzFMh/Sf84mhrahut22TX5KxWGuyQ==
+webpack@5.42.1:
+  version "5.42.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.42.1.tgz#3347d0d93e79fe70bf62e51981024c80b9c8c3df"
+  integrity sha512-msikozzXrG2Hdx+dElq0fyNvxPFsaM2dKLc/l+xkMmhO/1qwVJ9K9gY+fi/49MYWcpSP7alnK5Q78Evrd1LiqQ==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.48"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In the webpack version we have (5.42.0), there is an error which prevents re-compiling the client after changes on local environment. The issue is fixed with latest release of webpack. This PR covers updating webpack version.

After this update, you should not see the following error in your terminal, when it needs to be re-compiled.

`TypeError: Cannot read property 'jsonData' of undefined`

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Run Artemis on your local machine
2. change something in the client side
3. see that re-compile works without any problem
