### PR TITLE
`Programming exercises`: Fix passed test cases bars layout on the grading page

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/grading/charts/test-case-passed-builds-chart.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/grading/charts/test-case-passed-builds-chart.component.ts
@@ -11,7 +11,7 @@ import { round } from 'app/shared/util/utils';
         </div>
     `,
     styles: [
-        '.chart-body { border-radius: 4px; background-color: #999; height: 10px; width: 100px; overflow: hidden; position: relative; }',
+        '.chart-body { border-radius: 4px; background-color: #999; height: 10px; max-width: 100px; overflow: hidden; position: relative; }',
         '.passed-bar { position: absolute; top: 0; left: 0; height: 10px; background-color: #28a745 }',
         '.failed-bar { position: absolute; top: 0; height: 10px; background-color: #dc3545 }',
     ],


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes #4528 

### Description
<!-- Describe your changes in detail -->
The layout should be same for Chrome and Firefox now. Furthermore, the bars should now adapt to smaller screens instead of getting cut off.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with Submissions that satisfy at least one test case
- Firefox 95.0.1 (I think it is the newest version)

1. Log in to Artemis
2. Navigate to Course Administration
3. Enter the grading page of the programming exercise
4. Check the layout of the passed test cases bar. Make sure it is fitted in the "Passed (%) column again.
5. Reduce the screen width and check whether the bars adapt to the changed dimensions

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

Nothing changed

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
For the broken layout, check the corresponding issue. Now it should look again like this:
![image](https://user-images.githubusercontent.com/80622272/146754742-6cca3770-ad92-4f46-9f5d-5dfd8cf6e8fe.png)

The current behavior on smaller screens:
![image](https://user-images.githubusercontent.com/80622272/146754893-07515ca3-36e8-4175-aec2-d4734ac04e4b.png)

How it should look now:
![image](https://user-images.githubusercontent.com/80622272/146754993-398548d3-87fa-4fd2-946f-a9405e11df47.png)
