### PR TITLE
[Bugfix] Fix quiz exercise exam routings

### DIFF
--- a/src/main/webapp/app/exam/manage/exam-management.route.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.route.ts
@@ -55,6 +55,8 @@ import { GradingSystemComponent } from 'app/grading-system/grading-system.compon
 import { ExampleSubmissionsComponent } from 'app/exercises/shared/example-submission/example-submissions.component';
 import { GradingKeyOverviewComponent } from 'app/grading-system/grading-key-overview/grading-key-overview.component';
 import { ExerciseStatisticsComponent } from 'app/exercises/shared/statistics/exercise-statistics.component';
+import { QuizParticipationComponent } from 'app/exercises/quiz/participate/quiz-participation.component';
+import { QuizReEvaluateComponent } from 'app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.component';
 
 @Injectable({ providedIn: 'root' })
 export class ExamResolve implements Resolve<Exam> {
@@ -585,6 +587,36 @@ export const examManagementRoute: Routes = [
         data: {
             authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
             pageTitle: 'artemisApp.plagiarism.plagiarism-detection',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
+        path: ':examId/exercise-groups/:exerciseGroupId/quiz-exercises/:exerciseId/preview',
+        component: QuizParticipationComponent,
+        data: {
+            authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.quizExercise.home.title',
+            mode: 'preview',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
+        path: ':examId/exercise-groups/:exerciseGroupId/quiz-exercises/:exerciseId/solution',
+        component: QuizParticipationComponent,
+        data: {
+            authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.quizExercise.home.title',
+            mode: 'solution',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
+        path: ':examId/exercise-groups/:exerciseGroupId/quiz-exercises/:exerciseId/re-evaluate',
+        component: QuizReEvaluateComponent,
+        data: {
+            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.quizExercise.home.title',
+            mode: 'solution',
         },
         canActivate: [UserRouteAccessService],
     },

--- a/src/main/webapp/app/exam/manage/exam-management.route.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.route.ts
@@ -57,6 +57,7 @@ import { GradingKeyOverviewComponent } from 'app/grading-system/grading-key-over
 import { ExerciseStatisticsComponent } from 'app/exercises/shared/statistics/exercise-statistics.component';
 import { QuizParticipationComponent } from 'app/exercises/quiz/participate/quiz-participation.component';
 import { QuizReEvaluateComponent } from 'app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.component';
+import { QuizPointStatisticComponent } from 'app/exercises/quiz/manage/statistics/quiz-point-statistic/quiz-point-statistic.component';
 
 @Injectable({ providedIn: 'root' })
 export class ExamResolve implements Resolve<Exam> {

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -82,7 +82,7 @@ export class QuizExerciseDetailComponent implements OnInit, OnChanges, Component
     @ViewChildren('editShortAnswer')
     editShortAnswerQuestionComponents: QueryList<ShortAnswerQuestionEditComponent>;
 
-    course: Course;
+    course?: Course;
     quizExercise: QuizExercise;
     exerciseGroup?: ExerciseGroup;
     courseRepository: CourseManagementService;

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistic.route.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistic.route.ts
@@ -53,4 +53,49 @@ export const quizStatisticRoute: Routes = [
         },
         canActivate: [UserRouteAccessService],
     },
+    {
+        path: ':courseId/exams/:examId/exercise-groups/:exerciseGroupId/quiz-exercises/:exerciseId/quiz-point-statistic',
+        component: QuizPointStatisticComponent,
+        data: {
+            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.course.home.title',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
+        path: ':courseId/exams/:examId/exercise-groups/:exerciseGroupId/quiz-exercises/:exerciseId/quiz-statistic',
+        component: QuizStatisticComponent,
+        data: {
+            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.course.home.title',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
+        path: ':courseId/exams/:examId/exercise-groups/:exerciseGroupId/quiz-exercises/:exerciseId/mc-question-statistic/:questionId',
+        component: MultipleChoiceQuestionStatisticComponent,
+        data: {
+            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.course.home.title',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
+        path: ':courseId/exams/:examId/exercise-groups/:exerciseGroupId/quiz-exercises/:exerciseId/dnd-question-statistic/:questionId',
+        component: DragAndDropQuestionStatisticComponent,
+        data: {
+            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.course.home.title',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
+        path: ':courseId/exams/:examId/exercise-groups/:exerciseGroupId/quiz-exercises/:exerciseId/sa-question-statistic/:questionId',
+        component: ShortAnswerQuestionStatisticComponent,
+        data: {
+            authorities: [Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.course.home.title',
+        },
+        canActivate: [UserRouteAccessService],
+    },
 ];

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.html
@@ -10,45 +10,80 @@
                     </button>
                     <div ngbDropdownMenu *ngIf="quizExercise">
                         <button
+                            *ngIf="!quizExercise.exerciseGroup"
                             class="dropdown-item"
-                            routerLink="/course-management/{{ quizExercise.course ? quizExercise.course!.id : quizExercise.exerciseGroup?.exam?.course?.id }}/quiz-exercises/{{
-                                quizExercise.id
-                            }}/quiz-point-statistic"
+                            routerLink="/course-management/{{ quizExercise.course!.id }}/quiz-exercises/{{ quizExercise.id }}/quiz-point-statistic"
                             jhiTranslate="showStatistic.quizPointStatisticTitle"
                         ></button>
                         <button
+                            *ngIf="quizExercise.exerciseGroup"
                             class="dropdown-item"
-                            routerLink="/course-management/{{ quizExercise.course ? quizExercise.course!.id : quizExercise.exerciseGroup?.exam?.course?.id }}/quiz-exercises/{{
-                                quizExercise.id
-                            }}/quiz-statistic"
+                            routerLink="/course-management/{{ quizExercise.exerciseGroup.exam!.course!.id }}/exams/{{ quizExercise.exerciseGroup.exam!.id }}/exercise-groups/{{
+                                quizExercise.exerciseGroup.id
+                            }}/quiz-exercises/{{ quizExercise.id }}/quiz-point-statistic"
+                            jhiTranslate="showStatistic.quizPointStatisticTitle"
+                        ></button>
+                        <button
+                            *ngIf="!quizExercise.exerciseGroup"
+                            class="dropdown-item"
+                            routerLink="/course-management/{{ quizExercise.course!.id }}/quiz-exercises/{{ quizExercise.id }}/quiz-statistic"
+                            jhiTranslate="showStatistic.quizStatisticTitle"
+                        ></button>
+                        <button
+                            *ngIf="quizExercise.exerciseGroup"
+                            class="dropdown-item"
+                            routerLink="/course-management/{{ quizExercise.exerciseGroup.exam!.course!.id }}/exams/{{ quizExercise.exerciseGroup.exam!.id }}/exercise-groups/{{
+                                quizExercise.exerciseGroup.id
+                            }}/quiz-exercises/{{ quizExercise.id }}/quiz-statistic"
                             jhiTranslate="showStatistic.quizStatisticTitle"
                         ></button>
                         <div *ngIf="quizExercise.quizQuestions">
                             <div *ngFor="let question of quizExercise.quizQuestions; let i = index">
                                 <button
