### PR TITLE
[Bugfix] - Exercise Detail Enhancements

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
@@ -17,16 +17,16 @@
             <span class="d-none d-md-inline" jhiTranslate="artemisApp.exercise.participations">Participations</span>
         </a>
 
-        <!--Submissions -->
-        <a *ngIf="exercise.isAtLeastInstructor && course" [routerLink]="baseResource + 'submissions'" class="btn btn-primary btn-sm me-1" style="margin-bottom: 10px">
-            <fa-icon [icon]="['far', 'list-alt']"></fa-icon>
-            <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.submissions">Submissions</span>
-        </a>
-
         <!-- Scores -->
         <a *ngIf="course" [routerLink]="baseResource + 'scores'" class="btn btn-info btn-sm me-1" style="margin-bottom: 10px">
             <fa-icon [icon]="'table'"></fa-icon>
             <span class="d-none d-md-inline" jhiTranslate="entity.action.scores">Scores</span>
+        </a>
+
+        <!--Submissions -->
+        <a *ngIf="exercise.isAtLeastInstructor && course" [routerLink]="baseResource + 'submissions'" class="btn btn-success btn-sm me-1" style="margin-bottom: 10px">
+            <fa-icon [icon]="['far', 'list-alt']"></fa-icon>
+            <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.submissions">Submissions</span>
         </a>
 
         <!-- Example Submission -->

--- a/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
@@ -17,16 +17,16 @@
             <span class="d-none d-md-inline" jhiTranslate="artemisApp.exercise.participations">Participations</span>
         </a>
 
-        <!-- Scores -->
-        <a *ngIf="course" [routerLink]="baseResource + 'scores'" class="btn btn-info btn-sm me-1" style="margin-bottom: 10px">
-            <fa-icon [icon]="'table'"></fa-icon>
-            <span class="d-none d-md-inline" jhiTranslate="entity.action.scores">Scores</span>
-        </a>
-
         <!--Submissions -->
         <a *ngIf="exercise.isAtLeastInstructor && course" [routerLink]="baseResource + 'submissions'" class="btn btn-success btn-sm me-1" style="margin-bottom: 10px">
             <fa-icon [icon]="['far', 'list-alt']"></fa-icon>
             <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.submissions">Submissions</span>
+        </a>
+
+        <!-- Scores -->
+        <a *ngIf="course" [routerLink]="baseResource + 'scores'" class="btn btn-info btn-sm me-1" style="margin-bottom: 10px">
+            <fa-icon [icon]="'table'"></fa-icon>
+            <span class="d-none d-md-inline" jhiTranslate="entity.action.scores">Scores</span>
         </a>
 
         <!-- Example Submission -->

--- a/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.html
@@ -40,6 +40,11 @@
             <span class="d-none d-md-inline" jhiTranslate="entity.action.exampleSubmissions">Example Submissions</span>
         </a>
 
+        <a *ngIf="exercise.teamMode && exercise.isAtLeastTutor" [routerLink]="baseResource + 'teams'" class="btn btn-primary btn-sm me-1" style="margin-bottom: 10px">
+            <fa-icon [icon]="'users'"></fa-icon>
+            <span class="d-none d-md-inline" jhiTranslate="artemisApp.exercise.teams">Teams</span>
+        </a>
+
         <!-- Delete exercise -->
         <button
             *ngIf="exercise.isAtLeastInstructor"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) **locally**
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We have an inconsistency with button colors. In general we use blue buttons for course content and turquoise for course assessment/scores. Green buttons are for submission. The exercise detail page for non programming exercises showed submissions in blue. Also, it was only possible to access the teams page of an exercise from the Exercises page and not from the exercise detail page.

### Description
<!-- Describe your changes in detail -->
Change button color of submissions button to green. As I would suggest the detail page to provide the maximum variety of exercise information and options, we also added the teams button here, because it is not displayed here yet.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate into an non-programming exercise and make sure the submissions button is green
4. Move into a team exercise and make sure the teams button ins accessable from the details page and navigates into the right page where you can add teams

### Screenshots
<img width="729" alt="Screenshot 2021-07-19 at 14 28 06" src="https://user-images.githubusercontent.com/44401560/126164162-46dcdadf-a50b-4938-852a-754630c7ccbf.png">

