### PR TITLE
changed buttons to links in assessment dashboard and teams page

### DIFF
--- a/docs/dev/guidelines/client.rst
+++ b/docs/dev/guidelines/client.rst
@@ -67,8 +67,8 @@ Some general aspects:
 ========
 
 1. Be aware that Buttons navigate only in the same tab while Links provide the option to use the context menu or a middle-click to open the page in a new tab. Therefore:
-2. Buttons are best used to trigger certain functionalities
-3. Links are best for navigating on Artemis
+2. Buttons are best used to trigger certain functionalities (e.g. ``<button (click)='deleteExercise(exercise)'>...</button``)
+3. Links are best for navigating on Artemis (e.g. ``<a [routerLink]='openExerciseEditor(exercise)' [queryParams]='getQueryParamsForEditor(exercise)'>...</a>``)
 
 9. Style
 ========

--- a/docs/dev/guidelines/client.rst
+++ b/docs/dev/guidelines/client.rst
@@ -63,7 +63,14 @@ Some general aspects:
 1. Use single quotes for strings.
 2. All strings visible to the user need to be localized (make an entry in the corresponding ``*.json`` file).
 
-8. Style
+8. Buttons and Links
+========
+
+1. Be aware that Buttons navigate only in the same tab while Links provide the option to use the context menu or a middle-click to open the page in a new tab. Therefore:
+2. Buttons are best used to trigger certain functionalities
+3. Links are best for navigating on Artemis
+
+9. Style
 ========
 
 1. Use arrow functions over anonymous function expressions.
@@ -90,7 +97,7 @@ Some general aspects:
 We use ``prettier`` to style code automatically and ``eslint`` to find additional issues.
 You can find the corresponding commands to invoked those tools in ``package.json``.
 
-9. Testing
+10. Testing
 ===========
 
 **If you are new to client testing, it is highly recommended that you work through the testing part of the angular tutorial:** https://angular.io/guide/testing
@@ -243,7 +250,7 @@ Some guidelines:
         });
     });
 
-10. Preventing Memory Leaks
+11. Preventing Memory Leaks
 ===========================
 
 It is crucial that you try to prevent memory leaks in both your components and your tests.
@@ -319,7 +326,7 @@ or
    jest --detectLeaks
 
 
-11. Defining Routes and Breadcrumbs
+12. Defining Routes and Breadcrumbs
 ===================================
 
 The ideal schema for routes is that every variable in a path is preceded by a unique path segment: ``\entityA\:entityIDA\entityB\:entityIDB``
@@ -354,7 +361,7 @@ When creating a completely new route you will have to register the new paths in 
 		}
 	}
 
-12. Strict Template Check
+13. Strict Template Check
 =========================
 
 To prevent errors for strict template rule in TypeScript, Artemis uses following approaches.

--- a/docs/dev/guidelines/client.rst
+++ b/docs/dev/guidelines/client.rst
@@ -68,7 +68,7 @@ Some general aspects:
 
 1. Be aware that Buttons navigate only in the same tab while Links provide the option to use the context menu or a middle-click to open the page in a new tab. Therefore:
 2. Buttons are best used to trigger certain functionalities (e.g. ``<button (click)='deleteExercise(exercise)'>...</button``)
-3. Links are best for navigating on Artemis (e.g. ``<a [routerLink]='openExerciseEditor(exercise)' [queryParams]='getQueryParamsForEditor(exercise)'>...</a>``)
+3. Links are best for navigating on Artemis (e.g. ``<a [routerLink]='getLinkForExerciseEditor(exercise)' [queryParams]='getQueryParamsForEditor(exercise)'>...</a>``)
 
 9. Style
 ========

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
@@ -387,7 +387,7 @@
                                                 *jhiExtensionPoint="overrideNewButton; context: { correctionRound: correctionRound }"
                                                 class="btn btn-success btn-sm guided-tour-new-assessment-btn"
                                                 [routerLink]="getAssessmentLink('new')"
-                                                [queryParams]="getComplaintQueryParams(correctionRound)"
+                                                [queryParams]="getAssessmentQueryParams(correctionRound)"
                                                 [class.disabled]="exercise === exerciseForGuidedTour || openingAssessmentEditorForNewSubmission"
                                                 [class.guided-tour]="exercise === exerciseForGuidedTour"
                                                 [ngStyle]="exercise === exerciseForGuidedTour ? { cursor: 'not-allowed' } : {}"

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
@@ -383,18 +383,19 @@
                                         </td>
 
                                         <td>
