### PR TITLE
`Programming exercises`: Fix an issue when creating external submissions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -220,6 +220,8 @@ public class ParticipationService {
             // fetch again to get additional objects
             ProgrammingExercise programmingExercise = programmingExerciseRepository.findByIdWithTemplateAndSolutionParticipationElseThrow(exercise.getId());
             ProgrammingExerciseStudentParticipation programmingParticipation = (ProgrammingExerciseStudentParticipation) participation;
+            // Note: we make sure to use the correct programming exercises here to avoid org.hibernate.LazyInitializationException later
+            programmingParticipation.setProgrammingExercise(programmingExercise);
             // Note: we need a repository, otherwise the student would not be possible to click resume (in case he wants to further participate after the deadline)
             programmingParticipation = copyRepository(programmingParticipation);
             programmingParticipation = configureRepository(programmingExercise, programmingParticipation);

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -28,7 +28,6 @@ import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
  * Service Implementation for managing Participation.
  */
 @Service
-// TODO: this class is too large. We need to split it into multiple smaller classes with fewer dependencies
 public class ParticipationService {
 
     private final Logger log = LoggerFactory.getLogger(ParticipationService.class);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
@@ -22,445 +22,445 @@ import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
 class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     @Autowired
-    private ProgrammingExerciseIntegrationServiceTest programmingExerciseIntegrationServiceTest;
+    private ProgrammingExerciseIntegrationTestService programmingExerciseIntegrationTestService;
 
     @BeforeEach
     void initTestCase() throws Exception {
         bitbucketRequestMockProvider.enableMockingOfRequests(true);
         bambooRequestMockProvider.enableMockingOfRequests(true);
-        programmingExerciseIntegrationServiceTest.setup(this, versionControlService);
+        programmingExerciseIntegrationTestService.setup(this, versionControlService);
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        programmingExerciseIntegrationServiceTest.tearDown();
+        programmingExerciseIntegrationTestService.tearDown();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseIsReleased_IsReleasedAndHasResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_IsReleasedAndHasResults();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseIsReleased_IsReleasedAndHasResults();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkIfProgrammingExerciseIsReleased_IsReleasedAndHasNoResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.checkIfProgrammingExerciseIsReleased_IsReleasedAndHasNoResults();
+        programmingExerciseIntegrationTestService.checkIfProgrammingExerciseIsReleased_IsReleasedAndHasNoResults();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     void testProgrammingExerciseIsReleased_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_forbidden();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseIsReleased_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectName() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectName();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectName();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds_addParticipantIdentifierToProjectNameError();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionAnonymizationCombining() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionAnonymizationCombining();
+        programmingExerciseIntegrationTestService.testExportSubmissionAnonymizationCombining();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByStudentLogins() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByStudentLogins();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByStudentLogins();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByStudentLogins_failToCreateZip() throws Exception {
         doThrow(IOException.class).when(zipFileService).createZipFile(any(Path.class), any(), eq(false));
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByStudentLogins_failToCreateZip();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByStudentLogins_failToCreateZip();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_invalidId_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete_invalidId_notFound();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete_invalidId_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExercise() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExercise();
+        programmingExerciseIntegrationTestService.testGetProgrammingExercise();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExerciseWithStructuredGradingInstruction() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithStructuredGradingInstruction();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithStructuredGradingInstruction();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testGetProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExercise_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testGetProgrammingExercise_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExerciseWithSetupParticipations() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithSetupParticipations();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithSetupParticipations();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     void testGetProgrammingExerciseWithJustTemplateAndSolutionParticipation() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithJustTemplateAndSolutionParticipation();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithJustTemplateAndSolutionParticipation();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testGetProgrammingExerciseWithSetupParticipations_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithSetupParticipations_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithSetupParticipations_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExerciseWithSetupParticipations_invalidId_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithSetupParticipations_invalidId_notFound();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithSetupParticipations_invalidId_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExercisesForCourse() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExercisesForCourse();
+        programmingExerciseIntegrationTestService.testGetProgrammingExercisesForCourse();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testGetProgrammingExercisesForCourse_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExercisesForCourse_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testGetProgrammingExercisesForCourse_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGenerateStructureOracle() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGenerateStructureOracle();
+        programmingExerciseIntegrationTestService.testGenerateStructureOracle();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidTemplateBuildPlan_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_invalidTemplateBuildPlan_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_invalidTemplateBuildPlan_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_idIsNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_idIsNull_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_idIsNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_staticCodeAnalysisMustNotChange_falseToTrue_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_staticCodeAnalysisMustNotChange_falseToTrue_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_staticCodeAnalysisMustNotChange_falseToTrue_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_staticCodeAnalysisMustNotChange_trueToFalse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_staticCodeAnalysisMustNotChange_trueToFalse_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_staticCodeAnalysisMustNotChange_trueToFalse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidTemplateVcs_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_invalidTemplateVcs_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_invalidTemplateVcs_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidSolutionBuildPlan_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_invalidSolutionBuildPlan_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_invalidSolutionBuildPlan_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidSolutionRepository_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_invalidSolutionRepository_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_invalidSolutionRepository_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_checkIfBuildPlanExistsFails_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_checkIfBuildPlanExistsFails_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_checkIfBuildPlanExistsFails_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_updatingCourseId_conflict() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExerciseShouldFailWithConflictWhenUpdatingCourseId();
+        programmingExerciseIntegrationTestService.updateProgrammingExerciseShouldFailWithConflictWhenUpdatingCourseId();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void updateTimeline_intructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTimeline_intructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.updateTimeline_intructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void updateTimeline_invalidId_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTimeline_invalidId_notFound();
+        programmingExerciseIntegrationTestService.updateTimeline_invalidId_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTimeline_ok() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTimeline_ok();
+        programmingExerciseIntegrationTestService.updateTimeline_ok();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void updateProblemStatement_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProblemStatement_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.updateProblemStatement_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProblemStatement_invalidId_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProblemStatement_invalidId_notFound();
+        programmingExerciseIntegrationTestService.updateProblemStatement_invalidId_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_exerciseIsNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_exerciseIsNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_exerciseIsNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_idIsNotNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_idIsNotNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_idIsNotNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_titleNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_titleNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_titleNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_titleContainsBadCharacter_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_titleContainsBadCharacter_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_titleContainsBadCharacter_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_invalidShortName_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_invalidShortName_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_invalidShortName_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_invalidCourseShortName_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_invalidCourseShortName_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_invalidCourseShortName_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_sameShortNameInCourse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_sameShortNameInCourse_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_sameShortNameInCourse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_shortNameContainsBadCharacters_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_shortNameContainsBadCharacters_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_shortNameContainsBadCharacters_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_noProgrammingLanguageSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_noProgrammingLanguageSet_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_noProgrammingLanguageSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_packageNameContainsBadCharacters_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_packageNameContainsBadCharacters_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_packageNameContainsBadCharacters_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_packageNameContainsKeyword_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_packageNameContainsKeyword_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_packageNameContainsKeyword_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_packageNameElementBeginsWithDigit_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_packageNameElementBeginsWithDigit_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_packageNameElementBeginsWithDigit_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_packageNameIsNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_packageNameIsNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_packageNameIsNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_maxScoreIsNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_maxScoreIsNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_maxScoreIsNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_noParticipationModeSelected_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_noParticipationModeSelected_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_noParticipationModeSelected_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_staticCodeAnalysisAndSequential_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_staticCodeAnalysisAndSequential_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_staticCodeAnalysisAndSequential_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_unsupportedProgrammingLanguageForStaticCodeAnalysis_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_unsupportedProgrammingLanguageForStaticCodeAnalysis_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_unsupportedProgrammingLanguageForStaticCodeAnalysis_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_noStaticCodeAnalysisButMaxPenalty_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_noStaticCodeAnalysisButMaxPenalty_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_noStaticCodeAnalysisButMaxPenalty_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_maxStaticCodePenaltyNegative_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_maxStaticCodePenaltyNegative_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_maxStaticCodePenaltyNegative_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_failToCheckIfProjectExistsInCi() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_failToCheckIfProjectExistsInCi();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_failToCheckIfProjectExistsInCi();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_projectTypeMissing_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_projectTypeMissing_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_projectTypeMissing_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_projectTypeNotExpected_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_projectTypeNotExpected_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_projectTypeNotExpected_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_onlineCodeEditorNotExpected_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_onlineCodeEditorNotExpected_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_onlineCodeEditorNotExpected_badRequest();
     }
 
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
@@ -468,296 +468,296 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     // It should fail for all ProgrammingExercises except Haskell and ocaml
     @EnumSource(value = ProgrammingLanguage.class, names = { "HASKELL", "OCAML" }, mode = EnumSource.Mode.EXCLUDE)
     public void createProgrammingExercise_checkoutSolutionRepositoryProgrammingLanguageNotSupported_badRequest(ProgrammingLanguage programmingLanguage) throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_checkoutSolutionRepositoryProgrammingLanguageNotSupported_badRequest(programmingLanguage);
+        programmingExerciseIntegrationTestService.createProgrammingExercise_checkoutSolutionRepositoryProgrammingLanguageNotSupported_badRequest(programmingLanguage);
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_invalidMaxScore_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_invalidMaxScore_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_invalidMaxScore_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_includedAsBonus_invalidBonusPoints_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_includedAsBonus_invalidBonusPoints_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_includedAsBonus_invalidBonusPoints_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_notIncluded_invalidBonusPoints_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_notIncluded_invalidBonusPoints_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_notIncluded_invalidBonusPoints_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_sourceExerciseIdNegative_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_sourceExerciseIdNegative_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_sourceExerciseIdNegative_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void importProgrammingExerciseMaxScoreNullBadRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExerciseMaxScoreNullBadRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExerciseMaxScoreNullBadRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_noParticipationModeSelected_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_noParticipationModeSelected_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_noParticipationModeSelected_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_noProgrammingLanguage_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_noProgrammingLanguage_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_noProgrammingLanguage_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_templateIdDoesNotExist_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_templateIdDoesNotExist_notFound();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_templateIdDoesNotExist_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_sameShortNameInCourse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_sameShortNameInCourse_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_sameShortNameInCourse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_sameTitleInCourse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_sameTitleInCourse_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_sameTitleInCourse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @CsvSource({ "false, false", "true, false", "false, true", })
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_scaChanged_badRequest(boolean recreateBuildPlan, boolean updateTemplate) throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_scaChanged_badRequest(recreateBuildPlan, updateTemplate);
+        programmingExerciseIntegrationTestService.importProgrammingExercise_scaChanged_badRequest(recreateBuildPlan, updateTemplate);
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void exportSubmissionsByStudentLogins_notInstructorForExercise_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.exportSubmissionsByStudentLogins_notInstructorForExercise_forbidden();
+        programmingExerciseIntegrationTestService.exportSubmissionsByStudentLogins_notInstructorForExercise_forbidden();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void exportSubmissionsByStudentLogins_exportAllAsTutor_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.exportSubmissionsByStudentLogins_exportAllAsTutor_forbidden();
+        programmingExerciseIntegrationTestService.exportSubmissionsByStudentLogins_exportAllAsTutor_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void generateStructureOracleForExercise_exerciseDoesNotExist_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.generateStructureOracleForExercise_exerciseDoesNotExist_badRequest();
+        programmingExerciseIntegrationTestService.generateStructureOracleForExercise_exerciseDoesNotExist_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void generateStructureOracleForExercise_userIsNotAdminInCourse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.generateStructureOracleForExercise_userIsNotAdminInCourse_badRequest();
+        programmingExerciseIntegrationTestService.generateStructureOracleForExercise_userIsNotAdminInCourse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void generateStructureOracleForExercise_invalidPackageName_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.generateStructureOracleForExercise_invalidPackageName_badRequest();
+        programmingExerciseIntegrationTestService.generateStructureOracleForExercise_invalidPackageName_badRequest();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void hasAtLeastOneStudentResult_exerciseDoesNotExist_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.hasAtLeastOneStudentResult_exerciseDoesNotExist_notFound();
+        programmingExerciseIntegrationTestService.hasAtLeastOneStudentResult_exerciseDoesNotExist_notFound();
     }
 
     @Test
     @WithMockUser(username = "tutoralt1", roles = "TA")
     public void hasAtLeastOneStudentResult_isNotTeachingAssistant_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.hasAtLeastOneStudentResult_isNotTeachingAssistant_forbidden();
+        programmingExerciseIntegrationTestService.hasAtLeastOneStudentResult_isNotTeachingAssistant_forbidden();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void getTestCases_asTutor() throws Exception {
-        programmingExerciseIntegrationServiceTest.getTestCases_asTutor();
+        programmingExerciseIntegrationTestService.getTestCases_asTutor();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "STUDENT")
     public void getTestCases_asStudent_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.getTestCases_asStudent_forbidden();
+        programmingExerciseIntegrationTestService.getTestCases_asStudent_forbidden();
     }
 
     @Test
     @WithMockUser(username = "other-teaching-assistant1", roles = "TA")
     public void getTestCases_tutorInOtherCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.getTestCases_tutorInOtherCourse_forbidden();
+        programmingExerciseIntegrationTestService.getTestCases_tutorInOtherCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_asInstrutor() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_asInstrutor();
+        programmingExerciseIntegrationTestService.updateTestCases_asInstrutor();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_asInstrutor_triggerBuildFails() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_asInstrutor_triggerBuildFails();
+        programmingExerciseIntegrationTestService.updateTestCases_asInstrutor_triggerBuildFails();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_nonExistingExercise_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_nonExistingExercise_notFound();
+        programmingExerciseIntegrationTestService.updateTestCases_nonExistingExercise_notFound();
     }
 
     @Test
     @WithMockUser(username = "other-instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_instructorInWrongCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_instructorInWrongCourse_forbidden();
+        programmingExerciseIntegrationTestService.updateTestCases_instructorInWrongCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_testCaseWeightSmallerThanZero_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_testCaseWeightSmallerThanZero_badRequest();
+        programmingExerciseIntegrationTestService.updateTestCases_testCaseWeightSmallerThanZero_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_testCaseMultiplierSmallerThanZero_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_testCaseMultiplierSmallerThanZero_badRequest();
+        programmingExerciseIntegrationTestService.updateTestCases_testCaseMultiplierSmallerThanZero_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_testCaseBonusPointsNull() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_testCaseBonusPointsNull();
+        programmingExerciseIntegrationTestService.updateTestCases_testCaseBonusPointsNull();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void resetTestCaseWeights_asInstructor() throws Exception {
-        programmingExerciseIntegrationServiceTest.resetTestCaseWeights_asInstructor();
+        programmingExerciseIntegrationTestService.resetTestCaseWeights_asInstructor();
     }
 
     @Test
     @WithMockUser(username = "other-instructor1", roles = "INSTRUCTOR")
     public void resetTestCaseWeights_instructorInWrongCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.resetTestCaseWeights_instructorInWrongCourse_forbidden();
+        programmingExerciseIntegrationTestService.resetTestCaseWeights_instructorInWrongCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void lockAllRepositories_asStudent_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.lockAllRepositories_asStudent_forbidden();
+        programmingExerciseIntegrationTestService.lockAllRepositories_asStudent_forbidden();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void lockAllRepositories_asTutor_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.lockAllRepositories_asTutor_forbidden();
+        programmingExerciseIntegrationTestService.lockAllRepositories_asTutor_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void lockAllRepositories() throws Exception {
-        programmingExerciseIntegrationServiceTest.lockAllRepositories();
+        programmingExerciseIntegrationTestService.lockAllRepositories();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void unlockAllRepositories_asStudent_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.unlockAllRepositories_asStudent_forbidden();
+        programmingExerciseIntegrationTestService.unlockAllRepositories_asStudent_forbidden();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void unlockAllRepositories_asTutor_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.unlockAllRepositories_asTutor_forbidden();
+        programmingExerciseIntegrationTestService.unlockAllRepositories_asTutor_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void unlockAllRepositories() throws Exception {
-        programmingExerciseIntegrationServiceTest.unlockAllRepositories();
+        programmingExerciseIntegrationTestService.unlockAllRepositories();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testCheckPlagiarism() throws Exception {
-        programmingExerciseIntegrationServiceTest.testCheckPlagiarism();
+        programmingExerciseIntegrationTestService.testCheckPlagiarism();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testCheckPlagiarismJplagReport() throws Exception {
-        programmingExerciseIntegrationServiceTest.testCheckPlagiarismJplagReport();
+        programmingExerciseIntegrationTestService.testCheckPlagiarismJplagReport();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testGetPlagiarismResult() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetPlagiarismResult();
+        programmingExerciseIntegrationTestService.testGetPlagiarismResult();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testGetPlagiarismResultWithoutResult() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetPlagiarismResultWithoutResult();
+        programmingExerciseIntegrationTestService.testGetPlagiarismResultWithoutResult();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testGetPlagiarismResultWithoutExercise() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetPlagiarismResultWithoutExercise();
+        programmingExerciseIntegrationTestService.testGetPlagiarismResultWithoutExercise();
     }
 
     // Auxiliary Repository Tests
@@ -765,109 +765,109 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateValidAuxiliaryRepository() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateValidAuxiliaryRepository();
+        programmingExerciseIntegrationTestService.testValidateValidAuxiliaryRepository();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryIdSetOnRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryIdSetOnRequest();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryIdSetOnRequest();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithoutName() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithoutName();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithoutName();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithTooLongName() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithTooLongName();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithTooLongName();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithDuplicatedName() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithDuplicatedName();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithDuplicatedName();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithRestrictedName() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithRestrictedName();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithRestrictedName();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithInvalidCheckoutDirectory() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithInvalidCheckoutDirectory();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithInvalidCheckoutDirectory();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithoutCheckoutDirectory() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithoutCheckoutDirectory();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithoutCheckoutDirectory();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithBlankCheckoutDirectory() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithBlankCheckoutDirectory();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithBlankCheckoutDirectory();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithTooLongCheckoutDirectory() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithTooLongCheckoutDirectory();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithTooLongCheckoutDirectory();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithDuplicatedCheckoutDirectory() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithDuplicatedCheckoutDirectory();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithDuplicatedCheckoutDirectory();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithNullCheckoutDirectory() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithNullCheckoutDirectory();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithNullCheckoutDirectory();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithTooLongDescription() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithTooLongDescription();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithTooLongDescription();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testValidateAuxiliaryRepositoryWithoutDescription() throws Exception {
-        programmingExerciseIntegrationServiceTest.testValidateAuxiliaryRepositoryWithoutDescription();
+        programmingExerciseIntegrationTestService.testValidateAuxiliaryRepositoryWithoutDescription();
     }
 
     @Test
     @WithMockUser(value = "tutor1", roles = "TA")
     public void testGetAuxiliaryRepositoriesMissingExercise() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetAuxiliaryRepositoriesMissingExercise();
+        programmingExerciseIntegrationTestService.testGetAuxiliaryRepositoriesMissingExercise();
     }
 
     @Test
     @WithMockUser(value = "tutor1", roles = "TA")
     public void testGetAuxiliaryRepositoriesOk() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetAuxiliaryRepositoriesOk();
+        programmingExerciseIntegrationTestService.testGetAuxiliaryRepositoriesOk();
     }
 
     @Test
     @WithMockUser(value = "student1", roles = "STUDENT")
     public void testGetAuxiliaryRepositoriesForbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetAuxiliaryRepositoriesForbidden();
+        programmingExerciseIntegrationTestService.testGetAuxiliaryRepositoriesForbidden();
     }
 
     @Test
     @WithMockUser(value = "tutor1", roles = "TA")
     public void testGetAuxiliaryRepositoriesEmptyOk() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetAuxiliaryRepositoriesEmptyOk();
+        programmingExerciseIntegrationTestService.testGetAuxiliaryRepositoriesEmptyOk();
     }
 
     // Tests for recreate build plan endpoint
