### PR TITLE
`Programming exercises`: Improve feedback preview for Python exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/FeedbackRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/FeedbackRepository.java
@@ -33,10 +33,14 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     String DEFAULT_FILEPATH = "notAvailable";
 
+    String PYTHON_EXCEPTION_LINE_PREFIX = "E       ";
+
     Pattern JVM_RESULT_MESSAGE_MATCHER = prepareJVMResultMessageMatcher(
             List.of("java.lang.AssertionError", "org.opentest4j.AssertionFailedError", "de.tum.in.test.api.util.UnexpectedExceptionError"));
 
     Predicate<String> IS_NOT_STACK_TRACE_LINE = line -> !line.startsWith("\tat ");
+
+    Predicate<String> IS_PYTHON_EXCEPTION_LINE = line -> line.startsWith(PYTHON_EXCEPTION_LINE_PREFIX);
 
     List<Feedback> findByResult(Result result);
 
@@ -205,6 +209,13 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
         if (programmingLanguage == ProgrammingLanguage.JAVA || programmingLanguage == ProgrammingLanguage.KOTLIN) {
             String messageWithoutStackTrace = message.lines().takeWhile(IS_NOT_STACK_TRACE_LINE).collect(Collectors.joining("\n")).trim();
             return JVM_RESULT_MESSAGE_MATCHER.matcher(messageWithoutStackTrace).replaceAll("");
+        }
+
+        if (programmingLanguage == ProgrammingLanguage.PYTHON) {
+            Optional<String> firstExceptionMessage = message.lines().filter(IS_PYTHON_EXCEPTION_LINE).findFirst();
+            if (firstExceptionMessage.isPresent()) {
+                return firstExceptionMessage.get().replace(PYTHON_EXCEPTION_LINE_PREFIX, "") + "\n\n" + message;
+            }
         }
 
         return message;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).

#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Feedback previews of Python exercises does not include information about the error itself. Only by expanding the feedback text, the actual error message line can be seen.

### Description
<!-- Describe your changes in detail -->
The error message line of pyTest can be identified by its `E       ` prefix and by copying this line to the top of the feedback text, this is then displayed in the feedback preview.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor or Student
- 1 Python Programming Exercise

1. Log in to Artemis
2. Start a Python exercise with the 'Online Editor'
3. Submit it and check the feedback previews

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

#### Before

![{664CD505-DA8D-4FF3-B3F2-2FA537068C32}](https://user-images.githubusercontent.com/45761921/140606797-b71a1f6b-3dc4-4c9f-82fe-613061e248bb.png)

#### After

![{5770C681-87D2-47C4-B4E8-C9617FB95B6D}1](https://user-images.githubusercontent.com/45761921/140606799-b43cfc03-4bb6-48cd-a679-9de8cbf36eb4.png)
