### PR TITLE
[Bugfix] Fix notification with title "null" for Metis related notifications

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/AnswerPostService.java
@@ -3,12 +3,15 @@ package de.tum.in.www1.artemis.service.metis;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.domain.Course;
+import de.tum.in.www1.artemis.domain.Exercise;
+import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.metis.AnswerPost;
 import de.tum.in.www1.artemis.domain.metis.Post;
 import de.tum.in.www1.artemis.domain.metis.Reaction;
 import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
+import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.metis.AnswerPostRepository;
 import de.tum.in.www1.artemis.repository.metis.PostRepository;
@@ -28,17 +31,20 @@ public class AnswerPostService extends PostingService {
 
     private final PostRepository postRepository;
 
+    private final LectureRepository lectureRepository;
+
     private final GroupNotificationService groupNotificationService;
 
     private final SingleUserNotificationService singleUserNotificationService;
 
     protected AnswerPostService(CourseRepository courseRepository, AuthorizationCheckService authorizationCheckService, UserRepository userRepository,
-            AnswerPostRepository answerPostRepository, PostRepository postRepository, ExerciseRepository exerciseRepository, GroupNotificationService groupNotificationService,
-            SingleUserNotificationService singleUserNotificationService) {
+            AnswerPostRepository answerPostRepository, PostRepository postRepository, ExerciseRepository exerciseRepository, LectureRepository lectureRepository,
+            GroupNotificationService groupNotificationService, SingleUserNotificationService singleUserNotificationService) {
         super(courseRepository, exerciseRepository, postRepository, authorizationCheckService);
         this.userRepository = userRepository;
         this.answerPostRepository = answerPostRepository;
         this.postRepository = postRepository;
+        this.lectureRepository = lectureRepository;
         this.groupNotificationService = groupNotificationService;
         this.singleUserNotificationService = singleUserNotificationService;
     }
@@ -153,6 +159,11 @@ public class AnswerPostService extends PostingService {
     void sendNotification(AnswerPost answerPost) {
         // notify via exercise
         if (answerPost.getPost().getExercise() != null) {
+            Post post = answerPost.getPost();
+            // set exercise retrieved from database to show title in notification
+            Exercise exercise = exerciseRepository.findByIdElseThrow(post.getExercise().getId());
+            post.setExercise(exercise);
+            answerPost.setPost(post);
             groupNotificationService.notifyTutorAndEditorAndInstructorGroupAboutNewAnswerForExercise(answerPost);
             singleUserNotificationService.notifyUserAboutNewAnswerForExercise(answerPost);
 
@@ -161,6 +172,11 @@ public class AnswerPostService extends PostingService {
         }
         // notify via lecture
         if (answerPost.getPost().getLecture() != null) {
+            Post post = answerPost.getPost();
+            // set lecture retrieved from database to show title in notification
+            Lecture lecture = lectureRepository.findByIdElseThrow(post.getLecture().getId());
+            post.setLecture(lecture);
+            answerPost.setPost(post);
             groupNotificationService.notifyTutorAndEditorAndInstructorGroupAboutNewAnswerForLecture(answerPost);
             singleUserNotificationService.notifyUserAboutNewAnswerForLecture(answerPost);
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
@@ -283,12 +283,18 @@ public class PostService extends PostingService {
     void sendNotification(Post post) {
         // notify via exercise
         if (post.getExercise() != null) {
+            // set exercise retrieved from database to show title in notification
+            Exercise exercise = exerciseRepository.findByIdElseThrow(post.getExercise().getId());
+            post.setExercise(exercise);
             groupNotificationService.notifyTutorAndEditorAndInstructorGroupAboutNewPostForExercise(post);
             // protect sample solution, grading instructions, etc.
             post.getExercise().filterSensitiveInformation();
         }
         // notify via lecture
         if (post.getLecture() != null) {
+            // set lecture retrieved from database to show title in notification
+            Lecture lecture = lectureRepository.findByIdElseThrow(post.getLecture().getId());
+            post.setLecture(lecture);
             groupNotificationService.notifyTutorAndEditorAndInstructorGroupAboutNewPostForLecture(post);
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) locally

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The payloads for `Post` and `AnswerPost` were reduced in #3703. For nested `Lecture`s and `Exercise` all fields other than id were set to null. But these parts  of `Post` and `AnswerPost` were used to create the notification text, the title was "null" for metis related notifications.

### Description
<!-- Describe your changes in detail -->
Retrieve the objects `Lecture` and `Exercise` in  `Post` and `AnswerPost` from DB before creating the notifications.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate a course
3. Create posts and answer posts for exercises AND lectures
4. Observe the notifications -> check if the title for exercises and lectures is set correctly and not to "null"

Before:
![image](https://user-images.githubusercontent.com/41366522/125527911-ea9cbb97-ff0d-438b-99b0-90b258ba8caa.png)

After fixing and testing:
<img width="292" alt="Bildschirmfoto 2021-07-13 um 23 30 43" src="https://user-images.githubusercontent.com/41366522/125527888-e2df2e77-d03f-4e05-8c0d-a1d6e8cd06f1.png">


