### PR TITLE
`Development`: Convert client service tests to Jest

### DIFF
--- a/src/test/javascript/spec/service/account.service.spec.ts
+++ b/src/test/javascript/spec/service/account.service.spec.ts
@@ -1,8 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import * as chai from 'chai';
-import { SinonStub, stub } from 'sinon';
 import { of } from 'rxjs';
-import sinonChai from 'sinon-chai';
 import { MockWebsocketService } from '../helpers/mocks/service/mock-websocket.service';
 import { MockHttpService } from '../helpers/mocks/service/mock-http.service';
 import { MockFeatureToggleService } from '../helpers/mocks/service/mock-feature-toggle.service';
@@ -12,13 +9,10 @@ import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.serv
 import { TranslateService } from '@ngx-translate/core';
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
 
-chai.use(sinonChai);
-const expect = chai.expect;
-
 describe('AccountService', () => {
     let accountService: AccountService;
     let httpService: MockHttpService;
-    let getStub: SinonStub;
+    let getStub: jest.SpyInstance;
     let translateService: TranslateService;
 
     const getUserUrl = 'api/account';
@@ -34,52 +28,54 @@ describe('AccountService', () => {
         translateService = TestBed.inject(TranslateService);
         // @ts-ignore
         accountService = new AccountService(translateService, new MockSyncStorage(), httpService, new MockWebsocketService(), new MockFeatureToggleService());
-        getStub = stub(httpService, 'get');
+        getStub = jest.spyOn(httpService, 'get');
 
-        expect(accountService.userIdentity).to.be.undefined;
-        expect(accountService.isAuthenticated()).to.be.false;
+        expect(accountService.userIdentity).toBe(undefined);
+        expect(accountService.isAuthenticated()).toBe(false);
     });
 
     afterEach(() => {
-        getStub.restore();
+        jest.restoreAllMocks();
     });
 
     it('should fetch the user on identity if the userIdentity is not defined yet', async () => {
-        getStub.returns(of({ body: user }));
+        getStub.mockReturnValue(of({ body: user }));
 
         const userReceived = await accountService.identity(false);
 
-        expect(getStub).to.have.been.calledOnceWithExactly(getUserUrl, { observe: 'response' });
-        expect(userReceived).to.deep.equal(user);
-        expect(accountService.userIdentity).to.deep.equal(user);
-        expect(accountService.isAuthenticated()).to.be.true;
+        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(getStub).toHaveBeenCalledWith(getUserUrl, { observe: 'response' });
+        expect(userReceived).toEqual(user);
+        expect(accountService.userIdentity).toEqual(user);
+        expect(accountService.isAuthenticated()).toBe(true);
     });
 
     it('should fetch the user on identity if the userIdentity is defined yet (force=true)', async () => {
         accountService.userIdentity = user;
-        expect(accountService.userIdentity).to.deep.equal(user);
-        expect(accountService.isAuthenticated()).to.be.true;
-        getStub.returns(of({ body: user2 }));
+        expect(accountService.userIdentity).toEqual(user);
+        expect(accountService.isAuthenticated()).toBe(true);
+        getStub.mockReturnValue(of({ body: user2 }));
 
         const userReceived = await accountService.identity(true);
 
-        expect(getStub).to.have.been.calledOnceWithExactly(getUserUrl, { observe: 'response' });
-        expect(userReceived).to.deep.equal(user2);
-        expect(accountService.userIdentity).to.deep.equal(user2);
-        expect(accountService.isAuthenticated()).to.be.true;
+        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(getStub).toHaveBeenCalledWith(getUserUrl, { observe: 'response' });
+        expect(userReceived).toEqual(user2);
+        expect(accountService.userIdentity).toEqual(user2);
+        expect(accountService.isAuthenticated()).toBe(true);
     });
 
     it('should NOT fetch the user on identity if the userIdentity is defined (force=false)', async () => {
         accountService.userIdentity = user;
-        expect(accountService.userIdentity).to.deep.equal(user);
-        expect(accountService.isAuthenticated()).to.be.true;
-        getStub.returns(of({ body: user2 }));
+        expect(accountService.userIdentity).toEqual(user);
+        expect(accountService.isAuthenticated()).toBe(true);
+        getStub.mockReturnValue(of({ body: user2 }));
 
         const userReceived = await accountService.identity(false);
 
-        expect(getStub).not.to.have.been.called;
-        expect(userReceived).to.deep.equal(user);
-        expect(accountService.userIdentity).to.deep.equal(user);
-        expect(accountService.isAuthenticated()).to.be.true;
+        expect(getStub).not.toHaveBeenCalled();
+        expect(userReceived).toEqual(user);
+        expect(accountService.userIdentity).toEqual(user);
+        expect(accountService.isAuthenticated()).toBe(true);
     });
 });

