### PR TITLE
[Bugfix] Bootstrap form control background color -> white

### DIFF
--- a/src/main/webapp/app/account/settings/settings.component.html
+++ b/src/main/webapp/app/account/settings/settings.component.html
@@ -99,7 +99,7 @@
 
                 <div class="form-group" *ngIf="languages && languages.length > 0">
                     <label for="langKey" jhiTranslate="settings.form.language">Language</label>
-                    <select class="form-control" id="langKey" name="langKey" formControlName="langKey">
+                    <select class="form-select" id="langKey" name="langKey" formControlName="langKey">
                         <option *ngFor="let language of languages" [value]="language">{{ language | findLanguageFromKey }}</option>
                     </select>
                 </div>

--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management-update.component.html
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management-update.component.html
@@ -19,7 +19,7 @@
                 </div>
                 <div class="form-group">
                     <label jhiTranslate="artemisApp.systemNotification.type">Type</label>
-                    <select class="form-control" name="type" [(ngModel)]="notification.type">
+                    <select class="form-select" name="type" [(ngModel)]="notification.type">
                         <option *ngFor="let systemNotificationType of systemNotificationTypes" [value]="systemNotificationType.value">{{ systemNotificationType.name }}</option>
                     </select>
                 </div>

--- a/src/main/webapp/app/admin/user-management/user-management-update.component.html
+++ b/src/main/webapp/app/admin/user-management/user-management-update.component.html
@@ -144,13 +144,13 @@
 
                 <div class="form-group" *ngIf="languages && languages.length > 0">
                     <label jhiTranslate="userManagement.langKey">Lang Key</label>
-                    <select class="form-control" id="langKey" name="langKey" [(ngModel)]="user.langKey">
+                    <select class="form-select" id="langKey" name="langKey" [(ngModel)]="user.langKey">
                         <option *ngFor="let language of languages" [value]="language">{{ language | findLanguageFromKey }}</option>
                     </select>
                 </div>
                 <div class="form-group">
                     <label jhiTranslate="userManagement.profiles">Profiles</label>
-                    <select class="form-control" multiple name="authority" [(ngModel)]="user.authorities">
+                    <select class="form-select" multiple name="authority" [(ngModel)]="user.authorities">
                         <option *ngFor="let authority of authorities" [value]="authority">{{ authority }}</option>
                     </select>
                 </div>

--- a/src/main/webapp/app/course/manage/course-update.component.html
+++ b/src/main/webapp/app/course/manage/course-update.component.html
@@ -125,7 +125,7 @@
                 </div>
                 <div class="form-group">
                     <label jhiTranslate="artemisApp.course.semester"></label>
-                    <select class="form-control" formControlName="semester">
+                    <select class="form-select" formControlName="semester">
                         <option *ngFor="let semester of getSemesters()" [value]="semester">{{ semester }}</option>
                     </select>
                 </div>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-update.component.html
@@ -120,7 +120,7 @@
             <label class="form-control-label" jhiTranslate="artemisApp.modelingExercise.diagramType" for="field_diagramType">Diagram Type</label>
             <select
                 [disabled]="isImport || !!modelingExercise.id"
-                class="form-control"
+                class="form-select"
                 name="diagramType"
                 [(ngModel)]="modelingExercise.diagramType"
                 (ngModelChange)="diagramTypeChanged()"

--- a/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
@@ -156,7 +156,7 @@
                                     </ng-template>
                                 </ng-template>
                                 <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
-                                    <select [ngModel]="value" class="p-1 form-control" (change)="updateEditedField(row, EditableField.VISIBILITY)(getEventValue($event))">
+                                    <select [ngModel]="value" class="p-1 form-select" (change)="updateEditedField(row, EditableField.VISIBILITY)(getEventValue($event))">
                                         <option *ngFor="let s of testCaseVisibilityList" [value]="s.value">
                                             {{ 'artemisApp.programmingExerciseTestCase.visibility.' + s.name | artemisTranslate }}
                                         </option>
