### PR TITLE
`Development`: Convert programming service client tests to Jest

### DIFF
--- a/src/test/javascript/spec/service/programming-exercise-grading.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise-grading.service.spec.ts
@@ -1,28 +1,21 @@
-import { async } from '@angular/core/testing';
-import * as chai from 'chai';
-import { SinonSpy, SinonStub, spy, stub } from 'sinon';
+import { async, TestBed } from '@angular/core/testing';
 import { of, Subject } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import sinonChai from 'sinon-chai';
 import { MockWebsocketService } from '../helpers/mocks/service/mock-websocket.service';
-import { IWebsocketService } from 'app/core/websocket/websocket.service';
+import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
 import { ProgrammingExerciseGradingService } from 'app/exercises/programming/manage/services/programming-exercise-grading.service';
 import { MockHttpService } from '../helpers/mocks/service/mock-http.service';
 import { ProgrammingExerciseTestCase } from 'app/entities/programming-exercise-test-case.model';
 import { Result } from 'app/entities/result.model';
-
-chai.use(sinonChai);
-const expect = chai.expect;
+import { HttpClient } from '@angular/common/http';
 
 describe('ProgrammingExerciseGradingService', () => {
-    let websocketService: IWebsocketService;
-    let httpService: MockHttpService;
+    let websocketService: JhiWebsocketService;
+    let httpService: HttpClient;
     let exercise1TestCaseSubject: Subject<Result>;
     let exercise2TestCaseSubject: Subject<Result>;
-    let subscribeSpy: SinonSpy;
-    let receiveStub: SinonStub;
-    let unsubscribeSpy: SinonSpy;
-    let getStub: SinonStub;
+    let receiveStub: jest.SpyInstance;
+    let getStub: jest.SpyInstance;
 
     let gradingService: ProgrammingExerciseGradingService;
 
@@ -44,28 +37,44 @@ describe('ProgrammingExerciseGradingService', () => {
     const exercise2Topic = `/topic/programming-exercise/${exercise2.id}/test-cases`;
 
     beforeEach(async(() => {
-        websocketService = new MockWebsocketService();
-        httpService = new MockHttpService();
-        gradingService = new ProgrammingExerciseGradingService(websocketService as any, httpService as any);
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: HttpClient, useClass: MockHttpService },
+                { provide: JhiWebsocketService, useClass: MockWebsocketService },
+            ],
+        })
+            .compileComponents()
+            .then(() => {
+                websocketService = TestBed.inject(JhiWebsocketService);
+                httpService = TestBed.inject(HttpClient);
+                gradingService = TestBed.inject(ProgrammingExerciseGradingService);
 
-        subscribeSpy = spy(websocketService, 'subscribe');
-        unsubscribeSpy = spy(websocketService, 'unsubscribe');
-        receiveStub = stub(websocketService, 'receive');
-        getStub = stub(httpService, 'get');
+                receiveStub = jest.spyOn(websocketService, 'receive');
+                getStub = jest.spyOn(httpService, 'get');
 
-        exercise1TestCaseSubject = new Subject();
-        exercise2TestCaseSubject = new Subject();
-        receiveStub.withArgs(exercise1Topic).returns(exercise1TestCaseSubject);
-        receiveStub.withArgs(exercise2Topic).returns(exercise2TestCaseSubject);
-        getStub.withArgs(`${gradingService.resourceUrl}/${exercise1.id}/test-cases`).returns(of(testCases1));
-        getStub.withArgs(`${gradingService.resourceUrl}/${exercise2.id}/test-cases`).returns(of(testCases2));
+                exercise1TestCaseSubject = new Subject();
+                exercise2TestCaseSubject = new Subject();
+                receiveStub.mockImplementation((arg1) => {
+                    switch (arg1) {
+                        case exercise1Topic:
+                            return exercise1TestCaseSubject;
+                        case exercise2Topic:
+                            return exercise2TestCaseSubject;
+                    }
+                });
+                getStub.mockImplementation((arg1) => {
+                    switch (arg1) {
+                        case `${gradingService.resourceUrl}/${exercise1.id}/test-cases`:
+                            return of(testCases1);
+                        case `${gradingService.resourceUrl}/${exercise2.id}/test-cases`:
+                            return of(testCases2);
+                    }
+                });
+            });
     }));
 
     afterEach(() => {
-        subscribeSpy.restore();
-        unsubscribeSpy.restore();
-        receiveStub.restore();
-        getStub.restore();
+        jest.restoreAllMocks();
     });
 
     it('should fetch the test cases via REST call if there is nothing stored yet for a given exercise', () => {
@@ -77,18 +86,18 @@ describe('ProgrammingExerciseGradingService', () => {
             .pipe(tap((newTestCases) => (testCasesExercise1 = newTestCases)))
             .subscribe();
 
-        expect(getStub).to.have.been.calledOnce;
-        expect(testCasesExercise1).to.deep.equal(testCases1);
-        expect(testCasesExercise2).to.be.undefined;
+        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(testCasesExercise1).toEqual(testCases1);
+        expect(testCasesExercise2).toBe(undefined);
 
         gradingService
             .subscribeForTestCases(exercise2.id)
             .pipe(tap((newTestCases) => (testCasesExercise2 = newTestCases)))
             .subscribe();
 
-        expect(getStub).to.have.been.calledTwice;
-        expect(testCasesExercise1).to.deep.equal(testCases1);
-        expect(testCasesExercise2).to.deep.equal(testCases2);
+        expect(getStub).toHaveBeenCalledTimes(2);
+        expect(testCasesExercise1).toEqual(testCases1);
+        expect(testCasesExercise2).toEqual(testCases2);
     });
 
     it('should reuse the same subject when there already is a connection established and not call the REST endpoint', () => {
@@ -104,8 +113,8 @@ describe('ProgrammingExerciseGradingService', () => {
             .pipe(tap((newTestCases) => (testCasesExercise1 = newTestCases)))
             .subscribe();
 
-        expect(getStub).to.have.been.calledOnce;
-        expect(testCasesExercise1).to.equal(testCases1);
+        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(testCasesExercise1).toBe(testCases1);
     });
 
     it('should notify subscribers on new test case value', () => {
@@ -123,12 +132,12 @@ describe('ProgrammingExerciseGradingService', () => {
             .pipe(tap((newTestCases) => (testCasesExercise1Subscriber2 = newTestCases)))
             .subscribe();
 
-        expect(testCasesExercise1Subscriber1).to.equal(testCases1);
-        expect(testCasesExercise1Subscriber2).to.equal(testCases1);
+        expect(testCasesExercise1Subscriber1).toBe(testCases1);
+        expect(testCasesExercise1Subscriber2).toBe(testCases1);
 
         gradingService.notifyTestCases(exercise1.id, newTestCasesOracle);
 
-        expect(testCasesExercise1Subscriber1).to.equal(newTestCasesOracle);
-        expect(testCasesExercise1Subscriber2).to.equal(newTestCasesOracle);
+        expect(testCasesExercise1Subscriber1).toBe(newTestCasesOracle);
+        expect(testCasesExercise1Subscriber2).toBe(newTestCasesOracle);
     });
 });

--- a/src/test/javascript/spec/service/programming-exercise-grading.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise-grading.service.spec.ts
@@ -114,7 +114,7 @@ describe('ProgrammingExerciseGradingService', () => {
             .subscribe();
 
         expect(getStub).toHaveBeenCalledTimes(1);
-        expect(testCasesExercise1).toBe(testCases1);
+        expect(testCasesExercise1).toEqual(testCases1);
     });
 
     it('should notify subscribers on new test case value', () => {
@@ -132,12 +132,12 @@ describe('ProgrammingExerciseGradingService', () => {
             .pipe(tap((newTestCases) => (testCasesExercise1Subscriber2 = newTestCases)))
             .subscribe();
 
-        expect(testCasesExercise1Subscriber1).toBe(testCases1);
-        expect(testCasesExercise1Subscriber2).toBe(testCases1);
+        expect(testCasesExercise1Subscriber1).toEqual(testCases1);
+        expect(testCasesExercise1Subscriber2).toEqual(testCases1);
 
         gradingService.notifyTestCases(exercise1.id, newTestCasesOracle);
 
-        expect(testCasesExercise1Subscriber1).toBe(newTestCasesOracle);
-        expect(testCasesExercise1Subscriber2).toBe(newTestCasesOracle);
+        expect(testCasesExercise1Subscriber1).toEqual(newTestCasesOracle);
+        expect(testCasesExercise1Subscriber2).toEqual(newTestCasesOracle);
     });
 });

--- a/src/test/javascript/spec/service/programming-exercise-grading.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise-grading.service.spec.ts
@@ -1,4 +1,4 @@
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { of, Subject } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { MockWebsocketService } from '../helpers/mocks/service/mock-websocket.service';
@@ -36,7 +36,7 @@ describe('ProgrammingExerciseGradingService', () => {
     const exercise1Topic = `/topic/programming-exercise/${exercise1.id}/test-cases`;
     const exercise2Topic = `/topic/programming-exercise/${exercise2.id}/test-cases`;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             providers: [
                 { provide: HttpClient, useClass: MockHttpService },
@@ -71,7 +71,7 @@ describe('ProgrammingExerciseGradingService', () => {
                     }
                 });
             });
-    }));
+    });
 
     afterEach(() => {
         jest.restoreAllMocks();

--- a/src/test/javascript/spec/service/programming-exercise-instruction.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise-instruction.service.spec.ts
@@ -1,13 +1,12 @@
-import { async } from '@angular/core/testing';
 import dayjs from 'dayjs';
 import { ProgrammingExerciseInstructionService, TestCaseState } from 'app/exercises/programming/shared/instructions-render/service/programming-exercise-instruction.service';
 
 describe('ProgrammingExerciseInstructionService', () => {
     let programmingExerciseInstructionService: ProgrammingExerciseInstructionService;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         programmingExerciseInstructionService = new ProgrammingExerciseInstructionService();
-    }));
+    });
 
     it('should determine a successful state for all tasks if the result is successful', () => {
         const result = {

--- a/src/test/javascript/spec/service/programming-exercise-instruction.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise-instruction.service.spec.ts
@@ -1,11 +1,6 @@
 import { async } from '@angular/core/testing';
 import dayjs from 'dayjs';
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
 import { ProgrammingExerciseInstructionService, TestCaseState } from 'app/exercises/programming/shared/instructions-render/service/programming-exercise-instruction.service';
-
-chai.use(sinonChai);
-const expect = chai.expect;
 
 describe('ProgrammingExerciseInstructionService', () => {
     let programmingExerciseInstructionService: ProgrammingExerciseInstructionService;
@@ -27,12 +22,12 @@ describe('ProgrammingExerciseInstructionService', () => {
         const testCases = result.feedbacks.map(({ text }: { text: string }) => text);
 
         const { testCaseState: taskState1, detailed: detailed1 } = programmingExerciseInstructionService.testStatusForTask(testCases.slice(0, 1), result);
-        expect(taskState1).to.equal(TestCaseState.SUCCESS);
-        expect(detailed1).to.deep.equal({ successfulTests: ['testBubbleSort'], failedTests: [], notExecutedTests: [] });
+        expect(taskState1).toBe(TestCaseState.SUCCESS);
+        expect(detailed1).toEqual({ successfulTests: ['testBubbleSort'], failedTests: [], notExecutedTests: [] });
 
         const { testCaseState: taskState2, detailed: detailed2 } = programmingExerciseInstructionService.testStatusForTask(testCases.slice(1), result);
-        expect(taskState2).to.equal(TestCaseState.SUCCESS);
-        expect(detailed2).to.deep.equal({ successfulTests: ['testMergeSort'], failedTests: [], notExecutedTests: [] });
+        expect(taskState2).toBe(TestCaseState.SUCCESS);
+        expect(detailed2).toEqual({ successfulTests: ['testMergeSort'], failedTests: [], notExecutedTests: [] });
     });
 
     it('should determine a failed state for a task if at least one test has failed (non legacy case)', () => {
@@ -48,8 +43,8 @@ describe('ProgrammingExerciseInstructionService', () => {
         const testCases = result.feedbacks.map(({ text }: { text: string }) => text);
 
         const { testCaseState: taskState1, detailed: detailed1 } = programmingExerciseInstructionService.testStatusForTask(testCases, result);
-        expect(taskState1).to.equal(TestCaseState.FAIL);
-        expect(detailed1).to.deep.equal({ successfulTests: ['testMergeSort'], failedTests: ['testBubbleSort'], notExecutedTests: [] });
+        expect(taskState1).toBe(TestCaseState.FAIL);
+        expect(detailed1).toEqual({ successfulTests: ['testMergeSort'], failedTests: ['testBubbleSort'], notExecutedTests: [] });
     });
 
     it('should determine a failed state for a task if at least one test has failed (legacy case)', () => {
@@ -62,8 +57,8 @@ describe('ProgrammingExerciseInstructionService', () => {
         const testCases = ['testBubbleSort', 'testMergeSort'];
 
         const { testCaseState: taskState1, detailed: detailed1 } = programmingExerciseInstructionService.testStatusForTask(testCases, result);
-        expect(taskState1).to.equal(TestCaseState.FAIL);
-        expect(detailed1).to.deep.equal({ successfulTests: ['testMergeSort'], failedTests: ['testBubbleSort'], notExecutedTests: [] });
+        expect(taskState1).toBe(TestCaseState.FAIL);
+        expect(detailed1).toEqual({ successfulTests: ['testMergeSort'], failedTests: ['testBubbleSort'], notExecutedTests: [] });
     });
 
     it('should determine a state if there is no feedback for the specified tests (non legacy only)', () => {
@@ -76,7 +71,7 @@ describe('ProgrammingExerciseInstructionService', () => {
         const testCases = ['testBubbleSort', 'testMergeSort'];
 
         const { testCaseState: taskState1, detailed: detailed1 } = programmingExerciseInstructionService.testStatusForTask(testCases, result);
-        expect(taskState1).to.equal(TestCaseState.NOT_EXECUTED);
-        expect(detailed1).to.deep.equal({ successfulTests: [], failedTests: [], notExecutedTests: ['testBubbleSort', 'testMergeSort'] });
+        expect(taskState1).toBe(TestCaseState.NOT_EXECUTED);
+        expect(detailed1).toEqual({ successfulTests: [], failedTests: [], notExecutedTests: ['testBubbleSort', 'testMergeSort'] });
     });
 });

--- a/src/test/javascript/spec/service/programming-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise.service.spec.ts
@@ -1,7 +1,5 @@
 import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
 import { take } from 'rxjs/operators';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
@@ -16,9 +14,6 @@ import { ProgrammingSubmission } from 'app/entities/programming-submission.model
 import { Result } from 'app/entities/result.model';
 import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
-
-chai.use(sinonChai);
-const expect = chai.expect;
 
 describe('ProgrammingExercise Service', () => {
     let injector: TestBed;
@@ -36,12 +31,15 @@ describe('ProgrammingExercise Service', () => {
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: AccountService, useClass: MockAccountService },
             ],
-        });
-        injector = getTestBed();
-        service = injector.get(ProgrammingExerciseService);
-        httpMock = injector.get(HttpTestingController);
+        })
+            .compileComponents()
+            .then(() => {
+                injector = getTestBed();
+                service = injector.get(ProgrammingExerciseService);
+                httpMock = injector.get(HttpTestingController);
 
-        defaultProgrammingExercise = new ProgrammingExercise(undefined, undefined);
+                defaultProgrammingExercise = new ProgrammingExercise(undefined, undefined);
+            });
     });
 
     describe('Service methods', () => {
@@ -60,7 +58,7 @@ describe('ProgrammingExercise Service', () => {
             service
                 .find(123)
                 .pipe(take(1))
-                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
+                .subscribe((resp) => expect(resp.body).toEqual(expected));
             const req = httpMock.expectOne({ method: 'GET' });
             req.flush(returnedFromService);
             tick();
@@ -82,7 +80,7 @@ describe('ProgrammingExercise Service', () => {
             service
                 .automaticSetup(new ProgrammingExercise(undefined, undefined))
                 .pipe(take(1))
-                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
+                .subscribe((resp) => expect(resp.body).toEqual(expected));
             const req = httpMock.expectOne({ method: 'POST' });
             req.flush(returnedFromService);
             tick();
@@ -110,7 +108,7 @@ describe('ProgrammingExercise Service', () => {
             service
                 .findWithTemplateAndSolutionParticipation(expected.id, true)
                 .pipe(take(1))
-                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
+                .subscribe((resp) => expect(resp.body).toEqual(expected));
             const req = httpMock.expectOne({ method: 'GET' });
             req.flush(returnedFromService);
             tick();
@@ -137,7 +135,7 @@ describe('ProgrammingExercise Service', () => {
             service
                 .update(expected)
                 .pipe(take(1))
-                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
+                .subscribe((resp) => expect(resp.body).toEqual(expected));
             const req = httpMock.expectOne({ method: 'PUT' });
             req.flush(returnedFromService);
             tick();
@@ -158,7 +156,7 @@ describe('ProgrammingExercise Service', () => {
             service
                 .updateTimeline(expected)
                 .pipe(take(1))
-                .subscribe((resp) => expect(resp.body).to.deep.equal(expected));
+                .subscribe((resp) => expect(resp.body).toEqual(expected));
             const req = httpMock.expectOne({ method: 'PUT' });
             req.flush(returnedFromService);
             tick();
@@ -184,7 +182,7 @@ describe('ProgrammingExercise Service', () => {
                 .query(expected)
                 .pipe(take(1))
                 .subscribe((resp) => {
-                    expect(resp.body).to.include.deep.members([expected]);
+                    expect(resp.body).toIncludeAllMembers([expected]);
                 });
             const req = httpMock.expectOne({ method: 'GET' });
             req.flush([returnedFromService]);
@@ -201,7 +199,7 @@ describe('ProgrammingExercise Service', () => {
 
         it('should make get request', fakeAsync(() => {
             const expectedBlob = new Blob(['abc', 'cfe']);
-            service.exportInstructorExercise(123).subscribe((resp) => expect(resp.body).to.deep.equal(expectedBlob));
+            service.exportInstructorExercise(123).subscribe((resp) => expect(resp.body).toEqual(expectedBlob));
             const req = httpMock.expectOne({ method: 'GET', url: `${resourceUrl}/123/export-instructor-exercise` });
             req.flush(expectedBlob);
             tick();

--- a/src/test/javascript/spec/service/programming-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-submission.service.spec.ts
@@ -1,9 +1,6 @@
-import * as chai from 'chai';
 import dayjs from 'dayjs';
-import { SinonStub, spy, stub } from 'sinon';
 import { BehaviorSubject, lastValueFrom, of, Subject } from 'rxjs';
 import { range as _range } from 'lodash-es';
-import sinonChai from 'sinon-chai';
 import { MockWebsocketService } from '../helpers/mocks/service/mock-websocket.service';
 import { MockHttpService } from '../helpers/mocks/service/mock-http.service';
 import {
@@ -24,9 +21,6 @@ import { HttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
 
-chai.use(sinonChai);
-const expect = chai.expect;
-
 describe('ProgrammingSubmissionService', () => {
     let websocketService: JhiWebsocketService;
     let httpService: HttpClient;
@@ -34,13 +28,13 @@ describe('ProgrammingSubmissionService', () => {
     let participationService: ProgrammingExerciseParticipationService;
     let submissionService: ProgrammingSubmissionService;
 
-    let httpGetStub: SinonStub;
-    let wsSubscribeStub: SinonStub;
-    let wsUnsubscribeStub: SinonStub;
-    let wsReceiveStub: SinonStub;
-    let participationWsLatestResultStub: SinonStub;
-    let getLatestResultStub: SinonStub;
-    let notifyAllResultSubscribersStub: SinonStub;
+    let httpGetStub: jest.SpyInstance;
+    let wsSubscribeStub: jest.SpyInstance;
+    let wsUnsubscribeStub: jest.SpyInstance;
+    let wsReceiveStub: jest.SpyInstance;
+    let participationWsLatestResultStub: jest.SpyInstance;
+    let getLatestResultStub: jest.SpyInstance;
+    let notifyAllResultSubscribersStub: jest.SpyInstance;
 
     let wsSubmissionSubject: Subject<Submission | undefined>;
     let wsLatestResultSubject: Subject<Result | undefined>;
@@ -59,8 +53,6 @@ describe('ProgrammingSubmissionService', () => {
         result2 = { id: 32, submission: currentSubmission2 } as any;
 
         TestBed.configureTestingModule({
-            imports: [],
-            declarations: [],
             providers: [
                 { provide: JhiWebsocketService, useClass: MockWebsocketService },
                 { provide: HttpClient, useClass: MockHttpService },
@@ -76,63 +68,62 @@ describe('ProgrammingSubmissionService', () => {
                 participationWebsocketService = TestBed.inject(ParticipationWebsocketService);
                 participationService = TestBed.inject(ProgrammingExerciseParticipationService);
 
-                httpGetStub = stub(httpService, 'get');
-                wsSubscribeStub = stub(websocketService, 'subscribe');
-                wsUnsubscribeStub = stub(websocketService, 'unsubscribe');
+                httpGetStub = jest.spyOn(httpService, 'get');
+                wsSubscribeStub = jest.spyOn(websocketService, 'subscribe');
+                wsUnsubscribeStub = jest.spyOn(websocketService, 'unsubscribe');
                 wsSubmissionSubject = new Subject<Submission | undefined>();
-                wsReceiveStub = stub(websocketService, 'receive').returns(wsSubmissionSubject);
+                wsReceiveStub = jest.spyOn(websocketService, 'receive').mockReturnValue(wsSubmissionSubject);
                 wsLatestResultSubject = new Subject<Result | undefined>();
-                participationWsLatestResultStub = stub(participationWebsocketService, 'subscribeForLatestResultOfParticipation').returns(wsLatestResultSubject as any);
-                getLatestResultStub = stub(participationService, 'getLatestResultWithFeedback');
-                notifyAllResultSubscribersStub = stub(participationWebsocketService, 'notifyAllResultSubscribers');
+                participationWsLatestResultStub = jest
+                    .spyOn(participationWebsocketService, 'subscribeForLatestResultOfParticipation')
+                    .mockReturnValue(wsLatestResultSubject as any);
+                getLatestResultStub = jest.spyOn(participationService, 'getLatestResultWithFeedback');
+                notifyAllResultSubscribersStub = jest.spyOn(participationWebsocketService, 'notifyAllResultSubscribers');
             });
     });
 
     afterEach(() => {
-        httpGetStub.restore();
-        wsSubscribeStub.restore();
-        wsUnsubscribeStub.restore();
-        wsReceiveStub.restore();
-        participationWsLatestResultStub.restore();
-        getLatestResultStub.restore();
-        notifyAllResultSubscribersStub.restore();
+        jest.restoreAllMocks();
     });
 
     it('should return cached subject as Observable for provided participation if exists', () => {
         const cachedSubject = new BehaviorSubject(undefined);
         // @ts-ignore
-        const fetchLatestPendingSubmissionSpy = spy(submissionService, 'fetchLatestPendingSubmissionByParticipationId');
+        const fetchLatestPendingSubmissionSpy = jest.spyOn(submissionService, 'fetchLatestPendingSubmissionByParticipationId');
         // @ts-ignore
-        const setupWebsocketSubscriptionSpy = spy(submissionService, 'setupWebsocketSubscriptionForLatestPendingSubmission');
+        const setupWebsocketSubscriptionSpy = jest.spyOn(submissionService, 'setupWebsocketSubscriptionForLatestPendingSubmission');
         // @ts-ignore
-        const subscribeForNewResultSpy = spy(submissionService, 'subscribeForNewResult');
+        const subscribeForNewResultSpy = jest.spyOn(submissionService, 'subscribeForNewResult');
         // @ts-ignore
         submissionService.submissionSubjects = { [participationId]: cachedSubject };
 
         submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true);
-        expect(fetchLatestPendingSubmissionSpy).to.not.have.been.called;
-        expect(setupWebsocketSubscriptionSpy).to.not.have.been.called;
-        expect(subscribeForNewResultSpy).to.not.have.been.called;
+        expect(fetchLatestPendingSubmissionSpy).not.toHaveBeenCalled();
+        expect(setupWebsocketSubscriptionSpy).not.toHaveBeenCalled();
+        expect(subscribeForNewResultSpy).not.toHaveBeenCalled();
     });
 
     it('should query httpService endpoint and setup the websocket subscriptions if no subject is cached for the provided participation', async () => {
-        httpGetStub.returns(of(currentSubmission));
+        httpGetStub.mockReturnValue(of(currentSubmission));
         const submission = await new Promise((resolve) => submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true).subscribe((s) => resolve(s)));
-        expect(submission).to.deep.equal({ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId });
-        expect(wsSubscribeStub).to.have.been.calledOnceWithExactly(submissionTopic);
-        expect(wsReceiveStub).to.have.been.calledOnceWithExactly(submissionTopic);
-        expect(participationWsLatestResultStub).to.have.been.calledOnceWithExactly(participationId, true, 10);
+        expect(submission).toEqual({ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId });
+        expect(wsSubscribeStub).toHaveBeenCalledTimes(1);
+        expect(wsSubscribeStub).toHaveBeenCalledWith(submissionTopic);
+        expect(wsReceiveStub).toHaveBeenCalledTimes(1);
+        expect(wsReceiveStub).toHaveBeenCalledWith(submissionTopic);
+        expect(participationWsLatestResultStub).toHaveBeenCalledTimes(1);
+        expect(participationWsLatestResultStub).toHaveBeenCalledWith(participationId, true, 10);
     });
 
     it('should emit undefined when a new result comes in for the given participation to signal that the building process is over', () => {
         const returnedSubmissions: Array<ProgrammingSubmissionStateObj | undefined> = [];
-        httpGetStub.returns(of(currentSubmission));
+        httpGetStub.mockReturnValue(of(currentSubmission));
         submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true).subscribe((s) => returnedSubmissions.push(s));
-        expect(returnedSubmissions).to.deep.equal([{ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId }]);
+        expect(returnedSubmissions).toEqual([{ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId }]);
         // Result comes in for submission.
         result.submission = currentSubmission;
         wsLatestResultSubject.next(result);
-        expect(returnedSubmissions).to.deep.equal([
+        expect(returnedSubmissions).toEqual([
             { submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId },
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
         ]);
@@ -140,31 +131,31 @@ describe('ProgrammingSubmissionService', () => {
 
     it('should NOT emit undefined when a new result comes that does not belong to the currentSubmission', () => {
         const returnedSubmissions: Array<ProgrammingSubmissionStateObj | undefined> = [];
-        httpGetStub.returns(of(currentSubmission));
+        httpGetStub.mockReturnValue(of(currentSubmission));
         submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true).subscribe((s) => returnedSubmissions.push(s));
-        expect(returnedSubmissions).to.deep.equal([{ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId }]);
+        expect(returnedSubmissions).toEqual([{ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId }]);
         // Result comes in for submission.
         result.submission = currentSubmission2;
         wsLatestResultSubject.next(result);
-        expect(returnedSubmissions).to.deep.equal([{ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId }]);
+        expect(returnedSubmissions).toEqual([{ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId }]);
     });
 
     it('should emit the newest submission when it was received through the websocket connection', () => {
         const returnedSubmissions: Array<ProgrammingSubmissionStateObj | undefined> = [];
         // No latest pending submission found.
-        httpGetStub.returns(of(undefined));
+        httpGetStub.mockReturnValue(of(undefined));
         submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true).subscribe((s) => returnedSubmissions.push(s));
-        expect(returnedSubmissions).to.deep.equal([{ submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId }]);
+        expect(returnedSubmissions).toEqual([{ submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId }]);
         // New submission comes in.
         wsSubmissionSubject.next(currentSubmission2);
-        expect(returnedSubmissions).to.deep.equal([
+        expect(returnedSubmissions).toEqual([
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
             { submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission2, participationId },
         ]);
         // Result comes in for submission.
         result.submission = currentSubmission2;
         wsLatestResultSubject.next(result);
-        expect(returnedSubmissions).to.deep.equal([
+        expect(returnedSubmissions).toEqual([
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
             { submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission2, participationId },
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
@@ -176,14 +167,14 @@ describe('ProgrammingSubmissionService', () => {
         // @ts-ignore
         submissionService.DEFAULT_EXPECTED_RESULT_ETA = 10;
         const returnedSubmissions: Array<ProgrammingSubmissionStateObj | undefined> = [];
-        httpGetStub.returns(of(undefined));
+        httpGetStub.mockReturnValue(of(undefined));
         submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true).subscribe((s) => returnedSubmissions.push(s));
         // We simulate that the latest result from the server does not belong the pending submission
-        getLatestResultStub = getLatestResultStub.returns(of(result));
+        getLatestResultStub = getLatestResultStub.mockReturnValue(of(result));
 
-        expect(returnedSubmissions).to.deep.equal([{ submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId }]);
+        expect(returnedSubmissions).toEqual([{ submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId }]);
         wsSubmissionSubject.next(currentSubmission2);
-        expect(returnedSubmissions).to.deep.equal([
+        expect(returnedSubmissions).toEqual([
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
             { submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission2, participationId },
         ]);
@@ -191,10 +182,11 @@ describe('ProgrammingSubmissionService', () => {
         await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
 
         // Expect the fallback mechanism to kick in after the timeout
-        expect(getLatestResultStub).to.have.been.calledOnceWithExactly(participationId, true);
+        expect(getLatestResultStub).toHaveBeenCalledTimes(1);
+        expect(getLatestResultStub).toHaveBeenCalledWith(participationId, true);
 
         // HAS_FAILED_SUBMISSION is expected as the result provided by getLatestResult does not match the pending submission
-        expect(returnedSubmissions).to.deep.equal([
+        expect(returnedSubmissions).toEqual([
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
             { submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission2, participationId },
             { submissionState: ProgrammingSubmissionState.HAS_FAILED_SUBMISSION, submission: currentSubmission2, participationId },
@@ -202,7 +194,7 @@ describe('ProgrammingSubmissionService', () => {
 
         // Now the result for the submission in - should be accepted even though technically too late!
         wsLatestResultSubject.next(result2);
-        expect(returnedSubmissions).to.deep.equal([
+        expect(returnedSubmissions).toEqual([
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
             { submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission2, participationId },
             { submissionState: ProgrammingSubmissionState.HAS_FAILED_SUBMISSION, submission: currentSubmission2, participationId },
@@ -215,14 +207,14 @@ describe('ProgrammingSubmissionService', () => {
         // @ts-ignore
         submissionService.DEFAULT_EXPECTED_RESULT_ETA = 10;
         const returnedSubmissions: Array<ProgrammingSubmissionStateObj | undefined> = [];
-        httpGetStub.returns(of(undefined));
+        httpGetStub.mockReturnValue(of(undefined));
         submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true).subscribe((s) => returnedSubmissions.push(s));
         // We simulate that the latest result from the server matches the pending submission
-        getLatestResultStub = getLatestResultStub.returns(of(result));
+        getLatestResultStub = getLatestResultStub.mockReturnValue(of(result));
 
-        expect(returnedSubmissions).to.deep.equal([{ submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId }]);
+        expect(returnedSubmissions).toEqual([{ submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId }]);
         wsSubmissionSubject.next(currentSubmission);
-        expect(returnedSubmissions).to.deep.equal([
+        expect(returnedSubmissions).toEqual([
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
             { submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId },
         ]);
@@ -230,12 +222,14 @@ describe('ProgrammingSubmissionService', () => {
         await new Promise<void>((resolve) => setTimeout(() => resolve(), 10));
 
         // Expect the fallback mechanism to kick in after the timeout
-        expect(getLatestResultStub).to.have.been.calledOnceWithExactly(participationId, true);
-        expect(notifyAllResultSubscribersStub).to.have.been.calledOnceWithExactly({ ...result, participation: { id: participationId } });
+        expect(getLatestResultStub).toHaveBeenCalledTimes(1);
+        expect(getLatestResultStub).toHaveBeenCalledWith(participationId, true);
+        expect(notifyAllResultSubscribersStub).toHaveBeenCalledTimes(1);
+        expect(notifyAllResultSubscribersStub).toHaveBeenCalledWith({ ...result, participation: { id: participationId } });
         wsLatestResultSubject.next(result);
 
         // HAS_NO_PENDING_SUBMISSION is expected as the result provided by getLatestResult matches the pending submission
-        expect(returnedSubmissions).to.deep.equal([
+        expect(returnedSubmissions).toEqual([
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
             { submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId },
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
@@ -243,7 +237,7 @@ describe('ProgrammingSubmissionService', () => {
 
         // If the "real" websocket connection triggers now for some reason, the submission state should not change
         wsLatestResultSubject.next(result);
-        expect(returnedSubmissions).to.deep.equal([
+        expect(returnedSubmissions).toEqual([
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
             { submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId },
             { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId },
@@ -261,9 +255,9 @@ describe('ProgrammingSubmissionService', () => {
         const pendingSubmissions = { [participation1.id!]: currentSubmission, [participation2.id!]: currentSubmission2 };
 
         // @ts-ignore
-        const fetchLatestPendingSubmissionSpy = spy(submissionService, 'fetchLatestPendingSubmissionByParticipationId');
+        const fetchLatestPendingSubmissionSpy = jest.spyOn(submissionService, 'fetchLatestPendingSubmissionByParticipationId');
 
-        httpGetStub.returns(of(pendingSubmissions));
+        httpGetStub.mockReturnValue(of(pendingSubmissions));
 
         // This load the submissions for participation 1 and 2, but not for 3.
         lastValueFrom(submissionService.getSubmissionStateOfExercise(exerciseId));
@@ -272,28 +266,33 @@ describe('ProgrammingSubmissionService', () => {
             submission = sub;
         });
 
-        expect(httpGetStub).to.have.been.calledOnceWithExactly('api/programming-exercises/3/latest-pending-submissions');
+        expect(httpGetStub).toHaveBeenCalledTimes(1);
+        expect(httpGetStub).toHaveBeenCalledWith('api/programming-exercises/3/latest-pending-submissions');
         // Fetching the latest pending submission should not trigger a rest call for a cached submission.
-        expect(fetchLatestPendingSubmissionSpy).not.to.have.been.called;
-        expect(submissionState).to.equal(ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION);
-        expect(submission).to.equal(currentSubmission);
+        expect(fetchLatestPendingSubmissionSpy).not.toHaveBeenCalled();
+        expect(submissionState).toEqual(ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION);
+        expect(submission).toEqual(currentSubmission);
 
         // Fetching the latest pending submission should trigger a rest call if the submission is not cached.
         await submissionService.getLatestPendingSubmissionByParticipationId(participation3.id!, exerciseId, true);
-        expect(fetchLatestPendingSubmissionSpy).to.have.been.calledOnceWithExactly(participation3.id);
+        expect(fetchLatestPendingSubmissionSpy).toHaveBeenCalledTimes(1);
+        expect(fetchLatestPendingSubmissionSpy).toHaveBeenCalledWith(participation3.id);
     });
 
     it('should not throw an error on getSubmissionStateOfExercise if state is an empty object', async () => {
         const exerciseId = 10;
         const submissionState: ExerciseSubmissionState = {};
         // @ts-ignore
-        const fetchLatestPendingSubmissionsByExerciseIdSpy = spy(submissionService, 'fetchLatestPendingSubmissionsByExerciseId');
-        httpGetStub.withArgs(SERVER_API_URL + `api/programming-exercises/${exerciseId}/latest-pending-submissions`).returns(of(submissionState));
+        const fetchLatestPendingSubmissionsByExerciseIdSpy = jest.spyOn(submissionService, 'fetchLatestPendingSubmissionsByExerciseId');
+        httpGetStub.mockReturnValue(of(submissionState));
 
         let receivedSubmissionState: ExerciseSubmissionState = {};
         submissionService.getSubmissionStateOfExercise(exerciseId).subscribe((state) => (receivedSubmissionState = state));
-        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).to.have.been.calledOnceWithExactly(exerciseId);
-        expect(receivedSubmissionState).to.deep.equal(submissionState);
+        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledTimes(1);
+        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledWith(exerciseId);
+        expect(receivedSubmissionState).toEqual(submissionState);
+        expect(httpGetStub).toHaveBeenCalledTimes(1);
+        expect(httpGetStub).toHaveBeenCalledWith(SERVER_API_URL + `api/programming-exercises/${exerciseId}/latest-pending-submissions`);
     });
 
     it('should correctly return the submission state based on the servers response', async () => {
@@ -304,13 +303,16 @@ describe('ProgrammingSubmissionService', () => {
             2: { submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId: 2 },
         };
         // @ts-ignore
-        const fetchLatestPendingSubmissionsByExerciseIdSpy = spy(submissionService, 'fetchLatestPendingSubmissionsByExerciseId');
-        httpGetStub.withArgs(SERVER_API_URL + `api/programming-exercises/${exerciseId}/latest-pending-submissions`).returns(of(submissionState));
+        const fetchLatestPendingSubmissionsByExerciseIdSpy = jest.spyOn(submissionService, 'fetchLatestPendingSubmissionsByExerciseId');
+        httpGetStub.mockReturnValue(of(submissionState));
 
         let receivedSubmissionState: ExerciseSubmissionState = {};
         submissionService.getSubmissionStateOfExercise(exerciseId).subscribe((state) => (receivedSubmissionState = state));
-        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).to.have.been.calledOnceWithExactly(exerciseId);
-        expect(receivedSubmissionState).to.deep.equal(expectedSubmissionState);
+        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledTimes(1);
+        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledWith(exerciseId);
+        expect(receivedSubmissionState).toEqual(expectedSubmissionState);
+        expect(httpGetStub).toHaveBeenCalledTimes(1);
+        expect(httpGetStub).toHaveBeenCalledWith(SERVER_API_URL + `api/programming-exercises/${exerciseId}/latest-pending-submissions`);
     });
 
     it('should recalculate the result eta based on the number of open submissions', () => {
@@ -325,32 +327,35 @@ describe('ProgrammingSubmissionService', () => {
             {},
         );
         // @ts-ignore
-        const fetchLatestPendingSubmissionsByExerciseIdSpy = spy(submissionService, 'fetchLatestPendingSubmissionsByExerciseId');
-        httpGetStub.withArgs(SERVER_API_URL + `api/programming-exercises/${exerciseId}/latest-pending-submissions`).returns(of(submissionState));
+        const fetchLatestPendingSubmissionsByExerciseIdSpy = jest.spyOn(submissionService, 'fetchLatestPendingSubmissionsByExerciseId');
+        httpGetStub.mockReturnValue(of(submissionState));
 
         let receivedSubmissionState: ExerciseSubmissionState = {};
         submissionService.getSubmissionStateOfExercise(exerciseId).subscribe((state) => (receivedSubmissionState = state));
-        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).to.have.been.calledOnceWithExactly(exerciseId);
-        expect(receivedSubmissionState).to.deep.equal(expectedSubmissionState);
+        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledTimes(1);
+        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledWith(exerciseId);
+        expect(receivedSubmissionState).toEqual(expectedSubmissionState);
+        expect(httpGetStub).toHaveBeenCalledTimes(1);
+        expect(httpGetStub).toHaveBeenCalledWith(SERVER_API_URL + `api/programming-exercises/${exerciseId}/latest-pending-submissions`);
 
         let resultEta = -1;
         submissionService.getResultEtaInMs().subscribe((eta) => (resultEta = eta));
 
         // With 340 submissions, the eta should now have increased.
-        expect(resultEta).to.equal(2000 * 60 + 3 * 1000 * 60);
+        expect(resultEta).toBe(2000 * 60 + 3 * 1000 * 60);
     });
 
     it('should only unsubscribe if no other participations use the topic', () => {
-        httpGetStub.returns(of(currentSubmission));
+        httpGetStub.mockReturnValue(of(currentSubmission));
         submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true);
         submissionService.getLatestPendingSubmissionByParticipationId(2, 10, true);
 
         // Should not unsubscribe as participation 2 still uses the same topic
         submissionService.unsubscribeForLatestSubmissionOfParticipation(participationId);
-        expect(wsUnsubscribeStub).to.not.have.been.called;
+        expect(wsUnsubscribeStub).not.toHaveBeenCalled();
 
         // Should now unsubscribe as last participation for topic was unsubscribed
         submissionService.unsubscribeForLatestSubmissionOfParticipation(2);
-        expect(wsUnsubscribeStub).to.have.been.called;
+        expect(wsUnsubscribeStub).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
