### PR TITLE
`Programming exercises`: Fix an issue based on a breaking change in Orion

### DIFF
--- a/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
+++ b/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
@@ -82,12 +82,12 @@ export class OrionAssessmentService {
                     const result = reader.result as string;
                     // remove prefix
                     const base64data = result.substr(result.indexOf(',') + 1);
-                    this.orionConnectorService.log("result first 30 characters " + result.substr(0, 30));
-                    this.orionConnectorService.log("result last 30 characters " + result.substr(result.length - 30, 30));
-                    this.orionConnectorService.log("base64data first 30 characters " + result.substr(0, 30));
-                    this.orionConnectorService.log("base64data last 30 characters " + result.substr(base64data.length - 30, 30));
-                    this.orionConnectorService.log("result length " + result.length);
-                    this.orionConnectorService.log("base64data length " + base64data.length);
+                    alert("result first 30 characters " + result.substr(0, 30));
+                    alert("result last 30 characters " + result.substr(result.length - 30, 30));
+                    alert("base64data first 30 characters " + result.substr(0, 30));
+                    alert("base64data last 30 characters " + result.substr(base64data.length - 30, 30));
+                    alert("result length " + result.length);
+                    alert("base64data length " + base64data.length);
                     this.orionConnectorService.downloadSubmission(submissionId, correctionRound, testRun, base64data);
                 };
                 reader.onerror = () => {

--- a/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
+++ b/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
@@ -82,6 +82,12 @@ export class OrionAssessmentService {
                     const result = reader.result as string;
                     // remove prefix
                     const base64data = result.substr(result.indexOf(',') + 1);
+                    this.orionConnectorService.log("result first 30 characters " + result.substr(0, 30));
+                    this.orionConnectorService.log("result last 30 characters " + result.substr(result.length - 30, 30));
+                    this.orionConnectorService.log("base64data first 30 characters " + result.substr(0, 30));
+                    this.orionConnectorService.log("base64data last 30 characters " + result.substr(base64data.length - 30, 30));
+                    this.orionConnectorService.log("result length " + result.length);
+                    this.orionConnectorService.log("base64data length " + base64data.length);
                     this.orionConnectorService.downloadSubmission(submissionId, correctionRound, testRun, base64data);
                 };
                 reader.onerror = () => {

--- a/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
+++ b/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
@@ -82,12 +82,6 @@ export class OrionAssessmentService {
                     const result = reader.result as string;
                     // remove prefix
                     const base64data = result.substr(result.indexOf(',') + 1);
-                    alert("result first 60 characters " + result.substr(0, 60));
-                    alert("result last 60 characters " + result.substr(result.length - 60, 60));
-                    alert("base64data first 60 characters " + base64data.substr(0, 60));
-                    alert("base64data last 60 characters " + base64data.substr(base64data.length - 60, 60));
-                    alert("result length " + result.length);
-                    alert("base64data length " + base64data.length);
                     this.orionConnectorService.downloadSubmission(submissionId, correctionRound, testRun, base64data);
                 };
                 reader.onerror = () => {

--- a/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
+++ b/src/main/webapp/app/orion/assessment/orion-assessment.service.ts
@@ -82,10 +82,10 @@ export class OrionAssessmentService {
                     const result = reader.result as string;
                     // remove prefix
                     const base64data = result.substr(result.indexOf(',') + 1);
-                    alert("result first 30 characters " + result.substr(0, 30));
-                    alert("result last 30 characters " + result.substr(result.length - 30, 30));
-                    alert("base64data first 30 characters " + result.substr(0, 30));
-                    alert("base64data last 30 characters " + result.substr(base64data.length - 30, 30));
+                    alert("result first 60 characters " + result.substr(0, 60));
+                    alert("result last 60 characters " + result.substr(result.length - 60, 60));
+                    alert("base64data first 60 characters " + base64data.substr(0, 60));
+                    alert("base64data last 60 characters " + base64data.substr(base64data.length - 60, 60));
                     alert("result length " + result.length);
                     alert("base64data length " + base64data.length);
                     this.orionConnectorService.downloadSubmission(submissionId, correctionRound, testRun, base64data);

--- a/src/main/webapp/app/shared/orion/orion-connector.service.ts
+++ b/src/main/webapp/app/shared/orion/orion-connector.service.ts
@@ -260,6 +260,8 @@ export class OrionConnectorService implements ArtemisOrionConnector {
      * @param base64data the student's submission as base64
      */
     downloadSubmission(submissionId: number, correctionRound: number, testRun: boolean, base64data: string) {
+        // Uncomment this line to also transfer the testRun flag. THIS IS A BREAKING CHANGE that will require all users to upgrade their Orion to a compatible version! Also uncomment in orion.ts
+        // theWindow().orionExerciseConnector.downloadSubmission(String(submissionId), String(correctionRound), testRun, base64data);
         theWindow().orionExerciseConnector.downloadSubmission(String(submissionId), String(correctionRound), base64data);
     }
 

--- a/src/main/webapp/app/shared/orion/orion-connector.service.ts
+++ b/src/main/webapp/app/shared/orion/orion-connector.service.ts
@@ -260,7 +260,9 @@ export class OrionConnectorService implements ArtemisOrionConnector {
      * @param base64data the student's submission as base64
      */
     downloadSubmission(submissionId: number, correctionRound: number, testRun: boolean, base64data: string) {
-        // Uncomment this line to also transfer the testRun flag. THIS IS A BREAKING CHANGE that will require all users to upgrade their Orion to a compatible version! Also uncomment in orion.ts
+        // Uncomment this line to also transfer the testRun flag.
+        // THIS IS A BREAKING CHANGE that will require all users to upgrade their Orion to a compatible version!
+        // Also change in orion.ts
         // theWindow().orionExerciseConnector.downloadSubmission(String(submissionId), String(correctionRound), testRun, base64data);
         theWindow().orionExerciseConnector.downloadSubmission(String(submissionId), String(correctionRound), base64data);
     }

--- a/src/main/webapp/app/shared/orion/orion-connector.service.ts
+++ b/src/main/webapp/app/shared/orion/orion-connector.service.ts
@@ -260,7 +260,7 @@ export class OrionConnectorService implements ArtemisOrionConnector {
      * @param base64data the student's submission as base64
      */
     downloadSubmission(submissionId: number, correctionRound: number, testRun: boolean, base64data: string) {
-        theWindow().orionExerciseConnector.downloadSubmission(String(submissionId), String(correctionRound), testRun, base64data);
+        theWindow().orionExerciseConnector.downloadSubmission(String(submissionId), String(correctionRound), base64data);
     }
 
     /**

--- a/src/main/webapp/app/shared/orion/orion.ts
+++ b/src/main/webapp/app/shared/orion/orion.ts
@@ -62,7 +62,9 @@ export interface OrionExerciseConnector {
      * @param testRun test run flag, also needed for navigation
      * @param base64data the student's submission as base64
      */
-    downloadSubmission(submissionId: string, correctionRound: string, testRun: boolean, base64data: string): void;
+    // Uncomment this line to also transfer the testRun flag. THIS IS A BREAKING CHANGE that will require all users to upgrade their Orion to a compatible version! Also uncomment in orion-connector.service.ts
+    // downloadSubmission(submissionId: string, correctionRound: string, testRun: boolean, base64data: string): void;
+    downloadSubmission(submissionId: string, correctionRound: string, base64data: string): void;
 
     /**
      * Initializes the feedback comments. See {@link OrionConnectorService} for details.

--- a/src/main/webapp/app/shared/orion/orion.ts
+++ b/src/main/webapp/app/shared/orion/orion.ts
@@ -62,7 +62,9 @@ export interface OrionExerciseConnector {
      * @param testRun test run flag, also needed for navigation
      * @param base64data the student's submission as base64
      */
-    // Uncomment this line to also transfer the testRun flag. THIS IS A BREAKING CHANGE that will require all users to upgrade their Orion to a compatible version! Also uncomment in orion-connector.service.ts
+    // Uncomment this line to also transfer the testRun flag.
+    // THIS IS A BREAKING CHANGE that will require all users to upgrade their Orion to a compatible version!
+    // Also change in orion-connector.service.ts
     // downloadSubmission(submissionId: string, correctionRound: string, testRun: boolean, base64data: string): void;
     downloadSubmission(submissionId: string, correctionRound: string, base64data: string): void;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation, Context and Description
The recent merge of #4279 accidentially introduced breaking changes to Artemis that made downloading assessments impossible. This PR reverts these changes to restore compatibility with the current Orion release; Later reintroduction needs to be syncronized with a new Orion release.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Tutor
- 1 Programming Exercise with Submissions

1. Install the current [release of Orion](https://github.com/ls1intum/Orion/releases)
2. Download a submission for Assessment
3. No error should occur

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
unchanged
