### PR TITLE
`General:` Fix an issue that complaints might not be properly displayed in the assessment dashboard

### DIFF
--- a/src/main/webapp/app/exercises/shared/result/result.component.html
+++ b/src/main/webapp/app/exercises/shared/result/result.component.html
@@ -14,7 +14,7 @@
             ><!-- we need to make sure that result is not null, otherwise the compiler complains below -->
             <span [ngClass]="textColorClass" class="guided-tour">
                 <fa-icon [icon]="resultIconClass" size="lg"></fa-icon>
-                <span class="score">
+                <span class="score" *ngIf="exercise">
                     <span *ngIf="!short" jhiTranslate="artemisApp.result.score">Score</span>
                     {{ roundScoreSpecifiedByCourseSettings(result.score, getCourseFromExercise(exercise!)) }}%,
                 </span>
@@ -53,7 +53,7 @@
     <ng-container *ngSwitchCase="ResultTemplateStatus.LATE">
         <span [ngClass]="textColorClass">
             <fa-icon [icon]="resultIconClass" size="lg"></fa-icon>
-            <span class="score">
+            <span class="score" *ngIf="exercise">
                 &nbsp;<span *ngIf="!short" jhiTranslate="artemisApp.result.score">Score:</span>
                 {{ roundScoreSpecifiedByCourseSettings(result!.score, getCourseFromExercise(exercise!)) }} %,
             </span>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Description
<!-- Describe your changes in detail -->
The assessment dashboard within exams does not display complaints properly since the result component tries to access an undefined exercise and therefore crashes. This seems to break the change detection, as a few seconds later the exercise is defined.
Other places where the result component was used have been broken aswell (e.g. the Submissions page), which is fixed with this PR.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students

1. Create an exercise _(the type does not matter)_
2. Participate with 2 students in the exercise
3. Assess the submissions
4. Complaint as student
5. Open the exam assessment dashboard and see that it does only display one complaint and errors are displayed on the console

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
#### Assessment Dashboard
<details>

Broken version:
![image](https://user-images.githubusercontent.com/63976129/138442986-6225c1d4-643b-42b7-9ae5-addde50355d1.png)
```
ERROR TypeError: Cannot read properties of undefined (reading 'course')
    at me.u [as getCourseFromExercise] (main.4e2130c08d7ec53f9d2c.js:sourcemap:1)
```

Fixed version:
![image](https://user-images.githubusercontent.com/63976129/138443080-14d1af67-72ea-475f-8985-9bea036065d7.png)

</details>

#### Submissions

<details>

Broken version:
![image](https://user-images.githubusercontent.com/63976129/138484598-e802280d-adba-4db7-bbd9-705bffd1a495.png)

Fixed version:
![image](https://user-images.githubusercontent.com/63976129/138484291-4f0cb9ef-abbb-4ca0-8f60-2e37501f22a0.png)

</details>


