### PR TITLE
`Development`: Fix e2e cypress tests modeling exercise assessment

### DIFF
--- a/src/test/cypress/integration/exercises/modeling/ModelingExerciseAssessment.spec.ts
+++ b/src/test/cypress/integration/exercises/modeling/ModelingExerciseAssessment.spec.ts
@@ -1,4 +1,3 @@
-import { BASE_API, PUT } from '../../../support/constants';
 import { artemis } from '../../../support/ArtemisTesting';
 import day from 'dayjs';
 
@@ -17,26 +16,14 @@ const student = userManagement.getStudentOne();
 const tutor = userManagement.getTutor();
 const instructor = userManagement.getInstructor();
 
-let course: any;
-let modelingExercise: any;
-
 describe('Modeling Exercise Assessment Spec', () => {
+    let course: any;
+    let modelingExercise: any;
+
     before('Log in as admin and create a course', () => {
-        cy.login(admin);
-        courseManagementRequests.createCourse().then((courseResp) => {
-            course = courseResp.body;
-            courseManagementRequests.addInstructorToCourse(course.id, instructor);
-            courseManagementRequests.addTutorToCourse(course, tutor);
-            courseManagementRequests.addStudentToCourse(course.id, student.username).then(() => {
-                courseManagementRequests.createModelingExercise({ course }, undefined, day(), day().add(5, 'seconds'), day().add(1, 'hour')).then((resp) => {
-                    modelingExercise = resp.body;
-                    cy.login(student).then(() => {
-                        courseManagementRequests.startExerciseParticipation(course.id, modelingExercise.id).then((participationReponse: any) => {
-                            courseManagementRequests.makeModelingExerciseSubmission(modelingExercise.id, participationReponse.body);
-                        });
-                    });
-                });
-            });
+        createCourseWithModelingExercise().then(() => {
+            makeModelingSubmissionAsStudent();
+            updateExerciseDueDate();
         });
     });
 
@@ -61,9 +48,7 @@ describe('Modeling Exercise Assessment Spec', () => {
         assessmentEditor.assessComponent(2, 'Good');
         assessmentEditor.openAssessmentForComponent(3);
         assessmentEditor.assessComponent(0, 'Unnecessary');
-        cy.intercept(PUT, BASE_API + 'modeling-submissions/*/result/*/assessment*').as('submitModelingAssessment');
-        assessmentEditor.submitWithoutInterception();
-        cy.wait('@submitModelingAssessment').its('response.statusCode').should('eq', 200);
+        assessmentEditor.submit();
     });
 
     describe('Handling complaints', () => {
@@ -97,4 +82,29 @@ describe('Modeling Exercise Assessment Spec', () => {
             cy.get('.alerts').should('contain.text', 'Response to complaint has been submitted');
         });
     });
+
+    function createCourseWithModelingExercise() {
+        cy.login(admin);
+        return courseManagementRequests.createCourse(true).then((response) => {
+            course = response.body;
+            courseManagementRequests.addStudentToCourse(course.id, student.username);
+            courseManagementRequests.addTutorToCourse(course, tutor);
+            courseManagementRequests.addInstructorToCourse(course.id, instructor);
+            courseManagementRequests.createModelingExercise({ course }).then((modelingResponse) => {
+                modelingExercise = modelingResponse.body;
+            });
+        });
+    }
+
+    function makeModelingSubmissionAsStudent() {
+        cy.login(student);
+        courseManagementRequests.startExerciseParticipation(course.id, modelingExercise.id).then((participation) => {
+            courseManagementRequests.makeModelingExerciseSubmission(modelingExercise.id, participation.body);
+        });
+    }
+
+    function updateExerciseDueDate() {
+        cy.login(admin);
+        courseManagementRequests.updateModelingExerciseDueDate(modelingExercise, day().add(5, 'seconds'));
+    }
 });

--- a/src/test/cypress/integration/exercises/modeling/ModelingExerciseManagement.spec.ts
+++ b/src/test/cypress/integration/exercises/modeling/ModelingExerciseManagement.spec.ts
@@ -81,7 +81,7 @@ describe('Modeling Exercise Management Spec', () => {
                     modelingExerciseExampleSubmission.assessComponent(2, 'Good');
                     modelingExerciseExampleSubmission.openAssessmentForComponent(3);
                     modelingExerciseExampleSubmission.assessComponent(0, 'Unnecessary');
-                    modelingExerciseExampleSubmission.submit();
+                    modelingExerciseExampleSubmission.submitExample();
                     cy.visit(`/course-management/${course.id}/modeling-exercises/${modelingExercise.id}`);
                     cy.get('.apollon-editor').should('exist');
                 });

--- a/src/test/cypress/integration/exercises/programming/ProgrammingExerciseAssessment.spec.ts
+++ b/src/test/cypress/integration/exercises/programming/ProgrammingExerciseAssessment.spec.ts
@@ -1,5 +1,6 @@
 import { CypressAssessmentType } from '../../../support/requests/CourseManagementRequests';
 import { artemis } from 'src/test/cypress/support/ArtemisTesting';
+import dayjs from 'dayjs';
 
 // The user management object
 const users = artemis.users;
@@ -114,7 +115,7 @@ describe('Programming exercise assessment', () => {
 
     function updateExerciseDueDate() {
         cy.login(admin);
-        courseManagement.updateProgrammingExerciseDueDate(exercise);
+        courseManagement.updateProgrammingExerciseDueDate(exercise, dayjs().add(5, 'seconds'));
     }
 
     function updateExerciseAssessmentDueDate() {

--- a/src/test/cypress/support/commands.ts
+++ b/src/test/cypress/support/commands.ts
@@ -81,6 +81,7 @@ Cypress.Commands.add('login', (credentials: CypressCredentials, url) => {
     }).then((response) => {
         expect(response.status).to.equal(200);
         localStorage.setItem(authTokenKey, '"' + response.body.id_token + '"');
+        cy.wait(50);
     });
     if (url) {
         cy.visit(url);

--- a/src/test/cypress/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
+++ b/src/test/cypress/support/pageobjects/assessment/ModelingExerciseAssessmentEditor.ts
@@ -25,9 +25,15 @@ export class ModelingExerciseAssessmentEditor extends AbstractExerciseAssessment
         return super.acceptComplaint(response, CypressExerciseType.MODELING);
     }
 
-    submit() {
+    submitExample() {
         cy.intercept(PUT, BASE_API + 'modeling-submissions/*/example-assessment').as('createExampleSubmission');
         cy.contains('Save Example Assessment').click();
         return cy.wait('@createExampleSubmission').its('response.statusCode').should('eq', 200);
+    }
+
+    submit() {
+        cy.intercept(PUT, BASE_API + 'modeling-submissions/*/result/*/assessment*').as('submitModelingAssessment');
+        super.submitWithoutInterception();
+        return cy.wait('@submitModelingAssessment').its('response.statusCode').should('eq', 200);
     }
 }

--- a/src/test/cypress/support/requests/CourseManagementRequests.ts
+++ b/src/test/cypress/support/requests/CourseManagementRequests.ts
@@ -148,6 +148,11 @@ export class CourseManagementRequests {
         return this.updateExercise(exercise, CypressExerciseType.PROGRAMMING);
     }
 
+    updateModelingExerciseDueDate(exercise: any, due = day()) {
+        exercise.dueDate = dayjsToString(due);
+        return this.updateExercise(exercise, CypressExerciseType.MODELING);
+    }
+
     private updateExercise(exercise: any, type: CypressExerciseType) {
         let url: string;
         switch (type) {
@@ -158,6 +163,8 @@ export class CourseManagementRequests {
                 url = TEXT_EXERCISE_BASE;
                 break;
             case CypressExerciseType.MODELING:
+                url = MODELING_EXERCISE_BASE;
+                break;
             case CypressExerciseType.QUIZ:
             default:
                 throw new Error(`Exercise type '${type}' is not supported yet!`);
@@ -290,15 +297,7 @@ export class CourseManagementRequests {
 
     updateModelingExerciseAssessmentDueDate(exercise: any, due = day()) {
         exercise.assessmentDueDate = dayjsToString(due);
-        return this.updateModelingExercise(exercise);
-    }
-
-    updateModelingExercise(exercise: any) {
-        return cy.request({
-            url: MODELING_EXERCISE_BASE,
-            method: PUT,
-            body: exercise,
-        });
+        return this.updateExercise(exercise, CypressExerciseType.MODELING);
     }
 
     deleteModelingExercise(exerciseID: number) {
@@ -470,16 +469,6 @@ export class CourseManagementRequests {
     updateTextExerciseAssessmentDueDate(exercise: any, due = day()) {
         exercise.assessmentDueDate = dayjsToString(due);
         return this.updateExercise(exercise, CypressExerciseType.TEXT);
-    }
-
-    /**
-     * Because the only difference between course exercises and exam exercises is the "course" or "exerciseGroup" field
-     * This function takes an exercise template and adds one of the fields to it
-     * @param exercise the exercise template
-     * @param body the exercise group or course the exercise will be added to
-     */
-    private getCourseOrExamExercise(exercise: object, body: { course: any } | { exerciseGroup: any }) {
-        return Object.assign({}, exercise, body);
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The `ModelingExerciseAssessment.spec` tests are flaky and sometimes fail with an authentication error without a body:
![image](https://user-images.githubusercontent.com/12861668/140322311-c583ca67-623b-450b-9e87-37ac7a4ff1d9.png)

### Description
<!-- Describe your changes in detail -->
In this PR I refactored the structure of the `ModelingExerciseAssessment.spec` to mimick the structure of the `ProgrammingExerciseAssessment.spec`. I also moved some code to page objects. The error consistently occured for me locally (before the changes) and was probably caused by several chained `then` calls. After my refactoring the tests passed for me locally, so I assume that the issue is fixed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
[The tests are executed by bamboo and pass.](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-QE-467/log)
### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
