### PR TITLE
replace deprecated slash with math.div

### DIFF
--- a/src/main/webapp/app/shared/circular-progress-bar/circular-progress-bar.component.scss
+++ b/src/main/webapp/app/shared/circular-progress-bar/circular-progress-bar.component.scss
@@ -113,7 +113,7 @@ Due to the split circle of progress-left and progress right, we must use the ani
     $stepName: ($i * math.div(100, $howManySteps));
 
     //animation only the left side if below 50%
-    @if $i <= ($howManySteps/2) {
+    @if $i <= math.div($howManySteps, 2) {
         .progress-circle[data-percentage='#{$stepName}'] {
             .progress-right .progress-bar-circle {
                 animation: loading-#{$i} $animationTime linear forwards;
@@ -125,22 +125,22 @@ Due to the split circle of progress-left and progress right, we must use the ani
         }
     }
     //animation only the right side if above 50%
-    @if $i > ($howManySteps/2) {
+    @if $i > math.div($howManySteps, 2) {
         .progress-circle[data-percentage='#{$stepName}'] {
             .progress-right .progress-bar-circle {
-                animation: loading-#{$howManySteps/2} $animationTime linear forwards; //set the animation to longest animation
+                animation: loading-#{math.div($howManySteps, 2)} $animationTime linear forwards; //set the animation to longest animation
             }
 
             .progress-left .progress-bar-circle {
-                animation: loading-#{$i - ($howManySteps/2)} $animationTime linear forwards $animationTime;
+                animation: loading-#{$i - math.div($howManySteps, 2)} $animationTime linear forwards $animationTime;
             }
         }
     }
 }
 
 //animation
-@for $i from 1 through ($howManySteps/2) {
-    $degrees: (180/ ($howManySteps/2));
+@for $i from 1 through math.div($howManySteps, 2) {
+    $degrees: math.div(180, math.div($howManySteps, 2));
     $degrees: ($degrees * $i);
 
     @keyframes loading-#{$i} {


### PR DESCRIPTION
### Checklist
- [X] I tested *all* changes 

### Motivation and Context
When starting the client the first time, I was overwhelmed with quite some deprecation warnings. So I chose to fix them.
There are still the `System.import()` deprecation warnings, however, those are dependent on angular, which will apparently be fixed (https://github.com/storybookjs/storybook/pull/15184), so this will hopefully be gone soon, too.

### Description
The division operation using the `/` is deprecated in scss. The replacement is `math.div()`.
```scss
10 / 18 //deprecated
math.div(10, 18) //replacement
```
I, therefore, replaced all occurrences of the deprecated operation with the replacement function.

### Steps for Testing
1. Start the client, locally, and make sure that there are no deprecation warnings apart from the `System.import()` warnings referencing `./node_modules/@angular/core/__ivy_ngcc__/fesm2015/core.js`
2. Make sure that the circular progress bar still works since this is the only component that was changed
