### PR TITLE
[Bugfix] Fix save button in text submission assessment

### DIFF
--- a/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-submission-assessment.component.ts
@@ -239,8 +239,7 @@ export class TextSubmissionAssessmentComponent extends TextAssessmentBaseCompone
         this.assessmentsService.trackAssessment(this.submission, 'save');
 
         this.saveBusy = true;
-        const participationid = this.result!.participation!.id;
-        this.assessmentsService.save(participationid!, this.result!.id!, this.assessments, this.textBlocksWithFeedback).subscribe(
+        this.assessmentsService.save(this.participation!.id!, this.result!.id!, this.assessments, this.textBlocksWithFeedback).subscribe(
             (response) => this.handleSaveOrSubmitSuccessWithAlert(response, 'artemisApp.textAssessment.saveSuccessful'),
             (error: HttpErrorResponse) => this.handleError(error),
         );


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] *Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] *Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [ ] *Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] *Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] *Server: I documented the Java code using JavaDoc style.
- [X] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] *Client: I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] *Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [ ] *Client: I documented the TypeScript code using JSDoc style.
- [X] *Client: I added multiple screenshots/screencasts of my UI changes
- [ ] *Client: I translated all newly inserted strings into English and German.
- [ ] *Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

[ ]* not needed

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is a bugfix for #3866.
 
### Description
<!-- Describe your changes in detail -->
`result.participation.id` is undefined, however `participation.id` corresponds to the correct participation id.
The submit button was already having this logic.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to Assessment Dashboard
4. Go to Exercise Dashboard that has a submission to assess
5. Click on assess submission
6. Assess the submission and click save
7. Saving the submission should work as expected
8. The success alert should show up as well as the value should persist on refresh

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

- Code Review
  - [x] Review 1
  - [x] Review 2
- Manual Tests
  - [x] Test 1
  - [x] Test 2

### Screenshots
<img width="1848" alt="Screen Shot 2021-09-26 at 16 17 57" src="https://user-images.githubusercontent.com/51077603/134811673-c9506ee4-058d-48a2-bdf4-fb455fdbfb94.png">