### PR TITLE
`Assessment`: Hide example submissions without assessments in tutor training

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextAssessmentResource.java
@@ -186,11 +186,13 @@ public class TextAssessmentResource extends AssessmentResource {
         // 1. Delete Text blocks
         textBlockService.deleteForSubmission((TextSubmission) submission);
 
-        // 2. Delete Feedbacks
+        // 2. Delete feedback and example assessment
         final var latestResult = submission.getLatestResult();
         if (latestResult != null) {
             latestResult.getFeedbacks().clear();
-            resultRepository.save(latestResult);
+            resultRepository.delete(latestResult);
+            submission.setResults(List.of());
+            submissionRepository.save(submission);
         }
 
         return ResponseEntity.noContent().build();
@@ -437,10 +439,6 @@ public class TextAssessmentResource extends AssessmentResource {
                 final List<Feedback> assessments = feedbackRepository.findByResult(result);
                 result.setFeedbacks(assessments);
             }
-        }
-        if (result == null) {
-            result = new Result();
-            result.setSubmission(textSubmission);
         }
 
         return ResponseEntity.ok().body(result);

--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
@@ -24,6 +24,7 @@ import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { FeedbackMarker, ExampleSubmissionAssessCommand } from 'app/exercises/shared/example-submission/example-submission-assess-command';
 import { getCourseFromExercise } from 'app/entities/exercise.model';
 import { Course } from 'app/entities/course.model';
