### PR TITLE
`Assessment`: Fix an issue with complaints after long assessment periods

### DIFF
--- a/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.html
+++ b/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.html
@@ -1,4 +1,18 @@
 <div *ngIf="complaint || showSection">
+    <p *ngIf="course!.complaintsEnabled">
+        <span
+            *ngIf="!isExamMode && remainingNumberOfComplaints == undefined"
+            [jhiTranslate]="'artemisApp.complaint.' + (exercise.teamMode ? 'descriptionTeam' : 'description')"
+            [translateValues]="{ maxComplaintNumber: course!.maxComplaints! }"
+        ></span>
+        <span
+            *ngIf="!isExamMode && remainingNumberOfComplaints >= 0"
+            [jhiTranslate]="'artemisApp.complaint.' + (exercise.teamMode ? 'descriptionTeamExtended' : 'descriptionExtended')"
+            [translateValues]="{ maxComplaintNumber: course!.maxComplaints!, allowedComplaints: remainingNumberOfComplaints }"
+        ></span>
+        <span *ngIf="isExamMode" [jhiTranslate]="'artemisApp.complaint.descriptionExam'"></span>
+        <fa-icon *ngIf="!isExamMode" [icon]="'info-circle'" title="{{ 'artemisApp.complaint.info' | artemisTranslate }}" class="info-icon" style="color: #ffc107"></fa-icon>
+    </p>
     <div class="mt-4" *ngIf="isCorrectUserToFileAction && !complaint">
         <button
             *ngIf="isExamMode || (course?.maxComplaints && course!.maxComplaints! > 0)"

--- a/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.html
+++ b/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.html
@@ -11,7 +11,7 @@
             [translateValues]="{ maxComplaintNumber: course!.maxComplaints!, allowedComplaints: remainingNumberOfComplaints }"
         ></span>
         <span *ngIf="isExamMode" [jhiTranslate]="'artemisApp.complaint.descriptionExam'"></span>
-        <fa-icon *ngIf="!isExamMode" [icon]="'info-circle'" title="{{ 'artemisApp.complaint.info' | artemisTranslate }}" class="info-icon" style="color: #ffc107"></fa-icon>
+        <fa-icon *ngIf="!isExamMode" [icon]="'info-circle'" title="{{ 'artemisApp.complaint.info' | artemisTranslate }}" class="info-icon"></fa-icon>
     </p>
     <div class="mt-4" *ngIf="isCorrectUserToFileAction && !complaint">
         <button

