### PR TITLE
`Development`: Speed up client tests for exercise group

### DIFF
--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.ts
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.ts
@@ -16,7 +16,6 @@ import { ProgrammingExerciseImportComponent } from 'app/exercises/programming/ma
 import { ModelingExerciseImportComponent } from 'app/exercises/modeling/manage/modeling-exercise-import.component';
 import { ModelingExercise } from 'app/entities/modeling-exercise.model';
 import { Course } from 'app/entities/course.model';
-import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { Exam } from 'app/entities/exam.model';
 import dayjs from 'dayjs';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
@@ -47,7 +46,6 @@ export class ExerciseGroupsComponent implements OnInit {
         private exerciseGroupService: ExerciseGroupService,
         public exerciseService: ExerciseService,
         private examManagementService: ExamManagementService,
-        private courseManagementService: CourseManagementService,
         private eventManager: EventManager,
         private alertService: AlertService,
         private modalService: NgbModal,

--- a/src/test/javascript/spec/component/exam/manage/exercise-groups.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exercise-groups.component.spec.ts
@@ -61,8 +61,8 @@ describe('Exercise Groups Component', () => {
             imports: [ArtemisTestModule, RouterTestingModule],
             declarations: [
                 ExerciseGroupsComponent,
-                ExamExerciseRowButtonsComponent,
-                ProgrammingExerciseInstructorStatusComponent,
+                MockComponent(ExamExerciseRowButtonsComponent),
+                MockComponent(ProgrammingExerciseInstructorStatusComponent),
                 MockComponent(AlertComponent),
                 MockComponent(AlertErrorComponent),
                 MockDirective(DeleteButtonDirective),
@@ -80,35 +80,33 @@ describe('Exercise Groups Component', () => {
                 { provide: Router, useClass: MockRouter },
                 { provide: NgbModal, useClass: MockNgbModalService },
             ],
-        }).compileComponents();
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(ExerciseGroupsComponent);
+                comp = fixture.componentInstance;
 
-        fixture = TestBed.createComponent(ExerciseGroupsComponent);
-        comp = fixture.componentInstance;
+                exerciseGroupService = TestBed.inject(ExerciseGroupService);
+                examManagementService = TestBed.inject(ExamManagementService);
+                eventManager = TestBed.inject(EventManager);
+                modalService = TestBed.inject(NgbModal);
+                router = TestBed.inject(Router);
 
-        exerciseGroupService = TestBed.inject(ExerciseGroupService);
-        examManagementService = TestBed.inject(ExamManagementService);
-        eventManager = TestBed.inject(EventManager);
-        modalService = TestBed.inject(NgbModal);
-        router = TestBed.inject(Router);
-
-        groups = [
-            {
-                id: 0,
-                exercises: [
-                    { id: 3, type: ExerciseType.TEXT },
-                    { id: 4, type: ExerciseType.PROGRAMMING },
-                ],
-            } as ExerciseGroup,
-            { id: 1 } as ExerciseGroup,
-            { id: 2 } as ExerciseGroup,
-        ];
+                groups = [
+                    {
+                        id: 0,
+                        exercises: [
+                            { id: 3, type: ExerciseType.TEXT },
+                            { id: 4, type: ExerciseType.PROGRAMMING },
+                        ],
+                    } as ExerciseGroup,
+                    { id: 1 } as ExerciseGroup,
+                    { id: 2 } as ExerciseGroup,
+                ];
+                // Always initialized and bind before tests
+                fixture.detectChanges();
+            });
     });
