### PR TITLE
`Assessment`: Add general feedback in example submissions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/TutorParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TutorParticipationService.java
@@ -177,10 +177,13 @@ public class TutorParticipationService {
                 }
                 return isMatch;
             });
+            if (hasMatchingInstructorFeedback) {
+                return Optional.empty();
+            }
 
-            var highestPriorityError = matchingInstructorFeedback.stream().map(feedback -> tutorFeedbackMatchesInstructorFeedback(tutorFeedback, feedback).get())
-                    .sorted(Comparator.reverseOrder()).findFirst();
-            return hasMatchingInstructorFeedback ? Optional.empty() : highestPriorityError;
+            // Return the highest priority error (the closest instructor feedback match)
+            return matchingInstructorFeedback.stream().map(feedback -> tutorFeedbackMatchesInstructorFeedback(tutorFeedback, feedback).get()).sorted(Comparator.reverseOrder())
+                    .findFirst();
         }
         else {
             if (matchingInstructorFeedback.size() > 1) {

--- a/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
+++ b/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
@@ -1,7 +1,7 @@
 <div (drop)="updateAssessmentOnDrop($event)" (dragover)="$event.preventDefault()" class="card mb-3">
     <div class="card-header" [class.color-cyan]="assessment.type == FeedbackType_AUTOMATIC">
         <jhi-grading-instruction-link-icon *ngIf="assessment.gradingInstruction!" [assessment]="assessment"></jhi-grading-instruction-link-icon>
-        <fa-icon [icon]="'trash-alt'" class="float-end" (click)="delete()" *ngIf="!disabled"></fa-icon>
+        <fa-icon [icon]="'trash-alt'" class="float-end" (click)="delete()" *ngIf="!readOnly"></fa-icon>
         <span class="badge bg-secondary float-end" *ngIf="assessment.type == FeedbackType_AUTOMATIC" title="{{ 'artemisApp.assessment.automaticGenerated' | artemisTranslate }}">
             <fa-icon [icon]="'robot'"></fa-icon>
             <span jhiTranslate="artemisApp.textAssessment.automatic">Automatic</span>
@@ -52,6 +52,21 @@
                     [required]="assessment.gradingInstruction ? false : true"
                 ></textarea>
             </div>
+        </div>
+        <!-- Text showing whether the tutor feedback is correct or not (upon validation on the server) -->
+        <div *ngIf="assessment.correctionStatus != undefined">
+            <span *ngIf="assessment.correctionStatus === 'CORRECT'" class="text-success"
+                >{{ 'artemisApp.exampleSubmission.feedback.' + assessment.correctionStatus! | artemisTranslate }}
+            </span>
+            <span *ngIf="assessment.correctionStatus !== 'CORRECT'" class="text-danger"
+                >{{ 'artemisApp.exampleSubmission.feedback.' + assessment.correctionStatus! | artemisTranslate }}
+            </span>
+
+            <!-- :warning: emoji was rendered as a black-white glyph, hence the solution with the fa-icon -->
+            <fa-layers *ngIf="assessment.correctionStatus != 'CORRECT'">
+                <fa-icon class="text-warning" [icon]="'exclamation-triangle'"></fa-icon>
+                <fa-icon [icon]="'exclamation'" size="2x" [styles]="{ width: '16px', 'margin-top': '-6px' }" [classes]="['text-dark']" transform="shrink-10"></fa-icon>
+            </fa-layers>
         </div>
 
         <jhi-assessment-correction-round-badge [feedback]="assessment" [highlightDifferences]="highlightDifferences"></jhi-assessment-correction-round-badge>

--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
@@ -76,7 +76,7 @@
             <button
                 class="btn btn-primary px-5"
                 (click)="checkAssessment()"
-                [disabled]="!feedbacks || !assessmentsAreValid"
+                [disabled]="!assessments || !assessmentsAreValid"
                 jhiTranslate="artemisApp.exampleSubmission.submitAssessment"
             >
                 Submit Assessment
@@ -111,7 +111,7 @@
                         [totalScore]="totalScore"
                         [readOnly]="readOnly"
                         [course]="course"
-                        (feedbackChanged)="onFeedbackChanged($event)"
+                        (feedbackChanged)="onReferencedFeedbackChanged($event)"
                     >
                     </jhi-modeling-assessment>
                 </div>
@@ -140,6 +140,14 @@
                     [(ngModel)]="assessmentExplanation"
                     [disabled]="readOnly"
                 ></textarea>
+
+                <jhi-unreferenced-feedback
+                    *ngIf="assessmentMode"
+                    [(feedbacks)]="unreferencedFeedback"
+                    [readOnly]="readOnly"
+                    [addReferenceIdForExampleSubmission]="true"
+                    (feedbacksChange)="onUnReferencedFeedbackChanged($event)"
+                ></jhi-unreferenced-feedback>
             </div>
 
             <jhi-collapsable-assessment-instructions class="col-auto pe-2" *ngIf="exercise" [readOnly]="readOnly" [exercise]="exercise" [collapsed]="!readOnly && !toComplete">

--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.ts
@@ -10,7 +10,7 @@ import { TutorParticipationService } from 'app/exercises/shared/dashboards/tutor
 import { UMLModel } from '@ls1intum/apollon';
 import { ModelingEditorComponent } from 'app/exercises/modeling/shared/modeling-editor.component';
 import { ExampleSubmission } from 'app/entities/example-submission.model';
-import { Feedback, FeedbackCorrectionError } from 'app/entities/feedback.model';
+import { Feedback, FeedbackCorrectionError, FeedbackType } from 'app/entities/feedback.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { ModelingAssessmentService } from 'app/exercises/modeling/assess/modeling-assessment.service';
 import { ModelingSubmission } from 'app/entities/modeling-submission.model';
@@ -44,7 +44,6 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
     modelingSubmission: ModelingSubmission;
     umlModel: UMLModel;
     explanationText: string;
-    feedbacks: Feedback[] = [];
     feedbackChanged = false;
     assessmentsAreValid = false;
     result: Result;
@@ -85,6 +84,12 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
     ];
 
     private exampleSubmissionId: number;
+
+    referencedFeedback: Feedback[] = [];
+    unreferencedFeedback: Feedback[] = [];
+    get assessments(): Feedback[] {
+        return [...this.referencedFeedback, ...this.unreferencedFeedback];
+    }
 
     constructor(
         private exerciseService: ExerciseService,
@@ -152,10 +157,7 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
             }
 
             this.modelingAssessmentService.getExampleAssessment(this.exerciseId, this.modelingSubmission.id!).subscribe((result) => {
-                if (result) {
-                    this.result = result;
-                    this.feedbacks = this.result.feedbacks || [];
-                }
+                this.updateAssessment(result);
                 this.checkScoreBoundaries();
             });
         });
