### PR TITLE
[Bugfix] Avoid 403 error in exam summary page

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -35,7 +35,7 @@ export class ExamPointsSummaryComponent implements OnInit {
     ) {}
 
     ngOnInit() {
-        if (this.exam.publishResultsDate && moment(this.exam.publishResultsDate).isBefore(this.serverDateService.now())) {
+        if (this.exam && this.exam.publishResultsDate && moment(this.exam.publishResultsDate).isBefore(this.serverDateService.now())) {
             this.calculateExamGrade();
         }
     }

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -35,7 +35,9 @@ export class ExamPointsSummaryComponent implements OnInit {
     ) {}
 
     ngOnInit() {
-        this.calculateExamGrade();
+        if (this.exam.publishResultsDate && moment(this.exam.publishResultsDate).isBefore(this.serverDateService.now())) {
+            this.calculateExamGrade();
+        }
     }
 
     /**
@@ -57,7 +59,7 @@ export class ExamPointsSummaryComponent implements OnInit {
             .matchPercentageToGradeStepForExam(this.courseId, this.exam!.id!, achievedPointsRelative)
             .pipe(
                 catchError((error: HttpErrorResponse) => {
-                    if (error.status === 404) {
+                    if (error.status === 404 || error.status === 403) {
                         return of(undefined);
                     }
                     return throwError(error);

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -59,7 +59,7 @@ export class ExamPointsSummaryComponent implements OnInit {
             .matchPercentageToGradeStepForExam(this.courseId, this.exam!.id!, achievedPointsRelative)
             .pipe(
                 catchError((error: HttpErrorResponse) => {
-                    if (error.status === 404 || error.status === 403) {
+                    if (error.status === 404) {
                         return of(undefined);
                     }
                     return throwError(error);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In the exam participation summary page, in the console a 403 error appears, when it is before the results release date and there is a grading scale.
![image](https://user-images.githubusercontent.com/33342534/125445338-15e8eed5-5af3-4d95-af85-665a35bb6b76.png)

### Description
<!-- Describe your changes in detail -->
This PR fixes this by only making the grade steps call to the server when when the result release date is over. In this way there is no 403 error anymore.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create an exam with one exercise
2. Set the exam visibility, start, end and release date for the results.
3. Create a grade-key
4. Participate with a student, after handing in the exam and seeing the exam summary page, there should be no 403 error anymore.