### PR TITLE
[Bugfix] - Allow higher scores than 100% in Score distribution

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/StatisticsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StatisticsService.java
@@ -208,7 +208,7 @@ public class StatisticsService {
 
         scores.forEach(score -> {
             var index = (int) (score.getScore() / 10.0);
-            if (index == 10) {
+            if (index >= 10) {
                 scoreDistribution[9] += 1;
             }
             else {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) **locally**.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Following error occurred on Production:
```
Jul 20 23:28:52 node1.artemis.ase.in.tum.de java[92057]: 2021-07-20 23:28:52.455 ERROR 92057 --- [nio-8080-exec-3] o.z.problem.spring.common.AdviceTraits   : Internal Server Error
Jul 20 23:28:52 node1.artemis.ase.in.tum.de java[92057]: java.lang.ArrayIndexOutOfBoundsException: Index 12 out of bounds for length 10
Jul 20 23:28:52 node1.artemis.ase.in.tum.de java[92057]:         at de.tum.in.www1.artemis.service.StatisticsService.lambda$getExerciseStatistics$2(StatisticsService.java:215)
Jul 20 23:28:52 node1.artemis.ase.in.tum.de java[92057]:         at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Jul 20 23:28:52 node1.artemis.ase.in.tum.de java[92057]:         at de.tum.in.www1.artemis.service.StatisticsService.getExerciseStatistics(StatisticsService.java:209)
Jul 20 23:28:52 node1.artemis.ase.in.tum.de java[92057]:         at de.tum.in.www1.artemis.web.rest.StatisticsResource.getExerciseStatistics(StatisticsResource.java:119)
Jul 20 23:28:52 node1.artemis.ase.in.tum.de java[92057]:         at de.tum.in.www1.artemis.web.rest.StatisticsResource$$FastClassBySpringCGLIB$$7925345e.invoke(<generated>)
```
Taking the code into account, it seems that it can be possible by manually changing the score in the database to have a score of more than 100% as the index 12 represents the Score / 100. This does not make sense in the context of a score distribution from 0 to 100%.

### Description
<!-- Describe your changes in detail -->
We therefore take scores >100% in the last score distribution section of (90,100]. Previously, we did assume that there is no such thing as a score >100%, so we change the `==` into a `>=`

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Code changes speak for themselves. If you want to test it, you can only test it **locally** as I think there is no official possibility to give scores higher than 100%. 

1. Log in to Artemis
2. Navigate to Course Administration
3. Participate an exercise
4. assess the exercise
5. Manually set the score of the assessment in the result collection to something >100
6. Also set the scores and points in the participant score collection in the database accordingly
5. Make sure in the Exercise Statistics, the assessment is counted into the (90,100] section
6. Reset the scores in the database to not cause any trouble after testing this PR