### PR TITLE
Fix the "previous" and "next" buttons for quiz statistics

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
@@ -138,11 +138,13 @@ export class QuizStatisticsFooterComponent implements OnInit, OnDestroy {
      * If the current page shows the first quiz question statistic then it will navigate to the quiz statistic
      */
     previousStatistic() {
+        const baseUrl = this.quizStatisticUtil.getBaseUrlForQuizExercise(this.quizExercise);
+
         if (this.isQuizStatistic) {
-            this.router.navigateByUrl(`/course-management/${getCourseId(this.quizExercise)}/quiz-exercises/${this.quizExercise.id}/quiz-point-statistic`);
+            this.router.navigateByUrl(baseUrl + `/quiz-point-statistic`);
         } else if (this.isQuizPointStatistic) {
             if (!this.quizExercise.quizQuestions || this.quizExercise.quizQuestions.length === 0) {
-                this.router.navigateByUrl(`/course-management/${getCourseId(this.quizExercise)}/quiz-exercises/${this.quizExercise.id}/quiz-statistic`);
+                this.router.navigateByUrl(baseUrl + `/quiz-statistic`);
             } else {
                 // go to previous question-statistic
                 this.quizStatisticUtil.navigateToStatisticOf(this.quizExercise, this.quizExercise.quizQuestions.last()!);
@@ -157,12 +159,14 @@ export class QuizStatisticsFooterComponent implements OnInit, OnDestroy {
      * If the current page shows the last quiz question statistic then it will navigate to the quiz point statistic
      */
     nextStatistic() {
+        const baseUrl = this.quizStatisticUtil.getBaseUrlForQuizExercise(this.quizExercise);
+
         if (this.isQuizPointStatistic) {
-            this.router.navigateByUrl(`/course-management/${getCourseId(this.quizExercise)}/quiz-exercises/${this.quizExercise.id}/quiz-statistic`);
+            this.router.navigateByUrl(baseUrl + `/quiz-statistic`);
         } else if (this.isQuizStatistic) {
             // go to quiz-statistic if the position = last position
             if (!this.quizExercise.quizQuestions || this.quizExercise.quizQuestions.length === 0) {
-                this.router.navigateByUrl(`/course-management/${getCourseId(this.quizExercise)}/quiz-exercises/${this.quizExercise.id}/quiz-point-statistic`);
+                this.router.navigateByUrl(baseUrl + `/quiz-point-statistic`);
             } else {
                 // go to next question-statistic
                 this.quizStatisticUtil.navigateToStatisticOf(this.quizExercise, this.quizExercise.quizQuestions[0]);

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.ts
@@ -13,7 +13,6 @@ import { QuizExerciseService } from 'app/exercises/quiz/manage/quiz-exercise.ser
 import { MultipleChoiceQuestionStatistic } from 'app/entities/quiz/multiple-choice-question-statistic.model';
 import { QuizPointStatistic } from 'app/entities/quiz/quiz-point-statistic.model';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
-import { getCourseId } from 'app/entities/exercise.model';
 import { Authority } from 'app/shared/constants/authority.constants';
 import { UI_RELOAD_TIME } from 'app/shared/constants/exercise-exam-constants';
 

--- a/src/main/webapp/app/exercises/quiz/shared/quiz-statistic-util.service.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/quiz-statistic-util.service.ts
@@ -9,6 +9,27 @@ export class QuizStatisticUtil {
     constructor(private router: Router) {}
 
     /**
+     * Gets the URL to the quiz exercise detail/edit view
+     * which is used as basis for all quiz related subroutes.
+     *
+     * @param quizExercise the exercise to get the URL for
+     * @returns string the URL to the quiz depending on if it is in an exam or not
+     */
+    getBaseUrlForQuizExercise(quizExercise: QuizExercise): string {
+        const courseId = getCourseId(quizExercise);
+
+        // Test if we're a course exercise
+        if (!quizExercise.exerciseGroup) {
+            return `/course-management/${courseId}/quiz-exercises/${quizExercise.id}`;
+        }
+
+        // Otherwise we are in the exam mode
+        const examId = quizExercise.exerciseGroup!.exam!.id!;
+        const groupId = quizExercise.exerciseGroup!.id!;
+        return `/course-management/${courseId}/exams/${examId}/exercise-groups/${groupId}/quiz-exercises/${quizExercise.id}`;
+    }
+
+    /**
      * go to the Template with the previous QuizStatistic
      * if first QuizQuestionStatistic -> go to the quiz-statistic
      *
@@ -16,13 +37,15 @@ export class QuizStatisticUtil {
      * @param question: the question of the current statistic
      */
     previousStatistic(quizExercise: QuizExercise, question: QuizQuestion) {
+        const baseUrl = this.getBaseUrlForQuizExercise(quizExercise);
+
         // find position in quiz
         const index = quizExercise.quizQuestions!.findIndex(function (quiz) {
             return quiz.id === question.id;
         });
         // go to quiz-statistic if the position = 0
         if (index === 0) {
-            this.router.navigateByUrl('/course-management/' + getCourseId(quizExercise) + '/quiz-exercises/' + quizExercise.id + '/quiz-point-statistic');
+            this.router.navigateByUrl(baseUrl + '/quiz-point-statistic');
         } else {
             // go to previous Question-statistic
             this.navigateToStatisticOf(quizExercise, quizExercise.quizQuestions![index - 1]);
@@ -37,13 +60,15 @@ export class QuizStatisticUtil {
      * @param question: the question of the current statistic
      */
     nextStatistic(quizExercise: QuizExercise, question: QuizQuestion) {
+        const baseUrl = this.getBaseUrlForQuizExercise(quizExercise);
+
         // find position in quiz
         const index = quizExercise.quizQuestions!.findIndex(function (quiz) {
             return quiz.id === question.id;
         });
         // go to quiz-statistic if the position = last position
         if (index === quizExercise.quizQuestions!.length - 1) {
-            this.router.navigateByUrl('/course-management/' + getCourseId(quizExercise) + '/quiz-exercises/' + quizExercise.id + '/quiz-point-statistic');
+            this.router.navigateByUrl(baseUrl + '/quiz-point-statistic');
         } else {
             // go to next Question-statistic
             this.navigateToStatisticOf(quizExercise, quizExercise.quizQuestions![index + 1]);
@@ -56,12 +81,14 @@ export class QuizStatisticUtil {
      * @param question Question for which to navigate to the statistics
      */
     navigateToStatisticOf(quizExercise: QuizExercise, question: QuizQuestion) {
+        const baseUrl = this.getBaseUrlForQuizExercise(quizExercise);
+
         if (question.type === QuizQuestionType.MULTIPLE_CHOICE) {
-            this.router.navigateByUrl(`/course-management/${getCourseId(quizExercise)}/quiz-exercises/${quizExercise.id}/mc-question-statistic/${question.id}`);
+            this.router.navigateByUrl(baseUrl + `/mc-question-statistic/${question.id}`);
         } else if (question.type === QuizQuestionType.DRAG_AND_DROP) {
-            this.router.navigateByUrl(`/course-management/${getCourseId(quizExercise)}/quiz-exercises/${quizExercise.id}/dnd-question-statistic/${question.id}`);
+            this.router.navigateByUrl(baseUrl + `/dnd-question-statistic/${question.id}`);
         } else if (question.type === QuizQuestionType.SHORT_ANSWER) {
-            this.router.navigateByUrl(`/course-management/${getCourseId(quizExercise)}/quiz-exercises/${quizExercise.id}/sa-question-statistic/${question.id}`);
+            this.router.navigateByUrl(baseUrl + `/sa-question-statistic/${question.id}`);
         }
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Using "Previous Question" or "Next Question" in the exam statistics for a quiz, you were redirected to the quiz on the course instead of on the exam.

### Description

We navigate to the correct exam route. (I added a helper method for getting the correct base-route.)

### Steps for Testing

1. Create or find a quiz which is over
2. Inspect the statistics and cycle through "Point Distribution", "Quiz Statistics" and all the questions using the previous and next buttons
3. Repeat 1. and 2. for an exam quiz exercise

### Test Coverage
quiz-statistic-util.service.ts: 33% -> 82%

### Screenshots
In the bottom right: The two buttons used for cycling
In the bottom left: The things to cycle through, "Point Distribution", "Quiz Statistics" and one question in this case
![grafik](https://user-images.githubusercontent.com/72132281/126802363-6868c293-d195-4ac9-8aeb-8cbff67225db.png)

