### PR TITLE
`General`: Fix an issue with automatic authentication when launching exercises using LTI

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LtiResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LtiResource.java
@@ -96,8 +96,8 @@ public class LtiResource {
             return;
         }
 
-        log.info("Request header X-Forwarded-Proto: {}", request.getHeader("X-Forwarded-Proto"));
-        log.info("Request header X-Forwarded-For: {}", request.getHeader("X-Forwarded-For"));
+        log.debug("Request header X-Forwarded-Proto: {}", request.getHeader("X-Forwarded-Proto"));
+        log.debug("Request header X-Forwarded-For: {}", request.getHeader("X-Forwarded-For"));
 
         if (!request.getRequestURL().toString().startsWith("https")) {
             log.error("The request url {} does not start with 'https'. Verification of the request will most probably fail."
@@ -105,7 +105,7 @@ public class LtiResource {
                     + "X-Forwarded-Proto and forward-headers-strategy: native", request.getRequestURL().toString());
         }
 
-        log.info("Try to verify LTI Oauth Request");
+        log.debug("Try to verify LTI Oauth Request");
 
         // Verify request
         String error = ltiService.verifyRequest(request);
@@ -115,7 +115,7 @@ public class LtiResource {
             return;
         }
 
-        log.info("Oauth Verification succeeded");
+        log.debug("Oauth Verification succeeded");
 
         // Check if exercise ID is valid
         Optional<Exercise> optionalExercise = exerciseRepository.findById(exerciseId);
@@ -125,7 +125,7 @@ public class LtiResource {
         }
 
         Exercise exercise = optionalExercise.get();
-        log.info("found exercise {}", exercise.getTitle());
+        log.debug("found exercise {}", exercise.getTitle());
         // Handle the launch request using LtiService
         try {
             ltiService.handleLaunchRequest(launchRequest, exercise);
@@ -136,19 +136,19 @@ public class LtiResource {
             return;
         }
 
-        log.info("handleLaunchRequest done");
+        log.debug("handleLaunchRequest done");
 
         // If the current user was created within the last 15 minutes, we just created the user
         // Display a welcome message to the user
         boolean isNewUser = SecurityUtils.isAuthenticated()
                 && TimeUnit.SECONDS.toMinutes(timeService.now().toEpochSecond() - userRepository.getUser().getCreatedDate().getEpochSecond()) < 15;
 
-        log.info("isNewUser: {}", isNewUser);
+        log.debug("isNewUser: {}", isNewUser);
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String jwt = tokenProvider.createToken(authentication, true);
 
-        log.info("created jwt token: {}", jwt);
+        log.debug("created jwt token: {}", jwt);
 
         // Note: The following redirect URL has to match the URL in user-route-access-service.ts in the method canActivate(...)
 

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -64,7 +64,6 @@ export class AccountService implements IAccountService {
     }
 
     private fetch(): Observable<HttpResponse<User>> {
-        console.log('fetch api/account');
         return this.http.get<User>(SERVER_API_URL + 'api/account', { observe: 'response' });
     }
 

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -64,6 +64,7 @@ export class AccountService implements IAccountService {
     }
 
     private fetch(): Observable<HttpResponse<User>> {
+        console.log('fetch api/account');
         return this.http.get<User>(SERVER_API_URL + 'api/account', { observe: 'response' });
     }
 

--- a/src/main/webapp/app/core/auth/account.service.ts
+++ b/src/main/webapp/app/core/auth/account.service.ts
@@ -14,7 +14,6 @@ import { Authority } from 'app/shared/constants/authority.constants';
 import { TranslateService } from '@ngx-translate/core';
 
 export interface IAccountService {
-    fetch: () => Observable<HttpResponse<User>>;
     save: (account: any) => Observable<HttpResponse<any>>;
     authenticate: (identity?: User) => void;
     hasAnyAuthority: (authorities: string[]) => Promise<boolean>;
@@ -64,7 +63,7 @@ export class AccountService implements IAccountService {
         }
     }
 
-    fetch(): Observable<HttpResponse<User>> {
+    private fetch(): Observable<HttpResponse<User>> {
         return this.http.get<User>(SERVER_API_URL + 'api/account', { observe: 'response' });
     }
 

--- a/src/main/webapp/app/core/auth/user-route-access-service.ts
+++ b/src/main/webapp/app/core/auth/user-route-access-service.ts
@@ -28,17 +28,8 @@ export class UserRouteAccessService implements CanActivate {
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | Promise<boolean> {
         // save the jwt token from get parameter for lti launch requests for online course users
         // Note: The following URL has to match the redirect URL in LtiResource.java in the method launch(...) shortly before the return
-        console.log('canActivate-> route.routeConfig!.path:' + route.routeConfig!.path);
-        console.log('canActivate-> route.queryParams:' + route.queryParams);
-        console.log('canActivate-> route.queryParams:' + route.queryParams['jwt']);
         const regexPattern = new RegExp(/\/courses\/\d+\/exercises\/\d+\?jwt=\w+/g);
         if (regexPattern.test(state.url) && route.queryParams['jwt']) {
-            console.log('regex hit with url: ' + state.url + ' and query param: ' + route.queryParams['jwt']);
-            const jwt = route.queryParams['jwt'];
-            this.localStorage.store('authenticationToken', jwt);
-            // TODO: remove old code below
-        } else if (route.routeConfig!.path === 'courses/:courseId/exercises/:exerciseId' && route.queryParams['jwt']) {
-            console.log('canActivate with path: ' + route.routeConfig!.path + ' and query param: ' + route.queryParams['jwt']);
             const jwt = route.queryParams['jwt'];
             this.localStorage.store('authenticationToken', jwt);
         }
@@ -86,7 +77,6 @@ export class UserRouteAccessService implements CanActivate {
      * @return {Promise<boolean>} True if authorities are empty or null, False if user not logged in or does not have required authorities.
      */
     checkLogin(authorities: string[], url: string): Promise<boolean> {
-        console.log('checkLogin: ' + authorities + ', url: ' + url);
         const accountService = this.accountService;
         return Promise.resolve(
             accountService.identity().then((account) => {
@@ -106,7 +96,6 @@ export class UserRouteAccessService implements CanActivate {
                     });
                 }
 
-                console.log('storeUrl: ' + url + ' because no account in checkLogin');
                 this.stateStorageService.storeUrl(url);
                 this.router.navigate(['accessdenied']).then(() => {
                     // only show the login dialog, if the user hasn't logged in yet

--- a/src/main/webapp/app/core/auth/user-route-access-service.ts
+++ b/src/main/webapp/app/core/auth/user-route-access-service.ts
@@ -29,6 +29,7 @@ export class UserRouteAccessService implements CanActivate {
         // save the jwt token from get parameter for lti launch requests for online course users
         // Note: The following URL has to match the redirect URL in LtiResource.java in the method launch(...) shortly before the return
         if (route.routeConfig!.path === 'courses/:courseId/exercises/:exerciseId' && route.queryParams['jwt']) {
+            console.log('canActivate with path: ' + route.routeConfig!.path + ' and query param: ' + route.queryParams['jwt']);
             const jwt = route.queryParams['jwt'];
             this.localStorage.store('authenticationToken', jwt);
         }
@@ -76,6 +77,7 @@ export class UserRouteAccessService implements CanActivate {
      * @return {Promise<boolean>} True if authorities are empty or null, False if user not logged in or does not have required authorities.
      */
     checkLogin(authorities: string[], url: string): Promise<boolean> {
+        console.log('checkLogin: ' + authorities + ', url: ' + url);
         const accountService = this.accountService;
         return Promise.resolve(
             accountService.identity().then((account) => {
@@ -95,6 +97,7 @@ export class UserRouteAccessService implements CanActivate {
                     });
                 }
 
+                console.log('storeUrl: ' + url + ' because no account in checkLogin');
                 this.stateStorageService.storeUrl(url);
                 this.router.navigate(['accessdenied']).then(() => {
                     // only show the login dialog, if the user hasn't logged in yet

--- a/src/main/webapp/app/core/auth/user-route-access-service.ts
+++ b/src/main/webapp/app/core/auth/user-route-access-service.ts
@@ -28,6 +28,7 @@ export class UserRouteAccessService implements CanActivate {
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | Promise<boolean> {
         // save the jwt token from get parameter for lti launch requests for online course users
         // Note: The following URL has to match the redirect URL in LtiResource.java in the method launch(...) shortly before the return
+        console.log('canActivate-> route.routeConfig!.path:' + route.routeConfig!.path);
         if (route.routeConfig!.path === 'courses/:courseId/exercises/:exerciseId' && route.queryParams['jwt']) {
             console.log('canActivate with path: ' + route.routeConfig!.path + ' and query param: ' + route.queryParams['jwt']);
             const jwt = route.queryParams['jwt'];

--- a/src/main/webapp/app/core/auth/user-route-access-service.ts
+++ b/src/main/webapp/app/core/auth/user-route-access-service.ts
@@ -29,7 +29,15 @@ export class UserRouteAccessService implements CanActivate {
         // save the jwt token from get parameter for lti launch requests for online course users
         // Note: The following URL has to match the redirect URL in LtiResource.java in the method launch(...) shortly before the return
         console.log('canActivate-> route.routeConfig!.path:' + route.routeConfig!.path);
-        if (route.routeConfig!.path === 'courses/:courseId/exercises/:exerciseId' && route.queryParams['jwt']) {
+        console.log('canActivate-> route.queryParams:' + route.queryParams);
+        console.log('canActivate-> route.queryParams:' + route.queryParams['jwt']);
+        const regexPattern = new RegExp(/\/courses\/\d+\/exercises\/\d+\?jwt=\w+/g);
+        if (regexPattern.test(state.url) && route.queryParams['jwt']) {
+            console.log('regex hit with url: ' + state.url + ' and query param: ' + route.queryParams['jwt']);
+            const jwt = route.queryParams['jwt'];
+            this.localStorage.store('authenticationToken', jwt);
+            // TODO: remove old code below
+        } else if (route.routeConfig!.path === 'courses/:courseId/exercises/:exerciseId' && route.queryParams['jwt']) {
             console.log('canActivate with path: ' + route.routeConfig!.path + ' and query param: ' + route.queryParams['jwt']);
             const jwt = route.queryParams['jwt'];
             this.localStorage.store('authenticationToken', jwt);

--- a/src/main/webapp/app/core/interceptor/auth-expired.interceptor.ts
+++ b/src/main/webapp/app/core/interceptor/auth-expired.interceptor.ts
@@ -28,7 +28,6 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
                         if (err.status === 401 && this.authServerProvider.getToken() != undefined) {
                             // save the url before the logout navigates to another page in a constant
                             const currentUrl = this.router.routerState.snapshot.url;
-                            console.log('auth expired with currentUrl: ' + currentUrl);
                             this.loginService.logout(false);
 
                             // TODO: logging out the user automatically interferes with the canDeactivate functionality.

--- a/src/main/webapp/app/core/interceptor/auth-expired.interceptor.ts
+++ b/src/main/webapp/app/core/interceptor/auth-expired.interceptor.ts
@@ -28,6 +28,7 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
                         if (err.status === 401 && this.authServerProvider.getToken() != undefined) {
                             // save the url before the logout navigates to another page in a constant
                             const currentUrl = this.router.routerState.snapshot.url;
+                            console.log('auth expired with currentUrl: ' + currentUrl);
                             this.loginService.logout(false);
 
                             // TODO: logging out the user automatically interferes with the canDeactivate functionality.

--- a/src/main/webapp/app/exam/manage/test-runs/test-run-management.component.html
+++ b/src/main/webapp/app/exam/manage/test-runs/test-run-management.component.html
@@ -87,7 +87,7 @@
                     <td [width]="350">
                         <div class="w-100 text-end">
                             <div class="btn-group" *ngIf="course?.isAtLeastInstructor">
-                                <ng-container *ngIf="testRun.user && testRun.user.id == instructor.id; else notOwnerOfTestRun">
+                                <ng-container *ngIf="testRun.user?.id == instructor?.id; else notOwnerOfTestRun">
                                     <ng-container *ngIf="!testRun.submitted; else submitted">
                                         <a class="btn btn-primary btn-sm me-1 mb-1" [routerLink]="['../test-runs/' + testRun.id + '/conduction']">
                                             <span *ngIf="!testRun.started" jhiTranslate="artemisApp.course.startDate">Start</span>

--- a/src/main/webapp/app/exam/manage/test-runs/test-run-management.component.ts
+++ b/src/main/webapp/app/exam/manage/test-runs/test-run-management.component.ts
@@ -24,7 +24,7 @@ export class TestRunManagementComponent implements OnInit {
     isLoading: boolean;
     isExamStarted: boolean;
     testRuns: StudentExam[] = [];
-    instructor: User;
+    instructor?: User;
     private dialogErrorSource = new Subject<string>();
     dialogError$ = this.dialogErrorSource.asObservable();
     predicate: string;
@@ -58,9 +58,9 @@ export class TestRunManagementComponent implements OnInit {
             },
             (error: HttpErrorResponse) => onError(this.alertService, error),
         );
-        this.accountService.fetch().subscribe((res) => {
-            if (res.body != undefined) {
-                this.instructor = res.body;
+        this.accountService.identity().then((user) => {
+            if (user) {
+                this.instructor = user;
             }
         });
     }
@@ -121,7 +121,7 @@ export class TestRunManagementComponent implements OnInit {
     get testRunCanBeAssessed(): boolean {
         if (!!this.testRuns && this.testRuns.length > 0) {
             for (const testRun of this.testRuns) {
-                if (testRun.user?.id === this.instructor.id && testRun.submitted) {
+                if (testRun.user?.id === this.instructor?.id && testRun.submitted) {
                     return true;
                 }
             }

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -185,6 +185,8 @@ export class HomeComponent implements OnInit, AfterViewChecked {
             const redirect = this.stateStorageService.getUrl();
             if (redirect && redirect !== '') {
                 this.stateStorageService.storeUrl('');
+                // TODO: this does not work with query parameters in the URL, they somehow get escaped, e.g. https://artemis.ase.in.tum.de/courses/10/exercises/5017%3Fjwt%3Dabc
+                // instead of https://artemis.ase.in.tum.de/courses/10/exercises/5017?jwt=abc
                 this.router.navigate([redirect]);
             } else {
                 // TODO: Remove redirect after summer 2021 term. New deep links should no longer use /#.

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -185,9 +185,7 @@ export class HomeComponent implements OnInit, AfterViewChecked {
             const redirect = this.stateStorageService.getUrl();
             if (redirect && redirect !== '') {
                 this.stateStorageService.storeUrl('');
-                // TODO: this does not work with query parameters in the URL, they somehow get escaped, e.g. https://artemis.ase.in.tum.de/courses/10/exercises/5017%3Fjwt%3Dabc
-                // instead of https://artemis.ase.in.tum.de/courses/10/exercises/5017?jwt=abc
-                this.router.navigate([redirect]);
+                this.router.navigateByUrl(redirect);
             } else {
                 // TODO: Remove redirect after summer 2021 term. New deep links should no longer use /#.
                 const url = this.router.url.startsWith('/#') ? this.router.url.substr(2) : 'courses';

--- a/src/test/javascript/spec/service/user-route-access.service.spec.ts
+++ b/src/test/javascript/spec/service/user-route-access.service.spec.ts
@@ -1,5 +1,3 @@
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 import { ActivatedRouteSnapshot, Route } from '@angular/router';
@@ -20,11 +18,8 @@ import { mockedActivatedRouteSnapshot } from '../helpers/mocks/activated-route/m
 import { CourseExerciseDetailsComponent } from 'app/overview/exercise-details/course-exercise-details.component';
 import { Authority } from 'app/shared/constants/authority.constants';
 
-chai.use(sinonChai);
-const expect = chai.expect;
-
 describe('UserRouteAccessService', () => {
-    const routeStateMock: any = { snapshot: {}, url: '/' };
+    const routeStateMock: any = { snapshot: {}, url: '/courses/20/exercises/4512?jwt=testToken' };
     const route = 'courses/:courseId/exercises/:exerciseId';
     let fixture: ComponentFixture<CourseExerciseDetailsComponent>;
     let service: UserRouteAccessService;
@@ -68,6 +63,6 @@ describe('UserRouteAccessService', () => {
         snapshot.data = { authorities: [Authority.USER] };
 
         service.canActivate(snapshot, routeStateMock);
-        expect(MockSyncStorage.retrieve('authenticationToken')).to.equal('testToken');
+        expect(MockSyncStorage.retrieve('authenticationToken')).toEqual('testToken');
     });
 });


### PR DESCRIPTION
Due to the changes related to lazy loading in #4313 launching an exercise over LTI did not work anymore. I investigated the issue, `route.routeConfig!.path` was not set any more, I replaced the check with a regex pattern.

I also improved the code in the test run component, because components should not directly fetch the user identity from the server and instead use the `identity()` method which potentially uses a cached user object. `fetch()` is now private so that this wrong use does not occur any more.

I also noticed that redirection for not logged in users does not work correctly when query params are in the code. I left a TODO in the corresponding file because this is out of scope for this PR

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing

**LTI:**
1. Logout from Artemis
2. Launch an exercise using LTI (e.g. on edx)
3. Make sure the user is automatically logged in and the exercise details page is shown correctly

**Test runs:**
1. Create an exam
2. Create multiple test runs and make sure everything works correctly (including deletion of the test run)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

