### PR TITLE
 ⚠ Fixed critical exam bug that lead to internal server error at creation time of programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotificationFactory.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/GroupNotificationFactory.java
@@ -112,8 +112,13 @@ public class GroupNotificationFactory {
 
         // Exercises for exams
         if (exercise.isExamExercise()) {
-            notification.setTarget(notification.getExamExerciseTargetWithExerciseUpdate(exercise));
-            notification.setPriority(NotificationPriority.HIGH);
+            if (Constants.LIVE_EXAM_EXERCISE_UPDATE_NOTIFICATION_TITLE.equals(title)) {
+                notification.setTarget(notification.getExamExerciseTargetWithExerciseUpdate(exercise));
+                notification.setPriority(NotificationPriority.HIGH);
+            }
+            else if (exercise instanceof ProgrammingExercise) {
+                notification.setTarget(notification.getExamProgrammingExerciseOrTestCaseTarget((ProgrammingExercise) exercise, "exerciseUpdated"));
+            }
         }
         // Exercises for courses (not for exams)
         else if (notificationType == NotificationType.EXERCISE_CREATED) {


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
Currently, it is not possible to create programming exercises for exams (in exam mode/exercise groups). An internal server error is created. By accident, I found out that I am the reason why this is not working for exam programming exercises. The current issue with course programming exercises seems unrelated (because it worked locally and e.g. on TS2 before just fine).

### Description
During my last Exam pop-up PR I changed how notifications for exams are created. I thought I only changed it for the case when an exercise is updated but (out of a reason I do not really understand) currently, tutors get notified when an exam (programming) exercise is created. This "edge-case" of EXERCISE_CREATED falls into my implementation that should only handle EXERCISE_UPDATED. This leads to a database failure. 
I added an if case to catch this "edge-case". 

The problem: Inside an exercise group when a new programming exercise is created a corresponding (I do not know why this design decision was made) EXERCISE_CREATED notification is build. But it falls into the same case as the EXERCISE_UPDATED for exam exercises and receives the entire problem statement as a property. Each notification is saved to the DB. The "target" property has a small size (~ 255 VARCHAR). For UPDATED the target with the huge problem statement is removed before saving. But not for CREATED. So the huge target property is saved and the DB leads to an internal server error. 

![image](https://user-images.githubusercontent.com/65814168/135503683-4995c19f-ba8e-4aec-8587-bdb4675492ce.png)

I am terribly sorry for not catching this prior.

### Steps for Testing
Log in to Artemis (e.g. TS2).
Find an exam and go to its exercise groups.
Add a completely new (not imported) programming exercise.
It should work (and not throw a 500 error code)

### Review Progress
#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
No changes.