### PR TITLE
`General`: Fix hints not shown in problem statement

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -109,6 +109,7 @@
                     [exercise]="exercise"
                     [participation]="exercise.studentParticipations! && exercise.studentParticipations![0]"
                     [personalParticipation]="true"
+                    [exerciseHints]="exercise.exerciseHints || []"
                 >
                 </jhi-programming-exercise-instructions>
             </div>

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse, HttpResponse } from '@angular/common/http';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { Result } from 'app/entities/result.model';
 import dayjs from 'dayjs';
 import { User } from 'app/core/user/user.model';
@@ -43,6 +43,8 @@ import { ArtemisNavigationUtilService } from 'app/utils/navigation.utils';
 import { setBuildPlanUrlForProgrammingParticipations } from 'app/exercises/shared/participation/participation.utils';
 import { SubmissionPolicyService } from 'app/exercises/programming/manage/services/submission-policy.service';
 import { SubmissionPolicy } from 'app/entities/submission-policy.model';
+import { ExerciseHint } from 'app/entities/exercise-hint.model';
+import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
 
 const MAX_RESULT_HISTORY_LENGTH = 5;
 
@@ -118,6 +120,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
         private submissionService: ProgrammingSubmissionService,
         private complaintService: ComplaintService,
         private navigationUtilService: ArtemisNavigationUtilService,
+        private exerciseHintService: ExerciseHintService,
     ) {}
 
     ngOnInit() {
@@ -175,6 +178,16 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
         });
     }
 
+    loadExerciseHints(exercise: Exercise) {
+        this.exerciseHintService
+            .findByExerciseId(exercise.id!)
+            .pipe(map(({ body }) => body || []))
+            .subscribe((exerciseHints: ExerciseHint[]) => {
+                console.log(exerciseHints);
+                exercise.exerciseHints = exerciseHints;
+            });
+    }
+
     handleNewExercise(newExercise: Exercise) {
         this.exercise = newExercise;
         this.exercise.studentParticipations = this.filterParticipations(newExercise.studentParticipations);
@@ -202,6 +215,7 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
                 this.submissionPolicy = submissionPolicy;
                 this.hasSubmissionPolicy = true;
             });
+            this.loadExerciseHints(newExercise);
         }
 
         // This is only needed in the local environment

--- a/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
@@ -60,6 +60,7 @@ import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { ComplaintsStudentViewComponent } from 'app/complaints/complaints-for-students/complaints-student-view.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
 
 chai.use(sinonChai);
 const expect = chai.expect;
@@ -145,6 +146,7 @@ describe('CourseExerciseDetailsComponent', () => {
                 MockProvider(ProgrammingSubmissionService),
                 MockProvider(ComplaintService),
                 MockProvider(ArtemisNavigationUtilService),
+                MockProvider(ExerciseHintService),
             ],
         })
             .compileComponents()


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #1400 
In the problem statement of the exercise details page for students, exercise hints would never show.

### Description
<!-- Describe your changes in detail -->
This was due to the fact that the exercise hints were never loaded from the server. Simply adding a call to `ExerciseHintService::findByExerciseId` and passing them to the `ProgrammingExerciseInstructionComponent` fixes this issue

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Programmign Exercise with Exercise Hints
- 1 Student

1. Log in to Artemis
2. Start the exercise with the student
3. Commit any changes that does not solve the task associated with the exercise hint
4. The '?' to show the exercise hints should appear after the build completed

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
<img width="388" alt="grafik" src="https://user-images.githubusercontent.com/18218285/143922630-22e7e73d-a721-4fa2-9700-f6161c2941fc.png">

After:
<img width="388" alt="grafik" src="https://user-images.githubusercontent.com/18218285/143922548-9a503966-5611-472b-8c8c-00e9dd19a723.png">