-                                            <button
+                                            <a
                                                 *jhiExtensionPoint="overrideNewButton; context: { correctionRound: correctionRound }"
                                                 class="btn btn-success btn-sm guided-tour-new-assessment-btn"
-                                                (click)="openAssessmentEditor('new', correctionRound)"
-                                                [disabled]="exercise === exerciseForGuidedTour || openingAssessmentEditorForNewSubmission"
+                                                [routerLink]="getAssessmentLink('new')"
+                                                [queryParams]="getComplaintQueryParams(correctionRound)"
+                                                [class.disabled]="exercise === exerciseForGuidedTour || openingAssessmentEditorForNewSubmission"
                                                 [class.guided-tour]="exercise === exerciseForGuidedTour"
                                                 [ngStyle]="exercise === exerciseForGuidedTour ? { cursor: 'not-allowed' } : {}"
                                             >
                                                 <fa-icon *ngIf="openingAssessmentEditorForNewSubmission" [icon]="'spinner'" [spin]="true"></fa-icon>
                                                 <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                                 {{ 'artemisApp.exerciseAssessmentDashboard.startAssessment' | artemisTranslate }}
-                                            </button>
+                                            </a>
                                         </td>
                                     </tr>
                                 </ng-container>
@@ -552,16 +553,21 @@
                                     </span>
                                 </td>
                                 <td>
-                                    <button
+                                    <a
                                         *ngIf="moreFeedbackRequest.accepted === undefined; else continueButton"
                                         class="btn btn-success btn-sm"
-                                        (click)="viewComplaint(moreFeedbackRequest)"
+                                        [routerLink]="getAssessmentLink(moreFeedbackRequest)"
+                                        [queryParams]="getComplaintQueryParams(moreFeedbackRequest)"
                                     >
                                         <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                         {{ 'artemisApp.exerciseAssessmentDashboard.evaluateMoreFeedbackRequest' | artemisTranslate }}
-                                    </button>
+                                    </a>
                                     <ng-template #continueButton>
-                                        <button class="btn btn-primary btn-sm" (click)="viewComplaint(moreFeedbackRequest)">
+                                        <button
+                                            class="btn btn-primary btn-sm"
+                                            [routerLink]="getAssessmentLink(moreFeedbackRequest)"
+                                            [queryParams]="getComplaintQueryParams(moreFeedbackRequest)"
+                                        >
                                             <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                             {{ 'artemisApp.exerciseAssessmentDashboard.showMoreFeedbackRequests' | artemisTranslate }}
                                         </button>

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
@@ -337,24 +337,26 @@
                                     <td>
                                         <ng-container *ngIf="(isTestRun && complaints.length === 0) || !isTestRun">
                                             <ng-container *jhiExtensionPoint="overrideOpenButton; context: { submission: submission, correctionRound: correctionRound }">
-                                                <button
+                                                <a
                                                     *ngIf="submission && calculateSubmissionStatusIsDraft(submission, correctionRound); else continueButton"
-                                                    (click)="openAssessmentEditor(submission, correctionRound)"
+                                                    [routerLink]="getAssessmentLink(submission)"
+                                                    [queryParams]="getAssessmentQueryParams(correctionRound)"
                                                     class="btn btn-warning btn-sm"
                                                 >
                                                     <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>&nbsp;{{
                                                         'artemisApp.exerciseAssessmentDashboard.continueAssessment' | artemisTranslate
                                                     }}
-                                                </button>
+                                                </a>
                                                 <ng-template #continueButton>
-                                                    <button
+                                                    <a
                                                         *ngIf="!!submission.results && !!submission.results[correctionRound]"
-                                                        (click)="openAssessmentEditor(submission, correctionRound)"
+                                                        [routerLink]="getAssessmentLink(submission)"
+                                                        [queryParams]="getAssessmentQueryParams(correctionRound)"
                                                         class="btn btn-primary btn-sm"
                                                     >
                                                         <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                                         &nbsp;{{ 'artemisApp.exerciseAssessmentDashboard.openAssessment' | artemisTranslate }}
