### PR TITLE
[Enhancements] Example solution export button should be visible only 'apollon' profile has been activated

### DIFF
--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.html
@@ -38,7 +38,7 @@
                 <dt>
                     <span jhiTranslate="artemisApp.exercise.sampleSolution">Sample Solution</span>
                     <button
-                        *ngIf="modelingExercise && modelingExercise.sampleSolutionModel"
+                        *ngIf="modelingExercise && modelingExercise.sampleSolutionModel && isApollonProfileActive"
                         (click)="downloadAsPDf()"
                         class="btn btn-primary m-2"
                         jhiTranslate="entity.action.export"

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise-detail.component.ts
@@ -15,6 +15,7 @@ import { AccountService } from 'app/core/auth/account.service';
 import { Course } from 'app/entities/course.model';
 import { EventManager } from 'app/core/util/event-manager.service';
 import { AlertService } from 'app/core/util/alert.service';
+import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 
 @Component({
     selector: 'jhi-modeling-exercise-detail',
@@ -37,6 +38,7 @@ export class ModelingExerciseDetailComponent implements OnInit, OnDestroy {
     isExamExercise: boolean;
 
     isAdmin = false;
+    isApollonProfileActive = false;
 
     constructor(
         private eventManager: EventManager,
@@ -46,6 +48,7 @@ export class ModelingExerciseDetailComponent implements OnInit, OnDestroy {
         private alertService: AlertService,
         private statisticsService: StatisticsService,
         private accountService: AccountService,
+        private profileService: ProfileService,
     ) {}
 
     ngOnInit() {
@@ -54,6 +57,12 @@ export class ModelingExerciseDetailComponent implements OnInit, OnDestroy {
             this.load(params['exerciseId']);
         });
         this.registerChangeInModelingExercises();
+        // Checks if the current environment includes "apollon" profile
+        this.profileService.getProfileInfo().subscribe((profileInfo) => {
+            if (profileInfo && profileInfo.activeProfiles.includes('apollon')) {
+                this.isApollonProfileActive = true;
+            }
+        });
     }
 
     load(id: number) {

--- a/src/test/javascript/spec/component/modeling-exercise/modeling-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-exercise/modeling-exercise-detail.component.spec.ts
@@ -7,7 +7,10 @@ import { ModelingExerciseDetailComponent } from 'app/exercises/modeling/manage/m
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { ModelingExerciseService } from 'app/exercises/modeling/manage/modeling-exercise.service';
 import { TranslateService } from '@ngx-translate/core';
-import { MockComponent, MockProvider } from 'ng-mocks';
+import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
+import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
+import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
+import { MockComponent } from 'ng-mocks';
 import { NonProgrammingExerciseDetailCommonActionsComponent } from 'app/exercises/shared/exercise-detail-common-actions/non-programming-exercise-detail-common-actions.component';
 import sinonChai from 'sinon-chai';
 import * as chai from 'chai';
@@ -47,7 +50,12 @@ describe('ModelingExercise Management Detail Component', () => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [ModelingExerciseDetailComponent, MockComponent(NonProgrammingExerciseDetailCommonActionsComponent)],
-            providers: [{ provide: ActivatedRoute, useValue: route }, MockProvider(TranslateService)],
+            providers: [
+                { provide: LocalStorageService, useClass: MockSyncStorage },
+                { provide: SessionStorageService, useClass: MockSyncStorage },
+                { provide: TranslateService, useClass: MockTranslateService },
+                { provide: ActivatedRoute, useValue: route },
+            ],
         })
             .overrideTemplate(ModelingExerciseDetailComponent, '')
             .compileComponents();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #3997 .

In the issue description, it's sated that export button is not working anymore. This situation was reported while running on the TS1.  Export button needs "apollon" profile in server configuration in order to work in properly. TS1 and TS3 have missing configuration. It was not a bug. However, when "apollon" profile is not active, we may not show users the export button to avoid this situation. This PR aims to cover improvement for export button. 

### Description
<!-- Describe your changes in detail -->
Now we are checking active profile information in modeling-exercise-detail.component. And only if "apollon" is activated, export button is visible in modeling exercise detail page.
and I added LocalStorageService, SessionStorageService in corresponding test-suite, because it complained about that.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor / 1 Editor
- 1 Modeling Exercise
- Check the functionality in two test servers (TS2 and TS3)

TS3 (apollon profile IS NOT active)
1. Log in to Artemis
2. Navigate to Course Management
3. Create one modeling exercise save changes
4.  you SHOULD NOT see export button in exercise detail page

TS2 (apollon profile IS active)
1. Log in to Artemis
2. Navigate to Course Management
3. Create one modeling exercise save changes
4.  you SHOULD see export button in exercise detail page

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
nothing

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Example Submission Export button in Modeling Exercise Detail Page
<img src="https://user-images.githubusercontent.com/23650630/135243841-48eef04f-68f1-4484-8724-5d197fba258e.png" width="500"/>