-                                    *ngIf="question.type === MULTIPLE_CHOICE"
+                                    *ngIf="question.type === MULTIPLE_CHOICE && !quizExercise.exerciseGroup"
                                     class="dropdown-item"
-                                    routerLink="/course-management/{{
-                                        quizExercise.course ? quizExercise.course.id : quizExercise.exerciseGroup?.exam?.course?.id
-                                    }}/quiz-exercises/{{ quizExercise.id }}/mc-question-statistic/{{ question.id }}"
+                                    routerLink="/course-management/{{ quizExercise.course!.id }}/quiz-exercises/{{ quizExercise.id }}/mc-question-statistic/{{ question.id }}"
                                 >
                                     {{ i + 1 }}. {{ question.title || '' | truncate }}
                                 </button>
                                 <button
-                                    *ngIf="question.type === DRAG_AND_DROP"
+                                    *ngIf="question.type === MULTIPLE_CHOICE && quizExercise.exerciseGroup"
                                     class="dropdown-item"
-                                    routerLink="/course-management/{{
-                                        quizExercise.course ? quizExercise.course.id : quizExercise.exerciseGroup?.exam?.course?.id
-                                    }}/quiz-exercises/{{ quizExercise.id }}/dnd-question-statistic/{{ question.id }}"
+                                    routerLink="/course-management/{{ quizExercise.exerciseGroup.exam!.course!.id }}/exams/{{
+                                        quizExercise.exerciseGroup.exam!.id
+                                    }}/exercise-groups/{{ quizExercise.exerciseGroup.id }}/quiz-exercises/{{ quizExercise.id }}/mc-question-statistic/{{ question.id }}"
                                 >
                                     {{ i + 1 }}. {{ question.title || '' | truncate }}
                                 </button>
                                 <button
-                                    *ngIf="question.type === SHORT_ANSWER"
+                                    *ngIf="question.type === DRAG_AND_DROP && !quizExercise.exerciseGroup"
                                     class="dropdown-item"
