### PR TITLE
`Programming exercises`: Remove iOS 14.5 requirement for the build plan for Swift Xcode programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooBuildPlanService.java
@@ -239,11 +239,8 @@ public class BambooBuildPlanService {
                 }
                 if (isXcodeProject) {
                     // add a requirement to be able to run the Xcode build tasks using fastlane
-                    var requirement1 = new Requirement("system.builder.fastlane.fastlane");
-                    // add a requirement to be able to run the Xcode build tasks
-                    var requirement2 = new Requirement("system.builder.xcode.Simulator - iOS 14.5");
-                    defaultJob.requirements(requirement1);
-                    defaultJob.requirements(requirement2);
+                    var requirement = new Requirement("system.builder.fastlane.fastlane");
+                    defaultJob.requirements(requirement);
                 }
                 return defaultStage.jobs(defaultJob);
             }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.

#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I implemented the changes with a good performance and prevented too many database calls.

#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This small PR removes the requirement: `Simulator - iOS 14.5` from the Build Plans for Swift Xcode programming exercises. This requirement is no longer available since the release of iOS 15 and caused failures for builds or never beginning / ending builds.

### Description
<!-- Describe your changes in detail -->
I deleted the adding of the requirement in the `BambooBuildPlanService.java` file to remove it from the Build Plan configurations.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- at least 1 Student

1. Log in to Artemis as Instructor
2. Navigate to Course Administration and create a new Swift Xcode Programming Exercise
3. Check the BASE and SOLUTION Build Plan on Bamboo and verify that they do not longer specify the `Simulator - iOS 14.5` requirement but only the `Fastlane` requirement (see Video below)
4. Check that the Template result is `Score 0%, 0 out of 2 passe`d and the Solution result is `Score 100%, 2 out of 2 passed`
5. Log in to Artemis as a Student
6. Participate in the exercise 
7. Check that your submission results get correctly updated and displayed by Artemis and the Build does not fail for valid submissions
7. Log in to Artemis as Instructor
8. Check the Student Build Plan on Bamboo: it should also contain the Fastlane requirement but no Simulator - iOS 14.5 requirement anymore

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
https://user-images.githubusercontent.com/82283581/136609377-843ab905-0ee3-4407-a8e9-7bdae792e699.mov