### PR TITLE
[Bugfix] Fix quiz drop-location issue in resize screen 

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
@@ -167,7 +167,7 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
 
         this.backgroundImage.endLoadingProcess
             .pipe(
-                filter((x) => x === ImageLoadingStatus.SUCCESS),
+                filter((loadingStatus) => loadingStatus === ImageLoadingStatus.SUCCESS),
                 // Some time until image render. Need to wait until image width is computed.
                 debounceTime(300),
             )

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
@@ -171,16 +171,24 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
                 // Some time until image render. Need to wait until image width is computed.
                 debounceTime(300),
             )
-            .subscribe(() => {
-                // Make the background image visible upon successful image load. Initially it is set to hidden and not
-                // conditionally loaded via '*ngIf' because otherwise the reference would be undefined and hence we
-                // wouldn't be able to subscribe to the loading process updates.
-                this.backgroundImage.element.nativeElement.style.visibility = 'visible';
+            .subscribe(() => this.adjustClickLayerWidth());
 
-                // Adjust the click layer to correspond to the area of the background image.
-                this.clickLayer.nativeElement.style.width = `${this.backgroundImage.element.nativeElement.offsetWidth}px`;
-                this.clickLayer.nativeElement.style.left = `${this.backgroundImage.element.nativeElement.offsetLeft}px`;
-            });
+        // Trigger click layer width adjustment upon window resize.
+        window.onresize = () => this.adjustClickLayerWidth();
+    }
+
+    /**
+     * Adjusts the click-layer width to equal the background image width.
+     */
+    adjustClickLayerWidth() {
+        // Make the background image visible upon successful image load. Initially it is set to hidden and not
+        // conditionally loaded via '*ngIf' because otherwise the reference would be undefined and hence we
+        // wouldn't be able to subscribe to the loading process updates.
+        this.backgroundImage.element.nativeElement.style.visibility = 'visible';
+
+        // Adjust the click layer to correspond to the area of the background image.
+        this.clickLayer.nativeElement.style.width = `${this.backgroundImage.element.nativeElement.offsetWidth}px`;
+        this.clickLayer.nativeElement.style.left = `${this.backgroundImage.element.nativeElement.offsetLeft}px`;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Follow up PR of [3789](https://github.com/ls1intum/Artemis/pull/3789).
Also, addresses this comment: https://github.com/ls1intum/Artemis/pull/3789#discussion_r672445301

### Description
<!-- Describe your changes in detail -->
Make the drop locations adjust to the screen if the user resizes it after uploading a background image.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a new quiz exercise and add a drag and drop question
2. Upload different sized images (small and big)
3. Create a drop location (drag onto the uploaded image)
4. Resize the screen.
5. Drop location should be adjusted.
4. Preview the quiz exercise
5. Save the quiz exercise


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


https://user-images.githubusercontent.com/51077603/126343437-48ef4806-3ac4-449b-9992-3f1cf5b3e091.mov