@@ -264,7 +264,7 @@
                                     <select
                                         [id]="row.id + '-state'"
                                         [ngModel]="value"
-                                        class="p-1 form-control"
+                                        class="p-1 form-select"
                                         (change)="updateEditedCategoryField(row, EditableField.STATE)(getEventValue($event))"
                                     >
                                         <option *ngFor="let s of categoryStateList" [value]="s.value">{{ s.name }}</option>

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-plans-and-repositories-preview.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-plans-and-repositories-preview.component.html
@@ -28,7 +28,7 @@
                     <div *ngIf="programmingExercise.auxiliaryRepositories != undefined && programmingExercise.auxiliaryRepositories.length > 0">
                         <div *ngFor="let auxiliaryRepository of programmingExercise.auxiliaryRepositories">
                             <li>
-                                <code class="text-white badge badge-success badge-primary label-preview">
+                                <code class="text-white badge bg-primary badge-success badge-primary label-preview">
                                     {{ getCourseShortName()?.toLowerCase() }}{{ programmingExercise.shortName.toLowerCase() }}-{{ auxiliaryRepository.name?.toLowerCase() }}
                                 </code>
                                 <jhi-help-icon-without-translation

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -161,7 +161,7 @@
             <select
                 #select
                 required
-                class="form-control"
+                class="form-select"
                 [ngModel]="selectedProgrammingLanguage"
                 (ngModelChange)="select.value = onProgrammingLanguageChange($event)"
                 name="programmingLanguage"
@@ -186,7 +186,7 @@
             <select
                 #select
                 required
-                class="form-control"
+                class="form-select"
                 [ngModel]="selectedProjectType"
                 (ngModelChange)="select.value = onProjectTypeChange($event)"
                 name="projectType"

--- a/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-create-form.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/apollon-diagrams/apollon-diagram-create-form.component.html
@@ -10,7 +10,7 @@
         </div>
         <div class="form-group-narrow">
             <label class="form-control-label" jhiTranslate="artemisApp.modelingExercise.diagramType" for="field_diagramType">Diagram Type</label>
-            <select class="form-control" name="diagramType" [(ngModel)]="apollonDiagram.diagramType" id="field_diagramType">
+            <select class="form-select" name="diagramType" [(ngModel)]="apollonDiagram.diagramType" id="field_diagramType">
                 <option value="ClassDiagram">{{ 'artemisApp.DiagramType.ClassDiagram' | artemisTranslate }}</option>
                 <option value="ActivityDiagram">{{ 'artemisApp.DiagramType.ActivityDiagram' | artemisTranslate }}</option>
                 <option value="ObjectDiagram">{{ 'artemisApp.DiagramType.ObjectDiagram' | artemisTranslate }}</option>

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
@@ -64,7 +64,7 @@
         <div class="question-options">
             <div class="form-group">
                 <span jhiTranslate="artemisApp.quizQuestion.scoringType" class="colon-suffix no-flex-shrink"></span>
-                <select class="form-control" [(ngModel)]="question.scoringType" (ngModelChange)="questionUpdated.emit()" title="scoring type">
+                <select class="form-select" [(ngModel)]="question.scoringType" (ngModelChange)="questionUpdated.emit()" title="scoring type">
                     <option value="ALL_OR_NOTHING">{{ 'artemisApp.quizExercise.scoringType.all_or_nothing' | artemisTranslate }}</option>
                     <option value="PROPORTIONAL_WITH_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_with_penalty' | artemisTranslate }}</option>
                     <option value="PROPORTIONAL_WITHOUT_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_without_penalty' | artemisTranslate }}</option>

--- a/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
@@ -31,7 +31,7 @@
         <div class="question-options" [hidden]="showPreview">
             <div class="form-group">
                 <span jhiTranslate="artemisApp.quizQuestion.scoringType" class="colon-suffix no-flex-shrink"></span>
