### PR TITLE
Replace the link to submissions for quiz exercise course details

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -56,7 +56,11 @@
                     <fa-icon [icon]="'book'"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.submissions">Submissions</span>
                 </a>
-                <a *ngIf="exercise.type === MODELING || exercise.type === QUIZ" [routerLink]="baseResource + 'statistics'" class="btn btn-info btn-sm me-1">
+                <a *ngIf="exercise.type === QUIZ" [routerLink]="baseResource + 'quiz-point-statistic'" class="btn btn-info btn-sm me-1">
+                    <fa-icon [icon]="'signal'"></fa-icon>
+                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.statistics">Statistics</span>
+                </a>
+                <a *ngIf="exercise.type === MODELING" [routerLink]="baseResource + 'statistics'" class="btn btn-info btn-sm me-1">
                     <fa-icon [icon]="'signal'"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.statistics">Statistics</span>
                 </a>

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -52,11 +52,11 @@
                     <fa-icon [icon]="'table'"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="entity.action.scores">Scores</span>
                 </a>
-                <a [routerLink]="baseResource + 'submissions'" class="btn btn-success btn-sm me-1">
+                <a *ngIf="exercise.type !== QUIZ" [routerLink]="baseResource + 'submissions'" class="btn btn-success btn-sm me-1">
                     <fa-icon [icon]="'book'"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.submissions">Submissions</span>
                 </a>
-                <a *ngIf="exercise.type === MODELING" [routerLink]="baseResource + 'statistics'" class="btn btn-info btn-sm me-1">
+                <a *ngIf="exercise.type === MODELING || exercise.type === QUIZ" [routerLink]="baseResource + 'statistics'" class="btn btn-info btn-sm me-1">
                     <fa-icon [icon]="'signal'"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.statistics">Statistics</span>
                 </a>

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -42,7 +42,7 @@
         >
         </jhi-submission-result-status>
         <div class="col-auto d-md-flex align-items-center" *ngIf="exercise.isAtLeastEditor">
-            <span class="me-1">{{ 'artemisApp.courseOverview.exerciseDetails.instructorActions.title' | artemisTranslate }}</span>
+            <span class="ms-1 me-1">{{ 'artemisApp.courseOverview.exerciseDetails.instructorActions.title' | artemisTranslate }}</span>
             <div class="btn-group flex-btn-group-container">
                 <a *ngIf="exercise.type !== QUIZ" [routerLink]="baseResource" class="btn btn-info btn-sm me-1">
                     <fa-icon [icon]="'eye'"></fa-icon>


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

Quiz exercises have no submissions list, therefore you cannot navigate to that page (and an error is thrown in the console).

### Description

We replace the "Submissions" link with "Statistics". A small left margin was also added to the title so that the text is not crammed (see screenshots).

### Steps for Testing

1. Create or find a quiz exercise
2. View it with an instructor account from the course (not the management!)
3. Make sure that "Submissions" is not present, but "Statistics" is an brings you to the correct page

### Screenshots
Before:
![grafik](https://user-images.githubusercontent.com/72132281/126977243-288a5f59-ff51-4b7b-a5a2-ad9ead05ac48.png)
After:
![grafik](https://user-images.githubusercontent.com/72132281/126980095-5c0a0ba0-48b6-4fed-9de1-0b1c42fbab0b.png)

