### PR TITLE
Enhancement: New columns for exam overview

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
@@ -54,8 +54,8 @@
     </div>
     <div class="col">
         <div class="row justify-content-end align-items-start pe-2">
-            <div *ngIf="!overviewPageOpen" class="d-flex mb-2 justify-content-end">
-                <button [class.invisible]="isProgrammingExercise() || isFileUploadExercise()" class="btn btn-primary" (click)="saveExercise()">
+            <div class="d-flex mb-2 justify-content-end">
+                <button *ngIf="!overviewPageOpen" [class.invisible]="isProgrammingExercise() || isFileUploadExercise()" class="btn btn-primary" (click)="saveExercise()">
                     {{ 'artemisApp.examParticipation.' + (exerciseIndex >= exercises.length - 1 ? 'submitLastExercise' : 'submitOtherExercise') | artemisTranslate }}
                 </button>
                 <button class="btn btn-danger ms-2" (click)="handInEarly()">

--- a/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
@@ -23,6 +23,11 @@
                         {{ 'artemisApp.examParticipation.exerciseName' | artemisTranslate }}
                     </span>
                 </th>
+                <th>
+                    <span>
+                        {{ 'artemisApp.examParticipation.exercisePoints' | artemisTranslate }}
+                    </span>
+                </th>
                 <th style="max-width: 50px">
                     <span>
                         {{ 'artemisApp.examParticipation.examStatus' | artemisTranslate }}
@@ -44,6 +49,9 @@
                     <a class="w-100" (click)="openExercise(item.exercise!)">
                         {{ item.exercise!.title }}
                     </a>
+                </td>
+                <td style="max-width: 30px">
+                    {{ item.exercise.maxPoints }}
                 </td>
                 <td style="max-width: 50px; font-weight: bold">
                     <div

--- a/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
@@ -51,7 +51,7 @@
                     </a>
                 </td>
                 <td style="max-width: 30px">
-                    {{ item.exercise.maxPoints }}
+                    {{ item.exercise!.maxPoints }}
                 </td>
                 <td style="max-width: 50px; font-weight: bold">
                     <div


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We add a new Points column to the exam overview within the exam. We add the 'Hand in early' Button to the exam overview. 

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis as a student
2. Navigate to an Exam -> start it
3. In the exam overview you can now see the exercise points, as well as the hand in early button. It should work correctly. 

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1424" alt="Bildschirmfoto 2021-07-09 um 09 06 35" src="https://user-images.githubusercontent.com/42205689/125037893-02ffce80-e095-11eb-8734-6ffbf1e7b918.png">
