### PR TITLE
`Development`: Fix cypress e2e test for static code analysis

### DIFF
--- a/src/main/webapp/app/exercises/shared/result/result-detail.component.html
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.component.html
@@ -23,7 +23,7 @@
                 <span class="result-score-chart-title">
                     <span jhiTranslate="artemisApp.result.score">Score</span>: {{ roundScoreSpecifiedByCourseSettings(result.score, getCourseFromExercise(exercise!)) }}%
                 </span>
-                <div #containerRef class="chart-space">
+                <div id="feedback-chart" #containerRef class="chart-space">
                     <ngx-charts-bar-horizontal-stacked
                         [view]="[containerRef.offsetWidth, 80]"
                         [results]="ngxData"

--- a/src/main/webapp/app/shared/chart/chart.component.ts
+++ b/src/main/webapp/app/shared/chart/chart.component.ts
@@ -10,7 +10,7 @@ export interface ChartPreset {
     selector: 'jhi-chart',
     template: `
         <div style="position: relative; width: 100%; height: 100%;">
-            <canvas id="chart" baseChart [datasets]="chartDatasets" [labels]="chartLabels" [options]="chartOptions" [chartType]="chartType"></canvas>
+            <canvas baseChart [datasets]="chartDatasets" [labels]="chartLabels" [options]="chartOptions" [chartType]="chartType"></canvas>
         </div>
     `,
 })

--- a/src/test/cypress/support/pageobjects/exercises/programming/ScaFeedbackModal.ts
+++ b/src/test/cypress/support/pageobjects/exercises/programming/ScaFeedbackModal.ts
@@ -5,7 +5,7 @@ export class ScaFeedbackModal {
     private readonly feedbackSelector = '#feedback-message';
 
     shouldShowPointChart() {
-        cy.get('#chart').should('be.visible');
+        cy.get('#feedback-chart').should('be.visible');
     }
 
     shouldShowFeedback(numberOfPassedTests: number, points: string) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The SCA Cypress test is failing because the chart element could not be matched. This has to do with the recent refactoring of the tests to only use id selectors. 2 hours ago another PR (#4321), which replaced the chart component, was merged. There was no merge conflict because I (wrongly) placed the id for the chart element on the chart component instead of the result component.

### Description
<!-- Describe your changes in detail -->
In this PR I moved the existing id from the chart component to the result-detail component to fix the test.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
I deployed this branch to TS3 and reran the SCA test. The test now passes:
![image](https://user-images.githubusercontent.com/12861668/145396131-404e2e74-ffb8-4f94-aab1-a9a8cfc36145.png)


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
