### PR TITLE
`Development`: Fix e2e cypress test result generation

### DIFF
--- a/src/test/cypress/cypress.json
+++ b/src/test/cypress/cypress.json
@@ -14,7 +14,7 @@
     "responseTimeout": 120000,
     "reporter": "junit",
     "reporterOptions": {
-        "mochaFile": "build/cypress/test-reports/test-results.xml",
+        "mochaFile": "build/cypress/test-reports/test-results.[hash].xml",
         "toConsole": false
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the Cypress Bamboo buildplans do not show test results properly. Cypress should create test reports for all tests, which can then be parsed by Bamboo and exposed directly in the build information. Currently a developer has to navigate to the logs of the build to get details about what test failed and why.

### Description
<!-- Describe your changes in detail -->
This PR fixes the report generation from Cypress, so that the reports can be parsed properly by Bamboo

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
I added the junit parser task to the testing buildplan and executed the [test suite using this branch](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-528). As you can see in total there were 60 tests executed and all passed.

#### Code Review
- [ ] Review 1
- [ ] Review 2
