### PR TITLE
Add a right margin to the "Not Released" tag in the exercises list

### DIFF
--- a/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
+++ b/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
@@ -44,7 +44,7 @@
             ></jhi-exercise-details-student-actions>
             <div class="exercise-tags col-auto col-sm d-flex justify-content-center mt-2">
                 <h4>
-                    <jhi-not-released-tag [exercise]="exercise"></jhi-not-released-tag>
+                    <jhi-not-released-tag class="me-1" [exercise]="exercise"></jhi-not-released-tag>
                 </h4>
                 <h4 *ngIf="!isPresentationMode">
                     <span class="badge bg-success me-1" [hidden]="!asQuizExercise(exercise).isActiveQuiz">{{


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Before:
![grafik](https://user-images.githubusercontent.com/72132281/125499147-83be7cac-8b27-4814-b43d-0553540f80c9.png)
After:
![grafik](https://user-images.githubusercontent.com/72132281/125499161-731f3200-b646-4bed-b323-605098355f51.png)

### Description

We add a right margin ("margin-end" => me)

### Steps for Testing

1. Create a quiz exercise with categories and a difficulty
2. Set the start date in the future (but don't set it visible yet)
3. View the course's exercises (student perspective) with an instructor

Also check if it still looks correct when the exercise is released:
![grafik](https://user-images.githubusercontent.com/72132281/125499487-91c37fb6-6394-4b7e-bdd7-818aee25474d.png)
![grafik](https://user-images.githubusercontent.com/72132281/125499752-9cb1aecf-12e3-4b97-8629-7738d4166f5c.png)

