### PR TITLE
[Bugfix] Show correct formula in quiz review

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
@@ -57,6 +57,8 @@
                     [question]="question"
                     [dragAndDropMapping]="mappings"
                     [correctlyMappedDragAndDropItems]="correctAnswer"
+                    [incorrectlyMappedDragAndDropItems]="countIncorrectMappings()"
+                    [mappedLocations]="countAssignedLocations()"
                     [questionIndex]="questionIndex"
                 ></jhi-quiz-scoring-infostudent-modal>
             </span>
@@ -109,7 +111,8 @@
                             <div
                                 class="drop-location results"
                                 [ngClass]="{
-                                    incorrect: !isLocationCorrect(dropLocation) && !dropLocation.invalid && !invalidDragItemForDropLocation(dropLocation) && !question.invalid
+                                    incorrect:
+                                        isLocationCorrect(dropLocation) === false && !dropLocation.invalid && !invalidDragItemForDropLocation(dropLocation) && !question.invalid
                                 }"
                                 [ngStyle]="{
                                     top: dropLocation.posY! / 2 + '%',
@@ -120,7 +123,7 @@
                             >
                                 <div
                                     class="result-symbol"
-                                    *ngIf="!isLocationCorrect(dropLocation) && !dropLocation.invalid && !invalidDragItemForDropLocation(dropLocation) && !question.invalid"
+                                    *ngIf="isLocationCorrect(dropLocation) === false && !dropLocation.invalid && !invalidDragItemForDropLocation(dropLocation) && !question.invalid"
                                 >
                                     <fa-icon [icon]="'exclamation-triangle'" size="2x" class="warning"></fa-icon>
                                 </div>
@@ -163,7 +166,8 @@
                             <div
                                 class="drop-location sampleSolution"
                                 [ngClass]="{
-                                    incorrect: !isLocationCorrect(dropLocation) && !dropLocation.invalid && !invalidDragItemForDropLocation(dropLocation) && !question.invalid
+                                    incorrect:
+                                        isLocationCorrect(dropLocation) === false && !dropLocation.invalid && !invalidDragItemForDropLocation(dropLocation) && !question.invalid
                                 }"
                                 [ngStyle]="{
                                     top: dropLocation.posY! / 2 + '%',
@@ -175,7 +179,7 @@
                                 <div
                                     class="result-symbol"
                                     *ngIf="
-                                        !isLocationCorrect(dropLocation) &&
+                                        isLocationCorrect(dropLocation) === false &&
                                         !dropLocation.invalid &&
                                         !invalidDragItemForDropLocation(dropLocation) &&
                                         !question.invalid &&

