### PR TITLE
`General`: Show statistics button for tutors on course detail view

### DIFF
--- a/src/main/webapp/app/course/manage/detail/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.html
@@ -57,7 +57,7 @@
                 <fa-icon [icon]="faEye"></fa-icon>
                 <span jhiTranslate="artemisApp.participantScores.pageTitle">Participant Score</span>
             </a>
-            <a *ngIf="course.isAtLeastInstructor" [routerLink]="['/course-management', course.id, 'course-statistics']" class="tab-item btn btn-info btn-md ms-1">
+            <a *ngIf="course.isAtLeastTutor" [routerLink]="['/course-management', course.id, 'course-statistics']" class="tab-item btn btn-info btn-md ms-1">
                 <fa-icon [icon]="faChartBar"></fa-icon>
                 <span jhiTranslate="artemisApp.courseOverview.menu.statistics">Statistics</span>
             </a>


### PR DESCRIPTION

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Closes #4472

### Description
The Statistics button is now consistently shown for tutors on both the course management cards and the course management detail view.

Since the Server-Endpoint only needs tutor rights and the button on cards also checked against tutor rights only, I decided to be consistent here and check for `isAtLeastTutor`, not against editor rights as suggested in the issue. 

### Steps for Testing
Prerequisites:
- 1 Tutor
1. Navigate to Course Management
2. Check that the Statistics-Button is shown
3. Click on one course to go to the course details
4. Check that the Statistics-Button is shown as well.
5. Click on the button, check that the page can be seen.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
![grafik](https://user-images.githubusercontent.com/26540346/147259123-801bfc89-11d1-49b3-8d4c-22379b213397.png)
