### PR TITLE
`Development`: Add missing client tests for Orion components

### DIFF
--- a/src/test/javascript/spec/component/orion/modal-confirm-autofocus.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/modal-confirm-autofocus.component.spec.ts
@@ -1,0 +1,34 @@
+import { ArtemisTestModule } from '../../test.module';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockProvider } from 'ng-mocks';
+import { By } from '@angular/platform-browser';
+import { ModalConfirmAutofocusComponent } from 'app/shared/orion/modal-confirm-autofocus/modal-confirm-autofocus.component';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { TranslatePipeMock } from '../../helpers/mocks/service/mock-translate.service';
+
+describe('ModalConfirmAutofocusComponent', () => {
+    let fixture: ComponentFixture<ModalConfirmAutofocusComponent>;
+    let modal: NgbActiveModal;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [ModalConfirmAutofocusComponent, TranslatePipeMock],
+            providers: [MockProvider(NgbActiveModal)],
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(ModalConfirmAutofocusComponent);
+                modal = TestBed.inject(NgbActiveModal);
+            });
+    });
+
+    it('should close modal on close button click', () => {
+        const closeButton = fixture.debugElement.query(By.css('.btn-danger'));
+        expect(closeButton).not.toBe(null);
+
+        const closeSpy = jest.spyOn(modal, 'close').mockImplementation();
+        closeButton.nativeElement.click();
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/test/javascript/spec/component/orion/orion-course-management-exercises.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-course-management-exercises.component.spec.ts
@@ -1,0 +1,27 @@
+import { ArtemisTestModule } from '../../test.module';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockComponent } from 'ng-mocks';
+import { By } from '@angular/platform-browser';
+import { OrionCourseManagementExercisesComponent } from 'app/orion/management/orion-course-management-exercises.component';
+import { CourseManagementExercisesComponent } from 'app/course/manage/course-management-exercises.component';
+
+describe('OrionCourseManagementExercisesComponent', () => {
+    let fixture: ComponentFixture<OrionCourseManagementExercisesComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [OrionCourseManagementExercisesComponent, MockComponent(CourseManagementExercisesComponent)],
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(OrionCourseManagementExercisesComponent);
+            });
+    });
+
+    it('should contain CourseManagementExercisesComponent', () => {
+        const courseExerciseDetails = fixture.debugElement.query(By.directive(CourseManagementExercisesComponent));
+
+        expect(courseExerciseDetails).not.toBe(null);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation, Context and Description
Currently there are two Orion components that did not havve any tests. Since they don't contain typescript code, this PR only adds dummy tests to make sure they can be initialized to get the coverage up.

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2

### Test Coverage
Tests don't run through on bamboo, but I hope 100% now for all Orion files (Also see #4254, the only lines missing there belong to the files tested here)
