### PR TITLE
[Bugfix] Change tooltip placement of jhi-help-icon to auto in team creation/import modal

### DIFF
--- a/src/main/webapp/app/exercises/shared/team/team-update-dialog/team-update-dialog.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-update-dialog/team-update-dialog.component.html
@@ -33,7 +33,7 @@
         <div class="form-group">
             <div>
                 <label class="label-narrow" jhiTranslate="artemisApp.team.shortName.label" for="teamShortName">Short Name</label>
-                <jhi-help-icon placement="right" text="artemisApp.team.shortName.tooltip"></jhi-help-icon>
+                <jhi-help-icon placement="auto" text="artemisApp.team.shortName.tooltip"></jhi-help-icon>
             </div>
             <input
                 type="text"
@@ -58,7 +58,7 @@
             <div class="d-flex align-items-end">
                 <div>
                     <label class="label-narrow" jhiTranslate="artemisApp.team.owner.label">Tutor</label>
-                    <jhi-help-icon placement="right" text="artemisApp.team.owner.tooltip" class="me-1"></jhi-help-icon>
+                    <jhi-help-icon placement="auto" text="artemisApp.team.owner.tooltip" class="me-1"></jhi-help-icon>
                 </div>
                 <fa-icon class="search-searching" [icon]="'spinner'" [spin]="true" *ngIf="searchingOwner"></fa-icon>
                 <span *ngIf="searchingOwnerQueryTooShort" class="label-inline-message text-danger" jhiTranslate="artemisApp.team.ownerSearch.queryTooShort">

--- a/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-dialog.component.html
+++ b/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-dialog.component.html
@@ -36,7 +36,7 @@
             <div class="d-flex align-items-end">
                 <div>
                     <label class="label-narrow" jhiTranslate="artemisApp.team.sourceExercise.label">Source exercise</label>
-                    <jhi-help-icon placement="right" text="artemisApp.team.sourceExercise.tooltip" class="me-1"></jhi-help-icon>
+                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceExercise.tooltip" class="me-1"></jhi-help-icon>
                 </div>
                 <fa-icon class="loading-spinner" [icon]="'spinner'" [spin]="true" *ngIf="searchingExercises"></fa-icon>
                 <span *ngIf="searchingExercisesNoResultsForQuery === ''" class="error-message text-danger">
@@ -65,7 +65,7 @@
             <div class="d-flex align-items-end">
                 <div>
                     <label class="label-narrow" jhiTranslate="artemisApp.team.sourceTeams.label">Source teams</label>
-                    <jhi-help-icon placement="right" text="artemisApp.team.sourceTeams.tooltip" class="me-1"></jhi-help-icon>
+                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.tooltip" class="me-1"></jhi-help-icon>
                 </div>
                 <fa-icon class="loading-spinner" [icon]="'spinner'" [spin]="true" *ngIf="loadingSourceTeams"></fa-icon>
                 <span *ngIf="loadingSourceTeamsFailed" class="error-message text-danger" jhiTranslate="artemisApp.team.loadSourceTeams.failed">
@@ -108,7 +108,7 @@
                     <hr class="mt-3 mb-2" />
                     <div>
                         <label jhiTranslate="artemisApp.team.sourceTeams.legend.label">Legend</label>
-                        <jhi-help-icon placement="right" text="artemisApp.team.sourceTeams.legend.tooltip" class="me-1"></jhi-help-icon>
+                        <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.legend.tooltip" class="me-1"></jhi-help-icon>
                     </div>
                     <div class="source-teams-legend-box">
                         <div class="source-teams-legend d-flex justify-content-between">
@@ -119,7 +119,7 @@
                                 </div>
                                 <div class="label-with-tooltip">
                                     <label jhiTranslate="artemisApp.team.sourceTeams.legend.items.conflictFreeTeam.label">Conflict-free team</label>
-                                    <jhi-help-icon placement="right" text="artemisApp.team.sourceTeams.legend.items.conflictFreeTeam.tooltip" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.legend.items.conflictFreeTeam.tooltip" class="me-1"></jhi-help-icon>
                                 </div>
                             </div>
                             <div>
@@ -129,7 +129,7 @@
                                 </div>
                                 <div class="label-with-tooltip">
                                     <label jhiTranslate="artemisApp.team.sourceTeams.legend.items.teamShortNameConflict.label">Team short name conflict</label>
-                                    <jhi-help-icon placement="right" text="artemisApp.team.sourceTeams.legend.items.teamShortNameConflict.tooltip" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.legend.items.teamShortNameConflict.tooltip" class="me-1"></jhi-help-icon>
                                 </div>
                             </div>
                             <div>
@@ -144,7 +144,7 @@
                                 </div>
                                 <div class="label-with-tooltip">
                                     <label jhiTranslate="artemisApp.team.sourceTeams.legend.items.studentConflict.label">Student conflict</label>
-                                    <jhi-help-icon placement="right" text="artemisApp.team.sourceTeams.legend.items.studentConflict.tooltip" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.legend.items.studentConflict.tooltip" class="me-1"></jhi-help-icon>
                                 </div>
                             </div>
                         </div>
@@ -157,7 +157,7 @@
             <div class="form-group mb-0">
                 <div>
                     <label class="label-narrow" jhiTranslate="artemisApp.team.importStrategy.label">Import conflict strategy</label>
-                    <jhi-help-icon placement="right" text="artemisApp.team.importStrategy.tooltip" class="me-1"></jhi-help-icon>
+                    <jhi-help-icon placement="auto" text="artemisApp.team.importStrategy.tooltip" class="me-1"></jhi-help-icon>
                 </div>
                 <div class="d-flex flex-column mt-2 ps-2">
                     <label class="d-flex align-items-start">

--- a/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-from-file-form.component.html
+++ b/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-from-file-form.component.html
@@ -1,6 +1,6 @@
 <div>
     <label class="label-narrow" jhiTranslate="artemisApp.team.sourceFile.label">Source file</label>
-    <jhi-help-icon placement="right" text="artemisApp.team.sourceFile.tooltip" class="me-1"></jhi-help-icon>
+    <jhi-help-icon placement="auto" text="artemisApp.team.sourceFile.tooltip" class="me-1"></jhi-help-icon>
     <fa-icon class="loading-spinner" [icon]="'spinner'" [spin]="true" *ngIf="loading"></fa-icon>
 </div>
 <div class="custom-file">


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [x] I tested *all* changes locally
- [x] Client: I added multiple screenshots/screencasts of my UI changes

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Solves issue #4029 where the position of the tooltip was fixed to right as `placement` property of the `jhi-help-icon` components. No tooltips were visible in the modals of importing or creating a team for a team exercise. I changed the value of the property to "auto", the tooltips are now shown properly.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Management, find or create a team exercise where there are not teams yet
3. Click on the `teams` button on the detail page of this exercise to be navigated to the teams page of that exercise, you can there choose of importing or creating a team. both option open a modal where the tooltips for the help icons are fixed -> should look like in the screenshot below.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

- Code Review
  - [x] Review 1
  - [x] Review 2
- Manual Tests
  - [x] Test 1
  - [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
it should no look like this:

https://user-images.githubusercontent.com/41366522/134814830-1e47ba09-c829-4540-84f1-9eb33c1e6d00.mov


