### PR TITLE
[Bugfix] Display repo link and commit hash properly on exam summary

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -574,8 +574,10 @@ public abstract class Exercise extends DomainObject {
                     // => if we can't find INITIALIZED, we return that one
                     relevantParticipation = participation;
                 }
+                // this case handles FINISHED participations which typically happen when manual results are involved
                 else if (participation.getExercise() instanceof ModelingExercise || participation.getExercise() instanceof TextExercise
-                        || participation.getExercise() instanceof FileUploadExercise) {
+                        || participation.getExercise() instanceof FileUploadExercise
+                        || (participation.getExercise() instanceof ProgrammingExercise && participation.getInitializationState() == InitializationState.FINISHED)) {
                     return participation;
                 }
             }

--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -554,6 +554,22 @@ public abstract class Exercise extends DomainObject {
     }
 
     /**
+     * Find the participation for this exercise
+     *
+     * @param participations the list of available participations
+     * @return the found participation, or null, if none exist
+     */
+    @Nullable
+    public StudentParticipation findParticipation(List<StudentParticipation> participations) {
+        for (StudentParticipation participation : participations) {
+            if (participation.getExercise() != null && participation.getExercise().equals(this)) {
+                return participation;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Find a relevant participation for this exercise (relevancy depends on InitializationState)
      *
      * @param participations the list of available participations

--- a/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Exercise.java
@@ -562,7 +562,7 @@ public abstract class Exercise extends DomainObject {
     @Nullable
     public StudentParticipation findParticipation(List<StudentParticipation> participations) {
         for (StudentParticipation participation : participations) {
-            if (participation.getExercise() != null && participation.getExercise().equals(this)) {
+            if (this.equals(participation.getExercise())) {
                 return participation;
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentParticipationRepository.java
@@ -628,7 +628,7 @@ public interface StudentParticipationRepository extends JpaRepository<StudentPar
      * Distinguishes between student exams and test runs and only loads the respective participations
      *
      * @param studentExam  studentExam with exercises loaded
-     * @param withAssessor (only for non test runs) if assessor should be loaded with the result
+     * @param withAssessor (only for non-test runs) if assessor should be loaded with the result
      * @return student's participations with submissions and results
      */
     default List<StudentParticipation> findByStudentExamWithEagerSubmissionsResult(StudentExam studentExam, boolean withAssessor) {

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -499,7 +499,7 @@ public class StudentExamService {
         var participations = studentParticipationRepository.findTestRunParticipationsByStudentIdAndIndividualExercisesWithEagerSubmissionsResult(instructor.getId(),
                 testRun.getExercises());
         testRun.getExercises().forEach(exercise -> {
-            var relevantParticipation = exercise.findRelevantParticipation(participations);
+            var relevantParticipation = exercise.findParticipation(participations);
             if (relevantParticipation != null) {
                 exercise.setStudentParticipations(Set.of(relevantParticipation));
             }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -559,7 +559,7 @@ public class StudentExamResource {
         }
 
         // get user's participation for the exercise
-        StudentParticipation participation = participations != null ? exercise.findRelevantParticipation(participations) : null;
+        StudentParticipation participation = participations != null ? exercise.findParticipation(participations) : null;
 
         // add relevant submission (relevancy depends on InitializationState) with its result to participation
         if (participation != null) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StudentExamResource.java
@@ -116,7 +116,7 @@ public class StudentExamResource {
         // connect the exercises and student participations correctly and make sure all relevant associations are available
         for (Exercise exercise : studentExam.getExercises()) {
             // add participation with submission and result to each exercise
-            filterParticipation(studentExam, exercise, participations, true);
+            filterParticipationForExercise(studentExam, exercise, participations, true);
         }
         studentExam.getUser().setVisibleRegistrationNumber();
 
@@ -520,7 +520,7 @@ public class StudentExamResource {
      * For all exercises from the student exam, fetch participation, submissions & result for the current user.
      *
      * @param studentExam the student exam in question
-     * @param currentUser logged in user with groups and authorities
+     * @param currentUser logged-in user with groups and authorities
      */
     private void fetchParticipationsSubmissionsAndResultsForStudentExam(StudentExam studentExam, User currentUser) {
         // fetch participations, submissions and results for these exercises, note: exams only contain individual exercises for now
@@ -532,7 +532,7 @@ public class StudentExamResource {
         // connect & filter the exercises and student participations including the latest submission and results where necessary, to make sure all relevant associations are
         // available
         for (Exercise exercise : studentExam.getExercises()) {
-            filterParticipation(studentExam, exercise, participations, isAtLeastInstructor);
+            filterParticipationForExercise(studentExam, exercise, participations, isAtLeastInstructor);
         }
     }
 
@@ -546,7 +546,7 @@ public class StudentExamResource {
      * @param participations the set of participations, wherein to search for the relevant participation
      * @param isAtLeastInstructor flag for instructor access privileges
      */
-    private void filterParticipation(StudentExam studentExam, Exercise exercise, List<StudentParticipation> participations, boolean isAtLeastInstructor) {
+    private void filterParticipationForExercise(StudentExam studentExam, Exercise exercise, List<StudentParticipation> participations, boolean isAtLeastInstructor) {
         // remove the unnecessary inner course attribute
         exercise.setCourse(null);
 
@@ -574,7 +574,7 @@ public class StudentExamResource {
                 setResultIfNecessary(studentExam, participation, isAtLeastInstructor);
 
                 if (exercise instanceof QuizExercise) {
-                    // filter quiz solutions when the publish result date is not set (or when set before the publish result date)
+                    // filter quiz solutions when the publishing result date is not set (or when set before the publish result date)
                     ((QuizSubmission) latestSubmission).filterForExam(studentExam.areResultsPublishedYet(), isAtLeastInstructor);
                 }
                 else {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I documented the Java code using JavaDoc style.

### Motivation
The following issue on the production server currently affects many EIST students. 

### Description
<!-- Describe your changes in detail -->
The message `You didn't submit any solution for this exercise.` is displayed in the exam summary, even if students submitted code. This is caused by the activation of manual assessments, which leads to a change of the `initialization state` of many programming exercises to `FINISHED`. This state was not covered from the server-side when retrieving the participations. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create an exam with programming exercises
2. Participate in the programming exercise _(submit/push at least once, to create a submission)_
3. Submit the exam and make sure that the message `You didn't submit any solution for this exercise.` is not displayed on the exam overview
4. Set the `initialization state` for the respective participation to `FINISHED`
   a) Local Programming exercise setup: 
      i) go to the table `participation` and manually set the `initialization state` of the participation that is referred to in the exam overview to `FINISHED`
      ii) Double check that the initialization state is displayed is `finished` on the participation view
         ![image](https://user-images.githubusercontent.com/63976129/127519789-aacec2dd-e7de-46e3-a139-6e9aeefb5ab9.png)
   b) Test server: 
    i) navigate to the student exam overview and _Assess unsubmitted exams_ (the grace period must be over)
    ii) Double check that the initialization state is displayed is `finished` on the participation view
         ![image](https://user-images.githubusercontent.com/63976129/127519789-aacec2dd-e7de-46e3-a139-6e9aeefb5ab9.png)

5. Reload the exam overview and check that `You didn't submit any solution for this exercise.` is not displayed, but instead the last commit hash and repo link

You might also want to double-check the correct behavior at other places in Artemis, where participations need to be loaded (e.g. the exam detail view and the exam scores page).

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Student participated in the exam but the `initialization state` of the exercise is `FINISHED` leading to a wrong message of the summary _(old version)_:
![image](https://user-images.githubusercontent.com/63976129/127514638-4e271793-c43d-4904-861d-c898cb0be1d5.png)
With the fixed version the last commit hash and repo link is displayed:
![image](https://user-images.githubusercontent.com/63976129/127515577-256e4867-c9ac-4a8f-bbad-67c247447759.png)

