### PR TITLE
[Bugfix] in exercise assessment dashboard show side table in exam mode

### DIFF
--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
@@ -6,8 +6,8 @@
 <jhi-alert></jhi-alert>
 
 <div *ngIf="exercise">
-    <div class="row my-3 d-flex justify-content-between">
-        <div class="col-sm-8" *ngIf="!isTestRun">
+    <div *ngIf="!isTestRun" class="row my-3 d-flex justify-content-between">
+        <div class="col-sm-8">
             <div>
                 <p class="h3" style="text-align: left">
                     {{ 'artemisApp.exerciseAssessmentDashboard.yourStatus' | artemisTranslate }}:
@@ -49,7 +49,6 @@
 
         <div class="col-sm-4" style="min-width: 400px">
             <jhi-side-panel
-                *ngIf="!isExamMode"
                 [panelHeader]="'artemisApp.exerciseAssessmentDashboard.exerciseInformation' | artemisTranslate"
                 [panelDescriptionHeader]="'artemisApp.exerciseAssessmentDashboard.totalYours' | artemisTranslate"
             >


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For exercise-assessment-dashboard view, show tutor graph and exercise information table in a consistent way.
Before, in exam mode, __tutor graph_ was shown_ while the _side table was hidden_.
This PR places both these ui elements under the same conditions.


### Description
<!-- Describe your changes in detail -->
For Exercise Assessment Dashboard view:
1. Set the conditions to show the tutor-graph and the side-table to true in case of a normal exercise and Exam mode. 
2. Set to false in case of Test Run.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to an Exam
4. Navigate to Assessment Dashboard
5. Navigate to Exercise Dashboard.
6. You should be able to see both the **tutor graph** as well as **side-table** on the right.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
### Before
<img width="1275" alt="Screenshot 2021-07-25 at 1 32 38 AM" src="https://user-images.githubusercontent.com/51077603/126883372-9590fa87-b0a8-4848-b0c5-3968c270a94e.png">

### After

<img width="1270" alt="Screenshot 2021-07-25 at 1 25 42 AM" src="https://user-images.githubusercontent.com/51077603/126883371-2d04e821-6e2d-4d36-950c-aff78a67d99b.png">
