### PR TITLE
`Development`: Enable info environment contributor after Spring upgrade

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -49,6 +49,8 @@ management:
             mode: full
         java:
             enabled: true
+        env:
+            enabled: true
     health:
         mail:
             enabled: false # When using the MailService, configure an SMTP server and set this to true

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -131,7 +131,8 @@ management:
     endpoint:
         jhimetrics:
             enabled: true
-        info:
+    info:
+        env:
             enabled: true
 
 sentry:

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -131,6 +131,8 @@ management:
     endpoint:
         jhimetrics:
             enabled: true
+        info:
+            enabled: true
 
 sentry:
     dsn: https://not-activated@sentry.io/0000000


### PR DESCRIPTION
Enable info environment contributor after Spring 2.6 upgrade
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#actuator-env-infocontributor-disabled-by-default

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.