### PR TITLE
`Development`: Fix wrong usages of `assertThat()` in server tests

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadExerciseIntegrationTest.java
@@ -35,9 +35,6 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
     @Autowired
     private FileUploadExerciseRepository fileUploadExerciseRepository;
 
-    @Autowired
-    private FileUploadSubmissionRepository fileUploadSubmissionRepository;
-
     private List<GradingCriterion> gradingCriteria;
 
     private final String creationFilePattern = "png, pdf, jPg      , r, DOCX";
@@ -277,7 +274,7 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
         for (var exercise : course.getExercises()) {
             request.delete("/api/file-upload-exercises/" + exercise.getId(), HttpStatus.OK);
         }
-        assertThat(exerciseRepo.findAll().isEmpty());
+        assertThat(exerciseRepo.findAll()).isEmpty();
     }
 
     @Test
@@ -288,7 +285,7 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
             request.delete("/api/file-upload-exercises/" + exercise.getId(), HttpStatus.FORBIDDEN);
         }
 
-        assertThat(exerciseRepo.findAll().size() == course.getExercises().size());
+        assertThat(exerciseRepo.findAll()).hasSize(course.getExercises().size());
     }
 
     @Test
@@ -316,7 +313,7 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
         FileUploadExercise fileUploadExercise = database.addCourseExamExerciseGroupWithOneFileUploadExercise();
 
         request.delete("/api/file-upload-exercises/" + fileUploadExercise.getId(), HttpStatus.OK);
-        assertThat(exerciseRepo.findAll().isEmpty());
+        assertThat(exerciseRepo.findAll()).isEmpty();
     }
 
     @Test
@@ -324,12 +321,13 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
     public void updateFileUploadExercise_asInstructor() throws Exception {
         Course course = database.addCourseWithThreeFileUploadExercise();
         FileUploadExercise fileUploadExercise = database.findFileUploadExerciseWithTitle(course.getExercises(), "released");
-        fileUploadExercise.setDueDate(ZonedDateTime.now().plusDays(10));
+        final ZonedDateTime dueDate = ZonedDateTime.now().plusDays(10);
+        fileUploadExercise.setDueDate(dueDate);
         fileUploadExercise.setAssessmentDueDate(ZonedDateTime.now().plusDays(11));
 
         FileUploadExercise receivedFileUploadExercise = request.putWithResponseBody("/api/file-upload-exercises/" + fileUploadExercise.getId() + "?notificationText=notification",
                 fileUploadExercise, FileUploadExercise.class, HttpStatus.OK);
-        assertThat(receivedFileUploadExercise.getDueDate().equals(ZonedDateTime.now().plusDays(10)));
+        assertThat(receivedFileUploadExercise.getDueDate()).isEqualToIgnoringNanos(dueDate);
         assertThat(receivedFileUploadExercise.getCourseViaExerciseGroupOrCourseMember()).as("course was set for normal exercise").isNotNull();
         assertThat(receivedFileUploadExercise.getExerciseGroup()).as("exerciseGroup was not set for normal exercise").isNull();
         assertThat(receivedFileUploadExercise.getCourseViaExerciseGroupOrCourseMember().getId()).as("courseId was not updated").isEqualTo(course.getId());
@@ -358,7 +356,7 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
         FileUploadExercise updatedFileUploadExercise = request.putWithResponseBody("/api/file-upload-exercises/" + fileUploadExercise.getId(), fileUploadExercise,
                 FileUploadExercise.class, HttpStatus.OK);
 
-        assertThat(updatedFileUploadExercise.getTitle().equals(newTitle));
+        assertThat(updatedFileUploadExercise.getTitle()).isEqualTo(newTitle);
         assertThat(!updatedFileUploadExercise.isCourseExercise()).as("course was not set for exam exercise");
         assertThat(updatedFileUploadExercise.getExerciseGroup()).as("exerciseGroup was set for exam exercise").isNotNull();
         assertThat(updatedFileUploadExercise.getExerciseGroup().getId()).as("exerciseGroupId was not updated").isEqualTo(fileUploadExercise.getExerciseGroup().getId());
@@ -406,7 +404,7 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
 
         // this seems to be a flaky test, based on the execution order, the following line has a problem with authentication, this should fix it
         database.changeUser("instructor1");
-        assertThat(receivedFileUploadExercises.size() == courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now()).get(0).getExercises().size());
+        assertThat(receivedFileUploadExercises).hasSize(courseRepo.findAllActiveWithEagerExercisesAndLectures(ZonedDateTime.now()).get(0).getExercises().size());
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingSubmissionIntegrationTest.java
@@ -699,7 +699,7 @@ public class ModelingSubmissionIntegrationTest extends AbstractSpringIntegration
                 HttpStatus.OK);
 
         final var submissionInDb = modelingSubmissionRepo.findById(submittedSubmission.getId());
