### PR TITLE
Fix video unit size

### DIFF
--- a/src/main/webapp/app/overview/course-lectures/video-unit/video-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/video-unit/video-unit.component.html
@@ -14,8 +14,8 @@
             </h5>
         </div>
         <div class="card-body unit-card-body" [ngbCollapse]="isCollapsed">
-            <div class="embed-responsive embed-responsive-16by9">
-                <iframe id="videoFrame" class="embed-responsive-item rounded" [src]="videoUrl" allow="fullscreen"></iframe>
+            <div class="ratio ratio-16x9">
+                <iframe id="videoFrame" class="rounded" [src]="videoUrl" allow="fullscreen"></iframe>
             </div>
             {{ videoUnit?.description }}
         </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
in Bootstrap 5 the API for ratios changed: https://getbootstrap.com/docs/5.0/helpers/ratio/ This broke our video units.


### Description
<!-- Describe your changes in detail -->
I applied the new classes as documented.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a video unit and check if it looks as intended.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

before | after 
--- | ---
![image](https://user-images.githubusercontent.com/44805696/125743843-fefbe9fc-4494-46f2-ba62-fe1a58b44ad5.png) | ![image](https://user-images.githubusercontent.com/44805696/125743758-08ffccfe-8b32-4662-a2ae-c014d659dd79.png)

