### PR TITLE
[Bugfix] make code editor readonly when conflict is present

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
@@ -137,6 +137,11 @@ export class CodeEditorAceComponent implements AfterViewInit, OnChanges, OnDestr
                 this.initEditorAfterFileChange();
             }
         }
+        if (changes.commitState && changes.commitState.currentValue === CommitState.CONFLICT) {
+            this.editor.setReadOnly(true);
+        } else if (changes.commitState && changes.commitState.previousValue === CommitState.CONFLICT && changes.commitState.currentValue !== CommitState.CONFLICT) {
+            this.editor.setReadOnly(false);
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When a conflict is present in a programming exercise on the online code editor, you can still edit your code. Furthermore, editing the code then resets the state to unsubmitted and the conflict cant be resolved anymore.

### Description
<!-- Describe your changes in detail -->
code editor gets set to readonly upon conflict, so that no code chanbges can then occur and the conflict state doesnt exit anymore without pressing "Resolve conflicts"

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a merge conflict in the online code editor (exam or course exercise)
    a. Open the online code editor
    b. Change a file and let the browser save it (automatically after 30s), do not submit
    c. Clone the repo and change the exact same file (and line of code) locally, commit and push
    d. Click on refresh in the online code editor (Alternative: try to submit the changes)
2. A dialog should appear with a message that there is a merge conflict
3. You should now not be able to edit the code in the code editor, and the Status on the bottom left, below the File browser should be "conflicted". Check that you can not exit this state without pressing "resolve conflicts".
