### PR TITLE
`Assessments`: Fix issue with referenced feedbacks for programming exercises after complaints

### DIFF
--- a/src/main/webapp/app/assessment/assessment.service.ts
+++ b/src/main/webapp/app/assessment/assessment.service.ts
@@ -9,6 +9,9 @@ import { Result } from 'app/entities/result.model';
  * For exam test runs, the original assessor is allowed to respond to complaints.
  */
 export const isAllowedToRespondToComplaintAction = (isAtLeastInstructor: boolean, isTestRun: boolean, isAssessor: boolean, complaint: Complaint, exercise?: Exercise): boolean => {
+    if (complaint.accepted !== undefined) {
+        return false;
+    }
     if (isAtLeastInstructor) {
         return true;
     }

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.html
@@ -56,6 +56,7 @@
             [readOnlyManualFeedback]="readOnly()"
             [highlightDifferences]="highlightDifferences"
             [course]="getCourseFromExercise(exercise)"
+            [referencedFeedback]="referencedFeedback"
             (onUpdateFeedback)="onUpdateFeedback($event)"
             (onFileLoad)="onFileLoad($event)"
         >

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -521,6 +521,9 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
                     return;
                 }
                 this.complaint = res.body;
+                if (this.manualResult) {
+                    this.complaint.result = this.manualResult;
+                }
             },
             (err: HttpErrorResponse) => {
                 this.onError(err?.message);

--- a/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.html
+++ b/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.html
@@ -22,6 +22,7 @@
     [isTutorAssessment]="hasTutorAssessment"
     [readOnlyManualFeedback]="true"
     [course]="course"
+    [referencedFeedback]="referencedFeedback"
 >
     <div editorTitle>
         <span>{{ exercise?.title }}</span>

--- a/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
@@ -20,7 +20,7 @@ import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/e
 import { ActivatedRoute } from '@angular/router';
 import { CodeEditorContainerComponent } from 'app/exercises/programming/shared/code-editor/container/code-editor-container.component';
 import { ProgrammingExerciseStudentParticipation } from 'app/entities/participation/programming-exercise-student-participation.model';
-import { getUnreferencedFeedback } from 'app/exercises/shared/result/result.utils';
+import { getReferencedFeedback, getUnreferencedFeedback } from 'app/exercises/shared/result/result.utils';
 import { SubmissionType } from 'app/entities/submission.model';
 import { Participation } from 'app/entities/participation/participation.model';
 import { SubmissionPolicyType } from 'app/entities/submission-policy.model';
@@ -189,6 +189,16 @@ export class CodeEditorStudentContainerComponent implements OnInit, OnDestroy {
     get unreferencedFeedback(): Feedback[] {
         if (this.latestResult) {
             return getUnreferencedFeedback(this.latestResult.feedbacks) ?? [];
+        }
+        return [];
+    }
+
+    /**
+     * Check whether or not a latestResult exists and if, returns the unreferenced feedback of it
+     */
+    get referencedFeedback(): Feedback[] {
+        if (this.latestResult) {
+            return getReferencedFeedback(this.latestResult.feedbacks) ?? [];
         }
         return [];
     }

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.html
@@ -39,7 +39,7 @@
         [annotations]="annotations"
         [commitState]="commitState"
         [editorState]="editorState"
-        [feedbacks]="(participation?.results && participation.results!.length > 0 && participation.results!.first()!.feedbacks) || []"
+        [feedbacks]="referencedFeedback"
         [readOnlyManualFeedback]="readOnlyManualFeedback"
         [isTutorAssessment]="isTutorAssessment"
         [highlightDifferences]="highlightDifferences"

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
@@ -25,6 +25,7 @@ import { Participation } from 'app/entities/participation/participation.model';
 import { CodeEditorInstructionsComponent } from 'app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component';
 import { Feedback } from 'app/entities/feedback.model';
 import { Course } from 'app/entities/course.model';
+import { Result } from 'app/entities/result.model';
 
 export enum CollapsableCodeEditorElement {
     FileBrowser,
@@ -79,6 +80,9 @@ export class CodeEditorContainerComponent implements ComponentCanDeactivate {
 
     @Input()
     participation: Participation;
+
+    @Input()
+    referencedFeedback: Feedback[] = [];
 
     /** END WIP */
 

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/container/code-editor-container.component.ts
@@ -25,7 +25,6 @@ import { Participation } from 'app/entities/participation/participation.model';
 import { CodeEditorInstructionsComponent } from 'app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component';
 import { Feedback } from 'app/entities/feedback.model';
 import { Course } from 'app/entities/course.model';
-import { Result } from 'app/entities/result.model';
 
 export enum CollapsableCodeEditorElement {
     FileBrowser,

--- a/src/main/webapp/app/exercises/shared/result/result.utils.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.utils.ts
@@ -34,3 +34,12 @@ export const addParticipationToResult = (result: Result | undefined, participati
 export const getUnreferencedFeedback = (feedbacks: Feedback[] | undefined): Feedback[] | undefined => {
     return feedbacks ? feedbacks.filter((feedbackElement) => !feedbackElement.reference && feedbackElement.type === FeedbackType.MANUAL_UNREFERENCED) : undefined;
 };
+
+/**
+ * searches for all referenced feedback in an array of feedbacks of a result
+ * @param feedbacks the feedback of a result
+ * @returns an array with the referenced feedback of the result
+ */
+export const getReferencedFeedback = (feedbacks: Feedback[] | undefined): Feedback[] | undefined => {
+    return feedbacks ? feedbacks.filter((feedbackElement) => feedbackElement.reference != undefined && feedbackElement.type === FeedbackType.MANUAL) : undefined;
+};

--- a/src/test/javascript/spec/component/course/course-management.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management.component.spec.ts
@@ -3,8 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CourseManagementComponent } from 'app/course/manage/course-management.component';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ArtemisTestModule } from '../../test.module';
-import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
-import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { of } from 'rxjs';
 import { HttpResponse } from '@angular/common/http';
 import { Course } from 'app/entities/course.model';
@@ -14,7 +12,6 @@ import { OrionFilterDirective } from 'app/shared/orion/orion-filter.directive';
 import { AlertComponent } from 'app/shared/alert/alert.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MockHasAnyAuthorityDirective } from '../../helpers/mocks/directive/mock-has-any-authority.directive';
-import { TranslateService } from '@ngx-translate/core';
 import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { DeleteButtonDirective } from 'app/shared/delete-dialog/delete-button.directive';
 import { CourseManagementCardComponent } from 'app/course/manage/overview/course-management-card.component';
@@ -24,6 +21,10 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { Exercise } from 'app/entities/exercise.model';
 import { SortByDirective } from 'app/shared/sort/sort-by.directive';
 import { SortDirective } from 'app/shared/sort/sort.directive';
+import { ExamManagementService } from 'app/exam/manage/exam-management.service';
+import { LectureService } from 'app/lecture/lecture.service';
+import { AlertService } from 'app/core/util/alert.service';
+import { EventManager } from 'app/core/util/event-manager.service';
 
 describe('CourseManagementComponent', () => {
     let fixture: ComponentFixture<CourseManagementComponent>;
@@ -101,7 +102,14 @@ describe('CourseManagementComponent', () => {
                 MockDirective(DeleteButtonDirective),
                 MockComponent(CourseManagementCardComponent),
             ],
-            providers: [{ provide: LocalStorageService, useClass: MockSyncStorage }, { provide: SessionStorageService, useClass: MockSyncStorage }, MockProvider(TranslateService)],
+            providers: [
+                MockProvider(ExamManagementService),
+                MockProvider(LectureService),
+                MockProvider(CourseManagementService),
+                MockProvider(AlertService),
+                MockProvider(EventManager),
+                MockProvider(GuidedTourService),
+            ],
         })
             .compileComponents()
             .then(() => {
@@ -124,11 +132,8 @@ describe('CourseManagementComponent', () => {
         jest.spyOn(guidedTourService, 'enableTourForCourseOverview').mockReturnValue(course187);
 
         fixture.detectChanges();
-        expect(component).not.toBeNull();
-        expect(component.showOnlyActive).toBeTrue();
+        expect(component.showOnlyActive).toBe(true);
         component.toggleShowOnlyActive();
-        expect(component.showOnlyActive).toBeFalse();
-        fixture.detectChanges();
-        expect(component).not.toBeNull();
+        expect(component.showOnlyActive).toBe(false);
     });
 });

--- a/src/test/javascript/spec/component/exam/participate/summary/exam-participation-summary.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/exam-participation-summary.component.spec.ts
@@ -145,29 +145,28 @@ describe('ExamParticipationSummaryComponent', () => {
     sharedSetup(['', '']);
 
     it('should expand all exercises and call print when Export PDF is clicked', fakeAsync(() => {
-        const printWindowStub = jest.spyOn(global.window, 'print').mockReturnValue();
+        const printWindowStub = jest.spyOn(global.window, 'print').mockImplementation();
         fixture.detectChanges();
         const exportToPDFButton = fixture.debugElement.query(By.css('#exportToPDFButton'));
         const toggleCollapseExerciseButtonOne = fixture.debugElement.query(By.css('#toggleCollapseExerciseButton-0'));
         const toggleCollapseExerciseButtonTwo = fixture.debugElement.query(By.css('#toggleCollapseExerciseButton-1'));
         const toggleCollapseExerciseButtonThree = fixture.debugElement.query(By.css('#toggleCollapseExerciseButton-2'));
         const toggleCollapseExerciseButtonFour = fixture.debugElement.query(By.css('#toggleCollapseExerciseButton-3'));
-        expect(exportToPDFButton).not.toBeNull();
-        expect(toggleCollapseExerciseButtonOne).not.toBeNull();
-        expect(toggleCollapseExerciseButtonTwo).not.toBeNull();
-        expect(toggleCollapseExerciseButtonThree).not.toBeNull();
-        expect(toggleCollapseExerciseButtonFour).not.toBeNull();
+        expect(exportToPDFButton).not.toBe(null);
+        expect(toggleCollapseExerciseButtonOne).not.toBe(null);
+        expect(toggleCollapseExerciseButtonTwo).not.toBe(null);
+        expect(toggleCollapseExerciseButtonThree).not.toBe(null);
+        expect(toggleCollapseExerciseButtonFour).not.toBe(null);
 
         toggleCollapseExerciseButtonOne.nativeElement.click();
         toggleCollapseExerciseButtonTwo.nativeElement.click();
         toggleCollapseExerciseButtonThree.nativeElement.click();
         toggleCollapseExerciseButtonFour.nativeElement.click();
-        expect(component.collapsedExerciseIds.length).toEqual(4);
+        expect(component.collapsedExerciseIds).toHaveLength(4);
 
         exportToPDFButton.nativeElement.click();
         expect(component.collapsedExerciseIds).toBeEmpty();
         tick();
-        expect(printWindowStub).toHaveBeenCalled();
-        printWindowStub.mockRestore();
+        expect(printWindowStub).toHaveBeenCalledTimes(1);
     }));
 });

--- a/src/test/javascript/spec/component/overview/course-exercises/course-exercise-row.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-exercises/course-exercise-row.component.spec.ts
@@ -1,9 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, DebugElement } from '@angular/core';
+import { DebugElement } from '@angular/core';
 import { ParticipationWebsocketService } from 'app/overview/participation-websocket.service';
 import { ArtemisTestModule } from '../../../test.module';
 import { TranslateModule } from '@ngx-translate/core';
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModule, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { MockCourseExerciseService } from '../../../helpers/mocks/service/mock-course-exercise.service';
 import { MockParticipationWebsocketService } from '../../../helpers/mocks/service/mock-participation-websocket.service';
 import { Result } from 'app/entities/result.model';
@@ -30,13 +30,14 @@ import { IncludedInScoreBadgeComponent } from 'app/exercises/shared/exercise-hea
 import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { OrionFilterDirective } from 'app/shared/orion/orion-filter.directive';
-import { RouterTestingModule } from '@angular/router/testing';
-import { CourseExerciseService } from 'app/exercises/shared/course-exercises/course-exercise.service';
-
-@Component({
-    template: '',
-})
-class DummyComponent {}
+import { MockParticipationService } from '../../../helpers/mocks/service/mock-participation.service';
+import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
+import { MockExerciseService } from '../../../helpers/mocks/service/mock-exercise.service';
+import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
+import { MockRouter } from '../../../helpers/mocks/mock-router';
+import { Router } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+import { MockHttpService } from '../../../helpers/mocks/service/mock-http.service';
 
 describe('CourseExerciseRowComponent', () => {
     let comp: CourseExerciseRowComponent;
@@ -47,35 +48,24 @@ describe('CourseExerciseRowComponent', () => {
 
     beforeAll(() => {
         return TestBed.configureTestingModule({
-            imports: [
-                ArtemisTestModule,
-                TranslateModule.forRoot(),
-                NgbModule,
-                RouterTestingModule.withRoutes([
-                    { path: 'courses/:courseId/exercises', component: DummyComponent },
-                    { path: 'courses/:courseId/exercises/:exerciseId', component: DummyComponent },
-                ]),
-            ],
+            imports: [ArtemisTestModule, TranslateModule.forRoot()],
             declarations: [
+                CourseExerciseRowComponent,
                 MockComponent(SubmissionResultStatusComponent),
                 MockComponent(ExerciseDetailsStudentActionsComponent),
                 MockComponent(NotReleasedTagComponent),
                 MockComponent(DifficultyBadgeComponent),
                 MockComponent(IncludedInScoreBadgeComponent),
+                MockDirective(NgbTooltip),
                 MockPipe(ArtemisTimeAgoPipe),
                 MockPipe(ArtemisTranslatePipe),
                 MockDirective(OrionFilterDirective),
-                CourseExerciseRowComponent,
-                DummyComponent,
             ],
             providers: [
-                DeviceDetectorService,
-                { provide: ParticipationWebsocketService, useClass: MockParticipationWebsocketService },
-                { provide: CourseManagementService, useClass: MockCourseService },
-                { provide: CourseExerciseService, useClass: MockCourseExerciseService },
                 { provide: AccountService, useClass: MockAccountService },
-                { provide: SessionStorageService, useClass: MockSyncStorage },
-                { provide: LocalStorageService, useClass: MockSyncStorage },
+                { provide: ParticipationService, useClass: MockParticipationService },
+                { provide: ExerciseService, useClass: MockExerciseService },
+                { provide: ParticipationWebsocketService, useClass: MockParticipationWebsocketService },
             ],
         })
             .compileComponents()

--- a/src/test/javascript/spec/component/overview/course-exercises/course-exercise-row.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-exercises/course-exercise-row.component.spec.ts
@@ -3,23 +3,17 @@ import { DebugElement } from '@angular/core';
 import { ParticipationWebsocketService } from 'app/overview/participation-websocket.service';
 import { ArtemisTestModule } from '../../../test.module';
 import { TranslateModule } from '@ngx-translate/core';
-import { NgbModule, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
-import { MockCourseExerciseService } from '../../../helpers/mocks/service/mock-course-exercise.service';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { MockParticipationWebsocketService } from '../../../helpers/mocks/service/mock-participation-websocket.service';
 import { Result } from 'app/entities/result.model';
-import { DeviceDetectorService } from 'ngx-device-detector';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../../helpers/mocks/service/mock-account.service';
 import dayjs from 'dayjs/esm';
-import { MockCourseService } from '../../../helpers/mocks/service/mock-course.service';
 import { Exercise, ExerciseType, ParticipationStatus } from 'app/entities/exercise.model';
 import { InitializationState } from 'app/entities/participation/participation.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { CourseExerciseRowComponent } from 'app/overview/course-exercises/course-exercise-row.component';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
-import { CourseManagementService } from 'app/course/manage/course-management.service';
-import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
-import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storage.service';
 import { Course } from 'app/entities/course.model';
 import { MockComponent, MockDirective, MockPipe } from 'ng-mocks';
 import { SubmissionResultStatusComponent } from 'app/overview/submission-result-status.component';
@@ -34,10 +28,6 @@ import { MockParticipationService } from '../../../helpers/mocks/service/mock-pa
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
 import { MockExerciseService } from '../../../helpers/mocks/service/mock-exercise.service';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
-import { MockRouter } from '../../../helpers/mocks/mock-router';
-import { Router } from '@angular/router';
-import { HttpClient } from '@angular/common/http';
-import { MockHttpService } from '../../../helpers/mocks/service/mock-http.service';
 
 describe('CourseExerciseRowComponent', () => {
     let comp: CourseExerciseRowComponent;

--- a/src/test/javascript/spec/helpers/mocks/service/mock-exercise.service.ts
+++ b/src/test/javascript/spec/helpers/mocks/service/mock-exercise.service.ts
@@ -13,6 +13,10 @@ export class MockExerciseService {
         return MockExerciseService.response([{ id: 1 } as Exercise, { id: 2 } as Exercise]);
     }
 
+    isActiveQuiz() {
+        return true;
+    }
+
     // helper method
     private static response<T>(entity: T) {
         return of({ body: entity }) as Observable<HttpResponse<T>>;

--- a/src/test/javascript/spec/integration/code-editor/code-editor-instructor.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-instructor.integration.spec.ts
@@ -11,7 +11,7 @@ import * as ace from 'brace';
 import { ArtemisTestModule } from '../../test.module';
 import { ProgrammingExerciseParticipationService } from 'app/exercises/programming/manage/services/programming-exercise-participation.service';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
-import { DomainType, FileType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
+import { CommitState, DomainType, FileType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
 import { MockAccountService } from '../../helpers/mocks/service/mock-account.service';
 import { MockRouter } from '../../helpers/mocks/mock-router';
 import { problemStatement } from '../../helpers/sample/problemStatement.json';
@@ -91,7 +91,7 @@ describe('CodeEditorInstructorIntegration', () => {
     let getLatestResultWithFeedbacksStub: jest.SpyInstance;
     let getHintsForExerciseStub: jest.SpyInstance;
 
-    let checkIfRepositoryIsCleanSubject: Subject<{ isClean: boolean }>;
+    let checkIfRepositoryIsCleanSubject: Subject<{ repositoryStatus: string }>;
     let getRepositoryContentSubject: Subject<{ [fileName: string]: FileType }>;
     let subscribeForLatestResultOfParticipationSubject: BehaviorSubject<Result | null>;
     let findWithParticipationsSubject: Subject<{ body: ProgrammingExercise }>;
@@ -107,21 +107,21 @@ describe('CodeEditorInstructorIntegration', () => {
                 CodeEditorContainerComponent,
                 KeysPipe,
                 CodeEditorInstructionsComponent,
+                UpdatingResultComponent,
+                CodeEditorBuildOutputComponent,
+                ProgrammingExerciseInstructorExerciseStatusComponent,
+                ProgrammingExerciseEditableInstructionComponent,
+                ProgrammingExerciseInstructionComponent,
                 MockComponent(CodeEditorGridComponent),
                 MockComponent(CodeEditorActionsComponent),
                 MockComponent(CodeEditorFileBrowserComponent),
                 MockComponent(CodeEditorAceComponent),
-                CodeEditorBuildOutputComponent,
                 MockPipe(ArtemisDatePipe),
                 MockComponent(AlertComponent),
                 MockComponent(IncludedInScoreBadgeComponent),
-                ProgrammingExerciseInstructorExerciseStatusComponent,
-                UpdatingResultComponent,
                 MockComponent(ProgrammingExerciseStudentTriggerBuildButtonComponent),
                 MockComponent(ExerciseHintStudentComponent),
-                ProgrammingExerciseEditableInstructionComponent,
                 MockComponent(MarkdownEditorComponent),
-                ProgrammingExerciseInstructionComponent,
                 MockComponent(ProgrammingExerciseInstructionAnalysisComponent),
                 MockPipe(ArtemisTranslatePipe),
                 MockDirective(NgbTooltip),
@@ -169,7 +169,7 @@ describe('CodeEditorInstructorIntegration', () => {
                 const exerciseHintService = containerDebugElement.injector.get(ExerciseHintService);
                 containerDebugElement.injector.get(Router);
 
-                checkIfRepositoryIsCleanSubject = new Subject<{ isClean: boolean }>();
+                checkIfRepositoryIsCleanSubject = new Subject<{ repositoryStatus: string }>();
                 getRepositoryContentSubject = new Subject<{ [fileName: string]: FileType }>();
                 subscribeForLatestResultOfParticipationSubject = new BehaviorSubject<Result | null>(null);
                 findWithParticipationsSubject = new Subject<{ body: ProgrammingExercise }>();
@@ -220,14 +220,13 @@ describe('CodeEditorInstructorIntegration', () => {
     const initContainer = (exercise: ProgrammingExercise) => {
         container.ngOnInit();
         routeSubject.next({ exerciseId: 1 });
-        expect(container.codeEditorContainer).toBe(undefined); // Have to use this as it's a component
+        expect(container.codeEditorContainer).toBe(undefined);
         expect(findWithParticipationsStub).toHaveBeenCalledTimes(1);
         expect(findWithParticipationsStub).toHaveBeenCalledWith(exercise.id);
         expect(container.loadingState).toBe(container.LOADING_STATE.INITIALIZING);
     };
 
     it('should load the exercise and select the template participation if no participation id is provided', () => {
-        jest.resetModules();
         // @ts-ignore
         const exercise = {
             id: 1,
@@ -264,7 +263,7 @@ describe('CodeEditorInstructorIntegration', () => {
         containerFixture.detectChanges();
         expect(container.codeEditorContainer.grid).not.toBe(undefined); // Have to use this as it's a component
 
-        checkIfRepositoryIsCleanSubject.next({ isClean: true });
+        checkIfRepositoryIsCleanSubject.next({ repositoryStatus: CommitState.CLEAN });
         getRepositoryContentSubject.next({ file: FileType.FILE, folder: FileType.FOLDER });
         containerFixture.detectChanges();
 

--- a/src/test/javascript/spec/service/assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/assessment.service.spec.ts
@@ -99,5 +99,10 @@ describe('Assessment Service', () => {
             expect(isAllowedAssessor).toBe(true);
             expect(isAllowedNotAssessor).toBe(false);
         });
+
+        it('should hide for resolved complaint', () => {
+            const isAllowed = isAllowedToRespondToComplaintAction(true, false, false, { ...complaint, accepted: true }, exercise);
+            expect(isAllowed).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [X] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For programming exercises with complaints, it is currently not possible to handle a complaint and add new referenced feedback (in the code editor) or change the existing one.
Actually, the feedback was saved but only the old one was shown.

### Description
<!-- Describe your changes in detail -->
I decided to pass the feedback that should be displayed directly to the editor and update all appropriate occurrences.

Because the tests kept failing on Bamboo, I took a look into them and decided to convert some from sinon to jest

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
**This only affects referenced feedback (in the code editor, not the one below).**
Prerequisites:
- 1 Tutor
- 1 Student
- 1 Automatic Programming Exercise with Complaints enabled and a submission
- 1 Manual Programming Exercise with Complaints enabled and a submission

1. Assess the manual exercise
2. The assessment due date passes
3. Complain with the student on both assessments
4. For both exercises, try to modify existing feedback, delete existing feedback and create new feedback (for automatic only the latter)
5. Accept the complaints with the new feedback
6. Reload the page and make sure that the feedback is still displayed correctly
7. The tutor should now not be able to add, remove or modify feedback. Neither in the code editor nor below
8. The student should be able to see the feedback properly

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
code-editor-tutor-assessment-container.component.ts: 52.99% | 82.54%
code-editor-student-container.component.ts: 75.34% | 93.18%
code-editor-container.component.ts: 83.67% | 82.79%
result.utils.ts: 75% |  100%