--- a/src/test/javascript/spec/service/activate.service.spec.ts
+++ b/src/test/javascript/spec/service/activate.service.spec.ts
@@ -1,4 +1,3 @@
-import { async } from '@angular/core/testing';
 import { ActivateService } from 'app/account/activate/activate.service';
 import { MockHttpService } from '../helpers/mocks/service/mock-http.service';
 import { HttpParams } from '@angular/common/http';
@@ -10,21 +9,21 @@ describe('ActivateService', () => {
 
     const getURL = SERVER_API_URL + 'api/activate';
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         httpService = new MockHttpService();
         // @ts-ignore
         activateService = new ActivateService(httpService);
         getStub = jest.spyOn(httpService, 'get');
-    }));
+    });
 
     afterEach(() => {
         jest.restoreAllMocks();
     });
 
-    it('should send a request to the server to activate the user', async () => {
+    it('should send a request to the server to activate the user', () => {
         const key = 'key';
 
-        await activateService.get(key);
+        activateService.get(key).subscribe();
 
         expect(getStub).toHaveBeenCalledTimes(1);
         expect(getStub).toHaveBeenCalledWith(getURL, {

--- a/src/test/javascript/spec/service/activate.service.spec.ts
+++ b/src/test/javascript/spec/service/activate.service.spec.ts
@@ -1,18 +1,12 @@
 import { async } from '@angular/core/testing';
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
-import { SinonStub, stub } from 'sinon';
 import { ActivateService } from 'app/account/activate/activate.service';
 import { MockHttpService } from '../helpers/mocks/service/mock-http.service';
 import { HttpParams } from '@angular/common/http';
 
-chai.use(sinonChai);
-const expect = chai.expect;
-
 describe('ActivateService', () => {
     let activateService: ActivateService;
     let httpService: MockHttpService;
-    let getStub: SinonStub;
+    let getStub: jest.SpyInstance;
 
     const getURL = SERVER_API_URL + 'api/activate';
 
@@ -20,11 +14,11 @@ describe('ActivateService', () => {
         httpService = new MockHttpService();
         // @ts-ignore
         activateService = new ActivateService(httpService);
-        getStub = stub(httpService, 'get');
+        getStub = jest.spyOn(httpService, 'get');
     }));
 
     afterEach(() => {
-        getStub.restore();
+        jest.restoreAllMocks();
     });
 
     it('should send a request to the server to activate the user', async () => {
@@ -32,7 +26,8 @@ describe('ActivateService', () => {
 
         await activateService.get(key);
 
-        expect(getStub).to.have.been.calledOnceWithExactly(getURL, {
+        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(getStub).toHaveBeenCalledWith(getURL, {
             params: new HttpParams().set('key', key),
         });
     });

--- a/src/test/javascript/spec/service/apollon-diagram.service.spec.ts
+++ b/src/test/javascript/spec/service/apollon-diagram.service.spec.ts
@@ -1,147 +1,135 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ApollonDiagramService } from 'app/exercises/quiz/manage/apollon-diagrams/apollon-diagram.service';
 import { ApollonDiagram } from 'app/entities/apollon-diagram.model';
 import { UMLDiagramType } from 'app/entities/modeling-exercise.model';
 import { HttpResponse } from '@angular/common/http';
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
-
-chai.use(sinonChai);
-const expect = chai.expect;
 
 const resourceUrl = SERVER_API_URL + 'api';
 
 describe('ApollonDiagramService', () => {
     let courseId: number;
     let apollonDiagram: ApollonDiagram;
+    let apollonDiagramService: ApollonDiagramService;
+    let httpTestingController: HttpTestingController;
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
             providers: [ApollonDiagramService],
-        });
+        })
+            .compileComponents()
+            .then(() => {
+                apollonDiagramService = TestBed.inject(ApollonDiagramService);
+                httpTestingController = TestBed.inject(HttpTestingController);
+            });
         courseId = 1;
         apollonDiagram = new ApollonDiagram(UMLDiagramType.ClassDiagram, courseId);
     });
 
-    it('should be initialized', inject([ApollonDiagramService], (apollonDiagramService: ApollonDiagramService) => {
-        expect(apollonDiagramService).to.be.ok;
+    it('should create a diagram', fakeAsync(() => {
+        // Set up
+        const url = `${resourceUrl}/course/${courseId}/apollon-diagrams`;
+        const responseObject = apollonDiagram;
+
+        let response: HttpResponse<ApollonDiagram>;
+
+        apollonDiagramService.create(apollonDiagram, courseId).subscribe((receivedResponse: HttpResponse<ApollonDiagram>) => {
+            response = receivedResponse;
+        });
+
+        const requestWrapper = httpTestingController.expectOne({ url });
+        requestWrapper.flush(responseObject);
+
+        tick();
+
+        expect(requestWrapper.request.method).toBe('POST');
+        expect(response!.body).toBe(responseObject);
+        expect(response!.status).toBe(200);
     }));
 
-    it('should create a diagram', fakeAsync(
-        inject([ApollonDiagramService, HttpTestingController], (apollonDiagramService: ApollonDiagramService, server: HttpTestingController) => {
-            // Set up
-            const url = `${resourceUrl}/course/${courseId}/apollon-diagrams`;
-            const responseObject = apollonDiagram;
+    it('should update a diagram', fakeAsync(() => {
+        // Set up
+        const url = `${resourceUrl}/course/${courseId}/apollon-diagrams`;
+        const responseObject = apollonDiagram;
 
-            let response: HttpResponse<ApollonDiagram>;
+        let response: HttpResponse<ApollonDiagram>;
 
-            apollonDiagramService.create(apollonDiagram, courseId).subscribe((receivedResponse: HttpResponse<ApollonDiagram>) => {
-                response = receivedResponse;
-            });
+        apollonDiagramService.update(apollonDiagram, courseId).subscribe((receivedResponse: HttpResponse<ApollonDiagram>) => {
+            response = receivedResponse;
+        });
 
-            const requestWrapper = server.expectOne({ url });
-            requestWrapper.flush(responseObject);
+        const requestWrapper = httpTestingController.expectOne({ url });
+        requestWrapper.flush(responseObject);
 
-            tick();
+        tick();
 
-            expect(requestWrapper.request.method).to.equal('POST');
-            expect(response!.body).to.equal(responseObject);
-            expect(response!.status).to.equal(200);
-        }),
-    ));
+        expect(requestWrapper.request.method).toBe('PUT');
+        expect(response!.body).toBe(responseObject);
+        expect(response!.status).toBe(200);
+    }));
 
-    it('should update a diagram', fakeAsync(
-        inject([ApollonDiagramService, HttpTestingController], (apollonDiagramService: ApollonDiagramService, server: HttpTestingController) => {
-            // Set up
-            const url = `${resourceUrl}/course/${courseId}/apollon-diagrams`;
-            const responseObject = apollonDiagram;
+    it('should find a diagram', fakeAsync(() => {
+        // Set up
+        const diagramId = 1;
+        const url = `${resourceUrl}/course/${courseId}/apollon-diagrams/${diagramId}`;
+        const responseObject = apollonDiagram;
 
-            let response: HttpResponse<ApollonDiagram>;
+        let response: HttpResponse<ApollonDiagram>;
 
-            apollonDiagramService.update(apollonDiagram, courseId).subscribe((receivedResponse: HttpResponse<ApollonDiagram>) => {
-                response = receivedResponse;
-            });
+        apollonDiagramService.find(diagramId, courseId).subscribe((receivedResponse: HttpResponse<ApollonDiagram>) => {
+            response = receivedResponse;
+        });
 
-            const requestWrapper = server.expectOne({ url });
-            requestWrapper.flush(responseObject);
+        const requestWrapper = httpTestingController.expectOne({ url });
+        requestWrapper.flush(responseObject);
 
-            tick();
+        tick();
 
-            expect(requestWrapper.request.method).to.equal('PUT');
-            expect(response!.body).to.equal(responseObject);
-            expect(response!.status).to.equal(200);
-        }),
-    ));
+        expect(requestWrapper.request.method).toBe('GET');
+        expect(response!.body).toBe(responseObject);
+        expect(response!.status).toBe(200);
+    }));
 
-    it('should find a diagram', fakeAsync(
-        inject([ApollonDiagramService, HttpTestingController], (apollonDiagramService: ApollonDiagramService, server: HttpTestingController) => {
-            // Set up
-            const diagramId = 1;
-            const url = `${resourceUrl}/course/${courseId}/apollon-diagrams/${diagramId}`;
-            const responseObject = apollonDiagram;
+    it('should delete a diagram', fakeAsync(() => {
+        // Set up
+        const diagramId = 1;
+        const url = `${resourceUrl}/course/${courseId}/apollon-diagrams/${diagramId}`;
+        const responseObject = apollonDiagram;
 
-            let response: HttpResponse<ApollonDiagram>;
+        let response: HttpResponse<void>;
 
-            apollonDiagramService.find(diagramId, courseId).subscribe((receivedResponse: HttpResponse<ApollonDiagram>) => {
-                response = receivedResponse;
-            });
+        apollonDiagramService.delete(diagramId, courseId).subscribe((receivedResponse: HttpResponse<void>) => {
+            response = receivedResponse;
+        });
 
-            const requestWrapper = server.expectOne({ url });
-            requestWrapper.flush(responseObject);
+        const requestWrapper = httpTestingController.expectOne({ url });
+        requestWrapper.flush(responseObject);
 
-            tick();
+        tick();
 
-            expect(requestWrapper.request.method).to.equal('GET');
-            expect(response!.body).to.equal(responseObject);
-            expect(response!.status).to.equal(200);
-        }),
-    ));
+        expect(requestWrapper.request.method).toBe('DELETE');
+        expect(response!.body).toBe(responseObject);
+        expect(response!.status).toBe(200);
+    }));
 
-    it('should delete a diagram', fakeAsync(
-        inject([ApollonDiagramService, HttpTestingController], (apollonDiagramService: ApollonDiagramService, server: HttpTestingController) => {
-            // Set up
-            const diagramId = 1;
-            const url = `${resourceUrl}/course/${courseId}/apollon-diagrams/${diagramId}`;
-            const responseObject = apollonDiagram;
+    it('should get diagrams by course', fakeAsync(() => {
+        // Set up
+        const url = `${resourceUrl}/course/${courseId}/apollon-diagrams`;
+        const responseObject = [apollonDiagram];
 
-            let response: HttpResponse<void>;
+        let response: HttpResponse<ApollonDiagram[]>;
 
-            apollonDiagramService.delete(diagramId, courseId).subscribe((receivedResponse: HttpResponse<void>) => {
-                response = receivedResponse;
-            });
+        apollonDiagramService.getDiagramsByCourse(courseId).subscribe((receivedResponse: HttpResponse<ApollonDiagram[]>) => {
+            response = receivedResponse;
+        });
 
-            const requestWrapper = server.expectOne({ url });
-            requestWrapper.flush(responseObject);
+        const requestWrapper = httpTestingController.expectOne({ url });
+        requestWrapper.flush(responseObject);
 
-            tick();
+        tick();
 
-            expect(requestWrapper.request.method).to.equal('DELETE');
-            expect(response!.body).to.equal(responseObject);
-            expect(response!.status).to.equal(200);
-        }),
-    ));
-
-    it('should get diagrams by course', fakeAsync(
-        inject([ApollonDiagramService, HttpTestingController], (apollonDiagramService: ApollonDiagramService, server: HttpTestingController) => {
-            // Set up
-            const url = `${resourceUrl}/course/${courseId}/apollon-diagrams`;
-            const responseObject = [apollonDiagram];
-
-            let response: HttpResponse<ApollonDiagram[]>;
-
-            apollonDiagramService.getDiagramsByCourse(courseId).subscribe((receivedResponse: HttpResponse<ApollonDiagram[]>) => {
-                response = receivedResponse;
-            });
-
-            const requestWrapper = server.expectOne({ url });
-            requestWrapper.flush(responseObject);
-
-            tick();
-
-            expect(requestWrapper.request.method).to.equal('GET');
-            expect(response!.body).to.equal(responseObject);
-            expect(response!.status).to.equal(200);
-        }),
-    ));
+        expect(requestWrapper.request.method).toBe('GET');
+        expect(response!.body).toBe(responseObject);
+        expect(response!.status).toBe(200);
+    }));
 });

--- a/src/test/javascript/spec/service/apollon-diagram.service.spec.ts
+++ b/src/test/javascript/spec/service/apollon-diagram.service.spec.ts
@@ -43,7 +43,7 @@ describe('ApollonDiagramService', () => {
         tick();
 
         expect(requestWrapper.request.method).toBe('POST');
-        expect(response!.body).toBe(responseObject);
+        expect(response!.body).toEqual(responseObject);
         expect(response!.status).toBe(200);
     }));
 
@@ -64,7 +64,7 @@ describe('ApollonDiagramService', () => {
         tick();
 
         expect(requestWrapper.request.method).toBe('PUT');
-        expect(response!.body).toBe(responseObject);
+        expect(response!.body).toEqual(responseObject);
         expect(response!.status).toBe(200);
     }));
 
@@ -86,7 +86,7 @@ describe('ApollonDiagramService', () => {
         tick();
 
         expect(requestWrapper.request.method).toBe('GET');
-        expect(response!.body).toBe(responseObject);
+        expect(response!.body).toEqual(responseObject);
         expect(response!.status).toBe(200);
     }));
 
@@ -108,7 +108,7 @@ describe('ApollonDiagramService', () => {
         tick();
 
         expect(requestWrapper.request.method).toBe('DELETE');
-        expect(response!.body).toBe(responseObject);
+        expect(response!.body).toEqual(responseObject);
         expect(response!.status).toBe(200);
     }));
 
@@ -129,7 +129,7 @@ describe('ApollonDiagramService', () => {
         tick();
 
         expect(requestWrapper.request.method).toBe('GET');
-        expect(response!.body).toBe(responseObject);
+        expect(response!.body).toEqual(responseObject);
         expect(response!.status).toBe(200);
     }));
 });

