### PR TITLE
[Enhancement] Admin metrics thread filtering

### DIFF
--- a/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.html
+++ b/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.html
@@ -7,7 +7,7 @@
 <div class="modal-body">
     <div class="mb-3">
         <span class="badge bg-primary hand" (click)="selectedThreadState = undefined">
-            <fa-icon *ngIf="selectedThreadState === undefined" icon="check"></fa-icon>
+            <fa-icon *ngIf="selectedThreadState == undefined" icon="check"></fa-icon>
             All&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpAll }}</span>
         </span>
 

--- a/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.html
+++ b/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.html
@@ -34,7 +34,7 @@
 
     <div class="mt-2">&nbsp;</div>
     {{ 'metrics.filter' | artemisTranslate }}: {{ filteredThreads.length }} {{ 'metrics.matches' | artemisTranslate }}
-    <input type="text" (keyup)="refreshTheFilter()" [(ngModel)]="threadFilter" class="form-control" />
+    <input type="text" (keyup)="refreshFilteredThreads()" [(ngModel)]="threadFilter" class="form-control" />
 
     <div class="pad" *ngFor="let thread of filteredThreads">
         <h6>

--- a/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.html
+++ b/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.html
@@ -6,39 +6,39 @@
 
 <div class="modal-body">
     <div class="mb-3">
-        <span class="badge bg-primary hand" (click)="threadStateFilter = undefined">
-            <fa-icon *ngIf="threadStateFilter === undefined" icon="check"></fa-icon>
+        <span class="badge bg-primary hand" (click)="selectedThreadState = undefined">
+            <fa-icon *ngIf="selectedThreadState === undefined" icon="check"></fa-icon>
             All&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpAll }}</span>
         </span>
 
-        <span class="badge bg-success hand" (click)="threadStateFilter = ThreadState.Runnable">
-            <fa-icon *ngIf="threadStateFilter === ThreadState.Runnable" icon="check"></fa-icon>
+        <span class="badge bg-success hand" (click)="selectedThreadState = ThreadState.Runnable">
+            <fa-icon *ngIf="selectedThreadState === ThreadState.Runnable" icon="check"></fa-icon>
             Runnable&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpRunnable }}</span>
         </span>
 
-        <span class="badge bg-info hand" (click)="threadStateFilter = ThreadState.Waiting">
-            <fa-icon *ngIf="threadStateFilter === ThreadState.Waiting" icon="check"></fa-icon>
+        <span class="badge bg-info hand" (click)="selectedThreadState = ThreadState.Waiting">
+            <fa-icon *ngIf="selectedThreadState === ThreadState.Waiting" icon="check"></fa-icon>
             Waiting&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpWaiting }}</span>
         </span>
 
-        <span class="badge bg-warning hand" (click)="threadStateFilter = ThreadState.TimedWaiting">
-            <fa-icon *ngIf="threadStateFilter === ThreadState.TimedWaiting" icon="check"></fa-icon>
+        <span class="badge bg-warning hand" (click)="selectedThreadState = ThreadState.TimedWaiting">
+            <fa-icon *ngIf="selectedThreadState === ThreadState.TimedWaiting" icon="check"></fa-icon>
             Timed Waiting&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpTimedWaiting }}</span>
         </span>
 
-        <span class="badge bg-danger hand" (click)="threadStateFilter = ThreadState.Blocked">
-            <fa-icon *ngIf="threadStateFilter === ThreadState.Blocked" icon="check"></fa-icon>
+        <span class="badge bg-danger hand" (click)="selectedThreadState = ThreadState.Blocked">
+            <fa-icon *ngIf="selectedThreadState === ThreadState.Blocked" icon="check"></fa-icon>
             Blocked&nbsp;<span class="badge badge-pill badge-default">{{ threadDumpBlocked }}</span>
         </span>
     </div>
 
     <div class="mt-2">&nbsp;</div>
-    Filter
-    <input type="text" [(ngModel)]="threadStateFilter" class="form-control" />
+    {{ 'metrics.filter' | artemisTranslate }}: {{ filteredThreads.length }} {{ 'metrics.matches' | artemisTranslate }}
+    <input type="text" (keyup)="refreshTheFilter()" [(ngModel)]="threadFilter" class="form-control" />
 
-    <div class="pad" *ngFor="let thread of getThreads()">
+    <div class="pad" *ngFor="let thread of filteredThreads">
         <h6>