-                                                    </button>
+                                                    </a>
                                                 </ng-template>
                                             </ng-container>
                                         </ng-container>
@@ -477,20 +479,25 @@
                                     {{ calculateComplaintStatus(submissionWithComplaint.complaint) }}
                                 </td>
                                 <td>
-                                    <button
+                                    <a
                                         *ngIf="submissionWithComplaint.complaint.accepted === undefined; else continueButton"
-                                        [disabled]="isComplaintLocked(submissionWithComplaint.complaint)"
+                                        [class.disabled]="isComplaintLocked(submissionWithComplaint.complaint)"
+                                        [routerLink]="getAssessmentLink(submissionWithComplaint.submission)"
+                                        [queryParams]="getComplaintQueryParams(submissionWithComplaint.complaint)"
                                         class="btn btn-success btn-sm"
-                                        (click)="viewComplaint(submissionWithComplaint.complaint)"
                                     >
                                         <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                         {{ 'artemisApp.exerciseAssessmentDashboard.evaluateComplaint' | artemisTranslate }}
-                                    </button>
+                                    </a>
                                     <ng-template #continueButton>
-                                        <button class="btn btn-primary btn-sm" (click)="viewComplaint(submissionWithComplaint.complaint)">
+                                        <a
+                                            [routerLink]="getAssessmentLink(submissionWithComplaint.submission)"
+                                            [queryParams]="getComplaintQueryParams(submissionWithComplaint.complaint)"
+                                            class="btn btn-primary btn-sm"
+                                        >
                                             <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                             {{ 'artemisApp.exerciseAssessmentDashboard.showComplaint' | artemisTranslate }}
-                                        </button>
+                                        </a>
                                     </ng-template>
                                 </td>
                             </tr>

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
@@ -651,13 +651,10 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
         if (complaint.complaintType === ComplaintType.MORE_FEEDBACK) {
             return this.getAssessmentQueryParams(this.numberOfAssessmentsOfCorrectionRounds.length - 1);
         }
-        const submissionToView = this.submissionsWithComplaints.filter((dto) => dto.submission.id === submission.id).pop()?.submission;
-        if (submissionToView) {
-            if (!submissionToView.results) {
-                submissionToView.results = [];
-            }
-            submissionToView.results = submissionToView.results?.filter((result) => result.assessmentType !== AssessmentType.AUTOMATIC);
-            return this.getAssessmentQueryParams(submissionToView.results!.length - 1);
+        const result = this.getSubmissionToViewFromComplaintSubmission(submission);
+
+        if (result !== undefined) {
+            return this.getAssessmentQueryParams(result.results!.length - 1);
         }
     }
 
@@ -671,13 +668,26 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
         if (complaint.complaintType === ComplaintType.MORE_FEEDBACK) {
             this.openAssessmentEditor(submission, this.numberOfAssessmentsOfCorrectionRounds.length - 1);
         }
+        const result = this.getSubmissionToViewFromComplaintSubmission(submission);
+
+        if (result !== undefined) {
+            this.openAssessmentEditor(result, result.results!.length - 1);
+        }
+    }
+
+    /**
+     * Returns either the corresponding submission to view or undefined.
+     * This complaint has to be a true complaint or else issues can arise.
+     * @param submission
+     */
+    getSubmissionToViewFromComplaintSubmission(submission: Submission) {
         const submissionToView = this.submissionsWithComplaints.filter((dto) => dto.submission.id === submission.id).pop()?.submission;
         if (submissionToView) {
             if (!submissionToView.results) {
                 submissionToView.results = [];
             }
             submissionToView.results = submissionToView.results?.filter((result) => result.assessmentType !== AssessmentType.AUTOMATIC);
-            this.openAssessmentEditor(submissionToView, submissionToView.results!.length - 1);
+            return submissionToView;
         }
     }
 

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
@@ -598,22 +598,6 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
     }
 
     /**
-     * Uses the router to navigate to the assessment editor for a given/new submission
-     * @param submission Either submission or 'new'.
-     * @param correctionRound
-     */
-    openAssessmentEditor(submission: Submission | 'new', correctionRound = 0): void {
-        if (!this.exercise || !this.exercise.type || !submission) {
-            return;
-        }
-
-        this.openingAssessmentEditorForNewSubmission = true;
-        const url = this.getAssessmentLink(submission);
-        this.router.navigate(url, { queryParams: this.getAssessmentQueryParams(correctionRound) });
-        this.openingAssessmentEditorForNewSubmission = false;
-    }
-
-    /**
      * Generates and returns the link to the assessment editor without query parameters
      * @param submission Either submission or 'new'.
      */
