### PR TITLE
[Test] Fix some broken and unstable cypress selectors

### DIFF
--- a/src/test/cypress/integration/ModelingExercise.spec.ts
+++ b/src/test/cypress/integration/ModelingExercise.spec.ts
@@ -1,6 +1,7 @@
 import { POST, BASE_API } from '../support/constants';
 import { dayjsToString } from '../support/utils';
 import { artemis } from '../support/ArtemisTesting';
+import { MODELING_SPACE } from '../support/pageobjects/ModelingEditor';
 
 // https://day.js.org/docs is a tool for date/time
 import dayjs from 'dayjs';
@@ -73,7 +74,7 @@ describe('Modeling Exercise Spec', () => {
             modelingEditor.addComponentToModel(1);
             createModelingExercise.save();
             cy.get('[jhitranslate="entity.action.export"]').should('be.visible');
-            cy.get('.sc-furvIG > :nth-child(1)').should('exist');
+            cy.get(`${MODELING_SPACE} > :nth-child(1)`).should('exist');
         });
 
         it('Creates Example Submission', () => {

--- a/src/test/cypress/integration/ModelingExercise.spec.ts
+++ b/src/test/cypress/integration/ModelingExercise.spec.ts
@@ -138,7 +138,7 @@ describe('Modeling Exercise Spec', () => {
             cy.get('.col-lg-8').contains(modelingExercise.title);
             cy.get('.btn-sm').should('contain.text', 'Start exercise').click();
             cy.wait('@createModelingParticipation');
-            cy.get('.btn').should('contain.text', 'Open modelling editor').click();
+            cy.get('.course-exercise-row').find('.btn-primary').click();
             modelingEditor.addComponentToModel(1);
             modelingEditor.addComponentToModel(2);
             modelingEditor.addComponentToModel(3);

--- a/src/test/cypress/integration/ModelingExercise.spec.ts
+++ b/src/test/cypress/integration/ModelingExercise.spec.ts
@@ -135,7 +135,7 @@ describe('Modeling Exercise Spec', () => {
         it('Student can start and submit their model', () => {
             cy.intercept(BASE_API + 'courses/*/exercises/*/participations').as('createModelingParticipation');
             cy.login(student, `/courses/${testCourse.id}`);
-            cy.get('.col-lg-8').contains(modelingExercise.title).click();
+            cy.get('.col-lg-8').contains(modelingExercise.title);
             cy.get('.btn-sm').should('contain.text', 'Start exercise').click();
             cy.wait('@createModelingParticipation');
             cy.get('.btn').should('contain.text', 'Open modelling editor').click();

--- a/src/test/cypress/integration/quiz-exercise/QuizExerciseParticipation.spec.ts
+++ b/src/test/cypress/integration/quiz-exercise/QuizExerciseParticipation.spec.ts
@@ -49,8 +49,8 @@ describe('Quiz Exercise Management', () => {
         it('Student can see a visible quiz', () => {
             courseManagementRequest.setQuizVisible(quizExercise.id);
             cy.login(student, '/courses/' + course.id);
-            cy.contains(quizExercise.title).should('be.visible').click();
-            cy.get('.btn').contains('Open quiz').click();
+            cy.contains(quizExercise.title).should('be.visible');
+            cy.get('.course-exercise-row').first().find('.btn-primary').click();
             cy.get('.quiz-waiting-for-start-overlay > span').should('contain.text', 'This page will refresh automatically, when the quiz starts.');
         });
 
@@ -58,8 +58,8 @@ describe('Quiz Exercise Management', () => {
             courseManagementRequest.setQuizVisible(quizExercise.id);
             courseManagementRequest.startQuizNow(quizExercise.id);
             cy.login(student, '/courses/' + course.id);
-            cy.contains(quizExercise.title).should('be.visible').click();
-            cy.get('.btn').contains('Start quiz').click();
+            cy.contains(quizExercise.title).should('be.visible');
+            cy.get('.course-exercise-row').first().find('.btn-primary').click();
             multipleChoiceQuiz.tickAnswerOption(0);
             multipleChoiceQuiz.tickAnswerOption(2);
             multipleChoiceQuiz.submit();

--- a/src/test/cypress/support/pageobjects/ModelingEditor.ts
+++ b/src/test/cypress/support/pageobjects/ModelingEditor.ts
@@ -1,25 +1,32 @@
 import { BASE_API, PUT } from '../constants';
 
+// TODO: find or create better selectors for modeling objects
+export const MODELING_SPACE = '.sc-jrAFXE';
+const COMPONENT_CONTAINER = '.sc-fFucqa';
+
 /**
  * This provides functions for interacting with the modeling editor
  * */
 export class ModelingEditor {
-    MODELING_SPACE = '.sc-furvIG';
-    COMPONENT_CONTAINER = '.sc-ksdxAp';
-
     /**
      * Adds a Modeling Component to the Example Solution
      * */
     addComponentToModel(componentNumber: number) {
-        cy.get(`${this.COMPONENT_CONTAINER} > :nth-child(${componentNumber}) > :nth-child(1) > :nth-child(1)`).drag(`${this.MODELING_SPACE}`, {
+        cy.get(`${COMPONENT_CONTAINER} > :nth-child(${componentNumber}) > :nth-child(1) > :nth-child(1)`).drag(`${MODELING_SPACE}`, {
             position: 'bottomLeft',
             force: true,
         });
     }
 
+    save() {
+        cy.intercept(PUT, BASE_API + 'exercises/*/modeling-submissions').as('createModelingSubmission');
+        cy.contains('Save').click();
+        return cy.wait('@createModelingSubmission');
+    }
+
     submit() {
         cy.intercept(PUT, BASE_API + 'exercises/*/modeling-submissions').as('createModelingSubmission');
         cy.get('.btn-primary').first().click();
-        cy.wait('@createModelingSubmission');
+        return cy.wait('@createModelingSubmission');
     }
 }

--- a/src/test/cypress/support/pageobjects/ModelingExerciseAssessmentEditor.ts
+++ b/src/test/cypress/support/pageobjects/ModelingExerciseAssessmentEditor.ts
@@ -1,14 +1,19 @@
+import { MODELING_SPACE } from './ModelingEditor';
+
+// TODO: find or create better selectors for this
+const FEEDBACK_CONTAINER = '.sc-lcuiOb';
+
 /**
  * A class which encapsulates UI selectors and actions for the Modeling Exercise Assessment editor
  */
 export class ModelingExerciseAssessmentEditor {
     openAssessmentForComponent(componentNumber: number) {
-        cy.get('.apollon-row').getSettled(`.sc-furvIG >> :nth-child(${componentNumber})`).children().eq(0).dblclick('top', { force: true });
+        cy.get('.apollon-row').getSettled(`${MODELING_SPACE} >> :nth-child(${componentNumber})`).children().eq(0).dblclick('top', { force: true });
     }
 
     assessComponent(points: number, feedback: string) {
-        cy.get('.sc-nVjpj > :nth-child(1) > :nth-child(2) > :nth-child(1) > :nth-child(2)').type(`${points}`);
-        cy.get('.sc-nVjpj > :nth-child(1) > :nth-child(3)').type(`${feedback}`);
+        cy.get(`${FEEDBACK_CONTAINER} > :nth-child(1) > :nth-child(2) > :nth-child(1) > :nth-child(2)`).type(`${points}`);
+        cy.get(`${FEEDBACK_CONTAINER} > :nth-child(1) > :nth-child(3)`).type(`${feedback}`);
     }
 
     addNewFeedback(points: number, feedback?: string) {


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? --> Due to some UI changes the DOM selectors we use in the cypress modeling exercise tests dont work any more. I update the selectors in this PR.
I also found some unstable selectors leading to flakiness in other tests which i adapt as well.
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail --> I update the relevant DOM selectors in the related page objects.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
I have created a tutorial for how to test cypress PRs <a href="https://confluence.ase.in.tum.de/display/ArTEMiS/Cypress+Tests">HERE</a> 
Please test all .spec files that were changed in this PR or ideally all of the existing ones.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

- Code Review
  - [ ] Review 1
  - [ ] Review 2
- Manual Tests
  - [ ] Test 1
  - [ ] Test 2