### PR TITLE
[Bugfix] Reloading a page stopped notification support

### DIFF
--- a/src/main/webapp/app/course/manage/course-management.service.ts
+++ b/src/main/webapp/app/course/manage/course-management.service.ts
@@ -432,7 +432,7 @@ export class CourseManagementService {
         // here is only made if there was no similar request made before.
         setTimeout(() => {
             // Retrieve courses if no courses were fetched before and are not queried at the moment.
-            if (!this.fetchingCoursesForNotifications && !this.coursesForNotifications) {
+            if (!this.fetchingCoursesForNotifications && !this.coursesForNotifications.getValue()) {
                 this.findAllForNotifications().subscribe(
                     (res: HttpResponse<Course[]>) => {
                         this.coursesForNotifications.next(res.body || undefined);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Previously if you reloaded the page you are currently on and this page was not the homepage (course-overview) you did not receive any notifications (anymore), unless you visited the homepage again.
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes this [issue](https://github.com/ls1intum/Artemis/issues/3700).
### Description
<!-- Describe your changes in detail -->
To read a very detailed explanation please look at the issue this PR is based on.
In summary, the inner code inside `course-management.service`'s method `getCoursesForNotifications()` was (as far as I know) never executed.
This was due to its **if** condition: `if (!this.fetchingCoursesForNotifications && !this.coursesForNotifications)`
`coursesForNotifications` is a BehaviorSubject that should provide the `notification.service` with the necessary `courses`.
`(private coursesForNotifications: BehaviorSubject<Course[] | undefined> = new BehaviorSubject<Course[] | undefined>(undefined); )`

I think that `this.coursesForNotifications` always exists when you reach this part of the code, therefore the entire if condition will never be true.

The change itself is very small: 
- instead of  checking if the BehaviorSubject exists : `!this.coursesForNotifications`
- I check if this BehaviorSubject already has a value stored (i.e. courses), if not then the inner code block should be executed.
`!this.coursesForNotifications.getValue()`

### Warning
This PR sadly does not fix this issue for quiz notifications but (as far as I could check) for all other notifications, like exercise changes, or even (my new) exam notifications. _(The problem behind quiz notifications is a different one and more complex)_

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Here is the .gif I used in my issue to demonstrate the problem. Just repeat the same steps and make sure that the notification is visible this time. (For written steps please look at the issue) (P.S. You have to use Artemis as an instructor and student at the same time, i.e. use two different "browser-session", e.g. student - chrome, instructor - edge, or simple use incognito mode for one user)
![Notification Bug](https://user-images.githubusercontent.com/65814168/125060018-39951380-e0ac-11eb-8ca9-c6ab73231c73.gif)

If you find any other notification type that still does not work, please contact me.