-        assertThat(submissionInDb.isPresent());
+        assertThat(submissionInDb).isPresent();
         assertThat(submissionInDb.get().getModel()).isEqualTo(validModel);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/simulation/ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/simulation/ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest.java
@@ -3,9 +3,6 @@ package de.tum.in.www1.artemis.programmingexercise.simulation;
 import static de.tum.in.www1.artemis.web.rest.ProgrammingSubmissionResultSimulationResource.Endpoints.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,7 +15,6 @@ import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.ProgrammingSubmission;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
-import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.repository.*;
 
 public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest extends AbstractSpringDevelopmentTest {
@@ -35,8 +31,6 @@ public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest ext
     @Autowired
     ResultRepository resultRepository;
 
-    private List<Long> participationIds;
-
     private Long exerciseId;
 
     private ProgrammingExercise exercise;
@@ -52,7 +46,6 @@ public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest ext
 
         exerciseId = exercise.getId();
         exercise = programmingExerciseRepository.findAllWithEagerParticipationsAndLegalSubmissions().get(0);
-        participationIds = exercise.getStudentParticipations().stream().map(Participation::getId).collect(Collectors.toList());
     }
 
     @AfterEach
@@ -70,10 +63,10 @@ public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest ext
         final ProgrammingSubmission returnedSubmission = request.postWithResponseBody(ROOT + SUBMISSIONS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null,
                 ProgrammingSubmission.class, HttpStatus.CREATED);
         assertThat(submissionRepository.findAll()).hasSize(1);
+
         ProgrammingSubmission submission = submissionRepository.findAll().get(0);
         assertThat(returnedSubmission).isEqualTo(submission);
-        assertThat(participationRepository.findById(submission.getParticipation().getId()));
-        assertThat(participationIds.contains(submission.getParticipation().getId()));
+        assertThat(participationRepository.findById(submission.getParticipation().getId())).isPresent();
         assertThat(submission.getType()).isEqualTo(SubmissionType.MANUAL);
         assertThat(submission.isSubmitted()).isTrue();
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/NotificationSettingsServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/NotificationSettingsServiceTest.java
@@ -107,7 +107,7 @@ public class NotificationSettingsServiceTest {
         assertThat(resultingTypeSet).contains(EXAM_ARCHIVE_STARTED);
         assertThat(resultingTypeSet).contains(COURSE_ARCHIVE_STARTED);
         assertThat(resultingTypeSet).contains(COURSE_ARCHIVE_STARTED);
-        assertThat(!resultingTypeSet.contains(ATTACHMENT_CHANGE));
+        assertThat(resultingTypeSet).doesNotContain(ATTACHMENT_CHANGE);
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
@@ -461,7 +461,7 @@ public class RequestUtilService {
 
         if (expectedResponseHeaders != null) {
             for (String header : expectedResponseHeaders) {
-                assertThat(res.getResponse().containsHeader(header));
+                assertThat(res.getResponse().containsHeader(header)).isTrue();
             }
         }
 


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
Using `assertThat()` without any further following assertions does test nothing. I found a few places where such ‘assertions’ where used and replaced them to now actually test something.

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2

### Test Coverage
Unchanged, but the tests now actually test what they were intended to.

### Screenshots
n/a
