### PR TITLE
Adapt test coverage threshold

### DIFF
--- a/src/test/javascript/jest.config.js
+++ b/src/test/javascript/jest.config.js
@@ -19,10 +19,10 @@ module.exports = {
     coverageThreshold: {
         global: {
             // TODO: in the future, the following values should be increase to at least 80%
-            statements: 77.67,
-            branches: 58.83,
-            functions: 67.32,
-            lines: 77.14,
+            statements: 77.4,
+            branches: 58.7,
+            functions: 67.1,
+            lines: 76.9,
         },
     },
     preset: 'jest-preset-angular',


### PR DESCRIPTION
### Motivation and Context
The last time the threshold was raised, the current coverage was taken as the new threshold which is apparently common practice. This causes issues since simple refactoring (e.g. shorter variable names causing multiple lines to collapse to one or vice versa) can already change these values on a small level. This causes the client tests to fail, which can only be fixed by creating tests even if they are not within the scope. In the best case, these were missing tests, but usually, they are just tests that have no value to the project.

### Description
The current values in the `develop` branch are (Stmts, Branch, Funcs, Lines) (77.73, 59, 67.47, 77.2). I rounded them down to one decimal and subtracted 0.3 as a leeway => (77.7, 59, 67.4, 77.2) => (77.4, 58.7, 67.1, 76.9).

I think 0.3 as a leeway is a good value. Other values can be proposed.

This ensures that small refactorings don't cause tests to fail due to the test coverage. Benefits:
- Better development experience
- No creation of useless tests to only satisfy the statistics => Higher test quality

### Steps for Testing
1. Take a look at the calculation of the numbers
2. Think about whether 0.3 as a leeway is reasonable.

### Review Progress
- Code Review
  - [x] Review 1
  - [x] Review 2