### PR TITLE
[Bugfix] Unify rounding of scores

### DIFF
--- a/src/main/webapp/app/course/course-scores/course-scores.component.html
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.html
@@ -70,14 +70,14 @@
                     <th>
                         {{ getLocaleConversionService().toLocaleString(averageNumberOfParticipatedExercises) }} ({{
                             getLocaleConversionService().toLocaleString(
-                                round((averageNumberOfParticipatedExercises / exercisesOfCourseThatAreIncludedInScoreCalculation.length) * 100)
+                                round((averageNumberOfParticipatedExercises / exercisesOfCourseThatAreIncludedInScoreCalculation.length) * 100, 1)
                             )
                         }}%)
                     </th>
                     <th>
                         {{ getLocaleConversionService().toLocaleString(averageNumberOfSuccessfulExercises) }} ({{
                             getLocaleConversionService().toLocaleString(
-                                round((averageNumberOfSuccessfulExercises / exercisesOfCourseThatAreIncludedInScoreCalculation.length) * 100)
+                                round((averageNumberOfSuccessfulExercises / exercisesOfCourseThatAreIncludedInScoreCalculation.length) * 100, 1)
                             )
                         }}
                         %)
@@ -87,14 +87,14 @@
                             {{ getLocaleConversionService().toLocaleString(averageNumberOfPointsPerExerciseTypes.get(exerciseType)!) }}
                             ({{
                                 getLocaleConversionService().toLocaleString(
-                                    round((averageNumberOfPointsPerExerciseTypes.get(exerciseType)! / maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100)
+                                    round((averageNumberOfPointsPerExerciseTypes.get(exerciseType)! / maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100, 1)
                                 )
                             }}%)
                         </th>
                     </ng-container>
                     <th>
                         {{ getLocaleConversionService().toLocaleString(averageNumberOfOverallPoints) }} ({{
-                            getLocaleConversionService().toLocaleString(round((averageNumberOfOverallPoints / maxNumberOfOverallPoints) * 100))
+                            getLocaleConversionService().toLocaleString(round((averageNumberOfOverallPoints / maxNumberOfOverallPoints) * 100, 1))
                         }}%)
                     </th>
                     <th *ngIf="gradingScaleExists">
@@ -109,7 +109,7 @@
                     <td>
                         {{ student.numberOfParticipatedExercises }} ({{
                             getLocaleConversionService().toLocaleString(
-                                round((student.numberOfParticipatedExercises / exercisesOfCourseThatAreIncludedInScoreCalculation.length) * 100)
+                                round((student.numberOfParticipatedExercises / exercisesOfCourseThatAreIncludedInScoreCalculation.length) * 100, 1)
                             )
                         }}%)
                     </td>
@@ -117,7 +117,7 @@
                         {{ student.numberOfSuccessfulExercises }}
                         ({{
                             getLocaleConversionService().toLocaleString(
-                                round((student.numberOfSuccessfulExercises / exercisesOfCourseThatAreIncludedInScoreCalculation.length) * 100)
+                                round((student.numberOfSuccessfulExercises / exercisesOfCourseThatAreIncludedInScoreCalculation.length) * 100, 1)
                             )
                         }}%)
                     </td>
@@ -126,14 +126,14 @@
                             {{ getLocaleConversionService().toLocaleString(student.sumPointsPerExerciseType.get(exerciseType)!) }}
                             ({{
                                 getLocaleConversionService().toLocaleString(
-                                    round((student.sumPointsPerExerciseType.get(exerciseType)! / maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100)
+                                    round((student.sumPointsPerExerciseType.get(exerciseType)! / maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100, 1)
                                 )
                             }}%)
                         </td>
                     </ng-container>
                     <td>
                         {{ getLocaleConversionService().toLocaleString(student.overallPoints) }} ({{
-                            getLocaleConversionService().toLocaleString(round((student.overallPoints / maxNumberOfOverallPoints) * 100))
+                            getLocaleConversionService().toLocaleString(round((student.overallPoints / maxNumberOfOverallPoints) * 100, 1))
                         }}%)
                     </td>
                     <td *ngIf="gradingScaleExists">

--- a/src/main/webapp/app/course/course-scores/course-scores.component.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.ts
@@ -437,7 +437,10 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
                         const exercisePointsPerType = student.sumPointsPerExerciseType.get(exerciseType)!;
                         let exerciseScoresPerType = 0;
                         if (this.maxNumberOfPointsPerExerciseType.get(exerciseType)! > 0) {
-                            exerciseScoresPerType = round((student.sumPointsPerExerciseType.get(exerciseType)! / this.maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100);
+                            exerciseScoresPerType = round(
+                                (student.sumPointsPerExerciseType.get(exerciseType)! / this.maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100,
+                                1,
+                            );
                         }
                         const exerciseTitleKeys = this.exerciseTitlesPerType.get(exerciseType)!;
                         const exercisePointValues = student.pointsPerExerciseType.get(exerciseType)!;
@@ -508,7 +511,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
                         rowDataAverage[title] = this.localeConversionService.toLocaleString(round(exerciseAveragePoints[index], 1));
                     });
 
-                    const averageScore = round((this.averageNumberOfPointsPerExerciseTypes.get(exerciseType)! / this.maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100);
+                    const averageScore = round((this.averageNumberOfPointsPerExerciseTypes.get(exerciseType)! / this.maxNumberOfPointsPerExerciseType.get(exerciseType)!) * 100, 1);
 
                     rowDataAverage[exerciseTypeName + ' ' + POINTS_KEY] = this.localeConversionService.toLocaleString(
                         this.averageNumberOfPointsPerExerciseTypes.get(exerciseType)!,

--- a/src/main/webapp/app/grading-system/grading-system.component.html
+++ b/src/main/webapp/app/grading-system/grading-system.component.html
@@ -81,7 +81,7 @@
             <tbody>
                 <tr *ngFor="let gradeStep of gradingScale.gradeSteps; let i = index" class="grading-scale-table-row">
                     <td>
-                        <input [(ngModel)]="gradeStep.lowerBoundPercentage" type="number" step="0.5" min="0" max="100" required (change)="setPoints(gradeStep, true)" />
+                        <input [(ngModel)]="gradeStep.lowerBoundPercentage" type="number" step="0.5" min="0" required (change)="setPoints(gradeStep, true)" />
                     </td>
                     <td>
                         <input
@@ -89,14 +89,13 @@
                             type="number"
                             step="0.5"
                             min="0"
-                            [max]="maxPoints || 0"
                             [required]="maxPoints != undefined && maxPoints > 0"
                             [disabled]="maxPoints == undefined || maxPoints <= 0"
                             (change)="setPercentage(gradeStep, true)"
                         />
                     </td>
                     <td>
-                        <input [(ngModel)]="gradeStep.upperBoundPercentage" type="number" step="0.5" min="0" max="100" required (change)="setPoints(gradeStep, false)" />
+                        <input [(ngModel)]="gradeStep.upperBoundPercentage" type="number" step="0.5" min="0" required (change)="setPoints(gradeStep, false)" />
                     </td>
                     <td>
                         <input
@@ -104,7 +103,6 @@
                             type="number"
                             step="0.5"
                             min="0"
-                            [max]="maxPoints || 0"
                             [required]="maxPoints != undefined && maxPoints > 0"
                             [disabled]="maxPoints == undefined || maxPoints <= 0"
                             (change)="setPercentage(gradeStep, false)"

--- a/src/main/webapp/i18n/en/instructorDashboard.json
+++ b/src/main/webapp/i18n/en/instructorDashboard.json
@@ -6,7 +6,7 @@
         "title": "Course Scores",
         "exerciseDashboard": "Exercise Scores",
         "participated": "Participated in Exercises (%)",
-        "successful": "Successfully Exercises (%)",
+        "successful": "Successful Exercises (%)",
         "quizPoints": "Quiz Points (%)",
         "programmingPoints": "Programming Points (%)",
         "modelingPoints": "Modelling Points (%)",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
#### Server
- [ ] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [ ] I implemented the changes with a good performance and prevented too many database calls.
- [ ] I documented the Java code using JavaDoc style.
#### Client
- [ ] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-testing/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#3841 sparked a discussion with Stephan about the unification of all score displays in Artemis.

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. ...

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
