### PR TITLE
`Exam Mode:` Let tooltips of stepwizard in exam quiz exercises overflow

### DIFF
--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.html
@@ -7,7 +7,7 @@
                         *ngIf="question.type === DRAG_AND_DROP"
                         class="btn btn-light btn-circle stepbutton stepwizardquiz-circle draganddropcolor-question"
                         (click)="navigateToQuestion(question.id!)"
-                        [ngbTooltip]="dragAndDropMappings[question.id!]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
+                        [ngbTooltip]="!!dragAndDropMappings.get(question.id!)?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
                         [ngClass]="!!dragAndDropMappings.get(question.id!)?.length ? 'changed-question' : ''"
                     >
                         <b class="fa">DD</b>
@@ -16,7 +16,7 @@
                         *ngIf="question.type === MULTIPLE_CHOICE"
                         class="btn btn-light btn-circle stepbutton stepwizardquiz-circle multiplechoicecolor-question"
                         (click)="navigateToQuestion(question.id!)"
-                        [ngbTooltip]="selectedAnswerOptions[question.id!]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
+                        [ngbTooltip]="!!selectedAnswerOptions.get(question.id!)?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
                         [ngClass]="!!selectedAnswerOptions.get(question.id!)?.length ? 'changed-question' : ''"
                     >
                         <b class="fa">MC</b>
@@ -25,7 +25,7 @@
                         *ngIf="question.type === SHORT_ANSWER"
                         class="btn btn-light btn-circle stepbutton stepwizardquiz-circle shortanswercolor-question"
                         (click)="navigateToQuestion(question.id!)"
-                        [ngbTooltip]="shortAnswerSubmittedTexts[question.id!]?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
+                        [ngbTooltip]="!!shortAnswerSubmittedTexts.get(question.id!)?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate"
                         [ngClass]="!!shortAnswerSubmittedTexts.get(question.id!)?.length ? 'changed-question' : ''"
                     >
                         <b class="fa">SA</b>

--- a/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.scss
+++ b/src/main/webapp/app/exam/participate/exercises/quiz/quiz-exam-submission.component.scss
@@ -105,10 +105,10 @@
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
-    overflow: hidden;
+    overflow: visible;
     position: fixed;
     height: 90vh;
-    top: 30%;
+    top: 45%;
 
     &__step {
         display: inline-block;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General

- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server(https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
Currently, hovering over one element of the step wizard, displays the tooltip incorrectly and with the wrong text.
![ArtemisBugExamQuizExerciseOverview(1)](https://user-images.githubusercontent.com/45300855/136809573-d56f8c4e-f701-41d7-83e0-7c12c588c4d5.png)

### Description
We changed the CSS overflow parameter to let the tooltip overflow. Also, now the appropriate text is displayed in the tooltip
![tooltip-now-overlaps](https://user-images.githubusercontent.com/45300855/136809697-23a5e67b-1590-4730-9b26-07794a0046cf.PNG)
![tooltip-now-displays-correct-text](https://user-images.githubusercontent.com/45300855/136809701-3c879d7c-97ed-4abf-a8f5-c0e66d4bd2b1.PNG)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Exam with a Quiz Exercise

1. Participate in the Exam with the Quiz Exercise
2. Make sure that the tooltip on the stepwizard items are displayed correctly

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
