### PR TITLE
`Development`: Improve client tests: fix leaks for exercise assessment dashboard and drag an drop questions

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.ts
@@ -263,6 +263,10 @@ export class DragAndDropQuestionEditComponent implements OnInit, OnChanges, Afte
         const jQueryBackgroundOffset = jQueryBackgroundElement.offset()!;
         const backgroundWidth = jQueryBackgroundElement.width()!;
         const backgroundHeight = jQueryBackgroundElement.height()!;
+        this.mouseMoveAction(event, jQueryBackgroundOffset, backgroundWidth, backgroundHeight);
+    }
+
+    private mouseMoveAction(event: MouseEvent, jQueryBackgroundOffset: { left: number; top: number }, backgroundWidth: number, backgroundHeight: number) {
         if (event.pageX) {
             // Moz
             this.mouse.x = event.pageX - jQueryBackgroundOffset.left;

--- a/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
@@ -1,21 +1,16 @@
 import * as ace from 'brace';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
 import { ArtemisTestModule } from '../../test.module';
-import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
-import { of, throwError, empty } from 'rxjs';
-import { HttpClient, HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { SidePanelComponent } from 'app/shared/side-panel/side-panel.component';
 import { CollapsableAssessmentInstructionsComponent } from 'app/assessment/assessment-instructions/collapsable-assessment-instructions/collapsable-assessment-instructions.component';
-import { AssessmentInstructionsComponent } from 'app/assessment/assessment-instructions/assessment-instructions/assessment-instructions.component';
 import { TutorParticipationGraphComponent } from 'app/shared/dashboards/tutor-participation-graph/tutor-participation-graph.component';
 import { TutorLeaderboardComponent } from 'app/shared/dashboards/tutor-leaderboard/tutor-leaderboard.component';
-import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { GuidedTourMapping } from 'app/guided-tour/guided-tour-setting.model';
 import { GuidedTourService } from 'app/guided-tour/guided-tour.service';
-import { DeviceDetectorService } from 'ngx-device-detector';
 import { ModelingSubmission } from 'app/entities/modeling-submission.model';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { HeaderExercisePageWithDetailsComponent } from 'app/exercises/shared/exercise-headers/header-exercise-page-with-details.component';
@@ -25,7 +20,6 @@ import { ModelingEditorComponent } from 'app/exercises/modeling/shared/modeling-
 import { ModelingSubmissionService } from 'app/exercises/modeling/participate/modeling-submission.service';
 import { TutorParticipationStatus } from 'app/entities/participation/tutor-participation.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
-import { HeaderParticipationPageComponent } from 'app/exercises/shared/exercise-headers/header-participation-page.component';
 import { StructuredGradingInstructionsAssessmentLayoutComponent } from 'app/assessment/structured-grading-instructions-assessment-layout/structured-grading-instructions-assessment-layout.component';
 import { StatsForDashboard } from 'app/course/dashboards/instructor-course-dashboard/stats-for-dashboard.model';
 import { TextSubmissionService } from 'app/exercises/text/participate/text-submission.service';
@@ -59,14 +53,14 @@ import { ExtensionPointDirective } from 'app/shared/extension-point/extension-po
 import { MockHasAnyAuthorityDirective } from '../../helpers/mocks/directive/mock-has-any-authority.directive';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { AssessmentWarningComponent } from 'app/assessment/assessment-warning/assessment-warning.component';
-import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { ComplaintService } from 'app/complaints/complaint.service';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AssessmentType } from 'app/entities/assessment-type.model';
 import { getLinkToSubmissionAssessment } from 'app/utils/navigation.utils';
 import { MockTranslateValuesDirective } from '../../helpers/mocks/directive/mock-translate-values.directive';
-import { TranslateService } from '@ngx-translate/core';
 import { NgxChartsModule } from '@swimlane/ngx-charts';
+import { RouterTestingModule } from '@angular/router/testing';
+import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
+import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 
 describe('ExerciseAssessmentDashboardComponent', () => {
     // needed to make sure ace is defined
@@ -190,13 +184,11 @@ describe('ExerciseAssessmentDashboardComponent', () => {
         MockComponent(TutorLeaderboardComponent),
         MockComponent(TutorParticipationGraphComponent),
         MockComponent(HeaderExercisePageWithDetailsComponent),
-        MockComponent(HeaderParticipationPageComponent),
         MockComponent(SidePanelComponent),
         MockComponent(InfoPanelComponent),
         MockComponent(ModelingEditorComponent),
         MockComponent(SecondCorrectionEnableButtonComponent),
         MockComponent(CollapsableAssessmentInstructionsComponent),
-        MockComponent(AssessmentInstructionsComponent),
         MockComponent(StructuredGradingInstructionsAssessmentLayoutComponent),
         MockComponent(LanguageTableCellComponent),
         MockComponent(ProgrammingExerciseInstructionComponent),
@@ -211,15 +203,12 @@ describe('ExerciseAssessmentDashboardComponent', () => {
         MockDirective(NgbTooltip),
         MockComponent(AssessmentWarningComponent),
     ];
+
     const providers = [
-        MockProvider(JhiLanguageHelper, { language: empty() }),
-        MockProvider(DeviceDetectorService),
-        MockProvider(HttpClient),
         MockProvider(ArtemisDatePipe),
         { provide: ActivatedRoute, useValue: route },
         { provide: LocalStorageService, useClass: MockSyncStorage },
         { provide: SessionStorageService, useClass: MockSyncStorage },
-        { provide: TranslateService, useClass: MockTranslateService },
     ];
 
     beforeEach(() => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Speedup of two tests
The exercise assessment dashboard test also had leaks according to our overview

### Description
<!-- Describe your changes in detail -->
I didn't include mock all providers for the exercise-assessment-dashboard test since it significantly increased the time the test took.

In order to be able to test one method for the drag and drop component, I separated one method into two which allowed me to inject values since I can't mock CSS.

I tested for leaks on the one test after the default refactoring ant all tests ran through => no leaks anymore

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [X] Review 1
- [X] Review 2
