### PR TITLE
`Development`: Speed up client tests for course group component

### DIFF
--- a/src/test/javascript/spec/component/course/course-group.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-group.component.spec.ts
@@ -17,23 +17,16 @@ import { DataTableComponent } from 'app/shared/data-table/data-table.component';
 import { DeleteButtonDirective } from 'app/shared/delete-dialog/delete-button.directive';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
-import * as chai from 'chai';
 import dayjs from 'dayjs';
-import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
+import { MockComponent, MockDirective, MockPipe, MockProvider, MockModule } from 'ng-mocks';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { Observable, of, throwError } from 'rxjs';
-import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import sinonChai from 'sinon-chai';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { ArtemisTestModule } from '../../test.module';
 import { MockRouterLinkDirective } from '../lecture-unit/lecture-unit-management.component.spec';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { AlertService } from 'app/core/util/alert.service';
-
-chai.use(sinonChai);
-const expect = chai.expect;
 
 describe('Course Management Detail Component', () => {
     let comp: CourseGroupComponent;
@@ -51,7 +44,7 @@ describe('Course Management Detail Component', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ArtemisTestModule, NgxDatatableModule],
+            imports: [ArtemisTestModule, MockModule(NgxDatatableModule)],
             declarations: [
                 CourseGroupComponent,
                 MockComponent(DataTableComponent),
@@ -75,130 +68,145 @@ describe('Course Management Detail Component', () => {
                 MockProvider(CourseManagementService),
                 MockProvider(UserService),
             ],
-        }).compileComponents();
-        fixture = TestBed.createComponent(CourseGroupComponent);
-        comp = fixture.componentInstance;
-        courseService = fixture.debugElement.injector.get(CourseManagementService);
-        userService = fixture.debugElement.injector.get(UserService);
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(CourseGroupComponent);
+                comp = fixture.componentInstance;
+                courseService = TestBed.inject(CourseManagementService);
+                userService = TestBed.inject(UserService);
+            });
     });
 
