### PR TITLE
`Programming exercises`: Fix validation for the creation of programming exercise for languages C, Python and empty

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -27,7 +27,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { onError } from 'app/shared/util/global.utils';
 import { AuxiliaryRepository } from 'app/entities/programming-exercise-auxiliary-repository-model';
 import { SubmissionPolicyType } from 'app/entities/submission-policy.model';
-import { faBan, faQuestionCircle, faSave, faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { faBan, faExclamationCircle, faQuestionCircle, faSave } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
     selector: 'jhi-programming-exercise-update',
@@ -677,30 +677,40 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
             });
         }
 
-        if (this.programmingExercise.packageName === undefined || this.programmingExercise.packageName === '') {
-            result.push({
-                translateKey: 'artemisApp.exercise.form.packageName.undefined',
-                translateValues: {},
-            });
-        } else {
-            const patternMatchJavaKotlin: RegExpMatchArray | null = this.programmingExercise.packageName.match(this.packageNamePatternForJavaKotlin);
-            const patternMatchSwift: RegExpMatchArray | null = this.programmingExercise.packageName.match(this.appNamePatternForSwift);
-            // window.alert(patternMatchJavaKotlin + ' ; ' + patternMatchSwift);
-            if (this.programmingExercise.programmingLanguage === ProgrammingLanguage.JAVA && (patternMatchJavaKotlin === null || patternMatchJavaKotlin.length === 0)) {
+        // validation on package name has not to be performed for languages Empty, C and Python
+        if (
+            this.programmingExercise.programmingLanguage !== ProgrammingLanguage.C &&
+            this.programmingExercise.programmingLanguage !== ProgrammingLanguage.PYTHON &&
+            this.programmingExercise.programmingLanguage !== ProgrammingLanguage.EMPTY
+        ) {
+            if (this.programmingExercise.packageName === undefined || this.programmingExercise.packageName === '') {
                 result.push({
-                    translateKey: 'artemisApp.exercise.form.packageName.pattern.JAVA',
+                    translateKey: 'artemisApp.exercise.form.packageName.undefined',
                     translateValues: {},
                 });
-            } else if (this.programmingExercise.programmingLanguage === ProgrammingLanguage.KOTLIN && (patternMatchJavaKotlin === null || patternMatchJavaKotlin.length === 0)) {
-                result.push({
-                    translateKey: 'artemisApp.exercise.form.packageName.pattern.KOTLIN',
-                    translateValues: {},
-                });
-            } else if (this.programmingExercise.programmingLanguage === ProgrammingLanguage.SWIFT && (patternMatchSwift === null || patternMatchSwift.length === 0)) {
-                result.push({
-                    translateKey: 'artemisApp.exercise.form.packageName.pattern.SWIFT',
-                    translateValues: {},
-                });
+            } else {
+                const patternMatchJavaKotlin: RegExpMatchArray | null = this.programmingExercise.packageName.match(this.packageNamePatternForJavaKotlin);
+                const patternMatchSwift: RegExpMatchArray | null = this.programmingExercise.packageName.match(this.appNamePatternForSwift);
+                // window.alert(patternMatchJavaKotlin + ' ; ' + patternMatchSwift);
+                if (this.programmingExercise.programmingLanguage === ProgrammingLanguage.JAVA && (patternMatchJavaKotlin === null || patternMatchJavaKotlin.length === 0)) {
+                    result.push({
+                        translateKey: 'artemisApp.exercise.form.packageName.pattern.JAVA',
+                        translateValues: {},
+                    });
+                } else if (
+                    this.programmingExercise.programmingLanguage === ProgrammingLanguage.KOTLIN &&
+                    (patternMatchJavaKotlin === null || patternMatchJavaKotlin.length === 0)
+                ) {
+                    result.push({
+                        translateKey: 'artemisApp.exercise.form.packageName.pattern.KOTLIN',
+                        translateValues: {},
+                    });
+                } else if (this.programmingExercise.programmingLanguage === ProgrammingLanguage.SWIFT && (patternMatchSwift === null || patternMatchSwift.length === 0)) {
+                    result.push({
+                        translateKey: 'artemisApp.exercise.form.packageName.pattern.SWIFT',
+                        translateValues: {},
+                    });
+                }
             }
         }
 

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -585,6 +585,16 @@ describe('ProgrammingExercise Management Update Component', () => {
                 translateValues: {},
             });
         });
+
+        it('should find no package name related validation error for languages that does not a package name', () => {
+            for (const programmingLanguage of [ProgrammingLanguage.C, ProgrammingLanguage.EMPTY, ProgrammingLanguage.PYTHON]) {
+                comp.programmingExercise.programmingLanguage = programmingLanguage;
+                expect(comp.getInvalidReasons()).not.toContainEqual({
+                    translateKey: 'artemisApp.exercise.form.packageName.undefined',
+                    translateValues: {},
+                });
+            }
+        });
     });
 });
 

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -586,7 +586,7 @@ describe('ProgrammingExercise Management Update Component', () => {
             });
         });
 
-        it('should find no package name related validation error for languages that does not a package name', () => {
+        it('should find no package name related validation error for languages that do not need a package name', () => {
             for (const programmingLanguage of [ProgrammingLanguage.C, ProgrammingLanguage.EMPTY, ProgrammingLanguage.PYTHON]) {
                 comp.programmingExercise.programmingLanguage = programmingLanguage;
                 expect(comp.getInvalidReasons()).not.toContainEqual({


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
This PR is linked to #4523. When creating a programming exercise for C, Python, and Empty, a validation error claiming an undefined package name is displayed and prevents the user from clicking the 'Generate'-Button and creating the exercise. However, these programming exercises do not need any package name.

### Description
In #4308, validation for the package names has been introduced containing a check that the package name is not undefined nor an empty string. This PR removes checking for an undefined/empty package name for the programming languages C, Python and Empty.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor/Editor

1. Log in to Artemis
2. Open the screen for creating programming exercises
3. Check that when choosing one of the above programming languages, no validation error for a missing package name is displayed.
4. Check that when choosing a different programming language than from the above the package name validation still works.


### Review Progress
#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
