### PR TITLE
`Notifications`: Hide system notifications when expired

### DIFF
--- a/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
+++ b/src/main/webapp/app/admin/system-notification-management/system-notification-management.component.ts
@@ -48,10 +48,13 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
     ) {
         this.itemsPerPage = ITEMS_PER_PAGE;
         this.routeData = this.activatedRoute.data.subscribe((data) => {
-            this.page = data['pagingParams'].page;
-            this.previousPage = data['pagingParams'].page;
-            this.reverse = data['pagingParams'].ascending;
-            this.predicate = data['pagingParams'].predicate;
+            const pagingParams = data['pagingParams'];
+            if (pagingParams) {
+                this.page = pagingParams.page;
+                this.previousPage = pagingParams.page;
+                this.reverse = pagingParams.ascending;
+                this.predicate = pagingParams.predicate;
+            }
         });
     }
 
@@ -135,7 +138,10 @@ export class SystemNotificationManagementComponent implements OnInit, OnDestroy 
      * Sorts parameters by specified order
      */
     sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+        const result = [];
+        if (this.predicate) {
+            result.push(this.predicate + ',' + (this.reverse ? 'asc' : 'desc'));
+        }
         if (this.predicate !== 'id') {
             result.push('id');
         }

--- a/src/main/webapp/app/shared/notification/system-notification/system-notification.component.ts
+++ b/src/main/webapp/app/shared/notification/system-notification/system-notification.component.ts
@@ -48,6 +48,12 @@ export class SystemNotificationComponent implements OnInit {
                 this.notification = notification;
                 this.setAlertClass();
                 this.setAlertIcon();
+                // set asynchronous timeout to update/check/hide current system notification
+                if (notification.expireDate) {
+                    setTimeout(() => {
+                        this.loadActiveNotification();
+                    }, 1000 + notification.expireDate.diff(dayjs(), 'ms'));
+                }
             } else {
                 this.notification = undefined;
             }

--- a/src/test/javascript/spec/component/shared/notification/system-notification.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/notification/system-notification.component.spec.ts
@@ -9,11 +9,12 @@ import { SystemNotificationComponent } from 'app/shared/notification/system-noti
 import { SystemNotificationService } from 'app/shared/notification/system-notification/system-notification.service';
 import { AccountService } from 'app/core/auth/account.service';
 import { ArtemisTestModule } from '../../../test.module';
-import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
 import { MockAccountService } from '../../../helpers/mocks/service/mock-account.service';
 import { SystemNotification, SystemNotificationType } from 'app/entities/system-notification.model';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { MockComponent } from 'ng-mocks';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -37,8 +38,8 @@ describe('System Notification Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, ArtemisSharedModule],
-            declarations: [SystemNotificationComponent],
+            imports: [ArtemisTestModule],
+            declarations: [SystemNotificationComponent, MockComponent(FaIconComponent)],
             providers: [
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
@@ -53,6 +54,7 @@ describe('System Notification Component', () => {
                 systemNotificationComponent = systemNotificationComponentFixture.componentInstance;
                 systemNotificationService = TestBed.inject(SystemNotificationService);
                 jhiWebsocketService = TestBed.inject(JhiWebsocketService);
+                sinon.stub(systemNotificationComponent, 'setTimedCheck');
             });
     });
 
@@ -61,9 +63,11 @@ describe('System Notification Component', () => {
             const notification = createActiveNotification(SystemNotificationType.WARNING);
             const fake = sinon.fake.returns(of(notification));
             sinon.replace(systemNotificationService, 'getActiveNotification', fake);
+            sinon.spy(systemNotificationService, 'sendSystemNotificationUpdateEvent');
             systemNotificationComponent.ngOnInit();
             tick(500);
             expect(systemNotificationService.getActiveNotification).to.have.been.calledOnce;
+            expect(systemNotificationComponent.setTimedCheck).to.have.been.calledOnce;
             expect(systemNotificationComponent.notification).to.equal(notification);
             expect(systemNotificationComponent.alertClass).to.equal('alert-warning');
             expect(systemNotificationComponent.alertIcon).to.equal('exclamation-triangle');


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
#### Client
- [ ] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-testing/).
- [ ] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Is a bugfix for [issue #1328](https://github.com/ls1intum/Artemis/issues/1328).
System notifications now disappear from the GUI when they expire.

### Description
<!-- Describe your changes in detail -->
I added a setTimeout mechanism that is triggered/updated when Artemis is (re)loaded or the admin deletes/updates/creates a system notification.

_(I also notice a couple of other issues with the current system notification implementation but resolving them seems to be a way bigger task (and I currently already have quite a lot of work to do))_

### Steps for Testing
Log in as an Admin.
Create/update a system notification so there is at least one active system notification. (Set the expiration time to be ca. 2-3 minutes)
This notification should be shown. 
Wait until the expiration date is reached.
The notification should disappear. 
If another notification is active at the same time it should be visible now instead.

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
TODO ADD actual coverage!

![image](https://user-images.githubusercontent.com/65814168/135771142-a6424068-f7cc-4252-9e58-81995bc47ff9.png)

