### PR TITLE
[Bugfix] Fix failing test in programming-submission.service.spec

### DIFF
--- a/src/test/javascript/spec/service/programming-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-submission.service.spec.ts
@@ -337,7 +337,7 @@ describe('ProgrammingSubmissionService', () => {
         submissionService.getResultEtaInMs().subscribe((eta) => (resultEta = eta));
 
         // With 340 submissions, the eta should now have increased.
-        expect(resultEta).to.equal(2000 * 60 + 3 * 4000 * 60);
+        expect(resultEta).to.equal(2000 * 60 + 3 * 1000 * 60);
     });
 
     it('should only unsubscribe if no other participations use the topic', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a failing test that was caused by #4062

### Description
<!-- Describe your changes in detail -->
This PR also fixes the calculation in the test case.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Run the test case "should recalculate the result eta based on the number of open submissions" in programming-submission.service.spec.ts
2. See that the test passes again

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2