@@ -216,7 +218,7 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
         this.modelingSubmission.explanationText = this.explanationText;
         this.modelingSubmission.exampleSubmission = true;
         if (this.result) {
-            this.result.feedbacks = this.feedbacks;
+            this.result.feedbacks = this.referencedFeedback.concat(this.unreferencedFeedback);
             setLatestSubmissionResult(this.modelingSubmission, this.result);
             delete this.result.submission;
         }
@@ -248,8 +250,14 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
         );
     }
 
-    onFeedbackChanged(feedbacks: Feedback[]) {
-        this.feedbacks = feedbacks;
+    onReferencedFeedbackChanged(referencedFeedback: Feedback[]) {
+        this.referencedFeedback = referencedFeedback;
+        this.feedbackChanged = true;
+        this.checkScoreBoundaries();
+    }
+
+    onUnReferencedFeedbackChanged(unreferencedFeedback: Feedback[]) {
+        this.unreferencedFeedback = unreferencedFeedback;
         this.feedbackChanged = true;
         this.checkScoreBoundaries();
     }
@@ -283,11 +291,11 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
             this.alertService.error('modelingAssessment.invalidAssessments');
             return;
         }
-        if (this.assessmentExplanation !== this.exampleSubmission.assessmentExplanation && this.feedbacks) {
+        if (this.assessmentExplanation !== this.exampleSubmission.assessmentExplanation && this.assessments) {
             this.updateAssessmentExplanationAndExampleAssessment();
         } else if (this.assessmentExplanation !== this.exampleSubmission.assessmentExplanation) {
             this.updateAssessmentExplanation();
-        } else if (this.feedbacks) {
+        } else if (this.assessments) {
             this.updateExampleAssessment();
         }
     }