@@ -875,25 +875,25 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     @Test
     @WithMockUser(value = "student1", roles = "STUDENT")
     public void testRecreateBuildPlansForbiddenStudent() throws Exception {
-        programmingExerciseIntegrationServiceTest.testRecreateBuildPlansForbidden();
+        programmingExerciseIntegrationTestService.testRecreateBuildPlansForbidden();
     }
 
     @Test
     @WithMockUser(value = "tutor1", roles = "TA")
     public void testRecreateBuildPlansForbiddenTutor() throws Exception {
-        programmingExerciseIntegrationServiceTest.testRecreateBuildPlansForbidden();
+        programmingExerciseIntegrationTestService.testRecreateBuildPlansForbidden();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testRecreateBuildPlansExerciseNotFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.testRecreateBuildPlansExerciseNotFound();
+        programmingExerciseIntegrationTestService.testRecreateBuildPlansExerciseNotFound();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testRecreateBuildPlansSuccess() throws Exception {
-        programmingExerciseIntegrationServiceTest.testRecreateBuildPlansExerciseSuccess();
+        programmingExerciseIntegrationTestService.testRecreateBuildPlansExerciseSuccess();
     }
 
     // Tests for export auxiliary repository for exercise endpoint
@@ -901,42 +901,42 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     @Test
     @WithMockUser(value = "student1", roles = "STUDENT")
     public void testExportAuxiliaryRepositoryForbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportAuxiliaryRepositoryForbidden();
+        programmingExerciseIntegrationTestService.testExportAuxiliaryRepositoryForbidden();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testExportEmptyAuxiliaryRepository() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportAuxiliaryRepositoryBadRequest();
+        programmingExerciseIntegrationTestService.testExportAuxiliaryRepositoryBadRequest();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testExportAuxiliaryRepositoryExerciseNotFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportAuxiliaryRepositoryExerciseNotFound();
+        programmingExerciseIntegrationTestService.testExportAuxiliaryRepositoryExerciseNotFound();
     }
 
     @Test
     @WithMockUser(value = "editor1", roles = "EDITOR")
     public void testExportAuxiliaryRepositoryRepositoryNotFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportAuxiliaryRepositoryRepositoryNotFound();