--- a/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.ts
+++ b/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.ts
@@ -143,8 +143,12 @@ export class ComplaintsStudentViewComponent implements OnInit {
         if (!actionThresholdInDays) {
             return false;
         }
-        if (!this.exercise.assessmentDueDate || dayjs().isAfter(dayjs(this.exercise.assessmentDueDate))) {
-            return dayjs().isSameOrBefore(dayjs(completionDate).add(actionThresholdInDays, 'day'));
+        const isWithinThreshold = dayjs().isSameOrBefore(dayjs(completionDate).add(actionThresholdInDays, 'day'));
+        if (!this.exercise.assessmentDueDate) {
+            return isWithinThreshold;
+        }
+        if (dayjs().isAfter(dayjs(this.exercise.assessmentDueDate))) {
+            return isWithinThreshold || dayjs().isBefore(dayjs(this.exercise.assessmentDueDate).add(actionThresholdInDays, 'day'));
         }
         return false;
     }

--- a/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.ts
+++ b/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.ts
@@ -18,6 +18,7 @@ import { AssessmentType } from 'app/entities/assessment-type.model';
 @Component({
     selector: 'jhi-complaint-student-view',
     templateUrl: './complaints-student-view.component.html',
+    styleUrls: ['../complaints.scss'],
 })
 export class ComplaintsStudentViewComponent implements OnInit {
     @Input() exercise: Exercise;

--- a/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.ts
+++ b/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.ts
@@ -149,7 +149,7 @@ export class ComplaintsStudentViewComponent implements OnInit {
             return isWithinThreshold;
         }
         if (dayjs().isAfter(dayjs(this.exercise.assessmentDueDate))) {
-            return isWithinThreshold || dayjs().isBefore(dayjs(this.exercise.assessmentDueDate).add(actionThresholdInDays, 'day'));
+            return isWithinThreshold || dayjs().isSameOrBefore(dayjs(this.exercise.assessmentDueDate).add(actionThresholdInDays, 'day'));
         }
         return false;
     }

--- a/src/main/webapp/app/complaints/complaints.scss
+++ b/src/main/webapp/app/complaints/complaints.scss
@@ -1,0 +1,3 @@
+.info-icon {
+    color: #ffc107;
+}

--- a/src/main/webapp/app/complaints/form/complaints-form.component.html
+++ b/src/main/webapp/app/complaints/form/complaints-form.component.html
@@ -3,20 +3,6 @@
     <div class="row">
         <div class="col-12">
             <h3>{{ complaintType === ComplaintType.COMPLAINT ? ('artemisApp.complaint.title' | artemisTranslate) : ('artemisApp.moreFeedback.title' | artemisTranslate) }}</h3>
-            <p *ngIf="complaintType === ComplaintType.COMPLAINT">
-                <span
-                    *ngIf="!examId && remainingNumberOfComplaints == undefined"
-                    [jhiTranslate]="'artemisApp.complaint.' + (exercise.teamMode ? 'descriptionTeam' : 'description')"
-                    [translateValues]="{ maxComplaintNumber: maxComplaintsPerCourse }"
-                ></span>
-                <span
-                    *ngIf="!examId && remainingNumberOfComplaints >= 0"
-                    [jhiTranslate]="'artemisApp.complaint.' + (exercise.teamMode ? 'descriptionTeamExtended' : 'descriptionExtended')"
-                    [translateValues]="{ maxComplaintNumber: maxComplaintsPerCourse, allowedComplaints: remainingNumberOfComplaints }"
-                ></span>
-                <span *ngIf="examId" [jhiTranslate]="'artemisApp.complaint.descriptionExam'"></span>
-                <fa-icon *ngIf="!examId" [icon]="'info-circle'" title="{{ 'artemisApp.complaint.info' | artemisTranslate }}" class="info-icon"></fa-icon>
-            </p>
             <p *ngIf="complaintType !== ComplaintType.COMPLAINT">
                 {{ 'artemisApp.moreFeedback.' + (exercise.teamMode ? 'descriptionTeam' : 'description') | artemisTranslate }}
                 <fa-icon [icon]="'info-circle'" title="{{ 'artemisApp.moreFeedback.info' | artemisTranslate }}" class="info-icon"></fa-icon>

--- a/src/main/webapp/app/complaints/form/complaints-form.component.scss
+++ b/src/main/webapp/app/complaints/form/complaints-form.component.scss
@@ -1,6 +1,0 @@
-.info-icon {
-    color: #ffc107;
-}
-.spinner {
-    color: gray;
-}

--- a/src/main/webapp/app/complaints/form/complaints-form.component.ts
+++ b/src/main/webapp/app/complaints/form/complaints-form.component.ts
@@ -10,7 +10,6 @@ import { AlertService } from 'app/core/util/alert.service';
 @Component({
     selector: 'jhi-complaint-form',
     templateUrl: './complaints-form.component.html',
-    styleUrls: ['./complaints-form.component.scss'],
 })
 export class ComplaintsFormComponent implements OnInit {
     @Input() exercise: Exercise;

--- a/src/main/webapp/app/complaints/form/complaints-form.component.ts
+++ b/src/main/webapp/app/complaints/form/complaints-form.component.ts
@@ -10,6 +10,7 @@ import { AlertService } from 'app/core/util/alert.service';
 @Component({
     selector: 'jhi-complaint-form',
     templateUrl: './complaints-form.component.html',
+    styleUrls: ['../complaints.scss'],
 })
 export class ComplaintsFormComponent implements OnInit {
     @Input() exercise: Exercise;

--- a/src/test/javascript/spec/component/complaints/complaint-student-view.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint-student-view.component.spec.ts
@@ -4,7 +4,7 @@ import { MockComplaintService } from '../../helpers/mocks/service/mock-complaint
 import { ArtemisTestModule } from '../../test.module';
 import { Exercise } from 'app/entities/exercise.model';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
-import { MockComponent, MockPipe } from 'ng-mocks';
+import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
 import { Participation } from 'app/entities/participation/participation.model';
 import { Result } from 'app/entities/result.model';
 import { Exam } from 'app/entities/exam.model';
@@ -22,6 +22,7 @@ import { MockAccountService } from '../../helpers/mocks/service/mock-account.ser
 import { ArtemisServerDateService } from 'app/shared/server-date.service';
 import dayjs from 'dayjs';
 import { AssessmentType } from 'app/entities/assessment-type.model';
+import { TranslateDirective } from 'app/shared/language/translate.directive';
 
 describe('ComplaintsStudentViewComponent', () => {
     const complaintTimeLimitDays = 7;
@@ -60,6 +61,7 @@ describe('ComplaintsStudentViewComponent', () => {
             declarations: [
                 ComplaintsStudentViewComponent,
                 MockPipe(ArtemisTranslatePipe),
+                MockDirective(TranslateDirective),
                 MockComponent(ComplaintsFormComponent),
                 MockComponent(ComplaintRequestComponent),
                 MockComponent(ComplaintResponseComponent),
@@ -325,5 +327,17 @@ describe('ComplaintsStudentViewComponent', () => {
         tick(100);
 
         expect(component.timeOfComplaintValid).toBe(false);
+    }));
+
+    it('complaint should be possible with long assessment periods', fakeAsync(() => {
+        component.exercise = { ...courseExercise, assessmentDueDate: dayjs().subtract(3, 'day') };
+        component.result = { ...result, completionDate: dayjs().subtract(complaintTimeLimitDays + 2, 'day') };
+
+        fixture.detectChanges();
+        tick(100);
+
+        expect(component.showSection).toBe(true);
+        expect(component.timeOfComplaintValid).toBe(true);
+        expect(component.timeOfFeedbackRequestValid).toBe(true);
     }));
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [X] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [X] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, if the assessment due date of an exercise is set, complaints are possible if the result date is not older than the complaint time threshold (default 7 days). If the submission was assessed manually e.g. right after the submission deadline it's not possible to complain if the assessment period is at least the same length as the complaint time threshold or otherwise you have less time

Additionally, it's not quite intuitive to know how many complaints the student has left if it's not possible to complain.

### Description
<!-- Describe your changes in detail -->

Now, if the assessment due date is set, it's additionally possible to complain if you are within the time threshold since the end of the assessment period.

I moved the already existing hint up the hierarchy (see screenshots)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
**As this works with the complaints threshold which is given in days, it's not possible to test this on the test servers unless you have already existing exercises that suit the requirements or have database access, you want to wait for at least 24h or have access to the database.**
You can use this exercise with **test user 53**: https://artemistest.ase.in.tum.de/courses/515/text-exercises/11107/participate/327958
**Please don't complain but only check if you could when using this exercise.**

Prerequisites:
- 1 Instructor
- 1 Student
- Course with Feedback requests and complaints enabled, the threshold must be **x** days
- 1 Exercise with non-automatic assessment, the assessment due date should be further away than x days from the date the submission as assessed
- 1 Submission of the exercise, handed in properly, assessed at the minimum x days before the assessment due date

Check the exercise as a student, you should still be able to complain.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
complaints-student-view.component.ts: 78.75% | 95.77%
complaints-form.component.ts: 85.71% | 100%

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
![](https://gyazo.com/99efd47cb3634828317f934790533662/raw)
After:
![](https://gyazo.com/e6a985da9c8c8a8021a6170ba5f27897/raw)