### PR TITLE
`Assessments`: Fix multiple issues for handling of complaints and feedback requests during assesment

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ComplaintResponseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ComplaintResponseService.java
@@ -263,11 +263,11 @@ public class ComplaintResponseService {
         }
         // for complaints, a different tutor should review the complaint
         else if (complaint.getComplaintType() == null || complaint.getComplaintType() == ComplaintType.COMPLAINT) {
-            return !user.getLogin().equals(assessor.getLogin());
+            return assessor == null || !user.getLogin().equals(assessor.getLogin());
         }
         // for more feedback requests, the same tutor should review the request
         else if (complaint.getComplaintType() != null && complaint.getComplaintType() == ComplaintType.MORE_FEEDBACK) {
-            return user.getLogin().equals(assessor.getLogin());
+            return assessor == null || user.getLogin().equals(assessor.getLogin());
         }
         return false;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
@@ -624,7 +624,8 @@ public class SubmissionService {
         // get all requests which belong to the exercise
         List<Complaint> requests = complaintRepository.getAllComplaintsByExerciseIdAndComplaintType(exerciseId, ComplaintType.MORE_FEEDBACK);
 
-        requests = requests.stream().filter(complaint -> complaint.getResult().getAssessor().equals(userRepository.getUser())).toList();
+        requests = requests.stream().filter(complaint -> complaint.getResult().getAssessor() == null || complaint.getResult().getAssessor().equals(userRepository.getUser()))
+                .toList();
 
         return getSubmissionsWithComplaintsFromComplaints(requests);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
@@ -608,7 +608,7 @@ public class SubmissionService {
         List<Complaint> complaints = complaintRepository.getAllComplaintsByExerciseIdAndComplaintType(exerciseId, ComplaintType.COMPLAINT);
 
         if (!isAtLeastInstructor) {
-            complaints = complaints.stream().filter(complaint -> !complaint.getResult().getAssessor().equals(userRepository.getUser())).toList();
+            complaints = complaints.stream().filter(complaint -> !userRepository.getUser().equals(complaint.getResult().getAssessor())).toList();
         }
 
         return getSubmissionsWithComplaintsFromComplaints(complaints);

--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
@@ -64,7 +64,7 @@
                 rows="4"
                 maxlength="2000"
                 [(ngModel)]="complaintResponse.responseText"
-                [readonly]="handled"
+                [readonly]="handled || isLockedForLoggedInUser"
                 [disabled]="handled || isLockedForLoggedInUser"
             ></textarea>
             <div *ngIf="!handled && complaint.complaintType === ComplaintType.COMPLAINT" class="d-flex flex-wrap gap-1 justify-content-between mt-3">

--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
@@ -217,6 +217,9 @@ export class ComplaintsForTutorComponent implements OnInit {
             if (this.isTestRun) {
                 return this.isAssessor;
             }
+            if (this.complaint.result && this.complaint.result.assessor == undefined) {
+                return true;
+            }
             return this.complaint!.complaintType === ComplaintType.COMPLAINT ? !this.isAssessor : this.isAssessor;
         }
     }

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
@@ -535,6 +535,7 @@
                                     <jhi-result
                                         [result]="submissionWithComplaint.submission.latestResult"
                                         [participation]="submissionWithComplaint.complaint.result!.participation!"
+                                        [exercise]="exercise"
                                     ></jhi-result>
                                 </td>
                                 <td>

--- a/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
+++ b/src/main/webapp/app/exercises/shared/dashboards/tutor/exercise-assessment-dashboard.component.html
@@ -619,7 +619,7 @@
                                 <td>{{ i + 1 }}</td>
                                 <td>{{ moreFeedbackRequest.complaint.submittedTime | artemisDate }}</td>
                                 <td>
-                                    <jhi-result [result]="moreFeedbackRequest.complaint.result"></jhi-result>
+                                    <jhi-result [result]="moreFeedbackRequest.complaint.result" [exercise]="exercise"></jhi-result>
                                 </td>
                                 <td>
                                     <span *ngIf="moreFeedbackRequest.complaint.accepted !== undefined">{{

--- a/src/main/webapp/i18n/de/complaintResponse.json
+++ b/src/main/webapp/i18n/de/complaintResponse.json
@@ -8,7 +8,7 @@
             "lockInformationYou": "Durch dich gesperrt bis {{endDate}}",
             "notUnlocked": "Nicht gesperrt",
             "lockStatus": "Status der Sperre",
-            "notAllowedToRespond": "Es ist dir nicht erlaubt, auf diese Anfrage zu antworten!\nBei Teamaufgaben sind Teamtutor:innen sowohl für Beschwerden als auch Mehr-Feedback Anfragen verantwortlich.\nBei individuellen Aufgaben werden Beschwerden von anderen Tutor:innen beantwortet und Mehr-Feedback Anfragen von Tutor:innen, die die Aufgabe bewertet haben.\nBei Testläufen für Klausuren dürfen auch bewertende Tutor:innen Beschwerden beantworten."
+            "notAllowedToRespond": "Es ist dir nicht erlaubt, auf diese Anfrage zu antworten!\nBei Teamaufgaben sind Teamtutor:innen sowohl für Beschwerden als auch Mehr-Feedback Anfragen verantwortlich.\nBei individuellen Aufgaben werden Beschwerden von anderen Tutor:innen beantwortet und Mehr-Feedback Anfragen von Tutor:innen, die die Aufgabe bewertet haben.\nBei Testläufen für Klausuren dürfen auch bewertende Tutor:innen Beschwerden beantworten.\nBeschwerden auf automatische Bewertungen können von allen Tutor:innen beantwortet werden."
         },
         "complaintResponse": {
             "title": "Antwort auf die Beschwerde",

--- a/src/main/webapp/i18n/en/complaintResponse.json
+++ b/src/main/webapp/i18n/en/complaintResponse.json
@@ -8,7 +8,7 @@
             "lockInformationYou": "Locked by YOU until {{endDate}}",
             "notUnlocked": "Not Locked",
             "lockStatus": "Lock Status",
-            "notAllowedToRespond": "You are not allowed to respond to the complaint or more feedback request!\nFor team exercises, the team tutor is the assessor and handles both complaints and feedback requests himself.\nFor individual exercises, complaints are handled by a secondary reviewer and feedback requests by the assessor himself.\nFor exam test runs, the original assessor is allowed to respond to complaints."
+            "notAllowedToRespond": "You are not allowed to respond to the complaint or more feedback request!\nFor team exercises, the team tutor is the assessor and handles both complaints and feedback requests himself.\nFor individual exercises, complaints are handled by a secondary reviewer and feedback requests by the assessor himself.\nFor exam test runs, the original assessor is allowed to respond to complaints.\nComplaints on automatic assessments can be answered by any tutor."
         },
         "complaintResponse": {
             "title": "Complaint's response",

--- a/src/test/java/de/tum/in/www1/artemis/service/ComplaintResponseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ComplaintResponseServiceTest.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Set;
 
@@ -98,9 +99,9 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         complaintWithResult.setResult(new Result());
         User user = new User();
 
-        assertThrows(IllegalArgumentException.class, () -> complaintResponseService.isUserAuthorizedToRespondToComplaint(complaintWithResult, null));
-        assertThrows(IllegalArgumentException.class, () -> complaintResponseService.isUserAuthorizedToRespondToComplaint(null, user));
-        assertThrows(IllegalArgumentException.class, () -> complaintResponseService.isUserAuthorizedToRespondToComplaint(complaintWithoutResult, user));
+        assertThatThrownBy(() -> complaintResponseService.isUserAuthorizedToRespondToComplaint(complaintWithResult, null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> complaintResponseService.isUserAuthorizedToRespondToComplaint(null, user)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> complaintResponseService.isUserAuthorizedToRespondToComplaint(complaintWithoutResult, user)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -110,7 +111,7 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
         Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
 
-        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, instructor));
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, instructor)).isTrue();
     }
 
     @Test
