### PR TITLE
`Development`: Fix cypress e2e tests for exam assessment

### DIFF
--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -33,7 +33,7 @@
                 <h2 class="text-center">{{ totalRelativeScore }}%</h2>
                 <h5 class="text-center points">{{ totalAbsoluteScore }} / {{ totalReachableScore }} Pts</h5>
             </div>
-            <ngx-charts-pie-chart id="score-chart" [view]="[200, 200]" [results]="ngxDoughnutData" [scheme]="ngxColor" [doughnut]="true" (select)="onSelect()">
+            <ngx-charts-pie-chart id="score-chart" [view]="[200, 200]" [results]="ngxDoughnutData" [scheme]="ngxColor" [doughnut]="true" [animations]="false" (select)="onSelect()">
                 <ng-template #tooltipTemplate let-model="model">
                     <span jhiTranslate="artemisApp.courseOverview.statistics.{{ model.name }}"></span>
                     <span>: {{ model.value }}</span>

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -127,7 +127,7 @@ describe('Exam assessment', () => {
                 modelingAssessment.clickNextAssessment();
                 modelingAssessment.assessComponent(-1, 'Wrong');
                 // Wait for the editor to save the changes
-                cy.wait(500);
+                cy.wait(1500);
                 examAssessment.submitModelingAssessment().then((assessmentResponse) => {
                     expect(assessmentResponse.response?.statusCode).to.equal(200);
                 });

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -123,9 +123,10 @@ describe('Exam assessment', () => {
                 modelingAssessment.openAssessmentForComponent(1);
                 modelingAssessment.assessComponent(-1, 'Wrong');
                 modelingAssessment.clickNextAssessment();
+                modelingAssessment.assessComponent(1, 'Good');
+                modelingAssessment.clickNextAssessment();
                 modelingAssessment.assessComponent(0, 'Neutral');
                 modelingAssessment.clickNextAssessment();
-                modelingAssessment.assessComponent(1, 'Good');
                 examAssessment.submitModelingAssessment().then((assessmentResponse) => {
                     expect(assessmentResponse.response?.statusCode).to.equal(200);
                 });

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -119,11 +119,9 @@ describe('Exam assessment', () => {
                 cy.login(tutor, '/course-management/' + course.id + '/exams');
                 cy.contains('Assessment Dashboard', { timeout: 60000 }).click();
                 startAssessing();
-                modelingAssessment.addNewFeedback(2, 'Good');
+                modelingAssessment.addNewFeedback(5, 'Good');
                 modelingAssessment.openAssessmentForComponent(1);
                 modelingAssessment.assessComponent(-1, 'Wrong');
-                modelingAssessment.clickNextAssessment();
-                modelingAssessment.assessComponent(1, 'Good');
                 modelingAssessment.clickNextAssessment();
                 modelingAssessment.assessComponent(0, 'Neutral');
                 modelingAssessment.clickNextAssessment();
@@ -131,7 +129,7 @@ describe('Exam assessment', () => {
                     expect(assessmentResponse.response?.statusCode).to.equal(200);
                 });
                 cy.login(student, '/courses/' + course.id + '/exams/' + exam.id);
-                cy.contains('2 of 10 points').should('be.visible');
+                cy.contains('4 of 10 points').should('be.visible');
             });
         });
 

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -56,43 +56,6 @@ describe('Exam assessment', () => {
         courseManagementRequests.deleteCourse(course.id);
     });
 
-    // For some reason the typing of cypress gets slower the longer the test runs, so we test the programming exercise first
-    describe('Exam programming exercise assessment', () => {
-        const examDuration = 155000;
-
-        before('Prepare exam', () => {
-            examEnd = dayjs().add(examDuration, 'milliseconds');
-            prepareExam(examEnd);
-        });
-
-        beforeEach('Create exam, exercise and submission', () => {
-            courseManagementRequests
-                .createProgrammingExercise({ exerciseGroup }, undefined, undefined, undefined, undefined, undefined, undefined, undefined, CypressAssessmentType.SEMI_AUTOMATIC)
-                .then((progRespone) => {
-                    const programmingExercise = progRespone.body;
-                    courseManagementRequests.generateMissingIndividualExams(exam);
-                    courseManagementRequests.prepareExerciseStartForExam(exam);
-                    cy.login(student, '/courses/' + course.id + '/exams/' + exam.id);
-                    examStartEnd.startExam();
-                    cy.contains(programmingExercise.title).should('be.visible').click();
-                    makeSubmissionAndVerifyResults(editorPage, programmingExercise.packageName, partiallySuccessful, () => {
-                        examNavigation.handInEarly();
-                        examStartEnd.finishExam();
-                    });
-                });
-        });
-
-        it('Assess a programming exercise submission (MANUAL)', () => {
-            cy.login(tutor, '/course-management/' + course.id + '/exams');
-            cy.contains('Assessment Dashboard', { timeout: examDuration }).click();
-            startAssessing();
-            examAssessment.addNewFeedback(2, 'Good job');
-            examAssessment.submit();
-            cy.login(student, '/courses/' + course.id + '/exams/' + exam.id);
-            cy.get('.question-options').contains('6.6 of 10 points').should('be.visible');
-        });
-    });
-
     describe('Exam exercise assessment', () => {
         beforeEach('Generate new exam name', () => {
             examEnd = dayjs().add(45, 'seconds');
@@ -203,6 +166,42 @@ describe('Exam assessment', () => {
             // Sometimes the feedback fails to load properly on the first load...
             cy.reloadUntilFound(`jhi-result:contains(${score})`);
             cy.get('jhi-result').contains(score).should('be.visible');
+        });
+    });
+
+    describe('Exam programming exercise assessment', () => {
+        const examDuration = 155000;
+
+        before('Prepare exam', () => {
+            examEnd = dayjs().add(examDuration, 'milliseconds');
+            prepareExam(examEnd);
+        });
+
+        beforeEach('Create exam, exercise and submission', () => {
+            courseManagementRequests
+                .createProgrammingExercise({ exerciseGroup }, undefined, undefined, undefined, undefined, undefined, undefined, undefined, CypressAssessmentType.SEMI_AUTOMATIC)
+                .then((progRespone) => {
+                    const programmingExercise = progRespone.body;
+                    courseManagementRequests.generateMissingIndividualExams(exam);
+                    courseManagementRequests.prepareExerciseStartForExam(exam);
+                    cy.login(student, '/courses/' + course.id + '/exams/' + exam.id);
+                    examStartEnd.startExam();
+                    cy.contains(programmingExercise.title).should('be.visible').click();
+                    makeSubmissionAndVerifyResults(editorPage, programmingExercise.packageName, partiallySuccessful, () => {
+                        examNavigation.handInEarly();
+                        examStartEnd.finishExam();
+                    });
+                });
+        });
+
+        it('Assess a programming exercise submission (MANUAL)', () => {
+            cy.login(tutor, '/course-management/' + course.id + '/exams');
+            cy.contains('Assessment Dashboard', { timeout: examDuration }).click();
+            startAssessing();
+            examAssessment.addNewFeedback(2, 'Good job');
+            examAssessment.submit();
+            cy.login(student, '/courses/' + course.id + '/exams/' + exam.id);
+            cy.get('.question-options').contains('6.6 of 10 points').should('be.visible');
         });
     });
 

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -125,6 +125,7 @@ describe('Exam assessment', () => {
                 modelingAssessment.clickNextAssessment();
                 modelingAssessment.assessComponent(0, 'Neutral');
                 modelingAssessment.clickNextAssessment();
+                modelingAssessment.assessComponent(1, 'Good');
                 examAssessment.submitModelingAssessment().then((assessmentResponse) => {
                     expect(assessmentResponse.response?.statusCode).to.equal(200);
                 });

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -95,7 +95,7 @@ describe('Exam assessment', () => {
 
     describe('Exam exercise assessment', () => {
         beforeEach('Generate new exam name', () => {
-            examEnd = dayjs().add(30, 'seconds');
+            examEnd = dayjs().add(45, 'seconds');
             prepareExam(examEnd);
         });
 
@@ -169,8 +169,8 @@ describe('Exam assessment', () => {
         let resultDate: Dayjs;
 
         beforeEach('Generate new exam name', () => {
-            examEnd = dayjs().add(15, 'seconds');
-            resultDate = examEnd.add(17, 'seconds');
+            examEnd = dayjs().add(25, 'seconds');
+            resultDate = examEnd.add(5, 'seconds');
             prepareExam(examEnd, resultDate);
         });
 

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -126,6 +126,8 @@ describe('Exam assessment', () => {
                 modelingAssessment.assessComponent(0, 'Neutral');
                 modelingAssessment.clickNextAssessment();
                 modelingAssessment.assessComponent(-1, 'Wrong');
+                // Wait for the editor to save the changes
+                cy.wait(500);
                 examAssessment.submitModelingAssessment().then((assessmentResponse) => {
                     expect(assessmentResponse.response?.statusCode).to.equal(200);
                 });

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -126,8 +126,7 @@ describe('Exam assessment', () => {
                 modelingAssessment.assessComponent(0, 'Neutral');
                 modelingAssessment.clickNextAssessment();
                 modelingAssessment.assessComponent(-1, 'Wrong');
-                // Wait for the editor to save the changes
-                cy.wait(1500);
+                modelingAssessment.clickNextAssessment();
                 examAssessment.submitModelingAssessment().then((assessmentResponse) => {
                     expect(assessmentResponse.response?.statusCode).to.equal(200);
                 });

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -130,7 +130,7 @@ describe('Exam assessment', () => {
                     expect(assessmentResponse.response?.statusCode).to.equal(200);
                 });
                 cy.login(student, '/courses/' + course.id + '/exams/' + exam.id);
-                cy.contains('1 of 10 points').should('be.visible');
+                cy.contains('2 of 10 points').should('be.visible');
             });
         });
 

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -125,13 +125,11 @@ describe('Exam assessment', () => {
                 modelingAssessment.clickNextAssessment();
                 modelingAssessment.assessComponent(0, 'Neutral');
                 modelingAssessment.clickNextAssessment();
-                modelingAssessment.assessComponent(-1, 'Wrong');
-                modelingAssessment.clickNextAssessment();
                 examAssessment.submitModelingAssessment().then((assessmentResponse) => {
                     expect(assessmentResponse.response?.statusCode).to.equal(200);
                 });
                 cy.login(student, '/courses/' + course.id + '/exams/' + exam.id);
-                cy.contains('2 of 10 points').should('be.visible');
+                cy.contains('3 of 10 points').should('be.visible');
             });
         });
 

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -119,9 +119,9 @@ describe('Exam assessment', () => {
                 cy.login(tutor, '/course-management/' + course.id + '/exams');
                 cy.contains('Assessment Dashboard', { timeout: 60000 }).click();
                 startAssessing();
-                modelingAssessment.addNewFeedback(2, 'Noice');
+                modelingAssessment.addNewFeedback(2, 'Good');
                 modelingAssessment.openAssessmentForComponent(1);
-                modelingAssessment.assessComponent(1, 'Good');
+                modelingAssessment.assessComponent(-1, 'Wrong');
                 modelingAssessment.clickNextAssessment();
                 modelingAssessment.assessComponent(0, 'Neutral');
                 modelingAssessment.clickNextAssessment();
@@ -129,7 +129,7 @@ describe('Exam assessment', () => {
                     expect(assessmentResponse.response?.statusCode).to.equal(200);
                 });
                 cy.login(student, '/courses/' + course.id + '/exams/' + exam.id);
-                cy.contains('3 of 10 points').should('be.visible');
+                cy.contains('1 of 10 points').should('be.visible');
             });
         });
 

--- a/src/test/cypress/integration/exercises/quiz-exercise/QuizExerciseParticipation.spec.ts
+++ b/src/test/cypress/integration/exercises/quiz-exercise/QuizExerciseParticipation.spec.ts
@@ -49,6 +49,7 @@ describe('Quiz Exercise Participation', () => {
         });
 
         it('Student can see a visible quiz', () => {
+            cy.login(admin);
             courseManagementRequest.setQuizVisible(quizExercise.id);
             cy.login(student, '/courses/' + course.id);
             courseOverview.openRunningExercise(quizExercise.id);
@@ -56,6 +57,7 @@ describe('Quiz Exercise Participation', () => {
         });
 
         it('Student can participate in MC quiz', () => {
+            cy.login(admin);
             courseManagementRequest.setQuizVisible(quizExercise.id);
             courseManagementRequest.startQuizNow(quizExercise.id);
             cy.login(student, '/courses/' + course.id);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently the cypress e2e test suite is failing because there are two failures in the exam assessment tests. The [quiz exam assessment failure](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBB-QE-395/test/case/461984208) is due to the test not having enough time to participate in the exam before it ends. The [modeling exam assessment failure](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBB-QE-394/test/case/437309640) is very strange. I cannot reproduce this locally and I also can't figure out why the test gets "3 out of 10 points" instead of the expected "2 out of 10 points". It seems like the last feedback is not properly saved when the test is executed by the build agent. However this also does not seem to be a timing issue because I added a sleep before submitting the assessment, but it did not fix the issue.

### Description
<!-- Describe your changes in detail -->
For both tests I increased the exam end date because it consistently failed for the quiz test and was also rather close for the modeling test. To me it also made not much sense that the result date was 17 seconds after the exam end date for the quiz assessment test, so I reduced the interval there to compensate for the increase in the exam end date. I also adjusted the created feedback for the modeling assessment test. Previously the test provided 4 feedbacks (+2 points, +1 point, +0 points and -1 point). Now the test creates only 3 feedbacks (+5 points, -1 point and 0 points).
During testing I have seen that the [`QuizExerciseParticipation.spec` is also flaky and sometimes fails with a 401 when setting a quiz visible](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-QE-682/test/case/467579980). I fixed this by making sure that the test is authenticated before the request is sent

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
I executed the bamboo buildplan three times for this PR. Two times all tests passed and once one test failed, but the failure is not related to the changes in this PR.

1. [Execution 1](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-683)
2. [Execution 2](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-684)
3. [Execution 3](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-685)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