-                <select class="form-control" [(ngModel)]="question.scoringType" (ngModelChange)="questionUpdated.emit()" title="scoring type">
+                <select class="form-select" [(ngModel)]="question.scoringType" (ngModelChange)="questionUpdated.emit()" title="scoring type">
                     <option value="ALL_OR_NOTHING">{{ 'artemisApp.quizExercise.scoringType.all_or_nothing' | artemisTranslate }}</option>
                     <option value="PROPORTIONAL_WITH_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_with_penalty' | artemisTranslate }}</option>
                     <option value="PROPORTIONAL_WITHOUT_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_without_penalty' | artemisTranslate }}</option>

--- a/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.html
@@ -30,7 +30,7 @@
     <div class="question-options">
         <div class="form-group">
             <span jhiTranslate="artemisApp.quizQuestion.scoringType" class="colon-suffix no-flex-shrink"></span>
-            <select class="form-control" [(ngModel)]="question.scoringType" title="scoring type">
+            <select class="form-select" [(ngModel)]="question.scoringType" title="scoring type">
                 <option value="ALL_OR_NOTHING">{{ 'artemisApp.quizExercise.scoringType.all_or_nothing' | artemisTranslate }}</option>
                 <option value="PROPORTIONAL_WITH_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_with_penalty' | artemisTranslate }}</option>
                 <option value="PROPORTIONAL_WITHOUT_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_without_penalty' | artemisTranslate }}</option>

--- a/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.html
@@ -65,7 +65,7 @@
         <div class="question-options">
             <div class="form-group">
                 <span jhiTranslate="artemisApp.quizQuestion.scoringType" class="colon-suffix no-flex-shrink"></span>
-                <select class="form-control" [(ngModel)]="shortAnswerQuestion.scoringType" (ngModelChange)="questionUpdated.emit()" title="scoring type">
+                <select class="form-select" [(ngModel)]="shortAnswerQuestion.scoringType" (ngModelChange)="questionUpdated.emit()" title="scoring type">
                     <option value="ALL_OR_NOTHING">{{ 'artemisApp.quizExercise.scoringType.all_or_nothing' | artemisTranslate }}</option>
                     <option value="PROPORTIONAL_WITH_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_with_penalty' | artemisTranslate }}</option>
                     <option value="PROPORTIONAL_WITHOUT_PENALTY">{{ 'artemisApp.quizExercise.scoringType.proportional_without_penalty' | artemisTranslate }}</option>

--- a/src/main/webapp/app/grading-system/grading-system.component.html
+++ b/src/main/webapp/app/grading-system/grading-system.component.html
@@ -21,14 +21,14 @@
             </div>
             <div class="form-group">
                 <span class="colon-suffix no-flex-shrink" jhiTranslate="artemisApp.gradingSystem.gradeType.title">Grade Type</span>
-                <select class="form-control" [(ngModel)]="gradingScale.gradeType" (change)="deleteGradeNames()" title="grade type">
+                <select class="form-select" [(ngModel)]="gradingScale.gradeType" (change)="deleteGradeNames()" title="grade type">
                     <option value="GRADE" jhiTranslate="artemisApp.gradingSystem.gradeType.grade">Grade</option>
                     <option value="BONUS" jhiTranslate="artemisApp.gradingSystem.gradeType.bonus">Bonus</option>
                 </select>
             </div>
             <div class="form-group">
                 <span class="colon-suffix no-flex-shrink" jhiTranslate="artemisApp.gradingSystem.inclusivity.title">Inclusivity</span>
-                <select class="form-control" [(ngModel)]="lowerBoundInclusivity" title="inclusivity">
+                <select class="form-select" [(ngModel)]="lowerBoundInclusivity" title="inclusivity">
                     <option [ngValue]="true" jhiTranslate="artemisApp.gradingSystem.inclusivity.lower">Lower Bound Inclusive</option>
                     <option [ngValue]="false" jhiTranslate="artemisApp.gradingSystem.inclusivity.upper">Upper Bound Inclusive</option>
                 </select>
