### PR TITLE
[Enhancement] Exam End Alert

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -325,6 +325,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
             .subscribe(
                 (studentExam: StudentExam) => {
                     this.studentExam = studentExam;
+                    this.alertService.addAlert({ type: 'success', msg: 'studentExam.submitSuccessful', timeout: 20000 }, []);
                 },
                 (error: Error) => {
                     // Explicitly check whether the error was caused by the submission not being in-time or already present, in this case, set hand in not possible

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -21,6 +21,7 @@
 <div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam">
     <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam" [courseId]="courseId"></jhi-exam-points-summary>
 </div>
+<jhi-alert></jhi-alert>
 <h4 class="mb-0">{{ 'artemisApp.exam.exercises' | artemisTranslate }}</h4>
 <div *ngFor="let exercise of studentExam.exercises; let i = index">
     <div class="question card">

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -21,7 +21,6 @@
 <div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam">
     <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam" [courseId]="courseId"></jhi-exam-points-summary>
 </div>
-<jhi-alert></jhi-alert>
 <h4 class="mb-0">{{ 'artemisApp.exam.exercises' | artemisTranslate }}</h4>
 <div *ngFor="let exercise of studentExam.exercises; let i = index">
     <div class="question card">

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -441,6 +441,7 @@
         }
     },
     "studentExam": {
+        "submitSuccessful": "Deine Klausur wurde erfolgreich abgegeben. Artemis erfordert keine weitere Aktion, das Fenster kann geschlossen werden. Halte dich an die Klausuranweisungen deiner Lehrenden.",
         "alreadySubmitted": "Du hast bereits abgegeben.",
         "submissionNotInTime": "Du hast die Klausur nicht rechtzeitig abgegeben. Sie wird nicht bewertet!",
         "handInFailed": "Die Abgabe der Klausur ist fehlgeschlagen. Bitte versuche es erneut!"

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -442,6 +442,7 @@
         }
     },
     "studentExam": {
+        "submitSuccessful": "Your exam was submitted successfully. Artemis does not require further action, the window can be closed. Be sure to follow your instructor's exam protocol.",
         "alreadySubmitted": "You have already submitted.",
         "submissionNotInTime": "You have not submitted your exam on time. It will not be graded!",
         "handInFailed": "Submission of your exam failed. Please try again!"


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I translated all newly inserted strings into English and German.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

### Motivation and Context
The end screen of an exam does currently not feature any information that the exam is done now so students might not be sufficiently sure whether it is save to close the browser window.

### Description
Upon successfully submitting the exam, an alert is shown to inform the student that the exam is finished and they can close their browser window.

### Steps for Testing

1. Log in to Artemis
2. Participate in an exam
   - Hand in early
   - Hand in regularly
   - Hand in with disconnected internet
   - Hand in under any other unusal circumstances
3. The alert should show if and only if the exam was saved correctly
4. Review the wording of the message

### Test Coverage
Unchanged

### Screenshots
![grafik](https://user-images.githubusercontent.com/61357727/125465027-f9937a79-6edd-438c-bcd1-4656fc9dfd93.png)
