### PR TITLE
Fix an issue in the programming exercise details page for instructors

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/AbstractBaseProgrammingExerciseParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/AbstractBaseProgrammingExerciseParticipation.java
@@ -62,6 +62,6 @@ public abstract class AbstractBaseProgrammingExerciseParticipation extends Parti
 
     @Override
     public String toString() {
-        return "Participation{" + "id=" + getId() + ", repositoryUrl='" + getRepositoryUrl() + "'" + ", buildPlanId='" + getBuildPlanId() + "}";
+        return getClass().getSimpleName() + "{" + "id=" + getId() + ", repositoryUrl='" + getRepositoryUrl() + "'" + ", buildPlanId='" + getBuildPlanId() + "}";
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/Participation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/Participation.java
@@ -274,8 +274,8 @@ public abstract class Participation extends DomainObject implements Participatio
 
     @Override
     public String toString() {
-        return "Participation{" + "id=" + getId() + ", initializationState=" + initializationState + ", initializationDate=" + initializationDate + ", results=" + results
-                + ", submissions=" + submissions + ", submissionCount=" + submissionCount + "}";
+        return getClass().getSimpleName() + "{" + "id=" + getId() + ", initializationState=" + initializationState + ", initializationDate=" + initializationDate + ", results="
+                + results + ", submissions=" + submissions + ", submissionCount=" + submissionCount + "}";
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/ProgrammingExerciseStudentParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/ProgrammingExerciseStudentParticipation.java
@@ -61,8 +61,9 @@ public class ProgrammingExerciseStudentParticipation extends StudentParticipatio
 
     @Override
     public String toString() {
-        return "Participation{" + "id=" + getId() + ", repositoryUrl='" + getRepositoryUrl() + "'" + ", buildPlanId='" + getBuildPlanId() + "'" + ", initializationState='"
-                + getInitializationState() + "'" + ", initializationDate='" + getInitializationDate() + "'" + ", presentationScore=" + getPresentationScore() + "}";
+        return getClass().getSimpleName() + "{" + "id=" + getId() + ", repositoryUrl='" + getRepositoryUrl() + "'" + ", buildPlanId='" + getBuildPlanId() + "'"
+                + ", initializationState='" + getInitializationState() + "'" + ", initializationDate='" + getInitializationDate() + "'" + ", presentationScore="
+                + getPresentationScore() + "}";
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/StudentParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/StudentParticipation.java
@@ -121,7 +121,7 @@ public class StudentParticipation extends Participation {
     @Override
     public String toString() {
         String participantString = getStudent().map(student -> "student=" + student).orElse("team=" + team);
-        return getClass().getSimpleName() + "" + "id=" + getId() + ", presentationScore=" + presentationScore + ", " + participantString + "}";
+        return getClass().getSimpleName() + "{" + "id=" + getId() + ", presentationScore=" + presentationScore + ", " + participantString + "}";
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/StudentParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/StudentParticipation.java
@@ -121,7 +121,7 @@ public class StudentParticipation extends Participation {
     @Override
     public String toString() {
         String participantString = getStudent().map(student -> "student=" + student).orElse("team=" + team);
-        return "StudentParticipation{" + "id=" + getId() + ", presentationScore=" + presentationScore + ", " + participantString + "}";
+        return getClass().getSimpleName() + "" + "id=" + getId() + ", presentationScore=" + presentationScore + ", " + participantString + "}";
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/TutorParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/TutorParticipation.java
@@ -94,6 +94,6 @@ public class TutorParticipation extends DomainObject {
 
     @Override
     public String toString() {
-        return "TutorParticipation{" + "id=" + getId() + ", status='" + getStatus() + "}";
+        return getClass().getSimpleName() + "{" + "id=" + getId() + ", status='" + getStatus() + "}";
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseImportService.java
@@ -103,7 +103,7 @@ public class ProgrammingExerciseImportService {
         setupExerciseForImport(newExercise);
 
         programmingExerciseParticipationService.setupInitialSolutionParticipation(newExercise);
-        programmingExerciseParticipationService.setupInitalTemplateParticipation(newExercise);
+        programmingExerciseParticipationService.setupInitialTemplateParticipation(newExercise);
         setupTestRepository(newExercise);
         programmingExerciseService.initParticipations(newExercise);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -134,6 +134,8 @@ public class ProgrammingExerciseParticipationService {
     }
 
     /**
+     * NOTE: do not use this method any more, because loading the participation reliably with their exercise does not work with Hibernate/Hazelcast in a multi node server setup
+     *
      * Check if the currently logged in user can access a given participation by accessing the exercise and course connected to this participation
      * The method will treat the participation types differently:
      * - ProgrammingExerciseStudentParticipations should only be accessible by its owner (student) or users with at least the role TA in the courses.
@@ -142,8 +144,8 @@ public class ProgrammingExerciseParticipationService {
      * @param participation to check permissions for.
      * @return true if the user can access the participation, false if not. Also returns false if the participation is not from a programming exercise.
      */
+    @Deprecated(since = "5.0.6", forRemoval = true)
     public boolean canAccessParticipation(ProgrammingExerciseParticipation participation) {
-        log.info("canAccessParticipation (generic): {}, progExercise: {}, exercise: {}", participation, participation.getProgrammingExercise(), participation.getExercise());
         User user = userRepository.getUserWithGroupsAndAuthorities();
         if (participation instanceof ProgrammingExerciseStudentParticipation studentParticipation) {
             // If the current user is owner of the participation, they are allowed to access it
@@ -162,6 +164,8 @@ public class ProgrammingExerciseParticipationService {
     }
 
     /**
+     * NOTE: do not use this method any more, because loading the participation reliably with their exercise does not work with Hibernate/Hazelcast in a multi node server setup
+     *
      * Returns whether a user is allowed to access a given participation (as owner or at least as tutor of the course).
      *
      * @param <T>           The {@link ProgrammingExerciseParticipation} sub-class
@@ -170,10 +174,10 @@ public class ProgrammingExerciseParticipationService {
      * @param user          The user, may be null, in which case the current user is fetched and used.
      * @return <code>true</code> if the current user is allowed to access the given participation, <code>false</code> otherwise
      */
+    @Deprecated(since = "5.0.6", forRemoval = true)
     private <T extends ProgrammingExerciseParticipation> boolean canAccessParticipation(@NotNull T participation, JpaRepository<T, Long> repository, User user) {
         // Note: if this participation was retrieved as Participation (abstract super class) from the database, the programming exercise might not be correctly initialized
         // To prevent null pointer exceptions, we therefore retrieve it again as concrete sub-class instance by using the provided repository
-        log.info("canAccessParticipation (concrete): {}, progExercise: {}, exercise: {}", participation, participation.getProgrammingExercise(), participation.getExercise());
         if (participation.getProgrammingExercise() == null || !Hibernate.isInitialized(participation.getProgrammingExercise())) {
             log.warn("canAccessParticipation: reload participation, because programming exercise is null or a proxy object");
             T participationFromDatabase = repository.findById(participation.getId()).get();
@@ -184,7 +188,6 @@ public class ProgrammingExerciseParticipationService {
             participation.setProgrammingExercise(participationFromDatabase.getProgrammingExercise());
         }
         // TODO: I think we should higher the following permissions to editor
-        log.info("canAccessParticipation (after reload): {}, progExercise: {}, exercise: {}", participation, participation.getProgrammingExercise(), participation.getExercise());
         return authCheckService.isAtLeastTeachingAssistantForExercise(participation.getProgrammingExercise(), user);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -1,6 +1,5 @@
 package de.tum.in.www1.artemis.service.programming;
 
-import java.security.Principal;
 import java.util.Optional;
 
 import javax.validation.constraints.NotNull;
@@ -62,10 +61,6 @@ public class ProgrammingExerciseParticipationService {
         this.gitService = gitService;
     }
 
-    public Optional<SolutionProgrammingExerciseParticipation> findSolutionParticipation(Long participationId) {
-        return solutionParticipationRepository.findById(participationId);
-    }
-
     /**
      * Retrieve the solution participation of the given programming exercise.
      *
@@ -73,6 +68,7 @@ public class ProgrammingExerciseParticipationService {
      * @return the SolutionProgrammingExerciseParticipation of programming exercise.
      * @throws EntityNotFoundException if the SolutionParticipation can't be found (could be that the programming exercise does not exist or it does not have a SolutionParticipation).
      */
+    // TODO: move into solutionParticipationRepository
     public SolutionProgrammingExerciseParticipation findSolutionParticipationByProgrammingExerciseId(Long programmingExerciseId) throws EntityNotFoundException {
         Optional<SolutionProgrammingExerciseParticipation> solutionParticipation = solutionParticipationRepository.findByProgrammingExerciseId(programmingExerciseId);
         if (solutionParticipation.isEmpty()) {
@@ -88,6 +84,7 @@ public class ProgrammingExerciseParticipationService {
      * @return the TemplateProgrammingExerciseParticipation of programming exercise.
      * @throws EntityNotFoundException if the TemplateParticipation can't be found (could be that the programming exercise does not exist or it does not have a TemplateParticipation).
      */
+    // TODO: move into templateParticipationRepository
     public TemplateProgrammingExerciseParticipation findTemplateParticipationByProgrammingExerciseId(Long programmingExerciseId) throws EntityNotFoundException {
         Optional<TemplateProgrammingExerciseParticipation> templateParticipation = templateParticipationRepository.findByProgrammingExerciseId(programmingExerciseId);
         if (templateParticipation.isEmpty()) {
@@ -137,15 +134,16 @@ public class ProgrammingExerciseParticipationService {
     }
 
     /**
-     * Check if the user can access a given participation by accessing the exercise and course connected to this participation
+     * Check if the currently logged in user can access a given participation by accessing the exercise and course connected to this participation
      * The method will treat the participation types differently:
-     * - ProgrammingExerciseStudentParticipations should only be accessible by its owner (student) and the courses instructor/tas.
-     * - Template/SolutionParticipations should only be accessible by the courses instructor/tas.
+     * - ProgrammingExerciseStudentParticipations should only be accessible by its owner (student) or users with at least the role TA in the courses.
+     * - Template/SolutionParticipations should only be accessible for users with at least the role TA in the courses.
      *
      * @param participation to check permissions for.
      * @return true if the user can access the participation, false if not. Also returns false if the participation is not from a programming exercise.
      */
     public boolean canAccessParticipation(ProgrammingExerciseParticipation participation) {
+        log.info("canAccessParticipation (generic): {}, progExercise: {}, exercise: {}", participation, participation.getProgrammingExercise(), participation.getExercise());
         User user = userRepository.getUserWithGroupsAndAuthorities();
         if (participation instanceof ProgrammingExerciseStudentParticipation studentParticipation) {
             // If the current user is owner of the participation, they are allowed to access it
@@ -164,7 +162,7 @@ public class ProgrammingExerciseParticipationService {
     }
 
     /**
-     * Returns whether a user is allowed to access a given participation.
+     * Returns whether a user is allowed to access a given participation (as owner or at least as tutor of the course).
      *
      * @param <T>           The {@link ProgrammingExerciseParticipation} sub-class
      * @param participation A participation of type <code>T</code>, must not be null
@@ -175,49 +173,18 @@ public class ProgrammingExerciseParticipationService {
     private <T extends ProgrammingExerciseParticipation> boolean canAccessParticipation(@NotNull T participation, JpaRepository<T, Long> repository, User user) {
         // Note: if this participation was retrieved as Participation (abstract super class) from the database, the programming exercise might not be correctly initialized
         // To prevent null pointer exceptions, we therefore retrieve it again as concrete sub-class instance by using the provided repository
+        log.info("canAccessParticipation (concrete): {}, progExercise: {}, exercise: {}", participation, participation.getProgrammingExercise(), participation.getExercise());
         if (participation.getProgrammingExercise() == null || !Hibernate.isInitialized(participation.getProgrammingExercise())) {
-            participation.setProgrammingExercise(repository.findById(participation.getId()).get().getProgrammingExercise());
+            log.warn("canAccessParticipation: reload participation, because programming exercise is null or a proxy object");
+            T participationFromDatabase = repository.findById(participation.getId()).get();
+            participation.setProgrammingExercise(participationFromDatabase.getProgrammingExercise());
+            if (participation.getProgrammingExercise() == null || !Hibernate.isInitialized(participation.getProgrammingExercise())) {
+                log.warn("canAccessParticipation: reload participation with an uninitialized programming exercise");
+            }
         }
+        // TODO: I think we should higher the following permissions to editor
+        log.info("canAccessParticipation (after reload): {}, progExercise: {}, exercise: {}", participation, participation.getProgrammingExercise(), participation.getExercise());
         return authCheckService.isAtLeastTeachingAssistantForExercise(participation.getProgrammingExercise(), user);
-    }
-
-    /**
-     * Check if the user can access a given participation.
-     * The method will treat the participation types differently:
-     * - ProgrammingExerciseStudentParticipations should only be accessible by its owner (student) and the courses instructor/tas.
-     * - Template/SolutionParticipations should only be accessible by the courses instructor/tas.
-     *
-     * TODO: why is this different to {@link #canAccessParticipation(ProgrammingExerciseParticipation)}?
-     *
-     * @param participation to check permissions for.
-     * @param principal object to check permissions of the user with.
-     * @return true if the user can access the participation, false if not. Also returns false if the participation is not from a programming exercise.
-     */
-    public boolean canAccessParticipation(ProgrammingExerciseParticipation participation, Principal principal) {
-        if (participation instanceof ProgrammingExerciseStudentParticipation) {
-            return canAccessParticipation((ProgrammingExerciseStudentParticipation) participation, principal);
-        }
-        else if (participation instanceof SolutionProgrammingExerciseParticipation) {
-            return canAccessParticipation((SolutionProgrammingExerciseParticipation) participation, principal);
-        }
-        else if (participation instanceof TemplateProgrammingExerciseParticipation) {
-            return canAccessParticipation((TemplateProgrammingExerciseParticipation) participation, principal);
-        }
-        return false;
-    }
-
-    private boolean canAccessParticipation(ProgrammingExerciseStudentParticipation participation, Principal principal) {
-        return participation.isOwnedBy(principal.getName());
-    }
-
-    private boolean canAccessParticipation(SolutionProgrammingExerciseParticipation participation, Principal principal) {
-        User user = userRepository.getUserWithGroupsAndAuthorities(principal.getName());
-        return authCheckService.isAtLeastEditorForExercise(participation.getExercise(), user);
-    }
-
-    private boolean canAccessParticipation(TemplateProgrammingExerciseParticipation participation, Principal principal) {
-        User user = userRepository.getUserWithGroupsAndAuthorities(principal.getName());
-        return authCheckService.isAtLeastEditorForExercise(participation.getExercise(), user);
     }
 
     /**
@@ -244,7 +211,7 @@ public class ProgrammingExerciseParticipationService {
      * @param newExercise The new exercise for which a participation should be generated
      */
     @NotNull
-    public void setupInitalTemplateParticipation(ProgrammingExercise newExercise) {
+    public void setupInitialTemplateParticipation(ProgrammingExercise newExercise) {
         final String exerciseRepoName = newExercise.generateRepositoryName(RepositoryType.TEMPLATE);
         TemplateProgrammingExerciseParticipation templateParticipation = new TemplateProgrammingExerciseParticipation();
         templateParticipation.setBuildPlanId(newExercise.generateBuildPlanId(BuildPlanType.TEMPLATE));

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseParticipationService.java
@@ -177,10 +177,11 @@ public class ProgrammingExerciseParticipationService {
         if (participation.getProgrammingExercise() == null || !Hibernate.isInitialized(participation.getProgrammingExercise())) {
             log.warn("canAccessParticipation: reload participation, because programming exercise is null or a proxy object");
             T participationFromDatabase = repository.findById(participation.getId()).get();
-            participation.setProgrammingExercise(participationFromDatabase.getProgrammingExercise());
-            if (participation.getProgrammingExercise() == null || !Hibernate.isInitialized(participation.getProgrammingExercise())) {
-                log.warn("canAccessParticipation: reload participation with an uninitialized programming exercise");
+            log.warn("canAccessParticipation: reloaded participation: {}", participationFromDatabase);
+            if (participationFromDatabase.getProgrammingExercise() == null || !Hibernate.isInitialized(participationFromDatabase.getProgrammingExercise())) {
+                log.error("canAccessParticipation: tried to reload participation, but received it again with an uninitialized programming exercise");
             }
+            participation.setProgrammingExercise(participationFromDatabase.getProgrammingExercise());
         }
         // TODO: I think we should higher the following permissions to editor
         log.info("canAccessParticipation (after reload): {}, progExercise: {}, exercise: {}", participation, participation.getProgrammingExercise(), participation.getExercise());

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
@@ -226,10 +226,10 @@ public class ProgrammingSubmissionService extends SubmissionService {
      */
     public Optional<ProgrammingSubmission> getLatestPendingSubmission(Long participationId, boolean filterGraded) throws EntityNotFoundException, IllegalArgumentException {
         Participation participation = participationRepository.findByIdElseThrow(participationId);
-        if (!(participation instanceof ProgrammingExerciseParticipation)) {
+        if (!(participation instanceof ProgrammingExerciseParticipation programmingExerciseParticipation)) {
             throw new IllegalArgumentException("Participation with id " + participationId + " is not a programming exercise participation!");
         }
-        if (!programmingExerciseParticipationService.canAccessParticipation((ProgrammingExerciseParticipation) participation)) {
+        if (!programmingExerciseParticipationService.canAccessParticipation(programmingExerciseParticipation)) {
             throw new AccessForbiddenException("Participation with id " + participationId + " can't be accessed by user " + SecurityUtils.getCurrentUserLogin());
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -700,7 +700,6 @@ public class ProgrammingExerciseResource {
     @GetMapping(Endpoints.PROGRAMMING_EXERCISE)
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<ProgrammingExercise> getProgrammingExercise(@PathVariable long exerciseId) {
-        // TODO: Split this route in two: One for normal and one for exam exercises
         log.debug("REST request to get ProgrammingExercise : {}", exerciseId);
         var programmingExercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesElseThrow(exerciseId);
         // Fetch grading criterion into exercise of participation

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -75,22 +75,13 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
             this.programmingExercise.isAtLeastEditor = this.accountService.isAtLeastEditorForExercise(this.programmingExercise);
             this.programmingExercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorForExercise(this.programmingExercise);
 
-            if (this.programmingExercise.templateParticipation) {
-                this.programmingExercise.templateParticipation.programmingExercise = this.programmingExercise;
-                this.loadLatestResultWithFeedbackAndSubmission(this.programmingExercise.templateParticipation.id!).subscribe((results) => {
-                    this.programmingExercise.templateParticipation!.results = results;
-                    this.loadingTemplateParticipationResults = false;
-                });
-            }
+            this.programmingExerciseService.findWithTemplateAndSolutionParticipation(programmingExercise.id!).subscribe((updatedProgrammingExercise) => {
+                // TODO: the feedback would be missing here, is that a problem?
+                this.programmingExercise = updatedProgrammingExercise.body!;
+                this.loadingTemplateParticipationResults = false;
+                this.loadingSolutionParticipationResults = false;
+            });
 
-            if (this.programmingExercise.solutionParticipation) {
-                this.programmingExercise.solutionParticipation.programmingExercise = this.programmingExercise;
-
-                this.loadLatestResultWithFeedbackAndSubmission(this.programmingExercise.solutionParticipation.id!).subscribe((results) => {
-                    this.programmingExercise.solutionParticipation!.results = results;
-                    this.loadingSolutionParticipationResults = false;
-                });
-            }
             this.statisticsService.getExerciseStatistics(programmingExercise.id).subscribe((statistics: ExerciseManagementStatisticsDto) => {
                 this.doughnutStats = statistics;
             });
@@ -114,20 +105,6 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
 
     ngOnDestroy(): void {
         this.dialogErrorSource.unsubscribe();
-    }
-
-    /**
-     * Load the latest result for the given participation. Will return [result] if there is a result, [] if not.
-     * @param participationId of the given participation.
-     * @return an empty array if there is no result or an array with the single latest result.
-     */
-    private loadLatestResultWithFeedbackAndSubmission(participationId: number): Observable<Result[]> {
-        return this.programmingExerciseParticipationService.getLatestResultWithFeedback(participationId, true).pipe(
-            catchError(() => of(null)),
-            map((result: Result | null) => {
-                return result ? [result] : [];
-            }),
-        );
     }
 
     combineTemplateCommits() {

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -75,9 +75,22 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
             this.programmingExercise.isAtLeastEditor = this.accountService.isAtLeastEditorForExercise(this.programmingExercise);
             this.programmingExercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorForExercise(this.programmingExercise);
 
-            this.programmingExerciseService.findWithTemplateAndSolutionParticipation(programmingExercise.id!).subscribe((updatedProgrammingExercise) => {
+            this.programmingExerciseService.findWithTemplateAndSolutionParticipation(programmingExercise.id!, true).subscribe((updatedProgrammingExercise) => {
                 // TODO: the feedback would be missing here, is that a problem?
                 this.programmingExercise = updatedProgrammingExercise.body!;
+                // get the latest results for further processing
+                if (this.programmingExercise.templateParticipation) {
+                    const templateSubmissions = this.programmingExercise.templateParticipation.submissions;
+                    if (templateSubmissions && templateSubmissions.length > 0) {
+                        this.programmingExercise.templateParticipation.results = templateSubmissions[templateSubmissions.length - 1].results;
+                    }
+                }
+                if (this.programmingExercise.solutionParticipation) {
+                    const solutionSubmissions = this.programmingExercise.solutionParticipation.submissions;
+                    if (solutionSubmissions && solutionSubmissions.length > 0) {
+                        this.programmingExercise.solutionParticipation.results = solutionSubmissions[solutionSubmissions.length - 1].results;
+                    }
+                }
                 this.loadingTemplateParticipationResults = false;
                 this.loadingSolutionParticipationResults = false;
             });

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -1,10 +1,8 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Observable, of, Subject } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 import { ProgrammingExercise, ProgrammingLanguage } from 'app/entities/programming-exercise.model';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
-import { Result } from 'app/entities/result.model';
 import { JhiAlertService } from 'ng-jhipster';
 import { ProgrammingExerciseParticipationType } from 'app/entities/programming-exercise-participation.model';
 import { ProgrammingExerciseParticipationService } from 'app/exercises/programming/manage/services/programming-exercise-participation.service';


### PR DESCRIPTION
Hibernate in combination with Hazelcast randomly leads to Null Pointer Exceptions when fetching template or solution participations for programming exercises in the `canAccessParticiption(...)` method. This happens more often on multi node sever setups, probably because of caching issues related to Hazelcast.

I changed how the programming exercise details page for instructors is loaded, which should solve the issue. The page needs a larger redesign with respect to the number of REST calls, but the change should solve the issue that you typically notice on Staging and Production, but not necessarily on the simple test servers (TS1, TS2, TS3, TS5) because they only have one server node.

I also removed a too similar method and unified the approach for `canAccessParticiption(...)`

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I added server integration tests 
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I documented the TypeScript code using JSDoc style.

### Steps for Testing
0. Execute the following steps on the staging environment: https://artemis-staging.ase.in.tum.de
1. Open the programming exercise details page of a programming exercise and make sure the template and solution results (at the bottom) are displayed correctly
2. Open `Edit in Editor` and submit multiple times for template and solution, make sure the result changes
3. Regularly check if the programming exercise details page then displays the correct, i.e. most recent, result for template and solution without any error messages (after the build has taken place)
