### PR TITLE
[Bugfix] - Fix Statistics Server Tests

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/StatisticsIntegrationTest.java
@@ -2,8 +2,8 @@ package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.YearMonth;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 
@@ -146,7 +146,8 @@ public class StatisticsIntegrationTest extends AbstractSpringIntegrationBambooBi
             parameters.add("periodIndex", "" + periodIndex);
             parameters.add("graphType", "" + graph);
             Integer[] result = request.get("/api/management/statistics/data", HttpStatus.OK, Integer[].class, parameters);
-            assertThat(result.length).isEqualTo(YearMonth.of(now.getYear(), now.minusMonths(1 - periodIndex).plusDays(1).getMonth()).lengthOfMonth());
+            var length = (int) ChronoUnit.DAYS.between(now.minusMonths(1), now);
+            assertThat(result.length).isEqualTo(length);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) **locally**.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Once a month, the statistics server test fail on the last day of the month.

### Description
<!-- Describe your changes in detail -->
We falsely add a day onto the date, which does not make a difference except for the last day of the month.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Checkout branch locally
2. execute `testDataForMonthEachGraph` with different dates: 30.07., 31.07., 15.07. (Change time on your system)

### Testing
30.07.:
<img width="1021" alt="Screenshot 2021-07-30 at 10 50 53" src="https://user-images.githubusercontent.com/44401560/127833818-11a01900-565a-490b-a14e-fa5fa7a15d90.png">

31.07.:
<img width="1024" alt="Screenshot 2021-07-31 at 10 52 52" src="https://user-images.githubusercontent.com/44401560/127833871-1eaa26ed-44b8-48d9-8e76-c9c19833117e.png">

15.08.:
<img width="1022" alt="Screenshot 2021-08-02 at 10 48 12" src="https://user-images.githubusercontent.com/44401560/127833906-01e7326a-ec7b-4329-8a81-06b45e2e8427.png">

