### PR TITLE
Show descriptive error message when submitting too long text submissions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextSubmissionResource.java
@@ -316,7 +316,7 @@ public class TextSubmissionResource {
      */
     private void checkTextLength(TextSubmission textSubmission) {
         if (textSubmission.getText() != null && textSubmission.getText().length() > 30000) {
-            throw new IllegalArgumentException("Text Submission cannot contain more than 30000 characters");
+            throw new BadRequestAlertException("Submission cannot contain more than 30000 characters", ENTITY_NAME, "textSubmissionTooLong");
         }
     }
 }

--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
@@ -239,7 +239,7 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
                     this.jhiAlertService.warning('entity.action.submitDeadlineMissedAlert');
                 }
             },
-            (err) => {
+            (err: HttpErrorResponse) => {
                 this.jhiAlertService.error(err.error.message);
                 this.isSaving = false;
             },

--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
@@ -239,8 +239,8 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
                     this.jhiAlertService.warning('entity.action.submitDeadlineMissedAlert');
                 }
             },
-            () => {
-                this.jhiAlertService.error('artemisApp.modelingEditor.error');
+            (err) => {
+                this.jhiAlertService.error(err.error.message);
                 this.isSaving = false;
             },
         );

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -34,6 +34,7 @@
         "feedbackCreditsNull": "Fehler! Wenn Feedback vorhanden ist, muss das Feedback eine Punktzahl haben.",
         "invalidGradeStepFormat": "Eine oder mehrere Notenstufen folgen nicht dem richtigen Format. Klicke auf das \"?\" für mehr Informationen.",
         "invalidGradeStepAdjacency": "Die Notenstufen bilden keinen gültigen Notenschlüssel ab. Klicke auf das \"?\" für mehr Informationen.",
-        "emptyGradeSteps": "Die Notenstufen dürfen nicht leer sein. Klicke auf das \"?\" für mehr Informationen."
+        "emptyGradeSteps": "Die Notenstufen dürfen nicht leer sein. Klicke auf das \"?\" für mehr Informationen.",
+        "textSubmissionTooLong": "Text Abgaben können höchstens 30000 Zeichen lang sein."
     }
 }

--- a/src/main/webapp/i18n/de/error.json
+++ b/src/main/webapp/i18n/de/error.json
@@ -35,6 +35,6 @@
         "invalidGradeStepFormat": "Eine oder mehrere Notenstufen folgen nicht dem richtigen Format. Klicke auf das \"?\" für mehr Informationen.",
         "invalidGradeStepAdjacency": "Die Notenstufen bilden keinen gültigen Notenschlüssel ab. Klicke auf das \"?\" für mehr Informationen.",
         "emptyGradeSteps": "Die Notenstufen dürfen nicht leer sein. Klicke auf das \"?\" für mehr Informationen.",
-        "textSubmissionTooLong": "Text Abgaben können höchstens 30000 Zeichen lang sein."
+        "textSubmissionTooLong": "Text Abgaben können höchstens 30.000 Zeichen lang sein."
     }
 }

--- a/src/main/webapp/i18n/en/error.json
+++ b/src/main/webapp/i18n/en/error.json
@@ -34,6 +34,7 @@
         "feedbackCreditsNull": "Error! If feedback is present, all elements must contain points.",
         "invalidGradeStepFormat": "One or more grade steps are not following the correct format. Click on the \"?\" for more information.",
         "invalidGradeStepAdjacency": "The grade steps don't map to a valid grading key. Click on the \"?\" for more information.",
-        "emptyGradeSteps": "Grade steps can't be empty. Click on the \"?\" for more information."
+        "emptyGradeSteps": "Grade steps can't be empty. Click on the \"?\" for more information.",
+        "textSubmissionTooLong": "Text submissions can not be longer than 30,000 characters."
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes
- [x] Client: I translated all newly inserted strings into English and German.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When submitting text exercises longer than 30,000 characters the error message didn't hint on what the issue was.

### Description
I changed the error to be a BadRequest error because it makes more sense than a 500. Also I made it throw an exception that shows it's message to the client.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Submit a long text submission to a text exercise (> 30,000 characters). (I copied this https://de.wikipedia.org/wiki/Metallocene)
2. observe that a message appears that sufficiently indicates what the issue is.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/44805696/125692369-7afefbf6-88d5-45c0-8d06-7d818464ea9f.png)
