### PR TITLE
`Development`: Allow missing javadoc for server tests in checkstyle configuration

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -9,6 +9,7 @@
             <property name="accessModifiers" value="public" />
             <property name="tokens" value="METHOD_DEF,ANNOTATION_FIELD_DEF"/>
             <property name="severity" value="error"/>
+            <property name="allowedAnnotations" value="Override,Test,ParameterizedTest,BeforeEach,AfterEach,BeforeAll,AfterAll"/>
         </module>
         <module name="MissingJavadocMethod">
             <property name="scope" value="public" />
@@ -16,6 +17,7 @@
             <property name="minLineCount" value="4" />
             <property name="tokens" value="METHOD_DEF,ANNOTATION_FIELD_DEF"/>
             <property name="severity" value="error"/>
+            <property name="allowedAnnotations" value="Override,Test,ParameterizedTest,BeforeEach,AfterEach,BeforeAll,AfterAll"/>
         </module>
     </module>
 </module>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
Codacy reports missing javadocs for server unit tests. Currently, nearly all test cases do not use javadoc. This leads to a lot of unnecessary reported issues.

### Description
This PR updates the Checkstyle configuration to ignore missing javadocs for methods annotated with `@Test`, `@ParameterizedTest` and similar. In the default Checkstyle configuration missing javadoc is allowed for `@Override`. It has been kept, as otherwise a lot of errors would be generated.

Codacy uses the `checkstyle.xml` from the branch `develop`. Therefore, no changes in Codacy can be seen until the PR is merged. The `server-style` CI-step still passes without any changes to the code.

### Steps for Testing
n/a

### Review Progress
#### Code Review
- [x] Review 1
- [ ] Review 2

### Test Coverage
n/a

### Screenshots
n/a