### PR TITLE
Increase length of MC quiz explanation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/AnswerOption.java
@@ -29,7 +29,7 @@ public class AnswerOption extends DomainObject {
     @JsonView(QuizView.Before.class)
     private String hint;
 
-    @Column(name = "explanation")
+    @Column(name = "explanation", length = 1000)
     @JsonView(QuizView.After.class)
     private String explanation;
 

--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizQuestion.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizQuestion.java
@@ -41,7 +41,7 @@ public abstract class QuizQuestion extends DomainObject {
     @JsonView(QuizView.Before.class)
     private String hint;
 
-    @Column(name = "explanation")
+    @Column(name = "explanation", length = 1000)
     @JsonView(QuizView.After.class)
     private String explanation;
 

--- a/src/main/resources/config/liquibase/changelog/20210824174800_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20210824174800_changelog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+    <changeSet author="julian-christl" id="20210824174800">
+        <modifyDataType tableName="answer_option" columnName="explanation" newDataType="varchar(1000)"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20210824174800_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20210824174800_changelog.xml
@@ -2,5 +2,6 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
     <changeSet author="julian-christl" id="20210824174800">
         <modifyDataType tableName="answer_option" columnName="explanation" newDataType="varchar(1000)"/>
+        <modifyDataType tableName="quiz_question" columnName="explanation" newDataType="varchar(1000)"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -128,6 +128,7 @@
     <include file="classpath:config/liquibase/changelog/20210720132912_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20210722093000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20210802213000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20210824174800_changelog.xml" relativeToChangelogFile="false"/>
 
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->

--- a/src/main/webapp/app/exercises/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.html
@@ -20,7 +20,7 @@
         <ng-template #renderedExplanation>
             <div [innerHTML]="renderedQuestion.explanation"></div>
         </ng-template>
-        <span class="label label-primary" [ngbPopover]="renderedExplanation" placement="right" triggers="mouseenter:mouseleave" *ngIf="question.explanation && showResult">
+        <span class="label label-primary" [ngbPopover]="renderedExplanation" placement="auto" triggers="mouseenter:mouseleave" *ngIf="question.explanation && showResult">
             <fa-icon [icon]="'exclamation-circle'"></fa-icon>
             <span jhiTranslate="artemisApp.quizQuestion.explanation"></span>
         </span>

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -1342,6 +1342,72 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         request.putWithResponseBody("/api/quiz-exercises/" + quizExercise.getId() + "/lorem-ipsum", quizExercise, QuizExercise.class, HttpStatus.BAD_REQUEST);
     }
 
+    @Test
+    @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
+    public void testMultipleChoiceQuizExplanationLength_Valid() throws Exception {
+        int validityThreshold = 1000;
+
+        QuizExercise quizExercise = createMultipleChoiceQuizExerciseDummy();
+        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
+        mc.setExplanation("0".repeat(validityThreshold));
+
+        request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.CREATED);
+    }
+
+    @Test
+    @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
+    public void testMultipleChoiceQuizExplanationLength_Invalid() throws Exception {
+        int validityThreshold = 1000;
+
+        QuizExercise quizExercise = createMultipleChoiceQuizExerciseDummy();
+        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
+        mc.setExplanation("0".repeat(validityThreshold + 1));
+
+        request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
+    public void testMultipleChoiceQuizOptionExplanationLength_Valid() throws Exception {
+        int validityThreshold = 1000;
+
+        QuizExercise quizExercise = createMultipleChoiceQuizExerciseDummy();
+        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
+        mc.getAnswerOptions().get(0).setExplanation("0".repeat(validityThreshold));
+
+        request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.CREATED);
+    }
+
+    @Test
+    @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
+    public void testMultipleChoiceQuizOptionExplanationLength_Inalid() throws Exception {
+        int validityThreshold = 1000;
+
+        QuizExercise quizExercise = createMultipleChoiceQuizExerciseDummy();
+        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
+        mc.getAnswerOptions().get(0).setExplanation("0".repeat(validityThreshold + 1));
+
+        request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private QuizExercise createMultipleChoiceQuizExerciseDummy() {
+        Course course = database.createCourse();
+        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) new MultipleChoiceQuestion().title("MC").score(4).text("Q1");
+        QuizExercise quizExercise = ModelFactory.generateQuizExercise(ZonedDateTime.now().plusHours(5), null, course);
+
+        mc.setScoringType(ScoringType.ALL_OR_NOTHING);
+        mc.getAnswerOptions().add(new AnswerOption().text("A").hint("H1").explanation("E1").isCorrect(true));
+        mc.getAnswerOptions().add(new AnswerOption().text("B").hint("H2").explanation("E2").isCorrect(false));
+        mc.setExplanation("Explanation");
+        mc.copyQuestionId();
+
+        quizExercise.addQuestions(mc);
+        quizExercise.setMaxPoints(quizExercise.getOverallQuizPoints());
+        quizExercise.setGradingInstructions(null);
+
+        return quizExercise;
+    }
+
     /**
      * Check that the general information of two exercises is equal.
      */

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -1342,6 +1342,9 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         request.putWithResponseBody("/api/quiz-exercises/" + quizExercise.getId() + "/lorem-ipsum", quizExercise, QuizExercise.class, HttpStatus.BAD_REQUEST);
     }
 