--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.ts
@@ -230,9 +230,9 @@ export class DragAndDropQuestionComponent implements OnChanges {
      * (Only possible if this.question.correctMappings is available)
      *
      * @param dropLocation {object} the drop location to check for correctness
-     * @return {boolean} true, if the drop location is correct, otherwise false
+     * @return {boolean | undefined} true, if the drop location is correct, false if not and undefined if the location is correctly left blank
      */
-    isLocationCorrect(dropLocation: DropLocation): boolean {
+    isLocationCorrect(dropLocation: DropLocation): boolean | undefined {
         if (!this.question.correctMappings) {
             return false;
         }
@@ -246,12 +246,27 @@ export class DragAndDropQuestionComponent implements OnChanges {
         const selectedItem = this.dragItemForDropLocation(dropLocation);
 
         if (selectedItem === null) {
-            return validDragItems.length === 0;
+            return validDragItems.length === 0 ? undefined : false;
         } else {
             return validDragItems.some(function (dragItem) {
                 return this.dragAndDropQuestionUtil.isSameDragItem(dragItem, selectedItem);
             }, this);
         }
+    }
+
+    /**
+     * Check if there is a drag item assigned to the given location in the solution of the question
+     * (Only possible if this.question.correctMappings is available)
+     *
+     * @param dropLocation {object} the drop location to check for mapping
+     * @return {boolean} true, if the drop location is part of a mapping, otherwise false.
+     */
+
+    isAssignedLocation(dropLocation: DropLocation): boolean {
+        if (!this.question.correctMappings) {
+            return false;
+        }
+        return this.question.correctMappings.some((mapping) => this.dragAndDropQuestionUtil.isSameDropLocation(dropLocation, mapping.dropLocation));
     }
 
     /**
@@ -285,8 +300,22 @@ export class DragAndDropQuestionComponent implements OnChanges {
 
     /**
      * counts the amount of right mappings for a question by using the isLocationCorrect Method
+     * drop locations that are correctly left blank are excluded because they are excluded from grading as well
      */
     countCorrectMappings(): void {
         this.correctAnswer = this.question.dropLocations!.filter((dropLocation) => this.isLocationCorrect(dropLocation)).length;
+    }
+
+    /**
+     * counts the amount of incorrect mappings for a question by using the isLocationCorrect Method
+     */
+    countIncorrectMappings(): number {
+        return this.question.dropLocations!.filter((dropLocation) => this.isLocationCorrect(dropLocation) === false).length;
+    }
+    /**
+     * counts the amount of drop locations participating in at least one mapping for a question by using the isAssignedLocation Method
+     */
+    countAssignedLocations(): number {
+        return this.question.dropLocations!.filter((dropLocation) => this.isAssignedLocation(dropLocation)).length;
     }
 }

--- a/src/main/webapp/app/exercises/quiz/shared/questions/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.html
@@ -176,7 +176,7 @@
                         paramQuestionScore: this.question.points,
                         paramWrongMappedItems: this.wronglyMappedDragAndDropItems,
                         paramRightMapping: this.correctlyMappedDragAndDropItems,
-                        paramDragAndDropElementsCount: this.dragAndDropZones,
+                        paramDragAndDropElementsCount: this.mappedLocations,
                         paramPoint: this.scorePoint,
                         paramScorePoint: this.questionPoint,
                         rightMap: this.rightMap,
@@ -184,9 +184,9 @@
                     }"
                 ></p>
                 <b
-                    >+ {{ this.correctlyMappedDragAndDropItems }}*{{ this.question.points }}/{{ this.dragAndDropZones }} - {{ this.wronglyMappedDragAndDropItems }}*{{
+                    >+ {{ this.correctlyMappedDragAndDropItems }}*{{ this.question.points }}/{{ this.mappedLocations }} - {{ this.wronglyMappedDragAndDropItems }}*{{
                         this.question.points
-                    }}/{{ this.dragAndDropZones }} = {{ this.score }}</b
+                    }}/{{ this.mappedLocations }} = {{ this.score }}</b
                 >
                 <p jhiTranslate="artemisApp.quizExercise.explanationText.KeepTrying"></p>
             </span>
@@ -199,7 +199,7 @@
                         paramQuestionScore: this.question.points,
                         paramWrongMappedItems: this.wronglyMappedDragAndDropItems,
                         paramRightMapping: this.correctlyMappedDragAndDropItems,
-                        paramDragAndDropElementsCount: this.dragAndDropZones,
+                        paramDragAndDropElementsCount: this.mappedLocations,
                         paramPoint: this.scorePoint,
                         paramScorePoint: this.questionPoint,
                         rightMap: this.rightMap,
@@ -207,9 +207,9 @@
                     }"
                 ></p>
                 <b
-                    >+ {{ this.correctlyMappedDragAndDropItems }}*{{ this.question.points }}/{{ this.dragAndDropZones }} - {{ this.wronglyMappedDragAndDropItems }}*{{
+                    >+ {{ this.correctlyMappedDragAndDropItems }}*{{ this.question.points }}/{{ this.mappedLocations }} - {{ this.wronglyMappedDragAndDropItems }}*{{
                         this.question.points
-                    }}/{{ this.dragAndDropZones }}
+                    }}/{{ this.mappedLocations }}
                     = 0
                 </b>
                 <p jhiTranslate="artemisApp.quizExercise.explanationText.zeroPointer"></p>
@@ -352,14 +352,14 @@
                         paramQuestionScore: this.question.points,
                         paramWrongMappedItems: this.wronglyMappedDragAndDropItems,
                         paramRightMapping: this.correctlyMappedDragAndDropItems,
-                        paramDragAndDropElementsCount: this.dragAndDropZones,
+                        paramDragAndDropElementsCount: this.mappedLocations,
                         paramPoint: this.scorePoint,
                         paramScorePoint: this.questionPoint,
                         rightMap: this.rightMap,
                         wrongMap: this.wrongMap
                     }"
                 ></p>
-                <b>+ {{ this.correctlyMappedDragAndDropItems }}*{{ this.question.points }}/{{ this.dragAndDropZones }} = {{ this.score }}</b>
+                <b>+ {{ this.correctlyMappedDragAndDropItems }}*{{ this.question.points }}/{{ this.mappedLocations }} = {{ this.score }}</b>
                 <p jhiTranslate="artemisApp.quizExercise.explanationText.KeepTrying"></p>
             </span>
 