@@ -120,7 +121,7 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
         Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
 
-        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, student2));
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, student2)).isFalse();
     }
 
     @Test
@@ -130,7 +131,7 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
         Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
 
-        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1)).isTrue();
     }
 
     @Test
@@ -140,7 +141,7 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
         Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
 
-        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2)).isFalse();
     }
 
     @Test
@@ -154,8 +155,8 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(submission.getId()).orElseThrow();
         textExerciseComplaint = this.complaintRepository.findByIdWithEagerAssessor(textExerciseComplaint.getId()).orElseThrow();
 
-        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
-        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1)).isFalse();
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2)).isTrue();
     }
 
     @Test
@@ -169,8 +170,8 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(submission.getId()).orElseThrow();
         textExerciseComplaint = this.complaintRepository.findByIdWithEagerAssessor(textExerciseComplaint.getId()).orElseThrow();
 
-        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
-        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1)).isFalse();
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2)).isTrue();
     }
 
     @Test
@@ -180,8 +181,8 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
         Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
 
-        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
-        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1)).isTrue();
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2)).isTrue();
     }
 
     @Test
@@ -195,8 +196,8 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(submission.getId()).orElseThrow();
         textExerciseComplaint = this.complaintRepository.findByIdWithEagerAssessor(textExerciseComplaint.getId()).orElseThrow();
 
-        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
-        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1)).isTrue();
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2)).isFalse();
     }
 
     @Test
@@ -206,7 +207,7 @@ public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambo
         this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.MORE_FEEDBACK);
         Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
 
