### PR TITLE
[Enhancement] Making exam navigation bar buttons consistent 

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
@@ -11,13 +11,13 @@
     <div class="col">
         <div class="d-flex justify-content-center">
             <!-- exam overview item -->
-            <div class="navigation-item">
-                <button class="btn w-100 synced overview" [ngClass]="getOverviewStatus()" [ngbTooltip]="'Exam Exercise Overview'" (click)="changePage(true, -1)">
+            <div class="navigation-item overview">
+                <button class="btn w-100 synced" [ngClass]="getOverviewStatus()" [ngbTooltip]="'Exam Exercise Overview'" (click)="changePage(true, -1)">
                     <fa-icon [icon]="'bars'"></fa-icon>
                 </button>
             </div>
             <div class="navigation-item">
-                <button *ngIf="!overviewPageOpen && exerciseIndex !== 0" class="btn btn-secondary w-100" (click)="changePage(false, exerciseIndex - 1, false)">
+                <button class="btn btn-secondary w-100" (click)="changePage(false, exerciseIndex - 1, false)">
                     <span aria-hidden="true">&laquo;</span>
                     <span class="sr-only">Previous</span>
                 </button>

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.html
@@ -17,7 +17,7 @@
                 </button>
             </div>
             <div class="navigation-item">
-                <button class="btn btn-secondary w-100" (click)="changePage(false, exerciseIndex - 1, false)">
+                <button class="btn btn-secondary w-100" (click)="changePage(false, exerciseIndex - 1, false)" [disabled]="exerciseIndex <= 0">
                     <span aria-hidden="true">&laquo;</span>
                     <span class="sr-only">Previous</span>
                 </button>
@@ -45,7 +45,11 @@
                 </div>
             </ng-container>
             <div class="navigation-item">
-                <button class="btn btn-secondary w-100" (click)="changePage(false, overviewPageOpen ? 0 : exerciseIndex + 1, false)">
+                <button
+                    class="btn btn-secondary w-100"
+                    (click)="changePage(false, overviewPageOpen ? 0 : exerciseIndex + 1, false)"
+                    [disabled]="exerciseIndex >= exercises.length - 1 || exerciseIndex < 0"
+                >
                     <span aria-hidden="true">&raquo;</span>
                     <span class="sr-only">Next</span>
                 </button>

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -57,12 +57,8 @@ export class ExamNavigationBarComponent implements OnInit {
      * @param exerciseIndex: index of the exercise to switch to, if it should not be used, you can pass -1
      * @param forceSave: true if forceSave shall be used.
      */
-    changePage(overviewPage: boolean, exerciseIndex: number, forceSave?: boolean) {
+    changePage(overviewPage: boolean, exerciseIndex: number, forceSave?: boolean): void {
         if (!overviewPage) {
-            // out of index -> do nothing
-            if (exerciseIndex > this.exercises.length - 1 || exerciseIndex < 0) {
-                return;
-            }
             // set index and emit event
             this.exerciseIndex = exerciseIndex;
             this.onPageChanged.emit({ overViewChange: false, exercise: this.exercises[this.exerciseIndex], forceSave: !!forceSave });


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The right and left navigation buttons of the exam navigation bar were not always displayed. If the leftmost exercise (or first exercise) is displayed, the navigate to the left button disappears. However, the navigate to the right button does not disappear when the rightmost (or last element) is displayed.
No matter which one is the preferred way, the behavior should be consistent.
![NavigationBarButtonsInconsistent](https://user-images.githubusercontent.com/63976129/125540046-a17e6e8d-c7cc-43e2-9ca5-58fb106096f4.gif)


### Description
<!-- Describe your changes in detail -->
I think that the UI is more intuitive if the buttons are always displayed. The exercises are enumerated, so it should be clear that going further to the left does not change the displayed exercise if the leftmost exercise is chosen. I am aware that this is a matter of taste, so feel free to criticize this decision!

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Create an exam exercise with multiple exercises (the exercise type shouldn't matter)
2. Check that the navigation bar and its buttons are displayed properly
3. Check that their functionality is given

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Consistent behavior with always displayed buttons, which are now disabled when leftmost / rightmost element or the overview is selected.
![buttonsNowConsistentAndDisabled](https://user-images.githubusercontent.com/63976129/125614082-a8446bd3-ae3d-47f6-b2b3-e272588d55a1.gif)


