### PR TITLE
fix overflowing text in drag and drop quizzes

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.scss
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.scss
@@ -133,7 +133,6 @@
 
                             span {
                                 border: none;
-                                padding: 0;
                                 vertical-align: middle;
                                 display: inline-block;
                                 font-size: 1rem;

--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.scss
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.scss
@@ -136,7 +136,7 @@
                                 padding: 0;
                                 vertical-align: middle;
                                 display: inline-block;
-                                white-space: nowrap;
+                                font-size: 1rem;
                             }
                         }
                     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

before | after
--- | ---
![Screenshot_20210713_113357](https://user-images.githubusercontent.com/44805696/125429206-79b5e978-251e-4ae5-9666-398a35644d5b.png) | ![Screenshot_20210713_113306](https://user-images.githubusercontent.com/44805696/125429218-9ea4fb21-d649-4861-8817-ff7c399e7c43.png)
![image](https://user-images.githubusercontent.com/44805696/125431372-0f9f4e07-ef5f-4d33-b4b8-98aeb9cac766.png) | ![image](https://user-images.githubusercontent.com/44805696/125431280-bf777b16-3831-450c-9378-9e968390fd87.png) 


### Description
<!-- Describe your changes in detail -->
I removed the `white-space: nowrap` property so the text remains visible and added a fixed font size of 1rem (this ensures that visually impaired users can see the text based on their device settings).
The text can potentially overflow; effectively enlarging the drop area but that seems reasonable to me.
Also `padding:0` caused some clipping

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a drag and drop quiz and try different arrangements of large and small texts on differently sized drop areas and make sure they are always readable.

### Test Coverage
unchanged