-            <span class="badge" [ngClass]="getBadgeClass(thread.threadState)">{{ thread.threadState }}</span>
+            <span class="badge" [ngClass]="getBgClass(thread.threadState)">{{ thread.threadState }}</span>
 
             &nbsp;{{ thread.threadName }} (ID {{ thread.threadId }})
 

--- a/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.ts
+++ b/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.ts
@@ -10,13 +10,13 @@ import { Thread, ThreadState } from '../../metrics.model';
 export class MetricsModalThreadsComponent implements OnInit {
     ThreadState = ThreadState;
 
-    private _selectedThreadState?: ThreadState;
+    private threadStateFilter?: ThreadState;
     get selectedThreadState(): ThreadState | undefined {
-        return this._selectedThreadState;
+        return this.threadStateFilter;
     }
     set selectedThreadState(newValue: ThreadState | undefined) {
-        this._selectedThreadState = newValue;
-        this.refreshTheFilter();
+        this.threadStateFilter = newValue;
+        this.refreshFilteredThreads();
     }
 
     threadFilter?: string;
@@ -76,11 +76,11 @@ export class MetricsModalThreadsComponent implements OnInit {
             return true;
         }
 
-        // Filter the threads only on the visible attributes
+        // Filter the threads only on the visible attributes and look for case-insensitive match
         const filteredAttributes = ['threadName', 'threadId', 'blockedTime', 'blockedCount', 'waitedTime', 'waitedCount', 'lockName'];
         return Object.keys(thread)
             .filter((key) => filteredAttributes.includes(key))
-            .some((key) => thread[key]?.toString().includes(this.threadFilter!));
+            .some((key) => thread[key]?.toString().toLowerCase().includes(this.threadFilter!.toLowerCase()));
     }
 
     private isMatchingSelectedThreadState(thread: Thread): boolean {
@@ -91,7 +91,7 @@ export class MetricsModalThreadsComponent implements OnInit {
         return thread.threadState === this.selectedThreadState!;
     }
 
-    refreshTheFilter() {
+    refreshFilteredThreads() {
         this.filteredThreads = this.threads?.filter((thread) => this.isMatchingTextFilter(thread) && this.isMatchingSelectedThreadState(thread)) ?? [];
     }
 

--- a/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.ts
+++ b/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.ts
@@ -72,7 +72,7 @@ export class MetricsModalThreadsComponent implements OnInit {
     }
 
     private isMatchingTextFilter(thread: Thread): boolean {
-        if (this.threadFilter === undefined) {
+        if (this.threadFilter == undefined) {
             return true;
         }
 
@@ -84,7 +84,7 @@ export class MetricsModalThreadsComponent implements OnInit {
     }
 
     private isMatchingSelectedThreadState(thread: Thread): boolean {
-        if (this.selectedThreadState === undefined) {
+        if (this.selectedThreadState == undefined) {
             return true;
         }
 

--- a/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.ts
+++ b/src/main/webapp/app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component.ts
@@ -9,8 +9,21 @@ import { Thread, ThreadState } from '../../metrics.model';
 })
 export class MetricsModalThreadsComponent implements OnInit {
     ThreadState = ThreadState;
-    threadStateFilter?: string;
+
+    private _selectedThreadState?: ThreadState;
+    get selectedThreadState(): ThreadState | undefined {
+        return this._selectedThreadState;
+    }
+    set selectedThreadState(newValue: ThreadState | undefined) {
+        this._selectedThreadState = newValue;
+        this.refreshTheFilter();
+    }
+
+    threadFilter?: string;
+
     threads?: Thread[];
+    filteredThreads: Thread[];
+
     threadDumpAll = 0;
     threadDumpBlocked = 0;
     threadDumpRunnable = 0;
@@ -21,21 +34,29 @@ export class MetricsModalThreadsComponent implements OnInit {
 
     ngOnInit(): void {
         this.threads?.forEach((thread) => {
-            if (thread.threadState === ThreadState.Runnable) {
-                this.threadDumpRunnable += 1;
-            } else if (thread.threadState === ThreadState.Waiting) {
-                this.threadDumpWaiting += 1;
-            } else if (thread.threadState === ThreadState.TimedWaiting) {
-                this.threadDumpTimedWaiting += 1;
-            } else if (thread.threadState === ThreadState.Blocked) {
-                this.threadDumpBlocked += 1;
+            switch (thread.threadState) {
+                case ThreadState.Runnable:
+                    this.threadDumpRunnable += 1;
+                    break;
+                case ThreadState.Waiting:
+                    this.threadDumpWaiting += 1;
+                    break;
+                case ThreadState.TimedWaiting:
+                    this.threadDumpTimedWaiting += 1;
+                    break;
+                case ThreadState.Blocked:
+                    this.threadDumpBlocked += 1;
+                    break;
+                default:
+                    break;
             }
         });
 
         this.threadDumpAll = this.threadDumpRunnable + this.threadDumpWaiting + this.threadDumpTimedWaiting + this.threadDumpBlocked;
+        this.filteredThreads = this.threads ?? [];
     }
 
-    getBadgeClass(threadState: ThreadState): string {
+    getBgClass(threadState: ThreadState): string {
         switch (threadState) {
             case ThreadState.Runnable:
                 return 'bg-success';
@@ -50,8 +71,28 @@ export class MetricsModalThreadsComponent implements OnInit {
         }
     }
 
-    getThreads(): Thread[] {
-        return this.threads?.filter((thread) => !this.threadStateFilter || thread.lockName?.includes(this.threadStateFilter)) ?? [];
+    private isMatchingTextFilter(thread: Thread): boolean {
+        if (this.threadFilter === undefined) {
+            return true;
+        }
+
+        // Filter the threads only on the visible attributes
+        const filteredAttributes = ['threadName', 'threadId', 'blockedTime', 'blockedCount', 'waitedTime', 'waitedCount', 'lockName'];
+        return Object.keys(thread)
+            .filter((key) => filteredAttributes.includes(key))
+            .some((key) => thread[key]?.toString().includes(this.threadFilter!));
+    }
+
+    private isMatchingSelectedThreadState(thread: Thread): boolean {
+        if (this.selectedThreadState === undefined) {
+            return true;
+        }
+
+        return thread.threadState === this.selectedThreadState!;
+    }
+
+    refreshTheFilter() {
+        this.filteredThreads = this.threads?.filter((thread) => this.isMatchingTextFilter(thread) && this.isMatchingSelectedThreadState(thread)) ?? [];
     }
 
     dismiss(): void {

--- a/src/main/webapp/i18n/de/metrics.json
+++ b/src/main/webapp/i18n/de/metrics.json
@@ -2,6 +2,8 @@
     "metrics": {
         "title": "Anwendungs-Metriken",
         "refresh.button": "Aktualisieren",
+        "filter": "Filter",
+        "matches": "Suchergebnis(se)",
         "updating": "Aktualisierung...",
         "jvm": {
             "title": "JVM Metriken",

--- a/src/main/webapp/i18n/en/metrics.json
+++ b/src/main/webapp/i18n/en/metrics.json
@@ -2,6 +2,8 @@
     "metrics": {
         "title": "Application Metrics",
         "refresh.button": "Refresh",
+        "filter": "Filter",
+        "matches": "Match(es)",
         "updating": "Updating...",
         "jvm": {
             "title": "JVM Metrics",

--- a/src/test/javascript/spec/component/admin/metrics-modal-threads.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/metrics-modal-threads.component.spec.ts
@@ -1,0 +1,168 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ArtemisTestModule } from '../../test.module';
+import { MetricsModalThreadsComponent } from 'app/admin/metrics/blocks/metrics-modal-threads/metrics-modal-threads.component';
+import { Thread, ThreadState } from 'app/admin/metrics/metrics.model';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+
+describe('MetricsModalThreadsComponent', () => {
+    let runnableThreads: Thread[];
+    let waitingThreads: Thread[];
+
+    let comp: MetricsModalThreadsComponent;
+    let fixture: ComponentFixture<MetricsModalThreadsComponent>;
+    let activeModal: NgbActiveModal;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [MetricsModalThreadsComponent],
+        })
+            .overrideTemplate(MetricsModalThreadsComponent, '')
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(MetricsModalThreadsComponent);
+                comp = fixture.componentInstance;
+                activeModal = TestBed.inject(NgbActiveModal);
+
+                runnableThreads = [createThread(1, ThreadState.Runnable), createThread(2, ThreadState.Runnable), createThread(3, ThreadState.Runnable)];
+                waitingThreads = [
+                    createThread(4, ThreadState.Waiting),
+                    createThread(5, ThreadState.Waiting),
+                    createThread(6, ThreadState.Waiting),
+                    createThread(7, ThreadState.Waiting),
+                ];
+            });
+    });
+
+    function createThread(id: number, threadState: ThreadState): Thread {
+        return {
+            threadName: '',
+            threadId: id,
+            blockedTime: -1,
+            blockedCount: -1,
+            waitedTime: -1,
+            waitedCount: -1,
+            lockName: null,
+            lockOwnerId: -1,
+            lockOwnerName: null,
+            daemon: false,
+            inNative: false,
+            suspended: false,
+            threadState: threadState,
+            priority: -1,
+            stackTrace: [],
+            lockedMonitors: [],
+            lockedSynchronizers: [],
+            lockInfo: null,
+        };
+    }
+
+    describe('onInit', () => {
+        it('counts all thread types', () => {
+            // GIVEN
+            comp.threads = runnableThreads.concat(waitingThreads);
+
+            // WHEN
+            comp.ngOnInit();
+
+            // THEN
+            expect(comp.threadDumpAll).toEqual(comp.threads.length);
+            expect(comp.threadDumpBlocked).toEqual(0);
+            expect(comp.threadDumpRunnable).toEqual(runnableThreads.length);
+            expect(comp.threadDumpTimedWaiting).toEqual(0);
+            expect(comp.threadDumpWaiting).toEqual(waitingThreads.length);
+        });
+    });
+
+    describe('background class', () => {
+        it('computes correct bg-* class based on thread state', () => {
+            expect(comp.getBgClass(ThreadState.Runnable)).toEqual('bg-success');
+            expect(comp.getBgClass(ThreadState.Waiting)).toEqual('bg-info');
+            expect(comp.getBgClass(ThreadState.TimedWaiting)).toEqual('bg-warning');
+            expect(comp.getBgClass(ThreadState.Blocked)).toEqual('bg-danger');
+            expect(comp.getBgClass(ThreadState.New)).toEqual('');
+            expect(comp.getBgClass(ThreadState.Terminated)).toEqual('');
+        });
+    });
+
+    describe('filters', () => {
+        describe('threads based on selected thread state', () => {
+            it('when selected thread state is undefined, nothing is filtered out', () => {
+                // GIVEN
+                comp.threads = runnableThreads.concat(waitingThreads);
+                comp.selectedThreadState = undefined;
+
+                // WHEN
+                comp.refreshTheFilter();
+
+                // THEN
+                expect(comp.filteredThreads).toEqual(runnableThreads.concat(waitingThreads));
+            });
+
+            it('when selected a specific thread state, only threads with specific thread state are returned', () => {
+                // GIVEN
+                comp.threads = runnableThreads.concat(waitingThreads);
+                comp.selectedThreadState = ThreadState.Runnable;
+
+                // WHEN
+                comp.refreshTheFilter();
+
+                // THEN
+                expect(comp.filteredThreads).toEqual(runnableThreads);
+            });
+        });
+
+        describe('threads based on filter text', () => {
+            it('when filter is undefined, nothing is filtered out', () => {
+                // GIVEN
+                comp.threads = runnableThreads.concat(waitingThreads);
+                comp.threadFilter = undefined;
+
+                // WHEN
+                comp.refreshTheFilter();
+
+                // THEN
+                expect(comp.filteredThreads).toEqual(runnableThreads.concat(waitingThreads));
+            });
+
+            it('when filter is entered, only matching results are returned', () => {
+                // GIVEN
+                comp.threads = runnableThreads.concat(waitingThreads);
+                comp.threadFilter = '2';
+
+                // WHEN
+                comp.refreshTheFilter();
+
+                // THEN
+                expect(comp.filteredThreads).toEqual([runnableThreads[1]]);
+            });
+        });
+
+        it('both on thread state and filter text', () => {
+            // GIVEN
+            comp.threads = runnableThreads.concat(waitingThreads);
+            comp.threadFilter = '2';
+            comp.selectedThreadState = ThreadState.Waiting;
+
+            // WHEN
+            comp.refreshTheFilter();
+
+            // THEN
+            expect(comp.filteredThreads).toEqual([]);
+        });
+    });
+
+    describe('on dismiss', () => {
+        it('calls activeModal.dismiss()', () => {
+            // GIVEN
+            let dismissSpy = jest.spyOn(activeModal, 'dismiss').mockImplementation(() => {});
+            expect(dismissSpy).not.toBeCalled();
+
+            // WHEN
+            comp.dismiss();
+
+            // THEN
+            expect(dismissSpy).toBeCalled();
+        });
+    });
+});

--- a/src/test/javascript/spec/component/admin/metrics-modal-threads.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/metrics-modal-threads.component.spec.ts
@@ -97,7 +97,7 @@ describe('MetricsModalThreadsComponent', () => {
                 comp.selectedThreadState = undefined;
 
                 // WHEN
-                comp.refreshTheFilter();
+                comp.refreshFilteredThreads();
 
                 // THEN
                 expect(comp.filteredThreads).toEqual(runnableThreads.concat(waitingThreads));
@@ -109,7 +109,7 @@ describe('MetricsModalThreadsComponent', () => {
                 comp.selectedThreadState = ThreadState.Runnable;
 
                 // WHEN
-                comp.refreshTheFilter();
+                comp.refreshFilteredThreads();
 
                 // THEN
                 expect(comp.filteredThreads).toEqual(runnableThreads);
@@ -123,7 +123,7 @@ describe('MetricsModalThreadsComponent', () => {
                 comp.threadFilter = undefined;
 
                 // WHEN
-                comp.refreshTheFilter();
+                comp.refreshFilteredThreads();
 
                 // THEN
                 expect(comp.filteredThreads).toEqual(runnableThreads.concat(waitingThreads));
@@ -135,7 +135,7 @@ describe('MetricsModalThreadsComponent', () => {
                 comp.threadFilter = '2';
 
                 // WHEN
-                comp.refreshTheFilter();
+                comp.refreshFilteredThreads();
 
                 // THEN
                 expect(comp.filteredThreads).toEqual([runnableThreads[1]]);
@@ -149,7 +149,7 @@ describe('MetricsModalThreadsComponent', () => {
             comp.selectedThreadState = ThreadState.Waiting;
 
             // WHEN
-            comp.refreshTheFilter();
+            comp.refreshFilteredThreads();
 
             // THEN
             expect(comp.filteredThreads).toEqual([]);

--- a/src/test/javascript/spec/component/admin/metrics-modal-threads.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/metrics-modal-threads.component.spec.ts
@@ -34,6 +34,10 @@ describe('MetricsModalThreadsComponent', () => {
             });
     });
 
+    afterEach(() => {
+        jest.clearAllMocks();
+    })
+
     function createThread(id: number, threadState: ThreadState): Thread {
         return {
             threadName: '',
@@ -48,7 +52,7 @@ describe('MetricsModalThreadsComponent', () => {
             daemon: false,
             inNative: false,
             suspended: false,
-            threadState: threadState,
+            threadState,
             priority: -1,
             stackTrace: [],
             lockedMonitors: [],
@@ -155,7 +159,7 @@ describe('MetricsModalThreadsComponent', () => {
     describe('on dismiss', () => {
         it('calls activeModal.dismiss()', () => {
             // GIVEN
-            let dismissSpy = jest.spyOn(activeModal, 'dismiss').mockImplementation(() => {});
+            const dismissSpy = jest.spyOn(activeModal, 'dismiss').mockImplementation(() => { });
             expect(dismissSpy).not.toBeCalled();
 
             // WHEN


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] *Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] *Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [ ] *Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] *Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] *Server: I documented the Java code using JavaDoc style.
- [X] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [X] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] *Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [X] Client: I documented the TypeScript code using JSDoc style.
- [X] Client: I added multiple screenshots/screencasts of my UI changes
- [X] Client: I translated all newly inserted strings into English and German.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

[ ]* not needed.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Enhance the filtering in the admin metrics page.

### Description
<!-- Describe your changes in detail -→
The filter depends on both the buttons at the top as well as the text written in the filter textfield. 
The filtering functionality works on all visible thread attributes.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis as an admin
2. Go to System Administration and click on Metrics
3. Click on Expand button in the Threads column
4. The modal view should look like in the screenshot below
5. Play around with the buttons at the top and the filter text field to test if the filter functionality is working.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

- Code Review
  - [x] Review 1
  - [ ] Review 2
- Manual Tests
  - [ ] Test 1
  - [ ] Test 2

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->
`metrics-modal-threads.component.ts` 89.36%

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1129" alt="threads" src="https://user-images.githubusercontent.com/51077603/134784776-2c361830-84a3-405c-9349-d5b3c1f2acf2.png">