### PR TITLE
[Bugfix] Set min date for automatic test execution in exam mode

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.html
@@ -35,8 +35,8 @@
                 <jhi-programming-exercise-test-schedule-date-picker
                     class="test-schedule-date me-2"
                     [(ngModel)]="exercise.buildAndTestStudentSubmissionsAfterDueDate"
-                    [startAt]="exercise.dueDate"
-                    [min]="exercise.dueDate"
+                    [startAt]="minTestExecutionDate"
+                    [min]="minTestExecutionDate"
                     [readOnly]="readOnly"
                     label="artemisApp.programmingExercise.timeline.afterDueDate"
                     tooltipText="artemisApp.programmingExercise.timeline.afterDueDateTooltip"

--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, OnChanges } from '@angular/core';
 import dayjs from 'dayjs';
 import { TranslateService } from '@ngx-translate/core';
 import { AssessmentType } from 'app/entities/assessment-type.model';
@@ -9,10 +9,11 @@ import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
     templateUrl: './programming-exercise-lifecycle.component.html',
     styleUrls: ['./programming-exercise-test-schedule-picker.scss'],
 })
-export class ProgrammingExerciseLifecycleComponent implements OnInit {
+export class ProgrammingExerciseLifecycleComponent implements OnInit, OnChanges {
     @Input() exercise: ProgrammingExercise;
     @Input() isExamMode: boolean;
     @Input() readOnly: boolean;
+    minTestExecutionDate = dayjs();
 
     readonly assessmentType = AssessmentType;
 
@@ -25,6 +26,20 @@ export class ProgrammingExerciseLifecycleComponent implements OnInit {
         if (!this.exercise.id) {
             this.exercise.assessmentType = AssessmentType.AUTOMATIC;
         }
+    }
+
+    /**
+     * Sets a proper minimum date for executing automatic tests depending on if its exam mode or not.
+     */
+    ngOnChanges(): void {
+        let testExecutionDate;
+        if (this.isExamMode) {
+            testExecutionDate = this.exercise.exerciseGroup?.exam?.endDate;
+        } else {
+            testExecutionDate = this.exercise.dueDate;
+        }
+        // If no due date has been set for the exam or the exercise we set the current date as minimum to prevent execution dates in the past
+        this.minTestExecutionDate = testExecutionDate ?? dayjs();
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
#### Client
- [ ] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-testing/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When adding a programming exercise to an exercise group in an exam one can select a date in the past for the date to execute the automatic tests. This should not be possible.

### Description
<!-- Describe your changes in detail -->
The old code set the minimum date for the datepicker to the `exercise.dueDate`. In exams the exercise does not have a due date because it is aligned with the exam dates instead. This PR calculates a minimum due date for exercises in courses as well as exams. In exam mode it takes the dueDate from the exam. For normal exercises the logic stays the same. If it can't find a due date it will set the minimun date to the current timestamp, so that no date in the past can be selected.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
