### PR TITLE
[Bugfix] Fix unreachable link for tutors-editors in course detail page

### DIFF
--- a/src/main/webapp/app/course/manage/detail/course-detail-doughnut-chart.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail-doughnut-chart.component.html
@@ -1,5 +1,5 @@
 <div class="doughnut mx-3">
-    <a *ngIf="titleLink" [routerLink]="['/course-management', courseId, titleLink]">
+    <a *ngIf="titleLink" [routerLink]="['/course-management', course.id, titleLink]">
         <h4 class="text-center">{{ 'artemisApp.course.detail.' + doughnutChartTitle + 'Title' | artemisTranslate }}</h4>
     </a>
     <h4 *ngIf="!titleLink" class="text-center">{{ 'artemisApp.course.detail.' + doughnutChartTitle + 'Title' | artemisTranslate }}</h4>

--- a/src/main/webapp/app/course/manage/detail/course-detail-doughnut-chart.component.ts
+++ b/src/main/webapp/app/course/manage/detail/course-detail-doughnut-chart.component.ts
@@ -4,6 +4,7 @@ import { ChartType } from 'chart.js';
 import { round } from 'app/shared/util/utils';
 import { DoughnutChartType } from './course-detail.component';
 import { Router } from '@angular/router';
+import { Course } from 'app/entities/course.model';
 
 @Component({
     selector: 'jhi-course-detail-doughnut-chart',
@@ -11,11 +12,11 @@ import { Router } from '@angular/router';
     styleUrls: ['./course-detail-doughnut-chart.component.scss'],
 })
 export class CourseDetailDoughnutChartComponent implements OnChanges, OnInit {
-    @Input() courseId: number;
     @Input() contentType: DoughnutChartType;
     @Input() currentPercentage: number | undefined;
     @Input() currentAbsolute: number | undefined;
     @Input() currentMax: number | undefined;
+    @Input() course: Course;
 
     receivedStats = false;
     doughnutChartTitle: string;
@@ -81,7 +82,10 @@ export class CourseDetailDoughnutChartComponent implements OnChanges, OnInit {
                 break;
             case DoughnutChartType.AVERAGE_COURSE_SCORE:
                 this.doughnutChartTitle = 'averageStudentScore';
-                this.titleLink = 'scores';
+                this.titleLink = undefined;
+                if (this.course.isAtLeastInstructor) {
+                    this.titleLink = 'scores';
+                }
                 break;
             default:
                 this.doughnutChartTitle = '';
@@ -93,8 +97,8 @@ export class CourseDetailDoughnutChartComponent implements OnChanges, OnInit {
      * handles clicks onto the graph, which then redirects the user to the corresponding page, e.g. complaints page for the complaints chart
      */
     openCorrespondingPage() {
-        if (this.courseId && this.titleLink) {
-            this.router.navigate(['/course-management', this.courseId, this.titleLink]);
+        if (this.course.id && this.titleLink) {
+            this.router.navigate(['/course-management', this.course.id, this.titleLink]);
         }
     }
 }

--- a/src/main/webapp/app/course/manage/detail/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.html
@@ -99,7 +99,7 @@
                 <div class="row">
                     <jhi-course-detail-doughnut-chart
                         class="doughnut-container col-md-6 my-3"
-                        [courseId]="course.id!"
+                        [course]="course"
                         [contentType]="DoughnutChartType.ASSESSMENT"
                         [currentPercentage]="courseDTO?.currentPercentageAssessments"
                         [currentAbsolute]="courseDTO?.currentAbsoluteAssessments"
@@ -107,7 +107,7 @@
                     ></jhi-course-detail-doughnut-chart>
                     <jhi-course-detail-doughnut-chart
                         class="doughnut-container col-md-6 my-3"
-                        [courseId]="course.id!"
+                        [course]="course"
                         [contentType]="DoughnutChartType.COMPLAINTS"
                         [currentPercentage]="courseDTO?.currentPercentageComplaints"
                         [currentAbsolute]="courseDTO?.currentAbsoluteComplaints"
@@ -117,7 +117,7 @@
                 <div class="row">
                     <jhi-course-detail-doughnut-chart
                         class="doughnut-container col-md-6 my-3"
-                        [courseId]="course.id!"
+                        [course]="course"
                         [contentType]="DoughnutChartType.FEEDBACK"
                         [currentPercentage]="courseDTO?.currentPercentageMoreFeedbacks"
                         [currentAbsolute]="courseDTO?.currentAbsoluteMoreFeedbacks"
@@ -125,7 +125,7 @@
                     ></jhi-course-detail-doughnut-chart>
                     <jhi-course-detail-doughnut-chart
                         class="doughnut-container col-md-6 my-3"
-                        [courseId]="course.id!"
+                        [course]="course"
                         [contentType]="DoughnutChartType.AVERAGE_COURSE_SCORE"
                         [currentPercentage]="courseDTO?.currentPercentageAverageScore"
                         [currentAbsolute]="courseDTO?.currentAbsoluteAverageScore"

--- a/src/test/javascript/spec/component/course/detail/course-detail-doughnut-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/course/detail/course-detail-doughnut-chart.component.spec.ts
@@ -10,6 +10,7 @@ import { CourseDetailDoughnutChartComponent } from 'app/course/manage/detail/cou
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockPipe } from 'ng-mocks';
 import { DoughnutChartType } from 'app/course/manage/detail/course-detail.component';
+import { Course } from 'app/entities/course.model';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -18,6 +19,7 @@ describe('CourseDetailDoughnutChartComponent', () => {
     let fixture: ComponentFixture<CourseDetailDoughnutChartComponent>;
     let component: CourseDetailDoughnutChartComponent;
 
+    const course = { id: 1 } as Course;
     const absolute = 80;
     const percentage = 80;
     const max = 100;
@@ -39,7 +41,7 @@ describe('CourseDetailDoughnutChartComponent', () => {
     });
 
     beforeEach(() => {
-        component.course.id = 1;
+        component.course = course;
         component.contentType = DoughnutChartType.ASSESSMENT;
         component.currentPercentage = absolute;
         component.currentAbsolute = percentage;

--- a/src/test/javascript/spec/component/course/detail/course-detail-doughnut-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/course/detail/course-detail-doughnut-chart.component.spec.ts
@@ -39,7 +39,7 @@ describe('CourseDetailDoughnutChartComponent', () => {
     });
 
     beforeEach(() => {
-        component.courseId = 1;
+        component.course.id = 1;
         component.contentType = DoughnutChartType.ASSESSMENT;
         component.currentPercentage = absolute;
         component.currentAbsolute = percentage;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

PR aims to fix #3537 . Editors or tutors can see Average Student Score chart in course detail page. However, `/scores` endpoint is allowed to instructors or higher roles. When tutor/editor click the title of this chart, Artemis navigates to empty page, and there is 403 error in the console.

### Description
<!-- Describe your changes in detail -->

Since `titlelink ` is initialized in the `CourseDetailDoughnutChartComponent`, there is no course related information in this component. So, the permission for this route is not checked in the client side. To fix this issue, I passed the `course ` as an input and removed the `courseId`. Then I checked the permission for user role, while `titleLink ` is initializing for Average Student Score. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Tutor/Editor steps:

1. Log in to Artemis as a Tutor/Editor
2. Navigate to Course Management
3. Go to Course Detail for one of the courses (the user should be tutor for this course)
4. See that Average Student Score chart title is plain text and you can not click on that.

Instructor steps:

1. Log in to Artemis as a Instructor
2. Navigate to Course Management
3. Go to Course Detail for one of the courses (the user should be instructor for this course)
4. See that Average Student Score chart title is clickable, and navigates to ` /scores ` page properly.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
nothings changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Tutor/Editor View**

<img src="https://user-images.githubusercontent.com/23650630/125168306-32056580-e1a5-11eb-9a93-07047d0b0737.png" width="500" />

**Instructor View**

<img src="https://user-images.githubusercontent.com/23650630/125168340-6b3dd580-e1a5-11eb-8801-a348ad924a2d.png" width="500" />
