### PR TITLE
`Development`: Fix server tests related to new password length requirement

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -268,7 +268,7 @@ public class InternalAuthenticationIntegrationTest extends AbstractSpringIntegra
         final var newGroups = Set.of("foo", "bar");
         student.setGroups(newGroups);
         final var managedUserVM = new ManagedUserVM(student);
-        managedUserVM.setPassword("asbdasd");
+        managedUserVM.setPassword("12345678");
 
         jenkinsRequestMockProvider.mockUpdateUserAndGroups(student.getLogin(), student, newGroups, oldGroups, false);
 

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
@@ -35,7 +35,7 @@ public class UserSaml2IntegrationTest extends AbstractSpringIntegrationSaml2Test
 
     private static final String STUDENT_NAME = "student1";
 
-    private static final String STUDENT_PASSWORD = "test123";
+    private static final String STUDENT_PASSWORD = "test1234";
 
     @Autowired
     private TokenProvider tokenProvider;

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
@@ -35,7 +35,7 @@ import de.tum.in.www1.artemis.service.dto.StaticCodeAnalysisReportDTO;
 
 public class ModelFactory {
 
-    public static final String USER_PASSWORD = "0000";
+    public static final String USER_PASSWORD = "00000000";
 
     public static Lecture generateLecture(ZonedDateTime startDate, ZonedDateTime endDate, Course course) {
         Lecture lecture = new Lecture();


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
Due to the new minimum password length requirement of eight characters in #4281 some server tests that used shorter than that password constants failed. Those constants have been adapted.

### Steps for Testing
n/a

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2

### Test Coverage
unchanged