### PR TITLE
[Bugfix] Fix "exercise-type-icon-tooptip-flickering" and several misalignments and style issue on lecture page

### DIFF
--- a/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
+++ b/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
@@ -1,14 +1,7 @@
 <div class="course-exercise-row row align-items-center mb-2 mt-2" (click)="showDetails($event)" [class.guided-tour]="hasGuidedTour">
     <div class="col-auto d-none d-sm-block">
         <div class="exercise-row-icon">
-            <fa-icon
-                *ngIf="exercise.type"
-                [icon]="getIcon(exercise.type)"
-                size="2x"
-                placement="right"
-                [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate"
-                container="body"
-            ></fa-icon>
+            <fa-icon *ngIf="exercise.type" [icon]="getIcon(exercise.type)" size="2x" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate" container="body"></fa-icon>
         </div>
     </div>
     <div class="col">

--- a/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.html
@@ -1,17 +1,18 @@
 <div class="row align-items-center mb-2 mt-2">
     <div class="card unit-card">
-        <h5 class="card-header unit-card-header" [class.rounded]="isCollapsed" (click)="handleCollapse($event)">
-            <fa-icon class="me-2" [icon]="getAttachmentIcon()" [ngbTooltip]="'artemisApp.attachmentUnit.tooltip' | artemisTranslate"></fa-icon>
-            {{ attachmentUnit?.attachment?.name ? attachmentUnit?.attachment?.name : '' }}
-            <span
-                *ngIf="!attachmentUnit?.visibleToStudents"
-                class="badge bg-warning ms-2"
-                placement="right"
-                ngbTooltip="{{ 'artemisApp.attachmentUnit.notReleasedTooltip' | artemisTranslate }} {{ attachmentUnit?.attachment?.releaseDate | artemisDate }}"
-            >
-                {{ 'artemisApp.courseOverview.exerciseList.notReleased' | artemisTranslate }}</span
-            >
-        </h5>
+        <div class="card-header unit-card-header row align-content-center" (click)="handleCollapse($event)">
+            <h5 class="m-0">
+                <fa-icon class="me-2" [icon]="getAttachmentIcon()" [ngbTooltip]="'artemisApp.attachmentUnit.tooltip' | artemisTranslate"> </fa-icon>
+                {{ attachmentUnit?.attachment?.name ? attachmentUnit?.attachment?.name : '' }}
+                <span
+                    *ngIf="!attachmentUnit?.visibleToStudents"
+                    class="badge bg-warning ms-2"
+                    ngbTooltip="{{ 'artemisApp.attachmentUnit.notReleasedTooltip' | artemisTranslate }} {{ attachmentUnit?.attachment?.releaseDate | artemisDate }}"
+                >
+                    {{ 'artemisApp.courseOverview.exerciseList.notReleased' | artemisTranslate }}
+                </span>
+            </h5>
+        </div>
         <div class="card-body unit-card-body" [ngbCollapse]="isCollapsed">
             <div *ngIf="attachmentUnit?.attachment?.uploadDate">
                 <span class="font-weight-bold"> {{ 'artemisApp.attachmentUnit.uploadDate' | artemisTranslate }}: </span>

--- a/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
@@ -33,7 +33,7 @@
                 </div>
             </div>
             <div class="row mb-2 markdown-preview" *ngIf="lecture!.description">
-                <div class="col-12 col-md-12 markdown-preview editor-outline-background" [innerHTML]="lecture.description | htmlForMarkdown"></div>
+                <div class="col-12 col-md-12 markdown-preview" [innerHTML]="lecture.description | htmlForMarkdown"></div>
             </div>
             <!-- LECTURE UNITS START-->
             <div class="row mb-2 mt-2 align-items-baseline" *ngIf="lecture!.lectureUnits">
@@ -44,7 +44,7 @@
                     {{ 'artemisApp.courseOverview.lectureDetails.downloadPdf' | artemisTranslate }}
                 </button>
             </div>
-            <div class="row mb-4" *ngFor="let lectureUnit of lectureUnits">
+            <div class="row m-0" *ngFor="let lectureUnit of lectureUnits">
                 <div class="col-11" [ngSwitch]="lectureUnit.type">
                     <jhi-exercise-unit *ngSwitchCase="LectureUnitType.EXERCISE" [exerciseUnit]="lectureUnit" [course]="lecture!.course!"></jhi-exercise-unit>
                     <jhi-attachment-unit *ngSwitchCase="LectureUnitType.ATTACHMENT" [attachmentUnit]="lectureUnit"></jhi-attachment-unit>
@@ -66,7 +66,7 @@
                     <h3>{{ 'artemisApp.courseOverview.lectureDetails.attachments' | artemisTranslate }}</h3>
                 </div>
             </div>
-            <div class="row mb-2" *ngIf="lecture!.attachments">
+            <div class="mb-2" *ngIf="lecture!.attachments">
                 <ul>
                     <li class="mb-3" *ngFor="let attachment of lecture!.attachments">
                         <h5 class="mb-1">
@@ -92,6 +92,8 @@
             </div>
         </div>
         <!-- LECTURE END -->
-        <router-outlet *ngIf="lecture && lecture.course?.postsEnabled" class="ms-3" (activate)="onChildActivate($event)"></router-outlet>
+        <div class="col d-flex flex-grow-1 justify-end px-0" style="max-width: min-content">
+            <router-outlet *ngIf="lecture && lecture.course?.postsEnabled" class="ms-3" (activate)="onChildActivate($event)"></router-outlet>
+        </div>
     </div>
 </div>

--- a/src/main/webapp/app/overview/course-lectures/text-unit/text-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/text-unit/text-unit.component.html
@@ -1,29 +1,26 @@
 <div class="row align-items-center mb-2 mt-2">
     <div class="card unit-card">
-        <div class="unit-card-header card-header container" [class.rounded]="isCollapsed" (click)="handleCollapse($event)">
-            <div class="row">
-                <div class="col-10">
-                    <h5 class="card-title my-auto">
-                        <fa-icon class="me-2" [icon]="'scroll'" [ngbTooltip]="'artemisApp.textUnit.tooltip' | artemisTranslate"></fa-icon>
-                        {{ textUnit?.name ? textUnit.name : '' }}
-                        <span
-                            *ngIf="!textUnit?.visibleToStudents"
-                            class="badge bg-warning"
-                            placement="right"
-                            ngbTooltip="{{ 'artemisApp.textUnit.notReleasedTooltip' | artemisTranslate }} {{ textUnit?.releaseDate | artemisDate }}"
-                        >
-                            {{ 'artemisApp.courseOverview.exerciseList.notReleased' | artemisTranslate }}</span
-                        >
-                    </h5>
-                </div>
-                <div class="col-2 btn-group flex-btn-group-container">
-                    <button id="popupButton" type="button" style="max-height: 40px" class="btn btn-sm btn-primary rounded-pill" (click)="openPopup($event)">
-                        <fa-icon [icon]="'external-link-alt'"></fa-icon>
-                        <span class="d-none d-md-inline" jhiTranslate="artemisApp.textUnit.isolated">View in Popup</span>
-                    </button>
-                </div>
+        <div class="unit-card-header card-header row align-content-center justify-content-between" (click)="handleCollapse($event)">
+            <div class="col-auto row align-content-center">
+                <h5 class="m-0">
+                    <fa-icon class="me-2" [icon]="'scroll'" [ngbTooltip]="'artemisApp.textUnit.tooltip' | artemisTranslate"> </fa-icon>
+                    {{ textUnit?.name ? textUnit.name : '' }}
+                    <span
+                        *ngIf="!textUnit?.visibleToStudents"
+                        class="badge bg-warning ms-2"
+                        ngbTooltip="{{ 'artemisApp.textUnit.notReleasedTooltip' | artemisTranslate }} {{ textUnit?.releaseDate | artemisDate }}"
+                    >
+                        {{ 'artemisApp.courseOverview.exerciseList.notReleased' | artemisTranslate }}
+                    </span>
+                </h5>
+            </div>
+            <div class="col-auto">
+                <button id="popupButton" type="button" style="max-height: 40px" class="btn btn-sm btn-primary rounded-pill" (click)="openPopup($event)">
+                    <fa-icon [icon]="'external-link-alt'"></fa-icon>
+                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.textUnit.isolated">View in Popup</span>
+                </button>
             </div>
         </div>
-        <div class="card-body markdown-preview unit-card-body" id="printContent" [ngbCollapse]="isCollapsed" [innerHtml]="formattedContent"></div>
+        <div class="card-body unit-card-body markdown-preview" id="printContent" [ngbCollapse]="isCollapsed" [innerHtml]="formattedContent"></div>
     </div>
 </div>

--- a/src/main/webapp/app/overview/course-lectures/video-unit/video-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/video-unit/video-unit.component.html
@@ -1,17 +1,18 @@
 <div class="row align-items-center mb-2 mt-2">
     <div class="card unit-card">
-        <h5 class="card-header unit-card-header" [class.rounded]="isCollapsed" (click)="handleCollapse($event)">
-            <fa-icon class="me-2" [icon]="'video'" [ngbTooltip]="'artemisApp.videoUnit.tooltip' | artemisTranslate"></fa-icon>
-            {{ videoUnit?.name ? videoUnit.name : '' }}
-            <span
-                *ngIf="!videoUnit?.visibleToStudents"
-                class="badge bg-warning ms-2"
-                placement="right"
-                ngbTooltip="{{ 'artemisApp.videoUnit.notReleasedTooltip' | artemisTranslate }} {{ videoUnit?.releaseDate | artemisDate }}"
-            >
-                {{ 'artemisApp.courseOverview.exerciseList.notReleased' | artemisTranslate }}</span
-            >
-        </h5>
+        <div class="card-header unit-card-header row align-content-center" (click)="handleCollapse($event)">
+            <h5 class="m-0">
+                <fa-icon class="col-auto me-2" [icon]="'video'" [ngbTooltip]="'artemisApp.videoUnit.tooltip' | artemisTranslate"> </fa-icon>
+                {{ videoUnit?.name ? videoUnit.name : '' }}
+                <span
+                    *ngIf="!videoUnit?.visibleToStudents"
+                    class="badge bg-warning ms-2"
+                    ngbTooltip="{{ 'artemisApp.videoUnit.notReleasedTooltip' | artemisTranslate }} {{ videoUnit?.releaseDate | artemisDate }}"
+                >
+                    {{ 'artemisApp.courseOverview.exerciseList.notReleased' | artemisTranslate }}
+                </span>
+            </h5>
+        </div>
         <div class="card-body unit-card-body" [ngbCollapse]="isCollapsed">
             <div class="embed-responsive embed-responsive-16by9">
                 <iframe id="videoFrame" class="embed-responsive-item rounded" [src]="videoUrl" allow="fullscreen"></iframe>

--- a/src/main/webapp/i18n/de/lectureUnit.json
+++ b/src/main/webapp/i18n/de/lectureUnit.json
@@ -22,7 +22,7 @@
         "textUnit": {
             "created": "Eine neue Texteinheit erstellt",
             "updated": "Texteinheit aktualisiert",
-            "tooltip": "Das ist eine Texteinheit.",
+            "tooltip": "Das ist eine Texteinheit",
             "isolated": "Isoliert öffnen",
             "notReleasedTooltip": "Text nur sichtbar für Tutor:innen und Lehrende. Veröffentlichungsdatum:",
             "markdownHelp": "Hier kann Markdown eingegeben werden. Mehr Informationen:",
@@ -47,7 +47,7 @@
         "videoUnit": {
             "created": "Eine neue Videoeinheit wurde erstellt",
             "updated": "Videoeinheit aktualisiert",
-            "tooltip": "Das ist eine Videoeinheit.",
+            "tooltip": "Das ist eine Videoeinheit",
             "description": "Beschreibung",
             "notReleasedTooltip": "Video nur sichtbar für Tutor:innen und Lehrende. Veröffentlichungsdatum:",
             "createVideoUnit": {
@@ -101,7 +101,7 @@
             "editAttachmentUnit": {
                 "title": "Bearbeite Dateieinheit"
             },
-            "tooltip": "Das ist eine Datei.",
+            "tooltip": "Das ist eine Datei",
             "uploadDate": "Upload Datum",
             "version": "Version",
             "FileName": "Dateiname",

--- a/src/main/webapp/i18n/en/lectureUnit.json
+++ b/src/main/webapp/i18n/en/lectureUnit.json
@@ -23,7 +23,7 @@
         "textUnit": {
             "created": "New text unit created",
             "updated": "Text unit updated",
-            "tooltip": "This is a text unit.",
+            "tooltip": "This is a text unit",
             "isolated": "View Isolated",
             "notReleasedTooltip": "Text only visible to teaching assistants and instructors. Release date:",
             "markdownHelp": "You can enter Markdown here. More information: ",
@@ -48,7 +48,7 @@
         "videoUnit": {
             "created": "A new video unit created",
             "updated": "Video unit updated",
-            "tooltip": "This is a video unit.",
+            "tooltip": "This is a video unit",
             "description": "Description",
             "notReleasedTooltip": "Video only visible to teaching assistants and instructors. Release date:",
             "createVideoUnit": {
@@ -102,7 +102,7 @@
             "editAttachmentUnit": {
                 "title": "Edit Attachment Unit"
             },
-            "tooltip": "This is an Attachment.",
+            "tooltip": "This is a lecture attachment",
             "uploadDate": "Upload Date",
             "version": "Version",
             "FileName": "Filename",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines.
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all newly inserted strings into English and German.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I recognized that the discussion section on lecture pages was misaligned and rather below than next to the lecture description/units.
When trying to fix this issue I stumbled upon several other issues which I fixed alongside.

### Description
<!-- Describe your changes in detail -->
- Fix sizes and alignment of lecture units
- Fix placement of discussion section
- Fix tooltips, that were flickering due to to the placement="right" attribute on the html tag
- **Note**: this also solves the problem of flickering icon tooltips on every occurence of `course-exercise-row` as shown in the video:

https://user-images.githubusercontent.com/41366522/125634966-f3cf6e2a-2838-4fc0-8bc3-46471ab520db.mov


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to a Lecture in the course overview -> chose (or create) a lecture that has all different types of lecture units
3. Collapse and uncollapse the lecture units
4. Change the screen size
5. Check the tooltips on the unit/exercise icon and "not released" badges.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
<img width="1439" alt="Bildschirmfoto 2021-07-14 um 14 43 45" src="https://user-images.githubusercontent.com/41366522/125633400-0ebf63fa-a5ac-4165-86f0-c2802f600108.png">

After:
<img width="1437" alt="Bildschirmfoto 2021-07-14 um 14 44 48" src="https://user-images.githubusercontent.com/41366522/125633465-682f57c6-9235-43b1-8aea-b771b4de5d16.png">