### PR TITLE
`Assessment`: Link more feedback requests page on course overview chart

### DIFF
--- a/src/main/webapp/app/course/manage/detail/course-detail-doughnut-chart.component.ts
+++ b/src/main/webapp/app/course/manage/detail/course-detail-doughnut-chart.component.ts
@@ -78,7 +78,7 @@ export class CourseDetailDoughnutChartComponent implements OnChanges, OnInit {
                 break;
             case DoughnutChartType.FEEDBACK:
                 this.doughnutChartTitle = 'moreFeedback';
-                this.titleLink = undefined;
+                this.titleLink = 'more-feedback-requests';
                 break;
             case DoughnutChartType.AVERAGE_COURSE_SCORE:
                 this.doughnutChartTitle = 'averageStudentScore';


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
The course overview charts currently link the list of complaints, but not the link of more feedback requests. This PR changes this and allows both pages to be accessed directly. 

### Description
Adds a link to /more-feedback-requests

### Steps for Testing
Prerequisites:
- Check this for each role (Tutor / Editor / Instructor)

1. Go to Course Management -> Course Detail (click on the title of a course).
2. Check that the More Feedback Requests chart contains a clickable link.
3. Make sure that the link redirects to the List of More Feedback Requests.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
unchanged

### Screenshots
![grafik](https://user-images.githubusercontent.com/26540346/141659989-21db9c9c-9855-46ee-be71-cc9cb7df0936.png)

