### PR TITLE
`Discussion`: Remove unused column `tutor_approved` in `answer_post`

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20211018091000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20211018091000_changelog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.9.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.9.xsd">
+    <changeSet author="lschlesinger" id="20211018091000">
+        <dropColumn tableName="answer_post" columnName="tutor_approved"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -137,6 +137,7 @@
     <include file="classpath:config/liquibase/changelog/20211002185000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20210930113000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20211008223400_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20211018091000_changelog.xml" relativeToChangelogFile="false"/>
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->
 </databaseChangeLog>

--- a/src/main/webapp/app/shared/metis/postings-header/answer-post-header/answer-post-header.component.html
+++ b/src/main/webapp/app/shared/metis/postings-header/answer-post-header/answer-post-header.component.html
@@ -35,7 +35,6 @@
     <div *ngIf="!isAnswerOfAnnouncement" class="col-auto ps-0">
         <div id="toggleElement" [ngClass]="isAtLeastTutorInCourse || isAuthorOfOriginalPost ? 'clickable' : ''" (click)="toggleResolvesPost()">
             <div *ngIf="posting.resolvesPost; else notResolved">
-                {{ isAnswerOfAnnouncement }}
                 <fa-icon
                     class="resolved"
                     [icon]="'check'"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Description
<!-- Describe your changes in detail -->

Hotfix for a currently occurring problem in production.
We recently interchanged the AnswerPost property `tutor_approved` by `resolves_post`, having a database column for each of the properties.
The legacy column `tutor_approved` was planned to be deleted afterwards.
At the same time, we copied the values from `tutor_approved`  to `resolves_post` and added a [not-nullable constraint ](https://github.com/ls1intum/Artemis/blob/develop/src/main/resources/config/liquibase/changelog/20210930113000_changelog.xml#L9)for the `tutor_approved` column.
This led to the problem when trying to write an AnswerPost into the `answer_post` table: we have a non-nullable `tutor-approved` column but the AnswerPost Domain Model does contain the `answer_post` property anymore.
The fix is to drop the legacy column, which is done in this PR.
