### PR TITLE
`Assessment`: Improve the color of assessment status in tutor training

### DIFF
--- a/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.html
+++ b/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.html
@@ -109,12 +109,17 @@
 
     <!-- Text showing whether the tutor feedback is correct or not (upon validation on the server) -->
     <div *ngIf="feedback.correctionStatus != undefined">
-        <span>{{ 'artemisApp.exampleSubmission.feedback.' + feedback.correctionStatus! | artemisTranslate }} </span>
+        <span *ngIf="feedback.correctionStatus === 'CORRECT'" class="text-success"
+            >{{ 'artemisApp.exampleSubmission.feedback.' + feedback.correctionStatus! | artemisTranslate }}
+        </span>
+        <span *ngIf="feedback.correctionStatus !== 'CORRECT'" class="text-danger"
+            >{{ 'artemisApp.exampleSubmission.feedback.' + feedback.correctionStatus! | artemisTranslate }}
+        </span>
 
         <!-- :warning: emoji was rendered as a black-white glyph, hence the solution with the fa-icon -->
         <fa-layers *ngIf="feedback.correctionStatus != 'CORRECT'">
             <fa-icon class="text-warning" [icon]="'exclamation-triangle'"></fa-icon>
-            <fa-icon [icon]="'exclamation'" size="2x" [styles]="{ width: '16px', 'margin-top': '-6px' }" transform="shrink-10"></fa-icon>
+            <fa-icon [icon]="'exclamation'" size="2x" [styles]="{ width: '16px', 'margin-top': '-6px' }" [classes]="['text-dark']" transform="shrink-10"></fa-icon>
         </fa-layers>
     </div>
 

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
@@ -251,7 +251,7 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
 
     /**
      * Checks the assessment of the tutor to the example submission tutorial.
-     * The tutor is informed if the given points of the assessment are fine, too low or too high.
+     * The tutor is informed if its assessment is different from the one of the instructor.
      */
     checkAssessment(): void {
         this.validateFeedback();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] *This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] *Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [ ] *I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] *I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] *I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [ ] *I implemented the changes with a good performance and prevented too many database calls.
- [ ] *I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] *I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] *I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] *I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] *I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] *I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

[ ] * - not needed

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR solved the problem of the wrong color that correction status has in tutor training for text exercises.
As seen in Before screenshots, the color is dependent on what score the tutor gave to the feedback. We want however, the color to always be red if the correction status is indicating a wrong assessment or green if the correction status shows a right assessment.

### Description
<!-- Describe your changes in detail -->
In order to achieve that we use `text-success` and `text-danger` css classes. As well as `text-dark` for coloring the exclamation mark.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Tutor

1. Log in to Artemis as Instructor
2. Navigate to Course Administration
3. Navigate to an existing or new Text exercise.
4. Create an example submissions and example assessment and check Used for Tutorial.
-----------------------------------------------------------------------------------------

1. Log in to Artemis as Tutor
2. Navigate to Course Administration
3. Navigate to the exercise dashboard of the exercise created as instructor and assess the example submission.
4. During the tutor training, observe the color that correction status takes. See after screenshots.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
#### Before
<img width="1160" alt="Screenshot 2021-11-22 at 12 41 52 AM" src="https://user-images.githubusercontent.com/51077603/142783751-fa6d3a51-3086-45ce-82cc-fc7fb461480c.png">

#### After
<img width="1246" alt="Screen Shot 2021-11-22 at 00 28 58" src="https://user-images.githubusercontent.com/51077603/142783849-bbf07aac-fdd8-4455-986a-7fe86cef73e3.png">
<img width="1232" alt="Screen Shot 2021-11-22 at 00 29 07" src="https://user-images.githubusercontent.com/51077603/142783852-84c43087-8508-4aea-a7a8-76e97d97be69.png">
<img width="1235" alt="Screen Shot 2021-11-22 at 00 29 18" src="https://user-images.githubusercontent.com/51077603/142783854-5a0bc38b-71fe-466f-9324-d8eb8bbb81a1.png">
