### PR TITLE
remove irrelevant exam column from student exam list

### DIFF
--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
@@ -107,18 +107,6 @@
                 </ng-template>
             </ngx-datatable-column>
 
-            <ngx-datatable-column prop="studentExam" [minWidth]="80" [width]="80">
-                <ng-template ngx-datatable-header-template>
-                    <span class="datatable-header-cell-wrapper" (click)="controls.onSort('studentExam')">
-                        <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.studentExams.exam"> Exam </span>
-                        <fa-icon [icon]="controls.iconForSortPropField('studentExam')"></fa-icon>
-                    </span>
-                </ng-template>
-                <ng-template ngx-datatable-cell-template let-value="value">
-                    <a routerLink="/course-management/{{ courseId }}/exams/{{ examId }}">{{ exam?.title }}</a>
-                </ng-template>
-            </ngx-datatable-column>
-
             <ngx-datatable-column prop="user" [minWidth]="120" [width]="120">
                 <ng-template ngx-datatable-header-template>
                     <span class="datatable-header-cell-wrapper" (click)="controls.onSort('user.name')">


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.

### Motivation and Context
The column `Exam` in the student exams list is irrelevant because it contains the same value for each row. This is because it only shows the student exams for the currently selected exam.

### Description
I simply removed that column from the template. No component changes were made since the exam is still required there.

### Steps for Testing
1. Log in to Artemis
2. Navigate to the Exam Management of an exam
3. View the Student Exams
4. Make sure that the view isn't broken and the exam column isn't present anymore

### Screenshots
Before:
![](https://gyazo.com/48c274e95ed78cfc66a40608e2164bcf/raw)
After:
![](https://gyazo.com/393631962841a55541c8f3bf50b1ae55/raw)
