### PR TITLE
[Tests] Improve coverage for programming exercise services

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
@@ -275,12 +275,30 @@ public class ProgrammingPlagiarismDetectionService {
         repositories.parallelStream().forEach(repository -> {
             var localPath = repository.getLocalPath();
             try {
-                programmingExerciseExportService.deleteTempLocalRepository(repository);
+                deleteTempLocalRepository(repository);
             }
             catch (GitException ex) {
                 log.error("Delete repository {} did not work as expected: {}", localPath, ex.getMessage());
             }
         });
+    }
+
+    /**
+     * Deletes the locally checked out repository.
+     *
+     * @param repository The repository that should get deleted
+     */
+    public void deleteTempLocalRepository(Repository repository) {
+        // we do some cleanup here to prevent future errors with file handling
+        // We can always delete the repository as it won't be used by the student (separate path)
+        if (repository != null) {
+            try {
+                gitService.deleteLocalRepository(repository);
+            }
+            catch (IOException ex) {
+                log.warn("Could not delete temporary repository {}: {}", repository.getLocalPath().toString(), ex.getMessage());
+            }
+        }
     }
 
     private LanguageOption getJPlagProgrammingLanguage(ProgrammingExercise programmingExercise) {

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -531,24 +531,6 @@ public class ProgrammingExerciseExportService {
     }
 
     /**
-     * Delete all temporary zipped repositories created during export
-     *
-     * @param pathsToZipeedRepos A list of all paths to the zip files, that should be deleted
-     */
-    private void deleteTempZipRepoFiles(List<Path> pathsToZipeedRepos) {
-        log.debug("Delete all temporary zip repo files");
-        // delete the temporary zipped repo files
-        for (Path zippedRepoFile : pathsToZipeedRepos) {
-            try {
-                Files.delete(zippedRepoFile);
-            }
-            catch (Exception ex) {
-                log.warn("Could not delete file {}. Error message: {}", zippedRepoFile, ex.getMessage());
-            }
-        }
-    }
-
-    /**
      * delete all files in the directory based on the given programming exercise and target path
      * @param programmingExercise the programming exercise for which repos have been downloaded
      * @param targetPath the path in which the repositories have been downloaded
@@ -562,24 +544,6 @@ public class ProgrammingExerciseExportService {
         }
         catch (IOException ex) {
             log.warn("The project root directory '" + projectPath + "' could not be deleted.", ex);
-        }
-    }
-
-    /**
-     * Deletes the locally checked out repository.
-     *
-     * @param repository The repository that should get deleted
-     */
-    public void deleteTempLocalRepository(Repository repository) {
-        // we do some cleanup here to prevent future errors with file handling
-        // We can always delete the repository as it won't be used by the student (separate path)
-        if (repository != null) {
-            try {
-                gitService.deleteLocalRepository(repository);
-            }
-            catch (IOException ex) {
-                log.warn("Could not delete temporary repository {}: {}", repository.getLocalPath().toString(), ex.getMessage());
-            }
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingSubmissionService.java
@@ -586,11 +586,6 @@ public class ProgrammingSubmissionService extends SubmissionService {
         return EXERCISE_TOPIC_ROOT + exerciseId + PROGRAMMING_SUBMISSION_TOPIC;
     }
 
-    public ProgrammingSubmission findByResultId(long resultId) throws EntityNotFoundException {
-        Optional<ProgrammingSubmission> programmingSubmission = programmingSubmissionRepository.findByResultId(resultId);
-        return programmingSubmission.orElseThrow(() -> new EntityNotFoundException("Could not find programming submission for result id " + resultId));
-    }
-
     /**
      * Given an exercise id and a tutor id, it returns all the programming submissions where the tutor has assessed a result
      *

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -2,7 +2,11 @@ package de.tum.in.www1.artemis.programmingexercise;
 
 import static de.tum.in.www1.artemis.programmingexercise.ProgrammingExerciseTestService.studentLogin;
 import static de.tum.in.www1.artemis.programmingexercise.ProgrammingSubmissionConstants.BITBUCKET_REQUEST;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doThrow;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -15,12 +19,14 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseMode;
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
+import de.tum.in.www1.artemis.exception.GitException;
 import de.tum.in.www1.artemis.service.programming.ProgrammingLanguageFeatureService;
 
 public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
@@ -290,6 +296,20 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testArchiveCourseWithProgrammingExercise() throws Exception {
         programmingExerciseTestService.testArchiveCourseWithProgrammingExercise();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testExportProgrammingExerciseInstructorMaterial_failToCreateZip() throws Exception {
+        doThrow(IOException.class).when(zipFileService).createZipFile(any(Path.class), any(), eq(false));
+        programmingExerciseTestService.exportProgrammingExerciseInstructorMaterial(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testExportProgrammingExerciseInstructorMaterial_failToExportRepository() throws Exception {
+        doThrow(GitException.class).when(fileService).getUniquePathString(anyString());
+        programmingExerciseTestService.exportProgrammingExerciseInstructorMaterial(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
@@ -1,6 +1,11 @@
 package de.tum.in.www1.artemis.programmingexercise;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +62,18 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    void testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectName() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectName();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    void testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError() throws Exception {
+        programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void textExportSubmissionsByParticipationIds() throws Exception {
         programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds();
     }
@@ -82,7 +99,14 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void textExportSubmissionsByStudentLogins() throws Exception {
-        programmingExerciseIntegrationServiceTest.textExportSubmissionsByStudentLogins();
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByStudentLogins();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    void textExportSubmissionsByStudentLogins_failToCreateZip() throws Exception {
+        doThrow(IOException.class).when(zipFileService).createZipFile(any(Path.class), any(), eq(false));
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByStudentLogins_failToCreateZip();
     }
 
     @Test
@@ -860,6 +884,12 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     @WithMockUser(value = "student1", roles = "STUDENT")
     public void testExportAuxiliaryRepositoryForbidden() throws Exception {
         programmingExerciseIntegrationServiceTest.testExportAuxiliaryRepositoryForbidden();
+    }
+
+    @Test
+    @WithMockUser(value = "editor1", roles = "EDITOR")
+    public void testExportEmptyAuxiliaryRepository() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportAuxiliaryRepositoryBadRequest();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
@@ -94,7 +94,7 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void textExportSubmissionsByStudentLogins() throws Exception {
-        programmingExerciseIntegrationServiceTest.textExportSubmissionsByStudentLogins();
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByStudentLogins();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -27,6 +28,7 @@ import javax.validation.constraints.NotNull;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.data.Offset;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.EmptyCommitException;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.StoredConfig;
@@ -58,10 +60,7 @@ import de.tum.in.www1.artemis.service.FileService;
 import de.tum.in.www1.artemis.service.UrlService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
-import de.tum.in.www1.artemis.util.DatabaseUtilService;
-import de.tum.in.www1.artemis.util.GitUtilService;
-import de.tum.in.www1.artemis.util.RequestUtilService;
-import de.tum.in.www1.artemis.util.ZipFileTestUtilService;
+import de.tum.in.www1.artemis.util.*;
 import de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResource;
 import de.tum.in.www1.artemis.web.rest.ProgrammingExerciseTestCaseResource;
 import de.tum.in.www1.artemis.web.rest.dto.ProgrammingExerciseTestCaseDTO;
@@ -257,6 +256,93 @@ public class ProgrammingExerciseIntegrationServiceTest {
         request.get("/api/programming-exercises/" + programmingExercise.getId() + "/test-case-state", HttpStatus.FORBIDDEN, Boolean.class);
     }
 
+    public void testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectName() throws Exception {
+        var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
+        var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), null);
+
+        doReturn(repository1).when(gitService).getOrCheckoutRepository(eq(participation1.getVcsRepositoryUrl()), anyString(), anyBoolean());
+        doReturn(repository2).when(gitService).getOrCheckoutRepository(eq(participation2.getVcsRepositoryUrl()), anyString(), anyBoolean());
+        doThrow(EmptyCommitException.class).when(gitService).stageAllChanges(any());
+
+        // Create the eclipse .project file which will be modified.
+        Path projectFilePath = Path.of(repository1.getLocalPath().toString(), ".project");
+        File projectFile = new File(projectFilePath.toString());
+        String projectFileContents = de.tum.in.www1.artemis.util.FileUtils.loadFileFromResources("test-data/repository-export/.project");
+        FileUtils.writeStringToFile(projectFile, projectFileContents, StandardCharsets.UTF_8);
+
+        // Create the maven .pom file
+        Path pomPath = Path.of(repository1.getLocalPath().toString(), "pom.xml");
+        File pomFile = new File(pomPath.toString());
+        String pomContents = de.tum.in.www1.artemis.util.FileUtils.loadFileFromResources("test-data/repository-export/pom.xml");
+        FileUtils.writeStringToFile(pomFile, pomContents, StandardCharsets.UTF_8);
+
+        var participation = programmingExerciseStudentParticipationRepository.findByExerciseIdAndStudentLogin(programmingExercise.getId(), "student1");
+        assertThat(participation).isPresent();
+
+        final var path = ROOT + EXPORT_SUBMISSIONS_BY_PARTICIPATIONS.replace("{exerciseId}", String.valueOf(programmingExercise.getId())).replace("{participationIds}",
+                String.join(",", List.of(participation.get().getId().toString())));
+        // all options false by default, only test if export works at all
+        var exportOptions = new RepositoryExportOptionsDTO();
+        exportOptions.setAddParticipantName(true);
+
+        downloadedFile = request.postWithResponseBodyFile(path, exportOptions, HttpStatus.OK);
+        assertThat(downloadedFile).exists();
+
+        // Make sure both repositories are present
+        String modifiedEclipseProjectFile = FileUtils.readFileToString(projectFile, StandardCharsets.UTF_8);
+        assertThat(modifiedEclipseProjectFile).contains("student1");
+
+        String modifiedPom = FileUtils.readFileToString(pomFile, StandardCharsets.UTF_8);
+        assertThat(modifiedPom).contains("student1");
+
+        Files.deleteIfExists(projectFilePath);
+        Files.deleteIfExists(pomPath);
+    }
+
+    public void textExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError() throws Exception {
+        var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
+        var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), null);
+
+        doReturn(repository1).when(gitService).getOrCheckoutRepository(eq(participation1.getVcsRepositoryUrl()), anyString(), anyBoolean());
+        doReturn(repository2).when(gitService).getOrCheckoutRepository(eq(participation2.getVcsRepositoryUrl()), anyString(), anyBoolean());
+
+        // Create the eclipse .project file which will be modified.
+        Path projectFilePath = Path.of(repository1.getLocalPath().toString(), ".project");
+        File projectFile = new File(projectFilePath.toString());
+        if (!projectFile.exists()) {
+            Files.createFile(projectFilePath);
+        }
+
+        // Create the maven .pom file
+        Path pomPath = Path.of(repository1.getLocalPath().toString(), "pom.xml");
+        File pomFile = new File(pomPath.toString());
+        if (!pomFile.exists()) {
+            Files.createFile(pomPath);
+        }
+
+        var participation = programmingExerciseStudentParticipationRepository.findByExerciseIdAndStudentLogin(programmingExercise.getId(), "student1");
+        assertThat(participation).isPresent();
+
+        final var path = ROOT + EXPORT_SUBMISSIONS_BY_PARTICIPATIONS.replace("{exerciseId}", String.valueOf(programmingExercise.getId())).replace("{participationIds}",
+                String.join(",", List.of(participation.get().getId().toString())));
+        // all options false by default, only test if export works at all
+        var exportOptions = new RepositoryExportOptionsDTO();
+        exportOptions.setAddParticipantName(true);
+
+        downloadedFile = request.postWithResponseBodyFile(path, exportOptions, HttpStatus.OK);
+        assertThat(downloadedFile).exists();
+
+        // Make sure both repositories are present
+        String modifiedEclipseProjectFile = FileUtils.readFileToString(projectFile, StandardCharsets.UTF_8);
+        assertThat(modifiedEclipseProjectFile).contains("");
+
+        String modifiedPom = FileUtils.readFileToString(pomFile, StandardCharsets.UTF_8);
+        assertThat(modifiedPom).contains("");
+
+        Files.deleteIfExists(projectFilePath);
+        Files.deleteIfExists(pomPath);
+    }
+
     public void textExportSubmissionsByParticipationIds() throws Exception {
         var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
         var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), null);
@@ -336,16 +422,24 @@ public class ProgrammingExerciseIntegrationServiceTest {
         request.postWithResponseBodyFile(path, getOptions(), HttpStatus.FORBIDDEN);
     }
 
-    public void textExportSubmissionsByStudentLogins() throws Exception {
+    public void testExportSubmissionsByStudentLogins() throws Exception {
+        File downloadedFile = exportSubmissionsByStudentLogins(HttpStatus.OK);
+        assertThat(downloadedFile).exists();
+        // TODO: unzip the files and add some checks
+    }
+
+    public void testExportSubmissionsByStudentLogins_failToCreateZip() throws Exception {
+        exportSubmissionsByStudentLogins(HttpStatus.BAD_REQUEST);
+    }
+
+    private File exportSubmissionsByStudentLogins(HttpStatus expectedStatus) throws Exception {
         var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
         var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), null);
         doReturn(repository1).when(gitService).getOrCheckoutRepository(eq(participation1.getVcsRepositoryUrl()), anyString(), anyBoolean());
         doReturn(repository2).when(gitService).getOrCheckoutRepository(eq(participation2.getVcsRepositoryUrl()), anyString(), anyBoolean());
         final var path = ROOT
                 + EXPORT_SUBMISSIONS_BY_PARTICIPANTS.replace("{exerciseId}", String.valueOf(programmingExercise.getId())).replace("{participantIdentifiers}", "student1,student2");
-        downloadedFile = request.postWithResponseBodyFile(path, getOptions(), HttpStatus.OK);
-        assertThat(downloadedFile).exists();
-        // TODO: unzip the files and add some checks
+        return request.postWithResponseBodyFile(path, getOptions(), expectedStatus);
     }
 
     private RepositoryExportOptionsDTO getOptions() {
@@ -1566,6 +1660,11 @@ public class ProgrammingExerciseIntegrationServiceTest {
     public void testExportAuxiliaryRepositoryForbidden() throws Exception {
         AuxiliaryRepository repository = addAuxiliaryRepositoryToExercise();
         request.get(defaultExportInstructorAuxiliaryRepository(repository), HttpStatus.FORBIDDEN, File.class);
+    }
+
+    public void testExportAuxiliaryRepositoryBadRequest() throws Exception {
+        AuxiliaryRepository repository = addAuxiliaryRepositoryToExercise();
+        request.get(defaultExportInstructorAuxiliaryRepository(repository), HttpStatus.BAD_REQUEST, File.class);
     }
 
     public void testExportAuxiliaryRepositoryExerciseNotFound() throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
@@ -267,7 +267,7 @@ public class ProgrammingExerciseIntegrationServiceTest {
         // Create the eclipse .project file which will be modified.
         Path projectFilePath = Path.of(repository1.getLocalPath().toString(), ".project");
         File projectFile = new File(projectFilePath.toString());
-        String projectFileContents = de.tum.in.www1.artemis.util.FileUtils.loadFileFromResources("test-data/repository-export/.project");
+        String projectFileContents = de.tum.in.www1.artemis.util.FileUtils.loadFileFromResources("test-data/repository-export/sample.project");
         FileUtils.writeStringToFile(projectFile, projectFileContents, StandardCharsets.UTF_8);
 
         // Create the maven .pom file

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseParticipationIntegrationTest.java
@@ -39,6 +39,9 @@ public class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpr
     private StudentParticipationRepository studentParticipationRepository;
 
     @Autowired
+    private ParticipationRepository participationRepository;
+
+    @Autowired
     private TemplateProgrammingExerciseParticipationRepository templateProgrammingExerciseParticipationRepository;
 
     @Autowired
@@ -262,6 +265,14 @@ public class ProgrammingExerciseParticipationIntegrationTest extends AbstractSpr
         ProgrammingSubmission submission = (ProgrammingSubmission) new ProgrammingSubmission().submissionDate(ZonedDateTime.now().minusSeconds(61L));
         submission = database.addProgrammingSubmission(programmingExercise, submission, "student1");
         request.get(participationsBaseUrl + submission.getParticipation().getId() + "/latest-pending-submission", HttpStatus.OK, ProgrammingSubmission.class);
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testGetLatestPendingSubmission_notProgrammingParticipation() throws Exception {
+        StudentParticipation studentParticipation = new StudentParticipation();
+        studentParticipation = participationRepository.save(studentParticipation);
+        request.get(participationsBaseUrl + studentParticipation.getId() + "/latest-pending-submission", HttpStatus.NOT_FOUND, ProgrammingSubmission.class);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -890,7 +890,7 @@ public class ProgrammingExerciseTestService {
         exportProgrammingExerciseInstructorMaterial(HttpStatus.FORBIDDEN);
     }
 
-    private java.io.File exportProgrammingExerciseInstructorMaterial(HttpStatus expectedStatus) throws Exception {
+    public java.io.File exportProgrammingExerciseInstructorMaterial(HttpStatus expectedStatus) throws Exception {
         generateProgrammingExerciseForExport();
 
         // Mock template repo

--- a/src/test/resources/test-data/repository-export/sample.project
+++ b/src/test/resources/test-data/repository-export/sample.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Java5</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION


<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)

### Description
<!-- Describe your changes in detail -->
This PR improves the code coverage of the `ProgrammingExerciseExportService` and `ProgrammingSubmissionService` classes to >= 90%.

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
ProgrammingExerciseExportService.java 90%
ProgrammingSubmissionService.java 90%
