### PR TITLE
[Bugfix] Buttons not displayed on programming exercise detail view

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -74,6 +74,11 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
             this.programmingExercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorForExercise(this.programmingExercise);
 
             this.programmingExerciseService.findWithTemplateAndSolutionParticipation(programmingExercise.id!, true).subscribe((updatedProgrammingExercise) => {
+                // copying access rights from old exercise to updated exercise since they set to false by default
+                updatedProgrammingExercise.body!.isAtLeastTutor = this.programmingExercise.isAtLeastTutor;
+                updatedProgrammingExercise.body!.isAtLeastEditor = this.programmingExercise.isAtLeastEditor;
+                updatedProgrammingExercise.body!.isAtLeastInstructor = this.programmingExercise.isAtLeastInstructor;
+
                 // TODO: the feedback would be missing here, is that a problem?
                 this.programmingExercise = updatedProgrammingExercise.body!;
                 // get the latest results for further processing


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] Client: I documented the TypeScript code using JSDoc style.
- [ ] Client: I added multiple screenshots/screencasts of my UI changes

### Description
<!-- Describe your changes in detail -->
The buttons were not displayed anymore for programming exercises.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a programming exercise
2. Navigate as editor/instructor to the exercise detail view
3. Verify that all buttons are displayed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
