### PR TITLE
Reduce the right padding of the course info column

### DIFF
--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -6,7 +6,7 @@
                 <div class="col-2 header-col image-col">
                     <jhi-secured-image *ngIf="course.courseIcon" [cachingStrategy]="CachingStrategy.LOCAL_STORAGE" [src]="course.courseIcon"></jhi-secured-image>
                 </div>
-                <div class="col-7 header-col title-col">
+                <div class="col-7 header-col title-col px-3">
                     <h5 class="card-title text-center">
                         {{ course.title }}
                     </h5>

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -21,7 +21,6 @@
 
         .title-col {
             justify-content: center;
-            padding: 0 3px 0 3px;
         }
 
         .course-info-col {

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -21,6 +21,7 @@
 
         .title-col {
             justify-content: center;
+            padding: 0 3px 0 3px;
         }
 
         .course-info-col {

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -25,7 +25,7 @@
 
         .course-info-col {
             justify-content: flex-end;
-            padding-right: 3px;
+            padding-right: 0;
 
             .course-info-amounts {
                 display: flex;

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -25,6 +25,7 @@
 
         .course-info-col {
             justify-content: flex-end;
+            padding-right: 3px;
 
             .course-info-amounts {
                 display: flex;


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

To prevent issues like
![grafik](https://user-images.githubusercontent.com/72132281/125652014-6da0f0ca-8e03-4d37-b7df-1b38fbafe27b.png)
we want to reduce the right padding of the course info column (from the default 12px to 0) and add padding to the title itself.

### Description
Before:
![grafik](https://user-images.githubusercontent.com/72132281/125651808-36a9b34e-2821-4460-97e2-74888f427e14.png)

After:
![grafik](https://user-images.githubusercontent.com/72132281/125651776-e0a2b18a-2513-4dca-891e-ed1b0148d960.png)

### Steps for Testing

1. Look at the students course overview on different screensizes and make sure the title fits

