### PR TITLE
[Bugfix/Change] instructors & editors now also receive exercise update notifications

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/GroupNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/GroupNotificationService.java
@@ -71,6 +71,8 @@ public class GroupNotificationService {
 
     /**
      * Notify all groups but tutors about an exercise update.
+     * Tutors will only work on the exercise during the assesment therefore it is not urgent to inform them about changes beforehand.
+     * Students, instructors, and editors should be notified about changed as quickly as possible. 
      *
      * @param exercise         that has been updated
      * @param notificationText that should be displayed

--- a/src/main/java/de/tum/in/www1/artemis/service/GroupNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/GroupNotificationService.java
@@ -70,18 +70,18 @@ public class GroupNotificationService {
     }
 
     /**
-     * Notify student groups about an exercise update.
+     * Notify all groups but tutors about an exercise update.
      *
      * @param exercise         that has been updated
      * @param notificationText that should be displayed
      */
-    public void notifyStudentGroupAboutExerciseUpdate(Exercise exercise, String notificationText) {
+    public void notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(Exercise exercise, String notificationText) {
         // Do not send a notification before the release date of the exercise.
         if (exercise.getReleaseDate() != null && exercise.getReleaseDate().isAfter(ZonedDateTime.now())) {
             return;
         }
-        // Create and send the notification.
         saveAndSend(createNotification(exercise, userRepository.getUser(), GroupNotificationType.STUDENT, NotificationType.EXERCISE_UPDATED, notificationText));
+        notifyEditorAndInstructorGroupAboutExerciseUpdate(exercise, notificationText);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -388,7 +388,7 @@ public class ProgrammingExerciseService {
 
         // Only send notification for course exercises
         if (notificationText != null && programmingExercise.isCourseExercise()) {
-            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(savedProgrammingExercise, notificationText);
+            groupNotificationService.notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(savedProgrammingExercise, notificationText);
         }
 
         return savedProgrammingExercise;
@@ -660,7 +660,7 @@ public class ProgrammingExerciseService {
         programmingExercise.setAssessmentDueDate(updatedProgrammingExercise.getAssessmentDueDate());
         ProgrammingExercise savedProgrammingExercise = programmingExerciseRepository.save(programmingExercise);
         if (notificationText != null) {
-            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(updatedProgrammingExercise, notificationText);
+            groupNotificationService.notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(updatedProgrammingExercise, notificationText);
         }
         return savedProgrammingExercise;
     }
@@ -680,7 +680,7 @@ public class ProgrammingExerciseService {
         programmingExercise.setProblemStatement(problemStatement);
         ProgrammingExercise updatedProgrammingExercise = programmingExerciseRepository.save(programmingExercise);
         if (notificationText != null) {
-            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(updatedProgrammingExercise, notificationText);
+            groupNotificationService.notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(updatedProgrammingExercise, notificationText);
         }
         return updatedProgrammingExercise;
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -186,7 +186,7 @@ public class FileUploadExerciseResource {
         exerciseService.updatePointsInRelatedParticipantScores(fileUploadExerciseBeforeUpdate, updatedExercise);
 
         if ((notificationText != null && fileUploadExercise.isCourseExercise()) || fileUploadExercise.isExamExercise()) {
-            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(fileUploadExercise, notificationText);
+            groupNotificationService.notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(fileUploadExercise, notificationText);
         }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, exerciseId.toString())).body(updatedExercise);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -196,7 +196,7 @@ public class ModelingExerciseResource {
         modelingExerciseService.scheduleOperations(updatedModelingExercise.getId());
 
         if ((notificationText != null && modelingExercise.isCourseExercise()) || modelingExercise.isExamExercise()) {
-            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(modelingExercise, notificationText);
+            groupNotificationService.notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(modelingExercise, notificationText);
         }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, modelingExercise.getId().toString()))
                 .body(updatedModelingExercise);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -192,7 +192,7 @@ public class QuizExerciseResource {
         if (notificationText != null && quizExercise.isCourseExercise()) {
             // notify websocket channel of changes to the quiz exercise
             quizMessagingService.sendQuizExerciseToSubscribedClients(quizExercise, "change");
-            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(quizExercise, notificationText);
+            groupNotificationService.notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(quizExercise, notificationText);
         }
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, quizExercise.getId().toString())).body(quizExercise);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -229,7 +229,7 @@ public class TextExerciseResource {
         }
 
         if ((notificationText != null && textExercise.isCourseExercise()) || textExercise.isExamExercise()) {
-            groupNotificationService.notifyStudentGroupAboutExerciseUpdate(textExercise, notificationText);
+            groupNotificationService.notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(textExercise, notificationText);
         }
 
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, textExercise.getId().toString())).body(updatedTextExercise);

--- a/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingExerciseIntegrationTest.java
@@ -184,7 +184,7 @@ public class ModelingExerciseIntegrationTest extends AbstractSpringIntegrationBa
         ModelingExercise returnedModelingExercise = request.putWithResponseBodyAndParams("/api/modeling-exercises", createdModelingExercise, ModelingExercise.class, HttpStatus.OK,
                 params);
         assertThat(returnedModelingExercise.getGradingCriteria().size()).isEqualTo(gradingCriteria.size());
-        verify(groupNotificationService).notifyStudentGroupAboutExerciseUpdate(returnedModelingExercise, notificationText);
+        verify(groupNotificationService).notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(returnedModelingExercise, notificationText);
 
         // use an arbitrary course id that was not yet stored on the server to get a bad request in the PUT call
         modelingExercise = modelingExerciseUtilService.createModelingExercise(100L, classExercise.getId());

--- a/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
@@ -343,7 +343,7 @@ public class CourseTestService {
 
         for (Course course : courses) {
             if (!course.getExercises().isEmpty()) {
-                groupNotificationService.notifyStudentGroupAboutExerciseUpdate(course.getExercises().iterator().next(), "notify");
+                groupNotificationService.notifyStudentAndEditorAndInstructorGroupAboutExerciseUpdate(course.getExercises().iterator().next(), "notify");
             }
             request.delete("/api/courses/" + course.getId(), HttpStatus.OK);
         }


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.
#### Client
_I did not change the client side_
#### Changes affecting Programming Exercises
_No changes to programming exercises besides a different GroupNotificationService call_ 
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->
This is a small change/bug fix that resolves this [issue](https://github.com/ls1intum/Artemis/issues/3846).
Instructors and Editors now also receive notifications when any exercise has been updated. (Why not also tutors? -> Tutors will read the exercise during the assessment. It is only critical for students to know about changes as quickly as possible and Instructors/Editors to verify the changes.)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Quick tipp: you have to provide the optional notification text otherwise no notification will be sent.
Log in as Instructor or Editor of a course and change some exercises with different types.
Check if you received notifications about your changes. _(Do not worry this makes sense if you have multiple editors, instructors, so the others are also informed about the changes.)_
### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
Very minor changes so the coverage did not change.
Just for details:
GroupNotificationService ~ 98%
ProgrammingExerciseService ~ 92%
FileUploadExerciseResource ~ 100%
ModelingExerciseResource ~ 90%
QuizExerciseResource ~ 100%
TextExerciseResource ~ 90%