### PR TITLE
`Discussion`: Reduce serialized user data attached to reactions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/metis/Reaction.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/metis/Reaction.java
@@ -28,6 +28,7 @@ import de.tum.in.www1.artemis.domain.User;
 public class Reaction extends DomainObject {
 
     @ManyToOne
+    @JsonIncludeProperties({ "id", "name" })
     private User user;
 
     @CreatedDate

--- a/src/test/javascript/spec/component/overview/course-discussion/course-discussion.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-discussion/course-discussion.component.spec.ts
@@ -305,7 +305,7 @@ describe('CourseDiscussionComponent', () => {
         const expectedPosts = metisCoursePosts.filter(
             (post: Post) =>
                 ((post.answers && post.answers.some((answer: AnswerPost) => answer.author === currentUser)) ||
-                    (post.reactions && post.reactions.some((reaction: Reaction) => reaction.user === currentUser))) &&
+                    (post.reactions && post.reactions.some((reaction: Reaction) => reaction.user?.id! === currentUser.id))) &&
                 !(post.answers && post.answers.some((answer: AnswerPost) => answer.resolvesPost === true)),
         );
         expect(component.posts).toHaveLength(expectedPosts.length);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
We want to minimize the data that is sent between client and server to ensure good performance and data protection.

### Description
<!-- Describe your changes in detail -->
The user associated to a reaction was not yet reduced to the minimum of properties required by the client which is the `id` and the `name`.
I adapted the java class `Reaction` and restricted the serialized properties to `id` and `name`.
The respective response for `GET` on `/posts` now contains a reduced version of the `User` object nested within a `Reaction` of a `Posting` -> see screenshot.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 User
- 1 Course with postings enabled

1. Log in to Artemis
2. Navigate to the course discussion page or any exercise or lecture page
3. React on a post and answer post. -> should work without error
4. Remove an existing reaction -> should work
5. Hover a reaction and read the name(s) -> should work
6. You can also inspect the response of the GET request to the `/post` endpoint, it should only include a user's id and it name as shown in the screenshot

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**After changes:**
<img width="2053" alt="Bildschirmfoto 2021-12-01 um 15 54 27" src="https://user-images.githubusercontent.com/41366522/144259559-5bddb659-7411-491f-ad58-798c244910d6.png">

**Before changes:**
<img width="2038" alt="Bildschirmfoto 2021-12-01 um 16 12 43" src="https://user-images.githubusercontent.com/41366522/144260495-85500957-3a11-433f-b140-3aee471122aa.png">