### PR TITLE
`General`: Unify the client-side password length validation

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/Constants.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/Constants.java
@@ -12,7 +12,7 @@ public final class Constants {
 
     public static final int USERNAME_MAX_LENGTH = 50;
 
-    public static final int PASSWORD_MIN_LENGTH = 4;
+    public static final int PASSWORD_MIN_LENGTH = 8;
 
     public static final int PASSWORD_MAX_LENGTH = 50;
 

--- a/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html
+++ b/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html
@@ -49,16 +49,18 @@
                                 class="form-text text-danger"
                                 *ngIf="passwordForm.get('newPassword')?.errors?.minlength"
                                 jhiTranslate="global.messages.validate.newpassword.minlength"
+                                [translateValues]="{ min: PASSWORD_MIN_LENGTH }"
                             >
-                                Your password is required to be at least 4 characters.
+                                Your password is required to be at least 8 characters.
                             </small>
 
                             <small
                                 class="form-text text-danger"
                                 *ngIf="passwordForm.get('newPassword')?.errors?.maxlength"
                                 jhiTranslate="global.messages.validate.newpassword.maxlength"
+                                [translateValues]="{ max: PASSWORD_MAX_LENGTH }"
                             >
-                                Your password cannot be longer than 100 characters.
+                                Your password cannot be longer than 50 characters.
                             </small>
                         </div>
 
@@ -89,16 +91,18 @@
                                 class="form-text text-danger"
                                 *ngIf="passwordForm.get('confirmPassword')?.errors?.minlength"
                                 jhiTranslate="global.messages.validate.confirmpassword.minlength"
+                                [translateValues]="{ min: PASSWORD_MIN_LENGTH }"
                             >
-                                Your password confirmation is required to be at least 4 characters.
+                                Your password confirmation is required to be at least 8 characters.
                             </small>
 
                             <small
                                 class="form-text text-danger"
                                 *ngIf="passwordForm.get('confirmPassword')?.errors?.maxlength"
                                 jhiTranslate="global.messages.validate.confirmpassword.maxlength"
+                                [translateValues]="{ max: PASSWORD_MAX_LENGTH }"
                             >
-                                Your password confirmation cannot be longer than 100 characters.
+                                Your password confirmation cannot be longer than 50 characters.
                             </small>
                         </div>
                     </div>

--- a/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts
+++ b/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts
@@ -14,8 +14,8 @@ export class PasswordResetFinishComponent implements OnInit, AfterViewInit {
     @ViewChild('newPassword', { static: false })
     newPassword?: ElementRef;
 
-    PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
-    PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
+    readonly PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
+    readonly PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
 
     initialized = false;
     doNotMatch = false;

--- a/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts
+++ b/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts
@@ -4,6 +4,7 @@ import { ActivatedRoute } from '@angular/router';
 import { PasswordResetFinishService } from './password-reset-finish.service';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { FormBuilder, Validators } from '@angular/forms';
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-password-reset-finish',
@@ -13,6 +14,9 @@ export class PasswordResetFinishComponent implements OnInit, AfterViewInit {
     @ViewChild('newPassword', { static: false })
     newPassword?: ElementRef;
 
+    PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
+    PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
+
     initialized = false;
     doNotMatch = false;
     error = false;
@@ -20,8 +24,8 @@ export class PasswordResetFinishComponent implements OnInit, AfterViewInit {
     key = '';
 
     passwordForm = this.fb.group({
-        newPassword: ['', [Validators.required, Validators.minLength(8), Validators.maxLength(100)]],
-        confirmPassword: ['', [Validators.required, Validators.minLength(8), Validators.maxLength(100)]],
+        newPassword: ['', [Validators.required, Validators.minLength(PASSWORD_MIN_LENGTH), Validators.maxLength(PASSWORD_MAX_LENGTH)]],
+        confirmPassword: ['', [Validators.required, Validators.minLength(PASSWORD_MIN_LENGTH), Validators.maxLength(PASSWORD_MAX_LENGTH)]],
     });
 
     passwordResetEnabled = false;

--- a/src/main/webapp/app/account/password/password.component.html
+++ b/src/main/webapp/app/account/password/password.component.html
@@ -58,16 +58,18 @@
                             class="form-text text-danger"
                             *ngIf="passwordForm.get('newPassword')?.errors?.minlength"
                             jhiTranslate="global.messages.validate.newpassword.minlength"
+                            [translateValues]="{ min: PASSWORD_MIN_LENGTH }"
                         >
-                            Your password is required to be at least 4 characters.
+                            Your password is required to be at least 8 characters.
                         </small>
 
                         <small
                             class="form-text text-danger"
                             *ngIf="passwordForm.get('newPassword')?.errors?.maxlength"
                             jhiTranslate="global.messages.validate.newpassword.maxlength"
+                            [translateValues]="{ max: PASSWORD_MAX_LENGTH }"
                         >
-                            Your password cannot be longer than 100 characters.
+                            Your password cannot be longer than 50 characters.
                         </small>
                     </div>
 
@@ -98,6 +100,7 @@
                             class="form-text text-danger"
                             *ngIf="passwordForm.get('confirmPassword')?.errors?.minlength"
                             jhiTranslate="global.messages.validate.confirmpassword.minlength"
+                            [translateValues]="{ min: PASSWORD_MIN_LENGTH }"
                         >
                             Your confirmation password is required to be at least 8 characters.
                         </small>
@@ -106,8 +109,9 @@
                             class="form-text text-danger"
                             *ngIf="passwordForm.get('confirmPassword')?.errors?.maxlength"
                             jhiTranslate="global.messages.validate.confirmpassword.maxlength"
+                            [translateValues]="{ max: PASSWORD_MAX_LENGTH }"
                         >
-                            Your confirmation password cannot be longer than 100 characters.
+                            Your confirmation password cannot be longer than 50 characters.
                         </small>
                     </div>
                 </div>

--- a/src/main/webapp/app/account/password/password.component.ts
+++ b/src/main/webapp/app/account/password/password.component.ts
@@ -12,8 +12,8 @@ import { PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH } from 'app/app.constants';
     templateUrl: './password.component.html',
 })
 export class PasswordComponent implements OnInit {
-    PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
-    PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
+    readonly PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
+    readonly PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
 
     doNotMatch = false;
     error = false;

--- a/src/main/webapp/app/account/password/password.component.ts
+++ b/src/main/webapp/app/account/password/password.component.ts
@@ -5,20 +5,24 @@ import { AccountService } from 'app/core/auth/account.service';
 import { PasswordService } from './password.service';
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { FormBuilder, Validators } from '@angular/forms';
+import { PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-password',
     templateUrl: './password.component.html',
 })
 export class PasswordComponent implements OnInit {
+    PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
+    PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
+
     doNotMatch = false;
     error = false;
     success = false;
     user?: User;
     passwordForm = this.fb.group({
         currentPassword: ['', [Validators.required]],
-        newPassword: ['', [Validators.required, Validators.minLength(8), Validators.maxLength(100)]],
-        confirmPassword: ['', [Validators.required, Validators.minLength(8), Validators.maxLength(100)]],
+        newPassword: ['', [Validators.required, Validators.minLength(PASSWORD_MIN_LENGTH), Validators.maxLength(PASSWORD_MAX_LENGTH)]],
+        confirmPassword: ['', [Validators.required, Validators.minLength(PASSWORD_MIN_LENGTH), Validators.maxLength(PASSWORD_MAX_LENGTH)]],
     });
     passwordResetEnabled = false;
 

--- a/src/main/webapp/app/account/register/register.component.html
+++ b/src/main/webapp/app/account/register/register.component.html
@@ -77,11 +77,21 @@
                             Your username is required.
                         </small>
 
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.minlength" jhiTranslate="register.messages.validate.login.minlength">
+                        <small
+                            class="form-text text-danger"
+                            *ngIf="registerForm.get('login')?.errors?.minlength"
+                            jhiTranslate="register.messages.validate.login.minlength"
+                            [translateValues]="{ min: USERNAME_MIN_LENGTH }"
+                        >
                             Your username is required to be at least 4 characters.
                         </small>
 
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.maxlength" jhiTranslate="register.messages.validate.login.maxlength">
+                        <small
+                            class="form-text text-danger"
+                            *ngIf="registerForm.get('login')?.errors?.maxlength"
+                            jhiTranslate="register.messages.validate.login.maxlength"
+                            [translateValues]="{ max: USERNAME_MAX_LENGTH }"
+                        >
                             Your username cannot be longer than 50 characters.
                         </small>
 

--- a/src/main/webapp/app/account/register/register.component.html
+++ b/src/main/webapp/app/account/register/register.component.html
@@ -78,7 +78,7 @@
                         </small>
 
                         <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.minlength" jhiTranslate="register.messages.validate.login.minlength">
-                            Your username is required to be at least 1 character.
+                            Your username is required to be at least 4 characters.
                         </small>
 
                         <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.maxlength" jhiTranslate="register.messages.validate.login.maxlength">
@@ -122,7 +122,7 @@
                         </small>
 
                         <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
-                            Your email cannot be longer than 50 characters.
+                            Your email cannot be longer than 100 characters.
                         </small>
 
                         <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.pattern" jhiTranslate="global.messages.validate.email.pattern">
@@ -148,12 +148,22 @@
                             Your password is required.
                         </small>
 
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors?.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
-                            Your password is required to be at least 4 characters.
+                        <small
+                            class="form-text text-danger"
+                            *ngIf="registerForm.get('password')?.errors?.minlength"
+                            jhiTranslate="global.messages.validate.newpassword.minlength"
+                            [translateValues]="{ min: PASSWORD_MIN_LENGTH }"
+                        >
+                            Your password is required to be at least 8 characters.
                         </small>
 
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors?.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
-                            Your password cannot be longer than 100 characters.
+                        <small
+                            class="form-text text-danger"
+                            *ngIf="registerForm.get('password')?.errors?.maxlength"
+                            jhiTranslate="global.messages.validate.newpassword.maxlength"
+                            [translateValues]="{ max: PASSWORD_MAX_LENGTH }"
+                        >
+                            Your password cannot be longer than 50 characters.
                         </small>
                     </div>
 
@@ -185,16 +195,18 @@
                             class="form-text text-danger"
                             *ngIf="registerForm.get('confirmPassword')?.errors?.minlength"
                             jhiTranslate="global.messages.validate.confirmpassword.minlength"
+                            [translateValues]="{ min: PASSWORD_MIN_LENGTH }"
                         >
-                            Your confirmation password is required to be at least 4 characters.
+                            Your confirmation password is required to be at least 8 characters.
                         </small>
 
                         <small
                             class="form-text text-danger"
                             *ngIf="registerForm.get('confirmPassword')?.errors?.maxlength"
                             jhiTranslate="global.messages.validate.confirmpassword.maxlength"
+                            [translateValues]="{ max: PASSWORD_MAX_LENGTH }"
                         >
-                            Your confirmation password cannot be longer than 100 characters.
+                            Your confirmation password cannot be longer than 50 characters.
                         </small>
                     </div>
                 </div>

--- a/src/main/webapp/app/account/register/register.component.ts
+++ b/src/main/webapp/app/account/register/register.component.ts
@@ -17,8 +17,8 @@ export class RegisterComponent implements OnInit, AfterViewInit {
     @ViewChild('login', { static: false })
     login?: ElementRef;
 
-    PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
-    PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
+    readonly PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
+    readonly PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
 
     doNotMatch = false;
     error = false;

--- a/src/main/webapp/app/account/register/register.component.ts
+++ b/src/main/webapp/app/account/register/register.component.ts
@@ -17,6 +17,8 @@ export class RegisterComponent implements OnInit, AfterViewInit {
     @ViewChild('login', { static: false })
     login?: ElementRef;
 
+    readonly USERNAME_MIN_LENGTH = USERNAME_MIN_LENGTH;
+    readonly USERNAME_MAX_LENGTH = USERNAME_MAX_LENGTH;
     readonly PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
     readonly PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
 

--- a/src/main/webapp/app/account/register/register.component.ts
+++ b/src/main/webapp/app/account/register/register.component.ts
@@ -7,6 +7,7 @@ import { ACCOUNT_REGISTRATION_BLOCKED, EMAIL_ALREADY_USED_TYPE, LOGIN_ALREADY_US
 import { ProfileService } from 'app/shared/layouts/profiles/profile.service';
 import { FormBuilder, Validators } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH, USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-register',
@@ -15,6 +16,9 @@ import { TranslateService } from '@ngx-translate/core';
 export class RegisterComponent implements OnInit, AfterViewInit {
     @ViewChild('login', { static: false })
     login?: ElementRef;
+
+    PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
+    PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
 
     doNotMatch = false;
     error = false;
@@ -28,10 +32,10 @@ export class RegisterComponent implements OnInit, AfterViewInit {
     registerForm = this.fb.group({
         firstName: ['', [Validators.required, Validators.minLength(2)]],
         lastName: ['', [Validators.required, Validators.minLength(2)]],
-        login: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50), Validators.pattern(this.usernamePattern)]],
+        login: ['', [Validators.required, Validators.minLength(USERNAME_MIN_LENGTH), Validators.maxLength(USERNAME_MAX_LENGTH), Validators.pattern(this.usernamePattern)]],
         email: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(100), Validators.email]],
-        password: ['', [Validators.required, Validators.minLength(8), Validators.maxLength(100)]],
-        confirmPassword: ['', [Validators.required, Validators.minLength(8), Validators.maxLength(100)]],
+        password: ['', [Validators.required, Validators.minLength(PASSWORD_MIN_LENGTH), Validators.maxLength(PASSWORD_MAX_LENGTH)]],
+        confirmPassword: ['', [Validators.required, Validators.minLength(PASSWORD_MIN_LENGTH), Validators.maxLength(PASSWORD_MAX_LENGTH)]],
     });
     isRegistrationEnabled = false;
     allowedEmailPattern?: string;

--- a/src/main/webapp/app/admin/user-management/user-management-update.component.html
+++ b/src/main/webapp/app/admin/user-management/user-management-update.component.html
@@ -19,7 +19,7 @@
                         [(ngModel)]="user.login"
                         required
                         [minLength]="USERNAME_MIN_LENGTH"
-                        [maxlength]="USERNAME_MAX_LENGTH"
+                        [maxLength]="USERNAME_MAX_LENGTH"
                         pattern="^[_.@A-Za-z0-9-]*$"
                     />
 
@@ -79,7 +79,7 @@
                         id="password"
                         placeholder="{{ 'global.menu.account.password' | artemisTranslate }}"
                         [minLength]="PASSWORD_MIN_LENGTH"
-                        [maxlength]="PASSWORD_MAX_LENGTH"
+                        [maxLength]="PASSWORD_MAX_LENGTH"
                         #password="ngModel"
                         [(ngModel)]="user.password"
                     />

--- a/src/main/webapp/app/admin/user-management/user-management-update.component.html
+++ b/src/main/webapp/app/admin/user-management/user-management-update.component.html
@@ -18,8 +18,8 @@
                         #loginInput="ngModel"
                         [(ngModel)]="user.login"
                         required
-                        minlength="1"
-                        maxlength="50"
+                        [minLength]="USERNAME_MIN_LENGTH"
+                        [maxlength]="USERNAME_MAX_LENGTH"
                         pattern="^[_.@A-Za-z0-9-]*$"
                     />
 
@@ -78,14 +78,19 @@
                         name="password"
                         id="password"
                         placeholder="{{ 'global.menu.account.password' | artemisTranslate }}"
-                        minlength="8"
-                        maxlength="100"
+                        [minLength]="PASSWORD_MIN_LENGTH"
+                        [maxlength]="PASSWORD_MAX_LENGTH"
                         #password="ngModel"
                         [(ngModel)]="user.password"
                     />
                     <div *ngIf="password.dirty && password.invalid">
-                        <small class="form-text text-danger" *ngIf="password.errors?.maxlength" [translateValues]="{ max: 100 }" jhiTranslate="userManagement.passwordConstraints">
-                            The password has to contain 8-100 characters!
+                        <small
+                            class="form-text text-danger"
+                            *ngIf="password.errors?.maxlength"
+                            jhiTranslate="userManagement.passwordConstraints"
+                            [translateValues]="{ min: PASSWORD_MIN_LENGTH, max: PASSWORD_MAX_LENGTH }"
+                        >
+                            The password has to contain 8-50 characters!
                         </small>
                     </div>
                 </div>

--- a/src/main/webapp/app/admin/user-management/user-management-update.component.ts
+++ b/src/main/webapp/app/admin/user-management/user-management-update.component.ts
@@ -8,12 +8,18 @@ import { OrganizationManagementService } from 'app/admin/organization-management
 import { OrganizationSelectorComponent } from 'app/shared/organization-selector/organization-selector.component';
 import { Organization } from 'app/entities/organization.model';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH, USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH } from 'app/app.constants';
 
 @Component({
     selector: 'jhi-user-management-update',
     templateUrl: './user-management-update.component.html',
 })
 export class UserManagementUpdateComponent implements OnInit {
+    USERNAME_MIN_LENGTH = USERNAME_MIN_LENGTH;
+    USERNAME_MAX_LENGTH = USERNAME_MAX_LENGTH;
+    PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
+    PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
+
     user: User;
     languages: string[];
     authorities: string[];

--- a/src/main/webapp/app/admin/user-management/user-management-update.component.ts
+++ b/src/main/webapp/app/admin/user-management/user-management-update.component.ts
@@ -15,10 +15,10 @@ import { PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH, USERNAME_MAX_LENGTH, USERNAME
     templateUrl: './user-management-update.component.html',
 })
 export class UserManagementUpdateComponent implements OnInit {
-    USERNAME_MIN_LENGTH = USERNAME_MIN_LENGTH;
-    USERNAME_MAX_LENGTH = USERNAME_MAX_LENGTH;
-    PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
-    PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
+    readonly USERNAME_MIN_LENGTH = USERNAME_MIN_LENGTH;
+    readonly USERNAME_MAX_LENGTH = USERNAME_MAX_LENGTH;
+    readonly PASSWORD_MIN_LENGTH = PASSWORD_MIN_LENGTH;
+    readonly PASSWORD_MAX_LENGTH = PASSWORD_MAX_LENGTH;
 
     user: User;
     languages: string[];

--- a/src/main/webapp/app/app.constants.ts
+++ b/src/main/webapp/app/app.constants.ts
@@ -10,10 +10,10 @@ export const DEBUG_INFO_ENABLED = __DEBUG_INFO_ENABLED__;
 export const MIN_SCORE_GREEN = 80;
 export const MIN_SCORE_ORANGE = 40;
 
-// NOTE: those values have to be the same as in Constant.java
+// NOTE: those values have to be the same as in Constants.java
 export const USERNAME_MIN_LENGTH = 4;
 export const USERNAME_MAX_LENGTH = 50;
-export const PASSWORD_MIN_LENGTH = 4;
+export const PASSWORD_MIN_LENGTH = 8;
 export const PASSWORD_MAX_LENGTH = 50;
 
 export const EXAM_START_WAIT_TIME_MINUTES = 5;

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -148,14 +148,14 @@
                 },
                 "newpassword": {
                     "required": "Ein neues Passwort wird benötigt.",
-                    "minlength": "Das neue Passwort muss mindestens 8 Zeichen lang sein",
-                    "maxlength": "Das neue Passwort darf nicht länger als 100 Zeichen sein",
+                    "minlength": "Das neue Passwort muss mindestens {{min}} Zeichen lang sein",
+                    "maxlength": "Das neue Passwort darf nicht länger als {{max}} Zeichen sein",
                     "strength": "Passwortstärke:"
                 },
                 "confirmpassword": {
                     "required": "Du musst das Passwort bestätigen.",
-                    "minlength": "Das bestätigte Passwort muss mindestens 8 Zeichen lang sein",
-                    "maxlength": "Das bestätigte Passwort darf nicht länger als 100 Zeichen sein"
+                    "minlength": "Das bestätigte Passwort muss mindestens {{min}} Zeichen lang sein",
+                    "maxlength": "Das bestätigte Passwort darf nicht länger als {{max}} Zeichen sein"
                 },
                 "email": {
                     "required": "Deine E-Mail-Adresse wird benötigt.",

--- a/src/main/webapp/i18n/de/global.json
+++ b/src/main/webapp/i18n/de/global.json
@@ -160,7 +160,7 @@
                 "email": {
                     "required": "Deine E-Mail-Adresse wird benötigt.",
                     "invalid": "Deine E-Mail-Adresse ist ungültig.",
-                    "minlength": "Deine E-Mail-Adresse muss mindestens 8 Zeichen lang sein",
+                    "minlength": "Deine E-Mail-Adresse muss mindestens 5 Zeichen lang sein",
                     "maxlength": "Deine E-Mail-Adresse darf nicht länger als 100 Zeichen sein",
                     "pattern": "Deine E-Mail-Adresse entspricht nicht dem geforderten Muster."
                 }

--- a/src/main/webapp/i18n/de/register.json
+++ b/src/main/webapp/i18n/de/register.json
@@ -8,8 +8,8 @@
             "validate": {
                 "login": {
                     "required": "Dein Login wird benötigt.",
-                    "minlength": "Dein Login muss mindestens 4 Zeichen lang sein",
-                    "maxlength": "Dein Login darf nicht länger als 50 Zeichen sein",
+                    "minlength": "Dein Login muss mindestens {{min}} Zeichen lang sein",
+                    "maxlength": "Dein Login darf nicht länger als {{max}} Zeichen sein",
                     "pattern": "Dein Login darf nur Kleinbuchstaben und Ziffern enthalten"
                 }
             },

--- a/src/main/webapp/i18n/de/user-management.json
+++ b/src/main/webapp/i18n/de/user-management.json
@@ -20,7 +20,7 @@
         "name": "Name",
         "randomPassword": "Zufälliges Passwort",
         "keepPassword": "Altes Passwort behalten",
-        "passwordConstraints": "Das Passwort muss zwischen 8 und 100 Zeichen enthalten!",
+        "passwordConstraints": "Das Passwort muss zwischen {{min}} und {{max}} Zeichen enthalten!",
         "groups": "Gruppen",
         "addGroup": "+ Gruppe",
         "enterGroup": "Gruppe eingeben",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -149,13 +149,13 @@
                 "newpassword": {
                     "required": "Your new password is required.",
                     "minlength": "Your password is required to be at least 8 characters.",
-                    "maxlength": "Your password cannot be longer than 100 characters.",
+                    "maxlength": "Your password cannot be longer than 50 characters.",
                     "strength": "Password strength:"
                 },
                 "confirmpassword": {
                     "required": "Your confirmation password is required.",
                     "minlength": "Your confirmation password is required to be at least 8 characters.",
-                    "maxlength": "Your confirmation password cannot be longer than 100 characters."
+                    "maxlength": "Your confirmation password cannot be longer than 50 characters."
                 },
                 "email": {
                     "required": "Your email is required.",

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -148,14 +148,14 @@
                 },
                 "newpassword": {
                     "required": "Your new password is required.",
-                    "minlength": "Your password is required to be at least 8 characters.",
-                    "maxlength": "Your password cannot be longer than 50 characters.",
+                    "minlength": "Your password is required to be at least {{min}} characters.",
+                    "maxlength": "Your password cannot be longer than {{max}} characters.",
                     "strength": "Password strength:"
                 },
                 "confirmpassword": {
                     "required": "Your confirmation password is required.",
-                    "minlength": "Your confirmation password is required to be at least 8 characters.",
-                    "maxlength": "Your confirmation password cannot be longer than 50 characters."
+                    "minlength": "Your confirmation password is required to be at least {{min}} characters.",
+                    "maxlength": "Your confirmation password cannot be longer than {{max}} characters."
                 },
                 "email": {
                     "required": "Your email is required.",

--- a/src/main/webapp/i18n/en/register.json
+++ b/src/main/webapp/i18n/en/register.json
@@ -8,8 +8,8 @@
             "validate": {
                 "login": {
                     "required": "Your username is required.",
-                    "minlength": "Your username is required to be at least 4 characters.",
-                    "maxlength": "Your username cannot be longer than 50 characters.",
+                    "minlength": "Your username is required to be at least {{min}} characters.",
+                    "maxlength": "Your username cannot be longer than {{max}} characters.",
                     "pattern": "Your username can only contain letters and digits."
                 }
             },

--- a/src/main/webapp/i18n/en/user-management.json
+++ b/src/main/webapp/i18n/en/user-management.json
@@ -20,7 +20,7 @@
         "name": "Name",
         "randomPassword": "Random password",
         "keepPassword": "Keep old password",
-        "passwordConstraints": "The password must contain 8-100 characters!",
+        "passwordConstraints": "The password must contain {{min}} to {{max}} characters!",
         "groups": "Groups",
         "addGroup": "+ Group",
         "enterGroup": "Enter a group",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
    - On a local test server as the regular artemistest{1-5} do not have internal user management with user registration enabled.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
Sometimes the maximum password length that was checked was 50, sometimes 100. The server checked for a length of 50.
In most cases the minimum password length was checked client-side to be eight, but actually ≧4 would have been okay, too.

Those checks and the corresponding error messages are now uniform with a minimum password length of eight and a maximum of 50.

### Description
There already existed constants for those length requirements but they were not used consistently. By using them consistently when validating inputs and when filling parameters of user-facing messages the validation and the information to the user about it are now more consistent.

As the client already checked for a minimum length of ≧ 8 and Gitlab required that length as minimum as well, basically no users should exists that have a password shorter than that. In the rare case that such users somehow exist, they can use the ‘forgot password’ functionality to set a new password from there.
The server already validated a password length ≦ 50. Therefore, no users with a password length between 50 and 100 should exist.

### Steps for Testing
This requires an Artemis installation with internal user management and user registration enabled, i.e. a local test server not the artemistest{1-5} ones.

1. Try to manually register as a new user.
    - The password length should be checked to be between eight and 50.
2. Try to change your password by clicking on username in the top-right corner → Password.
    - The password length should be checked to be between eight and 50.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
n/a

### Screenshots
n/a
