### PR TITLE
[bug fix] fixed system notifications not loading

### DIFF
--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
@@ -48,10 +48,13 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
     ) {
         this.itemsPerPage = ITEMS_PER_PAGE;
         this.routeData = this.activatedRoute.data.subscribe((data) => {
-            this.page = data['pagingParams'].page;
-            this.previousPage = data['pagingParams'].page;
-            this.reverse = data['pagingParams'].ascending;
-            this.predicate = data['pagingParams'].predicate;
+            const pagingParams = data['pagingParams'];
+            if (pagingParams) {
+                this.page = pagingParams.page;
+                this.previousPage = pagingParams.page;
+                this.reverse = pagingParams.ascending;
+                this.predicate = pagingParams.predicate;
+            }
         });
     }
 
@@ -135,7 +138,10 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
      * Sorts parameters by specified order
      */
     sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        const result = [];
+        if (this.predicate) {
+            result.push(this.predicate + ',' + (this.reverse ? 'asc' : 'desc'));
+        }
         if (this.predicate !== 'id') {
             result.push('id');
         }


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.

### Motivation, Context, and Description
I initially wanted to work on a different issue but noticed/remembered that system notifications are no longer loaded. This issue occurred only recently _(I tested system notifications during the big update PR testing sessions and everything worked fine)_. 

![image](https://user-images.githubusercontent.com/65814168/135733840-3a74330f-5bcd-4aa9-bcd5-f0dfad17e1f0.png)

So I tried to look into this issue and created a small fix/hack so the system notifications are loaded again.

The error message states that an internal server error occurs in the SystemNotificationResource class. The problem here is that a SQL query is created where one group by value is undefined. This value is taken from the input parameter "pageable" that the client creates. (see image where sort[0] is undefined)
![image](https://user-images.githubusercontent.com/65814168/135733562-c070fc73-a5cf-4dfb-a859-7ed2cf51ab5a.png)

Issue is in the client :
The underlying issue is that the router should load specific data (like page) but it is empty/undefined. I do not know the reason for this or how to fix it. It would be great if an expert in this field could look into this.

But the system notifications work as intended again and I only added 2 small if cases to check if the data is undefined or not.
I am not sure if this is the best way to solve this issue so I am curious about your opinions.

### Steps for Testing
Log into Artemis as an Admin (e.g. user 12).
Go to the admin tools -> system notification management page
The system notifications should work just as before.
There should also not be any issues in the developer debugger console.
Make sure related functions still work (e.g. delete, change, display, etc.)

### Review Progress
#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
I only added two small if cases that check if the data is undefined or not so no changes to the test coverage.
![image](https://user-images.githubusercontent.com/65814168/135733743-3269b78d-ed84-4b98-824f-60e94dfaec03.png)
