### PR TITLE
`General`: Fix chart series tooltip in performance statistics in exercises for disabled lines 

### DIFF
--- a/src/main/webapp/app/overview/visualizations/exercise-scores-chart/exercise-scores-chart.component.html
+++ b/src/main/webapp/app/overview/visualizations/exercise-scores-chart/exercise-scores-chart.component.html
@@ -20,13 +20,13 @@
         >
             <ng-template #tooltipTemplate let-model="model">
                 <h6>{{ model.name }}</h6>
-                <span>{{ model.series }}: {{ model.value - 1 }} %</span>
+                <span>{{ model.series }}: {{ Math.max(model.value - 1, 0) }} %</span>
             </ng-template>
             <ng-template #seriesTooltipTemplate let-model="model">
                 <h6>{{ model[0].name }}</h6>
-                <span> {{ model[0].series }}: {{ model[0].value - 1 }} %</span><br />
-                <span> {{ model[1].series }}: {{ model[1].value - 1 }} %</span><br />
-                <span> {{ model[2].series }}: {{ model[2].value - 1 }} %</span><br />
+                <span> {{ model[0].series }}: {{ Math.max(model[0].value - 1, 0) }} %</span><br />
+                <span> {{ model[1].series }}: {{ Math.max(model[1].value - 1, 0) }} %</span><br />
+                <span> {{ model[2].series }}: {{ Math.max(model[2].value - 1, 0) }} %</span><br />
                 <span style="font-weight: bold" jhiTranslate="artemisApp.exercise-scores-chart.exerciseType" [translateValues]="{ type: model[0].exerciseType }"></span>
             </ng-template>
         </ngx-charts-line-chart>

--- a/src/main/webapp/app/overview/visualizations/exercise-scores-chart/exercise-scores-chart.component.ts
+++ b/src/main/webapp/app/overview/visualizations/exercise-scores-chart/exercise-scores-chart.component.ts
@@ -24,6 +24,8 @@ export class ExerciseScoresChartComponent implements AfterViewInit, OnChanges {
     exerciseScores: ExerciseScoresDTO[] = [];
     excludedExerciseScores: ExerciseScoresDTO[] = [];
 
+    readonly Math = Math;
+
     // ngx
     ngxData: any[] = [];
     backUpData: any[] = [];


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When the user disables a line in Performance in Exercises, the series tooltip shows -1% for the corresponding line. This is fixed in this PR.

### Description
<!-- Describe your changes in detail -->
I disabled negative values in the tooltip as I could not imagine a use case where negative relative values in one score type would be needed/meaningful. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Course with exercises (the Performance in Exercises Chart is filled)

1. Log in to Artemis
2. Navigate to the student statistic tab of the course
3. Scroll down to the Performance in Exercises chart
4. Disable one line (by clicking on the corresponding legend entry)
5. Hover over an exercise in the chart (not a specific line but anywhere on the vertical line of the corresponding x axis tick)
6. Make sure that the score of the disabled line is changed to 0

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
Nothing changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Current series tooltip:
![image](https://user-images.githubusercontent.com/80622272/145992342-98cf2938-3a62-4c98-b912-84b5b9ba51aa.png)

How it should look:
![image](https://user-images.githubusercontent.com/80622272/145992885-d64937c8-0b93-487b-bf28-bf158494430f.png)
