### PR TITLE
`Assessment`: Fix issue with non modifiable feedbacks being deletable

### DIFF
--- a/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
+++ b/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
@@ -16,8 +16,8 @@
                 step="0.5"
                 [(ngModel)]="assessment.credits"
                 (ngModelChange)="emitChanges()"
-                [readOnly]="disabled || assessment.gradingInstruction || readOnly"
-                [disabled]="disabled"
+                [readOnly]="assessment.gradingInstruction || readOnly"
+                [disabled]="readOnly"
                 [required]="!assessment.gradingInstruction"
             />
         </div>
@@ -43,13 +43,13 @@
                     [(ngModel)]="assessment.detailText"
                     (ngModelChange)="emitChanges()"
                     [readOnly]="readOnly"
-                    [disabled]="disabled"
+                    [disabled]="readOnly"
                     [placeholder]="
                         assessment.gradingInstruction!
                             ? ('artemisApp.assessment.additionalFeedbackCommentPlaceholder' | artemisTranslate)
                             : ('artemisApp.assessment.feedbackCommentPlaceholder' | artemisTranslate)
                     "
-                    [required]="assessment.gradingInstruction ? false : true"
+                    [required]="!assessment.gradingInstruction"
                 ></textarea>
             </div>
         </div>

--- a/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.ts
+++ b/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.ts
@@ -12,7 +12,6 @@ export class AssessmentDetailComponent {
     @Input() public assessment: Feedback;
     @Output() public assessmentChange = new EventEmitter<Feedback>();
     @Output() public deleteAssessment = new EventEmitter<Feedback>();
-    @Input() public disabled = false;
     @Input() public readOnly: boolean;
     @Input() highlightDifferences: boolean;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/ls1intum/Artemis/pull/4315#pullrequestreview-811154377

@lschlesinger found an issue that could not be completely reproduced anymore. I could reproduce that for the read-only mode the feedbacks were still delectable. It was not possible to save anything.

### Description
<!-- Describe your changes in detail -->
I saw that one attribute was not used so I decided to remove it. Once I used the actual attribute for the conditionals, it worked.
I'm not sure why it works because I didn't change the conditional for the delete button but since it's working consistently, I didn't further investigate.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Tutor
- 2 Students
- 1 Exercise with Manual correction and one submission

1. Assess the submission as a tutor
2. The assessment due date passes
3. Reopen the submission through the exercise assessment dashboard
4. Make sure that you can neither add, nor remove, nor modify any feedback

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
assessment-detail.component.ts: 71.42% | 83.33%

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![](https://gyazo.com/9bdaae579aaf363bdb60c0f6ac9baa17/raw)