### PR TITLE
`Development`: Exclude style checks from Java run configurations

### DIFF
--- a/.idea/runConfigurations/Artemis__Server_.xml
+++ b/.idea/runConfigurations/Artemis__Server_.xml
@@ -7,7 +7,7 @@
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
     <method v="2">
-      <option name="Gradle.BeforeRunTask" enabled="true" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification" />
+      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessJavaCheck -x checkstyleMain -x checkstyleTest" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Artemis__Server_.xml
+++ b/.idea/runConfigurations/Artemis__Server_.xml
@@ -7,7 +7,7 @@
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
     <method v="2">
-      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessJavaCheck -x checkstyleMain -x checkstyleTest" />
+      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessCheck -x checkstyleMain -x checkstyleTest" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Artemis__Server__Athene_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Athene_.xml
@@ -7,7 +7,7 @@
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
     <method v="2">
-      <option name="Gradle.BeforeRunTask" enabled="true" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification" />
+      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessJavaCheck -x checkstyleMain -x checkstyleTest" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Artemis__Server__Athene_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Athene_.xml
@@ -7,7 +7,7 @@
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
     <method v="2">
-      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessJavaCheck -x checkstyleMain -x checkstyleTest" />
+      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessCheck -x checkstyleMain -x checkstyleTest" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Artemis__Server__Jenkins___Gitlab_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Jenkins___Gitlab_.xml
@@ -7,7 +7,7 @@
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
     <method v="2">
-      <option name="Gradle.BeforeRunTask" enabled="true" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification" />
+      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessJavaCheck -x checkstyleMain -x checkstyleTest" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Artemis__Server__Jenkins___Gitlab_.xml
+++ b/.idea/runConfigurations/Artemis__Server__Jenkins___Gitlab_.xml
@@ -7,7 +7,7 @@
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="SHORTEN_COMMAND_LINE" value="MANIFEST" />
     <method v="2">
-      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessJavaCheck -x checkstyleMain -x checkstyleTest" />
+      <option name="Gradle.BeforeRunTask" enabled="false" tasks="build" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="-x webapp -x test -x jacocoTestCoverageVerification -x spotlessCheck -x checkstyleMain -x checkstyleTest" />
     </method>
   </configuration>
 </component>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During development, you need quick startup times and small style issues slow you down.

### Description
<!-- Describe your changes in detail -->
I removed the style checks from the Java run configurations. They can still be executed manually and get executed in the pipeline.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