+    /**
+     * test that a quiz question with an explanation within valid length can be created
+     */
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testMultipleChoiceQuizExplanationLength_Valid() throws Exception {
@@ -1354,6 +1357,9 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.CREATED);
     }
 
+    /**
+     * test that a quiz question with an explanation without valid length can't be created
+     */
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testMultipleChoiceQuizExplanationLength_Invalid() throws Exception {
@@ -1366,6 +1372,9 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    /**
+     * test that a quiz question with an option with an explanation with valid length can be created
+     */
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testMultipleChoiceQuizOptionExplanationLength_Valid() throws Exception {
@@ -1378,6 +1387,10 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.CREATED);
     }
 
+
+    /**
+     * test that a quiz question with an option with an explanation without valid length can't be created
+     */
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testMultipleChoiceQuizOptionExplanationLength_Inalid() throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/QuizExerciseIntegrationTest.java
@@ -1351,8 +1351,8 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         int validityThreshold = 1000;
 
         QuizExercise quizExercise = createMultipleChoiceQuizExerciseDummy();
-        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
-        mc.setExplanation("0".repeat(validityThreshold));
+        MultipleChoiceQuestion question = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
+        question.setExplanation("0".repeat(validityThreshold));
 
         request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.CREATED);
     }
@@ -1366,8 +1366,8 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         int validityThreshold = 1000;
 
         QuizExercise quizExercise = createMultipleChoiceQuizExerciseDummy();
-        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
-        mc.setExplanation("0".repeat(validityThreshold + 1));
+        MultipleChoiceQuestion question = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
+        question.setExplanation("0".repeat(validityThreshold + 1));
 
         request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -1381,8 +1381,8 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         int validityThreshold = 1000;
 
         QuizExercise quizExercise = createMultipleChoiceQuizExerciseDummy();
-        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
-        mc.getAnswerOptions().get(0).setExplanation("0".repeat(validityThreshold));
+        MultipleChoiceQuestion question = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
+        question.getAnswerOptions().get(0).setExplanation("0".repeat(validityThreshold));
 
         request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.CREATED);
     }
@@ -1397,24 +1397,24 @@ public class QuizExerciseIntegrationTest extends AbstractSpringIntegrationBamboo
         int validityThreshold = 1000;
 
         QuizExercise quizExercise = createMultipleChoiceQuizExerciseDummy();
-        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
-        mc.getAnswerOptions().get(0).setExplanation("0".repeat(validityThreshold + 1));
+        MultipleChoiceQuestion question = (MultipleChoiceQuestion) quizExercise.getQuizQuestions().get(0);
+        question.getAnswerOptions().get(0).setExplanation("0".repeat(validityThreshold + 1));
 
         request.postWithResponseBody("/api/quiz-exercises/", quizExercise, QuizExercise.class, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     private QuizExercise createMultipleChoiceQuizExerciseDummy() {
         Course course = database.createCourse();
-        MultipleChoiceQuestion mc = (MultipleChoiceQuestion) new MultipleChoiceQuestion().title("MC").score(4).text("Q1");
+        MultipleChoiceQuestion question = (MultipleChoiceQuestion) new MultipleChoiceQuestion().title("MC").score(4).text("Q1");
         QuizExercise quizExercise = ModelFactory.generateQuizExercise(ZonedDateTime.now().plusHours(5), null, course);
 
-        mc.setScoringType(ScoringType.ALL_OR_NOTHING);
-        mc.getAnswerOptions().add(new AnswerOption().text("A").hint("H1").explanation("E1").isCorrect(true));
-        mc.getAnswerOptions().add(new AnswerOption().text("B").hint("H2").explanation("E2").isCorrect(false));
-        mc.setExplanation("Explanation");
-        mc.copyQuestionId();
+        question.setScoringType(ScoringType.ALL_OR_NOTHING);
+        question.getAnswerOptions().add(new AnswerOption().text("A").hint("H1").explanation("E1").isCorrect(true));
+        question.getAnswerOptions().add(new AnswerOption().text("B").hint("H2").explanation("E2").isCorrect(false));
+        question.setExplanation("Explanation");
+        question.copyQuestionId();
 
-        quizExercise.addQuestions(mc);
+        quizExercise.addQuestions(question);
         quizExercise.setMaxPoints(quizExercise.getOverallQuizPoints());
         quizExercise.setGradingInstructions(null);
 


### PR DESCRIPTION
### Checklist
- [X] I tested *all* changes and *all* related features
- [X] Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [X] Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
Fixes #2799 
Also when fixing the issue, I saw that the question explanation tooltip was flickering.

### Description
I increased the length of the explanation columns of the quiz question itself as well as the multiple-choice option.
Additionally, I set the tooltip orientation to auto as it was for all the other quiz types.
Finally, I created four tests covering the column thresholds.

### Steps for Testing
1. Create a quiz with an MC question which as an explanation set and participate
2. The explanation of the question should show up when you hover over it.

### Review Progress
- Code Review
  - [ ] Review 1
  - [ ] Review 2
- Manual Tests
  - [ ] Test 1
  - [ ] Test 2

### Screenshots
![1ac7721aca26c98a8cb217ac848acfce](https://user-images.githubusercontent.com/64264938/131761304-da594ce4-6d86-4fda-9dca-34550a38da1b.png)
![explanation_tooltip](https://user-images.githubusercontent.com/64264938/131761058-3731f99a-388d-4f10-97b2-99989b920b19.jpg)