### PR TITLE
Hook the console.error and console.warn methods and forward them to t…

### DIFF
--- a/src/test/cypress/plugins/index.ts
+++ b/src/test/cypress/plugins/index.ts
@@ -19,5 +19,15 @@
 module.exports = (on, config) => {
     // `on` is used to hook into various events Cypress emits
     // `config` is the resolved Cypress config
+    on(`task`, {
+        error(message) {
+            console.error('\x1b[31m', 'ERROR: ', message, '\x1b[0m');
+            return null;
+        },
+        warn(message) {
+            console.error('\x1b[33m', 'WARNING: ', message, '\x1b[0m');
+            return null;
+        },
+    });
 };
 /*eslint-enable */

--- a/src/test/cypress/support/index.ts
+++ b/src/test/cypress/support/index.ts
@@ -22,3 +22,18 @@ import './utils';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+/**
+ * We register hooks on the console.error and console.warn methods and forward their content to the process console to allow better debugging with cypress:run.
+ */
+/*eslint-disable */
+Cypress.on('window:before:load', (win) => {
+    cy.stub(win.console, 'error').callsFake((msg) => {
+        cy.now('task', 'error', msg);
+    });
+
+    cy.stub(win.console, 'warn').callsFake((msg) => {
+        cy.now('task', 'warn', msg);
+    });
+});
+/*eslint-enable */


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently it is quite hard to determine what actually failed a cypress test when it's run in headless mode (in the bamboo buildplan or locally via `yarn cypress:run`). Being able to see console warnings and errors can help identifying the underlying issue.

### Description
<!-- Describe your changes in detail -->
In this PR I added hooks for the `console.error` and `console.warn` methods, which then forward the error messages to stdout.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->


1. Specify a baseUrl (e.g. https://vmbruegge60.in.tum.de) in cypress.json
2. Create a new file: `src/test/cypress/integration/ConsoleLog.spec.ts`
3. Paste in the following content for the file:
```typescript
describe('Console log test', () => {
    it('Tests the console log hooks ', () => {
        // We have to visit a page to get a window object
        cy.visit('/');
        // We get the window object and log some stuff with it's console object
        cy.window().then((win) => {
            win.console.error('This should be logged in the console');
            win.console.warn('This should also be logged in the console');
            win.console.log('This should NOT be logged in the console');
            win.console.info('This should also NOT be logged in the console');
        });
    });
});
```
4. Run the spec file: `yarn cypress:run --spec src/test/cypress/integration/ConsoleLog.spec.ts` (Linux/Mac) or `yarn cypress:run --spec src\test\cypress\integration\ConsoleLog.spec.ts` (Windows)
5. The output in the shell should contain the messages from `console.error` and `console.warn`, but not from `console.log` and `console.info`

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
**Before:**
![image](https://user-images.githubusercontent.com/12861668/127049383-5287479e-a9b2-4e8d-aa51-d545eeb8532e.png)

**After:**
![image](https://user-images.githubusercontent.com/12861668/127049275-800d1ea6-f2aa-4354-8110-cd0651f3a3e9.png)
