### PR TITLE
`Programming Exercises:` Filter docker image messages in the build logs to improve their readability

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/BuildLogEntryService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/BuildLogEntryService.java
@@ -111,9 +111,12 @@ public class BuildLogEntryService {
 
     private boolean isDockerImageLog(String log) {
         return (log.startsWith("Unable to find image '") && log.endsWith("' locally")) || (log.startsWith("Digest: sha256:") && log.length() == 79)
-                || log.startsWith("Status: Downloaded newer image for ") || log.endsWith(": Pulling fs layer") || log.endsWith(": Waiting") || log.endsWith(": Verifying Checksum")
-                || log.endsWith(": Download complete") || log.endsWith(": Pull complete") || ".".equals(log) || "Jenkins does not seem to be running inside a container".equals(log)
-                || log.startsWith("Jenkins seems to be running inside container ");
+                || log.startsWith("Status: Downloaded newer image for ") || "Jenkins does not seem to be running inside a container".equals(log)
+                || log.startsWith("Jenkins seems to be running inside container ") || ".".equals(log)
+                // Each of the following is prefixed by a 12 character hash, so the length is the length of the suffix + 12
+                || (log.endsWith(": Pulling fs layer") && log.length() == 30) || (log.endsWith(": Waiting") && log.length() == 21)
+                || (log.endsWith(": Verifying Checksum") && log.length() == 32) || (log.endsWith(": Download complete") && log.length() == 31)
+                || (log.endsWith(": Pull complete") && log.length() == 27);
     }
 
     /**


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
Whenever some docker image is not present, the build agent downloads it, leaving lots of entries in the log. These entries are then shown to the student as feedback without providing relevant information and possibly confusing them.

### Description
This PR adds a filter to the build logs to remove most of the docker download logs. Some logs are too generic to be reliably filtered without risking to lose relevant information.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Students
- 1 Programming Exercise

1. Log in to Artemis
2. Create/Locate the programming exercise
3. Push a build error
4. The logs should not contain any errors as shown in the screenshot
5. Also try different languages
6. Also take a look at the build output to see if any image was downloaded (only if it was, the fix does anything)

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
Not notably changed

### Screenshots
![grafik](https://user-images.githubusercontent.com/61357727/136851859-6f153fd3-42be-49f2-8179-4829bdbf7c68.png)
