### PR TITLE
Fix the "Clone Repository" popover position

### DIFF
--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
@@ -10,7 +10,7 @@
         [hideLabelMobile]="false"
         [ngbPopover]="popContent"
         [autoClose]="'outside'"
-        placement="right"
+        placement="end"
         container="body"
     ></button>
     <ng-template #popContent style="max-width: 660px">

--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
@@ -2,7 +2,7 @@
     <button
         jhi-exercise-action-button
         buttonIcon="download"
-        class="clone-repository"
+        class="ms-2 clone-repository"
         [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
         [buttonLabel]="'artemisApp.exerciseActions.cloneRepository' | artemisTranslate"
         [buttonLoading]="loading"


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Since the bootstrap update the popover when clicking on the "Clone Repository" button was over the button and no longer right next to it.

### Description

The popover is now to the right again. In the exam mode the "Clone Repository" button has a bit more margin on the left.

### Steps for Testing

1. Find or create an exam with a programming exercise
2. Start a test run (or an actual run) and go to the programming exercise
3. Click on "Clone Repository"
4. Find or create a programming exercise for a course
5. Open the exercise from the students perspective
6. Click on "Clone Repository"

In both cases the popvoer should be right to the button:
![grafik](https://user-images.githubusercontent.com/72132281/126336936-68b0a369-b25d-42d1-99b0-68c07429d2e6.png)
