### PR TITLE
[Bugfix] assessment of complaints cant be opened

### DIFF
--- a/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.ts
+++ b/src/main/webapp/app/complaints/list-of-complaints/list-of-complaints.component.ts
@@ -123,8 +123,8 @@ export class ListOfComplaintsComponent implements OnInit {
             exercise.id!,
             studentParticipation.id,
             submissionId,
-            this.examId ? this.examId : 0,
-            exercise.exerciseGroup?.id!,
+            0, // even if the list of complaints are part of an exam, the assessment of non-exam exercises gets executed
+            0,
             complaint.result.id,
         );
         this.router.navigate(url, { queryParams: { 'correction-round': this.correctionRound } });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
assessing complaints wasn't working

### Description
<!-- Describe your changes in detail -->
although assessment routes normally distinguish between exam mode and normal exercise, in the case of assessing exam mode complaints this isn't the case, here the normal assessment route is always used.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. find an exam with open complaints
2. assess a complaint and submit the assessment
3. open the assessment again after assessing it
