### PR TITLE
`Assessment`: Fix button to more feedback request in exercise assessment dashboard

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
@@ -600,6 +600,7 @@ public class SubmissionService {
      * This method gets all complaints of an exercise and returns them together with their corresponding submission in a DTO
      *
      * @param exerciseId the exerciseId of the exercise of which the complaints are fetched
+     * @param isAtLeastInstructor if the user is an instructor
      * @return a list of DTOs containing a complaint and its submission
      */
     public List<SubmissionWithComplaintDTO> getSubmissionsWithComplaintsForExercise(Long exerciseId, boolean isAtLeastInstructor) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/SubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/SubmissionResource.java
@@ -151,7 +151,7 @@ public class SubmissionResource {
     }
 
     /**
-     * Get /exercises/:exerciseId//more-feedback-reqeusts-with-complaints
+     * Get /exercises/:exerciseId//more-feedback-requests-with-complaints
      *
      * Get all more feedback requests associated to an exercise which have more feedback requests in,
      * but filter out the ones that are about the tutor who is doing the request, since tutors cannot act on their own complaint

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
@@ -575,7 +575,10 @@
                     [ngbTooltip]="'artemisApp.exerciseAssessmentDashboard.moreFeedbackRequestHint' | artemisTranslate"
                 ></fa-icon>
                 <div class="table-responsive">
-                    <table class="table table-striped exercise-table" *ngIf="moreFeedbackRequests && moreFeedbackRequests!.length > 0; else noMoreFeedbackRequests">
+                    <table
+                        class="table table-striped exercise-table"
+                        *ngIf="submissionsWithMoreFeedbackRequests && submissionsWithMoreFeedbackRequests!.length > 0; else noMoreFeedbackRequests"
+                    >
                         <thead>
                             <tr>
                                 <th>#</th>
@@ -586,26 +589,26 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <tr *ngFor="let moreFeedbackRequest of moreFeedbackRequests; let i = index">
+                            <tr *ngFor="let moreFeedbackRequest of submissionsWithMoreFeedbackRequests; let i = index">
                                 <td>{{ i + 1 }}</td>
-                                <td>{{ moreFeedbackRequest.submittedTime | artemisDate }}</td>
+                                <td>{{ moreFeedbackRequest.complaint.submittedTime | artemisDate }}</td>
                                 <td>
-                                    <jhi-result [result]="moreFeedbackRequest.result"></jhi-result>
+                                    <jhi-result [result]="moreFeedbackRequest.complaint.result"></jhi-result>
                                 </td>
                                 <td>
-                                    <span *ngIf="moreFeedbackRequest.accepted !== undefined">{{
+                                    <span *ngIf="moreFeedbackRequest.complaint.accepted !== undefined">{{
                                         'artemisApp.exerciseAssessmentDashboard.moreFeedbackRequestEvaluated' | artemisTranslate
                                     }}</span>
-                                    <span *ngIf="moreFeedbackRequest.accepted === undefined"
+                                    <span *ngIf="moreFeedbackRequest.complaint.accepted === undefined"
                                         >{{ 'artemisApp.exerciseAssessmentDashboard.moreFeedbackRequestNotEvaluated' | artemisTranslate }}
                                     </span>
                                 </td>
                                 <td>
                                     <a
-                                        *ngIf="moreFeedbackRequest.accepted === undefined; else continueButton"
+                                        *ngIf="moreFeedbackRequest.complaint.accepted === undefined; else continueButton"
                                         class="btn btn-success btn-sm"
-                                        [routerLink]="getAssessmentLink(moreFeedbackRequest)"
-                                        [queryParams]="getComplaintQueryParams(moreFeedbackRequest)"
+                                        [routerLink]="getAssessmentLink(moreFeedbackRequest.submission)"
+                                        [queryParams]="getComplaintQueryParams(moreFeedbackRequest.complaint)"
                                     >
                                         <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                         {{ 'artemisApp.exerciseAssessmentDashboard.evaluateMoreFeedbackRequest' | artemisTranslate }}
@@ -613,8 +616,8 @@
                                     <ng-template #continueButton>
                                         <button
                                             class="btn btn-primary btn-sm"
-                                            [routerLink]="getAssessmentLink(moreFeedbackRequest)"
-                                            [queryParams]="getComplaintQueryParams(moreFeedbackRequest)"
+                                            [routerLink]="getAssessmentLink(moreFeedbackRequest.submission)"
+                                            [queryParams]="getComplaintQueryParams(moreFeedbackRequest.complaint)"
                                         >
                                             <fa-icon [icon]="'folder-open'" [fixedWidth]="true"></fa-icon>
                                             {{ 'artemisApp.exerciseAssessmentDashboard.showMoreFeedbackRequests' | artemisTranslate }}

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.ts
@@ -98,7 +98,7 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
     nextExampleSubmissionId: number;
     exampleSolutionModel: UMLModel;
     complaints: Complaint[] = [];
-    moreFeedbackRequests: Complaint[] = [];
+    submissionsWithMoreFeedbackRequests: SubmissionWithComplaintDTO[] = [];
     submissionsWithComplaints: SubmissionWithComplaintDTO[] = [];
     submissionLockLimitReached = false;
     openingAssessmentEditorForNewSubmission = false;
@@ -330,8 +330,10 @@ export class ExerciseAssessmentDashboardComponent implements OnInit {
                 (error: HttpErrorResponse) => onError(this.alertService, error),
             );
 
-            this.complaintService.getMoreFeedbackRequestsForTutor(this.exerciseId).subscribe(
-                (res: HttpResponse<Complaint[]>) => (this.moreFeedbackRequests = res.body as Complaint[]),
+            this.submissionService.getSubmissionsWithMoreFeedbackRequestsForTutor(this.exerciseId).subscribe(
+                (res: HttpResponse<SubmissionWithComplaintDTO[]>) => {
+                    this.submissionsWithMoreFeedbackRequests = res.body || [];
+                },
                 (error: HttpErrorResponse) => onError(this.alertService, error),
             );
 

--- a/src/main/webapp/app/exercises/shared/submission/submission.service.ts
+++ b/src/main/webapp/app/exercises/shared/submission/submission.service.ts
@@ -62,6 +62,16 @@ export class SubmissionService {
             .pipe(map((res) => this.convertDTOsFromServer(res)));
     }
 
+    /**
+     * Find more feedback requests for tutor in this exercise.
+     * @param exerciseId
+     */
+    getSubmissionsWithMoreFeedbackRequestsForTutor(exerciseId: number): Observable<HttpResponse<SubmissionWithComplaintDTO[]>> {
+        return this.http
+            .get<SubmissionWithComplaintDTO[]>(`api/exercises/${exerciseId}/more-feedback-requests-with-complaints`, { observe: 'response' })
+            .pipe(map((res) => this.convertDTOsFromServer(res)));
+    }
+
     protected convertDTOsFromServer(res: HttpResponse<SubmissionWithComplaintDTO[]>) {
         if (res.body) {
             res.body.forEach((dto) => {

--- a/src/test/java/de/tum/in/www1/artemis/FileUploadAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadAssessmentIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
+import de.tum.in.www1.artemis.domain.enumeration.ComplaintType;
 import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
 import de.tum.in.www1.artemis.domain.enumeration.IncludedInOverallScore;
 import de.tum.in.www1.artemis.domain.exam.Exam;
@@ -670,7 +671,7 @@ public class FileUploadAssessmentIntegrationTest extends AbstractSpringIntegrati
         var submissions = database.getAllSubmissionsOfExercise(exercise);
 
         Submission submission = submissions.get(0);
-        database.addComplaintToSubmission(submission, "student1");
+        database.addComplaintToSubmission(submission, "student1", ComplaintType.COMPLAINT);
         assertThat(submission.getResults().size()).isEqualTo(2);
         Result lastResult = submission.getLatestResult();
         request.delete("/api/participations/" + submission.getParticipation().getId() + "/file-upload-submissions/" + submission.getId() + "/results/" + lastResult.getId(),

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2973,13 +2973,13 @@ public class DatabaseUtilService {
         }
     }
 
-    public void addComplaintToSubmission(Submission submission, String userLogin) {
+    public void addComplaintToSubmission(Submission submission, String userLogin, ComplaintType type) {
         Result result = submission.getLatestResult();
         if (result != null) {
             result.hasComplaint(true);
             resultRepo.save(result);
         }
-        Complaint complaint = new Complaint().participant(getUserByLogin(userLogin)).result(result).complaintType(ComplaintType.COMPLAINT);
+        Complaint complaint = new Complaint().participant(getUserByLogin(userLogin)).result(result).complaintType(type);
         complaintRepo.save(complaint);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -2683,18 +2683,17 @@ public class DatabaseUtilService {
 
     public Submission addModelingSubmissionWithFinishedResultAndAssessor(ModelingExercise exercise, ModelingSubmission submission, String login, String assessorLogin) {
         StudentParticipation participation = createAndSaveParticipationForExercise(exercise, login);
-        return addSubmissionWithFinishedResultsWithAssessor(participation, exercise, submission, login, assessorLogin);
+        return addSubmissionWithFinishedResultsWithAssessor(participation, submission, assessorLogin);
     }
 
     public Submission addSubmissionWithTwoFinishedResultsWithAssessor(Exercise exercise, Submission submission, String login, String assessorLogin) {
         StudentParticipation participation = createAndSaveParticipationForExercise(exercise, login);
-        submission = addSubmissionWithFinishedResultsWithAssessor(participation, exercise, submission, login, assessorLogin);
-        submission = addSubmissionWithFinishedResultsWithAssessor(participation, exercise, submission, login, assessorLogin);
+        submission = addSubmissionWithFinishedResultsWithAssessor(participation, submission, assessorLogin);
+        submission = addSubmissionWithFinishedResultsWithAssessor(participation, submission, assessorLogin);
         return submission;
     }
 
-    public Submission addSubmissionWithFinishedResultsWithAssessor(StudentParticipation participation, Exercise exercise, Submission submission, String login,
-            String assessorLogin) {
+    public Submission addSubmissionWithFinishedResultsWithAssessor(StudentParticipation participation, Submission submission, String assessorLogin) {
         Result result = new Result();
         result.setAssessor(getUserByLogin(assessorLogin));
         result.setCompletionDate(ZonedDateTime.now());
@@ -2975,7 +2974,12 @@ public class DatabaseUtilService {
     }
 
     public void addComplaintToSubmission(Submission submission, String userLogin) {
-        Complaint complaint = new Complaint().participant(getUserByLogin(userLogin)).result(submission.getLatestResult()).complaintType(ComplaintType.COMPLAINT);
+        Result result = submission.getLatestResult();
+        if (result != null) {
+            result.hasComplaint(true);
+            resultRepo.save(result);
+        }
+        Complaint complaint = new Complaint().participant(getUserByLogin(userLogin)).result(result).complaintType(ComplaintType.COMPLAINT);
         complaintRepo.save(complaint);
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [X] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [X] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [X] I documented the Java code using JavaDoc style.
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [X] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With #4178 we found that one couldn't click the button to resolve the more feedback request in the exercise assessment dashboard anymore.

### Description
<!-- Describe your changes in detail -->
I chose to use the same style used for the complaints to retrieve the requests with their submission. I refactored the server side to prevent code duplication and added tests for both service methods.
The reason it didn't work was that the submission that was accessible to the request didn't contain the participation. The participation is, however, needed to form the link to the submission.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Tutor+
- 1 More Feedback Request on your exercise

1. Go to the exercise assessment dashboard of your exercise
2. Try to open the more feedback request

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
submission.service.ts: 46.67% | 68.49%
exercise-assessment-dashboard.component.ts: 60.47% | 83.59%
SubmissionResource.java: 30% | 88%
SubmissionService.java: 22% | 96%

### Screenshots
Affected button:
![](https://user-images.githubusercontent.com/64264938/139873140-5711dcff-20f7-4905-a2ff-5e9c0e5caddb.png)