### PR TITLE
Problem Statement not loading in exam code editor after reloading page

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -267,7 +267,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
      * @param result - result to which instructions will be attached.
      */
     loadAndAttachResultDetails(result: Result): Observable<Result> {
-        return this.resultService.getFeedbackDetailsForResult(result.participation!.id!, result.id!).pipe(
+        return this.resultService.getFeedbackDetailsForResult(this.participation!.id!, result.id!).pipe(
             map((res) => res && res.body),
             map((feedbacks: Feedback[]) => {
                 result.feedbacks = feedbacks;

--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -267,7 +267,8 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
      * @param result - result to which instructions will be attached.
      */
     loadAndAttachResultDetails(result: Result): Observable<Result> {
-        return this.resultService.getFeedbackDetailsForResult(this.participation!.id!, result.id!).pipe(
+        const currentParticipation = result.participation ? result.participation : this.participation;
+        return this.resultService.getFeedbackDetailsForResult(currentParticipation.id!, result.id!).pipe(
             map((res) => res && res.body),
             map((feedbacks: Feedback[]) => {
                 result.feedbacks = feedbacks;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When participating in an exam with the only code editor the problem statement is not loading after reloading the page. This is an unacceptable behavior since students can not access the problem statement for a programming exercise anymore after reloading the page.

### Description
<!-- Describe your changes in detail -->
The problem statement will now be loaded for programming exercises, also after refreshing the page.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create an exam with a programming exercise
2. Participate in the programming exercise with the online code editor (submit at least once)
3. Close the browser
4. See that the problem statement is loaded correctly (if test cases are shown to students they should also be marked properly)

Make sure to extensively test this, e.g. closing the browser, reloading the page with/without clearing the browser cache, creativity is welcome!
It does also make a difference whether you already participated in an exercise or not. So different combinations of participating states and reload the page.


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
This is the broken version, the problem statement is not loading after closing the browser:
![ProblemStatementNotLoading](https://user-images.githubusercontent.com/63976129/125278717-5da65e00-e313-11eb-954f-dd640b0e0d79.gif)

Screencast of the working solution:
![ProblemStatementLoading](https://user-images.githubusercontent.com/63976129/125278360-ecff4180-e312-11eb-85e1-a2f0086b0fa6.gif)