### PR TITLE
`Development`: Fix cypress e2e text exercise management test

### DIFF
--- a/src/test/cypress/integration/exercises/text/TextExerciseManagement.spec.ts
+++ b/src/test/cypress/integration/exercises/text/TextExerciseManagement.spec.ts
@@ -47,7 +47,7 @@ describe('Text exercise management', () => {
         textCreation.typeProblemStatement(problemStatement);
         textCreation.typeExampleSolution(exampleSolution);
         cy.get('[jhitranslate="artemisApp.textExercise.exampleSubmissionsRequireExercise"]').should('be.visible');
-        textCreation.create();
+        textCreation.create().its('response.statusCode').should('eq', 201);
 
         // Create an example submission
         exampleSubmissions.clickCreateExampleSubmission();
@@ -56,11 +56,13 @@ describe('Text exercise management', () => {
         exampleSubmissionCreation.showsExampleSolution(exampleSolution);
         const submission = 'This is an\nexample\nsubmission';
         exampleSubmissionCreation.typeExampleSubmission(submission);
-        exampleSubmissionCreation.clickCreateNewExampleSubmission().its('response.body.submission.text').should('eq', submission);
-
-        // Make sure example submission is shown in the list
-        cy.contains('Example Submissions Board').click();
-        cy.contains('Example Submission 1').should('be.visible');
+        exampleSubmissionCreation
+            .clickCreateNewExampleSubmission()
+            .its('response')
+            .then((response: any) => {
+                expect(response.statusCode).to.equal(200);
+                expect(response.body.submission.text).to.equal(submission);
+            });
 
         // Make sure text exercise is shown in exercises list
         cy.visit(`course-management/${course.id}/exercises`);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The [text exercise management cypress test fails](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBB-QE-369/test/case/436838794), because after submitting an example submission it clicks on an element in the breadcrumbs to go back and verify that the example submission has been created. The breadcrumb element does not have a good jquery selector, so the test simply searches by its translated text value. This is bad because as it happened the translated text can change and break the test.

### Description
<!-- Describe your changes in detail -->
This PR removes the part where the test goes back using the breadcrumbs entirely. The test doesn't have to go back at all. Instead the test now verifies that the request, which submits the example submission, gets a HTTP 200 from the Artemis Server as a response. This makes the test independent from translated strings, decreasing the likelihood of a similar failure in the future.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
[Test are executed by bamboo and the `TextExerciseManagement` spec is not failing anymore](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-615)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