-
-    // Always initialized and bind before tests
-    beforeEach(fakeAsync(() => {
-        fixture.detectChanges();
-        tick();
-    }));
 
     it('loads the exercise groups', fakeAsync(() => {
         const mockResponse = new HttpResponse<Exam>({ body: exam });
@@ -117,7 +115,7 @@ describe('Exercise Groups Component', () => {
 
         comp.loadExerciseGroups().subscribe((response) => {
             expect(response.body).not.toBeNull();
-            expect(response.body!.id).toEqual(exam.id);
+            expect(response.body!.id).toBe(exam.id);
         });
 
         tick();
@@ -132,19 +130,19 @@ describe('Exercise Groups Component', () => {
         comp.loadLatestIndividualEndDateOfExam().subscribe((response) => {
             expect(response).not.toBeNull();
             expect(response!.body).not.toBeNull();
-            expect(response!.body!.latestIndividualEndDate).toEqual(latestIndividualEndDate);
+            expect(response!.body!.latestIndividualEndDate).toBe(latestIndividualEndDate);
         });
 
         tick();
     }));
 
-    it('removes an exercise from group', fakeAsync(() => {
+    it('removes an exercise from group', () => {
         comp.exerciseGroups = groups;
 
         comp.removeExercise(3, 0);
 
         expect(comp.exerciseGroups[0].exercises).toHaveLength(1);
-    }));
+    });
 
     it('deletes an exercise group', fakeAsync(() => {
         comp.exerciseGroups = groups;
@@ -163,35 +161,35 @@ describe('Exercise Groups Component', () => {
         const icon = 'check-double';
         const exercise = { type: ExerciseType.QUIZ } as Exercise;
 
-        expect(comp.exerciseIcon(exercise)).toEqual(icon);
+        expect(comp.exerciseIcon(exercise)).toBe(icon);
     });
 
     it('returns the exercise icon type file upload', () => {
         const icon = 'file-upload';
         const exercise = { type: ExerciseType.FILE_UPLOAD } as Exercise;
 
-        expect(comp.exerciseIcon(exercise)).toEqual(icon);
+        expect(comp.exerciseIcon(exercise)).toBe(icon);
     });
 
     it('returns the exercise icon type modeling', () => {
         const icon = 'project-diagram';
         const exercise = { type: ExerciseType.MODELING } as Exercise;
 
-        expect(comp.exerciseIcon(exercise)).toEqual(icon);
+        expect(comp.exerciseIcon(exercise)).toBe(icon);
     });
 
     it('returns the exercise icon type programming', () => {
         const icon = 'keyboard';
         const exercise = { type: ExerciseType.PROGRAMMING } as Exercise;
 
-        expect(comp.exerciseIcon(exercise)).toEqual(icon);
+        expect(comp.exerciseIcon(exercise)).toBe(icon);
     });
 
     it('returns the exercise icon type text', () => {
         const icon = 'font';
         const exercise = { type: ExerciseType.TEXT } as Exercise;
 
-        expect(comp.exerciseIcon(exercise)).toEqual(icon);
+        expect(comp.exerciseIcon(exercise)).toBe(icon);
     });
 
     it('opens the import modal for programming exercises', fakeAsync(() => {
@@ -240,8 +238,8 @@ describe('Exercise Groups Component', () => {
 
         comp.moveUp(from);
 
-        expect(comp.exerciseGroups[to].id).toEqual(fromId);
-        expect(comp.exerciseGroups[from].id).toEqual(toId);
+        expect(comp.exerciseGroups[to].id).toBe(fromId);
+        expect(comp.exerciseGroups[from].id).toBe(toId);
     });
 
     it('moves down an exercise group', () => {
@@ -254,8 +252,8 @@ describe('Exercise Groups Component', () => {
 
         comp.moveDown(from);
 
-        expect(comp.exerciseGroups[to].id).toEqual(fromId);
-        expect(comp.exerciseGroups[from].id).toEqual(toId);
+        expect(comp.exerciseGroups[to].id).toBe(fromId);
+        expect(comp.exerciseGroups[from].id).toBe(toId);
     });
 
     it('maps exercise types to exercise groups', () => {
@@ -267,7 +265,7 @@ describe('Exercise Groups Component', () => {
         const map = comp.exerciseGroupToExerciseTypesDict;
 
         expect(map).toBeDefined();
-        expect(map.size).toEqual(groups.length);
+        expect(map.size).toBe(groups.length);
         expect(map.get(firstGroupId)).toEqual(expectedResult);
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As part of client test speed improvements, I fixed the tests for the exercise group components.

### Description
<!-- Describe your changes in detail -->
Improvement:
7.376 s, 371 MB heap size -> Not marked, 280 MB heap size

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Run `npm test -- src/test/javascript/spec/component/exam/manage/exercise-groups.component.spec.ts` at project root.
Prerequisites:
None
