### PR TITLE
Fix exercise management buttons overlapping the table

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -1,34 +1,35 @@
 <div>
-    <h4>
-        <span *ngIf="course && !showHeading">{{ course.title }} - </span
-        ><span *ngIf="programmingExercises && showHeading">{{ getAmountOfExercisesString(programmingExercises) }} </span>
-        <span jhiTranslate="artemisApp.programmingExercise.home.title">Programming Exercises</span>
+    <h4 class="d-flex mb-3 flex-wrap justify-content-end">
+        <span class="mb-1 me-auto">
+            <span *ngIf="course && !showHeading"> {{ course.title }} - </span>
+            <span *ngIf="programmingExercises && showHeading">{{ getAmountOfExercisesString(programmingExercises) }} </span>
+            <span jhiTranslate="artemisApp.programmingExercise.home.title">Programming Exercises</span>
+        </span>
+
         <ng-container *jhiExtensionPoint="overrideGenerateAndImportButton">
-            <button
-                *ngIf="course && course.isAtLeastEditor"
-                id="jh-import-entity"
-                class="btn btn-primary float-end jh-create-entity create-programming-exercise me-1"
-                [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
-                (click)="openImportModal()"
-            >
-                <fa-icon [icon]="'plus'"></fa-icon>
-                <span class="hidden-sm-down" jhiTranslate="artemisApp.programmingExercise.home.importLabel"> Import new programming exercise </span>
-            </button>
             <a
                 *ngIf="course && course.isAtLeastEditor"
                 id="jh-create-entity"
-                class="btn btn-primary float-end jh-create-entity create-programming-exercise me-1"
+                class="btn btn-primary jh-create-entity create-programming-exercise text-truncate mb-1 me-1"
                 [jhiFeatureToggleLink]="FeatureToggle.PROGRAMMING_EXERCISES"
                 [routerLink]="['/course-management', courseId, 'programming-exercises', 'new']"
             >
                 <fa-icon [icon]="'plus'"></fa-icon>
                 <span class="hidden-sm-down" jhiTranslate="artemisApp.programmingExercise.home.generateLabel">Generate new Programming Exercise</span>
             </a>
+            <button
+                *ngIf="course && course.isAtLeastEditor"
+                id="jh-import-entity"
+                class="btn btn-primary jh-create-entity create-programming-exercise text-truncate mb-1 me-1"
+                [jhiFeatureToggle]="FeatureToggle.PROGRAMMING_EXERCISES"
+                (click)="openImportModal()"
+            >
+                <fa-icon [icon]="'plus'"></fa-icon>
+                <span class="hidden-sm-down" jhiTranslate="artemisApp.programmingExercise.home.importLabel"> Import new programming exercise </span>
+            </button>
         </ng-container>
     </h4>
     <jhi-alert *ngIf="showAlertHeading"></jhi-alert>
-    <div class="row"></div>
-    <br />
     <div class="table-responsive" *ngIf="programmingExercises && programmingExercises.length > 0">
         <table class="table table-striped">
             <thead>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [ ] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
This fixes #3993. We want the buttons to wrap, shrink and render properly even for small screens.

### Description
- Some changes to style classes
- Removing unnecessary elements

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

- Code Review
  - [ ] Review 1
  - [ ] Review 2
- Manual Tests
  - [ ] Test 1
  - [ ] Test 2

### Test Coverage
_Not applicable._

### Screenshots
- ![eist21_artemis_button_table_fix_large2](https://user-images.githubusercontent.com/11130248/133308364-ff5298f4-1407-4657-ba1e-b152e16ff6e2.gif)
- ![eist21_artemis_button_table_fix_medium2](https://user-images.githubusercontent.com/11130248/133308508-a213cd60-5f6a-4748-88ba-b4c9579d5c21.gif)
- ![eist21_artemis_button_table_fix_small](https://user-images.githubusercontent.com/11130248/133308376-c9bca9e5-1278-46de-8d6e-c3510e4b2d96.gif)