+import { ArtemisNavigationUtilService } from 'app/utils/navigation.utils';
 
 @Component({
     selector: 'jhi-example-modeling-submission',
@@ -96,6 +97,7 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
         private route: ActivatedRoute,
         private router: Router,
         private location: Location,
+        private navigationUtilService: ArtemisNavigationUtilService,
     ) {}
 
     ngOnInit(): void {
@@ -198,8 +200,7 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
                 this.alertService.success('artemisApp.modelingEditor.saveSuccessful');
 
                 // Update the url with the new id, without reloading the page, to make the history consistent
-                const newUrl = window.location.hash.replace('#', '').replace('new', `${this.exampleSubmissionId}`);
-                this.location.go(newUrl);
+                this.navigationUtilService.replaceNewWithIdInUrl(window.location.href, this.exampleSubmissionId);
             },
             (error: HttpErrorResponse) => {
                 onError(this.alertService, error);

--- a/src/main/webapp/app/exercises/text/assess/text-assessment.service.ts
+++ b/src/main/webapp/app/exercises/text/assess/text-assessment.service.ts
@@ -167,7 +167,13 @@ export class TextAssessmentService {
         return this.http.get<Result>(`${this.resourceUrl}/exercises/${exerciseId}/submissions/${submissionId}/example-result`);
     }
 
-    public deleteExampleFeedback(exerciseId: number, exampleSubmissionId: number): Observable<void> {
+    /**
+     * Deletes the example assessment associated with given example submission.
+     *
+     * @param exerciseId   id of the exercise for which the example assessment should be deleted
+     * @param submissionId id of the submission for which the example assessment should be deleted
+     */
+    public deleteExampleAssessment(exerciseId: number, exampleSubmissionId: number): Observable<void> {
         return this.http.delete<void>(`${this.resourceUrl}/exercises/${exerciseId}/example-submissions/${exampleSubmissionId}/example-text-assessment/feedback`);
     }
 

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
@@ -16,7 +16,7 @@
                         name="usedForTutorial"
                         id="field_usedForTutorial"
                         [(ngModel)]="exampleSubmission.usedForTutorial"
-                        (ngModelChange)="unsavedChanges = true"
+                        (ngModelChange)="unsavedSubmissionChanges = true"
                     />
                     <label class="form-check-label" for="field_usedForTutorial">{{ 'artemisApp.exampleSubmission.usedForTutorial' | artemisTranslate }}</label>
                 </div>
@@ -28,7 +28,12 @@
                         <fa-icon [icon]="'save'"></fa-icon>
                         {{ 'artemisApp.exampleSubmission.createNewSubmission' | artemisTranslate }}
                     </button>
-                    <button *ngSwitchCase="SubmissionButtonStates.UPDATE" (click)="updateExampleTextSubmission()" class="btn btn-primary col-auto">
+                    <button
+                        *ngSwitchCase="SubmissionButtonStates.UPDATE"
+                        (click)="updateExampleTextSubmission()"
+                        class="btn btn-primary col-auto"
+                        [disabled]="!unsavedSubmissionChanges"
+                    >
                         <fa-icon [icon]="'save'"></fa-icon>
                         {{ 'artemisApp.exampleSubmission.updateExampleSubmission' | artemisTranslate }}
                     </button>
@@ -45,7 +50,7 @@
                         (click)="startAssessment()"
                         class="btn btn-primary col-auto ms-auto me-3"
                         id="createNewAssessment"
-                        [disabled]="unsavedChanges"
+                        [disabled]="unsavedSubmissionChanges"
                     >
                         <fa-icon [icon]="'save'"></fa-icon>
                         {{ 'artemisApp.exampleSubmission.createNewAssessment' | artemisTranslate }}
@@ -79,7 +84,7 @@
         left-body
         *ngIf="state.ui === UIStates.SUBMISSION"
         [(ngModel)]="submission!.text"
-        (ngModelChange)="unsavedChanges = true"
+        (ngModelChange)="unsavedSubmissionChanges = true"
         style="width: 100%; height: 50vh"
     ></textarea>
     <jhi-score-display

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
@@ -182,7 +182,7 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
      * Updates the example submission.
      */
     updateExampleTextSubmission(): void {
-        this.saveSubmissionIfNeeded().subscribe((exampleSubmissionResponse: HttpResponse<ExampleSubmission>) => {
+        this.saveSubmissionIfNeeded().subscribe(() => {
             this.state.edit();
             this.alertService.success('artemisApp.exampleSubmission.saveSuccessful');
         }, this.alertService.error);

--- a/src/main/webapp/app/utils/navigation.utils.ts
+++ b/src/main/webapp/app/utils/navigation.utils.ts
@@ -66,6 +66,12 @@ export class ArtemisNavigationUtilService {
             this.navigateBackWithOptional(['course-management', exercise.course!.id!.toString(), exercise.type! + '-exercises'], exercise.id?.toString());
         }
     }
+
+    replaceNewWithIdInUrl(url: string, id: number) {
+        const newUrl = url.slice(0, -3) + id;
+        const regex = /http(s)?:\/\/([a-zA-Z0-9\.\:]*)(?<rest>\/.*)/;
+        this.location.go(newUrl.match(regex)!.groups!.rest);
+    }
 }
 
 export const navigateToExampleSubmissions = (router: Router, exercise: Exercise): void => {

--- a/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextAssessmentIntegrationTest.java
@@ -236,7 +236,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         database.addExampleSubmission(exampleSubmission);
         request.delete("/api/exercises/" + exampleSubmission.getExercise().getId() + "/example-submissions/" + exampleSubmission.getId() + "/example-text-assessment/feedback",
                 HttpStatus.NO_CONTENT);
-        assertThat(exampleSubmissionRepository.findByIdWithEagerResultAndFeedbackElseThrow(exampleSubmission.getId()).getSubmission().getLatestResult().getFeedbacks()).isEmpty();
+        assertThat(exampleSubmissionRepository.findByIdWithEagerResultAndFeedbackElseThrow(exampleSubmission.getId()).getSubmission().getLatestResult()).isNull();
         assertThat(textBlockRepository.findAllWithEagerClusterBySubmissionId(exampleSubmission.getId())).isEmpty();
     }
 
@@ -630,10 +630,9 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
         final var exampleSubmission = ModelFactory.generateExampleSubmission(textSubmission, textExercise, true);
         database.addExampleSubmission(exampleSubmission);
 
-        Result result = request.get("/api/exercises/" + textExercise.getId() + "/submissions/" + textSubmission.getId() + "/example-result", expectedStatus, Result.class);
+        Result result = request.getNullable("/api/exercises/" + textExercise.getId() + "/submissions/" + textSubmission.getId() + "/example-result", expectedStatus, Result.class);
 
-        if (expectedStatus == HttpStatus.OK) {
-            assertThat(result).as("result found").isNotNull();
+        if (expectedStatus == HttpStatus.OK && result != null) {
             assertThat(result.getSubmission().getId()).as("result for correct submission").isEqualTo(textSubmission.getId());
         }
 
@@ -671,9 +670,7 @@ public class TextAssessmentIntegrationTest extends AbstractSpringIntegrationBamb
     @WithMockUser(value = "tutor1", roles = "TA")
     public void getExampleResultForNonExampleSubmissionAsTutor() throws Exception {
         final var result = getExampleResultForTutor(HttpStatus.OK, false);
-        assertThat(result.getFeedbacks()).isEmpty();
-        assertThat(result.getScore()).isNull();
-        assertThat(result.getResultString()).isNull();
+        assertThat(result).isNull();
     }
 
     private void cancelAssessment(HttpStatus expectedStatus) throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/RequestUtilService.java
@@ -353,7 +353,7 @@ public class RequestUtilService {
 
     public <T> T getNullable(String path, HttpStatus expectedStatus, Class<T> responseType) throws Exception {
         final var res = get(path, expectedStatus, String.class, new LinkedMultiValueMap<>());
-        if (res != null && res.equals("")) {
+        if (res == null || res.equals("")) {
             return null;
         }
 

--- a/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
@@ -91,6 +91,10 @@ describe('ExampleTextSubmissionComponent', () => {
         submission.id = SUBMISSION_ID;
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     it('should fetch example submission with result for existing example submission and switch to edit state', async () => {
         // GIVEN
         // @ts-ignore
@@ -109,7 +113,7 @@ describe('ExampleTextSubmissionComponent', () => {
         expect(comp.state.constructor.name).toEqual('EditState');
     });
 
-    it('should fetch only fetch exercise for new example submission and stay in new state', async () => {
+    it('should only fetch exercise for new example submission and stay in new state', async () => {
         // GIVEN
         // @ts-ignore
         activatedRouteSnapshot.paramMap.params = { exerciseId: EXERCISE_ID, exampleSubmissionId: 'new' };
@@ -136,13 +140,11 @@ describe('ExampleTextSubmissionComponent', () => {
         comp.exercise!.isAtLeastInstructor = true;
         comp.exampleSubmission = exampleSubmission;
         comp.submission = submission;
-        jest.spyOn(assessmentsService, 'getExampleResult').mockReturnValue(of(result));
 
         // WHEN
         await comp.startAssessment();
 
         // THEN
-        expect(assessmentsService.getExampleResult).toHaveBeenCalledWith(EXERCISE_ID, SUBMISSION_ID);
         expect(comp.state.constructor.name).toEqual('NewAssessmentState');
     });
 
@@ -208,7 +210,7 @@ describe('ExampleTextSubmissionComponent', () => {
         comp.state = State.forExistingAssessmentWithContext(comp);
         comp['prepareTextBlocksAndFeedbacks']();
         comp.validateFeedback();
-        jest.spyOn(assessmentsService, 'deleteExampleFeedback').mockReturnValue(of());
+        jest.spyOn(assessmentsService, 'deleteExampleAssessment').mockReturnValue(of({}));
 
         // WHEN
         fixture.detectChanges();
@@ -218,9 +220,11 @@ describe('ExampleTextSubmissionComponent', () => {
 
         // THEN
         expect(comp.state.constructor.name).toEqual('EditState');
-        expect(assessmentsService.deleteExampleFeedback).toHaveBeenCalledWith(EXERCISE_ID, EXAMPLE_SUBMISSION_ID);
+        expect(assessmentsService.deleteExampleAssessment).toHaveBeenCalledWith(EXERCISE_ID, EXAMPLE_SUBMISSION_ID);
         expect(comp.submission?.blocks).toBeUndefined();
-        expect(comp.result?.feedbacks).toBeUndefined();
+        expect(comp.submission?.results).toBeUndefined();
+        expect(comp.submission?.latestResult).toBeUndefined();
+        expect(comp.result).toBeUndefined();
         expect(comp.textBlockRefs).toHaveLength(0);
         expect(comp.unusedTextBlockRefs).toHaveLength(0);
     }));

--- a/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
@@ -210,7 +210,7 @@ describe('ExampleTextSubmissionComponent', () => {
         comp.state = State.forExistingAssessmentWithContext(comp);
         comp['prepareTextBlocksAndFeedbacks']();
         comp.validateFeedback();
-        jest.spyOn(assessmentsService, 'deleteExampleAssessment').mockReturnValue(of({}));
+        jest.spyOn(assessmentsService, 'deleteExampleAssessment').mockReturnValue(of(undefined));
 
         // WHEN
         fixture.detectChanges();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] *Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] *I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [ ] *I implemented the changes with a good performance and prevented too many database calls.
- [ ] *I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] *I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [ ] *I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] *I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] *I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

[ ] * - not needed

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently whenever an instructor creates an example submission, an empty example assessment is automatically created.
This causes issues with assessment (tutor) training, since even example submissions with empty example assessments are shown to the tutors. This PR fixes the issue and hence shows to the tutors only the example submissions that have a corresponding assessment created by instructor.

### Description
<!-- Describe your changes in detail -->
Example assessment is now not created automatically with example submission, as well as when clicking on edit example submission button, not only feedback but also the whole example assessment is removed. 

### Steps for Testing

<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Tutor

Tutors should not see example submissions without example assessments

1. Log in to Artemis as **Instructor**
2. Navigate to Course Management and pick a course
3. Navigate to a Text or Modeling Exercise
4. Create 2 Example Submissions. One with and the second without example assessment
5. Log in as **tutor**
6. Navigate to Course Management and then Exercise Dashboard of the previously mentioned exercise.
7. You should be able to read/assess only those example submission, that have an assessment (see screenshot)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

#### After
Tutors should see only those example submissions that have example assessment created by the instructor.

<img width="1206" alt="Screenshot 2021-11-30 at 2 52 00 AM" src="https://user-images.githubusercontent.com/51077603/143971577-5d7c548a-28aa-415c-9390-10dd16bc3da1.png">

https://user-images.githubusercontent.com/51077603/144029924-23d27f7a-a714-41a1-911b-539b6b70be49.mov

