### PR TITLE
Bugfix/exam mode programming exercise status sync

### DIFF
--- a/src/main/webapp/app/app.main.ts
+++ b/src/main/webapp/app/app.main.ts
@@ -1,4 +1,5 @@
 import './polyfills';
+import 'app/shared/util/array.extension';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { ProdConfig } from './core/config/prod.config';
 import { ArtemisAppModule } from './app.module';

--- a/src/main/webapp/app/entities/exam-exercise-overview-item.model.ts
+++ b/src/main/webapp/app/entities/exam-exercise-overview-item.model.ts
@@ -1,9 +1,7 @@
 import { Exercise } from 'app/entities/exercise.model';
-import { Submission } from 'app/entities/submission.model';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 export class ExamExerciseOverviewItem {
-    public exercise?: Exercise;
-    public submission?: Submission;
-    public icon?: IconProp;
+    public exercise: Exercise;
+    public icon: IconProp;
 }

--- a/src/main/webapp/app/entities/submission.model.ts
+++ b/src/main/webapp/app/entities/submission.model.ts
@@ -55,12 +55,7 @@ export abstract class Submission implements BaseEntity {
  * @param submission
  */
 export function getLatestSubmissionResult(submission: Submission | undefined): Result | undefined {
-    if (submission?.results) {
-        const length = submission.results.length;
-        if (length > 0) {
-            return submission.results[length - 1];
-        }
-    }
+    return submission?.results?.last();
 }
 
 /**

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
@@ -12,7 +12,7 @@
         <div class="d-flex justify-content-center">
             <!-- exam overview item -->
             <div class="navigation-item">
-                <button class="btn w-100 synced overview" [ngClass]="getOverviewStatus()" [ngbTooltip]="'Exam Exercise Overview'" (click)="changePage(true)">
+                <button class="btn w-100 synced overview" [ngClass]="getOverviewStatus()" [ngbTooltip]="'Exam Exercise Overview'" (click)="changePage(true, -1)">
                     <fa-icon [icon]="'bars'"></fa-icon>
                 </button>
             </div>

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -54,7 +54,7 @@ export class ExamNavigationBarComponent implements OnInit {
 
     /**
      * @param overviewPage: user wants to switch to the overview page
-     * @param exerciseIndex: exercise to switch to (might be undefined)
+     * @param exerciseIndex: index of the exercise to switch to, if it should not be used, you can pass -1
      * @param forceSave: true if forceSave shall be used.
      */
     changePage(overviewPage: boolean, exerciseIndex: number, forceSave?: boolean) {
@@ -113,7 +113,7 @@ export class ExamNavigationBarComponent implements OnInit {
      * also determines the used icon and its color
      *
      * @param exerciseIndex index of the exercise
-     * @return whether the status of the exercise
+     * @return the sync status of the exercise (whether the corresponding submission is saved on the server or not)
      */
     setExerciseButtonStatus(exerciseIndex: number): 'synced' | 'synced active' | 'notSynced' {
         // start with a yellow status (edit icon)

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -111,12 +111,16 @@ export class ExamNavigationBarComponent implements OnInit {
     /**
      * calculate the exercise status (also see exam-exercise-overview-page.component.ts --> make sure the logic is consistent)
      * also determines the used icon and its color
+     * TODO: we should try to extract a method for the common logic which avoids side effects (i.e. changing this.icon)
+     *  this method could e.g. return the sync status and the icon
      *
      * @param exerciseIndex index of the exercise
      * @return the sync status of the exercise (whether the corresponding submission is saved on the server or not)
      */
     setExerciseButtonStatus(exerciseIndex: number): 'synced' | 'synced active' | 'notSynced' {
         // start with a yellow status (edit icon)
+        // TODO: it's a bit weired, that it works that multiple icons (one per exercise) are hold in the same instance variable of the component
+        //  we should definitely refactor this and e.g. use the same ExamExerciseOverviewItem as in exam-exercise-overview-page.component.ts !
         this.icon = 'edit';
         const exercise = this.exercises[exerciseIndex];
         const submission = ExamParticipationService.getSubmissionForExercise(exercise);

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -108,29 +108,36 @@ export class ExamNavigationBarComponent implements OnInit {
         return this.overviewPageOpen ? 'active' : '';
     }
 
+    /**
+     * calculate the exercise status (also see exam-exercise-overview-page.component.ts --> make sure the logic is consistent)
+     * also determines the used icon and its color
+     *
+     * @param exerciseIndex index of the exercise
+     * @return whether the status of the exercise
+     */
     setExerciseButtonStatus(exerciseIndex: number): 'synced' | 'synced active' | 'notSynced' {
+        // start with a yellow status (edit icon)
         this.icon = 'edit';
         const exercise = this.exercises[exerciseIndex];
         const submission = ExamParticipationService.getSubmissionForExercise(exercise);
-        if (submission) {
-            if (submission.submitted) {
-                this.icon = 'check';
-            }
-            if (submission.isSynced) {
-                // make button blue
-                if (exerciseIndex === this.exerciseIndex && !this.overviewPageOpen) {
-                    return 'synced active';
-                } else {
-                    return 'synced';
-                }
+        if (!submission) {
+            // in case no participation/submission yet exists -> display synced
+            return 'synced';
+        }
+        if (submission.submitted) {
+            this.icon = 'check';
+        }
+        if (submission.isSynced) {
+            // make button blue (except for the current page)
+            if (exerciseIndex === this.exerciseIndex && !this.overviewPageOpen) {
+                return 'synced active';
             } else {
-                // make button yellow
-                this.icon = 'edit';
-                return 'notSynced';
+                return 'synced';
             }
         } else {
-            // in case no participation yet exists -> display synced
-            return 'synced';
+            // make button yellow
+            this.icon = 'edit';
+            return 'notSynced';
         }
     }
 

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -52,19 +52,19 @@ export class ExamNavigationBarComponent implements OnInit {
         this.examAboutToEnd.emit();
     }
 
-    /*
-        @param exerciseIndex: exercise to switch to
-        @param overviewPage: user wants to switch to the overview page
-        @param forceSave: true if forceSave shall be used.
+    /**
+     * @param overviewPage: user wants to switch to the overview page
+     * @param exerciseIndex: exercise to switch to (might be undefined)
+     * @param forceSave: true if forceSave shall be used.
      */
-    changePage(overviewPage: boolean, exerciseIndex?: number, forceSave?: boolean) {
+    changePage(overviewPage: boolean, exerciseIndex: number, forceSave?: boolean) {
         if (!overviewPage) {
             // out of index -> do nothing
-            if (exerciseIndex! > this.exercises.length - 1 || exerciseIndex! < 0) {
+            if (exerciseIndex > this.exercises.length - 1 || exerciseIndex < 0) {
                 return;
             }
             // set index and emit event
-            this.exerciseIndex = exerciseIndex!;
+            this.exerciseIndex = exerciseIndex;
             this.onPageChanged.emit({ overViewChange: false, exercise: this.exercises[this.exerciseIndex], forceSave: !!forceSave });
         } else if (overviewPage) {
             // set index and emit event

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -261,11 +261,9 @@ export class ExamParticipationService {
         }
     }
 
-    getExerciseButtonTooltip(
-        exercise: Exercise,
-        submission = ExamParticipationService.getSubmissionForExercise(exercise),
-    ): 'submitted' | 'notSubmitted' | 'synced' | 'notSynced' | 'notSavedOrSubmitted' {
-        // submission does not yet exist for this exercise.
+    getExerciseButtonTooltip(exercise: Exercise): 'submitted' | 'notSubmitted' | 'synced' | 'notSynced' | 'notSavedOrSubmitted' {
+        const submission = ExamParticipationService.getSubmissionForExercise(exercise);
+        // The submission might not yet exist for this exercise.
         // When the participant navigates to the exercise the submissions are created.
         // Until then show, that the exercise is synced
         if (!submission) {

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -248,17 +248,11 @@ export class ExamParticipationService {
     }
 
     public static getSubmissionForExercise(exercise: Exercise) {
-        if (
-            exercise &&
-            exercise.studentParticipations &&
-            exercise.studentParticipations.length > 0 &&
-            exercise.studentParticipations[0].submissions &&
-            exercise.studentParticipations[0].submissions.length > 0
-        ) {
-            return exercise.studentParticipations[0].submissions[0];
-        } else {
-            return undefined;
+        if (exercise && exercise.studentParticipations && exercise.studentParticipations.length > 0 && exercise.studentParticipations[0].submissions) {
+            // NOTE: using "submissions[0]" might not work for programming exercises with multiple submissions, it is better to always take the last submission
+            return exercise.studentParticipations[0].submissions.last();
         }
+        // implicitly return undefined
     }
 
     getExerciseButtonTooltip(exercise: Exercise): 'submitted' | 'notSubmitted' | 'synced' | 'notSynced' | 'notSavedOrSubmitted' {

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -93,7 +93,7 @@ export class ExamParticipationService {
         const url = this.getResourceURL(courseId, examId) + '/start';
         return this.httpClient.get<StudentExam>(url).pipe(
             map((studentExam: StudentExam) => {
-                const convertedStudentExam = this.convertStudentExamDateFromServer(studentExam);
+                const convertedStudentExam = ExamParticipationService.convertStudentExamDateFromServer(studentExam);
                 this.adjustRepositoryUrlsForProgrammingExercises(convertedStudentExam);
                 this.currentlyLoadedStudentExam.next(convertedStudentExam);
                 return convertedStudentExam;
@@ -105,7 +105,7 @@ export class ExamParticipationService {
         const url = this.getResourceURL(courseId, examId) + '/test-run/' + testRunId + '/conduction';
         return this.httpClient.get<StudentExam>(url).pipe(
             map((studentExam: StudentExam) => {
-                const convertedStudentExam = this.convertStudentExamDateFromServer(studentExam);
+                const convertedStudentExam = ExamParticipationService.convertStudentExamDateFromServer(studentExam);
                 this.adjustRepositoryUrlsForProgrammingExercises(convertedStudentExam);
                 this.currentlyLoadedStudentExam.next(convertedStudentExam);
                 return convertedStudentExam;
@@ -210,12 +210,12 @@ export class ExamParticipationService {
 
     private convertStudentExamFromServer(studentExam: StudentExam): StudentExam {
         studentExam.exercises = this.exerciseService.convertExercisesDateFromServer(studentExam.exercises);
-        studentExam.exam = this.convertExamDateFromServer(studentExam.exam);
+        studentExam.exam = ExamParticipationService.convertExamDateFromServer(studentExam.exam);
         this.adjustRepositoryUrlsForProgrammingExercises(studentExam);
         return studentExam;
     }
 
-    private convertExamDateFromServer(exam?: Exam) {
+    private static convertExamDateFromServer(exam?: Exam) {
         if (exam) {
             exam.visibleDate = exam.visibleDate ? moment(exam.visibleDate) : undefined;
             exam.startDate = exam.startDate ? moment(exam.startDate) : undefined;
@@ -227,19 +227,19 @@ export class ExamParticipationService {
         return exam;
     }
 
-    private convertStudentExamDateFromServer(studentExam: StudentExam): StudentExam {
-        studentExam.exam = this.convertExamDateFromServer(studentExam.exam);
+    private static convertStudentExamDateFromServer(studentExam: StudentExam): StudentExam {
+        studentExam.exam = ExamParticipationService.convertExamDateFromServer(studentExam.exam);
         return studentExam;
     }
 
     private adjustRepositoryUrlsForProgrammingExercises(studentExam: StudentExam) {
-        // add user indepentend repositoryUrl to all student participations
+        // add user independent repositoryUrl to all student participations
         if (studentExam.exercises) {
-            studentExam.exercises!.forEach((ex) => {
-                if (ex.type === ExerciseType.PROGRAMMING && ex.studentParticipations) {
-                    ex.studentParticipations!.forEach((sp) => {
-                        if (sp.type === ParticipationType.PROGRAMMING) {
-                            addUserIndependentRepositoryUrl(sp);
+            studentExam.exercises!.forEach((exercise) => {
+                if (exercise.type === ExerciseType.PROGRAMMING && exercise.studentParticipations) {
+                    exercise.studentParticipations!.forEach((studentParticipation) => {
+                        if (studentParticipation.type === ParticipationType.PROGRAMMING) {
+                            addUserIndependentRepositoryUrl(studentParticipation);
                         }
                     });
                 }
@@ -274,6 +274,7 @@ export class ExamParticipationService {
         if (exercise.type !== ExerciseType.PROGRAMMING) {
             return submission.isSynced ? 'synced' : 'notSynced';
         }
+        // programming exercise
         if (submission.submitted && submission.isSynced) {
             return 'submitted'; // You have submitted an exercise. You can submit again
         } else if (!submission.submitted && submission.isSynced) {

--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -252,7 +252,6 @@ export class ExamParticipationService {
             // NOTE: using "submissions[0]" might not work for programming exercises with multiple submissions, it is better to always take the last submission
             return exercise.studentParticipations[0].submissions.last();
         }
-        // implicitly return undefined
     }
 
     getExerciseButtonTooltip(exercise: Exercise): 'submitted' | 'notSubmitted' | 'synced' | 'notSynced' | 'notSavedOrSubmitted' {

--- a/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
@@ -41,23 +41,23 @@
                     {{ i + 1 }}
                 </td>
                 <td style="max-width: 30px">
-                    <div [ngbTooltip]="getIconTooltip(item.exercise!.type) | artemisTranslate">
-                        <fa-icon [icon]="getIcon(item.exercise!.type)" placement="right" container="body"></fa-icon>
+                    <div [ngbTooltip]="getIconTooltip(item.exercise.type) | artemisTranslate">
+                        <fa-icon [icon]="getIcon(item.exercise.type)" placement="right" container="body"></fa-icon>
                     </div>
                 </td>
                 <td style="max-width: 100px; font-weight: bold">
-                    <a class="w-100" (click)="openExercise(item.exercise!)">
-                        {{ item.exercise!.title }}
+                    <a class="w-100" (click)="openExercise(item.exercise)">
+                        {{ item.exercise.title }}
                     </a>
                 </td>
                 <td style="max-width: 30px">
-                    {{ item.exercise!.maxPoints }}
+                    {{ item.exercise.maxPoints }}
                 </td>
                 <td style="max-width: 50px; font-weight: bold">
                     <div
                         style="max-width: 10px"
                         [ngClass]="setExerciseIconStatus(item)"
-                        [ngbTooltip]="'artemisApp.examParticipation.' + getExerciseButtonTooltip(item.exercise!, item.submission!) | artemisTranslate"
+                        [ngbTooltip]="'artemisApp.examParticipation.' + getExerciseButtonTooltip(item.exercise) | artemisTranslate"
                     >
                         <fa-icon [icon]="item.icon!"></fa-icon>
                     </div>

--- a/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.ts
@@ -43,9 +43,19 @@ export class ExamExerciseOverviewPageComponent extends ExamPageComponent impleme
         this.onPageChanged.emit({ overViewChange: false, exercise, forceSave: false });
     }
 
+    /**
+     * calculate the exercise status (also see exam-navigation-bar.component.ts --> make sure the logic is consistent)
+     * also determines the used icon and its color
+     *
+     * @param item the item for which the exercise status should be calculated
+     * @return whether the status of the exercise
+     */
     setExerciseIconStatus(item: ExamExerciseOverviewItem): 'synced' | 'notSynced' {
+        // start with a yellow status (edit icon)
+        item.icon = 'edit';
         const submission = ExamParticipationService.getSubmissionForExercise(item.exercise);
         if (!submission) {
+            // in case no participation/submission yet exists -> display synced
             return 'synced';
         }
         if (submission.submitted) {

--- a/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.ts
@@ -46,6 +46,8 @@ export class ExamExerciseOverviewPageComponent extends ExamPageComponent impleme
     /**
      * calculate the exercise status (also see exam-navigation-bar.component.ts --> make sure the logic is consistent)
      * also determines the used icon and its color
+     * TODO: we should try to extract a method for the common logic which avoids side effects (i.e. changing this.icon)
+     *  this method could e.g. return the sync status and the icon
      *
      * @param item the item for which the exercise status should be calculated
      * @return the sync status of the exercise (whether the corresponding submission is saved on the server or not)

--- a/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.ts
@@ -48,7 +48,7 @@ export class ExamExerciseOverviewPageComponent extends ExamPageComponent impleme
      * also determines the used icon and its color
      *
      * @param item the item for which the exercise status should be calculated
-     * @return whether the status of the exercise
+     * @return the sync status of the exercise (whether the corresponding submission is saved on the server or not)
      */
     setExerciseIconStatus(item: ExamExerciseOverviewItem): 'synced' | 'notSynced' {
         // start with a yellow status (edit icon)

--- a/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.ts
@@ -28,7 +28,6 @@ export class ExamExerciseOverviewPageComponent extends ExamPageComponent impleme
         this.studentExam.exercises?.forEach((exercise) => {
             const item = new ExamExerciseOverviewItem();
             item.exercise = exercise;
-            item.submission = this.getSubmissionForExercise(exercise);
             item.icon = 'edit';
             this.examExerciseOverviewItems.push(item);
         });
@@ -45,13 +44,14 @@ export class ExamExerciseOverviewPageComponent extends ExamPageComponent impleme
     }
 
     setExerciseIconStatus(item: ExamExerciseOverviewItem): 'synced' | 'notSynced' {
-        if (!item?.submission) {
+        const submission = ExamParticipationService.getSubmissionForExercise(item.exercise);
+        if (!submission) {
             return 'synced';
         }
-        if (item.submission.submitted) {
+        if (submission.submitted) {
             item.icon = 'check';
         }
-        if (item.submission.isSynced) {
+        if (submission.isSynced) {
             // make status blue
             return 'synced';
         } else {

--- a/src/main/webapp/app/exam/participate/exercises/file-upload/file-upload-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/file-upload/file-upload-exam-submission.component.ts
@@ -121,9 +121,9 @@ export class FileUploadExamSubmissionComponent extends ExamSubmissionComponent i
             // clear submitted file so that it is not displayed in the input (this might be confusing)
             this.submissionFile = undefined;
             const filePath = this.studentSubmission!.filePath!.split('/');
-            this.submittedFileName = filePath[filePath.length - 1];
+            this.submittedFileName = filePath.last()!;
             const fileName = this.submittedFileName.split('.');
-            this.submittedFileExtension = fileName[fileName.length - 1];
+            this.submittedFileExtension = fileName.last()!;
         }
     }
 
@@ -149,7 +149,6 @@ export class FileUploadExamSubmissionComponent extends ExamSubmissionComponent i
 
     /**
      * Pass on an error to the browser console and the jhiAlertService.
-     * @param error
      */
     private onError() {
         this.jhiAlertService.error(this.translateService.instant('error.fileUploadSavingError'));

--- a/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.ts
@@ -202,9 +202,9 @@ export class FileUploadSubmissionComponent implements OnInit, ComponentCanDeacti
         // clear submitted file so that it is not displayed in the input (this might be confusing)
         this.submissionFile = undefined;
         const filePath = this.submission!.filePath!.split('/');
-        this.submittedFileName = filePath[filePath.length - 1];
+        this.submittedFileName = filePath.last()!;
         const fileName = this.submittedFileName.split('.');
-        this.submittedFileExtension = fileName[fileName.length - 1];
+        this.submittedFileExtension = fileName.last()!;
     }
 
     downloadFile(filePath: string) {

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -80,13 +80,13 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
                 if (this.programmingExercise.templateParticipation) {
                     const templateSubmissions = this.programmingExercise.templateParticipation.submissions;
                     if (templateSubmissions && templateSubmissions.length > 0) {
-                        this.programmingExercise.templateParticipation.results = templateSubmissions[templateSubmissions.length - 1].results;
+                        this.programmingExercise.templateParticipation.results = templateSubmissions.last()?.results;
                     }
                 }
                 if (this.programmingExercise.solutionParticipation) {
                     const solutionSubmissions = this.programmingExercise.solutionParticipation.submissions;
                     if (solutionSubmissions && solutionSubmissions.length > 0) {
-                        this.programmingExercise.solutionParticipation.results = solutionSubmissions[solutionSubmissions.length - 1].results;
+                        this.programmingExercise.solutionParticipation.results = solutionSubmissions.last()?.results;
                     }
                 }
                 this.loadingTemplateParticipationResults = false;

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
@@ -145,7 +145,7 @@ export class QuizStatisticsFooterComponent implements OnInit, OnDestroy {
                 this.router.navigateByUrl(`/course-management/${getCourseId(this.quizExercise)}/quiz-exercises/${this.quizExercise.id}/quiz-statistic`);
             } else {
                 // go to previous question-statistic
-                this.quizStatisticUtil.navigateToStatisticOf(this.quizExercise, this.quizExercise.quizQuestions[this.quizExercise.quizQuestions.length - 1]);
+                this.quizStatisticUtil.navigateToStatisticOf(this.quizExercise, this.quizExercise.quizQuestions.last());
             }
         } else {
             this.quizStatisticUtil.previousStatistic(this.quizExercise, this.question);

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
@@ -145,7 +145,7 @@ export class QuizStatisticsFooterComponent implements OnInit, OnDestroy {
                 this.router.navigateByUrl(`/course-management/${getCourseId(this.quizExercise)}/quiz-exercises/${this.quizExercise.id}/quiz-statistic`);
             } else {
                 // go to previous question-statistic
-                this.quizStatisticUtil.navigateToStatisticOf(this.quizExercise, this.quizExercise.quizQuestions.last());
+                this.quizStatisticUtil.navigateToStatisticOf(this.quizExercise, this.quizExercise.quizQuestions.last()!);
             }
         } else {
             this.quizStatisticUtil.previousStatistic(this.quizExercise, this.question);

--- a/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.ts
@@ -87,7 +87,7 @@ class TextBlockRefGroup {
         return this.refs[0].block!.startIndex!;
     }
     private get endIndex(): number {
-        return this.refs[this.refs.length - 1].block!.endIndex!;
+        return this.refs.last().block!.endIndex!;
     }
 
     getText(submission: TextSubmission): string {
@@ -105,7 +105,7 @@ class TextBlockRefGroup {
 
     static fromTextBlockRefs = (textBlockRefs: TextBlockRef[]): TextBlockRefGroup[] =>
         textBlockRefs.reduce((groups: TextBlockRefGroup[], elem: TextBlockRef) => {
-            const lastGroup = groups[groups.length - 1];
+            const lastGroup = groups.last();
             if (lastGroup && !lastGroup.hasFeedback && !elem.feedback) {
                 lastGroup.addRef(elem);
             } else {

--- a/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.ts
@@ -51,7 +51,7 @@ export class ManualTextblockSelectionComponent {
         }
 
         if (textBlock) {
-            textBlock.startIndex = baseIndex + startIndexInGroup;
+            textBlock.startIndex = baseIndex! + startIndexInGroup;
             textBlock.endIndex = textBlock.startIndex + text.length;
             textBlock.setTextFromSubmission(this.submission);
             textBlock.computeId();
@@ -83,11 +83,12 @@ class TextBlockRefGroup {
         return this.hasFeedback ? this.refs[0] : null;
     }
 
-    get startIndex(): number {
-        return this.refs[0].block!.startIndex!;
+    get startIndex() {
+        return this.refs[0].block?.startIndex;
     }
-    private get endIndex(): number {
-        return this.refs.last().block!.endIndex!;
+
+    private get endIndex() {
+        return this.refs.last()?.block?.endIndex;
     }
 
     getText(submission: TextSubmission): string {

--- a/src/main/webapp/app/grading-system/grading-system.component.ts
+++ b/src/main/webapp/app/grading-system/grading-system.component.ts
@@ -253,7 +253,7 @@ export class GradingSystemComponent implements OnInit {
             }
         }
         // check if first and last grade step are valid
-        if (sortedGradeSteps[0].lowerBoundPercentage !== 0 || sortedGradeSteps[sortedGradeSteps.length - 1].upperBoundPercentage !== 100) {
+        if (sortedGradeSteps[0].lowerBoundPercentage !== 0 || sortedGradeSteps.last().upperBoundPercentage !== 100) {
             this.invalidGradeStepsMessage = this.translateService.instant('artemisApp.gradingSystem.error.invalidFirstAndLastStep');
             return false;
         }
@@ -461,7 +461,7 @@ export class GradingSystemComponent implements OnInit {
             this.gradingScale.gradeSteps = [];
         }
         const gradeStepsArrayLength = this.gradingScale.gradeSteps.length;
-        const lowerBound = gradeStepsArrayLength === 0 ? 0 : this.gradingScale.gradeSteps[gradeStepsArrayLength - 1].upperBoundPercentage;
+        const lowerBound = gradeStepsArrayLength === 0 ? 0 : this.gradingScale.gradeSteps.last().upperBoundPercentage;
         const gradeStep: GradeStep = {
             gradeName: '',
             lowerBoundPercentage: lowerBound,

--- a/src/main/webapp/app/grading-system/grading-system.component.ts
+++ b/src/main/webapp/app/grading-system/grading-system.component.ts
@@ -253,7 +253,7 @@ export class GradingSystemComponent implements OnInit {
             }
         }
         // check if first and last grade step are valid
-        if (sortedGradeSteps[0].lowerBoundPercentage !== 0 || sortedGradeSteps.last().upperBoundPercentage !== 100) {
+        if (sortedGradeSteps[0].lowerBoundPercentage !== 0 || sortedGradeSteps.last()!.upperBoundPercentage !== 100) {
             this.invalidGradeStepsMessage = this.translateService.instant('artemisApp.gradingSystem.error.invalidFirstAndLastStep');
             return false;
         }
@@ -461,7 +461,7 @@ export class GradingSystemComponent implements OnInit {
             this.gradingScale.gradeSteps = [];
         }
         const gradeStepsArrayLength = this.gradingScale.gradeSteps.length;
-        const lowerBound = gradeStepsArrayLength === 0 ? 0 : this.gradingScale.gradeSteps.last().upperBoundPercentage;
+        const lowerBound = gradeStepsArrayLength === 0 ? 0 : this.gradingScale.gradeSteps.last()!.upperBoundPercentage;
         const gradeStep: GradeStep = {
             gradeName: '',
             lowerBoundPercentage: lowerBound,

--- a/src/main/webapp/app/guided-tour/guided-tour.service.ts
+++ b/src/main/webapp/app/guided-tour/guided-tour.service.ts
@@ -576,12 +576,12 @@ export class GuidedTourService {
         }
 
         let previousStepLocation = this.router.url;
-        const tourStepWithUrl = this.availableTourForComponent.steps.filter((tourStep, index) => {
+        const tourStepsWithUrl = this.availableTourForComponent.steps.filter((tourStep, index) => {
             return tourStep.pageUrl && index < this.currentTourStepIndex;
         });
 
-        if (tourStepWithUrl) {
-            const lastTourStepWithUrl = tourStepWithUrl[tourStepWithUrl.length - 1];
+        if (tourStepsWithUrl) {
+            const lastTourStepWithUrl = tourStepsWithUrl.last();
             const previousStepLocationKey = lastTourStepWithUrl && lastTourStepWithUrl.pageUrl ? lastTourStepWithUrl.pageUrl : this.router.url;
             if (this.pageUrls.has(previousStepLocationKey)) {
                 previousStepLocation = <string>this.pageUrls.get(previousStepLocationKey);

--- a/src/main/webapp/app/overview/course-score-calculation.service.ts
+++ b/src/main/webapp/app/overview/course-score-calculation.service.ts
@@ -145,7 +145,7 @@ export class CourseScoreCalculationService {
                 chosenResult = new Result();
                 chosenResult.score = 0;
             } else {
-                chosenResult = resultsArray[resultsArray.length - 1];
+                chosenResult = resultsArray.last()!;
             }
         } else {
             chosenResult = new Result();

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -381,7 +381,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
 
         const ratedResults = this.studentParticipation?.results?.filter((result: Result) => result.rated).sort(this.resultSortFunction);
         if (ratedResults) {
-            const latestResult = ratedResults.length ? ratedResults[ratedResults.length - 1] : undefined;
+            const latestResult = ratedResults.last();
             if (latestResult) {
                 latestResult.participation = this.studentParticipation;
             }

--- a/src/main/webapp/app/shared/data-table/data-table.component.ts
+++ b/src/main/webapp/app/shared/data-table/data-table.component.ts
@@ -362,7 +362,7 @@ export class DataTableComponent implements OnInit, OnChanges {
                 // For autocomplete.
                 map(({ text, searchWords }) => {
                     // We only execute the autocomplete for the last keyword in the provided list.
-                    const lastSearchWord = searchWords.length ? searchWords[searchWords.length - 1] : null;
+                    const lastSearchWord = searchWords.last();
                     // Don't execute autocomplete for less then two inputted characters.
                     if (!lastSearchWord || lastSearchWord.length < this.minSearchQueryLength) {
                         this.searchQueryTooShort = true;
@@ -408,8 +408,6 @@ export class DataTableComponent implements OnInit, OnChanges {
 
     /**
      * Method updates the displayed entities (will be only one entity if the search text is unique per entity).
-     *
-     * @param entity Entity that was selected via autocomplete
      */
     filterAfterAutocompleteSelect = () => {
         this.updateEntities();

--- a/src/main/webapp/app/shared/util/array.extension.ts
+++ b/src/main/webapp/app/shared/util/array.extension.ts
@@ -1,0 +1,16 @@
+export {};
+
+declare global {
+    export interface Array<T> {
+        last(): T | undefined;
+    }
+}
+
+if (!Array.prototype.last) {
+    Array.prototype.last = function () {
+        if (!this.length) {
+            return undefined;
+        }
+        return this[this.length - 1];
+    };
+}

--- a/src/main/webapp/app/shared/util/global.utils.ts
+++ b/src/main/webapp/app/shared/util/global.utils.ts
@@ -1,13 +1,28 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { JhiAlertService } from 'ng-jhipster';
 
+declare global {
+    interface Array<T> {
+        last(): T | undefined;
+    }
+}
+
+if (!Array.prototype.last) {
+    Array.prototype.last = function () {
+        if (!this.length) {
+            return undefined;
+        }
+        return this[this.length - 1];
+    };
+}
+
 /**
  * Prepares a string for insertion into a regex.
  * Example: [test].*[/test] -> \[test\].*\[\/test\]
- * @param s
+ * @param text
  */
-export const escapeStringForUseInRegex = (s: string) => {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+export const escapeStringForUseInRegex = (text: string) => {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 };
 
 type StringPositions = Array<{ start: number; end: number; word: string }>;
@@ -24,7 +39,7 @@ export const getStringSegmentPositions = (stringToSegment: string, delimiter: st
         return [...result, { start: 0, end: 0, word: '' }];
     }
     const nextComma = stringToSegment.indexOf(delimiter);
-    const lastElement = result.length ? result[result.length - 1] : null;
+    const lastElement = result.last();
     // End condition: the string does not have any more segments.
     if (nextComma === -1) {
         return [

--- a/src/main/webapp/app/shared/util/global.utils.ts
+++ b/src/main/webapp/app/shared/util/global.utils.ts
@@ -1,21 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { JhiAlertService } from 'ng-jhipster';
 
-declare global {
-    interface Array<T> {
-        last(): T | undefined;
-    }
-}
-
-if (!Array.prototype.last) {
-    Array.prototype.last = function () {
-        if (!this.length) {
-            return undefined;
-        }
-        return this[this.length - 1];
-    };
-}
-
 /**
  * Prepares a string for insertion into a regex.
  * Example: [test].*[/test] -> \[test\].*\[\/test\]

--- a/src/test/javascript/jest.ts
+++ b/src/test/javascript/jest.ts
@@ -1,6 +1,7 @@
 import 'jest-preset-angular/setup-jest';
 import './jest-global-mocks';
 import 'jest-canvas-mock';
+import 'app/shared/util/global.utils';
 
 const noop = () => {};
 
@@ -15,19 +16,3 @@ Object.defineProperty(window, 'getComputedStyle', {
         },
     }),
 });
-
-// Same as in global.utils.ts
-declare global {
-    interface Array<T> {
-        last(): T | undefined;
-    }
-}
-
-if (!Array.prototype.last) {
-    Array.prototype.last = function () {
-        if (!this.length) {
-            return undefined;
-        }
-        return this[this.length - 1];
-    };
-}

--- a/src/test/javascript/jest.ts
+++ b/src/test/javascript/jest.ts
@@ -1,7 +1,7 @@
 import 'jest-preset-angular/setup-jest';
 import './jest-global-mocks';
 import 'jest-canvas-mock';
-import 'app/shared/util/global.utils';
+import 'app/shared/util/array.extension';
 
 const noop = () => {};
 

--- a/src/test/javascript/jest.ts
+++ b/src/test/javascript/jest.ts
@@ -15,3 +15,19 @@ Object.defineProperty(window, 'getComputedStyle', {
         },
     }),
 });
+
+// Same as in global.utils.ts
+declare global {
+    interface Array<T> {
+        last(): T | undefined;
+    }
+}
+
+if (!Array.prototype.last) {
+    Array.prototype.last = function () {
+        if (!this.length) {
+            return undefined;
+        }
+        return this[this.length - 1];
+    };
+}

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
@@ -497,7 +497,7 @@ describe('QuizExercise Management Detail Component', () => {
                 comp.addMultipleChoiceQuestion();
 
                 expect(comp.quizExercise.quizQuestions).to.have.lengthOf(amountQuizQuestions + 1);
-                expect(comp.quizExercise.quizQuestions![comp.quizExercise.quizQuestions!.length - 1].type).to.equal(QuizQuestionType.MULTIPLE_CHOICE);
+                expect(comp.quizExercise.quizQuestions?.last()?.type).to.equal(QuizQuestionType.MULTIPLE_CHOICE);
             });
 
             it('should add empty DnD question', () => {
@@ -505,7 +505,7 @@ describe('QuizExercise Management Detail Component', () => {
                 comp.addDragAndDropQuestion();
 
                 expect(comp.quizExercise.quizQuestions).to.have.lengthOf(amountQuizQuestions + 1);
-                expect(comp.quizExercise.quizQuestions![comp.quizExercise.quizQuestions!.length - 1].type).to.equal(QuizQuestionType.DRAG_AND_DROP);
+                expect(comp.quizExercise.quizQuestions?.last()?.type).to.equal(QuizQuestionType.DRAG_AND_DROP);
             });
 
             it('should add empty SA question', () => {
@@ -513,7 +513,7 @@ describe('QuizExercise Management Detail Component', () => {
                 comp.addShortAnswerQuestion();
 
                 expect(comp.quizExercise.quizQuestions).to.have.lengthOf(amountQuizQuestions + 1);
-                expect(comp.quizExercise.quizQuestions![comp.quizExercise.quizQuestions!.length - 1].type).to.equal(QuizQuestionType.SHORT_ANSWER);
+                expect(comp.quizExercise.quizQuestions?.last()?.type).to.equal(QuizQuestionType.SHORT_ANSWER);
             });
 
             afterAll(() => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The exam navigation bar and the exam exercise overview page are not in sync, which may confuse students when working on an exam.

### Description
<!-- Describe your changes in detail -->
It can happen that the navigation bar shows a different exercise status than the exam exercise overview.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Work on an exam programming exercise with the online code editor 
2. Submit the exercise
3. Change something but don't submit it
4. Go to the overview and see that it is not updated properly

The described process that visualizes the bug
![OverviewNotUpdated](https://user-images.githubusercontent.com/63976129/125210414-fac7af00-e29f-11eb-94e5-9b1adf619203.gif)

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Fixed version:
![FixedOverviewNotUpdated](https://user-images.githubusercontent.com/63976129/125215390-aa5e4a80-e2bb-11eb-8700-14f79dd1c02a.gif)
