### PR TITLE
Fix size of drag and drop items outside drag area

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-item.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-item.component.html
@@ -3,7 +3,7 @@
         <jhi-secured-image *ngIf="dragItem.pictureFilePath" [src]="dragItem.pictureFilePath" [mobileDragAndDrop]="isMobile"></jhi-secured-image>
     </div>
     <div class="drag-item-text" *ngIf="dragItem && !dragItem.pictureFilePath">
-        <div [fittext]="true" [activateOnResize]="true" [maxFontSize]="17" [minFontSize]="5" [delay]="150">
+        <div [fittext]="true" [activateOnResize]="true" [maxFontSize]="17" [minFontSize]="15" [delay]="150">
             <span dnd-draggable [dragEnabled]="!clickDisabled" [dragData]="dragItem">{{ dragItem.text }}</span>
         </div>
     </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Drag and drop items' text is too small when items are not dropped into their boxes.

### Description
<!-- Describe your changes in detail -->
I changed the minimum font size.
For accessibility reasons it's rather bad practice to use pixels as a unit for font sizes, I'd open a follow up PR to tackle this if you want @krusche. For now we don't have time to test such changes before the exams.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a drag and drop quiz
2. Test if everything remains readable across different screen sizes and browsers using the preview.


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

before | after
--- | ---
![image](https://user-images.githubusercontent.com/44805696/126313419-a6719760-11da-408f-b1b4-0bafc6352691.png) | ![image](https://user-images.githubusercontent.com/44805696/126313313-02c0eadc-fddc-41e2-89a8-6197f475f407.png)
![image](https://user-images.githubusercontent.com/44805696/126313504-e95b9d4a-3985-4339-b369-90a9266a4242.png) | ![image](https://user-images.githubusercontent.com/44805696/126313610-95839818-0389-40f9-9ad7-95e05195201d.png)