@@ -371,14 +371,14 @@
                         paramQuestionScore: this.question.points,
                         paramWrongMappedItems: this.wronglyMappedDragAndDropItems,
                         paramRightMapping: this.correctlyMappedDragAndDropItems,
-                        paramDragAndDropElementsCount: this.dragAndDropZones,
+                        paramDragAndDropElementsCount: this.mappedLocations,
                         paramPoint: this.scorePoint,
                         paramScorePoint: this.questionPoint,
                         rightMap: this.rightMap,
                         wrongMap: this.wrongMap
                     }"
                 ></p>
-                <b>+ {{ this.correctlyMappedDragAndDropItems }}*{{ this.question.points }}/{{ this.dragAndDropZones }} = 0 </b>
+                <b>+ {{ this.correctlyMappedDragAndDropItems }}*{{ this.question.points }}/{{ this.mappedLocations }} = 0 </b>
                 <p jhiTranslate="artemisApp.quizExercise.explanationText.zeroPointer"></p>
                 <p jhiTranslate="artemisApp.quizExercise.explanationText.KeepTrying"></p>
             </span>

--- a/src/main/webapp/app/exercises/quiz/shared/questions/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/quiz-scoring-infostudent-modal/quiz-scoring-info-student-modal.component.ts
@@ -26,6 +26,8 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
     @Input() questionIndex: number; // Question Index of the question
     @Input() question: QuizQuestion;
     @Input() dragAndDropMapping = new Array<DragAndDropMapping>();
+    @Input() incorrectlyMappedDragAndDropItems: number;
+    @Input() mappedLocations: number;
     @Input() multipleChoiceMapping = new Array<AnswerOption>();
     @Input() shortAnswerText = new Array<ShortAnswerSubmittedText>();
     @Input() correctlyMappedDragAndDropItems: number; // Amount of correctly mapped drag and drop items
@@ -45,7 +47,6 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
     checkForWrongAnswers = new Array<AnswerOption>();
 
     /* Drag and Drop Counting Variables*/
-    dragAndDropZones: number; // Amount of drag and drop Zones
     wronglyMappedDragAndDropItems: number; // Amount of wrongly mapped drag and drop item
     differenceDragAndDrop: number; // Difference between the wronglyMappedDragAndDropItems and correctlyMappedDragAndDropItems
 
@@ -166,8 +167,7 @@ export class QuizScoringInfoStudentModalComponent implements AfterViewInit {
     private countDragAndDrop() {
         const translationBasePath = 'artemisApp.quizExercise.explanationText.';
         const dndQuestion = this.question as DragAndDropQuestion;
-        this.dragAndDropZones = dndQuestion.dropLocations!.length;
-        this.wronglyMappedDragAndDropItems = this.dragAndDropZones - this.correctlyMappedDragAndDropItems;
+        this.wronglyMappedDragAndDropItems = this.incorrectlyMappedDragAndDropItems;
         this.differenceDragAndDrop = this.correctlyMappedDragAndDropItems - this.wronglyMappedDragAndDropItems;
 
         if (this.correctlyMappedDragAndDropItems === 1) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [x] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-testing/).
- [x] Client: I documented the TypeScript code using JSDoc style.
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes #3876

### Description
<!-- Describe your changes in detail -->
So far, in the amount of correct mappings, the correctly-empty drop locations were included. This changed by excluding them in the corresponding method `countCorrectMappings()`.
The denominator in the formula was based on the amount of drop locations. This is changed by introducing the method `countAssignedLocations()`.
Last, the amount of incorrect mappings was derived by subtracting the amount of correct mappings from the total amount of drop locations, which is incorrect when correctly-empty drop locations are included. This is changed by introducing the method `countIncorrectMappings()`.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a Drag and Drop Quiz with drop locations that are correctly empty
4. Participate as student multiple times and try different answers
5. In review, click on the question mark right next to the score
6. Make sure that the empty drop locations are not counted as correct when left empty but are counted as incorrect when wrongly assigned (the formula is shown only when the answer is not fully correct)
7. Also make sure that the empty drop locations are not included in the denominators
8. To be more general: make sure that the displayed calculation satisfies the score that the answer achieves.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

- Code Review
  - [ ] Review 1
  - [ ] Review 2
- Manual Tests
  - [ ] Test 1
  - [ ] Test 2

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
I reproduced the example of the related issue. This is how the calculation should look now:
![image](https://user-images.githubusercontent.com/80622272/132499233-6747fd17-a40b-4f50-876e-f1a0efeec72c.png)

