### PR TITLE
`Development`: Rename some server tests with confusing names

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
@@ -38,14 +38,14 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textProgrammingExerciseIsReleased_IsReleasedAndHasResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.textProgrammingExerciseIsReleased_IsReleasedAndHasResults();
+    void testProgrammingExerciseIsReleased_IsReleasedAndHasResults() throws Exception {
+        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_IsReleasedAndHasResults();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textProgrammingExerciseIsReleased_IsNotReleasedAndHasResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.textProgrammingExerciseIsReleased_IsNotReleasedAndHasResults();
+    void testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults() throws Exception {
+        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults();
     }
 
     @Test
@@ -56,8 +56,8 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
-    void textProgrammingExerciseIsReleased_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.textProgrammingExerciseIsReleased_forbidden();
+    void testProgrammingExerciseIsReleased_forbidden() throws Exception {
+        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_forbidden();
     }
 
     @Test
@@ -69,13 +69,13 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError() throws Exception {
-        programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError();
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textExportSubmissionsByParticipationIds() throws Exception {
-        programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds();
+    void testExportSubmissionsByParticipationIds() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds();
     }
 
     @Test
@@ -86,25 +86,25 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
+    void testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
-    void textExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden();
+    void testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textExportSubmissionsByStudentLogins() throws Exception {
+    void testExportSubmissionsByStudentLogins() throws Exception {
         programmingExerciseIntegrationServiceTest.testExportSubmissionsByStudentLogins();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textExportSubmissionsByStudentLogins_failToCreateZip() throws Exception {
+    void testExportSubmissionsByStudentLogins_failToCreateZip() throws Exception {
         doThrow(IOException.class).when(zipFileService).createZipFile(any(Path.class), any(), eq(false));
         programmingExerciseIntegrationServiceTest.testExportSubmissionsByStudentLogins_failToCreateZip();
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
@@ -45,14 +45,14 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textProgrammingExerciseIsReleased_IsReleasedAndHasResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.textProgrammingExerciseIsReleased_IsReleasedAndHasResults();
+    void testProgrammingExerciseIsReleased_IsReleasedAndHasResults() throws Exception {
+        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_IsReleasedAndHasResults();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textProgrammingExerciseIsReleased_IsNotReleasedAndHasResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.textProgrammingExerciseIsReleased_IsNotReleasedAndHasResults();
+    void testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults() throws Exception {
+        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults();
     }
 
     @Test
@@ -63,14 +63,14 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
-    void textProgrammingExerciseIsReleased_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.textProgrammingExerciseIsReleased_forbidden();
+    void testProgrammingExerciseIsReleased_forbidden() throws Exception {
+        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textExportSubmissionsByParticipationIds() throws Exception {
-        programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds();
+    void testExportSubmissionsByParticipationIds() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds();
     }
 
     @Test
@@ -81,19 +81,19 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
+    void testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
-    void textExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.textExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden();
+    void testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden() throws Exception {
+        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void textExportSubmissionsByStudentLogins() throws Exception {
+    void testExportSubmissionsByStudentLogins() throws Exception {
         programmingExerciseIntegrationServiceTest.testExportSubmissionsByStudentLogins();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationServiceTest.java
@@ -91,9 +91,6 @@ public class ProgrammingExerciseIntegrationServiceTest {
     private CourseRepository courseRepository;
 
     @Autowired
-    private GradingCriterionRepository gradingCriterionRepository;
-
-    @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
 
     @Autowired
@@ -217,7 +214,7 @@ public class ProgrammingExerciseIntegrationServiceTest {
         }
     }
 
-    public void textProgrammingExerciseIsReleased_IsReleasedAndHasResults() throws Exception {
+    public void testProgrammingExerciseIsReleased_IsReleasedAndHasResults() throws Exception {
         programmingExercise.setReleaseDate(ZonedDateTime.now().minusHours(5L));
         programmingExerciseRepository.save(programmingExercise);
         StudentParticipation participation = database.createAndSaveParticipationForExercise(programmingExercise, "student1");
@@ -230,7 +227,7 @@ public class ProgrammingExerciseIntegrationServiceTest {
         assertThat(releaseStateDTO.isTestCasesChanged()).isFalse();
     }
 
-    public void textProgrammingExerciseIsReleased_IsNotReleasedAndHasResults() throws Exception {
+    public void testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults() throws Exception {
         programmingExercise.setReleaseDate(ZonedDateTime.now().plusHours(5L));
         programmingExerciseRepository.save(programmingExercise);
         StudentParticipation participation = database.createAndSaveParticipationForExercise(programmingExercise, "student1");
@@ -255,7 +252,7 @@ public class ProgrammingExerciseIntegrationServiceTest {
         assertThat(releaseStateDTO.isTestCasesChanged()).isTrue();
     }
 
-    public void textProgrammingExerciseIsReleased_forbidden() throws Exception {
+    public void testProgrammingExerciseIsReleased_forbidden() throws Exception {
         request.get("/api/programming-exercises/" + programmingExercise.getId() + "/test-case-state", HttpStatus.FORBIDDEN, Boolean.class);
     }
 
@@ -302,7 +299,7 @@ public class ProgrammingExerciseIntegrationServiceTest {
         Files.deleteIfExists(pomPath);
     }
 
-    public void textExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError() throws Exception {
+    public void testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError() throws Exception {
         var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
         var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), null);
 
@@ -346,7 +343,7 @@ public class ProgrammingExerciseIntegrationServiceTest {
         Files.deleteIfExists(pomPath);
     }
 
-    public void textExportSubmissionsByParticipationIds() throws Exception {
+    public void testExportSubmissionsByParticipationIds() throws Exception {
         var repository1 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile.toPath(), null);
         var repository2 = gitService.getExistingCheckedOutRepositoryByLocalPath(localRepoFile2.toPath(), null);
         doReturn(repository1).when(gitService).getOrCheckoutRepository(eq(participation1.getVcsRepositoryUrl()), anyString(), anyBoolean());
@@ -411,12 +408,12 @@ public class ProgrammingExerciseIntegrationServiceTest {
         }
     }
 
-    public void textExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
+    public void testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
         final var path = ROOT + EXPORT_SUBMISSIONS_BY_PARTICIPATIONS.replace("{exerciseId}", String.valueOf(programmingExercise.getId())).replace("{participationIds}", "10");
         request.postWithResponseBodyFile(path, getOptions(), HttpStatus.BAD_REQUEST);
     }
 
-    public void textExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden() throws Exception {
+    public void testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden() throws Exception {
         database.addInstructor("other-instructors", "instructoralt");
         var participationIds = programmingExerciseStudentParticipationRepository.findAll().stream().map(participation -> participation.getId().toString())
                 .collect(Collectors.toList());

--- a/src/test/java/de/tum/in/www1/artemis/service/SubmissionServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/SubmissionServiceTest.java
@@ -183,7 +183,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testProgrammingExerciseGetRandomSubmissionEligibleForNewAssessmentNoAssessments() {
 
         submission1 = new ProgrammingSubmission();
@@ -207,7 +207,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testFileUploadExerciseGetRandomSubmissionEligibleForNewAssessment() {
         submission1 = new FileUploadSubmission();
         submission2 = new FileUploadSubmission();
@@ -229,7 +229,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testFileUploadExerciseGetRandomSubmissionEligibleForNewAssessmentWithoutSubmission() {
         // setup
         queryTestingBasics(this.examFileUploadExercise);
@@ -250,7 +250,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testTextExerciseGetRandomSubmissionEligibleForNewAssessmentNoAssessments() {
         submission1 = new TextSubmission();
         submission2 = new TextSubmission();
@@ -272,7 +272,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testTextExerciseGetRandomSubmissionEligibleForNewAssessmentOneAssessmentsWithoutLock() {
         submission1 = new TextSubmission();
         submission2 = new TextSubmission();
@@ -310,7 +310,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testTextExerciseGetRandomSubmissionEligibleForNewAssessmentOneAssessmentsWithLock() {
         submission1 = new TextSubmission();
         submission2 = new TextSubmission();
@@ -342,7 +342,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testTextExerciseGetRandomSubmissionEligibleForNewAssessmentOneAssessmentsInSecondCorrectionRoundWithoutLock() {
         submission1 = new TextSubmission();
         submission2 = new TextSubmission();
@@ -373,7 +373,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testTextExerciseGetRandomSubmissionEligibleForNewAssessmentOneAssessmentsInSecondCorrectionRoundWithLock() {
         submission1 = new TextSubmission();
         submission2 = new TextSubmission();
@@ -409,7 +409,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testModelingExerciseGetRandomSubmissionEligibleForNewAssessmentNoAssessments() {
         submission1 = new ModelingSubmission();
         submission2 = new ModelingSubmission();
@@ -432,7 +432,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testModelingExerciseGetRandomSubmissionEligibleForNewAssessmentOneAssessmentsWithoutLock() {
         submission1 = new ModelingSubmission();
         submission2 = new ModelingSubmission();
@@ -470,7 +470,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testModelingExerciseGetRandomSubmissionEligibleForNewAssessmentOneAssessmentsWithLock() {
         submission1 = new ModelingSubmission();
         submission2 = new ModelingSubmission();
@@ -502,7 +502,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testModelingExerciseGetRandomSubmissionEligibleForNewAssessmentOneAssessmentsInSecondCorrectionRoundWithoutLock() {
         submission1 = new ModelingSubmission();
         submission2 = new ModelingSubmission();
@@ -533,7 +533,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testModelingExerciseGetRandomSubmissionEligibleForNewAssessmentOneAssessmentsInSecondCorrectionRoundWithLock() {
         submission1 = new ModelingSubmission();
         submission2 = new ModelingSubmission();
@@ -602,7 +602,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testGetSubmissionsWithComplaintsForExerciseAsTutor() {
         var participation1 = database.createAndSaveParticipationForExercise(examTextExercise, "student1");
         var participation2 = database.createAndSaveParticipationForExercise(examTextExercise, "student2");
@@ -633,7 +633,7 @@ public class SubmissionServiceTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     @Test
-    @WithMockUser(username = "tutor1", roles = "TUTOR")
+    @WithMockUser(username = "tutor1", roles = "TA")
     public void testGetSubmissionsWithMoreFeedbackRequestsForExerciseAsTutor() {
         var participation1 = database.createAndSaveParticipationForExercise(examTextExercise, "student1");
         var participation2 = database.createAndSaveParticipationForExercise(examTextExercise, "student2");


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally ~~and was confirmed by another developer on a test server~~.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
The server tests had a typo in their name (test → text) which made no sense in the context of testing programming exercises. This PR fixes that typo.
Additionally, another test suite used the the role ‘TUTOR’ for mock users, every other test class uses the role identifier ‘TA’ instead.

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
n/a

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
unchanged