### PR TITLE
`General`: Prevent first exercise title from getting cut-off in the chart performance in exercises

### DIFF
--- a/src/main/webapp/app/overview/visualizations/exercise-scores-chart/exercise-scores-chart.component.html
+++ b/src/main/webapp/app/overview/visualizations/exercise-scores-chart/exercise-scores-chart.component.html
@@ -15,7 +15,7 @@
             [showXAxisLabel]="true"
             [yScaleMax]="maxScale"
             [yScaleMin]="1"
-            [maxXAxisTickLength]="20"
+            [maxXAxisTickLength]="15"
             (select)="onSelect($event)"
         >
             <ng-template #tooltipTemplate let-model="model">

--- a/src/main/webapp/app/overview/visualizations/exercise-scores-chart/exercise-scores-chart.component.ts
+++ b/src/main/webapp/app/overview/visualizations/exercise-scores-chart/exercise-scores-chart.component.ts
@@ -59,9 +59,6 @@ export class ExerciseScoresChartComponent implements AfterViewInit, OnChanges {
     }
 
     ngOnChanges(): void {
-        this.exerciseScores = this.exerciseScores.concat(this.excludedExerciseScores);
-        this.excludedExerciseScores = this.exerciseScores.filter((score) => this.filteredExerciseIDs.includes(score.exerciseId!));
-        this.exerciseScores = this.exerciseScores.filter((score) => !this.filteredExerciseIDs.includes(score.exerciseId!));
         this.initializeChart();
     }
 
@@ -84,6 +81,9 @@ export class ExerciseScoresChartComponent implements AfterViewInit, OnChanges {
     }
 
     private initializeChart(): void {
+        this.exerciseScores = this.exerciseScores.concat(this.excludedExerciseScores);
+        this.excludedExerciseScores = this.exerciseScores.filter((score) => this.filteredExerciseIDs.includes(score.exerciseId!));
+        this.exerciseScores = this.exerciseScores.filter((score) => !this.filteredExerciseIDs.includes(score.exerciseId!));
         // we show all the exercises ordered by their release data
         const sortedExerciseScores = sortBy(this.exerciseScores, (exerciseScore) => exerciseScore.releaseDate);
         this.addData(sortedExerciseScores);

--- a/src/test/javascript/spec/component/overview/course-statistics/visualizations/exercise-scores-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-statistics/visualizations/exercise-scores-chart.component.spec.ts
@@ -77,10 +77,12 @@ describe('ExerciseScoresChartComponent', () => {
             body: [firstExercise, secondExercise],
             status: 200,
         });
+        component.filteredExerciseIDs = [];
         const getScoresStub = jest.spyOn(exerciseScoresChartService, 'getExerciseScoresForCourse').mockReturnValue(of(exerciseScoresResponse));
         component.ngAfterViewInit();
         expect(getScoresStub).toHaveBeenCalledTimes(1);
         expect(component.ngxData).toHaveLength(3);
+
         // datasets[0] is student score
         expect(component.ngxData[0].series).toHaveLength(2);
         const studentFirstExerciseDataPoint = component.ngxData[0].series[0];
@@ -115,6 +117,7 @@ describe('ExerciseScoresChartComponent', () => {
             status: 200,
         });
 
+        component.filteredExerciseIDs = [];
         const getScoresStub = jest.spyOn(exerciseScoresChartService, 'getExerciseScoresForCourse').mockReturnValue(of(exerciseScoresResponse));
         component.ngAfterViewInit();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Due to the tick threshold, the first exercise title can exceed the div containing the chart and therefore gets cut-off
![image](https://user-images.githubusercontent.com/80622272/144893028-6da5cd56-78a7-4187-b574-54b9a1968a3e.png)


### Description
<!-- Describe your changes in detail -->
I reduced the maximum tick length from 20 to 15 in order to prevent such visual bugs. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Exercise with a rather long title (try >=20 characters) that has a release and due date (it has to be the first exercise in the chart)
- Alternatively, log in as test user 2 and go to [this course](https://artemistest.ase.in.tum.de/courses/481/statistics) on TS1.

1. Log in to Artemis
2. Click on the corresponding course card
3. Switch to statistics tab
4. Inspect the Performance in Exercises chart and make sure the exercise title does not get cut-off

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before: 
![image](https://user-images.githubusercontent.com/80622272/145017200-cad6d556-c8bf-4590-aed1-bf333c2b950a.png)

After:
![image](https://user-images.githubusercontent.com/80622272/145017361-85c5fb08-c2e2-443a-aec1-7fc921715f29.png)