-    afterEach(function () {
-        sinon.restore();
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     it('should initialize', () => {
         fixture.detectChanges();
-        expect(CourseGroupComponent).to.be.ok;
+        expect(CourseGroupComponent).toBeTruthy();
     });
 
     describe('OnInit', () => {
         it('should load all course group users', () => {
-            const getUsersStub = sinon.stub(courseService, 'getAllUsersInCourseGroup');
-            getUsersStub.returns(of(new HttpResponse({ body: [courseGroupUser] })));
+            const getUsersStub = jest.spyOn(courseService, 'getAllUsersInCourseGroup').mockImplementation();
+            getUsersStub.mockReturnValue(of(new HttpResponse({ body: [courseGroupUser] })));
             fixture.detectChanges();
             comp.ngOnInit();
-            expect(comp.course).to.deep.equal(course);
-            expect(comp.courseGroup).to.deep.equal(courseGroup);
-            expect(getUsersStub).to.have.been.called;
+            expect(comp.course).toEqual(course);
+            expect(comp.courseGroup).toEqual(courseGroup);
+            expect(getUsersStub).toHaveBeenCalled();
         });
     });
 
     describe('searchAllUsers', () => {
         let loginOrName: string;
         let loginStream: Observable<{ text: string; entities: User[] }>;
-        let searchStub: SinonStub;
+        let searchStub: jest.SpyInstance;
 
         beforeEach(() => {
             loginOrName = 'testLoginOrName';
             loginStream = of({ text: loginOrName, entities: [] });
-            searchStub = sinon.stub(userService, 'search');
+            searchStub = jest.spyOn(userService, 'search').mockImplementation();
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
         });
 
         it('should search users for given login or name', () => {
-            searchStub.returns(of(new HttpResponse({ body: [courseGroupUser] })));
+            searchStub.mockReturnValue(of(new HttpResponse({ body: [courseGroupUser] })));
             comp.searchAllUsers(loginStream).subscribe((users: any) => {
-                expect(users).to.deep.equal([courseGroupUser]);
+                expect(users).toEqual([courseGroupUser]);
             });
-            expect(searchStub).to.have.been.calledWith(loginOrName);
+            expect(searchStub).toHaveBeenCalledWith(loginOrName);
         });
 
         it('should set search no results if search returns no result', () => {
-            searchStub.returns(of(new HttpResponse({ body: [] })));
+            searchStub.mockReturnValue(of(new HttpResponse({ body: [] })));
             comp.searchAllUsers(loginStream).subscribe((users: any) => {
-                expect(users).to.deep.equal([]);
+                expect(users).toEqual([]);
             });
-            expect(comp.searchNoResults).to.equal(true);
-            expect(searchStub).to.have.been.calledWith(loginOrName);
+            expect(comp.searchNoResults).toBe(true);
+            expect(searchStub).toHaveBeenCalledWith(loginOrName);
         });
 
         it('should return empty if search text is shorter than three characters', () => {
             loginStream = of({ text: 'ab', entities: [] });
-            searchStub.returns(of(new HttpResponse({ body: [courseGroupUser] })));
+            searchStub.mockReturnValue(of(new HttpResponse({ body: [courseGroupUser] })));
             comp.searchAllUsers(loginStream).subscribe((users: any) => {
-                expect(users).to.deep.equal([]);
+                expect(users).toEqual([]);
             });
-            expect(searchStub).not.to.have.been.called;
+            expect(searchStub).not.toHaveBeenCalled();
         });
 
         it('should return empty if search fails', () => {
-            searchStub.returns(throwError(new Error('')));
+            searchStub.mockReturnValue(throwError(new Error('')));
             comp.searchAllUsers(loginStream).subscribe((users: any) => {
-                expect(users).to.deep.equal([]);
+                expect(users).toEqual([]);
             });
-            expect(comp.searchFailed).to.be;
-            expect(searchStub).to.have.been.calledWith(loginOrName);
+            expect(comp.searchFailed).toBe(true);
+            expect(searchStub).toHaveBeenCalledWith(loginOrName);
         });
     });
 
     describe('onAutocompleteSelect', () => {
-        let addUserStub: sinon.SinonStub;
-        let fake: sinon.SinonSpy;
+        let addUserStub: jest.SpyInstance;
+        let fake: jest.Mock;
         let user: User;
 
         beforeEach(() => {
-            addUserStub = sinon.stub(courseService, 'addUserToCourseGroup');
-            addUserStub.returns(of(new HttpResponse()));
-            fake = sinon.fake();
+            addUserStub = jest.spyOn(courseService, 'addUserToCourseGroup').mockImplementation();
+            addUserStub.mockReturnValue(of(new HttpResponse()));
+            fake = jest.fn();
             user = courseGroupUser;
             comp.allCourseGroupUsers = [];
             comp.course = course;
             comp.courseGroup = courseGroup;
         });
+
         it('should add the selected user to course group', () => {
             comp.onAutocompleteSelect(user, fake);
-            expect(addUserStub).to.have.been.calledWith(course.id, courseGroup, user.login);
-            expect(comp.allCourseGroupUsers).to.deep.equal([courseGroupUser]);
-            expect(fake).to.have.been.calledWithExactly(user);
+            expect(addUserStub).toHaveBeenCalledWith(course.id, courseGroup, user.login);
+            expect(comp.allCourseGroupUsers).toEqual([courseGroupUser]);
+            expect(fake).toHaveBeenCalledWith(user);
         });
+
         it('should call callback if user is already in the group', () => {
             comp.allCourseGroupUsers = [user];
             comp.onAutocompleteSelect(user, fake);
-            expect(addUserStub).not.to.have.been.called;
-            expect(comp.allCourseGroupUsers).to.deep.equal([courseGroupUser]);
-            expect(fake).to.have.been.calledWithExactly(user);
+            expect(addUserStub).not.toHaveBeenCalled();
+            expect(comp.allCourseGroupUsers).toEqual([courseGroupUser]);
+            expect(fake).toHaveBeenCalledWith(user);
         });
     });
 
     describe('removeFromGroup', () => {
-        let removeUserStub: sinon.SinonStub;
+        let removeUserStub: jest.SpyInstance;
 
         beforeEach(() => {
-            removeUserStub = sinon.stub(courseService, 'removeUserFromCourseGroup');
-            removeUserStub.returns(of(new HttpResponse()));
+            removeUserStub = jest.spyOn(courseService, 'removeUserFromCourseGroup').mockImplementation();
+            removeUserStub.mockReturnValue(of(new HttpResponse()));
             comp.allCourseGroupUsers = [courseGroupUser, courseGroupUser2];
             comp.course = course;
             comp.courseGroup = courseGroup;
         });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
         it('should given user from group', () => {
             comp.removeFromGroup(courseGroupUser);
-            expect(removeUserStub).to.have.been.calledWith(course.id, courseGroup, courseGroupUser.login);
-            expect(comp.allCourseGroupUsers).to.deep.equal([courseGroupUser2]);
+            expect(removeUserStub).toHaveBeenCalledWith(course.id, courseGroup, courseGroupUser.login);
+            expect(comp.allCourseGroupUsers).toEqual([courseGroupUser2]);
         });
+
         it('should not do anything if users has no login', () => {
             const user = { ...courseGroupUser };
             delete user.login;
             comp.removeFromGroup(user);
-            expect(removeUserStub).not.to.have.been.called;
+            expect(removeUserStub).not.toHaveBeenCalled();
         });
     });
 
@@ -207,19 +215,21 @@ describe('Course Management Detail Component', () => {
             comp.courseGroup = CourseGroup.STUDENTS;
             comp.course = { ...course };
             comp.course.studentGroupName = 'testStudentGroupName';
-            expect(comp.courseGroupName).to.equal(comp.course.studentGroupName);
+            expect(comp.courseGroupName).toEqual(comp.course.studentGroupName);
         });
+
         it('should return courses teachingAssistantGroupName if group is tutors', () => {
             comp.courseGroup = CourseGroup.TUTORS;
             comp.course = { ...course };
             comp.course.teachingAssistantGroupName = 'testTeachingAssistantGroupName';
-            expect(comp.courseGroupName).to.equal(comp.course.teachingAssistantGroupName);
+            expect(comp.courseGroupName).toEqual(comp.course.teachingAssistantGroupName);
         });
+
         it('should return courses instructorGroupName if group is instructors', () => {
             comp.courseGroup = CourseGroup.INSTRUCTORS;
             comp.course = { ...course };
             comp.course.instructorGroupName = 'testInstructorGroupName';
-            expect(comp.courseGroupName).to.equal(comp.course.instructorGroupName);
+            expect(comp.courseGroupName).toEqual(comp.course.instructorGroupName);
         });
     });
 
