### PR TITLE
[Bugfix] Export Select All Not Visible In Exam

### DIFF
--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.ts
@@ -62,7 +62,7 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
                     tap(({ body: exercise }) => {
                         this.exercise = exercise!;
                         // TODO workaround since find does not support exam exercise permissions properly
-                        if(this.exercise.exerciseGroup?.exam?.course) {
+                        if (this.exercise.exerciseGroup?.exam?.course) {
                             this.exercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.exerciseGroup?.exam?.course!);
                         }
                         this.isAtLeastInstructor = this.exercise.isAtLeastInstructor;

--- a/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/repo-export/programming-assessment-repo-export-dialog.component.ts
@@ -10,6 +10,7 @@ import { Exercise } from 'app/entities/exercise.model';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { downloadZipFileFromResponse } from 'app/shared/util/download.util';
+import { AccountService } from 'app/core/auth/account.service';
 
 @Component({
     selector: 'jhi-exercise-scores-repo-export-dialog',
@@ -38,6 +39,7 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
         private repoExportService: ProgrammingAssessmentRepoExportService,
         public activeModal: NgbActiveModal,
         private jhiAlertService: JhiAlertService,
+        private accountService: AccountService,
     ) {}
 
     ngOnInit() {
@@ -59,6 +61,10 @@ export class ProgrammingAssessmentRepoExportDialogComponent implements OnInit {
                 .pipe(
                     tap(({ body: exercise }) => {
                         this.exercise = exercise!;
+                        // TODO workaround since find does not support exam exercise permissions properly
+                        if(this.exercise.exerciseGroup?.exam?.course) {
+                            this.exercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.exerciseGroup?.exam?.course!);
+                        }
                         this.isAtLeastInstructor = this.exercise.isAtLeastInstructor;
                     }),
                     catchError((err) => {

--- a/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise.service.ts
@@ -275,7 +275,7 @@ export class ExerciseService {
     }
 
     /**
-     * Look up permissions and add/replace isAtLeastInstuctor, isAtLeastEditor and isAtLeastTutor to http request containing a course
+     * Look up permissions and add/replace isAtLeastInstructor, isAtLeastEditor and isAtLeastTutor to http request containing a course
      * @param { ERT } res - Response from server including a course
      */
     checkPermission<ERT extends EntityResponseType>(res: ERT): ERT {

--- a/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.ts
+++ b/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.ts
@@ -47,7 +47,7 @@ export class SubmissionExportDialogComponent implements OnInit {
                 tap(({ body: exercise }) => {
                     this.exercise = exercise!;
                     // TODO workaround since find does not support exam exercise permissions properly
-                    if(this.exercise.exerciseGroup?.exam?.course) {
+                    if (this.exercise.exerciseGroup?.exam?.course) {
                         this.exercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.exerciseGroup?.exam?.course!);
                     }
                 }),

--- a/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.ts
+++ b/src/main/webapp/app/exercises/shared/submission-export/submission-export-dialog.component.ts
@@ -8,6 +8,7 @@ import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { SubmissionExportOptions, SubmissionExportService } from './submission-export.service';
 import { downloadZipFileFromResponse } from 'app/shared/util/download.util';
+import { AccountService } from 'app/core/auth/account.service';
 
 @Component({
     selector: 'jhi-exercise-submission-export-dialog',
@@ -28,6 +29,7 @@ export class SubmissionExportDialogComponent implements OnInit {
         private submissionExportService: SubmissionExportService,
         public activeModal: NgbActiveModal,
         private jhiAlertService: JhiAlertService,
+        private accountService: AccountService,
     ) {}
 
     ngOnInit() {
@@ -44,6 +46,10 @@ export class SubmissionExportDialogComponent implements OnInit {
             .pipe(
                 tap(({ body: exercise }) => {
                     this.exercise = exercise!;
+                    // TODO workaround since find does not support exam exercise permissions properly
+                    if(this.exercise.exerciseGroup?.exam?.course) {
+                        this.exercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(this.exercise.exerciseGroup?.exam?.course!);
+                    }
                 }),
                 catchError((err) => {
                     this.jhiAlertService.error(err);


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
When exporting submissions/repos, instructors have the option to export all students. This button was missing in exams

### Description
The underlying issue is that exerciseService.find does not set permissions for exam exercises. However fixing this will affect a lot of other classes and therefore cause potential further issues. This PR only adds a small, local fix to ensure the button is displayed in the mentioned case. The larger fix will be adressed at a later time.

### Steps for Testing
1. Log in to Artemis
2. Export all student submissions for an exercises with any/all combination of the following
      1. exam/not exam
      2. programming/non-programming
      3. (instructor/not instructor) (only instructors can open the dialog in the first place, but review the code to make sure the button is never shown to any non-instructor)

### Test Coverage
Not notably changed

### Screenshots
The button:
![grafik](https://user-images.githubusercontent.com/61357727/126410557-db076a45-ee10-40c1-bd67-9a472990829a.png)

