### PR TITLE
`Development`: Speed up client tests of plagiarism inspector

### DIFF
--- a/src/test/javascript/spec/component/plagiarism/plagiarism-inspector.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/plagiarism-inspector.component.spec.ts
@@ -12,13 +12,18 @@ import { PlagiarismStatus } from 'app/exercises/shared/plagiarism/types/Plagiari
 import { TextExerciseService } from 'app/exercises/text/manage/text-exercise/text-exercise.service';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { TextExercise } from 'app/entities/text-exercise.model';
-import { ArtemisPlagiarismModule } from 'app/exercises/shared/plagiarism/plagiarism.module';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
 import { TextPlagiarismResult } from 'app/exercises/shared/plagiarism/types/text/TextPlagiarismResult';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
-import { MockProvider } from 'ng-mocks';
+import { MockProvider, MockDirective, MockComponent, MockPipe } from 'ng-mocks';
 import { TranslateService } from '@ngx-translate/core';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { PlagiarismDetailsComponent } from 'app/exercises/shared/plagiarism/plagiarism-details/plagiarism-details.component';
+import { PlagiarismRunDetailsComponent } from 'app/exercises/shared/plagiarism/plagiarism-run-details/plagiarism-run-details.component';
+import { PlagiarismSidebarComponent } from 'app/exercises/shared/plagiarism/plagiarism-sidebar/plagiarism-sidebar.component';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { NgModel } from '@angular/forms';
 
 jest.mock('app/shared/util/download.util', () => ({
     downloadFile: jest.fn(),
@@ -75,8 +80,16 @@ describe('Plagiarism Inspector Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, ArtemisPlagiarismModule],
-            declarations: [],
+            imports: [ArtemisTestModule],
+            declarations: [
+                PlagiarismInspectorComponent,
+                MockPipe(ArtemisTranslatePipe),
+                MockDirective(NgbTooltip),
+                MockDirective(NgModel),
+                MockComponent(PlagiarismDetailsComponent),
+                MockComponent(PlagiarismRunDetailsComponent),
+                MockComponent(PlagiarismSidebarComponent),
+            ],
             providers: [{ provide: ActivatedRoute, useValue: activatedRoute }, MockProvider(JhiWebsocketService), MockProvider(TranslateService)],
         })
             .compileComponents()


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
#### Server
- [ ] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [ ] I implemented the changes with a good performance and prevented too many database calls.
- [ ] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

[ ]: these are not related to this PR

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR speeds up the client tests for the plagiarism-inspector.component.ts.
 

### Description
<!-- Describe your changes in detail -->
I removed unnecessary imports and restructured the code.
As well as removed left sinon/chai fragments

**Speed before (local): 18.713 s
Speed after (local): 1.218 s**

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
 Not changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