@@ -301,14 +309,11 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
                     this.exampleSubmission = exampleSubmissionResponse.body!;
                     this.assessmentExplanation = this.exampleSubmission.assessmentExplanation!;
                 }),
-                concatMap(() => this.modelingAssessmentService.saveExampleAssessment(this.feedbacks, this.exampleSubmissionId)),
+                concatMap(() => this.modelingAssessmentService.saveExampleAssessment(this.assessments, this.exampleSubmissionId)),
             )
             .subscribe(
                 (result: Result) => {
-                    this.result = result;
-                    if (this.result) {
-                        this.feedbacks = this.result.feedbacks!;
-                    }
+                    this.updateAssessment(result);
                     this.alertService.success('modelingAssessmentEditor.messages.saveSuccessful');
                 },
                 () => {
@@ -329,12 +334,9 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
     }
 
     private updateExampleAssessment() {
-        this.modelingAssessmentService.saveExampleAssessment(this.feedbacks, this.exampleSubmissionId).subscribe(
+        this.modelingAssessmentService.saveExampleAssessment(this.assessments, this.exampleSubmissionId).subscribe(
             (result: Result) => {
-                this.result = result;
-                if (this.result) {
-                    this.feedbacks = this.result.feedbacks!;
-                }
+                this.updateAssessment(result);
                 this.alertService.success('modelingAssessmentEditor.messages.saveSuccessful');
             },
             () => {
@@ -349,14 +351,13 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
      * because a score is not a number/empty.
      */
     public checkScoreBoundaries() {
-        if (!this.feedbacks || this.feedbacks.length === 0) {
+        if (this.assessments.length === 0) {
             this.totalScore = 0;
             this.assessmentsAreValid = true;
             return;
         }
 
-        const credits = this.feedbacks.map((feedback) => feedback.credits);
-
+        const credits = this.assessments.map((feedback) => feedback.credits);
         if (!credits.every((credit) => credit != undefined && !isNaN(credit))) {
             this.invalidError = 'The score field must be a number and can not be empty!';
             this.assessmentsAreValid = false;
@@ -404,27 +405,27 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
         const result = new Result();
         setLatestSubmissionResult(exampleSubmission.submission, result);
         delete result.submission;
-        getLatestSubmissionResult(exampleSubmission.submission)!.feedbacks = this.feedbacks;
+        getLatestSubmissionResult(exampleSubmission.submission)!.feedbacks = this.assessments;
 
         const command = new ExampleSubmissionAssessCommand(this.tutorParticipationService, this.alertService, this);
         command.assessExampleSubmission(exampleSubmission, this.exerciseId);
     }
 
     markAllFeedbackToCorrect() {
-        this.feedbacks.forEach((feedback) => {
+        this.assessments.forEach((feedback) => {
             feedback.correctionStatus = 'CORRECT';
         });
-        this.assessmentEditor.resultFeedbacks = this.feedbacks;
+        this.assessmentEditor.resultFeedbacks = this.referencedFeedback;
     }
 
     markWrongFeedback(correctionErrors: FeedbackCorrectionError[]) {
         correctionErrors.forEach((correctionError) => {
-            const validatedFeedback = this.feedbacks.find((feedback) => feedback.reference === correctionError.reference);
+            const validatedFeedback = this.assessments.find((feedback) => feedback.reference === correctionError.reference);
             if (validatedFeedback != undefined) {
                 validatedFeedback.correctionStatus = correctionError.type;
             }
         });
-        this.assessmentEditor.resultFeedbacks = this.feedbacks;
+        this.assessmentEditor.resultFeedbacks = this.referencedFeedback;
     }
 
     readAndUnderstood() {
@@ -432,5 +433,13 @@ export class ExampleModelingSubmissionComponent implements OnInit, FeedbackMarke
             this.alertService.success('artemisApp.exampleSubmission.readSuccessfully');
             this.back();
         });
+    }
+
+    private updateAssessment(result: Result) {
+        this.result = result;
+        if (result) {
+            this.referencedFeedback = result.feedbacks?.filter((feedback) => feedback.type !== FeedbackType.MANUAL_UNREFERENCED) || [];
+            this.unreferencedFeedback = result.feedbacks?.filter((feedback) => feedback.type === FeedbackType.MANUAL_UNREFERENCED) || [];
+        }
     }
 }

--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.module.ts
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.module.ts
@@ -7,6 +7,7 @@ import { AssessmentInstructionsModule } from 'app/assessment/assessment-instruct
 import { ArtemisSharedModule } from 'app/shared/shared.module';
 import { ArtemisResultModule } from 'app/exercises/shared/result/result.module';
 import { ModelingAssessmentModule } from 'app/exercises/modeling/assess/modeling-assessment.module';
+import { ArtemisAssessmentSharedModule } from 'app/assessment/assessment-shared.module';
 
 @NgModule({
     imports: [
@@ -15,6 +16,7 @@ import { ModelingAssessmentModule } from 'app/exercises/modeling/assess/modeling
         ArtemisModelingEditorModule,
         ArtemisExampleModelingSubmissionRoutingModule,
         ModelingAssessmentModule,
+        ArtemisAssessmentSharedModule,
         AssessmentInstructionsModule,
         ClipboardModule,
     ],

--- a/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.html
+++ b/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.html
@@ -9,7 +9,7 @@
         </div>
         <div *ngFor="let assessment of unreferencedFeedback; let i = index" class="col-12 col-lg-6 col-xl-6">
             <jhi-assessment-detail
-                *ngIf="assessment.reference == null"
+                *ngIf="assessment.type === FeedbackType.MANUAL_UNREFERENCED"
                 [(assessment)]="unreferencedFeedback[i]"
                 (assessmentChange)="updateAssessment(assessment)"
                 (deleteAssessment)="deleteAssessment($event)"

--- a/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.ts
+++ b/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.ts
@@ -12,8 +12,6 @@ export class UnreferencedFeedbackComponent {
     unreferencedFeedback: Feedback[] = [];
     assessmentsAreValid: boolean;
 
-    private unreferencedFeedbackId = 1;
-
     @Input() busy: boolean;
     @Input() readOnly: boolean;
     @Input() highlightDifferences: boolean;
@@ -68,12 +66,29 @@ export class UnreferencedFeedbackComponent {
 
         // Assign the next id to the unreferenced feedback
         if (this.addReferenceIdForExampleSubmission) {
-            feedback.reference = this.unreferencedFeedbackId.toString();
-            this.unreferencedFeedbackId++;
+            feedback.reference = this.generateNewUnreferencedFeedbackReference().toString();
         }
 
         this.unreferencedFeedback.push(feedback);
         this.validateFeedback();
         this.feedbacksChange.emit(this.unreferencedFeedback);
+    }
+
+    /**
+     * Generate the new reference, by computing what is currently the maximum reference within all feedback and add 1
+     */
+    private generateNewUnreferencedFeedbackReference(): number {
+        if (this.unreferencedFeedback.length === 0) {
+            return 1;
+        }
+
+        const references = this.unreferencedFeedback.map((feedback) => {
+            const id = +(feedback.reference ?? '0');
+            if (isNaN(id)) {
+                return 0;
+            }
+            return id;
+        });
+        return Math.max(...references.concat([0])) + 1;
     }
 }

--- a/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.ts
+++ b/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.ts
@@ -7,17 +7,26 @@ import { Feedback, FeedbackType } from 'app/entities/feedback.model';
     styleUrls: [],
 })
 export class UnreferencedFeedbackComponent {
+    FeedbackType = FeedbackType;
+
     unreferencedFeedback: Feedback[] = [];
     assessmentsAreValid: boolean;
+
     @Input() busy: boolean;
     @Input() readOnly: boolean;
     @Input() highlightDifferences: boolean;
 
-    @Output() feedbacksChange = new EventEmitter<Feedback[]>();
+    /**
+     * In order to make it possible to mark unreferenced feedback based on the correction status, we assign reference ids to the unreferenced feedback
+     */
+    @Input() addReferenceIdForExampleSubmission = false;
 
     @Input() set feedbacks(feedbacks: Feedback[]) {
         this.unreferencedFeedback = [...feedbacks];
     }
+
+    @Output() feedbacksChange = new EventEmitter<Feedback[]>();
+
     public deleteAssessment(assessmentToDelete: Feedback): void {
         const indexToDelete = this.unreferencedFeedback.indexOf(assessmentToDelete);
         this.unreferencedFeedback.splice(indexToDelete, 1);
@@ -54,6 +63,11 @@ export class UnreferencedFeedbackComponent {
         const feedback = new Feedback();
         feedback.credits = 0;
         feedback.type = FeedbackType.MANUAL_UNREFERENCED;
+
+        if (this.addReferenceIdForExampleSubmission) {
+            feedback.reference = (this.unreferencedFeedback.length + 1).toString();
+        }
+
         this.unreferencedFeedback.push(feedback);
         this.validateFeedback();
         this.feedbacksChange.emit(this.unreferencedFeedback);

--- a/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.ts
+++ b/src/main/webapp/app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component.ts
@@ -12,6 +12,8 @@ export class UnreferencedFeedbackComponent {
     unreferencedFeedback: Feedback[] = [];
     assessmentsAreValid: boolean;
 
+    private unreferencedFeedbackId = 1;
+
     @Input() busy: boolean;
     @Input() readOnly: boolean;
     @Input() highlightDifferences: boolean;
@@ -64,8 +66,10 @@ export class UnreferencedFeedbackComponent {
         feedback.credits = 0;
         feedback.type = FeedbackType.MANUAL_UNREFERENCED;
 
+        // Assign the next id to the unreferenced feedback
         if (this.addReferenceIdForExampleSubmission) {
-            feedback.reference = (this.unreferencedFeedback.length + 1).toString();
+            feedback.reference = this.unreferencedFeedbackId.toString();
+            this.unreferencedFeedbackId++;
         }
 
         this.unreferencedFeedback.push(feedback);

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
@@ -122,6 +122,14 @@
     <!--endregion-->
 </jhi-resizeable-container>
 
+<jhi-unreferenced-feedback
+    *ngIf="state.ui === UIStates.ASSESSMENT"
+    [(feedbacks)]="unreferencedFeedback"
+    [readOnly]="readOnly"
+    [addReferenceIdForExampleSubmission]="true"
+    (feedbacksChange)="validateFeedback()"
+></jhi-unreferenced-feedback>
+
 <div class="col-12 text-end pt-2" *ngIf="toComplete">
     <button class="btn btn-primary col-3 guided-tour-check-assessment" (click)="checkAssessment()" [disabled]="!assessmentsAreValid" id="checkAssessment">
         {{ 'artemisApp.exampleSubmission.submitAssessment' | artemisTranslate }}

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
@@ -305,7 +305,7 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
      * Validate the feedback of the assessment
      */
     validateFeedback(): void {
-        this.assessmentsAreValid = this.referencedFeedback.filter(Feedback.isPresent).length > 0;
+        this.assessmentsAreValid = this.assessments.length > 0;
         this.totalScore = this.computeTotalScore(this.assessments);
 
         if (this.guidedTourService.currentTour && this.toComplete) {

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
@@ -12,7 +12,7 @@ import { GuidedTourService } from 'app/guided-tour/guided-tour.service';
 import { tutorAssessmentTour } from 'app/guided-tour/tours/tutor-assessment-tour';
 import { TextSubmissionService } from 'app/exercises/text/participate/text-submission.service';
 import { ExampleSubmission } from 'app/entities/example-submission.model';
-import { Feedback, FeedbackCorrectionError } from 'app/entities/feedback.model';
+import { Feedback, FeedbackCorrectionError, FeedbackType } from 'app/entities/feedback.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { ResultService } from 'app/exercises/shared/result/result.service';
 import { TextExercise } from 'app/entities/text-exercise.model';
@@ -41,7 +41,7 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
     exampleSubmission = new ExampleSubmission();
     assessmentsAreValid = false;
     result?: Result;
-    private unreferencedFeedback: Feedback[] = [];
+    unreferencedFeedback: Feedback[] = [];
     totalScore: number;
     readOnly: boolean;
     toComplete: boolean;
@@ -264,10 +264,14 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
         command.assessExampleSubmission(this.exampleSubmissionForNetwork(), this.exerciseId);
     }
 
+    /**
+     * Mark all referenced and unreferenced feedback as 'CORRECT'
+     */
     markAllFeedbackToCorrect() {
         this.textBlockRefs
             .map((ref) => ref.feedback)
             .filter((feedback) => feedback != undefined)
+            .concat(this.unreferencedFeedback)
             .forEach((feedback) => {
                 feedback!.correctionStatus = 'CORRECT';
             });
@@ -278,6 +282,11 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
             const textBlockRef = this.textBlockRefs.find((ref) => ref.feedback?.reference === correctionError.reference);
             if (textBlockRef != undefined && textBlockRef.feedback != undefined) {
                 textBlockRef.feedback.correctionStatus = correctionError.type;
+            } else {
+                const unreferencedFeedbackToBeMarked = this.unreferencedFeedback.find((feedback) => feedback.reference === correctionError.reference);
+                if (unreferencedFeedbackToBeMarked) {
+                    unreferencedFeedbackToBeMarked.correctionStatus = correctionError.type;
+                }
             }
         });
     }
@@ -318,6 +327,10 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
     private prepareTextBlocksAndFeedbacks() {
         const matchBlocksWithFeedbacks = TextAssessmentService.matchBlocksWithFeedbacks(this.submission?.blocks || [], this.result?.feedbacks || []);
         this.sortAndSetTextBlockRefs(matchBlocksWithFeedbacks, this.textBlockRefs, this.unusedTextBlockRefs, this.submission);
+
+        if (!this.toComplete) {
+            this.unreferencedFeedback = this.result?.feedbacks?.filter((feedback) => feedback.type === FeedbackType.MANUAL_UNREFERENCED) ?? [];
+        }
     }
 
     editSubmission(): void {

--- a/src/test/java/de/tum/in/www1/artemis/TutorParticipationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TutorParticipationIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
 import de.tum.in.www1.artemis.domain.enumeration.TutorParticipationStatus;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.participation.TutorParticipation;
@@ -121,6 +122,26 @@ public class TutorParticipationIntegrationTest extends AbstractSpringIntegration
     }
 
     /**
+     * Tests when tutor provides unnecessry unreferenced feedback in text example assessment, bad request exception is thrown
+     */
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testTutorParticipateInTextExerciseWithExampleSubmissionAddingUnnecessaryUnreferencedFeedbackBadRequest() throws Exception {
+        ExampleSubmission exampleSubmission = prepareTextExampleSubmission(true);
+
+        // Tutor reviewed the instructions.
+        var tutor = database.getUserByLogin("tutor1");
+        var tutorParticipation = new TutorParticipation().tutor(tutor).status(TutorParticipationStatus.REVIEWED_INSTRUCTIONS);
+        tutorParticipationService.createNewParticipation(textExercise, tutor);
+        exampleSubmission.addTutorParticipations(tutorParticipation);
+        exampleSubmissionService.save(exampleSubmission);
+
+        exampleSubmission.getSubmission().getLatestResult().addFeedback(ModelFactory.createPositiveFeedback(FeedbackType.MANUAL_UNREFERENCED));
+        var path = "/api/exercises/" + textExercise.getId() + "/assess-example-submission";
+        request.postWithResponseBody(path, exampleSubmission, TutorParticipation.class, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
      * Tests the tutor training with example submission in Modelling exercises.
      * In case tutor has provided a feedback which was not provided by the instructor, response is BAD_REQUEST.
      */
@@ -137,6 +158,26 @@ public class TutorParticipationIntegrationTest extends AbstractSpringIntegration
         exampleSubmissionService.save(exampleSubmission);
 
         exampleSubmission.getSubmission().getLatestResult().addFeedback(ModelFactory.createManualTextFeedback(1D, "6aba5764-d102-4740-9675-b2bd0a4f2680"));
+        var path = "/api/exercises/" + textExercise.getId() + "/assess-example-submission";
+        request.postWithResponseBody(path, exampleSubmission, TutorParticipation.class, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * Tests when tutor provides unnecessry unreferenced feedback in modeling example assessment, bad request exception is thrown
+     */
+    @Test
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testTutorParticipateInModelingExerciseWithExampleSubmissionAddingUnnecessaryUnreferencedFeedbackBadRequest() throws Exception {
+        ExampleSubmission exampleSubmission = prepareModelingExampleSubmission(true);
+
+        // Tutor reviewed the instructions.
+        var tutor = database.getUserByLogin("tutor1");
+        var tutorParticipation = new TutorParticipation().tutor(tutor).status(TutorParticipationStatus.REVIEWED_INSTRUCTIONS);
+        tutorParticipationService.createNewParticipation(textExercise, tutor);
+        exampleSubmission.addTutorParticipations(tutorParticipation);
+        exampleSubmissionService.save(exampleSubmission);
+
+        exampleSubmission.getSubmission().getLatestResult().addFeedback(ModelFactory.createPositiveFeedback(FeedbackType.MANUAL_UNREFERENCED));
         var path = "/api/exercises/" + textExercise.getId() + "/assess-example-submission";
         request.postWithResponseBody(path, exampleSubmission, TutorParticipation.class, HttpStatus.BAD_REQUEST);
     }

--- a/src/test/javascript/spec/component/assessment-shared/assessment-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-detail.component.spec.ts
@@ -4,7 +4,7 @@ import { MockComponent, MockModule, MockPipe, MockDirective, MockProvider } from
 import { Feedback } from 'app/entities/feedback.model';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
-import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { FaIconComponent, FaLayersComponent } from '@fortawesome/angular-fontawesome';
 import { GradingInstruction } from 'app/exercises/shared/structured-grading-criterion/grading-instruction.model';
 import { AssessmentDetailComponent } from 'app/assessment/assessment-detail/assessment-detail.component';
 import { GradingInstructionLinkIconComponent } from 'app/shared/grading-instruction-link-icon/grading-instruction-link-icon.component';
@@ -25,6 +25,7 @@ describe('Assessment Detail Component', () => {
                 AssessmentDetailComponent,
                 MockComponent(GradingInstructionLinkIconComponent),
                 MockComponent(FaIconComponent),
+                MockComponent(FaLayersComponent),
                 MockPipe(ArtemisTranslatePipe),
                 MockDirective(NgModel),
                 MockComponent(AssessmentCorrectionRoundBadgeComponent),

--- a/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
@@ -28,6 +28,7 @@ import { of, throwError } from 'rxjs';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { ArtemisTestModule } from '../../test.module';
 import { TextBlockRef } from 'app/entities/text-block-ref.model';
+import { UnreferencedFeedbackComponent } from 'app/exercises/shared/unreferenced-feedback/unreferenced-feedback.component';
 
 describe('ExampleTextSubmissionComponent', () => {
     let fixture: ComponentFixture<ExampleTextSubmissionComponent>;
@@ -60,6 +61,7 @@ describe('ExampleTextSubmissionComponent', () => {
                 MockComponent(ScoreDisplayComponent),
                 MockComponent(TextAssessmentAreaComponent),
                 MockComponent(AssessmentInstructionsComponent),
+                MockComponent(UnreferencedFeedbackComponent),
                 MockPipe(ArtemisTranslatePipe),
                 MockComponent(AlertComponent),
             ],


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] *Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] *I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] *I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] *I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [ ] *I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] *I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] *I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

[ ] * - not needed

### Motivation and Context
When tutors are assessing students' submission, they are able to create general (unreferenced) feedback.
However, this was not possible when tutors were assessing example submissions.
In this PR, we add the possibility to create general feedback for both text and modelling example submissions.

### Description
Added unreferenced-feedback to both text and modeling example submission editors.
Adjusted the tutor training logic to work with unreferenced feedback. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Tutor

1. Log in to Artemis as **Instructor**
2. Navigate to Course Management
3. Navigate to a text or modeling exercise
4. Create an example submission and example assessment with general feedback. Check **Tutors need to assess this submission** checkbox

1. Log in as **Tutor**
2. Navigate to Exercise Dashboard of the above mentioned exercise
3. Assess the example submission and observe that the system's messages are displayed as expected (tutor training logic is correct, see screenshot)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Tutor assessing an example submission and receiving systems' status for each feedback.
<img width="1858" alt="after" src="https://user-images.githubusercontent.com/51077603/143968790-27f28431-82a0-4958-98c8-43a688bbeab0.png">