### PR TITLE
[Tests] Speedup Orion Tests

### DIFF
--- a/src/test/javascript/spec/component/orion/code-editor-instructor-and-editor-orion-container.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/code-editor-instructor-and-editor-orion-container.component.spec.ts
@@ -3,7 +3,6 @@ import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import { CodeEditorInstructorAndEditorOrionContainerComponent } from 'app/orion/management/code-editor-instructor-and-editor-orion-container.component';
 import { ArtemisTestModule } from '../../test.module';
-import { OrionModule } from 'app/shared/orion/orion.module';
 import { OrionConnectorService } from 'app/shared/orion/orion-connector.service';
 import { OrionBuildAndTestService } from 'app/shared/orion/orion-build-and-test.service';
 import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
@@ -20,6 +19,7 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { TranslateService } from '@ngx-translate/core';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { BehaviorSubject } from 'rxjs';
+import { OrionButtonComponent } from 'app/shared/orion/orion-button/orion-button.component';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -31,7 +31,7 @@ describe('CodeEditorInstructorAndEditorOrionContainerComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, OrionModule],
+            imports: [ArtemisTestModule],
             declarations: [
                 CodeEditorInstructorAndEditorOrionContainerComponent,
                 MockComponent(UpdatingResultComponent),
@@ -40,6 +40,7 @@ describe('CodeEditorInstructorAndEditorOrionContainerComponent', () => {
                 MockComponent(ExerciseHintStudentComponent),
                 MockComponent(ProgrammingExerciseEditableInstructionComponent),
                 MockComponent(ProgrammingExerciseStudentTriggerBuildButtonComponent),
+                MockComponent(OrionButtonComponent),
                 MockPipe(ArtemisTranslatePipe),
             ],
             providers: [

--- a/src/test/javascript/spec/component/orion/orion-exercise-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-exercise-assessment-dashboard.component.spec.ts
@@ -44,7 +44,12 @@ describe('OrionExerciseAssessmentDashboardComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
-            declarations: [OrionExerciseAssessmentDashboardComponent, MockComponent(ExerciseAssessmentDashboardComponent), MockPipe(ArtemisTranslatePipe), MockComponent(OrionButtonComponent)],
+            declarations: [
+                OrionExerciseAssessmentDashboardComponent,
+                MockComponent(ExerciseAssessmentDashboardComponent),
+                MockPipe(ArtemisTranslatePipe),
+                MockComponent(OrionButtonComponent),
+            ],
             providers: [
                 MockProvider(ProgrammingSubmissionService),
                 MockProvider(OrionConnectorService),

--- a/src/test/javascript/spec/component/orion/orion-exercise-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-exercise-assessment-dashboard.component.spec.ts
@@ -16,12 +16,12 @@ import { JhiAlertService } from 'ng-jhipster';
 import { ProgrammingAssessmentRepoExportService } from 'app/exercises/programming/assess/repo-export/programming-assessment-repo-export.service';
 import { ArtemisTestModule } from '../../test.module';
 import { ExerciseAssessmentDashboardComponent } from 'app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component';
-import { OrionModule } from 'app/shared/orion/orion.module';
 import { TranslateService } from '@ngx-translate/core';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { OrionState } from 'app/shared/orion/orion';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { OrionButtonComponent } from 'app/shared/orion/orion-button/orion-button.component';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -43,8 +43,8 @@ describe('OrionExerciseAssessmentDashboardComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, OrionModule],
-            declarations: [OrionExerciseAssessmentDashboardComponent, MockComponent(ExerciseAssessmentDashboardComponent), MockPipe(ArtemisTranslatePipe)],
+            imports: [ArtemisTestModule],
+            declarations: [OrionExerciseAssessmentDashboardComponent, MockComponent(ExerciseAssessmentDashboardComponent), MockPipe(ArtemisTranslatePipe), MockComponent(OrionButtonComponent)],
             providers: [
                 MockProvider(ProgrammingSubmissionService),
                 MockProvider(OrionConnectorService),

--- a/src/test/javascript/spec/component/orion/orion-exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-exercise-details-student-actions.component.spec.ts
@@ -4,10 +4,8 @@ import * as sinonChai from 'sinon-chai';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { OrionConnectorService } from 'app/shared/orion/orion-connector.service';
 import { SinonSpy, SinonStub, spy, stub } from 'sinon';
-import { TranslateModule } from '@ngx-translate/core';
 import { BehaviorSubject, of } from 'rxjs';
-import { ArtemisSharedModule } from 'app/shared/shared.module';
-import { MockComponent, MockProvider } from 'ng-mocks';
+import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
 import { FeatureToggleService } from 'app/shared/feature-toggle/feature-toggle.service';
 import { OrionExerciseDetailsStudentActionsComponent } from 'app/orion/participation/orion-exercise-details-student-actions.component';
 import { Exercise } from 'app/entities/exercise.model';
@@ -15,10 +13,11 @@ import { ExerciseActionButtonComponent } from 'app/shared/components/exercise-ac
 import { ProgrammingExerciseStudentParticipation } from 'app/entities/participation/programming-exercise-student-participation.model';
 import { ArtemisTestModule } from '../../test.module';
 import { ArtemisOrionConnector, OrionState } from 'app/shared/orion/orion';
-import { OrionModule } from 'app/shared/orion/orion.module';
 import { OrionBuildAndTestService } from 'app/shared/orion/orion-build-and-test.service';
 import { ExerciseDetailsStudentActionsComponent } from 'app/overview/exercise-details/exercise-details-student-actions.component';
 import { ActivatedRoute } from '@angular/router';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { OrionButtonComponent } from 'app/shared/orion/orion-button/orion-button.component';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -38,8 +37,9 @@ describe('OrionExerciseDetailsStudentActionsComponent', () => {
 
     beforeEach(async () => {
         return TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, TranslateModule.forRoot(), OrionModule, ArtemisSharedModule],
-            declarations: [OrionExerciseDetailsStudentActionsComponent, MockComponent(ExerciseActionButtonComponent), MockComponent(ExerciseDetailsStudentActionsComponent)],
+            imports: [ArtemisTestModule],
+            declarations: [OrionExerciseDetailsStudentActionsComponent, MockComponent(ExerciseActionButtonComponent), MockComponent(ExerciseDetailsStudentActionsComponent), MockComponent(OrionButtonComponent),
+                MockPipe(ArtemisTranslatePipe)],
             providers: [
                 MockProvider(OrionBuildAndTestService),
                 MockProvider(OrionConnectorService),

--- a/src/test/javascript/spec/component/orion/orion-exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-exercise-details-student-actions.component.spec.ts
@@ -38,8 +38,13 @@ describe('OrionExerciseDetailsStudentActionsComponent', () => {
     beforeEach(async () => {
         return TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
-            declarations: [OrionExerciseDetailsStudentActionsComponent, MockComponent(ExerciseActionButtonComponent), MockComponent(ExerciseDetailsStudentActionsComponent), MockComponent(OrionButtonComponent),
-                MockPipe(ArtemisTranslatePipe)],
+            declarations: [
+                OrionExerciseDetailsStudentActionsComponent,
+                MockComponent(ExerciseActionButtonComponent),
+                MockComponent(ExerciseDetailsStudentActionsComponent),
+                MockComponent(OrionButtonComponent),
+                MockPipe(ArtemisTranslatePipe),
+            ],
             providers: [
                 MockProvider(OrionBuildAndTestService),
                 MockProvider(OrionConnectorService),

--- a/src/test/javascript/spec/component/orion/orion-programming-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-programming-exercise.component.spec.ts
@@ -10,7 +10,6 @@ import { OrionProgrammingExerciseComponent } from 'app/orion/management/orion-pr
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { MockComponent, MockPipe, MockProvider } from 'ng-mocks';
-import { OrionModule } from 'app/shared/orion/orion.module';
 import { TranslateService } from '@ngx-translate/core';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { BehaviorSubject } from 'rxjs';

--- a/src/test/javascript/spec/component/orion/orion-programming-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-programming-exercise.component.spec.ts
@@ -15,6 +15,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { BehaviorSubject } from 'rxjs';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
+import { OrionButtonComponent } from 'app/shared/orion/orion-button/orion-button.component';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -29,8 +30,8 @@ describe('OrionProgrammingExerciseComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, OrionModule],
-            declarations: [OrionProgrammingExerciseComponent, MockComponent(ProgrammingExerciseComponent), MockPipe(ArtemisTranslatePipe)],
+            imports: [ArtemisTestModule],
+            declarations: [OrionProgrammingExerciseComponent, MockComponent(ProgrammingExerciseComponent), MockPipe(ArtemisTranslatePipe), MockComponent(OrionButtonComponent)],
             providers: [MockProvider(TranslateService), MockProvider(OrionConnectorService), MockProvider(ProgrammingExerciseService), { provide: Router, useValue: router }],
         })
             .compileComponents()

--- a/src/test/javascript/spec/service/orion-version-validator.service.spec.ts
+++ b/src/test/javascript/spec/service/orion-version-validator.service.spec.ts
@@ -1,13 +1,15 @@
 import * as chai from 'chai';
+import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import { SinonSpy, SinonStub, spy, stub } from 'sinon';
 import { OrionVersionValidator } from 'app/shared/orion/outdated-plugin-warning/orion-version-validator.service';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { Router } from '@angular/router';
-import { MockProfileService } from '../helpers/mocks/service/mock-profile.service';
-import { MockRouter } from '../helpers/mocks/mock-router';
 import { of } from 'rxjs';
 import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
+import { TestBed } from '@angular/core/testing';
+import { ArtemisTestModule } from '../test.module';
+import { MockProvider } from 'ng-mocks';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -32,9 +34,6 @@ function setUserAgent(userAgent: string) {
 
 describe('OrionValidatorService', () => {
     let orionVersionValidator: OrionVersionValidator;
-    let profileService: ProfileService;
-    let router: Router;
-
     let profileInfoStub: SinonStub;
     let navigateSpy: SinonSpy;
 
@@ -46,21 +45,20 @@ describe('OrionValidatorService', () => {
     const legacy = 'IntelliJ';
 
     beforeEach(() => {
-        // @ts-ignore
-        profileService = new MockProfileService();
-        // @ts-ignore
-        router = new MockRouter();
-        orionVersionValidator = new OrionVersionValidator(profileService, router);
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            providers: [OrionVersionValidator, MockProvider(Router), MockProvider(ProfileService)],
+        });
+        orionVersionValidator = TestBed.inject(OrionVersionValidator);
 
-        profileInfoStub = stub(profileService, 'getProfileInfo');
-        navigateSpy = spy(router, 'navigateByUrl');
-
+        profileInfoStub = stub(TestBed.inject(ProfileService), 'getProfileInfo');
         profileInfoStub.returns(of(profileInfo));
+
+        navigateSpy = spy(TestBed.inject(Router), 'navigateByUrl');
     });
 
     afterEach(() => {
-        profileInfoStub.restore();
-        navigateSpy.restore();
+        sinon.restore();
     });
 
     it('should route to the error page if a legacy version is used', () => {


### PR DESCRIPTION
### Motivation, Context, and Description
Removes the Orion module from all Orion tests and instead mocks the associated components in order to improve the test runtime.

For unknown reasons the bamboo test build fails, however the github action test build works just fine

### Steps for Testing

1. Review Code
2. Check build

### Test Coverage
Everything in /orion: still 100%
