### PR TITLE
Adjust breadcrumbs for organizations

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/OrganizationRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/OrganizationRepository.java
@@ -64,6 +64,19 @@ public interface OrganizationRepository extends JpaRepository<Organization, Long
     Long getNumberOfCoursesByOrganizationId(@Param("organizationId") long organizationId);
 
     /**
+     * Returns the title of the organization with the given id
+     *
+     * @param organizationId the id of the organization
+     * @return the name/title of the organization or null if the organization does not exist
+     */
+    @Query("""
+            SELECT o.name
+            FROM Organization o
+            WHERE o.id = :organizationId
+            """)
+    String getOrganizationTitle(@Param("organizationId") Long organizationId);
+
+    /**
      * Get an organization with eagerly loaded users, or else throw exception
      * @param organizationId the id of the organization to find
      * @return the organization entity with eagerly loaded users, if it exists

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/OrganizationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/OrganizationResource.java
@@ -282,4 +282,17 @@ public class OrganizationResource {
         Set<Organization> organizations = organizationRepository.findAllOrganizationsByUserId(userId);
         return new ResponseEntity<>(organizations, HttpStatus.OK);
     }
+
+    /**
+     * GET organizations/:organizationId/title : Returns the title of the organization with the given id
+     *
+     * @param organizationId the id of the organization
+     * @return the title of the organization wrapped in an ResponseEntity or 404 Not Found if no organization with that id exists
+     */
+    @GetMapping("organizations/{organizationId}/title")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<String> getOrganizationTitle(@PathVariable Long organizationId) {
+        final var title = organizationRepository.getOrganizationTitle(organizationId);
+        return title == null ? ResponseEntity.notFound().build() : ResponseEntity.ok(title);
+    }
 }

--- a/src/main/webapp/app/admin/organization-management/organization-management.service.ts
+++ b/src/main/webapp/app/admin/organization-management/organization-management.service.ts
@@ -101,4 +101,8 @@ export class OrganizationManagementService {
     addUserToOrganization(organizationId: number, userLogin: String): Observable<HttpResponse<void>> {
         return this.http.post<void>(`${this.resourceUrl}/user/${userLogin}/organization/${organizationId}`, {}, { observe: 'response' });
     }
+
+    getTitle(organizationId: number): Observable<HttpResponse<string>> {
+        return this.http.get(`${this.resourceUrl}/${organizationId}/title`, { observe: 'response', responseType: 'text' });
+    }
 }

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -27,6 +27,7 @@ import { ApollonDiagramService } from 'app/exercises/quiz/manage/apollon-diagram
 import { LectureService } from 'app/lecture/lecture.service';
 import { ExamManagementService } from 'app/exam/manage/exam-management.service';
 import { Authority } from 'app/shared/constants/authority.constants';
+import { OrganizationManagementService } from 'app/admin/organization-management/organization-management.service';
 
 @Component({
     selector: 'jhi-navbar',
@@ -76,6 +77,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
         private apollonDiagramService: ApollonDiagramService,
         private lectureService: LectureService,
         private examService: ExamManagementService,
+        private organisationService: OrganizationManagementService,
     ) {
         this.version = VERSION ? VERSION : '';
         this.isNavbarCollapsed = true;
@@ -281,6 +283,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
             case 'exams':
                 this.routeExamId = Number(segment);
                 this.addResolvedTitleAsCrumb(this.examService.getTitle(this.routeExamId), currentPath, segment);
+                break;
+            case 'organization-management':
+                this.addResolvedTitleAsCrumb(this.organisationService.getTitle(Number(segment)), currentPath, segment);
                 break;
             case 'import':
                 // Special case: Don't display the ID here but the name directly (clicking the ID wouldn't work)

--- a/src/test/java/de/tum/in/www1/artemis/OrganizationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/OrganizationIntegrationTest.java
@@ -417,4 +417,15 @@ public class OrganizationIntegrationTest extends AbstractSpringIntegrationBamboo
         assertThat(updatedOrganization.getUsers()).hasSize(1);
         assertThat(updatedOrganization.getUsers()).contains(users.get(0));
     }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    public void testGetOrganizationTitle() throws Exception {
+        Organization organization = database.createOrganization();
+        organization.setName("Test Organization");
+        organization = organizationRepo.save(organization);
+
+        final var title = request.get("/api/organizations/" + organization.getId() + "/title", HttpStatus.OK, String.class);
+        assertThat(title).isEqualTo(organization.getName());
+    }
 }

--- a/src/test/javascript/spec/component/shared/navbar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/navbar.component.spec.ts
@@ -28,6 +28,7 @@ import * as sinonChai from 'sinon-chai';
 import { MockRouter } from '../../helpers/mocks/mock-router';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { ArtemisTestModule } from '../../test.module';
+import { OrganizationManagementService } from 'app/admin/organization-management/organization-management.service';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -183,6 +184,23 @@ describe('NavbarComponent', () => {
         // Use matching here to ignore non-semantic differences between objects
         sinon.assert.match(component.breadcrumbs[0], { label: 'userManagement.home.title', translate: true, uri: '/admin/user-management/' } as MockBreadcrumb);
         sinon.assert.match(component.breadcrumbs[1], { label: 'test_user', translate: false, uri: '/admin/user-management/test_user/' } as MockBreadcrumb);
+    });
+
+    it('should build breadcrumbs for organization management', () => {
+        const testUrl = '/admin/organization-management/1';
+        router.setUrl(testUrl);
+
+        const organizationService = fixture.debugElement.injector.get(OrganizationManagementService);
+        const organizationStub = sinon.stub(organizationService, 'getTitle').returns(of({ body: 'Organization Name' } as HttpResponse<string>));
+
+        fixture.detectChanges();
+
+        expect(organizationStub).to.have.been.calledWith(1);
+        expect(component.breadcrumbs.length).to.equal(2);
+
+        // Use matching here to ignore non-semantic differences between objects
+        sinon.assert.match(component.breadcrumbs[0], { label: 'organizationManagement.title', translate: true, uri: '/admin/organization-management/' } as MockBreadcrumb);
+        sinon.assert.match(component.breadcrumbs[1], { label: 'Organization Name', translate: false, uri: '/admin/organization-management/1/' } as MockBreadcrumb);
     });
 
     it('should not error without translation', () => {


### PR DESCRIPTION
### Checklist
- [x] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [x] Server: I implemented the changes with a good performance and prevented too many database calls
- [x] Server: I documented the Java code using JavaDoc style.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage)
- [x] Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context

There were no breadcrumbs in the organization management other than for the overview.

### Description

Now each organization will display the title as breadcrumb (and the edit page an edit crumb).

### Steps for Testing

1. Navigate to Organization Management (as admin)
2. Open an organization and check that the title is displayed
3. Edit an organization and check that a "Edit" crumb is displayed
4. Open the creation page and check that a "Create" crumb is displayed.

### Review Progress

- Code Review
  - [x] Review 1
  - [x] Review 2
- Manual Tests
  - [x] Test 1
  - [x] Test 2

### Screenshots

![grafik](https://user-images.githubusercontent.com/72132281/130360024-6d8607b1-9fd7-47d4-9782-0851ce19a513.png)

![grafik](https://user-images.githubusercontent.com/72132281/130360004-860cdf57-1b15-4654-bb43-6c4a67b288fb.png)
