### PR TITLE
[Enhancement] - Fix Course Overview rounding

### DIFF
--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -38,8 +38,8 @@
                 baseChart
                 [routerLink]="['/courses', course.id!]"
                 id="score-chart"
-                height="150"
-                width="150"
+                height="175"
+                width="175"
                 [legend]="false"
                 [datasets]="doughnutChartData"
                 [options]="totalScoreOptions"

--- a/src/main/webapp/app/overview/course-card.component.ts
+++ b/src/main/webapp/app/overview/course-card.component.ts
@@ -8,6 +8,7 @@ import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service'
 import { CourseScoreCalculationService } from 'app/overview/course-score-calculation.service';
 import { CourseStatisticsDataSet } from 'app/overview/course-statistics/course-statistics.component';
 import { CachingStrategy } from 'app/shared/image/secured-image.component';
+import { round } from 'app/shared/util/utils';
 
 @Component({
     selector: 'jhi-overview-course-card',
@@ -77,7 +78,7 @@ export class CourseCardComponent implements OnChanges {
             this.totalReachableScore = scores.get('reachableScore')!;
 
             // Adjust for bonus points, i.e. when the student has achieved more than is reachable
-            const scoreNotReached = Math.max(0, this.totalReachableScore - this.totalAbsoluteScore);
+            const scoreNotReached = round(Math.max(0, this.totalReachableScore - this.totalAbsoluteScore), 1);
             this.doughnutChartData[0].data = [this.totalAbsoluteScore, scoreNotReached];
         }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->
Fixes #3668 

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Issue #3668 shows an edge case where rounding was not done correctly.
Sometimes when courses have large number of points and the student has points with one decimal, the number are cut off

### Description
<!-- Describe your changes in detail -->
Added some additional rounding and made the doughnut chart a little bit bigger.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

See issue:
1. Log in to Artemis
2. Create a course with 1 total point
3. Give yourself 0.7 points
4. Go to the Course Overview
5. Hover over the red part of the doughnut
6. Make sure the number is rounded correctly to one decimal

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
![Screenshot 2021-07-10 at 16 26 43](https://user-images.githubusercontent.com/44401560/125166438-e3070280-e19b-11eb-9377-111b7fc0fb20.png)

Now:
![Screenshot 2021-07-10 at 16 26 07](https://user-images.githubusercontent.com/44401560/125166458-fade8680-e19b-11eb-86b3-a979e0a5f9c9.png)

We made the doughnut chart a little bit bigger to prevent number being cut off
Before:
![Screenshot 2021-07-10 at 16 19 58](https://user-images.githubusercontent.com/44401560/125166479-15186480-e19c-11eb-9a80-1c7b67b95648.png)

Now:
![Screenshot 2021-07-10 at 16 22 48](https://user-images.githubusercontent.com/44401560/125166486-1c3f7280-e19c-11eb-9e63-84585a7d08fc.png)


