### PR TITLE
[Enhancement] Improve Handling of Team Names

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -1203,14 +1203,8 @@ public class GitService {
         var courseShortName = exercise.getCourseViaExerciseGroupOrCourseMember().getShortName();
         var participation = (ProgrammingExerciseStudentParticipation) repo.getParticipation();
 
-        // The zip filename is either the student login, team name or some default string.
-        var studentTeamOrDefault = "-student-submission" + repo.getParticipation().getId();
-        if (participation.getStudent().isPresent()) {
-            studentTeamOrDefault = participation.getStudent().get().getLogin();
-        }
-        else if (participation.getTeam().isPresent()) {
-            studentTeamOrDefault = participation.getTeam().get().getName();
-        }
+        // The zip filename is either the student login, team short name or some default string.
+        var studentTeamOrDefault = Optional.ofNullable(participation.getParticipantIdentifier()).orElse("student-submission" + repo.getParticipation().getId());
 
         String zipRepoName = fileService.removeIllegalCharacters(courseShortName + "-" + exercise.getTitle() + "-" + participation.getId());
         if (hideStudentName) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -130,7 +130,7 @@ public class ParticipationResource {
         Participant participant = user;
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.STUDENT, exercise, user);
 
-        // if the user is a student and the exercise has a release date, he cannot start the exercise before the release date
+        // if the user is a student and the exercise has a release date, they cannot start the exercise before the release date
         if (exercise.getReleaseDate() != null && exercise.getReleaseDate().isAfter(now())) {
             if (authCheckService.isOnlyStudentInCourse(exercise.getCourseViaExerciseGroupOrCourseMember(), user)) {
                 return forbidden();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TeamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TeamResource.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.artemis.web.rest;
 import static de.tum.in.www1.artemis.config.Constants.SHORT_NAME_PATTERN;
 import static de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException.NOT_ALLOWED;
 import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
+import static de.tum.in.www1.artemis.web.rest.util.StringUtil.stripIllegalCharacters;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -121,6 +122,8 @@ public class TeamResource {
         if (!shortNameMatcher.matches()) {
             throw new BadRequestAlertException("The team name must start with a letter.", ENTITY_NAME, "teamShortNameInvalid");
         }
+        // Also remove illegal characters from the long name
+        team.setName(stripIllegalCharacters(team.getName()));
         // Tutors can only create teams for themselves while instructors can select any tutor as the team owner
         if (!authCheckService.isAtLeastInstructorForExercise(exercise, user)) {
             team.setOwner(user);
@@ -162,6 +165,8 @@ public class TeamResource {
         if (!team.getShortName().equals(existingTeam.get().getShortName())) {
             return forbidden(ENTITY_NAME, "shortNameChangeForbidden", "The team's short name cannot be changed after the team has been created.");
         }
+        // Remove illegal characters from the long name
+        team.setName(stripIllegalCharacters(team.getName()));
 
         // Prepare auth checks
         User user = userRepository.getUserWithGroupsAndAuthorities();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/util/StringUtil.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/util/StringUtil.java
@@ -1,0 +1,20 @@
+package de.tum.in.www1.artemis.web.rest.util;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Utility class for String manipulation
+ */
+public class StringUtil {
+
+    public static String ILLEGAL_CHARACTERS = "#%&{}\\<>*?/$!'\":@+`|=";
+
+    /**
+     * Removes all chars from ILLEGAL_CHARACTERS from the input String
+     * @param input String to strip
+     * @return stripped String
+     */
+    public static String stripIllegalCharacters(String input) {
+        return StringUtils.replaceChars(input, ILLEGAL_CHARACTERS, null);
+    }
+}

--- a/src/test/java/de/tum/in/www1/artemis/StringUtilTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StringUtilTest.java
@@ -1,12 +1,13 @@
 package de.tum.in.www1.artemis;
 
-import org.junit.jupiter.api.Test;
-
 import static de.tum.in.www1.artemis.web.rest.util.StringUtil.ILLEGAL_CHARACTERS;
 import static de.tum.in.www1.artemis.web.rest.util.StringUtil.stripIllegalCharacters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Test;
+
 public class StringUtilTest {
+
     @Test
     public void testEmpty() {
         assertEquals("", stripIllegalCharacters(""));

--- a/src/test/java/de/tum/in/www1/artemis/StringUtilTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StringUtilTest.java
@@ -1,0 +1,34 @@
+package de.tum.in.www1.artemis;
+
+import org.junit.jupiter.api.Test;
+
+import static de.tum.in.www1.artemis.web.rest.util.StringUtil.ILLEGAL_CHARACTERS;
+import static de.tum.in.www1.artemis.web.rest.util.StringUtil.stripIllegalCharacters;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StringUtilTest {
+    @Test
+    public void testEmpty() {
+        assertEquals("", stripIllegalCharacters(""));
+    }
+
+    @Test
+    public void testOnlyIllegals() {
+        assertEquals("", stripIllegalCharacters(ILLEGAL_CHARACTERS));
+    }
+
+    @Test
+    public void testNormal() {
+        assertEquals("abcdefg", stripIllegalCharacters("abcdefg"));
+    }
+
+    @Test
+    public void testUmlaut() {
+        assertEquals("abcdefgäöü", stripIllegalCharacters("abcdefgäöü"));
+    }
+
+    @Test
+    public void testWithIllegal() {
+        assertEquals("a^bcdefg(ä)öü", stripIllegalCharacters("a^b\"c$d%e&f/g(ä)ö?ü"));
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
Currently team names can cause problems

### Description
 - Use the team short name as filename for an exported programming submission
 - Remove all problematic characters from the team name at creation and update.

The later change will also require client changes that will be done at a later time

### Steps for Testing

1. Log in to Artemis
2. Locate/Create a team programming exercise
3. Create a team with illegal characters -> The server should store the name without them
4. Participate
5. Export the exercise -> The zip file should only contain the team short name

Also export any other programming exercise and make sure the names are working properly

### Test Coverage
StringUtils -> 100%
