### PR TITLE
Fix the grading link for exam programming exercises

### DIFF
--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
@@ -153,7 +153,7 @@
                     ><fa-icon [icon]="'book'"></fa-icon
                 ></a>
                 <a
-                    *ngIf="course.isAtLeastInstructor && details.type === exerciseType.PROGRAMMING"
+                    *ngIf="course.isAtLeastEditor && details.type === exerciseType.PROGRAMMING"
                     [routerLink]="['/course-management', course.id, 'programming-exercises', details.id, 'grading', 'test-cases']"
                     class="btn btn-info me-1 mb-1"
                     [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.shortTitle' | artemisTranslate"

--- a/src/main/webapp/app/exam/manage/exam-management.route.ts
+++ b/src/main/webapp/app/exam/manage/exam-management.route.ts
@@ -55,6 +55,7 @@ import { GradingSystemComponent } from 'app/grading-system/grading-system.compon
 import { ExampleSubmissionsComponent } from 'app/exercises/shared/example-submission/example-submissions.component';
 import { GradingKeyOverviewComponent } from 'app/grading-system/grading-key-overview/grading-key-overview.component';
 import { ExerciseStatisticsComponent } from 'app/exercises/shared/statistics/exercise-statistics.component';
+import { ProgrammingExerciseConfigureGradingComponent } from 'app/exercises/programming/manage/grading/programming-exercise-configure-grading.component';
 
 @Injectable({ providedIn: 'root' })
 export class ExamResolve implements Resolve<Exam> {
@@ -585,6 +586,15 @@ export const examManagementRoute: Routes = [
         data: {
             authorities: [Authority.TA, Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
             pageTitle: 'artemisApp.plagiarism.plagiarism-detection',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
+        path: ':examId/exercise-groups/:exerciseGroupId/programming-exercises/:exerciseId/grading/:tab',
+        component: ProgrammingExerciseConfigureGradingComponent,
+        data: {
+            authorities: [Authority.EDITOR, Authority.INSTRUCTOR, Authority.ADMIN],
+            pageTitle: 'artemisApp.programmingExercise.home.title',
         },
         canActivate: [UserRouteAccessService],
     },

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -9,7 +9,7 @@
     </a>
 
     <a
-        *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.PROGRAMMING"
+        *ngIf="course.isAtLeastEditor && exercise.type === exerciseType.PROGRAMMING"
         [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, 'programming-exercises', exercise.id, 'grading', 'test-cases']"
         class="btn btn-info btn-sm me-1"
     >

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -10,7 +10,7 @@
 
     <a
         *ngIf="course.isAtLeastInstructor && exercise.type === exerciseType.PROGRAMMING"
-        [routerLink]="['/course-management', course.id, 'programming-exercises', exercise.id, 'grading', 'test-cases']"
+        [routerLink]="['/course-management', course.id, 'exams', exam.id, 'exercise-groups', exerciseGroupId, 'programming-exercises', exercise.id, 'grading', 'test-cases']"
         class="btn btn-info btn-sm me-1"
     >
         <fa-icon [icon]="'file-signature'"></fa-icon>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
Closes #3693.

### Description

When clicking on "Grading" of an exam programming exercise you now get redirected to a grading page inside the exam, so that you can still use breadcrumbs properly.

### Steps for Testing

1. Create or find an exam with a programming exercise
2. Open the grading page and make sure it works as for course exercises
3. Make sure the breadcrumbs are correct and that you can navigate back to exercise groups or exams for example

Example testcase: https://artemistest2.ase.in.tum.de/course-management/1915/exams/103/exercise-groups