### PR TITLE
Fix 404 errors when deleting exercises from the detail view

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { ProgrammingExercise, ProgrammingLanguage } from 'app/entities/programming-exercise.model';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
@@ -65,6 +65,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
         private profileService: ProfileService,
         private statisticsService: StatisticsService,
         private sortService: SortService,
+        private router: Router,
     ) {}
 
     ngOnInit() {
@@ -206,6 +207,12 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
                     content: 'Deleted a programming exercise',
                 });
                 this.dialogErrorSource.next('');
+
+                if (!this.isExamExercise) {
+                    this.router.navigateByUrl(`/course-management/${this.courseId}/exercises/`);
+                } else {
+                    this.router.navigateByUrl(`/course-management/${this.courseId}/exams/${this.programmingExercise.exerciseGroup?.exam?.id}/exercise-groups`);
+                }
             },
             (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
         );

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -209,7 +209,7 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
                 this.dialogErrorSource.next('');
 
                 if (!this.isExamExercise) {
-                    this.router.navigateByUrl(`/course-management/${this.courseId}/exercises/`);
+                    this.router.navigateByUrl(`/course-management/${this.courseId}/exercises`);
                 } else {
                     this.router.navigateByUrl(`/course-management/${this.courseId}/exams/${this.programmingExercise.exerciseGroup?.exam?.id}/exercise-groups`);
                 }

--- a/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.ts
@@ -98,7 +98,7 @@ export class NonProgrammingExerciseDetailCommonActionsComponent implements OnIni
      */
     private navigateToOverview() {
         if (!this.isExamExercise) {
-            this.router.navigateByUrl(`/course-management/${this.course.id}/exercises/`);
+            this.router.navigateByUrl(`/course-management/${this.course.id}/exercises`);
         } else {
             this.router.navigateByUrl(`/course-management/${this.course.id}/exams/${this.exercise.exerciseGroup?.exam?.id}/exercise-groups`);
         }

--- a/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component.ts
@@ -7,11 +7,11 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { FileUploadExerciseService } from 'app/exercises/file-upload/manage/file-upload-exercise.service';
 import { ModelingExerciseService } from 'app/exercises/modeling/manage/modeling-exercise.service';
 import { Course } from 'app/entities/course.model';
+import { Router } from '@angular/router';
 
 @Component({
     selector: 'jhi-non-programming-exercise-detail-common-actions',
     templateUrl: './non-programming-exercise-detail-common-actions.component.html',
-    styles: [],
 })
 export class NonProgrammingExerciseDetailCommonActionsComponent implements OnInit {
     @Input()
@@ -33,6 +33,7 @@ export class NonProgrammingExerciseDetailCommonActionsComponent implements OnIni
         private fileUploadExerciseService: FileUploadExerciseService,
         private modelingExerciseService: ModelingExerciseService,
         private eventManager: JhiEventManager,
+        private router: Router,
     ) {}
 
     ngOnInit(): void {
@@ -57,6 +58,7 @@ export class NonProgrammingExerciseDetailCommonActionsComponent implements OnIni
                             content: 'Deleted a textExercise',
                         });
                         this.dialogErrorSource.next('');
+                        this.navigateToOverview();
                     },
                     (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
                 );
@@ -69,6 +71,7 @@ export class NonProgrammingExerciseDetailCommonActionsComponent implements OnIni
                             content: 'Deleted an fileUploadExercise',
                         });
                         this.dialogErrorSource.next('');
+                        this.navigateToOverview();
                     },
                     (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
                 );
@@ -81,11 +84,23 @@ export class NonProgrammingExerciseDetailCommonActionsComponent implements OnIni
                             content: 'Deleted an modelingExercise',
                         });
                         this.dialogErrorSource.next('');
+                        this.navigateToOverview();
                     },
                     (error: HttpErrorResponse) => this.dialogErrorSource.next(error.message),
                 );
                 break;
             default:
+        }
+    }
+
+    /**
+     * Navigates back to the exercises list
+     */
+    private navigateToOverview() {
+        if (!this.isExamExercise) {
+            this.router.navigateByUrl(`/course-management/${this.course.id}/exercises/`);
+        } else {
+            this.router.navigateByUrl(`/course-management/${this.course.id}/exams/${this.exercise.exerciseGroup?.exam?.id}/exercise-groups`);
         }
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context

When deleting an exercise from the details page 404 errors are thrown:
![grafik](https://user-images.githubusercontent.com/72132281/126176614-1dee89d5-cdea-4c03-9065-d9a2450e1722.png)

### Description

We navigate back to the exercises list (exercise groups for exams) instead of staying on the page of an deleted exercise.

### Steps for Testing

1. Create a new exercise (any type besides quiz)
2. Go to the detail page and delete it
3. Repeat the same for exams
4. No 404 Not Found error should be throw because of the deleting
5. You should be redirected back to the exercises list (exercise groups for exams)

