### PR TITLE
[Enhancement] Exam Programming Exercises Show Template And Solution Participation

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -409,8 +409,8 @@
                         ></jhi-programming-exercise-instructor-trigger-build-button>
                     </div>
                 </dd>
-                <dd *ngIf="programmingExercise.isAtLeastEditor && programmingExercise?.templateParticipation">
-                    <a [routerLink]="getParticipationSubmissionLink(programmingExercise.templateParticipation!.id)" [queryParams]="{ isTmpOrSolutionProgrParticipation: true }">
+                <dd *ngIf="programmingExercise.isAtLeastEditor && programmingExercise?.templateParticipation?.id">
+                    <a [routerLink]="getParticipationSubmissionLink(programmingExercise!.templateParticipation!.id!)" [queryParams]="{ isTmpOrSolutionProgrParticipation: true }">
                         <span jhiTranslate="artemisApp.programmingExercise.detail.showTemplateSubmissions">Show Submissions</span>
                     </a>
                 </dd>
@@ -440,8 +440,8 @@
                         ></jhi-programming-exercise-instructor-trigger-build-button>
                     </div>
                 </dd>
-                <dd *ngIf="programmingExercise.isAtLeastEditor && programmingExercise?.solutionParticipation">
-                    <a [routerLink]="getParticipationSubmissionLink(programmingExercise.solutionParticipation!.id)" [queryParams]="{ isTmpOrSolutionProgrParticipation: true }">
+                <dd *ngIf="programmingExercise.isAtLeastEditor && programmingExercise?.solutionParticipation?.id">
+                    <a [routerLink]="getParticipationSubmissionLink(programmingExercise!.solutionParticipation!.id!)" [queryParams]="{ isTmpOrSolutionProgrParticipation: true }">
                         <span jhiTranslate="artemisApp.programmingExercise.detail.showSolutionSubmissions">Show Submissions</span>
                     </a>
                 </dd>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -410,15 +410,7 @@
                     </div>
                 </dd>
                 <dd *ngIf="programmingExercise.isAtLeastEditor && programmingExercise?.templateParticipation">
-                    <a
-                        [routerLink]="[
-                            this.baseResource,
-                            'participations',
-                            programmingExercise.templateParticipation?.id,
-                            'submissions'
-                        ]"
-                        [queryParams]="{ isTmpOrSolutionProgrParticipation: true }"
-                    >
+                    <a [routerLink]="getParticipationSubmissionLink(programmingExercise.templateParticipation!.id)" [queryParams]="{ isTmpOrSolutionProgrParticipation: true }">
                         <span jhiTranslate="artemisApp.programmingExercise.detail.showTemplateSubmissions">Show Submissions</span>
                     </a>
                 </dd>
@@ -449,15 +441,7 @@
                     </div>
                 </dd>
                 <dd *ngIf="programmingExercise.isAtLeastEditor && programmingExercise?.solutionParticipation">
-                    <a
-                        [routerLink]="[
-                            this.baseResource,
-                            'participations',
-                            programmingExercise.solutionParticipation?.id,
-                            'submissions'
-                        ]"
-                        [queryParams]="{ isTmpOrSolutionProgrParticipation: true }"
-                    >
+                    <a [routerLink]="getParticipationSubmissionLink(programmingExercise.solutionParticipation!.id)" [queryParams]="{ isTmpOrSolutionProgrParticipation: true }">
                         <span jhiTranslate="artemisApp.programmingExercise.detail.showSolutionSubmissions">Show Submissions</span>
                     </a>
                 </dd>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -409,13 +409,10 @@
                         ></jhi-programming-exercise-instructor-trigger-build-button>
                     </div>
                 </dd>
-                <dd *ngIf="programmingExercise.course != undefined && programmingExercise.isAtLeastEditor && programmingExercise?.templateParticipation">
+                <dd *ngIf="programmingExercise.isAtLeastEditor && programmingExercise?.templateParticipation">
                     <a
                         [routerLink]="[
-                            '/course-management',
-                            programmingExercise.course.id,
-                            'programming-exercises',
-                            programmingExercise.id,
+                            this.baseResource,
                             'participations',
                             programmingExercise.templateParticipation?.id,
                             'submissions'
@@ -451,13 +448,10 @@
                         ></jhi-programming-exercise-instructor-trigger-build-button>
                     </div>
                 </dd>
-                <dd *ngIf="programmingExercise.course != undefined && programmingExercise.isAtLeastEditor && programmingExercise?.solutionParticipation">
+                <dd *ngIf="programmingExercise.isAtLeastEditor && programmingExercise?.solutionParticipation">
                     <a
                         [routerLink]="[
-                            '/course-management',
-                            programmingExercise.course.id,
-                            'programming-exercises',
-                            programmingExercise.id,
+                            this.baseResource,
                             'participations',
                             programmingExercise.solutionParticipation?.id,
                             'submissions'

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -291,7 +291,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
 
     /**
      * Generates the link to any participation's submissions, used for the link to template and solution submissions
-     * @param id id of the participation
+     * @param id of the participation
      */
     getParticipationSubmissionLink(id: number) {
         const link = [this.baseResource, 'participations', id];

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -288,4 +288,17 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
     private onError(error: HttpErrorResponse) {
         this.jhiAlertService.error(error.message);
     }
+
+    /**
+     * Generates the link to any participation's submissions, used for the link to template and solution submissions
+     * @param id id of the participation
+     */
+    getParticipationSubmissionLink(id: number) {
+        const link = [this.baseResource, 'participations', id];
+        // For unknown reason normal exercises append /submissions to the submission view whereas exam exercises do not
+        if (!this.isExamExercise) {
+            link.push('submissions');
+        }
+        return link;
+    }
 }

--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
@@ -30,12 +30,12 @@
         <div class="hint" *ngIf="question.hint || (question.explanation && showResult)">
             <span class="label label-info" [ngbPopover]="renderedHint" placement="auto" triggers="mouseenter:mouseleave" *ngIf="question.hint">
                 <fa-icon [icon]="['far', 'question-circle']"></fa-icon>
-                <span jhiTranslate="artemisApp.quizQuestion.hint"></span> </span
-            >
+                <span jhiTranslate="artemisApp.quizQuestion.hint"></span>
+            </span>
             <ng-template #renderedHint>
                 <div [innerHTML]="renderedQuestion.hint"></div>
             </ng-template>
-            <br/>
+            <br />
             <span class="label label-primary" [ngbPopover]="renderedExplanation" placement="auto" triggers="mouseenter:mouseleave" *ngIf="question.explanation && showResult">
                 <fa-icon [icon]="'exclamation-circle'"></fa-icon>
                 <span jhiTranslate="artemisApp.quizQuestion.explanation"></span>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Normal programming exercises feature a link to the template and example submissions. Such link was missing for exam exercises.

### Description
Fixes the issue that prevented the links from getting shown and adds the right router link for exam exercises.

### Steps for Testing

1. Log in to Artemis
2. Create/Locate a normal programming exercise
3. Click the links for template and example submissions on the details page
4. Create/Locate an exam programming exercise
5. Click the links for template and example submissions on the details page
6. All links should work properly

### Test Coverage
not notably changed

### Screenshots
Before:
![grafik](https://user-images.githubusercontent.com/61357727/125837992-deb938b7-3431-41b6-9fee-51f95a632cd1.png)
After:
![grafik](https://user-images.githubusercontent.com/61357727/125838033-7e11a65b-4a71-443f-bea2-3d0b4dbc8f35.png)

