### PR TITLE
`Development`: Remove automatic PR comments to use Draft PRs

### DIFF
--- a/.github/workflows/pullrequest-opened.yml
+++ b/.github/workflows/pullrequest-opened.yml
@@ -21,13 +21,3 @@ jobs:
           project: Artemis Development
           column: In progress
           repo-token: ${{ secrets.GH_TOKEN_ADD_TO_PROJECT }}
-
-  commentOnNonDraft:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false && !contains(github.event.issue.labels.*.name, 'ready for review') && github.event.pull_request.user.login != 'dependabot[bot]'
-    steps:
-      - name: Comment PR
-        uses: thollander/actions-comment-pull-request@main
-        with:
-          message: 'Still in progress? Consider converting to draft.'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@actions comments on non-draft pull requests without the `ready for review` label:
<img width="911" alt="image" src="https://user-images.githubusercontent.com/6382716/141791557-9c8beffa-c5c6-4792-9dbc-79e6228ef91b.png">

Let's have a vote if we should keep this Action around:

- :+1: We should **DISABLE** the automatic comment.
- :-1: We should **KEEP** the automatic comment.

(Use reactions to vote.)