### PR TITLE
`Notifications`: Do not send exercise released notifications for quizzes

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/GroupNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/GroupNotificationService.java
@@ -38,9 +38,9 @@ public class GroupNotificationService {
 
     private final UserRepository userRepository;
 
-    private MailService mailService;
+    private final MailService mailService;
 
-    private NotificationSettingsService notificationSettingsService;
+    private final NotificationSettingsService notificationSettingsService;
 
     public GroupNotificationService(GroupNotificationRepository groupNotificationRepository, SimpMessageSendingOperations messagingTemplate, UserRepository userRepository,
             MailService mailService, NotificationSettingsService notificationSettingsService) {

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/NotificationSettingsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/NotificationSettingsService.java
@@ -18,7 +18,7 @@ import de.tum.in.www1.artemis.repository.NotificationSettingRepository;
 @Service
 public class NotificationSettingsService {
 
-    private NotificationSettingRepository notificationSettingRepository;
+    private final NotificationSettingRepository notificationSettingRepository;
 
     // notification settings settingIds analogous to client side
     // course wide discussion notification setting group

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/SingleUserNotificationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/SingleUserNotificationService.java
@@ -25,9 +25,9 @@ public class SingleUserNotificationService {
 
     private final SimpMessageSendingOperations messagingTemplate;
 
-    private MailService mailService;
+    private final MailService mailService;
 
-    private NotificationSettingsService notificationSettingsService;
+    private final NotificationSettingsService notificationSettingsService;
 
     public SingleUserNotificationService(SingleUserNotificationRepository singleUserNotificationRepository, SimpMessageSendingOperations messagingTemplate, MailService mailService,
             NotificationSettingsService notificationSettingsService) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -135,8 +135,6 @@ public class QuizExerciseResource {
 
         quizExercise = quizExerciseService.save(quizExercise);
 
-        groupNotificationService.checkNotificationForExerciseRelease(quizExercise, instanceMessageSendService);
-
         return ResponseEntity.created(new URI("/api/quiz-exercises/" + quizExercise.getId()))
                 .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, quizExercise.getId().toString())).body(quizExercise);
     }
@@ -194,8 +192,6 @@ public class QuizExerciseResource {
 
         quizExercise = quizExerciseService.save(quizExercise);
         exerciseService.logUpdate(quizExercise, quizExercise.getCourseViaExerciseGroupOrCourseMember(), user);
-
-        groupNotificationService.checkAndCreateAppropriateNotificationsWhenUpdatingExercise(originalQuiz, quizExercise, notificationText, instanceMessageSendService);
 
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, quizExercise.getId().toString())).body(quizExercise);
     }


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation, Context, and Description
![image](https://user-images.githubusercontent.com/65814168/143952941-1bd7a148-d95c-4fc9-a32f-067ce885bcdb.png)
@krusche noticed an "Exercise released" notification for a not yet visible (or started) quiz exercise. 

Quiz Exercises should never trigger such a notification. They have their custom "Quiz Started" (pop-up) notification.

This bug appeared if you created a new quiz 
a) without a set start date (can only be in the future) -> the notification was triggered instantly
b) with a set start date -> scheduled "released" notification

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor (log in as both users side by side to see if everything works fine) (this can be done by using a different second browser or incognito mode)
- 1 Student
- 1 new Quiz Exercise

Create a new quiz exercise (with and without a start date) and check if no "exercise released" notification is created (for the student and instructor).
Make sure the "quiz started" notification + pop-up are still created

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
I removed 2 lines of code, so there is no change in the test coverage.