-        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
-        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1)).isTrue();
+        assertThat(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2)).isTrue();
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/ComplaintResponseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ComplaintResponseServiceTest.java
@@ -1,0 +1,212 @@
+package de.tum.in.www1.artemis.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
+import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.enumeration.ComplaintType;
+import de.tum.in.www1.artemis.repository.ComplaintRepository;
+import de.tum.in.www1.artemis.repository.ResultRepository;
+import de.tum.in.www1.artemis.repository.TextExerciseRepository;
+import de.tum.in.www1.artemis.repository.UserRepository;
+
+@AutoConfigureTestDatabase
+public class ComplaintResponseServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+
+    @Autowired
+    private ComplaintResponseService complaintResponseService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ComplaintRepository complaintRepository;
+
+    @Autowired
+    private TextExerciseRepository textExerciseRepository;
+
+    @Autowired
+    private ResultRepository resultRepository;
+
+    private Course course;
+
+    private TextExercise textExercise;
+
+    private TextExercise teamTextExercise;
+
+    private User student1;
+
+    private User student2;
+
+    private User tutor1;
+
+    private User tutor2;
+
+    private User instructor;
+
+    private Team team;
+
+    @BeforeEach
+    public void initTestCase() throws Exception {
+        this.database.addUsers(2, 2, 0, 1);
+        this.course = this.database.createCourse();
+
+        this.student1 = this.database.getUserByLogin("student1");
+        this.student1.setGroups(Set.of(this.course.getStudentGroupName()));
+        userRepository.save(this.student1);
+
+        this.student2 = this.database.getUserByLogin("student2");
+        this.student2.setGroups(Set.of(this.course.getStudentGroupName()));
+        userRepository.save(this.student2);
+
+        this.tutor1 = this.database.getUserByLogin("tutor1");
+        this.tutor1.setGroups(Set.of(this.course.getTeachingAssistantGroupName()));
+        userRepository.save(this.tutor1);
+
+        this.tutor2 = this.database.getUserByLogin("tutor2");
+        this.tutor2.setGroups(Set.of(this.course.getTeachingAssistantGroupName()));
+        userRepository.save(this.tutor2);
+
+        this.instructor = this.database.getUserByLogin("instructor1");
+        this.instructor.setGroups(Set.of(this.course.getInstructorGroupName()));
+        userRepository.save(this.instructor);
+
+        this.textExercise = this.database.createIndividualTextExercise(course, null, null, null);
+        this.teamTextExercise = this.database.createTeamTextExercise(course, null, null, null);
+
+        this.team = this.database.createTeam(Set.of(this.student1), this.tutor1, this.teamTextExercise, "Team");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        database.resetDatabase();
+    }
+
+    @Test
+    public void testIsUserAuthorizedToRespondToComplaintCheckInput() {
+        Complaint complaintWithoutResult = new Complaint();
+        Complaint complaintWithResult = new Complaint();
+        complaintWithResult.setResult(new Result());
+        User user = new User();
+
+        assertThrows(IllegalArgumentException.class, () -> complaintResponseService.isUserAuthorizedToRespondToComplaint(complaintWithResult, null));
+        assertThrows(IllegalArgumentException.class, () -> complaintResponseService.isUserAuthorizedToRespondToComplaint(null, user));
+        assertThrows(IllegalArgumentException.class, () -> complaintResponseService.isUserAuthorizedToRespondToComplaint(complaintWithoutResult, user));
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testIsUserAuthorizedToRespondToComplaintForInstructor() {
+        Result textExerciseResult = this.database.createParticipationSubmissionAndResult(textExercise.getId(), student1, 0d, 0d, 10, true);
+        this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
+        Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
+
+        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, instructor));
+    }
+
+    @Test
+    @WithMockUser(username = "student2", roles = "INSTRUCTOR")
+    public void testIsUserAuthorizedToRespondToComplaintForStudent() {
+        Result textExerciseResult = this.database.createParticipationSubmissionAndResult(textExercise.getId(), student1, 0d, 0d, 10, true);
+        this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
+        Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
+
+        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, student2));
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testIsUserAuthorizedToRespondToComplaintForTeamOwner() {
+        Result textExerciseResult = this.database.createParticipationSubmissionAndResult(teamTextExercise.getId(), team, 0d, 0d, 10, true);
+        this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
+        Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
+
+        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
+    }
+
+    @Test
+    @WithMockUser(username = "tutor2", roles = "TA")
+    public void testIsUserAuthorizedToRespondToComplaintForNotTeamOwner() {
+        Result textExerciseResult = this.database.createParticipationSubmissionAndResult(teamTextExercise.getId(), team, 0d, 0d, 10, true);
+        this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
+        Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
+
+        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testIsUserAuthorizedToRespondToComplaintForNoComplaintType() {
+        Result textExerciseResult = this.database.createParticipationSubmissionAndResult(textExercise.getId(), student1, 0d, 0d, 10, true);
+        Submission submission = textExerciseResult.getSubmission();
+        textExerciseResult.setAssessor(tutor1);
+        resultRepository.save(textExerciseResult);
+        this.database.addComplaintToSubmission(submission, student1.getLogin(), null);
+        Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(submission.getId()).orElseThrow();
+        textExerciseComplaint = this.complaintRepository.findByIdWithEagerAssessor(textExerciseComplaint.getId()).orElseThrow();
+
+        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
+        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testIsUserAuthorizedToRespondToComplaintForComplaints() {
+        Result textExerciseResult = this.database.createParticipationSubmissionAndResult(textExercise.getId(), student1, 0d, 0d, 10, true);
+        Submission submission = textExerciseResult.getSubmission();
+        textExerciseResult.setAssessor(tutor1);
+        resultRepository.save(textExerciseResult);
+        this.database.addComplaintToSubmission(submission, student1.getLogin(), ComplaintType.COMPLAINT);
+        Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(submission.getId()).orElseThrow();
+        textExerciseComplaint = this.complaintRepository.findByIdWithEagerAssessor(textExerciseComplaint.getId()).orElseThrow();
+
+        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
+        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testIsUserAuthorizedToRespondToComplaintForComplaintsWithAutomaticAssessment() {
+        Result textExerciseResult = this.database.createParticipationSubmissionAndResult(textExercise.getId(), student1, 0d, 0d, 10, true);
+        this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.COMPLAINT);
+        Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
+
+        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
+        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testIsUserAuthorizedToRespondToComplaintForFeedbackRequest() {
+        Result textExerciseResult = this.database.createParticipationSubmissionAndResult(textExercise.getId(), student1, 0d, 0d, 10, true);
+        Submission submission = textExerciseResult.getSubmission();
+        textExerciseResult.setAssessor(tutor1);
+        resultRepository.save(textExerciseResult);
+        this.database.addComplaintToSubmission(submission, student1.getLogin(), ComplaintType.MORE_FEEDBACK);
+        Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(submission.getId()).orElseThrow();
+        textExerciseComplaint = this.complaintRepository.findByIdWithEagerAssessor(textExerciseComplaint.getId()).orElseThrow();
+
+        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
+        assertFalse(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+    }
+
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testIsUserAuthorizedToRespondToComplaintForFeedbackRequestWithAutomaticAssessment() {
+        Result textExerciseResult = this.database.createParticipationSubmissionAndResult(textExercise.getId(), student1, 0d, 0d, 10, true);
+        this.database.addComplaintToSubmission(textExerciseResult.getSubmission(), student1.getLogin(), ComplaintType.MORE_FEEDBACK);
+        Complaint textExerciseComplaint = this.complaintRepository.findByResultSubmissionId(textExerciseResult.getSubmission().getId()).orElseThrow();
+
+        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor1));
+        assertTrue(complaintResponseService.isUserAuthorizedToRespondToComplaint(textExerciseComplaint, tutor2));
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple **unit** tests (Spring) related to the features (with a high test coverage).
- [X] I implemented the changes with a good performance and prevented too many database calls.
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [X] I added multiple screenshots/screencasts of my UI changes.
- [X] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- Fixes #4265
- Fixes an issue I found during debugging where more feedback requests don't get displayed for automatic results (that don't have an assessor).
- Fixes an issue found during development where for results with no assessor (automatic grading) no tutor was able to handle the complaint/feedback request).

### Description
<!-- Describe your changes in detail -->
- I directly provided the exercise to the result detail component because the exercise is not retrieved properly.
- I also added the edge case that no assessor is set for the more feedback request retrieval.
- I added more edge case handling in server and client for the case that the assessor of the original result is not set due to automatic feedback

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Tutor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Participate with both students and make sure that you solve at least one rated test
2. Complain with one student after the end, request more feedback with the other one
3. Check the assessment dashboard with the tutor. You might have to start participating in the assessment first. Make sure that 
    - Both the complaint and the more feedback request get correctly displayed in their tables
    - When clicking on the result, all feedbacks are correctly displayed.
    - When accessing complaint and more feedback request you don't get any errors and can **in theory** answer => Not disabled
    - When the instructor takes over the lock, the tutor can't answer the complaint or request anymore (disabled)
    - When the lock was released the tutor can get the lock again and can now answer the complaint and feedback request (here please test it out)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<img width="1361" alt="Bildschirmfoto 2021-11-09 um 15 26 21" src="https://user-images.githubusercontent.com/64264938/140942341-de279e92-815c-48c6-9493-a338f5c0e732.png">