### PR TITLE
Adjust the width of the course card title in the students view

### DIFF
--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -6,7 +6,7 @@
                 <div class="col-2 header-col image-col">
                     <jhi-secured-image *ngIf="course.courseIcon" [cachingStrategy]="CachingStrategy.LOCAL_STORAGE" [src]="course.courseIcon"></jhi-secured-image>
                 </div>
-                <div class="col-8 header-col title-col">
+                <div class="col-7 header-col title-col">
                     <h5 class="card-title text-center">
                         {{ course.title }}
                     </h5>


### PR DESCRIPTION
### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Before:
![grafik](https://user-images.githubusercontent.com/72132281/125500418-e02242cf-0881-4c45-9e60-1a5ef510ce64.png)
After:
![grafik](https://user-images.githubusercontent.com/72132281/125500427-5d3c6c8d-7803-4685-9b86-febbab6a2b55.png)

### Description

The webpack update css changes seem to have regressed this, so we reduce the width the title can take. That way it no longer overflows into the dates.

### Steps for Testing

1. Go to the students view for courses
2. Resize the screen and make sure the title doesn't overlap at different sizes
