### PR TITLE
Use UTC timezone in cypress tests

### DIFF
--- a/src/test/cypress/support/utils.ts
+++ b/src/test/cypress/support/utils.ts
@@ -1,6 +1,10 @@
+import utc from 'dayjs/plugin/utc';
 import { TIME_FORMAT } from './constants';
 import { v4 as uuidv4 } from 'uuid';
 import day from 'dayjs';
+
+// Add utc plugin to use the utc timezone
+day.extend(utc);
 
 /**
  * This file contains all of the global utility functions not directly related to cypress.
@@ -14,11 +18,11 @@ export function generateUUID() {
 }
 
 /**
- * Formats the dayjs object with the time format which the backend uses.
+ * Formats the dayjs object with the time format which the backend uses. Also makes sure that dayjs uses the utc timezone.
  * @param dayjs the dayjs object
- * @returns a formatted string representing the date
+ * @returns a formatted string representing the date with utc timezone
  */
 export function dayjsToString(dayjs: day.Dayjs) {
     // We need to add the Z at the end. Otherwise the backend can't parse it.
-    return dayjs.format(TIME_FORMAT) + 'Z';
+    return dayjs.utc().format(TIME_FORMAT) + 'Z';
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The Cypress tests use dayjs to generate and format dates. Per default dayjs uses the local timezone, which can cause issues with tests that rely on deadlines, because the backend expects the date format in UTC.

### Description
<!-- Describe your changes in detail -->
We already have a utility function, which handles converting the dayjs object to a string with the proper format. In this PR I simply adjusted the utility function so that it uses the dayjs utc plugin to create a date format with the utc timezone.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Create a new spec file `src\test\cypress\integration\TimeZone.spec.ts`
2. Paste in the following content:
```typescript
import day from 'dayjs';
import { dayjsToString } from '../support/utils';

describe('Timezone', () => {
    it('Logs the current time in utc format', function () {
        cy.log(dayjsToString(day()));
    });
});
```
3. Open the cypress testrunner: `yarn cypress:open`
4. Execute the newly created TimeZone spec
5. Compare the time date you get with your current time in UTC (use this [website ](https://www.timeanddate.com/worldclock/timezone/utc) for example)
6. The date should be in utc format and time:
![image](https://user-images.githubusercontent.com/12861668/129758232-4b89e4fd-2eea-494d-96ca-c3342a464e1e.png)


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

- Code Review
  - [x] Review 1
  - [x] Review 2

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
[Tests still pass](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-176)
