### PR TITLE
`Development`: Use id selectors for quiz drag items in cypress e2e tests

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
@@ -177,6 +177,7 @@
                     [ngClass]="{ disabled: !question.backgroundFilePath }"
                 >
                     <div
+                        id="drop-location"
                         class="drop-location"
                         *ngFor="let dropLocation of question.dropLocations"
                         [ngClass]="dropAllowed ? 'drop-allowed' : ''"

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/drag-and-drop-question-statistic/drag-and-drop-question-statistic.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/drag-and-drop-question-statistic/drag-and-drop-question-statistic.component.html
@@ -39,6 +39,7 @@
                         <div class="click-layer">
                             <div *ngIf="!showSolution">
                                 <div
+                                    id="drop-location"
                                     class="drop-location"
                                     *ngFor="let dropLocation of question.dropLocations; let i = index"
                                     [ngStyle]="{

--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
@@ -81,6 +81,7 @@
                 <div class="click-layer">
                     <div *ngIf="!showResult">
                         <div
+                            id="drop-location"
                             class="drop-location"
                             *ngFor="let dropLocation of question.dropLocations"
                             [ngClass]="dropAllowed ? 'drop-allowed' : ''"
@@ -247,9 +248,10 @@
                     dnd-droppable
                 >
                     <jhi-drag-item
+                        id="drag-item-{{ i }}"
                         (dragenter)="drag()"
                         (dragend)="drop()"
-                        *ngFor="let dragItem of getUnassignedDragItems()"
+                        *ngFor="let dragItem of getUnassignedDragItems(); let i = index"
                         [dragItem]="dragItem"
                         [clickDisabled]="clickDisabled"
                         [minWidth]="'160'"

--- a/src/test/cypress/integration/exercises/quiz-exercise/QuizExerciseParticipation.spec.ts
+++ b/src/test/cypress/integration/exercises/quiz-exercise/QuizExerciseParticipation.spec.ts
@@ -107,7 +107,7 @@ describe('Quiz Exercise Participation', () => {
         it('Student can participate in DnD Quiz', () => {
             cy.login(student, '/courses/' + course.id);
             courseOverview.startExercise(quizExercise.id, CypressExerciseType.QUIZ);
-            dragAndDropQuiz.dragItemIntoDragArea();
+            dragAndDropQuiz.dragItemIntoDragArea(0);
             dragAndDropQuiz.submit();
         });
     });

--- a/src/test/cypress/support/pageobjects/exercises/quiz/DragAndDropQuiz.ts
+++ b/src/test/cypress/support/pageobjects/exercises/quiz/DragAndDropQuiz.ts
@@ -1,8 +1,8 @@
 import { POST, EXERCISE_BASE } from '../../../constants';
 
 export class DragAndDropQuiz {
-    dragItemIntoDragArea() {
-        cy.get('#drag-items').children().eq(0).drag('.drop-location');
+    dragItemIntoDragArea(itemIndex: number) {
+        cy.get('#drag-item-' + itemIndex).drag('#drop-location');
     }
 
     submit() {

--- a/src/test/cypress/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
@@ -30,7 +30,7 @@ export class QuizExerciseCreationPage {
             cy.get('.click-layer').trigger('mousedown', { x: 50, y: 50 }).trigger('mousemove', { x: 500, y: 300 }).trigger('mouseup');
         });
         this.createDragAndDropItem('Rick Astley');
-        cy.get('#drag-item-0').drag('.drop-location');
+        cy.get('#drag-item-0').drag('#drop-location');
         cy.fixture('quiz_exercise_fixtures/dragAndDropQuiz.txt').then((fileContent) => {
             cy.get('.ace_text-input').focus().clear().type(fileContent);
         });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR extends #4465 and adds dynamic ids to the quiz dropdown and individual drag items. The affected tests still pass for me locally