### PR TITLE
[Bugfix] Fix local repository path to fix online editor issues

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -495,7 +495,7 @@ public class GitService {
      * @return path of the local file system
      */
     public Path getLocalPathOfRepo(String targetPath, VcsRepositoryUrl targetUrl) {
-        return Paths.get(targetPath, folderNameForRepositoryUrl(targetUrl));
+        return Paths.get(targetPath.replaceAll("^\\./", ""), folderNameForRepositoryUrl(targetUrl));
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In the base PR the online editor is completely broken. New files can't be created, existing files can't be deleted or renamed. Build errors are also not shown in the ace editor. This should be fixed.

### Description
<!-- Describe your changes in detail -->
I investigated the network requests a bit and found that the backend does not provide correct file paths to the frontend when it initially retrieves all files.
This is the response object from the getFiles route on develop:
```json
{
   "":"FOLDER",
   "src/de/test":"FOLDER",
   "src/de/test/BubbleSort.java":"FILE",
   "src":"FOLDER",
   "src/de/test/Client.java":"FILE",
   "src/de":"FOLDER",
   "src/de/test/MergeSort.java":"FILE"
}
```
This is the response in the base PR:
```json
{
   "repos/JTCJPEX/jtcjpex-artemis_test_user_12/src/de/test/MergeSort.java":"FILE",
   "repos/JTCJPEX/jtcjpex-artemis_test_user_12/src/de/test/Client.java":"FILE",
   "repos/JTCJPEX/jtcjpex-artemis_test_user_12/src/de":"FOLDER",
   "repos/JTCJPEX/jtcjpex-artemis_test_user_12/src/de/test/BubbleSort.java":"FILE",
   "repos/JTCJPEX/jtcjpex-artemis_test_user_12/src/de/test":"FOLDER",
   "repos/JTCJPEX/jtcjpex-artemis_test_user_12":"FOLDER",
   "repos/JTCJPEX/jtcjpex-artemis_test_user_12/src":"FOLDER"
}
```
After some debugging I found out that the `localPath` field of the `Repository` class changed in the backend. For some reason it has "./" at the start of the path (which is not the case on develop). My fix is to simply remove the "./" at the start, but I feel like this fix does not really adress the origin of the issue, because I still don't know where the "./" comes from. As far as I could see the application yml files, which provide the `repo-clone-path` variable in their configuration, have not been changed in that regard by the base PR. Maybe some code previously removed the "./" and was changed/removed, but if that is the case I haven't found it yet.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

- Code Review
  - [x] Review 1
  - [x] Review 2
- Manual Tests
  - [x] Test 1
  - [x] Test 2
