### PR TITLE
[Enhancement] Add result information to exam summary page

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -21,7 +21,10 @@
 <div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam">
     <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam" [courseId]="courseId"></jhi-exam-points-summary>
 </div>
-<h4 class="mb-0">{{ 'artemisApp.exam.exercises' | artemisTranslate }}</h4>
+<div class="mb-0">
+    <fa-icon [icon]="'info-circle'" class="info-icon"></fa-icon>
+    {{ 'artemisApp.exam.resultInformation' | artemisTranslate }}
+</div>
 <div *ngFor="let exercise of studentExam.exercises; let i = index">
     <div class="question card">
         <div class="question-options card-header question-card-header">

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -21,7 +21,7 @@
 <div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam">
     <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam" [courseId]="courseId"></jhi-exam-points-summary>
 </div>
-<div class="mb-0">
+<div *ngIf="!resultsPublished" class="mb-0">
     <fa-icon [icon]="'info-circle'" class="info-icon"></fa-icon>
     {{ 'artemisApp.exam.resultInformation' | artemisTranslate }}
 </div>

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -38,6 +38,7 @@
             "date": "Datum",
             "time": "Zeit",
             "durationWithFormat": "Dauer (mm:ss)",
+            "resultInformation": "Dein Ergebnis wird nach Abschluss der Korrektur an dieser Stelle für dich veröffentlicht. Du kommst zu dieser Seite, indem du in der Klausuren Übersicht des Kurses auf diese Klausur klickst.",
             "course": "Kurs",
             "exercises": "Aufgaben",
             "points": "Punkte",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -38,6 +38,7 @@
             "date": "Date",
             "time": "Time",
             "durationWithFormat": "Duration (mm:ss)",
+            "resultInformation": "Your result will be published here as soon as the correction is finished. You can get to this page by clicking on this exam in the exam overview of this course.",
             "course": "Course",
             "exercises": "Exercises",
             "points": "Points",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test 
- [x] Client: I translated all newly inserted strings into English and German.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Addresses the improvement suggestion made during exam testing session.

### Description
<!-- Describe your changes in detail -->
We add a short disclaimer on top of the exam summary page to indicate, that this page will also be the place where the exam results will be published after the correction is finished.
I added this statement and introduced the required translation strings. The statement will only be visible before the results were published.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. As instructor: Navigate to Course Administration
3. As instructor: Create a simple exam (we not already done and reusable)
- Choose start time soon (e.g. during the next 10 mins)
- Choose end time a bit later (e.g. 5 mins later, so that you can participate and hand in)
- Choose result publication time a bit later
- Create one exercise group with one exercise is enough
- Register one student
4. As student: Participate as that student and hand in anything
5. As student: Observe the exam summary page after having submitted: Read the inserted statement regarding the result and check if that is, what you would expect as student.
6. As student: wait for the results to be published (should have been set to some minutes after exercise due date). Reload the page after that time has passed and check if the information is gone and results are shown instead. 

Is the text I chose understandable and precise?

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Old view before result publication-> redundant title "Exercise":**
<img width="1308" alt="Bildschirmfoto 2021-07-13 um 12 57 25" src="https://user-images.githubusercontent.com/41366522/125440433-8eab004a-adb2-4105-8104-67ff73d7534b.png">



**New view before result publication -> information on exam results:**
<img width="1312" alt="Bildschirmfoto 2021-07-13 um 12 55 57" src="https://user-images.githubusercontent.com/41366522/125440322-50d8d700-2164-4587-b205-fc5b27a9730a.png">


**New view after result publication -> no information on exam results:**
<img width="1318" alt="Bildschirmfoto 2021-07-13 um 13 13 55" src="https://user-images.githubusercontent.com/41366522/125442675-b0b7689b-cacf-4516-8f1b-2664266d7fd4.png">