@@ -655,23 +639,6 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
 
         if (result !== undefined) {
             return this.getAssessmentQueryParams(result.results!.length - 1);
-        }
-    }
-
-    /**
-     * Show complaint depending on the exercise type
-     * @param complaint that we want to show
-     */
-    viewComplaint(complaint: Complaint) {
-        const submission: Submission = complaint.result?.submission!;
-        // numberOfAssessmentsOfCorrectionRounds size is the number of correction rounds
-        if (complaint.complaintType === ComplaintType.MORE_FEEDBACK) {
-            this.openAssessmentEditor(submission, this.numberOfAssessmentsOfCorrectionRounds.length - 1);
-        }
-        const result = this.getSubmissionToViewFromComplaintSubmission(submission);
-
-        if (result !== undefined) {
-            this.openAssessmentEditor(result, result.results!.length - 1);
         }
     }
 

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
@@ -650,10 +650,11 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
     getSubmissionToViewFromComplaintSubmission(submission: Submission): Submission | undefined {
         const submissionToView = this.submissionsWithComplaints.find((dto) => dto.submission.id === submission.id)?.submission;
         if (submissionToView) {
-            if (!submissionToView.results) {
+            if (submissionToView.results) {
+                submissionToView.results = submissionToView.results.filter((result) => result.assessmentType !== AssessmentType.AUTOMATIC);
+            } else {
                 submissionToView.results = [];
             }
-            submissionToView.results = submissionToView.results?.filter((result) => result.assessmentType !== AssessmentType.AUTOMATIC);
             return submissionToView;
         }
     }

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
@@ -647,8 +647,8 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
      * This complaint has to be a true complaint or else issues can arise.
      * @param submission
      */
-    getSubmissionToViewFromComplaintSubmission(submission: Submission) {
-        const submissionToView = this.submissionsWithComplaints.filter((dto) => dto.submission.id === submission.id).pop()?.submission;
+    getSubmissionToViewFromComplaintSubmission(submission: Submission): Submission | undefined {
+        const submissionToView = this.submissionsWithComplaints.find((dto) => dto.submission.id === submission.id)?.submission;
         if (submissionToView) {
             if (!submissionToView.results) {
                 submissionToView.results = [];

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
@@ -120,14 +120,13 @@
                             placement="left"
                             container="body"
                         >
-                            <button
-                                [disabled]="isAssessmentButtonDisabled(value, value.submission)"
-                                (click)="openAssessmentEditor(value, value.participation, value.submission)"
+                            <a
+                                [class.disabled]="isAssessmentButtonDisabled(value, value.submission)"
+                                [routerLink]="getAssessmentLink(exercise, value.participation, value.submission)"
                                 class="btn btn-warning btn-sm"
+                                ><fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
+                                {{ 'artemisApp.exerciseAssessmentDashboard.' + assessmentAction(value.submission) + 'Assessment' | artemisTranslate }}</a
                             >
-                                <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
-                                <span [jhiTranslate]="'artemisApp.exerciseAssessmentDashboard.' + assessmentAction(value.submission) + 'Assessment'"></span>
-                            </button>
                         </div>
                         <fa-icon
                             class="mx-3"

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.ts
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.ts
@@ -123,9 +123,19 @@ export class TeamParticipationTableComponent implements OnInit {
      * @param submission Either submission or 'new'
      */
     async openAssessmentEditor(exercise: Exercise, participation: Participation, submission: Submission | 'new'): Promise<void> {
-        const submissionUrlParameter: number | 'new' = submission === 'new' ? 'new' : submission.id!;
-        const route = getLinkToSubmissionAssessment(exercise.type!, this.course.id!, exercise.id!, participation.id, submissionUrlParameter, 0, 0);
+        const route = this.getAssessmentLink(exercise, participation, submission);
         await this.router.navigate(route);
+    }
+
+    /**
+     * Generates and returns the link that leads to the assessment editor
+     * @param exercise Exercise to which the submission belongs
+     * @param participation Participation for which the editor should be opened
+     * @param submission Either submission or 'new'
+     */
+    getAssessmentLink(exercise: Exercise, participation: Participation, submission: Submission | 'new'): string[] {
+        const submissionUrlParameter: number | 'new' = submission === 'new' ? 'new' : submission.id!;
+        return getLinkToSubmissionAssessment(exercise.type!, this.course.id!, exercise.id!, participation.id, submissionUrlParameter, 0, 0);
     }
 
     /**

--- a/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
@@ -41,7 +41,7 @@ import { FileUploadExercise } from 'app/entities/file-upload-exercise.model';
 import { ProgrammingSubmissionService } from 'app/exercises/programming/participate/programming-submission.service';
 import { ProgrammingSubmission } from 'app/entities/programming-submission.model';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
-import { Complaint, ComplaintType } from 'app/entities/complaint.model';
+import { ComplaintType } from 'app/entities/complaint.model';
 import { Language } from 'app/entities/tutor-group.model';
 import { Submission, SubmissionExerciseType } from 'app/entities/submission.model';
 import { TutorParticipationService } from 'app/exercises/shared/dashboards/tutor/tutor-participation.service';
@@ -561,59 +561,6 @@ describe('ExerciseAssessmentDashboardComponent', () => {
             expect(submissionToView).to.eql(expectedSubmissionToView);
         });
     });
-
-    /*describe('openAssessmentEditor', () => {
-        it('should not openExampleSubmission', () => {
-            navigateSpy.resetHistory();
-            const submission = { id: 8 };
-            comp.openAssessmentEditor(submission);
-            expect(navigateSpy).to.have.not.been.called;
-        });
-
-        it('should openExampleSubmission with modelingExercise', () => {
-            comp.exercise = exercise;
-            comp.exercise.type = ExerciseType.MODELING;
-            comp.courseId = 4;
-            comp.exercise = exercise;
-            comp.exerciseId = exercise.id!;
-            const submission = { id: 8 };
-            comp.openAssessmentEditor(submission);
-
-            const expectedUrl = [
-                '/course-management',
-                comp.courseId.toString(),
-                'modeling-exercises',
-                exercise.id!.toString(),
-                'submissions',
-                submission.id.toString(),
-                'assessment',
-            ];
-            expect(navigateSpy).to.have.been.calledWith(expectedUrl, { queryParams: { 'correction-round': 0 } });
-        });
-
-        it('should openExampleSubmission with programmingExercise', () => {
-            comp.exercise = exercise;
-            comp.exercise.type = ExerciseType.PROGRAMMING;
-            comp.courseId = 4;
-            comp.exerciseId = exercise.id!;
-            const submission = { id: 8 };
-
-            const expectedUrl = [
-                '/course-management',
-                comp.courseId.toString(),
-                'programming-exercises',
-                exercise.id!.toString(),
-                'submissions',
-                submission.id.toString(),
-                'assessment',
-            ];
-            comp.openAssessmentEditor(submission);
-            expect(navigateSpy).to.have.been.calledWith(expectedUrl);
-            comp.isTestRun = true;
-            comp.openAssessmentEditor(submission);
-            expect(navigateSpy).to.have.been.calledWith(expectedUrl);
-        });
-    });*/
 
     describe('openExampleSubmission', () => {
         const courseId = 4;

--- a/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
@@ -24,7 +24,7 @@ import { ModelingSubmission } from 'app/entities/modeling-submission.model';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { HeaderExercisePageWithDetailsComponent } from 'app/exercises/shared/exercise-headers/header-exercise-page-with-details.component';
 import { ExerciseAssessmentDashboardComponent } from 'app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component';
-import { Exercise, ExerciseType } from 'app/entities/exercise.model';
+import { ExerciseType } from 'app/entities/exercise.model';
 import { ModelingEditorComponent } from 'app/exercises/modeling/shared/modeling-editor.component';
 import { ModelingSubmissionService } from 'app/exercises/modeling/participate/modeling-submission.service';
 import { TutorParticipationStatus } from 'app/entities/participation/tutor-participation.model';
@@ -158,8 +158,6 @@ describe('ExerciseAssessmentDashboardComponent', () => {
         participation,
     } as TextSubmission;
     const programmingSubmissionAssessed = { id: 28, results: [result1, result2], participation } as ProgrammingSubmission;
-
-    const complaint = { id: 29, result: { id: 30, submission: textSubmission } } as Complaint;
 
     const numberOfAssessmentsOfCorrectionRounds = [
         { inTime: 1, late: 1 },


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [X] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [X] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [X] Client: I documented the TypeScript code using JSDoc style.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language]

 **Testing:**
- [x] Documentation
- [x] Tests (1st person)
- [x] Tests (2nd person)
- [x] Source Code (1st person)
- [x] Source Code (2nd person)
- [x] Team-Page
- [x] Course Assessment Dashboard
- [x] Exam Assessment Dashboard (Test Run)
- [x] Exam Assessment Dashboard (Default)

### Motivation and Context
**Team-Page:** When assessing team exercises, you often need to open multiple old exercises aside to compare everything for the current assessment. Currently, you have to open the same page in multiple tabs and navigate to each exercise instead of just quickly opening all pages in a new tab.
**Assessment-Dashboard:** Sometimes, you need to compare different assessments or complaints, so it's the same here. However, this was just another button occurrence I found, so I updated it as well.

### Description
I replaced some buttons which opened assessment editors with links.
=> Previously, one could only open them with left-click, now left-click, context-menu and middle-click are all available for these buttons.
Technically this relates to the user interface. However, nothing was visually changed, so I didn't add any screenshots.
I furthermore removed the now unreferenced methods and their tests and added tests for my newly created methods.
I also added a short documentation entry.

## Steps for Testing
**Documentation**
Please check whether it's consistent with the rest of the documentation and makes sense.

### Code Review
Please check this thoroughly since I'm new to Artemis. Let me know if I should improve something.
I suggest that you start with the TypeScript changes before looking at the HTML. Also, you might want to review component by component.
After that, you can check out the tests. I'd like to have your opinion on whether they are too dumb to miss some test cases. With new systems, I always need some time to adapt my testing skills to that environment.

### Teams (not changed from the first time)
**Requirements:**
- Instructor Account and additional account for the submission if needed
- Team exercise with a team (containing instructor or the mentioned additional one) and no submission of this team
1. Navigate to the Exercises of your course
2. Open the Teams section of your team exercise
3. Open your team view by clicking on the short name
4. Make sure that you can't assess the exercise (disabled link)
5. Submit a submission for this team
6. Make sure that the previous disabled button is navigatable like a link (context menu, middle mouse click to open in a new tab, etc.)
7. Make sure that after opening this the first time, actions from Step 6 are still possible. Left-click should be still an option.

### Assessment Dashboard (changed)
**Requirements**
- Instructor Account and additional account for the submission if needed
- An course exercise with two submissions
1. Navigate to the assessment dashboard
2. Open the dashboard for the corresponding exercise
3. Make sure the assessment button behaves as in 6./7. above when starting an assessment
4. Make sure it behaves the same after opening it the first time and after **assessing the submission**
5. Assess the second exercise
5. File a complaint about the assessment from step 4
6. Make sure that the button for the complaint behaves the same (+ after the complaint was resolved)
7. File a feedback request about the assessment from step 5
8. Make sure that the button for the feedback request behaves the same (+ after the request was resolved)

### Exam Assessment Dashboard Test Run (not changed)
**Requirement**
- Instructor Account
- Exam with at least one exercise
1. Conduct a test run. Assess your test run and make sure that when clicking the button in the assessment dashboard, the query parameters include the test run key
2. Test the same way as you did in the course assessment dashboard minus the feedback request

### Exam Assessment Dashboard (not changed)
**Requirement**
- Instructor Account
- Exam with at least one exercise, conducted once
1. Test the same way as you did in the previous sections. Make sure that the query parameters do not contain a test run

## Screenshots
Teams:
![ee691e0a63a19ddee330e842bb722f91](https://user-images.githubusercontent.com/64264938/129274886-32361a55-da42-4c8a-911e-0560bd687f6d.png)
Assessment Dashbards (Here the course AD, but the other two look the same minus More Feedback Request)
![25279a421e009dbf8641b092f0eecd3b](https://user-images.githubusercontent.com/64264938/129274889-77f04072-43af-43b8-a4e9-1d4a7dc58acf.png)

## Test Coverage
exercise-assessment-dashboard.component.ts 83.8%
team-participation-table.component.ts 93.24%