### PR TITLE
`Development`: Fix cypress e2e tests for exercise assessments

### DIFF
--- a/src/test/cypress/integration/exercises/modeling/ModelingExerciseAssessment.spec.ts
+++ b/src/test/cypress/integration/exercises/modeling/ModelingExerciseAssessment.spec.ts
@@ -36,7 +36,6 @@ describe('Modeling Exercise Assessment Spec', () => {
         cy.login(tutor, '/course-management');
         cy.get(`[href="/course-management/${course.id}/assessment-dashboard"]`).click();
         cy.url().should('contain', `/course-management/${course.id}/assessment-dashboard`);
-        courseAssessmentDashboard.checkShowFinishedExercises();
         courseAssessmentDashboard.clickExerciseDashboardButton();
         exerciseAssessmentDashboard.clickHaveReadInstructionsButton();
         exerciseAssessmentDashboard.clickStartNewAssessment();

--- a/src/test/cypress/integration/exercises/programming/ProgrammingExerciseAssessment.spec.ts
+++ b/src/test/cypress/integration/exercises/programming/ProgrammingExerciseAssessment.spec.ts
@@ -47,7 +47,6 @@ describe('Programming exercise assessment', () => {
     it('Assesses the programming exercise submission', () => {
         cy.login(tutor, '/course-management');
         coursesPage.openAssessmentDashboardOfCourse(course.shortName);
-        courseAssessment.checkShowFinishedExercises();
         courseAssessment.clickExerciseDashboardButton();
         exerciseAssessment.clickHaveReadInstructionsButton();
         exerciseAssessment.clickStartNewAssessment();

--- a/src/test/cypress/integration/exercises/text/TextExerciseAssessment.spec.ts
+++ b/src/test/cypress/integration/exercises/text/TextExerciseAssessment.spec.ts
@@ -48,7 +48,6 @@ describe('Text exercise assessment', () => {
     it('Assesses the text exercise submission', () => {
         cy.login(tutor, '/course-management');
         coursesPage.openAssessmentDashboardOfCourse(course.shortName);
-        courseAssessment.checkShowFinishedExercises();
         courseAssessment.clickExerciseDashboardButton();
         exerciseAssessment.clickHaveReadInstructionsButton();
         cy.contains('There are no complaints at the moment').should('be.visible');

--- a/src/test/cypress/support/pageobjects/assessment/CourseAssessmentDashboardPage.ts
+++ b/src/test/cypress/support/pageobjects/assessment/CourseAssessmentDashboardPage.ts
@@ -21,10 +21,6 @@ export class CourseAssessmentDashboardPage {
         cy.get(this.exerciseDashboardButtonSelector).click();
     }
 
-    checkShowFinishedExercises() {
-        cy.get('#field_showFinishedExercise').check();
-    }
-
     clickEvaluateQuizzes() {
         cy.intercept(POST, COURSE_BASE + '*/exams/*/student-exams/evaluate-quiz-exercises').as('evaluateQuizzes');
         cy.get('#evaluateQuizExercisesButton').click();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A recent change inverted the functionality of a checkboxin the assessment dashboard ("Show finished exercises" -> "Hide Finished"). That change seems to have removed the id for the html element, so the tests failed.

### Description
<!-- Describe your changes in detail -->
Because of the invertion of the functionality the tests do not need to check the checkbox anymore, so I simply removed the related code.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
[Tests are executed by Bamboo and pass again](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-707)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
