### PR TITLE
`Development`: Fix e2e cypress test for text exercise participation

### DIFF
--- a/src/test/cypress/integration/exercises/text/TextExerciseParticipation.spec.ts
+++ b/src/test/cypress/integration/exercises/text/TextExerciseParticipation.spec.ts
@@ -9,6 +9,7 @@ const courseManagement = artemis.requests.courseManagement;
 
 // PageObjects
 const textEditor = artemis.pageobjects.textExercise.editor;
+const courseOverview = artemis.pageobjects.courseOverview;
 
 describe('Text exercise participation', () => {
     let course: any;
@@ -25,20 +26,21 @@ describe('Text exercise participation', () => {
 
     it('Creates a text exercise in the UI', () => {
         cy.login(users.getStudentOne(), `/courses/${course.id}/exercises`);
-        cy.contains('Start exercise').click();
-        cy.get('[data-icon="folder-open"]').click();
+        courseOverview.startExercise(exerciseTitle);
+        courseOverview.openRunningExercise(exerciseTitle);
 
         // Verify the initial state of the text editor
-        cy.get('jhi-header-participation-page').contains(exerciseTitle).should('be.visible');
-        cy.get('[jhitranslate="artemisApp.exercise.problemStatement"]').should('be.visible');
-        cy.get('.exercise-details-table').should('be.visible');
-        cy.contains('No Submission').should('be.visible');
+        textEditor.shouldShowExerciseTitleInHeader(exerciseTitle);
+        textEditor.shouldShowProblemStatement();
+        textEditor.getHeaderElement().contains('No Submission').should('be.visible');
 
         // Make a submission
         cy.fixture('loremIpsum.txt').then((submission) => {
+            textEditor.shouldShowNumberOfWords(0);
+            textEditor.shouldShowNumberOfCharacters(0);
             textEditor.typeSubmission(submission);
-            cy.contains('Number of words: 100').should('be.visible');
-            cy.contains('Number of characters: 591').should('be.visible');
+            textEditor.shouldShowNumberOfWords(100);
+            textEditor.shouldShowNumberOfCharacters(591);
             textEditor
                 .submit()
                 .its('response')
@@ -47,8 +49,8 @@ describe('Text exercise participation', () => {
                     expect(response.body.submitted).equals(true);
                     expect(response.statusCode).equals(200);
                 });
-            cy.get('.alert-success').should('be.visible');
-            cy.get('[jhitranslate="artemisApp.result.noResult"]').should('be.visible');
+            textEditor.shouldShowAlert();
+            textEditor.shouldShowNoGradedResultAvailable();
         });
     });
 

--- a/src/test/cypress/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/cypress/support/pageobjects/course/CourseOverviewPage.ts
@@ -14,9 +14,13 @@ export class CourseOverviewPage {
         cy.wait('@participateInExerciseQuery');
     }
 
-    openRunningProgrammingExercise(exerciseName: string) {
+    openRunningExercise(exerciseTitle: string) {
+        this.getExerciseCardRootElement(exerciseTitle).find('[buttonicon="folder-open"]').click();
+    }
+
+    openRunningProgrammingExercise(exerciseTitle: string) {
         cy.intercept(GET, BASE_API + 'programming-exercise-participations/*/student-participation-with-latest-result-and-feedbacks').as('initialQuery');
-        this.getExerciseCardRootElement(exerciseName).find('[buttonicon="folder-open"]').click();
+        this.openRunningExercise(exerciseTitle);
         cy.wait('@initialQuery').wait(2000);
     }
 

--- a/src/test/cypress/support/pageobjects/exercises/text/TextEditorPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/text/TextEditorPage.ts
@@ -21,4 +21,32 @@ export class TextEditorPage {
         cy.get('.btn-primary').click();
         return cy.wait('@textSubmission');
     }
+
+    shouldShowExerciseTitleInHeader(exerciseTitle: string) {
+        cy.get('jhi-header-participation-page').contains(exerciseTitle).should('be.visible');
+    }
+
+    shouldShowProblemStatement() {
+        cy.get('[jhitranslate="artemisApp.exercise.problemStatement"]').should('be.visible');
+    }
+
+    getHeaderElement() {
+        return cy.get('jhi-header-participation-page');
+    }
+
+    shouldShowNumberOfWords(numberOfWords: number) {
+        cy.get('.badge').contains(`Number of words: ${numberOfWords}`).should('be.visible');
+    }
+
+    shouldShowNumberOfCharacters(numberOfWords: number) {
+        cy.get('.badge').contains(`Number of characters: ${numberOfWords}`).should('be.visible');
+    }
+
+    shouldShowAlert() {
+        cy.get('.alert-success').should('be.visible');
+    }
+
+    shouldShowNoGradedResultAvailable() {
+        cy.get('[jhitranslate="artemisApp.result.noResult"]').should('be.visible');
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The `TextExercisePaticipation.spec.ts` test is failing because it had issues finding the exercise title in the UI (there are now several locations in the DOM instead of only one).

### Description
<!-- Describe your changes in detail -->
I made the selector more accurate to only look for the title in the header of the page. I also took the opportunity to refactor the test and improve code quality by extending the text editor page object.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
[The tests are executed by bamboo](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-QE-431/log) and the `TextExerciseParticipation.spec.ts` test is now passing.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
