### PR TITLE
[Hotfix] Show assessment node in the tutor-participation graph

### DIFF
--- a/src/main/webapp/app/shared/dashboards/tutor-participation-graph/tutor-participation-graph.component.ts
+++ b/src/main/webapp/app/shared/dashboards/tutor-participation-graph/tutor-participation-graph.component.ts
@@ -38,7 +38,7 @@ export class TutorParticipationGraphComponent implements OnInit, OnChanges {
 
     routerLink: string;
 
-    shouldShowManualAssessments: boolean;
+    shouldShowManualAssessments = true;
 
     constructor(private router: Router) {}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
`tutor-participation-graph` component was not showing the **assessment information node** for various exercises. 
Number of assessments is critical because if not shown, instructors/tutors can't understand how many student's submissions are left to be assessed. 

### Description
The issue was happening because `shouldShowManualAssessments` is set to `false` by default and was only reset for programming exercises. 
Setting this value to `true` by default seems to fix this issue.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Pick a course
4. Open Assessment Dashboard
5. Tutor participation graph should have display assessment information.
6. Please check for EXAM assessment dashboard as well.


### Before
<img width="1157" alt="Screenshot 2021-08-04 at 2 23 14 PM" src="https://user-images.githubusercontent.com/51077603/128180066-927bfe3c-e177-4f04-aab5-8f2537e321e7.png">

### After
<img width="1258" alt="Screenshot 2021-08-04 at 2 25 57 PM" src="https://user-images.githubusercontent.com/51077603/128180370-f34141bf-1359-46ab-87aa-cf12a0ce680f.png">

