### PR TITLE
[Bugfix] Fix export routing for quiz exercises

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-management.route.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-management.route.ts
@@ -13,6 +13,25 @@ export const quizManagementRoute: Routes = [
         redirectTo: ':courseId/exercises',
     },
     {
+        path: ':courseId/quiz-exercises/new',
+        component: QuizExerciseDetailComponent,
+        data: {
+            authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.quizExercise.home.title',
+        },
+        canActivate: [UserRouteAccessService],
+        canDeactivate: [PendingChangesGuard],
+    },
+    {
+        path: ':courseId/quiz-exercises/export',
+        component: QuizExerciseExportComponent,
+        data: {
+            authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.quizExercise.home.title',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
         path: ':courseId/quiz-exercises/:exerciseId',
         component: QuizExerciseDetailComponent,
         data: {
@@ -40,25 +59,6 @@ export const quizManagementRoute: Routes = [
         },
         canActivate: [UserRouteAccessService],
         canDeactivate: [PendingChangesGuard],
-    },
-    {
-        path: ':courseId/quiz-exercises/new',
-        component: QuizExerciseDetailComponent,
-        data: {
-            authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
-            pageTitle: 'artemisApp.quizExercise.home.title',
-        },
-        canActivate: [UserRouteAccessService],
-        canDeactivate: [PendingChangesGuard],
-    },
-    {
-        path: ':courseId/quiz-exercises/export',
-        component: QuizExerciseExportComponent,
-        data: {
-            authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
-            pageTitle: 'artemisApp.quizExercise.home.title',
-        },
-        canActivate: [UserRouteAccessService],
     },
     {
         path: ':courseId/quiz-exercises/:exerciseId/preview',

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-management.route.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-management.route.ts
@@ -16,7 +16,7 @@ export const quizManagementRoute: Routes = [
         path: ':courseId/quiz-exercises/new',
         component: QuizExerciseDetailComponent,
         data: {
-            authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
+            authorities: [Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
             pageTitle: 'artemisApp.quizExercise.home.title',
         },
         canActivate: [UserRouteAccessService],
@@ -26,7 +26,7 @@ export const quizManagementRoute: Routes = [
         path: ':courseId/quiz-exercises/export',
         component: QuizExerciseExportComponent,
         data: {
-            authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
+            authorities: [Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
             pageTitle: 'artemisApp.quizExercise.home.title',
         },
         canActivate: [UserRouteAccessService],
@@ -54,7 +54,7 @@ export const quizManagementRoute: Routes = [
         path: ':courseId/quiz-exercises/:exerciseId/edit',
         component: QuizExerciseDetailComponent,
         data: {
-            authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
+            authorities: [Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
             pageTitle: 'artemisApp.quizExercise.home.title',
         },
         canActivate: [UserRouteAccessService],

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -164,7 +164,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
         posts: 'artemisApp.metis.overview.title',
         scores: 'entity.action.scores',
         assessment: 'artemisApp.assessment.assessment',
-        export: 'artemisApp.quizExercise.export.title',
+        export: 'artemisApp.quizExercise.export.export',
         re_evaluate: 'entity.action.re-evaluate',
         solution: 'artemisApp.quizExercise.solution',
         preview: 'artemisApp.quizExercise.previewMode',


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #3433 
Fixes #3317

- Problem is that export button does not work for quiz exercises. Export navigates to Create New Quiz Page. Routing definitions were correct, but I changed the order of the routes in the `quizManagementRoute`. (just move up the 'new' and 'export' routes) According to [official documentation](https://angular.io/guide/router#route-order), the router uses a first-match wins strategy when matching routes, so more specific routes should be placed above less specific routes. After reordering, routing works again. 

- When the user opened Export Quiz Exercise page, the last segment was wrong in the breadcrumb. Export string is set with wrong translation. I also fixed this in the `NavbarComponent`

- In addition, I re-organized the authorizations in quiz management routes.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Following steps cover only export routing. **Please check that all routes  related with quiz exercises are working properly in course and exam. e.g Preview, Solutions, Create, Edit, Re-Evaluate, Submissions, Delete.**

1. Log in to Artemis as INSTRUCTOR
2. Navigate to Course Management
3. Go to Exercises for the course, to see Export Quiz Exercises button, you need to have at least one quiz exercise.
4. click that, it should open the correct page, not the Create New Quiz Exercise page.
5. look at the breadcrumbs in that page, it should be correct (see screenshot)


### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

nothings changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<img src="https://user-images.githubusercontent.com/23650630/125208109-e4febd80-e290-11eb-8cc3-f8c05cef7427.png" width="500"/>

<img src="https://user-images.githubusercontent.com/23650630/125208019-5be78680-e290-11eb-8612-b15a7e789cc3.png" width="500"/>

