### PR TITLE
[Bugfix] Fix example solution repo url in programming exercise assessment dashboard

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -496,6 +496,8 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
 
     /**
      * Find a programming exercise by its id, including template and solution but without results.
+     * TODO: we should remove this method later on and use 'findByIdWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesElseThrow' in all places,
+     *  they have same functionality.
      *
      * @param programmingExerciseId of the programming exercise.
      * @return The programming exercise related to the given id

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -66,6 +66,8 @@ public class ExerciseResource {
 
     private final ExampleSubmissionRepository exampleSubmissionRepository;
 
+    private final ProgrammingExerciseRepository programmingExerciseRepository;
+
     public ExerciseResource(ExerciseService exerciseService, ParticipationService participationService, UserRepository userRepository, ExamDateService examDateService,
             AuthorizationCheckService authCheckService, TutorParticipationService tutorParticipationService, ExampleSubmissionRepository exampleSubmissionRepository,
             ComplaintRepository complaintRepository, SubmissionRepository submissionRepository, TutorLeaderboardService tutorLeaderboardService,
@@ -81,6 +83,7 @@ public class ExerciseResource {
         this.gradingCriterionRepository = gradingCriterionRepository;
         this.examDateService = examDateService;
         this.exerciseRepository = exerciseRepository;
+        this.programmingExerciseRepository = programmingExerciseRepository;
     }
 
     /**
@@ -149,6 +152,10 @@ public class ExerciseResource {
         // Programming exercises with only automatic assessment should *NOT* be available on the assessment dashboard!
         if (exercise instanceof ProgrammingExercise && exercise.getAssessmentType().equals(AssessmentType.AUTOMATIC)) {
             return badRequest();
+        }
+
+        if (exercise instanceof ProgrammingExercise) {
+            exercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(exerciseId);
         }
 
         Set<ExampleSubmission> exampleSubmissions = this.exampleSubmissionRepository.findAllWithResultByExerciseId(exerciseId);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -149,12 +149,11 @@ public class ExerciseResource {
         User user = userRepository.getUserWithGroupsAndAuthorities();
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, exercise, user);
 
-        // Programming exercises with only automatic assessment should *NOT* be available on the assessment dashboard!
-        if (exercise instanceof ProgrammingExercise && exercise.getAssessmentType().equals(AssessmentType.AUTOMATIC)) {
-            return badRequest();
-        }
-
         if (exercise instanceof ProgrammingExercise) {
+            // Programming exercises with only automatic assessment should *NOT* be available on the assessment dashboard!
+            if (exercise.getAssessmentType().equals(AssessmentType.AUTOMATIC)) {
+                return badRequest();
+            }
             exercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesElseThrow(exerciseId);
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -155,7 +155,7 @@ public class ExerciseResource {
         }
 
         if (exercise instanceof ProgrammingExercise) {
-            exercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(exerciseId);
+            exercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationTeamAssignmentConfigCategoriesElseThrow(exerciseId);
         }
 
         Set<ExampleSubmission> exampleSubmissions = this.exampleSubmissionRepository.findAllWithResultByExerciseId(exerciseId);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #3782 

As described in the issue, currently exercise solution repository url navigates to homepage in programming exercise exercise dashboard. Actually, the link is empty. It happens because when exercise retrieving from database, it just sends the exercise object from the `exerciseRepository`.  However, solution repo url is stored in `participation`, so we need to get the additional data. 

To achieve that, after retrieving the exercise , it also retrieves the data from `participation`, if the exercise is type of programming.

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Management
3. Create one programming exercise
4. Go to exercise dashboard for this exercise, check that Example Solution Repository URL navigates to Bitbucket page(or Gitlab if you tested on ts2)
5. start your participation for exercise
6. confirm that you do not have any problem
7. open the Instructions tab at the right side, check Example Solution URL navigates to Bitbucket page(or Gitlab if you tested on ts2)

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before Starting you participation for the exercise
<img src="https://user-images.githubusercontent.com/23650630/126218828-e016aab3-d06d-42cd-af91-992d5d685d08.png" width="500" />

Instructions tab in the Exercise Dashboard After Starting you participation
<img src="https://user-images.githubusercontent.com/23650630/126219560-8f1e328d-197c-42bf-b10a-d40d71d2df02.png" width="500" />
