### PR TITLE
fix course overview height difference when no exercise exists

### DIFF
--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -49,7 +49,7 @@
             ></canvas>
         </div>
         <ng-template #noStatistic>
-            <h6 jhiTranslate="artemisApp.studentDashboard.noStatistics">No statistics available</h6>
+            <h6 class="no-statistics" jhiTranslate="artemisApp.studentDashboard.noStatistics">No statistics available</h6>
         </ng-template>
     </div>
 

--- a/src/main/webapp/app/overview/course-card.scss
+++ b/src/main/webapp/app/overview/course-card.scss
@@ -85,6 +85,14 @@
             width: 150px;
             height: 150px;
         }
+
+        .no-statistics {
+            display: flex;
+            height: 175px;
+            justify-content: center;
+            flex-direction: column;
+            margin-bottom: 0;
+        }
     }
 
     .card-footer {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) locally.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We have inconsistencies with the card height when no exercises are shown (See screenshot).

### Description
<!-- Describe your changes in detail -->
Adapt height of course cards with no exercises.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Overview
3. Search for a course which does not have any exercises. The height should be the same as for courses with exercises

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
![Screenshot 2021-07-20 at 12 23 56](https://user-images.githubusercontent.com/44401560/126327904-9cd8eac4-59cb-40c1-adaf-54b1f4df7698.png)

Now:
![Screenshot 2021-07-20 at 14 48 55](https://user-images.githubusercontent.com/44401560/126327939-1b475da3-b4e7-4bc6-bf0b-9833268152cc.png)