+        programmingExerciseIntegrationTestService.testExportAuxiliaryRepositoryRepositoryNotFound();
     }
 
     @Test
     @WithMockUser(value = "instructoralt1", roles = "INSTRUCTOR")
     public void testReEvaluateAndUpdateProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testReEvaluateAndUpdateProgrammingExercise_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testReEvaluateAndUpdateProgrammingExercise_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testReEvaluateAndUpdateProgrammingExercise_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.testReEvaluateAndUpdateProgrammingExercise_notFound();
+        programmingExerciseIntegrationTestService.testReEvaluateAndUpdateProgrammingExercise_notFound();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testReEvaluateAndUpdateProgrammingExercise_isNotSameGivenExerciseIdInRequestBody_conflict() throws Exception {
-        programmingExerciseIntegrationServiceTest.testReEvaluateAndUpdateProgrammingExercise_isNotSameGivenExerciseIdInRequestBody_conflict();
+        programmingExerciseIntegrationTestService.testReEvaluateAndUpdateProgrammingExercise_isNotSameGivenExerciseIdInRequestBody_conflict();
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
@@ -26,7 +26,7 @@ import de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResource;
 public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
     @Autowired
-    private ProgrammingExerciseIntegrationServiceTest programmingExerciseIntegrationServiceTest;
+    private ProgrammingExerciseIntegrationTestService programmingExerciseIntegrationTestService;
 
     @Autowired
     private ProgrammingExerciseResource programmingExerciseResource;
@@ -35,84 +35,84 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
     void initTestCase() throws Exception {
         gitlabRequestMockProvider.enableMockingOfRequests();
         jenkinsRequestMockProvider.enableMockingOfRequests(jenkinsServer);
-        programmingExerciseIntegrationServiceTest.setup(this, versionControlService);
+        programmingExerciseIntegrationTestService.setup(this, versionControlService);
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        programmingExerciseIntegrationServiceTest.tearDown();
+        programmingExerciseIntegrationTestService.tearDown();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseIsReleased_IsReleasedAndHasResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_IsReleasedAndHasResults();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseIsReleased_IsReleasedAndHasResults();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseIsReleased_IsNotReleasedAndHasResults();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkIfProgrammingExerciseIsReleased_IsReleasedAndHasNoResults() throws Exception {
-        programmingExerciseIntegrationServiceTest.checkIfProgrammingExerciseIsReleased_IsReleasedAndHasNoResults();
+        programmingExerciseIntegrationTestService.checkIfProgrammingExerciseIsReleased_IsReleasedAndHasNoResults();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     void testProgrammingExerciseIsReleased_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseIsReleased_forbidden();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseIsReleased_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionAnonymizationCombining() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionAnonymizationCombining();
+        programmingExerciseIntegrationTestService.testExportSubmissionAnonymizationCombining();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds_invalidParticipationId_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByParticipationIds_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testExportSubmissionsByStudentLogins() throws Exception {
-        programmingExerciseIntegrationServiceTest.testExportSubmissionsByStudentLogins();
+        programmingExerciseIntegrationTestService.testExportSubmissionsByStudentLogins();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_failToDeleteBuildPlan() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete_failToDeleteBuildPlan();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete_failToDeleteBuildPlan();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_buildPlanNotFoundInJenkins() throws Exception {
-        var programmingExercise = programmingExerciseIntegrationServiceTest.programmingExercise;
+        var programmingExercise = programmingExerciseIntegrationTestService.programmingExercise;
         final var projectKey = programmingExercise.getProjectKey();
         final var path = ROOT + PROGRAMMING_EXERCISE.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
         var params = new LinkedMultiValueMap<String, String>();
@@ -130,7 +130,7 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_buildPlanFailsInJenkins() throws Exception {
-        var programmingExercise = programmingExerciseIntegrationServiceTest.programmingExercise;
+        var programmingExercise = programmingExerciseIntegrationTestService.programmingExercise;
         final var projectKey = programmingExercise.getProjectKey();
         final var path = ROOT + PROGRAMMING_EXERCISE.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));
         var params = new LinkedMultiValueMap<String, String>();
@@ -147,205 +147,205 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_buildPlanDoesntExist() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete_buildPlanDoesntExist();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete_buildPlanDoesntExist();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_failToDeleteCiProject() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete_failToDeleteCiProject();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete_failToDeleteCiProject();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_failToDeleteVcsProject() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete_failToDeleteVcsProject();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete_failToDeleteVcsProject();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_failToDeleteVcsRepositories() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete_failToDeleteVcsRepositories();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete_failToDeleteVcsRepositories();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_invalidId_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete_invalidId_notFound();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete_invalidId_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testProgrammingExerciseDelete_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testProgrammingExerciseDelete_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testProgrammingExerciseDelete_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExercise() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExercise();
+        programmingExerciseIntegrationTestService.testGetProgrammingExercise();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExerciseWithStructuredGradingInstruction() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithStructuredGradingInstruction();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithStructuredGradingInstruction();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testGetProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExercise_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testGetProgrammingExercise_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExerciseWithSetupParticipations() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithSetupParticipations();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithSetupParticipations();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     void testGetProgrammingExerciseWithJustTemplateAndSolutionParticipation() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithJustTemplateAndSolutionParticipation();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithJustTemplateAndSolutionParticipation();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testGetProgrammingExerciseWithSetupParticipations_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithSetupParticipations_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithSetupParticipations_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExerciseWithSetupParticipations_invalidId_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExerciseWithSetupParticipations_invalidId_notFound();
+        programmingExerciseIntegrationTestService.testGetProgrammingExerciseWithSetupParticipations_invalidId_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetProgrammingExercisesForCourse() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExercisesForCourse();
+        programmingExerciseIntegrationTestService.testGetProgrammingExercisesForCourse();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     void testGetProgrammingExercisesForCourse_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetProgrammingExercisesForCourse_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.testGetProgrammingExercisesForCourse_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGenerateStructureOracle() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGenerateStructureOracle();
+        programmingExerciseIntegrationTestService.testGenerateStructureOracle();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidTemplateBuildPlan_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_invalidTemplateBuildPlan_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_invalidTemplateBuildPlan_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_idIsNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_idIsNull_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_idIsNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_staticCodeAnalysisMustNotChange_falseToTrue_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_staticCodeAnalysisMustNotChange_falseToTrue_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_staticCodeAnalysisMustNotChange_falseToTrue_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_staticCodeAnalysisMustNotChange_trueToFalse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_staticCodeAnalysisMustNotChange_trueToFalse_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_staticCodeAnalysisMustNotChange_trueToFalse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidTemplateVcs_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_invalidTemplateVcs_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_invalidTemplateVcs_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidSolutionBuildPlan_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_invalidSolutionBuildPlan_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_invalidSolutionBuildPlan_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_invalidSolutionRepository_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_invalidSolutionRepository_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_invalidSolutionRepository_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_checkIfBuildPlanExistsFails_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExercise_checkIfBuildPlanExistsFails_badRequest();
+        programmingExerciseIntegrationTestService.updateProgrammingExercise_checkIfBuildPlanExistsFails_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProgrammingExercise_updatingCourseId_conflict() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProgrammingExerciseShouldFailWithConflictWhenUpdatingCourseId();
+        programmingExerciseIntegrationTestService.updateProgrammingExerciseShouldFailWithConflictWhenUpdatingCourseId();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void updateTimeline_intructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTimeline_intructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.updateTimeline_intructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void updateTimeline_invalidId_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTimeline_invalidId_notFound();
+        programmingExerciseIntegrationTestService.updateTimeline_invalidId_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTimeline_ok() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTimeline_ok();
+        programmingExerciseIntegrationTestService.updateTimeline_ok();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void updateProblemStatement_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProblemStatement_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.updateProblemStatement_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateProblemStatement_invalidId_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateProblemStatement_invalidId_notFound();
+        programmingExerciseIntegrationTestService.updateProblemStatement_invalidId_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_failToCheckIfProjectExistsInCi() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_failToCheckIfProjectExistsInCi();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_failToCheckIfProjectExistsInCi();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_jenkinsJobIsNullOrUrlEmpty() throws Exception {
-        var programmingExercise = programmingExerciseIntegrationServiceTest.programmingExercise;
+        var programmingExercise = programmingExerciseIntegrationTestService.programmingExercise;
         programmingExercise.setId(null);
         programmingExercise.setTitle("unique-title");
         programmingExercise.setShortName("testuniqueshortname");
@@ -367,169 +367,169 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_exerciseIsNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_exerciseIsNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_exerciseIsNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_idIsNotNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_idIsNotNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_idIsNotNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_titleNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_titleNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_titleNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_titleContainsBadCharacter_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_titleContainsBadCharacter_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_titleContainsBadCharacter_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_invalidShortName_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_invalidShortName_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_invalidShortName_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_invalidCourseShortName_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_invalidCourseShortName_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_invalidCourseShortName_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_sameShortNameInCourse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_sameShortNameInCourse_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_sameShortNameInCourse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_shortNameContainsBadCharacters_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_shortNameContainsBadCharacters_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_shortNameContainsBadCharacters_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_noProgrammingLanguageSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_noProgrammingLanguageSet_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_noProgrammingLanguageSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_packageNameContainsBadCharacters_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_packageNameContainsBadCharacters_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_packageNameContainsBadCharacters_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_packageNameContainsKeyword_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_packageNameContainsKeyword_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_packageNameContainsKeyword_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_packageNameElementBeginsWithDigit_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_packageNameElementBeginsWithDigit_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_packageNameElementBeginsWithDigit_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_packageNameIsNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_packageNameIsNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_packageNameIsNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_maxScoreIsNull_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_maxScoreIsNull_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_maxScoreIsNull_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_noParticipationModeSelected_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_noParticipationModeSelected_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_noParticipationModeSelected_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_staticCodeAnalysisAndSequential_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_staticCodeAnalysisAndSequential_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_staticCodeAnalysisAndSequential_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_unsupportedProgrammingLanguageForStaticCodeAnalysis_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_unsupportedProgrammingLanguageForStaticCodeAnalysis_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_unsupportedProgrammingLanguageForStaticCodeAnalysis_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_noStaticCodeAnalysisButMaxPenalty_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_noStaticCodeAnalysisButMaxPenalty_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_noStaticCodeAnalysisButMaxPenalty_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_maxStaticCodePenaltyNegative_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_maxStaticCodePenaltyNegative_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_maxStaticCodePenaltyNegative_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_projectTypeMissing_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_projectTypeMissing_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_projectTypeMissing_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_projectTypeNotExpected_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_projectTypeNotExpected_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_projectTypeNotExpected_badRequest();
     }
 
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
@@ -537,295 +537,295 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
     // It should fail for all ProgrammingExercises except Haskell
     @EnumSource(value = ProgrammingLanguage.class, names = { "HASKELL", "KOTLIN", "VHDL", "ASSEMBLER", "OCAML" }, mode = EnumSource.Mode.EXCLUDE)
     public void createProgrammingExercise_checkoutSolutionRepositoryProgrammingLanguageNotSupported_badRequest(ProgrammingLanguage programmingLanguage) throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_checkoutSolutionRepositoryProgrammingLanguageNotSupported_badRequest(programmingLanguage);
+        programmingExerciseIntegrationTestService.createProgrammingExercise_checkoutSolutionRepositoryProgrammingLanguageNotSupported_badRequest(programmingLanguage);
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_invalidMaxScore_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_invalidMaxScore_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_invalidMaxScore_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_includedAsBonus_invalidBonusPoints_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_includedAsBonus_invalidBonusPoints_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_includedAsBonus_invalidBonusPoints_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createProgrammingExercise_notIncluded_invalidBonusPoints_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.createProgrammingExercise_notIncluded_invalidBonusPoints_badRequest();
+        programmingExerciseIntegrationTestService.createProgrammingExercise_notIncluded_invalidBonusPoints_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_sourceExerciseIdNegative_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_sourceExerciseIdNegative_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_sourceExerciseIdNegative_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void importProgrammingExerciseMaxScoreNullBadRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExerciseMaxScoreNullBadRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExerciseMaxScoreNullBadRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_noParticipationModeSelected_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_noParticipationModeSelected_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_noParticipationModeSelected_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_noProgrammingLanguage_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_noProgrammingLanguage_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_noProgrammingLanguage_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_instructorNotInCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_instructorNotInCourse_forbidden();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_instructorNotInCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_templateIdDoesNotExist_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_templateIdDoesNotExist_notFound();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_templateIdDoesNotExist_notFound();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_sameShortNameInCourse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_sameShortNameInCourse_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_sameShortNameInCourse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_sameTitleInCourse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_sameTitleInCourse_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_sameTitleInCourse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_staticCodeAnalysisMustBeSet_badRequest();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @CsvSource({ "false, false", "true, false", "false, true", })
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_scaChanged_badRequest(boolean recreateBuildPlan, boolean updateTemplate) throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_scaChanged_badRequest(recreateBuildPlan, updateTemplate);
+        programmingExerciseIntegrationTestService.importProgrammingExercise_scaChanged_badRequest(recreateBuildPlan, updateTemplate);
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_eitherCourseOrExerciseGroupSet_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_vcsProjectWithSameKeyAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_bambooProjectWithSameKeyAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_vcsProjectWithSameTitleAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void importProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.importProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest();
+        programmingExerciseIntegrationTestService.importProgrammingExercise_bambooProjectWithSameTitleAlreadyExists_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void exportSubmissionsByStudentLogins_notInstructorForExercise_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.exportSubmissionsByStudentLogins_notInstructorForExercise_forbidden();
+        programmingExerciseIntegrationTestService.exportSubmissionsByStudentLogins_notInstructorForExercise_forbidden();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void exportSubmissionsByStudentLogins_exportAllAsTutor_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.exportSubmissionsByStudentLogins_exportAllAsTutor_forbidden();
+        programmingExerciseIntegrationTestService.exportSubmissionsByStudentLogins_exportAllAsTutor_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void generateStructureOracleForExercise_exerciseDoesNotExist_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.generateStructureOracleForExercise_exerciseDoesNotExist_badRequest();
+        programmingExerciseIntegrationTestService.generateStructureOracleForExercise_exerciseDoesNotExist_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructoralt1", roles = "INSTRUCTOR")
     public void generateStructureOracleForExercise_userIsNotAdminInCourse_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.generateStructureOracleForExercise_userIsNotAdminInCourse_badRequest();
+        programmingExerciseIntegrationTestService.generateStructureOracleForExercise_userIsNotAdminInCourse_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void generateStructureOracleForExercise_invalidPackageName_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.generateStructureOracleForExercise_invalidPackageName_badRequest();
+        programmingExerciseIntegrationTestService.generateStructureOracleForExercise_invalidPackageName_badRequest();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void hasAtLeastOneStudentResult_exerciseDoesNotExist_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.hasAtLeastOneStudentResult_exerciseDoesNotExist_notFound();
+        programmingExerciseIntegrationTestService.hasAtLeastOneStudentResult_exerciseDoesNotExist_notFound();
     }
 
     @Test
     @WithMockUser(username = "tutoralt1", roles = "TA")
     public void hasAtLeastOneStudentResult_isNotTeachingAssistant_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.hasAtLeastOneStudentResult_isNotTeachingAssistant_forbidden();
+        programmingExerciseIntegrationTestService.hasAtLeastOneStudentResult_isNotTeachingAssistant_forbidden();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void getTestCases_asTutor() throws Exception {
-        programmingExerciseIntegrationServiceTest.getTestCases_asTutor();
+        programmingExerciseIntegrationTestService.getTestCases_asTutor();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "STUDENT")
     public void getTestCases_asStudent_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.getTestCases_asStudent_forbidden();
+        programmingExerciseIntegrationTestService.getTestCases_asStudent_forbidden();
     }
 
     @Test
     @WithMockUser(username = "other-teaching-assistant1", roles = "TA")
     public void getTestCases_tutorInOtherCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.getTestCases_tutorInOtherCourse_forbidden();
+        programmingExerciseIntegrationTestService.getTestCases_tutorInOtherCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_asInstrutor() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_asInstrutor();
+        programmingExerciseIntegrationTestService.updateTestCases_asInstrutor();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_asInstrutor_triggerBuildFails() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_asInstrutor_triggerBuildFails();
+        programmingExerciseIntegrationTestService.updateTestCases_asInstrutor_triggerBuildFails();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_nonExistingExercise_notFound() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_nonExistingExercise_notFound();
+        programmingExerciseIntegrationTestService.updateTestCases_nonExistingExercise_notFound();
     }
 
     @Test
     @WithMockUser(username = "other-instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_instructorInWrongCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_instructorInWrongCourse_forbidden();
+        programmingExerciseIntegrationTestService.updateTestCases_instructorInWrongCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_testCaseWeightSmallerThanZero_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_testCaseWeightSmallerThanZero_badRequest();
+        programmingExerciseIntegrationTestService.updateTestCases_testCaseWeightSmallerThanZero_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_testCaseMultiplierSmallerThanZero_badRequest() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_testCaseMultiplierSmallerThanZero_badRequest();
+        programmingExerciseIntegrationTestService.updateTestCases_testCaseMultiplierSmallerThanZero_badRequest();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateTestCases_testCaseBonusPointsNull() throws Exception {
-        programmingExerciseIntegrationServiceTest.updateTestCases_testCaseBonusPointsNull();
+        programmingExerciseIntegrationTestService.updateTestCases_testCaseBonusPointsNull();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void resetTestCaseWeights_asInstructor() throws Exception {
-        programmingExerciseIntegrationServiceTest.resetTestCaseWeights_asInstructor();
+        programmingExerciseIntegrationTestService.resetTestCaseWeights_asInstructor();
     }
 
     @Test
     @WithMockUser(username = "other-instructor1", roles = "INSTRUCTOR")
     public void resetTestCaseWeights_instructorInWrongCourse_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.resetTestCaseWeights_instructorInWrongCourse_forbidden();
+        programmingExerciseIntegrationTestService.resetTestCaseWeights_instructorInWrongCourse_forbidden();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void lockAllRepositories_asStudent_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.lockAllRepositories_asStudent_forbidden();
+        programmingExerciseIntegrationTestService.lockAllRepositories_asStudent_forbidden();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void lockAllRepositories_asTutor_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.lockAllRepositories_asTutor_forbidden();
+        programmingExerciseIntegrationTestService.lockAllRepositories_asTutor_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void lockAllRepositories() throws Exception {
-        programmingExerciseIntegrationServiceTest.lockAllRepositories();
+        programmingExerciseIntegrationTestService.lockAllRepositories();
     }
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void unlockAllRepositories_asStudent_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.unlockAllRepositories_asStudent_forbidden();
+        programmingExerciseIntegrationTestService.unlockAllRepositories_asStudent_forbidden();
     }
 
     @Test
     @WithMockUser(username = "tutor1", roles = "TA")
     public void unlockAllRepositories_asTutor_forbidden() throws Exception {
-        programmingExerciseIntegrationServiceTest.unlockAllRepositories_asTutor_forbidden();
+        programmingExerciseIntegrationTestService.unlockAllRepositories_asTutor_forbidden();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void unlockAllRepositories() throws Exception {
-        programmingExerciseIntegrationServiceTest.unlockAllRepositories();
+        programmingExerciseIntegrationTestService.unlockAllRepositories();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testCheckPlagiarism() throws Exception {
-        programmingExerciseIntegrationServiceTest.testCheckPlagiarism();
+        programmingExerciseIntegrationTestService.testCheckPlagiarism();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testCheckPlagiarismJplagReport() throws Exception {
-        programmingExerciseIntegrationServiceTest.testCheckPlagiarismJplagReport();
+        programmingExerciseIntegrationTestService.testCheckPlagiarismJplagReport();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testGetPlagiarismResult() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetPlagiarismResult();
+        programmingExerciseIntegrationTestService.testGetPlagiarismResult();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testGetPlagiarismResultWithoutResult() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetPlagiarismResultWithoutResult();
+        programmingExerciseIntegrationTestService.testGetPlagiarismResultWithoutResult();
     }
 
     @Test
     @WithMockUser(value = "instructor1", roles = "INSTRUCTOR")
     public void testGetPlagiarismResultWithoutExercise() throws Exception {
-        programmingExerciseIntegrationServiceTest.testGetPlagiarismResultWithoutExercise();
+        programmingExerciseIntegrationTestService.testGetPlagiarismResultWithoutExercise();
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -67,8 +67,13 @@ import de.tum.in.www1.artemis.web.rest.dto.ProgrammingExerciseTestCaseDTO;
 import de.tum.in.www1.artemis.web.rest.dto.RepositoryExportOptionsDTO;
 import de.tum.in.www1.artemis.web.websocket.dto.ProgrammingExerciseTestCaseStateDTO;
 
+/**
+ * Note: this class should be independent of the actual VCS and CIS and contains common test logic for both scenarios:
+ * 1) Bamboo + Bitbucket
+ * 2) Jenkins + Gitlab
+ */
 @Service
-public class ProgrammingExerciseIntegrationServiceTest {
+public class ProgrammingExerciseIntegrationTestService {
 
     @Value("${artemis.repo-download-clone-path}")
     private String repoDownloadClonePath;

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -173,8 +173,8 @@ public class ProgrammingExerciseTestService {
 
     private MockDelegate mockDelegate;
 
-    public List<User> setupTestUsers(int numberOfStudents, int numberOfTutors, int numberOfEditors, int numberOfInstructors) {
-        return database.addUsers(ProgrammingExerciseTestService.numberOfStudents + numberOfStudents, numberOfTutors + 1, numberOfEditors + 1, numberOfInstructors + 1);
+    public List<User> setupTestUsers(int additionalStudents, int additionalTutors, int additionalEditors, int additionalInstructors) {
+        return database.addUsers(numberOfStudents + additionalStudents, additionalTutors + 1, additionalEditors + 1, additionalInstructors + 1);
     }
 
     public void setup(MockDelegate mockDelegate, VersionControlService versionControlService, ContinuousIntegrationService continuousIntegrationService) throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doReturn;
 
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
@@ -36,6 +37,13 @@ public class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGi
         Course course = database.addCourseWithOneProgrammingExercise();
         this.programmingExercise = database.findProgrammingExerciseWithTitle(course.getExercises(), "Programming");
         MockitoAnnotations.openMocks(this);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        database.resetDatabase();
+        gitlabRequestMockProvider.reset();
+        jenkinsRequestMockProvider.reset();
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
 import de.tum.in.www1.artemis.domain.*;
@@ -31,7 +32,7 @@ public class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGi
 
     @BeforeEach
     void init() {
-        database.addUsers(3, 0, 0, 0);
+        database.addUsers(3, 0, 0, 1);
         Course course = database.addCourseWithOneProgrammingExercise();
         this.programmingExercise = database.findProgrammingExerciseWithTitle(course.getExercises(), "Programming");
         MockitoAnnotations.openMocks(this);
@@ -41,6 +42,7 @@ public class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGi
      * Test for methods of {@link ParticipationService} used by {@link de.tum.in.www1.artemis.web.rest.ResultResource#createResultForExternalSubmission(Long, String, Result)}.
      */
     @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testCreateParticipationForExternalSubmission() throws Exception {
         Optional<User> student = userRepository.findOneWithGroupsAndAuthoritiesByLogin("student1");
         var someURL = new VcsRepositoryUrl("http://vcs.fake.fake");

--- a/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
@@ -37,6 +37,8 @@ public class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGi
         Course course = database.addCourseWithOneProgrammingExercise();
         this.programmingExercise = database.findProgrammingExerciseWithTitle(course.getExercises(), "Programming");
         MockitoAnnotations.openMocks(this);
+        jenkinsRequestMockProvider.enableMockingOfRequests(jenkinsServer);
+        gitlabRequestMockProvider.enableMockingOfRequests();
     }
 
     @AfterEach
@@ -65,6 +67,11 @@ public class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGi
 
         StudentParticipation participation = participationService.createParticipationWithEmptySubmissionIfNotExisting(programmingExercise, student.get(), SubmissionType.EXTERNAL);
         assertThat(participation).isNotNull();
+        assertThat(participation.getSubmissions()).hasSize(1);
+        assertThat(participation.getStudent().get()).isEqualTo(student.get());
+        ProgrammingSubmission programmingSubmission = (ProgrammingSubmission) participation.findLatestSubmission().get();
+        assertThat(programmingSubmission.getType()).isEqualTo(SubmissionType.EXTERNAL);
+        assertThat(programmingSubmission.getResults()).isNullOrEmpty(); // results are not added in the invoked method above
     }
 
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ParticipationServiceTest.java
@@ -1,0 +1,60 @@
+package de.tum.in.www1.artemis.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
+import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
+import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
+import de.tum.in.www1.artemis.repository.UserRepository;
+
+public class ParticipationServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
+
+    @Autowired
+    private ParticipationService participationService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private ProgrammingExercise programmingExercise;
+
+    @BeforeEach
+    void init() {
+        database.addUsers(3, 0, 0, 0);
+        Course course = database.addCourseWithOneProgrammingExercise();
+        this.programmingExercise = database.findProgrammingExerciseWithTitle(course.getExercises(), "Programming");
+        MockitoAnnotations.openMocks(this);
+    }
+
+    /**
+     * Test for methods of {@link ParticipationService} used by {@link de.tum.in.www1.artemis.web.rest.ResultResource#createResultForExternalSubmission(Long, String, Result)}.
+     */
+    @Test
+    public void testCreateParticipationForExternalSubmission() throws Exception {
+        Optional<User> student = userRepository.findOneWithGroupsAndAuthoritiesByLogin("student1");
+        var someURL = new VcsRepositoryUrl("http://vcs.fake.fake");
+        // Copy Repository in ParticipationService#copyRepository(..)
+        doReturn(someURL).when(versionControlService).copyRepository(any(String.class), any(String.class), any(String.class), any(String.class));
+        // Configure Repository in ParticipationService#configureRepository(..)
+        doNothing().when(versionControlService).configureRepository(any(), any(), any(), anyBoolean());
+        // Configure WebHook in ParticipationService#configureRepositoryWebHook(..)
+        doNothing().when(versionControlService).addWebHookForParticipation(any());
+        // Do Nothing when setRepositoryPermissionsToReadOnly in ParticipationService#createParticipationWithEmptySubmissionIfNotExisting
+        doNothing().when(versionControlService).setRepositoryPermissionsToReadOnly(any(), any(String.class), any());
+
+        StudentParticipation participation = participationService.createParticipationWithEmptySubmissionIfNotExisting(programmingExercise, student.get(), SubmissionType.EXTERNAL);
+        assertThat(participation).isNotNull();
+    }
+
+}


### PR DESCRIPTION
Prevent a LazyInitializationException by using the correct exercise object

Fixes #4411 

TODO: we should create a server integration test that fails with the current version on `develop` and passes with the changes in this PR

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
1. Create a programming exercise
2. Add an external submission
3. Make sure everything works correctly (check the participation, submission and scores page)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
