### PR TITLE
`Assessment`: Fix missing translation on example submission board

### DIFF
--- a/src/main/webapp/app/exercises/shared/example-submission/example-submissions.component.html
+++ b/src/main/webapp/app/exercises/shared/example-submission/example-submissions.component.html
@@ -14,7 +14,7 @@
             <a *ngIf="exercise.course.isAtLeastEditor" class="btn btn-primary me-1 mb-1" (click)="openImportModal()">
                 <fa-icon [icon]="faPlus"></fa-icon>
                 <fa-icon class="d-xl-none" [icon]="faFont"></fa-icon>
-                <span class="d-none d-xl-inline" jhiTranslate="artemisApp.exampleSubmission.importExampleSubmission"></span>
+                <span class="d-none d-xl-inline" jhiTranslate="artemisApp.exampleSubmission.useAsExampleSubmission"></span>
             </a>
         </div>
     </div>


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
PR #4397 introduced a missing translation error on the example submission board. 

### Description
I replaced the old key `importExampleSubmission` with the new key `useAsExampleSubmission`.

### Steps for Testing

1. Go to the example submission board (Course Management -> Exercises -> Select a Modeling or Text Exercise -> Example Submissions)
2. Check that the text is displayed correctly (see Screenshot)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
old:
![grafik](https://user-images.githubusercontent.com/26540346/146810174-5eac2100-8728-495d-a115-e560e84d4207.png)

new: 
![grafik](https://user-images.githubusercontent.com/26540346/146810156-4849194f-5c94-40b2-ac76-19d406b80200.png)

