### PR TITLE
[Quickfix] Fixed broken selectors in Modeling Exercise spec

### DIFF
--- a/src/test/cypress/integration/ModelingExercise.spec.ts
+++ b/src/test/cypress/integration/ModelingExercise.spec.ts
@@ -135,7 +135,7 @@ describe('Modeling Exercise Spec', () => {
             cy.intercept(BASE_API + 'courses/*/exercises/*/participations').as('createModelingParticipation');
             cy.login(student, `/courses/${testCourse.id}`);
             cy.get('.col-lg-8').contains(modelingExercise.title).click();
-            cy.contains('Start exercise').click();
+            cy.get('.btn-sm').should('contain.text', 'Start exercise').click();
             cy.wait('@createModelingParticipation');
             cy.get('.btn').should('contain.text', 'Open modelling editor').click();
             modelingEditor.addComponentToModel(1);
@@ -174,7 +174,7 @@ describe('Modeling Exercise Spec', () => {
             modelingExerciseExampleSubmission.assessComponent(2, 'Good');
             modelingExerciseExampleSubmission.openAssessmentForComponent(3);
             modelingExerciseExampleSubmission.assessComponent(0, 'Unnecessary');
-            cy.get('.top-container > :nth-child(3) > :nth-child(4)').click();
+            cy.get('[jhitranslate="entity.action.submit"]').click();
             cy.get('.alerts').should('contain.text', 'Your assessment was submitted successfully!');
         });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
One of the recently merged PRs changed something in the assessment UI, which broke a JQuery selector. Because of this cypress didn't find the "Start exercise" and "Submit" buttons, which caused the tests to fail. This PR fixes the selectors and improved them to be more stable

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
[The tests pass](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-242) again on bamboo


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
