### PR TITLE
Improve performance in exam mode with programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/LtiService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/LtiService.java
@@ -438,31 +438,34 @@ public class LtiService {
     public void onNewResult(StudentParticipation participation) {
         if (this.OAUTH_KEY.isPresent() && this.OAUTH_SECRET.isPresent()) {
             // Get the LTI outcome URL
-            participation.getStudents().forEach(student -> ltiOutcomeUrlRepository.findByUserAndExercise(student, participation.getExercise()).ifPresent(ltiOutcomeUrl -> {
+            var students = participation.getStudents();
+            if (students != null) {
+                students.forEach(student -> ltiOutcomeUrlRepository.findByUserAndExercise(student, participation.getExercise()).ifPresent(ltiOutcomeUrl -> {
 
-                String score = "0.00";
+                    String score = "0.00";
 
-                // Get the latest result
-                Optional<Result> latestResult = resultRepository.findFirstByParticipationIdOrderByCompletionDateDesc(participation.getId());
+                    // Get the latest result
+                    Optional<Result> latestResult = resultRepository.findFirstByParticipationIdOrderByCompletionDateDesc(participation.getId());
 
-                if (latestResult.isPresent() && latestResult.get().getScore() != null) {
-                    // LTI scores needs to be formatted as String between "0.00" and "1.00"
-                    score = String.format(Locale.ROOT, "%.2f", latestResult.get().getScore().floatValue() / 100);
-                }
+                    if (latestResult.isPresent() && latestResult.get().getScore() != null) {
+                        // LTI scores needs to be formatted as String between "0.00" and "1.00"
+                        score = String.format(Locale.ROOT, "%.2f", latestResult.get().getScore().floatValue() / 100);
+                    }
 
-                try {
-                    log.info("Reporting score {} for participation {} to LTI consumer with outcome URL {} using the source id {}", score, participation, ltiOutcomeUrl.getUrl(),
-                            ltiOutcomeUrl.getSourcedId());
-                    HttpPost request = IMSPOXRequest.buildReplaceResult(ltiOutcomeUrl.getUrl(), OAUTH_KEY.get(), OAUTH_SECRET.get(), ltiOutcomeUrl.getSourcedId(), score, null,
-                            false);
-                    HttpResponse response = client.execute(request);
-                    String responseString = new BasicResponseHandler().handleResponse(response);
-                    log.info("Response from LTI consumer: {}", responseString);
-                }
-                catch (Exception ex) {
-                    log.error("Reporting to LTI consumer failed", ex);
-                }
-            }));
+                    try {
+                        log.info("Reporting score {} for participation {} to LTI consumer with outcome URL {} using the source id {}", score, participation, ltiOutcomeUrl.getUrl(),
+                                ltiOutcomeUrl.getSourcedId());
+                        HttpPost request = IMSPOXRequest.buildReplaceResult(ltiOutcomeUrl.getUrl(), OAUTH_KEY.get(), OAUTH_SECRET.get(), ltiOutcomeUrl.getSourcedId(), score, null,
+                                false);
+                        HttpResponse response = client.execute(request);
+                        String responseString = new BasicResponseHandler().handleResponse(response);
+                        log.info("Response from LTI consumer: {}", responseString);
+                    }
+                    catch (Exception ex) {
+                        log.error("Reporting to LTI consumer failed", ex);
+                    }
+                }));
+            }
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticProgrammingExerciseCleanupService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/AutomaticProgrammingExerciseCleanupService.java
@@ -135,7 +135,9 @@ public class AutomaticProgrammingExerciseCleanupService {
 
         Set<ProgrammingExerciseStudentParticipation> participationsWithBuildPlanToDelete = new HashSet<>();
 
-        programmingExerciseStudentParticipationRepository.findAllWithBuildPlanIdWithResults().forEach(participation -> {
+        var participationsWithBuildPlans = programmingExerciseStudentParticipationRepository.findAllWithBuildPlanIdWithResults();
+        log.info("Found {} potential build plans to delete", participationsWithBuildPlans.size());
+        participationsWithBuildPlans.forEach(participation -> {
 
             if (participation.getBuildPlanId() == null || participation.getParticipant() == null) {
                 // NOTE: based on the query above, this code is not reachable. We check it anyway to be 100% sure such participations won't be processed
@@ -172,6 +174,7 @@ public class AutomaticProgrammingExerciseCleanupService {
         deleteBuildPlans(participationsWithBuildPlanToDelete);
     }
 
+    // returns false if the participation should be cleaned after the criteria checked in this method
     private boolean checkBuildAndTestExercises(ProgrammingExercise programmingExercise, ProgrammingExerciseStudentParticipation participation,
             Set<ProgrammingExerciseStudentParticipation> participationsWithBuildPlanToDelete, AtomicLong countAfterBuildAndTestDate) {
         if (programmingExercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null) {
@@ -219,6 +222,7 @@ public class AutomaticProgrammingExerciseCleanupService {
         }
     }
 
+    // returns false if the participation should be cleaned after the criteria checked in this method
     private boolean checkFutureExamExercises(ProgrammingExercise programmingExercise) {
         if (programmingExercise.isExamExercise() && programmingExercise.getExerciseGroup().getExam() != null) {
             var exam = programmingExercise.getExerciseGroup().getExam();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseGroupResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseGroupResource.java
@@ -42,8 +42,6 @@ public class ExerciseGroupResource {
     @Value("${jhipster.clientApp.name}")
     private String applicationName;
 
-    private final StudentParticipationRepository studentParticipationRepository;
-
     private final ExerciseGroupRepository exerciseGroupRepository;
 
     private final ExamRepository examRepository;
@@ -56,10 +54,8 @@ public class ExerciseGroupResource {
 
     private final AuditEventRepository auditEventRepository;
 
-    public ExerciseGroupResource(StudentParticipationRepository studentParticipationRepository, ExerciseGroupRepository exerciseGroupRepository,
-            ExamAccessService examAccessService, UserRepository userRepository, ExerciseService exerciseService, AuditEventRepository auditEventRepository,
-            ExamRepository examRepository) {
-        this.studentParticipationRepository = studentParticipationRepository;
+    public ExerciseGroupResource(ExerciseGroupRepository exerciseGroupRepository, ExamAccessService examAccessService, UserRepository userRepository,
+            ExerciseService exerciseService, AuditEventRepository auditEventRepository, ExamRepository examRepository) {
         this.exerciseGroupRepository = exerciseGroupRepository;
         this.examRepository = examRepository;
         this.examAccessService = examAccessService;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseHintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseHintResource.java
@@ -150,7 +150,7 @@ public class ExerciseHintResource {
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Set<ExerciseHint>> getExerciseHintsForExercise(@PathVariable Long exerciseId) {
         log.debug("REST request to get ExerciseHint : {}", exerciseId);
-        ProgrammingExercise programmingExercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(exerciseId);
+        ProgrammingExercise programmingExercise = programmingExerciseRepository.findByIdElseThrow(exerciseId);
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.STUDENT, programmingExercise, null);
         Set<ExerciseHint> exerciseHints = exerciseHintRepository.findByExerciseId(exerciseId);
         return ResponseEntity.ok(exerciseHints);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingAssessmentResource.java
@@ -190,7 +190,7 @@ public class ProgrammingAssessmentResource extends AssessmentResource {
         }
         // remove information about the student for tutors to ensure double-blind assessment
         if (!isAtLeastInstructor) {
-            ((StudentParticipation) newManualResult.getParticipation()).filterSensitiveInformation();
+            newManualResult.getParticipation().filterSensitiveInformation();
         }
         // Note: we always need to report the result over LTI, otherwise it might never become visible in the external system
         ltiService.onNewResult((StudentParticipation) newManualResult.getParticipation());

--- a/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
+++ b/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
@@ -410,7 +410,7 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
                 .subscribe();
         } else {
             // only process, but do not try to fetchPending the latest one, e.g. because it was already downloaded shortly before (example: exam start)
-            this.processPendingSubmission(undefined, participationId, exerciseId, personal);
+            this.processPendingSubmission(undefined, participationId, exerciseId, personal).subscribe();
         }
         // We just remove the initial undefined from the pipe as it is only used to make the setup process easier.
         return this.submissionSubjects[participationId].asObservable().pipe(filter((stateObj) => stateObj !== undefined)) as Observable<ProgrammingSubmissionStateObj>;

--- a/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
+++ b/src/main/webapp/app/exercises/programming/participate/programming-submission.service.ts
@@ -394,8 +394,9 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
      * @param exerciseId id of ProgrammingExercise
      * @param personal whether the current user is a participant in the participation.
      * @param forceCacheOverride whether the cache should definitely be overridden, default is false
+     * @param fetchPending whether the latest pending submission should be fetched from the server
      */
-    public getLatestPendingSubmissionByParticipationId = (participationId: number, exerciseId: number, personal: boolean, forceCacheOverride = false) => {
+    public getLatestPendingSubmissionByParticipationId = (participationId: number, exerciseId: number, personal: boolean, forceCacheOverride = false, fetchPending = true) => {
         const subject = this.submissionSubjects[participationId];
         if (!forceCacheOverride && subject) {
             return subject.asObservable().pipe(filter((stateObj) => stateObj !== undefined)) as Observable<ProgrammingSubmissionStateObj>;
@@ -403,9 +404,14 @@ export class ProgrammingSubmissionService implements IProgrammingSubmissionServi
         // The setup process is difficult, because it should not happen that multiple subscribers trigger the setup process at the same time.
         // There the subject is returned before the REST call is made, but will emit its result as soon as it returns.
         this.submissionSubjects[participationId] = new BehaviorSubject<ProgrammingSubmissionStateObj | undefined>(undefined);
-        this.fetchLatestPendingSubmissionByParticipationId(participationId)
-            .pipe(switchMap((submission) => this.processPendingSubmission(submission, participationId, exerciseId, personal)))
-            .subscribe();
+        if (fetchPending) {
+            this.fetchLatestPendingSubmissionByParticipationId(participationId)
+                .pipe(switchMap((submission) => this.processPendingSubmission(submission, participationId, exerciseId, personal)))
+                .subscribe();
+        } else {
+            // only process, but do not try to fetchPending the latest one, e.g. because it was already downloaded shortly before (example: exam start)
+            this.processPendingSubmission(undefined, participationId, exerciseId, personal);
+        }
         // We just remove the initial undefined from the pipe as it is only used to make the setup process easier.
         return this.submissionSubjects[participationId].asObservable().pipe(filter((stateObj) => stateObj !== undefined)) as Observable<ProgrammingSubmissionStateObj>;
     };


### PR DESCRIPTION
When students enter the exam mode, 1 unnecessary REST call to `latest-pending-submisison` was performed for each exercise simultaneously. In case 2.000 students participate in an exam with 2 programming exercises, this means 4.000 requests at the exact same time which are unnecessary.

In addition, when students hand in, 1 unnecessary REST call to `exercise-hints/{exerciseHintId}` was made per exercise, while exercise hints are not even supported. In the scenario above this would lead to 4.000 within ~30s which are unnecessary.

This PR also solve a null pointer exception in LTI Resource (which I do not really understand why it happens) in the context of manual results in team programming exercises. It also includes some minor code improvements.

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Steps for Testing
1. Create an exam with programming exercises (instructor account)
2. Participate in those programming exercises (student account) using the online code editor and git
3. Make sure the build animation is shown properly and the result comes in.

There could be a theoretic edge case now which is quite unlikely to happen and hard to test: If you reload the page between submission and result arrival (you can stop the build on the CI system), you might not see the red button for the failed build. However, I was not able to reproduce this issue. 

In case, someone finds it, we can solve this by passing the submission and its missing result to the right component in the client on exam start, but we should not have so many unnecessary REST calls just for this rare edge case.