### PR TITLE
[Bugfix] Error of no matching route when opening team assessement page for text exercise

### DIFF
--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
@@ -122,7 +122,7 @@
                         >
                             <button
                                 [disabled]="isAssessmentButtonDisabled(value, value.submission)"
-                                (click)="openAssessmentEditor(value, value.submission)"
+                                (click)="openAssessmentEditor(value, value.participation, value.submission)"
                                 class="btn btn-warning btn-sm"
                             >
                                 <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.ts
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.ts
@@ -14,6 +14,7 @@ import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service'
 import { AssessmentType } from 'app/entities/assessment-type.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { onError } from 'app/shared/util/global.utils';
+import { Participation } from 'app/entities/participation/participation.model';
 
 const currentExerciseRowClass = 'datatable-row-current-exercise';
 
@@ -119,9 +120,9 @@ export class TeamParticipationTableComponent implements OnInit {
      * @param exercise Exercise to which the submission belongs
      * @param submission Either submission or 'new'
      */
-    async openAssessmentEditor(exercise: Exercise, submission: Submission | 'new'): Promise<void> {
+    async openAssessmentEditor(exercise: Exercise, participation: Participation, submission: Submission | 'new'): Promise<void> {
         const submissionUrlParameter: number | 'new' = submission === 'new' ? 'new' : submission.id!;
-        const route = `/course-management/${this.course.id}/${exercise.type}-exercises/${exercise.id}/submissions/${submissionUrlParameter}/assessment`;
+        const route = `/course-management/${this.course.id}/${exercise.type}-exercises/${exercise.id}/participations/${participation.id}/submissions/${submissionUrlParameter}/assessment`;
         await this.router.navigate([route]);
     }
 

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.ts
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.ts
@@ -15,6 +15,7 @@ import { AssessmentType } from 'app/entities/assessment-type.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { onError } from 'app/shared/util/global.utils';
 import { Participation } from 'app/entities/participation/participation.model';
+import { getLinkToSubmissionAssessment } from 'app/utils/navigation.utils';
 
 const currentExerciseRowClass = 'datatable-row-current-exercise';
 
@@ -118,11 +119,12 @@ export class TeamParticipationTableComponent implements OnInit {
     /**
      * Uses the router to navigate to the assessment editor for a given/new submission
      * @param exercise Exercise to which the submission belongs
+     * @param participation Participation for which the editor should be opened
      * @param submission Either submission or 'new'
      */
     async openAssessmentEditor(exercise: Exercise, participation: Participation, submission: Submission | 'new'): Promise<void> {
         const submissionUrlParameter: number | 'new' = submission === 'new' ? 'new' : submission.id!;
-        const route = `/course-management/${this.course.id}/${exercise.type}-exercises/${exercise.id}/participations/${participation.id}/submissions/${submissionUrlParameter}/assessment`;
+        const route = getLinkToSubmissionAssessment(exercise.type!, this.course.id!, exercise.id!, participation.id, submissionUrlParameter, 0, 0);
         await this.router.navigate([route]);
     }
 

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.ts
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.ts
@@ -125,7 +125,7 @@ export class TeamParticipationTableComponent implements OnInit {
     async openAssessmentEditor(exercise: Exercise, participation: Participation, submission: Submission | 'new'): Promise<void> {
         const submissionUrlParameter: number | 'new' = submission === 'new' ? 'new' : submission.id!;
         const route = getLinkToSubmissionAssessment(exercise.type!, this.course.id!, exercise.id!, participation.id, submissionUrlParameter, 0, 0);
-        await this.router.navigate([route]);
+        await this.router.navigate(route);
     }
 
     /**

--- a/src/test/javascript/spec/component/team/team-participation-table.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team-participation-table.component.spec.ts
@@ -220,11 +220,14 @@ describe('TeamParticipationTableComponent', () => {
     }));
 
     it('Navigate to assessment editor when opening exercise submission', fakeAsync(() => {
-        comp.openAssessmentEditor(exercise1, 'new');
+        const participation = exercise2.studentParticipations![0];
+        comp.openAssessmentEditor(exercise2, participation, 'new');
         tick();
         expect(router.navigate).to.have.been.calledOnce;
         const navigationUrl = router.navigate.getCall(0).args[0];
-        expect(navigationUrl).to.deep.equal([`/course-management/${course.id}/${exercise1.type}-exercises/${exercise1.id}/submissions/new/assessment`]);
+        expect(navigationUrl).to.deep.equal([
+            ['/course-management', course.id!.toString(), exercise2.type! + '-exercises', exercise2.id!.toString(), 'submissions', 'new', 'assessment'],
+        ]);
     }));
 
     it('Check enabled assessment button for exercises without due date', fakeAsync(() => {

--- a/src/test/javascript/spec/component/team/team-participation-table.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team-participation-table.component.spec.ts
@@ -226,7 +226,13 @@ describe('TeamParticipationTableComponent', () => {
         expect(router.navigate).to.have.been.calledOnce;
         const navigationUrl = router.navigate.getCall(0).args[0];
         expect(navigationUrl).to.deep.equal([
-            ['/course-management', course.id!.toString(), exercise2.type! + '-exercises', exercise2.id!.toString(), 'submissions', 'new', 'assessment'],
+            '/course-management',
+            course.id!.toString(),
+            exercise2.type! + '-exercises',
+            exercise2.id!.toString(),
+            'submissions',
+            'new',
+            'assessment',
         ]);
     }));
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] We tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR should solve #3759

### Description
<!-- Describe your changes in detail -->
When text exercise routes were refactored, the route for navigating to the assessment editor for text exercises changed (now `participation/{participationId}` is included). Inside the participation table for team exercises, the route was not changed accordingly.
We fix this by delegating the build of the route to the dedicated navigation util service instead of using a hardcoded route.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis as Instructor
2. Navigate to Course Administration
3. If not already existent, create a **team** exercise of type Text - also testing other exercise types would be great
4. Participate as student in this exercise and submit anything

--- fist screencast ---
5. As instructor: navigate to the team participation table (as shown in the screencast)
6. Start/Open the assessment by clicking the button; it would be could if you can check both cases, start new assessment (first assessment) and open assessment (continue with existing assessment) -> check if the navigation works and no error is shown in the console
7. Save the assessment and navigate back to the participation table
8. Open the existing assessment again -> check if the navigation works and no error is shown in the console

-- second screencast --
9. Go back to course management
10. Select a team text exercise
11. Select submission
12. Start/Open the assessment by clicking the button; it would be could if you can check both cases, start new assessment (first assessment) and open assessment (continue with existing assessment) -> check if the navigation works and no error is shown in the console

1. Screencast How to navigate to the team participation table to start the assessment?

https://user-images.githubusercontent.com/41366522/125776741-20b8b27b-a285-46fa-8f1c-4010d45e35d9.mov


2. Screencast How to navigate to the team exercise submission otherwise?

https://user-images.githubusercontent.com/41366522/125777240-d783cf92-4e72-4175-bc2e-164b2adcca87.mov