@@ -227,7 +237,7 @@ describe('Course Management Detail Component', () => {
         it('should change user size to given number', () => {
             const size = 5;
             comp.handleUsersSizeChange(size);
-            expect(comp.filteredUsersSize).to.equal(size);
+            expect(comp.filteredUsersSize).toEqual(size);
         });
     });
 
@@ -235,19 +245,20 @@ describe('Course Management Detail Component', () => {
         it('should format user info into appropriate format', () => {
             const name = 'testName';
             const user = { ...courseGroupUser, name };
-            expect(comp.searchResultFormatter(user)).to.equal(`${name} (${user.login})`);
+            expect(comp.searchResultFormatter(user)).toEqual(`${name} (${user.login})`);
         });
     });
 
     describe('searchTextFromUser', () => {
         it('converts a user to a string that can be searched for', () => {
             const user = courseGroupUser;
-            expect(comp.searchTextFromUser(user)).to.equal(user.login);
+            expect(comp.searchTextFromUser(user)).toEqual(user.login);
         });
+
         it('should return empty string if user does not have login', () => {
             const user = { ...courseGroupUser };
             delete user.login;
-            expect(comp.searchTextFromUser(user)).to.equal('');
+            expect(comp.searchTextFromUser(user)).toEqual('');
         });
     });
 });

