### PR TITLE
`Development`: Fix cypress e2e tests for exercise participations

### DIFF
--- a/src/test/cypress/integration/exercises/modeling/ModelingExerciseParticipation.spec.ts
+++ b/src/test/cypress/integration/exercises/modeling/ModelingExerciseParticipation.spec.ts
@@ -1,5 +1,4 @@
 import { artemis } from '../../../support/ArtemisTesting';
-import { CypressExerciseType } from '../../../support/requests/CourseManagementRequests';
 
 // pageobjects
 const courseManagement = artemis.pageobjects.courseManagement;
@@ -34,7 +33,7 @@ describe('Modeling Exercise Participation Spec', () => {
 
     it('Student can start and submit their model', () => {
         cy.login(student, `/courses/${course.id}`);
-        courseOverview.startExercise(modelingExercise.id, CypressExerciseType.MODELING);
+        courseOverview.startExercise(modelingExercise.id);
         cy.get('#open-exercise-' + modelingExercise.id).click();
         modelingEditor.addComponentToModel(1);
         modelingEditor.addComponentToModel(2);

--- a/src/test/cypress/integration/exercises/quiz-exercise/QuizExerciseParticipation.spec.ts
+++ b/src/test/cypress/integration/exercises/quiz-exercise/QuizExerciseParticipation.spec.ts
@@ -1,7 +1,6 @@
 import { artemis } from '../../../support/ArtemisTesting';
 import multipleChoiceQuizTemplate from '../../../fixtures/quiz_exercise_fixtures/multipleChoiceQuiz_template.json';
 import shortAnswerQuizTemplate from '../../../fixtures/quiz_exercise_fixtures/shortAnswerQuiz_template.json';
-import { CypressExerciseType } from 'src/test/cypress/support/requests/CourseManagementRequests';
 
 // Accounts
 const admin = artemis.users.getAdmin();
@@ -60,7 +59,7 @@ describe('Quiz Exercise Participation', () => {
             courseManagementRequest.setQuizVisible(quizExercise.id);
             courseManagementRequest.startQuizNow(quizExercise.id);
             cy.login(student, '/courses/' + course.id);
-            courseOverview.startExercise(quizExercise.id, CypressExerciseType.QUIZ);
+            courseOverview.startExercise(quizExercise.id);
             multipleChoiceQuiz.tickAnswerOption(0);
             multipleChoiceQuiz.tickAnswerOption(2);
             multipleChoiceQuiz.submit();
@@ -80,7 +79,7 @@ describe('Quiz Exercise Participation', () => {
         it('Student can participate in SA quiz', () => {
             const quizQuestionId = quizExercise.quizQuestions[0].id;
             cy.login(student, '/courses/' + course.id);
-            courseOverview.startExercise(quizExercise.id, CypressExerciseType.QUIZ);
+            courseOverview.startExercise(quizExercise.id);
             shortAnswerQuiz.typeAnswer(0, 1, quizQuestionId, 'give');
             shortAnswerQuiz.typeAnswer(1, 1, quizQuestionId, 'let');
             shortAnswerQuiz.typeAnswer(2, 1, quizQuestionId, 'run');
@@ -106,7 +105,7 @@ describe('Quiz Exercise Participation', () => {
 
         it('Student can participate in DnD Quiz', () => {
             cy.login(student, '/courses/' + course.id);
-            courseOverview.startExercise(quizExercise.id, CypressExerciseType.QUIZ);
+            courseOverview.startExercise(quizExercise.id);
             dragAndDropQuiz.dragItemIntoDragArea(0);
             dragAndDropQuiz.submit();
         });

--- a/src/test/cypress/integration/exercises/text/TextExerciseParticipation.spec.ts
+++ b/src/test/cypress/integration/exercises/text/TextExerciseParticipation.spec.ts
@@ -1,5 +1,4 @@
 import { artemis } from '../../../support/ArtemisTesting';
-import { CypressExerciseType } from '../../../support/requests/CourseManagementRequests';
 
 // The user management object
 const users = artemis.users;
@@ -28,7 +27,7 @@ describe('Text exercise participation', () => {
 
     it('Creates a text exercise in the UI', () => {
         cy.login(users.getStudentOne(), `/courses/${course.id}/exercises`);
-        courseOverview.startExercise(exercise.id, CypressExerciseType.TEXT);
+        courseOverview.startExercise(exercise.id);
         courseOverview.openRunningExercise(exercise.id);
 
         // Verify the initial state of the text editor

--- a/src/test/cypress/support/pageobjects/course/CourseOverviewPage.ts
+++ b/src/test/cypress/support/pageobjects/course/CourseOverviewPage.ts
@@ -1,5 +1,4 @@
-import { BASE_API, GET, POST } from '../../constants';
-import { COURSE_BASE, CypressExerciseType } from '../../requests/CourseManagementRequests';
+import { BASE_API, GET } from '../../constants';
 
 /**
  * A class which encapsulates UI selectors and actions for the course overview page (/courses/*).
@@ -7,21 +6,8 @@ import { COURSE_BASE, CypressExerciseType } from '../../requests/CourseManagemen
 export class CourseOverviewPage {
     readonly participationRequestId = 'participateInExerciseQuery';
 
-    startExercise(exerciseId: string, exerciseType: CypressExerciseType) {
-        switch (exerciseType) {
-            case CypressExerciseType.MODELING:
-            case CypressExerciseType.TEXT:
-            case CypressExerciseType.PROGRAMMING:
-                cy.intercept(POST, COURSE_BASE + '*/exercises/*/participations').as(this.participationRequestId);
-                break;
-            case CypressExerciseType.QUIZ:
-                cy.intercept(GET, BASE_API + 'exercises/*/participation').as(this.participationRequestId);
-                break;
-            default:
-                throw new Error(`Exercise type '${exerciseType}' is not supported yet!`);
-        }
+    startExercise(exerciseId: string) {
         cy.get('#start-exercise-' + exerciseId).click();
-        cy.wait('@participateInExerciseQuery');
     }
 
     openRunningExercise(exerciseId: string) {

--- a/src/test/cypress/support/pageobjects/exercises/programming/OnlineEditorPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/programming/OnlineEditorPage.ts
@@ -1,6 +1,5 @@
 import { DELETE } from './../../../constants';
 import { artemis } from './../../../ArtemisTesting';
-import { CypressExerciseType } from '../../../requests/CourseManagementRequests';
 import { GET, BASE_API, POST } from '../../../constants';
 import { CypressCredentials } from '../../../users';
 
@@ -157,7 +156,7 @@ export function startParticipationInProgrammingExercise(courseId: string, exerci
     cy.log('Participating in the programming exercise as a student...');
     courses.openCourse(courseId);
     cy.url().should('include', '/exercises');
-    courseOverview.startExercise(exerciseId, CypressExerciseType.PROGRAMMING);
+    courseOverview.startExercise(exerciseId);
     courseOverview.openRunningProgrammingExercise(exerciseId);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The cypress e2e tests for exercise participations are currently failing because cypress couldn't intercept the request to start a participation in an exercise. Most likely the url of the API endpoint was changed or another endpoint is called now. However the tests shouldn't wait for this request in the first place. This was a relic because the old test environment performed poorly when starting a programming exercise participation. It sometimes took more than 20 seconds to create a participation. By intercepting the request to the Artemis Server it was possible to allow the tests to wait until the request has returned (up to 60 seconds). The new test environment performs better so the interception is not needed anymore.

### Description
<!-- Describe your changes in detail -->
I removed the request interception, so the cypress tests only wait for the next UI element to show up and aren't dependent on the communication between the Artemis Client and Artemis Server.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
[Tests are executed by Bamboo and pass again](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETBBT-722)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2