### PR TITLE
[Bug-fix] practice mode for quizzes created additional wrong quiz-started notification(s)

### DIFF
--- a/src/main/webapp/app/shared/notification/notification.service.ts
+++ b/src/main/webapp/app/shared/notification/notification.service.ts
@@ -138,7 +138,7 @@ export class NotificationService {
                 this.subscribedTopics.push(quizExerciseTopic);
                 this.jhiWebsocketService.subscribe(quizExerciseTopic);
                 this.jhiWebsocketService.receive(quizExerciseTopic).subscribe((quizExercise: QuizExercise) => {
-                    if (quizExercise.visibleToStudents && quizExercise.started) {
+                    if (quizExercise.visibleToStudents && quizExercise.started && !quizExercise.isOpenForPractice) {
                         this.addNotificationToObserver(NotificationService.createNotificationFromStartedQuizExercise(quizExercise));
                     }
                 });


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
@krusche noticed that when you as an instructor press the "Release For Practice" button for quiz exercises, that "quiz started" notifications were wrongfully created. (See .gif)
![Quiz Notification Bug](https://user-images.githubusercontent.com/65814168/125763645-ababe673-4e25-43b8-a0dc-4297fd56f616.gif)


I fixed this by adding a check in the notification.service to only create/add/show a "quiz-started" notification if the quiz-exercise this notification is based on is **not** in practice mode.

### Description
<!-- Describe your changes in detail -->
This error is a product of the weird legacy implementation for quiz exercise notifications.
Instead of subscribing to new notifications that are created on the server, quiz notifications are only created if the notification.service registers a new quiz-**exercise** or a quiz-exercise **update**.
Therefore, if the instructor sets a quiz exercise to practice mode, the notification.service registers an quiz-exercise update and creates a new "quiz-started" notification.

### Steps for Testing
Just follow the .gifs

**Written Steps:**
1. Log in to Artemis as an Instructor and a Student at the same time (to accomplish this you have to use two different "browser sessions", i.e. you can not just open it in a new tab but have to e.g. open the instructor in one chrome browser, the student in incognito mode or e.g. edge or any other browser.
2. As a student you should stay on the course overview page and not in the quiz-page (the notifications will not be shown there)
3. As an instructor you have to find a quiz (start it, wait until it is over, maybe reload the page) and click on the "Release for Practice" button.
4. Observe the correct behavior (i.e. no "quiz-started" notification pop-up or notification element in the notification sidebar should appear).

This is how the correct behavior should look like:
![Quiz Notification Bugfixed](https://user-images.githubusercontent.com/65814168/125765612-52ebeb03-5ceb-47c5-9b12-e9b66e2a5753.gif)
