### PR TITLE
[Bugfix] Fix breadcrumbs for exercise assessment dashboard

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -268,6 +268,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
             case 'file-upload-exercises':
             case 'programming-exercises':
             case 'quiz-exercises':
+            case 'assessment-dashboard':
                 this.addResolvedTitleAsCrumb(this.exerciseService.getTitle(Number(segment)), currentPath, segment);
                 break;
             case 'hints':

--- a/src/test/javascript/spec/component/shared/navbar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/navbar.component.spec.ts
@@ -358,6 +358,34 @@ describe('NavbarComponent', () => {
             sinon.assert.match(component.breadcrumbs[5], conflictCrumb);
         });
 
+        it('exercise assessment dashboard', () => {
+            let courseId = 1;
+            let exerciseId = 2;
+            const testUrl = `/course-management/${courseId}/assessment-dashboard/${exerciseId}`;
+            router.setUrl(testUrl);
+
+            fixture.detectChanges();
+
+            expect(courseManagementStub).to.have.been.calledWith(courseId);
+            expect(exerciseStub).to.have.been.calledWith(exerciseId);
+
+            expect(component.breadcrumbs.length).to.equal(4);
+
+            // Use matching here to ignore non-semantic differences between objects
+            sinon.assert.match(component.breadcrumbs[0], courseManagementCrumb);
+            sinon.assert.match(component.breadcrumbs[1], testCourseCrumb);
+            sinon.assert.match(component.breadcrumbs[2], {
+                label: 'artemisApp.assessmentDashboard.home.title',
+                translate: true,
+                uri: '/course-management/1/assessment-dashboard/',
+            } as MockBreadcrumb);
+            sinon.assert.match(component.breadcrumbs[3], {
+                label: 'Test Exercise',
+                translate: false,
+                uri: '/course-management/1/assessment-dashboard/2/'
+            } as MockBreadcrumb);
+        });
+
         it('modeling exercise example submission', () => {
             const testUrl = '/course-management/1/modeling-exercises/2/example-submissions/new';
             router.setUrl(testUrl);

--- a/src/test/javascript/spec/component/shared/navbar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/navbar.component.spec.ts
@@ -359,8 +359,8 @@ describe('NavbarComponent', () => {
         });
 
         it('exercise assessment dashboard', () => {
-            let courseId = 1;
-            let exerciseId = 2;
+            const courseId = 1;
+            const exerciseId = 2;
             const testUrl = `/course-management/${courseId}/assessment-dashboard/${exerciseId}`;
             router.setUrl(testUrl);
 
@@ -382,7 +382,7 @@ describe('NavbarComponent', () => {
             sinon.assert.match(component.breadcrumbs[3], {
                 label: 'Test Exercise',
                 translate: false,
-                uri: '/course-management/1/assessment-dashboard/2/'
+                uri: '/course-management/1/assessment-dashboard/2/',
             } as MockBreadcrumb);
         });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
- [X] I tested *all* changes and *all* related features with different users (student, tutor, editor, instructor, admin) on the test server https://artemistest.ase.in.tum.de.
- [ ] *Server: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] *Server: I added multiple integration tests (Spring) related to the features (with a high test coverage)
- [ ] *Server: I added `@PreAuthorize` and check the course groups for all new REST Calls (security)
- [ ] *Server: I implemented the changes with a good performance and prevented too many database calls
- [ ] *Server: I documented the Java code using JavaDoc style.
- [X] Client: I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [X] Client: I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] *Client: I added `authorities` to all new routes and check the course groups for displaying navigation elements (links, buttons)
- [X] Client: I documented the TypeScript code using JSDoc style.
- [X] Client: I added multiple screenshots/screencasts of my UI changes
- [ ] *Client: I translated all newly inserted strings into English and German.
- [ ] *Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).

*no needed

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Before this PR, the breadcrumbs for exercise-dashboard did not contain the last segment information about the name of the exercise. (They looked the same as course assessment dashboard)
This PR fixes the breadcrumbs.

### Description
<!-- Describe your changes in detail -->
I added the missing case in the handling of the integer-segment of the breadcrumbs as well as added tests for it.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to Course Administration and pick a course
3. Go to Assessment Dashboard .
4. Go to Exercise Dashboard
5. Breadcrumbs should contain the name of the exercise as the last segment in the breadcrumb

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

- Code Review
  - [x] Review 1
  - [x] Review 2
- Manual Tests
  - [x] Test 1
  - [x] Test 2

### Test Coverage
<!-- Please add the test coverage for all changes files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan -->
<!-- * ExerciseService.java: 85% -->
<!-- * programming-exercise.component.ts 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![bread](https://user-images.githubusercontent.com/51077603/135166345-332372db-db97-4fb7-896b-b7e62ae6e18c.jpg)

