### PR TITLE
Fix flacky testExportCourseCannotExportSingleParticipationGitApiException test

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseExamExportService.java
@@ -432,6 +432,12 @@ public class CourseExamExportService {
      */
     private Optional<Path> createCourseZipFile(Path outputZipFile, List<Path> filesToZip, Path relativeZipPath, List<String> exportErrors) {
         try {
+            // Create the parent directories if they don't exist otherwise the zip file cannot be created.
+            Path parentDir = outputZipFile.getParent();
+            if (!Files.exists(parentDir)) {
+                Files.createDirectories(parentDir);
+            }
+
             zipFileService.createZipFile(outputZipFile, filesToZip, relativeZipPath);
             log.info("Successfully created zip file: {}", outputZipFile);
             return Optional.of(outputZipFile);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Resolves #3777 which is a flaky test. 

### Description
<!-- Describe your changes in detail -->
This PR adds a new check: when a course archive needs to be created, we check if the parent directories exist and create the necessary folders if they are not present.