-                                    routerLink="/course-management/{{
-                                        quizExercise.course ? quizExercise.course.id : quizExercise.exerciseGroup?.exam?.course?.id
-                                    }}/quiz-exercises/{{ quizExercise.id }}/sa-question-statistic/{{ question.id }}"
+                                    routerLink="/course-management/{{ quizExercise.course!.id }}/quiz-exercises/{{ quizExercise.id }}/dnd-question-statistic/{{ question.id }}"
+                                >
+                                    {{ i + 1 }}. {{ question.title || '' | truncate }}
+                                </button>
+                                <button
+                                    *ngIf="question.type === DRAG_AND_DROP && quizExercise.exerciseGroup"
+                                    class="dropdown-item"
+                                    routerLink="/course-management/{{ quizExercise.exerciseGroup.exam!.course!.id }}/exams/{{
+                                        quizExercise.exerciseGroup.exam!.id
+                                    }}/exercise-groups/{{ quizExercise.exerciseGroup.id }}/quiz-exercises/{{ quizExercise.id }}/dnd-question-statistic/{{ question.id }}"
+                                >
+                                    {{ i + 1 }}. {{ question.title || '' | truncate }}
+                                </button>
+                                <button
+                                    *ngIf="question.type === SHORT_ANSWER && !quizExercise.exerciseGroup"
+                                    class="dropdown-item"
+                                    routerLink="/course-management/{{ quizExercise.course!.id }}/quiz-exercises/{{ quizExercise.id }}/sa-question-statistic/{{ question.id }}"
+                                >
+                                    {{ i + 1 }}. {{ question.title || '' | truncate }}
+                                </button>
+                                <button
+                                    *ngIf="question.type === SHORT_ANSWER && quizExercise.exerciseGroup"
+                                    class="dropdown-item"
+                                    routerLink="/course-management/{{ quizExercise.exerciseGroup.exam!.course!.id }}/exams/{{
+                                        quizExercise.exerciseGroup.exam!.id
+                                    }}/exercise-groups/{{ quizExercise.exerciseGroup.id }}/quiz-exercises/{{ quizExercise.id }}/sa-question-statistic/{{ question.id }}"
                                 >
                                     {{ i + 1 }}. {{ question.title || '' | truncate }}
                                 </button>

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -47,7 +47,7 @@
 
     <a
         *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.QUIZ"
-        [routerLink]="['/course-management', course.id, 'quiz-exercises', exercise.id, 'quiz-point-statistic']"
+        [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, 'quiz-exercises', exercise.id, 'quiz-point-statistic']"
         class="btn btn-info btn-sm me-1"
     >
         <fa-icon [icon]="'signal'"></fa-icon>

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -37,7 +37,7 @@
 
     <!-- Example Submission -->
     <a
-        *ngIf="course.isAtLeastEditor"
+        *ngIf="course.isAtLeastEditor && exercise.type !== exerciseType.QUIZ && exercise.type !== exerciseType.PROGRAMMING"
         [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, exercise.type + '-exercises', exercise.id, 'example-submissions']"
         class="btn btn-success btn-sm me-1"
     >
@@ -64,7 +64,7 @@
     </a>
 
     <!-- The route expects a preferred participationId. As we only have Exercises and not ProgrammingExercises with
-    participations, we pass a hardcoded number. The code editor component will load the proper ProgrammingExercise, choose
+    participation, we pass a hardcoded number. The code editor component will load the proper ProgrammingExercise, choose
     a participation and update the url displayed in the browser -->
     <a
         *ngIf="course.isAtLeastEditor && exercise.type === exerciseType.PROGRAMMING"
@@ -77,7 +77,7 @@
 
     <a
         *ngIf="course.isAtLeastEditor && exercise.type === exerciseType.QUIZ"
-        [routerLink]="['/course-management', course.id, 'quiz-exercises', exercise.id, 'preview']"
+        [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, 'quiz-exercises', exercise.id, 'preview']"
         class="btn btn-success btn-sm me-1"
     >
         <fa-icon [icon]="'eye'"></fa-icon>
@@ -86,7 +86,7 @@
 
     <a
         *ngIf="course.isAtLeastEditor && exercise.type === exerciseType.QUIZ"
-        [routerLink]="['/course-management', course.id, 'quiz-exercises', exercise.id, 'solution']"
+        [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, 'quiz-exercises', exercise.id, 'solution']"
         class="btn btn-success btn-sm me-1"
     >
         <fa-icon [icon]="'eye'"></fa-icon>
@@ -103,7 +103,7 @@
         <!-- Only show the re-evaluate button after the exam has ended -->
         <a
             *ngIf="isExamOver() && course.isAtLeastInstructor"
-            [routerLink]="['/course-management', course.id, 'quiz-exercises', exercise.id, 're-evaluate']"
+            [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, 'quiz-exercises', exercise.id, 're-evaluate']"
             class="btn btn-warning btn-sm me-1"
         >
             <fa-icon [icon]="'wrench'"></fa-icon>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [ ] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] Client: I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #3316 

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