--- a/src/test/javascript/spec/service/course-score-calculation.service.spec.ts
+++ b/src/test/javascript/spec/service/course-score-calculation.service.spec.ts
@@ -1,6 +1,3 @@
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
-import * as sinon from 'sinon';
 import { CourseScoreCalculationService, ScoreType } from 'app/overview/course-score-calculation.service';
 import { TextExercise } from 'app/entities/text-exercise.model';
 import { Course } from 'app/entities/course.model';
@@ -10,18 +7,11 @@ import { StudentParticipation } from 'app/entities/participation/student-partici
 import { ParticipationType } from 'app/entities/participation/participation.model';
 import { Result } from 'app/entities/result.model';
 
-chai.use(sinonChai);
-const expect = chai.expect;
-
 describe('CourseScoreCalculationService', () => {
     let courseScoreCalculationService: CourseScoreCalculationService;
 
     beforeEach(() => {
         courseScoreCalculationService = new CourseScoreCalculationService();
-    });
-
-    afterEach(() => {
-        sinon.restore();
     });
 
     it('should return the correctly calculate the course score for all normal exercise', () => {
@@ -154,19 +144,19 @@ describe('CourseScoreCalculationService', () => {
         expectedReachableScore?: number,
     ) {
         if (expectedAbsoluteScore) {
-            expect(resultMap.get(ScoreType.ABSOLUTE_SCORE)).to.equal(expectedAbsoluteScore);
+            expect(resultMap.get(ScoreType.ABSOLUTE_SCORE)).toBe(expectedAbsoluteScore);
         }
         if (expectedRelativeScore) {
-            expect(resultMap.get(ScoreType.RELATIVE_SCORE)).to.equal(expectedRelativeScore);
+            expect(resultMap.get(ScoreType.RELATIVE_SCORE)).toBe(expectedRelativeScore);
         }
         if (expectedCurrentRelativeScore) {
-            expect(resultMap.get(ScoreType.MAX_POINTS)).to.equal(expectedMaxPoints);
+            expect(resultMap.get(ScoreType.MAX_POINTS)).toBe(expectedMaxPoints);
         }
         if (expectedPresentationScore) {
-            expect(resultMap.get(ScoreType.PRESENTATION_SCORE)).to.equal(expectedPresentationScore);
+            expect(resultMap.get(ScoreType.PRESENTATION_SCORE)).toBe(expectedPresentationScore);
         }
         if (expectedReachableScore) {
-            expect(resultMap.get(ScoreType.REACHABLE_POINTS)).to.equal(expectedReachableScore);
+            expect(resultMap.get(ScoreType.REACHABLE_POINTS)).toBe(expectedReachableScore);
         }
     }
 });

--- a/src/test/javascript/spec/service/exercise-scores-chart.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-scores-chart.service.spec.ts
@@ -5,13 +5,8 @@ import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.serv
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
 import { SessionStorageService } from 'ngx-webstorage';
 import { TranslateService } from '@ngx-translate/core';
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
 import { take } from 'rxjs/operators';
 import { ExerciseScoresChartService, ExerciseScoresDTO } from 'app/overview/visualizations/exercise-scores-chart.service';
-
-chai.use(sinonChai);
-const expect = chai.expect;
 
 describe('Exercise Scores Chart Service', () => {
     let injector: TestBed;
@@ -36,10 +31,6 @@ describe('Exercise Scores Chart Service', () => {
 
     afterEach(() => {
         httpMock.verify();
-    });
-
-    it('should be created', () => {
-        expect(service).to.be.ok;
     });
 
     it('should find all by course id', () => {

--- a/src/test/javascript/spec/service/exercise-update-warning.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-update-warning.service.spec.ts
@@ -1,13 +1,8 @@
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
 import { ExerciseUpdateWarningService } from 'app/exercises/shared/exercise-update-warning/exercise-update-warning.service';
 import { getTestBed } from '@angular/core/testing';
 import { GradingInstruction } from 'app/exercises/shared/structured-grading-criterion/grading-instruction.model';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
 import { Exercise } from 'app/entities/exercise.model';
-
-chai.use(sinonChai);
-const expect = chai.expect;
 
 describe('Exercise Update Warning Service', () => {
     let updateWarningService: ExerciseUpdateWarningService;
@@ -35,20 +30,20 @@ describe('Exercise Update Warning Service', () => {
         exercise.gradingCriteria = [gradingCriterionWithoutInstruction];
         backupExercise.gradingCriteria = [gradingCriterion];
         updateWarningService.loadExercise(exercise, backupExercise);
-        expect(updateWarningService.instructionDeleted).to.equal(true);
+        expect(updateWarningService.instructionDeleted).toBe(true);
     });
 
     it('should set creditChanged as true', () => {
         exercise.gradingCriteria = [gradingCriterionCreditsChanged];
         backupExercise.gradingCriteria = [gradingCriterion];
         updateWarningService.loadExercise(exercise, backupExercise);
-        expect(updateWarningService.creditChanged).to.equal(true);
+        expect(updateWarningService.creditChanged).toBe(true);
     });
 
     it('should set usageCountChanged as true', () => {
         exercise.gradingCriteria = [gradingCriterionUsageCountChanged];
         backupExercise.gradingCriteria = [gradingCriterion];
         updateWarningService.loadExercise(exercise, backupExercise);
-        expect(updateWarningService.usageCountChanged).to.equal(true);
+        expect(updateWarningService.usageCountChanged).toBe(true);
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