--- a/src/test/javascript/spec/component/course/course-group.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-group.component.spec.ts
@@ -159,7 +159,7 @@ describe('Course Management Detail Component', () => {
         });
 
         it('should add the selected user to course group', () => {
-            let fake = jest.fn();
+            const fake = jest.fn();
             comp.onAutocompleteSelect(user, fake);
             expect(addUserStub).toHaveBeenCalledWith(course.id, courseGroup, user.login);
             expect(comp.allCourseGroupUsers).toEqual([courseGroupUser]);
@@ -167,7 +167,7 @@ describe('Course Management Detail Component', () => {
         });
 
         it('should call callback if user is already in the group', () => {
-            let fake = jest.fn();
+            const fake = jest.fn();
             comp.allCourseGroupUsers = [user];
             comp.onAutocompleteSelect(user, fake);
             expect(addUserStub).not.toHaveBeenCalled();

--- a/src/test/javascript/spec/component/course/course-group.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-group.component.spec.ts
@@ -84,18 +84,17 @@ describe('Course Management Detail Component', () => {
 
     it('should initialize', () => {
         fixture.detectChanges();
-        expect(CourseGroupComponent).toBeTruthy();
+        expect(CourseGroupComponent).not.toBe(null);
     });
 
     describe('OnInit', () => {
         it('should load all course group users', () => {
-            const getUsersStub = jest.spyOn(courseService, 'getAllUsersInCourseGroup').mockImplementation();
-            getUsersStub.mockReturnValue(of(new HttpResponse({ body: [courseGroupUser] })));
+            const getUsersStub = jest.spyOn(courseService, 'getAllUsersInCourseGroup').mockReturnValue(of(new HttpResponse({ body: [courseGroupUser] })));
             fixture.detectChanges();
             comp.ngOnInit();
             expect(comp.course).toEqual(course);
             expect(comp.courseGroup).toEqual(courseGroup);
-            expect(getUsersStub).toHaveBeenCalled();
+            expect(getUsersStub).toHaveBeenCalledTimes(2);
         });
     });
 
@@ -107,11 +106,7 @@ describe('Course Management Detail Component', () => {
         beforeEach(() => {
             loginOrName = 'testLoginOrName';
             loginStream = of({ text: loginOrName, entities: [] });
-            searchStub = jest.spyOn(userService, 'search').mockImplementation();
-        });
-
-        afterEach(() => {
-            jest.restoreAllMocks();
+            searchStub = jest.spyOn(userService, 'search');
         });
 
         it('should search users for given login or name', () => {
@@ -152,13 +147,11 @@ describe('Course Management Detail Component', () => {
 
     describe('onAutocompleteSelect', () => {
         let addUserStub: jest.SpyInstance;
-        let fake: jest.Mock;
         let user: User;
 
         beforeEach(() => {
             addUserStub = jest.spyOn(courseService, 'addUserToCourseGroup').mockImplementation();
             addUserStub.mockReturnValue(of(new HttpResponse()));
-            fake = jest.fn();
             user = courseGroupUser;
             comp.allCourseGroupUsers = [];
             comp.course = course;
@@ -166,6 +159,7 @@ describe('Course Management Detail Component', () => {
         });
 
         it('should add the selected user to course group', () => {
+            let fake = jest.fn();
             comp.onAutocompleteSelect(user, fake);
             expect(addUserStub).toHaveBeenCalledWith(course.id, courseGroup, user.login);
             expect(comp.allCourseGroupUsers).toEqual([courseGroupUser]);
@@ -173,6 +167,7 @@ describe('Course Management Detail Component', () => {
         });
 
         it('should call callback if user is already in the group', () => {
+            let fake = jest.fn();
             comp.allCourseGroupUsers = [user];
             comp.onAutocompleteSelect(user, fake);
             expect(addUserStub).not.toHaveBeenCalled();
@@ -190,10 +185,6 @@ describe('Course Management Detail Component', () => {
             comp.allCourseGroupUsers = [courseGroupUser, courseGroupUser2];
             comp.course = course;
             comp.courseGroup = courseGroup;
-        });
-
-        afterEach(() => {
-            jest.restoreAllMocks();
         });
 
         it('should given user from group', () => {
@@ -215,21 +206,21 @@ describe('Course Management Detail Component', () => {
             comp.courseGroup = CourseGroup.STUDENTS;
             comp.course = { ...course };
             comp.course.studentGroupName = 'testStudentGroupName';
-            expect(comp.courseGroupName).toEqual(comp.course.studentGroupName);
+            expect(comp.courseGroupName).toBe(comp.course.studentGroupName);
         });
 
         it('should return courses teachingAssistantGroupName if group is tutors', () => {
             comp.courseGroup = CourseGroup.TUTORS;
             comp.course = { ...course };
             comp.course.teachingAssistantGroupName = 'testTeachingAssistantGroupName';
-            expect(comp.courseGroupName).toEqual(comp.course.teachingAssistantGroupName);
+            expect(comp.courseGroupName).toBe(comp.course.teachingAssistantGroupName);
         });
 
         it('should return courses instructorGroupName if group is instructors', () => {
             comp.courseGroup = CourseGroup.INSTRUCTORS;
             comp.course = { ...course };
             comp.course.instructorGroupName = 'testInstructorGroupName';
-            expect(comp.courseGroupName).toEqual(comp.course.instructorGroupName);
+            expect(comp.courseGroupName).toBe(comp.course.instructorGroupName);
         });
     });
 
@@ -237,7 +228,7 @@ describe('Course Management Detail Component', () => {
         it('should change user size to given number', () => {
             const size = 5;
             comp.handleUsersSizeChange(size);
-            expect(comp.filteredUsersSize).toEqual(size);
+            expect(comp.filteredUsersSize).toBe(size);
         });
     });
 
@@ -245,20 +236,20 @@ describe('Course Management Detail Component', () => {
         it('should format user info into appropriate format', () => {
             const name = 'testName';
             const user = { ...courseGroupUser, name };
-            expect(comp.searchResultFormatter(user)).toEqual(`${name} (${user.login})`);
+            expect(comp.searchResultFormatter(user)).toBe(`${name} (${user.login})`);
         });
     });
 
     describe('searchTextFromUser', () => {
         it('converts a user to a string that can be searched for', () => {
             const user = courseGroupUser;
-            expect(comp.searchTextFromUser(user)).toEqual(user.login);
+            expect(comp.searchTextFromUser(user)).toBe(user.login);
         });
 
         it('should return empty string if user does not have login', () => {
             const user = { ...courseGroupUser };
             delete user.login;
-            expect(comp.searchTextFromUser(user)).toEqual('');
+            expect(comp.searchTextFromUser(user)).toBe('');
         });
     });
 });

--- a/src/test/javascript/spec/component/course/course-group.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-group.component.spec.ts
@@ -115,6 +115,7 @@ describe('Course Management Detail Component', () => {
                 expect(users).toEqual([courseGroupUser]);
             });
             expect(searchStub).toHaveBeenCalledWith(loginOrName);
+            expect(searchStub).toHaveBeenCalledTimes(1);
         });
 
         it('should set search no results if search returns no result', () => {
@@ -124,6 +125,7 @@ describe('Course Management Detail Component', () => {
             });
             expect(comp.searchNoResults).toBe(true);
             expect(searchStub).toHaveBeenCalledWith(loginOrName);
+            expect(searchStub).toHaveBeenCalledTimes(1);
         });
 
         it('should return empty if search text is shorter than three characters', () => {
@@ -142,6 +144,7 @@ describe('Course Management Detail Component', () => {
             });
             expect(comp.searchFailed).toBe(true);
             expect(searchStub).toHaveBeenCalledWith(loginOrName);
+            expect(searchStub).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -150,8 +153,7 @@ describe('Course Management Detail Component', () => {
         let user: User;
 
         beforeEach(() => {
-            addUserStub = jest.spyOn(courseService, 'addUserToCourseGroup').mockImplementation();
-            addUserStub.mockReturnValue(of(new HttpResponse()));
+            addUserStub = jest.spyOn(courseService, 'addUserToCourseGroup').mockReturnValue(of(new HttpResponse<void>()));
             user = courseGroupUser;
             comp.allCourseGroupUsers = [];
             comp.course = course;
@@ -162,8 +164,10 @@ describe('Course Management Detail Component', () => {
             const fake = jest.fn();
             comp.onAutocompleteSelect(user, fake);
             expect(addUserStub).toHaveBeenCalledWith(course.id, courseGroup, user.login);
+            expect(addUserStub).toHaveBeenCalledTimes(1);
             expect(comp.allCourseGroupUsers).toEqual([courseGroupUser]);
             expect(fake).toHaveBeenCalledWith(user);
+            expect(fake).toHaveBeenCalledTimes(1);
         });
 
         it('should call callback if user is already in the group', () => {
@@ -173,6 +177,7 @@ describe('Course Management Detail Component', () => {
             expect(addUserStub).not.toHaveBeenCalled();
             expect(comp.allCourseGroupUsers).toEqual([courseGroupUser]);
             expect(fake).toHaveBeenCalledWith(user);
+            expect(fake).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -180,8 +185,7 @@ describe('Course Management Detail Component', () => {
         let removeUserStub: jest.SpyInstance;
 
         beforeEach(() => {
-            removeUserStub = jest.spyOn(courseService, 'removeUserFromCourseGroup').mockImplementation();
-            removeUserStub.mockReturnValue(of(new HttpResponse()));
+            removeUserStub = jest.spyOn(courseService, 'removeUserFromCourseGroup').mockReturnValue(of(new HttpResponse<void>()));
             comp.allCourseGroupUsers = [courseGroupUser, courseGroupUser2];
             comp.course = course;
             comp.courseGroup = courseGroup;
@@ -190,6 +194,7 @@ describe('Course Management Detail Component', () => {
         it('should given user from group', () => {
             comp.removeFromGroup(courseGroupUser);
             expect(removeUserStub).toHaveBeenCalledWith(course.id, courseGroup, courseGroupUser.login);
+            expect(removeUserStub).toHaveBeenCalledTimes(1);
             expect(comp.allCourseGroupUsers).toEqual([courseGroupUser2]);
         });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
#### Server
- [ ] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [ ] I implemented the changes with a good performance and prevented too many database calls.
- [ ] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

- [ ] : not relevant

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR speeds up the client tests in course-group.component.spec.ts.

### Description
<!-- Describe your changes in detail -->
I removed every occurrences of sinon and chai and converted it to jest. Also I did some restructuring.
I mocked one module (NgxDatatableModule) for speed improvements.

Speed before (local): 14.591 s
Speed after (local): 1.816 s

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
not changed