@@ -36,7 +36,7 @@
             <div class="form-group">
                 <ng-container *ngIf="this.gradingScale.gradeType == GradeType.GRADE">
                     <span class="colon-suffix no-flex-shrink" jhiTranslate="artemisApp.gradingSystem.firstPassingGrade">First Passing Grade</span>
-                    <select class="form-control" title="first passing grade" [(ngModel)]="firstPassingGrade">
+                    <select class="form-select" title="first passing grade" [(ngModel)]="firstPassingGrade">
                         <option *ngFor="let gradeStep of gradeStepsWithNonemptyNames()" [ngValue]="gradeStep.gradeName">
                             {{ gradeStep.gradeName }}
                         </option>

--- a/src/main/webapp/app/overview/course-registration-selector/course-registration-selector.component.html
+++ b/src/main/webapp/app/overview/course-registration-selector/course-registration-selector.component.html
@@ -10,7 +10,7 @@
         {{ 'artemisApp.studentDashboard.register.registerSuccessful' | artemisTranslate }}
     </div>
     <div class="col-12 col-sm-auto" *ngIf="showCourseSelection && coursesToSelect.length > 0 && userIsAllowedToRegister">
-        <select class="form-control" id="field_course" name="course" [(ngModel)]="courseToRegister">
+        <select class="form-select" id="field_course" name="course" [(ngModel)]="courseToRegister">
             <option [ngValue]="undefined" selected disabled>{{ 'artemisApp.studentDashboard.register.pleaseSelectCourse' | artemisTranslate }}</option>
             <option [ngValue]="course" *ngFor="let course of coursesToSelect; trackBy: trackCourseById">{{ course.title }}</option>
         </select>

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -139,6 +139,18 @@ a.btn {
     width: auto;
 }
 
+.form-control,
+.form-select,
+.form-check-input,
+.form-control:hover,
+.form-control:focus {
+    background-color: white;
+}
+
+.form-check-input:checked {
+    background-color: $primary;
+}
+
 .btn-primary input,
 .btn input {
     position: absolute;

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -134,17 +134,17 @@ a.btn {
     text-align: left;
 }
 
-.form-inline .form-control {
-    display: inline-block;
-    width: auto;
-}
-
 .form-control,
 .form-select,
 .form-check-input,
 .form-control:hover,
 .form-control:focus {
     background-color: white;
+}
+
+.form-inline .form-control {
+    display: inline-block;
+    width: auto;
 }
 
 .form-check-input:checked {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
After updating the bootstrap library, the form related objects (form-control, form-select, etc.) were using the `$body-bg` as the background color. We however want the color to remain white.

### Description
- Set the background-color of form components to white.
- Add the arrow indicator to the dropdown input fields (`<select>`)
- Set background-color to primary for the auxiliary repositories

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

All text fields, checkboxes, dropdown menus should have white background instead of a grey one.
Could be tested by checking:
- login screen
- exercise update (create/edit) screens
- etc.

### Screenshots

#### Before:
![image](https://user-images.githubusercontent.com/51077603/128531139-bed12b00-0201-4131-9ff0-415fe9a168fa.png)
![image (1)](https://user-images.githubusercontent.com/51077603/128531177-5e30997c-c0c6-4b41-a626-883e5e320f48.png)

#### After:
![Image 06 08 21 at 16 46](https://user-images.githubusercontent.com/51077603/128528648-9c5999ad-be45-4a0f-8e8a-2125c8fc42b0.jpg)
![Image 06 08 21 at 16 45](https://user-images.githubusercontent.com/51077603/128528505-160c8abc-f270-40a4-b443-e6f0aa0e8a7e.jpg)
![Image 06 08 21 at 16 44](https://user-images.githubusercontent.com/51077603/128528405-b8d30bab-cd16-4e25-8349-07c564d4186c.jpg)
![Image 06 08 21 at 16 49](https://user-images.githubusercontent.com/51077603/128530882-63102c6a-0cb0-4a17-be39-e7e6e6ee652d.jpg)
