### PR TITLE
`Programming exercises`: Increase the legend's readability of charts in feedback details

### DIFF
--- a/src/main/webapp/app/exercises/shared/result/result-detail.scss
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.scss
@@ -1,3 +1,5 @@
+@import 'src/main/webapp/content/scss/artemis-variables';
+
 .feedback-item {
     border-radius: 4px;
     border-style: solid;
@@ -87,5 +89,5 @@
 }
 
 ::ng-deep .legend-label {
-    color: #212529 !important;
+    color: $artemis-dark !important;
 }

--- a/src/main/webapp/app/exercises/shared/result/result-detail.scss
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.scss
@@ -83,4 +83,9 @@
 ::ng-deep .legend-labels {
     background-color: transparent !important;
     text-align: center !important;
+    font-weight: bolder;
+}
+
+::ng-deep .legend-label {
+    color: #212529 !important;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A student complained that the legend below the chart representing the reached score for a programming exercise is rather hard to read with the new implementation. After looking at the screenshot, I have to agree, the font is not optimal per default with `ngx-charts`.

### Description
<!-- Describe your changes in detail -->
I changed the font size to bolder as well as the font color. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Programming Exercise with at least one commit of the student. You can use [this submission](https://artemistest.ase.in.tum.de/courses/481/exercises/13320) on TS1 of test user 2 if you want.

1. Log in to Artemis
2. Navigate to the exercise details of the programming exercise
3. Click on the feedback on the right (XY of Z passed...)
4. Inspect the legend. Make sure the Points are now easier to read.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
Nothing changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Old legend appearance:
![image](https://user-images.githubusercontent.com/80622272/145839321-08e9e0d1-c6ca-486d-a0ae-a7ce177a68ad.png)

**New** legend appearance:
![image](https://user-images.githubusercontent.com/80622272/145853894-1af4f9a1-a20f-4a72-bc65-defaac2bf973.png)
