### PR TITLE
`Development`: Improve code quality in quiz exercise detail client tests

### DIFF
--- a/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
@@ -939,7 +939,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should be valid if MC question hint has exactly 255 characters', () => {
                 const { question } = createValidMCQuestion();
-                question.hint = new Array(255 + 1).join('f');
+                question.hint = 'f'.repeat(255);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(true);
@@ -947,7 +947,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should be valid if MC question explanation has exactly 500 characters', () => {
                 const { question } = createValidMCQuestion();
-                question.explanation = new Array(500 + 1).join('f');
+                question.explanation = 'f'.repeat(500);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(true);
@@ -955,7 +955,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should not be valid if MC question hint has more than 255 characters', () => {
                 const { question } = createValidMCQuestion();
-                question.hint = new Array(255 + 2).join('f');
+                question.hint = 'f'.repeat(255 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(false);
@@ -963,7 +963,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should not be valid if MC question explanation has more than 500 characters', () => {
                 const { question } = createValidMCQuestion();
-                question.explanation = new Array(500 + 2).join('f');
+                question.explanation = 'f'.repeat(500 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(false);
@@ -971,7 +971,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should be valid if MC answer option hint has exactly 255 characters', () => {
                 const { question } = createValidMCQuestion();
-                question.answerOptions![0]!.hint = new Array(255 + 1).join('f');
+                question.answerOptions![0]!.hint = 'f'.repeat(255);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(true);
@@ -979,7 +979,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should be valid if MC answer option explanation has exactly 500 characters', () => {
                 const { question } = createValidMCQuestion();
-                question.answerOptions![0]!.explanation = new Array(500 + 1).join('f');
+                question.answerOptions![0]!.explanation = 'f'.repeat(500);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(true);
@@ -987,7 +987,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should not be valid if MC answer option hint has more than 255 characters', () => {
                 const { question } = createValidMCQuestion();
-                question.answerOptions![0]!.hint = new Array(255 + 2).join('f');
+                question.answerOptions![0]!.hint = 'f'.repeat(255 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(false);
@@ -995,7 +995,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should not be valid if MC answer option explanation has more than 1000 characters', () => {
                 const { question } = createValidMCQuestion();
-                question.answerOptions![0]!.explanation = new Array(500 + 2).join('f');
+                question.answerOptions![0]!.explanation = 'f'.repeat(500 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(false);
@@ -1020,7 +1020,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should be valid if DnD question hint has exactly 255 characters', () => {
                 const { question } = createValidDnDQuestion();
-                question.hint = new Array(255 + 1).join('f');
+                question.hint = 'f'.repeat(255);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(true);
@@ -1028,7 +1028,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should be valid if DnD question explanation has exactly 500 characters', () => {
                 const { question } = createValidDnDQuestion();
-                question.explanation = new Array(500 + 1).join('f');
+                question.explanation = 'f'.repeat(500);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(true);
@@ -1036,7 +1036,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should not be valid if DnD question hint has more than 255 characters', () => {
                 const { question } = createValidDnDQuestion();
-                question.hint = new Array(255 + 2).join('f');
+                question.hint = 'f'.repeat(255 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(false);
@@ -1044,7 +1044,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should not be valid if DnD question explanation has more than 500 characters', () => {
                 const { question } = createValidDnDQuestion();
-                question.explanation = new Array(500 + 2).join('f');
+                question.explanation = 'f'.repeat(500 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toBe(false);
@@ -1065,7 +1065,7 @@ describe('QuizExercise Management Detail Component', () => {
             it('should not be valid with SA question with too long answer option', () => {
                 const { question } = createValidSAQuestion();
                 // @ts-ignore
-                question.solutions[0].text = new Array(251).join('a');
+                question.solutions[0].text = 'a'.repeat(250);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
                 expect(comp.quizIsValid).toEqual(false);
@@ -1441,7 +1441,7 @@ describe('QuizExercise Management Detail Component', () => {
                 });
 
                 it('should put reason for too long title', () => {
-                    quizExercise.title = new Array(251).join('a');
+                    quizExercise.title = 'a'.repeat(250);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.quizTitleLength');
                 });
 
@@ -1505,7 +1505,7 @@ describe('QuizExercise Management Detail Component', () => {
                 });
 
                 it('should put reason for too long title', () => {
-                    question.title = new Array(251).join('a');
+                    question.title = 'a'.repeat(250);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.questionTitleLength');
                 });
 
@@ -1515,28 +1515,28 @@ describe('QuizExercise Management Detail Component', () => {
                 });
 
                 it('should put reason if question explanation is too long', () => {
-                    question.explanation = new Array(500 + 2).join('f');
+                    question.explanation = 'f'.repeat(500 + 1);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.questionExplanationLength');
                 });
 
                 it('should put reason if question hint is too long', () => {
-                    question.hint = new Array(255 + 2).join('f');
+                    question.hint = 'f'.repeat(255 + 1);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.questionHintLength');
                 });
 
                 it('should put reason if answer option explanation is too long', () => {
-                    answerOption1.explanation = new Array(500 + 2).join('f');
+                    answerOption1.explanation = 'f'.repeat(500 + 1);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.answerExplanationLength');
                 });
 
                 it('should put reason if answer option hint is too long', () => {
-                    answerOption1.hint = new Array(255 + 2).join('f');
+                    answerOption1.hint = 'f'.repeat(255 + 1);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.answerHintLength');
                 });
 
                 it('should put reason exactly once if more than one answer option explanation is too long', () => {
-                    answerOption1.explanation = new Array(500 + 2).join('f');
-                    answerOption2.explanation = new Array(500 + 2).join('f');
+                    answerOption1.explanation = 'f'.repeat(500 + 1);
+                    answerOption2.explanation = 'f'.repeat(500 + 1);
                     const invalidReasonsAnswerOptions = comp
                         .computeInvalidReasons()
                         .filter((reason) => reason.translateKey === 'artemisApp.quizExercise.invalidReasons.answerExplanationLength');
@@ -1544,8 +1544,8 @@ describe('QuizExercise Management Detail Component', () => {
                 });
 
                 it('should put reason exactly once if more than one answer option hint is too long', () => {
-                    answerOption1.hint = new Array(255 + 2).join('f');
-                    answerOption2.hint = new Array(255 + 2).join('f');
+                    answerOption1.hint = 'f'.repeat(255 + 1);
+                    answerOption2.hint = 'f'.repeat(255 + 1);
                     const invalidReasonsAnswerOptions = comp
                         .computeInvalidReasons()
                         .filter((reason) => reason.translateKey === 'artemisApp.quizExercise.invalidReasons.answerHintLength');
@@ -1605,12 +1605,12 @@ describe('QuizExercise Management Detail Component', () => {
                 });
 
                 it('should put reason if question explanation is too long', () => {
-                    question.explanation = new Array(500 + 2).join('f');
+                    question.explanation = 'f'.repeat(500 + 1);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.questionExplanationLength');
                 });
 
                 it('should put reason if question hint is too long', () => {
-                    question.hint = new Array(255 + 2).join('f');
+                    question.hint = 'f'.repeat(255 + 1);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.questionHintLength');
                 });
             });
@@ -1662,7 +1662,7 @@ describe('QuizExercise Management Detail Component', () => {
                 });
 
                 it('should put reason for too long answer option', () => {
-                    shortAnswerSolution1.text = new Array(251).join('a');
+                    shortAnswerSolution1.text = 'a'.repeat(250);
                     filterReasonAndExpectMoreThanOneInArray('artemisApp.quizExercise.invalidReasons.quizAnswerOptionLength');
                 });
 


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
This PR changes how the tests create their test string input. Instead of using an array and joining empty elements, I now directly use the `repeat()` method. This makes the code more readable, since the given number now corresponds with the length of the new string. The old method needs the number to be 1 higher than the expected length since joining only adds the text between two array elements.

Locally the speed gets also improved a little bit, from ~860ms to ~770ms. 

### Description
Use `repeat()` instead of `join()` to create test strings.

### Steps for Testing
Code review should be fine.

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
unchanged 

