### PR TITLE
Enable Deletion of Programming Exercise Template/Solution Submissions/Results

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 
 import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.security.Role;
@@ -214,11 +215,11 @@ public abstract class AssessmentResource {
         // check authentication
         Submission submission = submissionRepository.findByIdWithResultsElseThrow(submissionId);
         Result result = resultRepository.findByIdWithEagerFeedbacksElseThrow(resultId);
-        StudentParticipation studentParticipation = (StudentParticipation) submission.getParticipation();
-        if (!studentParticipation.getId().equals(participationId)) {
+        Participation participation = submission.getParticipation();
+        if (!participation.getId().equals(participationId)) {
             return badRequest("participationId", "400", "participationId in path does not match the id of the participation to submission " + submissionId + " !");
         }
-        Exercise exercise = exerciseRepository.findByIdElseThrow(studentParticipation.getExercise().getId());
+        Exercise exercise = exerciseRepository.findByIdElseThrow(participation.getExercise().getId());
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, exercise, null);
 
         if (!submission.getResults().contains(result)) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/SubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/SubmissionResource.java
@@ -14,7 +14,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
+import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
@@ -182,11 +182,11 @@ public class SubmissionResource {
     }
 
     private Course findCourseFromSubmission(Submission submission) {
-        StudentParticipation studentParticipation = (StudentParticipation) submission.getParticipation();
-        if (studentParticipation.getExercise() != null && studentParticipation.getExercise().getCourseViaExerciseGroupOrCourseMember() != null) {
-            return studentParticipation.getExercise().getCourseViaExerciseGroupOrCourseMember();
+        Participation participation = submission.getParticipation();
+        if (participation.getExercise() != null && participation.getExercise().getCourseViaExerciseGroupOrCourseMember() != null) {
+            return participation.getExercise().getCourseViaExerciseGroupOrCourseMember();
         }
 
-        return studentParticipationRepository.findByIdElseThrow(studentParticipation.getId()).getExercise().getCourseViaExerciseGroupOrCourseMember();
+        return studentParticipationRepository.findByIdElseThrow(participation.getId()).getExercise().getCourseViaExerciseGroupOrCourseMember();
     }
 }

--- a/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.ts
+++ b/src/main/webapp/app/exercises/shared/participation-submission/participation-submission.component.ts
@@ -200,28 +200,28 @@ export class ParticipationSubmissionComponent implements OnInit {
     }
 
     deleteResult(submission: Submission, result: Result) {
-        if (this.exercise && submission.id && result.id && submission.participation?.id) {
+        if (this.exercise && submission.id && result.id && this.participationId) {
             switch (this.exercise.type) {
                 case ExerciseType.TEXT:
-                    this.textAssessmentService.deleteAssessment(submission.participation.id, submission.id, result.id).subscribe(
+                    this.textAssessmentService.deleteAssessment(this.participationId, submission.id, result.id).subscribe(
                         () => this.updateResults(submission, result),
                         (error: HttpErrorResponse) => this.handleErrorResponse(error),
                     );
                     break;
                 case ExerciseType.MODELING:
-                    this.modelingAssessmentsService.deleteAssessment(submission.participation.id, submission.id, result.id).subscribe(
+                    this.modelingAssessmentsService.deleteAssessment(this.participationId, submission.id, result.id).subscribe(
                         () => this.updateResults(submission, result),
                         (error: HttpErrorResponse) => this.handleErrorResponse(error),
                     );
                     break;
                 case ExerciseType.FILE_UPLOAD:
-                    this.fileUploadAssessmentService.deleteAssessment(submission.participation.id, submission.id, result.id).subscribe(
+                    this.fileUploadAssessmentService.deleteAssessment(this.participationId, submission.id, result.id).subscribe(
                         () => this.updateResults(submission, result),
                         (error: HttpErrorResponse) => this.handleErrorResponse(error),
                     );
                     break;
                 case ExerciseType.PROGRAMMING:
-                    this.programmingAssessmentService.deleteAssessment(submission.participation.id, submission.id, result.id).subscribe(
+                    this.programmingAssessmentService.deleteAssessment(this.participationId, submission.id, result.id).subscribe(
                         () => this.updateResults(submission, result),
                         (error: HttpErrorResponse) => this.handleErrorResponse(error),
                     );


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
Deleting submissions or individual results of submissions of programming exercise template and solution participations is not possible currently. This issue is described in #4008 and #4009 respectively.
This PR closes #4008, closes #4009

### Description
1. The client participation submission component now uses the participationId specified in the route instead of retrieving it from the participation reference of the submission. The previous approach worked well for everything unrelated to template and solution participations, but not for template and solution participations. The new approach works for every type of participation.
2. The deletion endpoints for results and submissions used an improper cast to `StudentParticipation` which is not a super-type of `TemplateProgrammingExerciseParticipation` or `SolutionProgrammingExerciseParticipation`, resulting in a class cast exception: https://sentry.ase.in.tum.de/share/issue/687a60648f174d4585063d5340ac35c0/.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Navigate to the programming exercise details page of your programming exercise
2. Scroll to the bottom of the page and click "Show Solution Submissions"
3. Artemis should navigate you to the submission overview of the solution participation.
4. Delete the entire submission by clicking the "Delete" button in the "rightest" column of the table and confirming the dialogue
5. Make sure the submission is actually gone by going back to the programming exercise details page.
6. Generate a new solution submission (e.g. by submitting anything in the online code editor)
7. Navigate back to the submission overview of the solution participation.
8. Click the small "Delete" button to the right of the result string and confirm the dialogue. The submission should now have 0 results.
9. Repeat the previous steps with the Template Participation

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

