### PR TITLE
`Development`: Convert client service tests to Jest

### DIFF
--- a/src/test/javascript/spec/service/guided-tour.service.spec.ts
+++ b/src/test/javascript/spec/service/guided-tour.service.spec.ts
@@ -17,8 +17,6 @@ import { Course } from 'app/entities/course.model';
 import { MockTranslateService, TranslatePipeMock } from '../helpers/mocks/service/mock-translate.service';
 import { AssessmentObject, GuidedTourAssessmentTask, GuidedTourModelingTask, personUML } from 'app/guided-tour/guided-tour-task.model';
 import { completedTour } from 'app/guided-tour/tours/general-tour';
-import * as sinon from 'sinon';
-import { SinonStub, stub } from 'sinon';
 import { HttpResponse } from '@angular/common/http';
 import { ParticipationService } from 'app/exercises/shared/participation/participation.service';
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
@@ -571,20 +569,19 @@ describe('GuidedTourService', () => {
         describe('enableUserInteraction', () => {
             const addEventListener = jest.fn();
             const htmlTarget = { addEventListener } as any;
-            let observeMutationsStub: SinonStub;
+            let observeMutationsStub: jest.SpyInstance;
             let handleWaitForSelectorEventSpy: jest.SpyInstance;
             let querySelectorSpy: jest.SpyInstance;
 
             beforeEach(() => {
                 guidedTourService.currentTour = tour;
-                observeMutationsStub = stub(guidedTourService, 'observeMutations');
+                observeMutationsStub = jest.spyOn(guidedTourService, 'observeMutations');
                 handleWaitForSelectorEventSpy = jest.spyOn<any, any>(guidedTourService, 'handleWaitForSelectorEvent');
                 querySelectorSpy = jest.spyOn(document, 'querySelector');
                 querySelectorSpy.mockClear();
             });
             afterEach(() => {
                 jest.clearAllMocks();
-                sinon.restore();
             });
             it('should enableUserInteraction with UserInteractionEvent.WAIT_FOR_SELECTOR', fakeAsync(() => {
                 const userInteractionEvent = UserInteractionEvent.WAIT_FOR_SELECTOR;
@@ -599,13 +596,13 @@ describe('GuidedTourService', () => {
             }));
             it('should enableUserInteraction with UserInteractionEvent.ACE_EDITOR', fakeAsync(() => {
                 const userInteractionEvent = UserInteractionEvent.ACE_EDITOR;
-                observeMutationsStub.returns(of({ addedNodes: { length: 0 } as NodeList, removedNodes: { length: 0 } as NodeList } as MutationRecord));
+                observeMutationsStub.mockReturnValue(of({ addedNodes: { length: 0 } as NodeList, removedNodes: { length: 0 } as NodeList } as MutationRecord));
                 guidedTourService.enableUserInteraction(htmlTarget, userInteractionEvent);
                 expect(querySelectorSpy).toHaveBeenCalledTimes(1);
             }));
             it('should enableUserInteraction with UserInteractionEvent.MODELING', fakeAsync(() => {
                 const userInteractionEvent = UserInteractionEvent.MODELING;
-                observeMutationsStub.returns(of({ addedNodes: { length: 0 } as NodeList, removedNodes: { length: 0 } as NodeList } as MutationRecord));
+                observeMutationsStub.mockReturnValue(of({ addedNodes: { length: 0 } as NodeList, removedNodes: { length: 0 } as NodeList } as MutationRecord));
                 guidedTourService.enableUserInteraction(htmlTarget, userInteractionEvent);
                 expect(querySelectorSpy).toHaveBeenCalledTimes(1);
             }));

--- a/src/test/javascript/spec/service/login.service.spec.ts
+++ b/src/test/javascript/spec/service/login.service.spec.ts
@@ -1,89 +1,96 @@
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
-import { SinonStub, stub } from 'sinon';
 import { of, throwError } from 'rxjs';
 import { MockWebsocketService } from '../helpers/mocks/service/mock-websocket.service';
 import { MockRouter } from '../helpers/mocks/mock-router';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 import { MockAuthServerProviderService } from '../helpers/mocks/service/mock-auth-server-provider.service';
 import { MockAlertService } from '../helpers/mocks/service/mock-alert.service';
-import { IAccountService } from 'app/core/auth/account.service';
-import { IWebsocketService } from 'app/core/websocket/websocket.service';
+import { AccountService } from 'app/core/auth/account.service';
+import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
 import { LoginService } from 'app/core/login/login.service';
-import { IAuthServerProvider } from 'app/core/auth/auth-jwt.service';
+import { AuthServerProvider } from 'app/core/auth/auth-jwt.service';
 import { MockNotificationService } from '../helpers/mocks/service/mock-notification.service';
-
-chai.use(sinonChai);
-const expect = chai.expect;
+import { TestBed } from '@angular/core/testing';
+import { AlertService } from 'app/core/util/alert.service';
+import { NotificationService } from 'app/shared/notification/notification.service';
+import { Router } from '@angular/router';
 
 describe('LoginService', () => {
-    let accountService: IAccountService;
-    let websocketService: IWebsocketService;
-    let authServerProvider: IAuthServerProvider;
-    let router: MockRouter;
-    let alertService: MockAlertService;
-    let notificationService: MockNotificationService;
+    let accountService: AccountService;
+    let authServerProvider: AuthServerProvider;
+    let router: Router;
+    let alertService: AlertService;
+    let notificationService: NotificationService;
     let loginService: LoginService;
 
-    let removeAuthTokenFromCachesStub: SinonStub;
-    let authenticateStub: SinonStub;
-    // let alertServiceClearStub: SinonStub;
-    let notificationServiceCleanUpStub: SinonStub;
-    let navigateByUrlStub: SinonStub;
-    let alertServiceErrorStub: SinonStub;
-
-    // TODO: reimplement this test using the typical TestBed configuration as in other tests
+    let removeAuthTokenFromCachesStub: jest.SpyInstance;
+    let authenticateStub: jest.SpyInstance;
+    let alertServiceClearStub: jest.SpyInstance;
+    let notificationServiceCleanUpStub: jest.SpyInstance;
+    let navigateByUrlStub: jest.SpyInstance;
+    let alertServiceErrorStub: jest.SpyInstance;
 
     beforeEach(() => {
-        accountService = new MockAccountService();
-        websocketService = new MockWebsocketService();
-        authServerProvider = new MockAuthServerProviderService();
-        router = new MockRouter();
-        alertService = new MockAlertService();
-        notificationService = new MockNotificationService();
-        // @ts-ignore
-        loginService = new LoginService(accountService, websocketService, authServerProvider, router, alertService, notificationService);
+        TestBed.configureTestingModule({
+            providers: [
+                { provide: AccountService, useClass: MockAccountService },
+                { provide: JhiWebsocketService, useClass: MockWebsocketService },
+                { provide: AuthServerProvider, useClass: MockAuthServerProviderService },
+                { provide: Router, useClass: MockRouter },
+                { provide: AlertService, useClass: MockAlertService },
+                { provide: NotificationService, useClass: MockNotificationService },
+            ],
+        })
+            .compileComponents()
+            .then(() => {
+                accountService = TestBed.inject(AccountService);
+                authServerProvider = TestBed.inject(AuthServerProvider);
+                router = TestBed.inject(Router);
+                alertService = TestBed.inject(AlertService);
+                notificationService = TestBed.inject(NotificationService);
+                loginService = TestBed.inject(LoginService);
 
-        removeAuthTokenFromCachesStub = stub(authServerProvider, 'removeAuthTokenFromCaches');
-        authenticateStub = stub(accountService, 'authenticate');
-        // alertServiceClearStub = stub(alertService, 'clear');
-        notificationServiceCleanUpStub = stub(notificationService, 'cleanUp');
-        navigateByUrlStub = stub(router, 'navigateByUrl');
-        alertServiceErrorStub = stub(alertService, 'error');
+                removeAuthTokenFromCachesStub = jest.spyOn(authServerProvider, 'removeAuthTokenFromCaches');
+                authenticateStub = jest.spyOn(accountService, 'authenticate');
+                alertServiceClearStub = jest.spyOn(alertService, 'clear');
+                notificationServiceCleanUpStub = jest.spyOn(notificationService, 'cleanUp');
+                navigateByUrlStub = jest.spyOn(router, 'navigateByUrl');
+                alertServiceErrorStub = jest.spyOn(alertService, 'error');
+            });
     });
 
     afterEach(() => {
-        removeAuthTokenFromCachesStub.restore();
-        authenticateStub.restore();
-        // alertServiceClearStub.restore();
-        notificationServiceCleanUpStub.restore();
-        navigateByUrlStub.restore();
-        alertServiceErrorStub.restore();
+        jest.restoreAllMocks();
     });
 
     it('should properly log out when every action is successful', () => {
-        removeAuthTokenFromCachesStub.returns(of(undefined));
-        navigateByUrlStub.returns(Promise.resolve(true));
+        removeAuthTokenFromCachesStub.mockReturnValue(of(undefined));
+        navigateByUrlStub.mockReturnValue(Promise.resolve(true));
         loginService.logout(true);
 
-        expect(removeAuthTokenFromCachesStub).to.have.been.calledOnceWithExactly();
-        expect(authenticateStub).to.have.been.calledOnceWithExactly(undefined);
-        // expect(alertServiceClearStub).to.have.been.calledOnceWithExactly();
-        expect(notificationServiceCleanUpStub).to.have.been.calledOnceWithExactly();
-        expect(navigateByUrlStub).to.have.been.calledOnceWithExactly('/');
-        expect(alertServiceErrorStub).not.to.have.been.called;
+        commonExpects();
+        expect(alertServiceErrorStub).not.toHaveBeenCalled();
     });
 
     it('should emit an error when an action fails', () => {
         const error = 'fatal error';
-        removeAuthTokenFromCachesStub.returns(of(undefined));
-        authenticateStub.throws(throwError(error));
+        removeAuthTokenFromCachesStub.mockReturnValue(of(undefined));
+        authenticateStub.mockReturnValue(throwError(error));
         loginService.logout(true);
 
-        expect(removeAuthTokenFromCachesStub).to.have.been.calledOnceWithExactly();
-        expect(authenticateStub).to.have.been.calledOnceWithExactly(undefined);
-        // expect(alertServiceClearStub).not.to.have.been.called;
-        expect(navigateByUrlStub).not.to.have.been.called;
-        expect(alertServiceErrorStub).to.have.been.calledOnce;
+        commonExpects();
+        expect(alertServiceErrorStub).toHaveBeenCalledTimes(1);
     });
+
+    function commonExpects() {
+        expect(removeAuthTokenFromCachesStub).toHaveBeenCalledTimes(1);
+        expect(removeAuthTokenFromCachesStub).toHaveBeenCalledWith();
+        expect(authenticateStub).toHaveBeenCalledTimes(1);
+        expect(authenticateStub).toHaveBeenCalledWith(undefined);
+        expect(notificationServiceCleanUpStub).toHaveBeenCalledTimes(1);
+        expect(notificationServiceCleanUpStub).toHaveBeenCalledWith();
+        expect(alertServiceClearStub).toHaveBeenCalledTimes(1);
+        expect(alertServiceClearStub).toHaveBeenCalledWith();
+        expect(navigateByUrlStub).toHaveBeenCalledTimes(1);
+        expect(navigateByUrlStub).toHaveBeenCalledWith('/');
+    }
 });

--- a/src/test/javascript/spec/service/notification.service.spec.ts
+++ b/src/test/javascript/spec/service/notification.service.spec.ts
@@ -128,7 +128,7 @@ describe('Notification Service', () => {
             const expectedResult = notificationArray.sort();
 
             notificationService.queryNotificationsFilteredBySettings().subscribe((resp) => {
-                expect(resp.body).toBe(expectedResult);
+                expect(resp.body).toEqual(expectedResult);
             });
 
             const req = httpMock.expectOne({ method: 'GET' });
@@ -138,7 +138,7 @@ describe('Notification Service', () => {
 
         it('should subscribe to single user notification updates and receive new single user notification', fakeAsync(() => {
             notificationService.subscribeToNotificationUpdates().subscribe((notification) => {
-                expect(notification).toBe(singleUserNotification);
+                expect(notification).toEqual(singleUserNotification);
             });
 
             tick(); // position of tick is very important here !
@@ -159,7 +159,7 @@ describe('Notification Service', () => {
 
         it('should subscribe to group notification updates and receive new group notification', fakeAsync(() => {
             notificationService.subscribeToNotificationUpdates().subscribe((notification) => {
-                expect(notification).toBe(groupNotification);
+                expect(notification).toEqual(groupNotification);
             });
 
             tick(); // position of tick is very important here !

--- a/src/test/javascript/spec/service/notification.service.spec.ts
+++ b/src/test/javascript/spec/service/notification.service.spec.ts
@@ -15,18 +15,11 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 import { JhiWebsocketService } from 'app/core/websocket/websocket.service';
 import { MockWebsocketService } from '../helpers/mocks/service/mock-websocket.service';
-import { SinonStub, stub } from 'sinon';
 import { Course } from 'app/entities/course.model';
 import { QuizExercise } from 'app/entities/quiz/quiz-exercise.model';
-import * as sinon from 'sinon';
-import sinonChai from 'sinon-chai';
-import * as chai from 'chai';
 import dayjs from 'dayjs';
 import { MetisService } from 'app/shared/metis/metis.service';
 import { MockMetisService } from '../helpers/mocks/service/mock-metis-service.service';
-
-chai.use(sinonChai);
-const expect = chai.expect;
 
 describe('Notification Service', () => {
     let notificationService: NotificationService;
@@ -34,15 +27,14 @@ describe('Notification Service', () => {
     let router: Router;
 
     let websocketService: JhiWebsocketService;
-    let wsSubscribeStub: SinonStub;
-    let wsReceiveNotificationStub: SinonStub;
+    let wsSubscribeStub: jest.SpyInstance;
+    let wsReceiveNotificationStub: jest.SpyInstance;
     let wsNotificationSubject: Subject<Notification | undefined>;
 
     let wsQuizExerciseSubject: Subject<QuizExercise | undefined>;
-    let wsReceiveQuizExerciseStub: SinonStub;
 
     let courseManagementService: CourseManagementService;
-    let cmGetCoursesForNotificationsStub: SinonStub;
+    let cmGetCoursesForNotificationsStub: jest.SpyInstance;
     let cmCoursesSubject: Subject<[Course] | undefined>;
     const course: Course = new Course();
     course.id = 42;
@@ -94,21 +86,23 @@ describe('Notification Service', () => {
                 router = TestBed.get(Router);
 
                 websocketService = TestBed.inject(JhiWebsocketService);
-                wsSubscribeStub = stub(websocketService, 'subscribe');
+                wsSubscribeStub = jest.spyOn(websocketService, 'subscribe');
                 wsNotificationSubject = new Subject<Notification | undefined>();
-                wsReceiveNotificationStub = stub(websocketService, 'receive').returns(wsNotificationSubject);
+                wsReceiveNotificationStub = jest.spyOn(websocketService, 'receive').mockReturnValue(wsNotificationSubject);
 
                 wsQuizExerciseSubject = new Subject<QuizExercise | undefined>();
 
                 courseManagementService = TestBed.inject(CourseManagementService);
                 cmCoursesSubject = new Subject<[Course] | undefined>();
-                cmGetCoursesForNotificationsStub = stub(courseManagementService, 'getCoursesForNotifications').returns(cmCoursesSubject as BehaviorSubject<[Course] | undefined>);
+                cmGetCoursesForNotificationsStub = jest
+                    .spyOn(courseManagementService, 'getCoursesForNotifications')
+                    .mockReturnValue(cmCoursesSubject as BehaviorSubject<[Course] | undefined>);
             });
     });
 
     afterEach(() => {
         httpMock.verify();
-        sinon.restore();
+        jest.restoreAllMocks();
     });
 
     describe('Service methods', () => {
@@ -116,16 +110,15 @@ describe('Notification Service', () => {
             notificationService.queryNotificationsFilteredBySettings().subscribe(() => {});
             const req = httpMock.expectOne({ method: 'GET' });
             const url = SERVER_API_URL + 'api/notifications';
-            expect(req.request.url).to.equal(url);
+            expect(req.request.url).toBe(url);
         });
 
         it('should navigate to notification target', () => {
-            sinon.spy(router, 'navigate');
-            sinon.replace(router, 'navigate', sinon.fake());
+            jest.spyOn(router, 'navigate').mockImplementation();
 
             notificationService.interpretNotification(quizNotification);
 
-            expect(router.navigate).to.have.been.calledOnce;
+            expect(router.navigate).toHaveBeenCalledTimes(1);
         });
 
         it('should convert date array from server', fakeAsync(() => {
@@ -135,7 +128,7 @@ describe('Notification Service', () => {
             const expectedResult = notificationArray.sort();
 
             notificationService.queryNotificationsFilteredBySettings().subscribe((resp) => {
-                expect(resp.body).to.equal(expectedResult);
+                expect(resp.body).toBe(expectedResult);
             });
 
             const req = httpMock.expectOne({ method: 'GET' });
@@ -145,17 +138,18 @@ describe('Notification Service', () => {
 
         it('should subscribe to single user notification updates and receive new single user notification', fakeAsync(() => {
             notificationService.subscribeToNotificationUpdates().subscribe((notification) => {
-                expect(notification).to.equal(singleUserNotification);
+                expect(notification).toBe(singleUserNotification);
             });
 
             tick(); // position of tick is very important here !
 
             const userId = 99; // based on MockAccountService
             const notificationTopic = `/topic/user/${userId}/notifications`;
-            expect(wsSubscribeStub).to.have.been.calledOnceWithExactly(notificationTopic);
+            expect(wsSubscribeStub).toHaveBeenCalledTimes(1);
+            expect(wsSubscribeStub).toHaveBeenCalledWith(notificationTopic);
             // websocket correctly subscribed to the topic
 
-            expect(wsReceiveNotificationStub).to.have.been.calledOnce;
+            expect(wsReceiveNotificationStub).toHaveBeenCalledTimes(1);
             // websocket "receive" called
 
             // add new single user notification
@@ -165,22 +159,23 @@ describe('Notification Service', () => {
 
         it('should subscribe to group notification updates and receive new group notification', fakeAsync(() => {
             notificationService.subscribeToNotificationUpdates().subscribe((notification) => {
-                expect(notification).to.equal(groupNotification);
+                expect(notification).toBe(groupNotification);
             });
 
             tick(); // position of tick is very important here !
 
-            expect(cmGetCoursesForNotificationsStub).to.have.been.calledOnce;
+            expect(cmGetCoursesForNotificationsStub).toHaveBeenCalledTimes(1);
             // courseManagementService.getCoursesForNotifications had been successfully subscribed to
 
             // push new courses
             cmCoursesSubject.next([course]);
 
             const notificationTopic = `/topic/course/${course.id}/TA`;
-            expect(wsSubscribeStub).to.have.been.calledWith(notificationTopic);
+            expect(wsSubscribeStub).toHaveBeenCalledTimes(3);
+            expect(wsSubscribeStub).toHaveBeenCalledWith(notificationTopic);
             // websocket correctly subscribed to the topic
 
-            expect(wsReceiveNotificationStub).to.have.been.called;
+            expect(wsReceiveNotificationStub).toHaveBeenCalledTimes(3);
             // websocket "receive" called
 
             // add new single user notification
@@ -189,30 +184,30 @@ describe('Notification Service', () => {
         }));
 
         it('should subscribe to quiz notification updates and receive a new quiz exercise and create a new quiz notification from it', fakeAsync(() => {
-            wsReceiveNotificationStub.restore();
-            wsReceiveQuizExerciseStub = stub(websocketService, 'receive').returns(wsQuizExerciseSubject);
+            const wsReceiveQuizExerciseStub = jest.spyOn(websocketService, 'receive').mockReturnValue(wsQuizExerciseSubject);
 
             notificationService.subscribeToNotificationUpdates().subscribe((notification) => {
                 // the quiz notification is created after a new quiz exercise has been detected, therefore the time will always be different
                 notification.notificationDate = undefined;
                 quizNotification.notificationDate = undefined;
 
-                expect(notification).to.be.deep.equal(quizNotification);
+                expect(notification).toEqual(quizNotification);
             });
 
             tick(); // position of tick is very important here !
 
-            expect(cmGetCoursesForNotificationsStub).to.have.been.calledOnce;
+            expect(cmGetCoursesForNotificationsStub).toHaveBeenCalledTimes(1);
             // courseManagementService.getCoursesForNotifications had been successfully subscribed to
 
             // push new courses
             cmCoursesSubject.next([course]);
 
             const notificationTopic = `/topic/course/${course.id}/TA`;
-            expect(wsSubscribeStub).to.have.been.calledWith(notificationTopic);
+            expect(wsSubscribeStub).toHaveBeenCalledTimes(3);
+            expect(wsSubscribeStub).toHaveBeenCalledWith(notificationTopic);
             // websocket correctly subscribed to the topic
 
-            expect(wsReceiveQuizExerciseStub).to.have.been.called;
+            expect(wsReceiveQuizExerciseStub).toHaveBeenCalledTimes(3);
             // websocket "receive" called
 
             // pushes new quizExercise

--- a/src/test/javascript/spec/service/password.service.spec.ts
+++ b/src/test/javascript/spec/service/password.service.spec.ts
@@ -1,4 +1,4 @@
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { MockHttpService } from '../helpers/mocks/service/mock-http.service';
 import { PasswordService } from 'app/account/password/password.service';
 import { HttpClient } from '@angular/common/http';
@@ -10,7 +10,7 @@ describe('ActivateService', () => {
 
     const postURL = SERVER_API_URL + 'api/account/change-password';
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             providers: [{ provide: HttpClient, useClass: MockHttpService }],
         })
@@ -20,17 +20,17 @@ describe('ActivateService', () => {
                 httpService = TestBed.inject(HttpClient);
                 postStub = jest.spyOn(httpService, 'post');
             });
-    }));
+    });
 
     afterEach(() => {
         jest.restoreAllMocks();
     });
 
-    it('should set a new password for the current user', async () => {
+    it('should set a new password for the current user', () => {
         const newPassword = 'newPassword';
         const currentPassword = 'currentPassword';
 
-        await passwordService.save(newPassword, currentPassword);
+        passwordService.save(newPassword, currentPassword).subscribe();
 
         expect(postStub).toHaveBeenCalledTimes(1);
         expect(postStub).toHaveBeenCalledWith(postURL, { currentPassword, newPassword });

--- a/src/test/javascript/spec/service/password.service.spec.ts
+++ b/src/test/javascript/spec/service/password.service.spec.ts
@@ -1,29 +1,29 @@
-import { async } from '@angular/core/testing';
-import * as chai from 'chai';
-import sinonChai from 'sinon-chai';
-import { SinonStub, stub } from 'sinon';
+import { async, TestBed } from '@angular/core/testing';
 import { MockHttpService } from '../helpers/mocks/service/mock-http.service';
 import { PasswordService } from 'app/account/password/password.service';
-
-chai.use(sinonChai);
-const expect = chai.expect;
+import { HttpClient } from '@angular/common/http';
 
 describe('ActivateService', () => {
     let passwordService: PasswordService;
-    let httpService: MockHttpService;
-    let postStub: SinonStub;
+    let httpService: HttpClient;
+    let postStub: jest.SpyInstance;
 
     const postURL = SERVER_API_URL + 'api/account/change-password';
 
     beforeEach(async(() => {
-        httpService = new MockHttpService();
-        // @ts-ignore
-        passwordService = new PasswordService(httpService);
-        postStub = stub(httpService, 'post');
+        TestBed.configureTestingModule({
+            providers: [{ provide: HttpClient, useClass: MockHttpService }],
+        })
+            .compileComponents()
+            .then(() => {
+                passwordService = TestBed.inject(PasswordService);
+                httpService = TestBed.inject(HttpClient);
+                postStub = jest.spyOn(httpService, 'post');
+            });
     }));
 
     afterEach(() => {
-        postStub.restore();
+        jest.restoreAllMocks();
     });
 
     it('should set a new password for the current user', async () => {
@@ -32,6 +32,7 @@ describe('ActivateService', () => {
 
         await passwordService.save(newPassword, currentPassword);
 
-        expect(postStub).to.have.been.calledOnceWithExactly(postURL, { currentPassword, newPassword });
+        expect(postStub).toHaveBeenCalledTimes(1);
+        expect(postStub).toHaveBeenCalledWith(postURL, { currentPassword, newPassword });
     });
 });

--- a/src/test/javascript/spec/service/text-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/text-submission.service.spec.ts
@@ -3,54 +3,54 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { take } from 'rxjs/operators';
 import { TextSubmissionService } from 'app/exercises/text/participate/text-submission.service';
 import { TextSubmission } from 'app/entities/text-submission.model';
-import sinonChai from 'sinon-chai';
-import * as chai from 'chai';
-
-chai.use(sinonChai);
-
-const expect = chai.expect;
 
 describe('TextSubmission Service', () => {
     let injector: TestBed;
     let service: TextSubmissionService;
     let httpMock: HttpTestingController;
     let elemDefault: TextSubmission;
-    let mockResponse: any;
+    const mockResponse = {
+        submissionExerciseType: 'text',
+        id: 1,
+        submitted: true,
+        type: 'MANUAL',
+        participation: {
+            type: 'student',
+            id: 1,
+            initializationState: 'FINISHED',
+            initializationDate: '2020-07-07T14:34:18.067248+02:00',
+            exercise: {
+                type: 'text',
+                id: 1,
+            },
+            participantIdentifier: 'ga27der',
+            participantName: 'Jonas Petry',
+        },
+        result: {
+            id: 5,
+            assessmentType: 'MANUAL',
+        },
+        submissionDate: '2020-07-07T14:34:25.194518+02:00',
+        durationInMinutes: 0,
+        text: 'Test\n\nTest\n\nTest',
+    };
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
-        });
-        injector = getTestBed();
-        service = injector.get(TextSubmissionService);
-        httpMock = injector.get(HttpTestingController);
+        })
+            .compileComponents()
+            .then(() => {
+                injector = getTestBed();
+                service = injector.get(TextSubmissionService);
+                httpMock = injector.get(HttpTestingController);
 
-        elemDefault = new TextSubmission();
-        mockResponse = {
-            submissionExerciseType: 'text',
-            id: 1,
-            submitted: true,
-            type: 'MANUAL',
-            participation: {
-                type: 'student',
-                id: 1,
-                initializationState: 'FINISHED',
-                initializationDate: '2020-07-07T14:34:18.067248+02:00',
-                exercise: {
-                    type: 'text',
-                    id: 1,
-                },
-                participantIdentifier: 'ga27der',
-                participantName: 'Jonas Petry',
-            },
-            result: {
-                id: 5,
-                assessmentType: 'MANUAL',
-            },
-            submissionDate: '2020-07-07T14:34:25.194518+02:00',
-            durationInMinutes: 0,
-            text: 'Test\n\nTest\n\nTest',
-        };
+                elemDefault = new TextSubmission();
+            });
+    });
+
+    afterEach(() => {
+        httpMock.verify();
     });
 
     it('should create a TextSubmission', fakeAsync(() => {
@@ -64,7 +64,7 @@ describe('TextSubmission Service', () => {
             .create(new TextSubmission(), 1)
             .pipe(take(1))
             .subscribe((resp: any) => {
-                expect(resp.body).to.deep.equal(expected);
+                expect(resp.body).toEqual(expected);
             });
         const req = httpMock.expectOne({ method: 'POST' });
         req.flush(returnedFromService);
@@ -81,7 +81,7 @@ describe('TextSubmission Service', () => {
         service
             .update(expected, 1)
             .pipe(take(1))
-            .subscribe((resp: any) => expect(resp.body).to.deep.equal(expected));
+            .subscribe((resp: any) => expect(resp.body).toEqual(expected));
         const req = httpMock.expectOne({ method: 'PUT' });
         req.flush(returnedFromService);
         tick();
@@ -89,7 +89,7 @@ describe('TextSubmission Service', () => {
 
     it('should not parse jwt from header', fakeAsync(() => {
         service.getTextSubmissionForExerciseForCorrectionRoundWithoutAssessment(1).subscribe((textSubmission) => {
-            expect(textSubmission.atheneTextAssessmentTrackingToken).to.be.undefined;
+            expect(textSubmission.atheneTextAssessmentTrackingToken).toBe(undefined);
         });
 
         const mockRequest = httpMock.expectOne({ method: 'GET' });
@@ -99,7 +99,7 @@ describe('TextSubmission Service', () => {
 
     it('should parse jwt from header', fakeAsync(() => {
         service.getTextSubmissionForExerciseForCorrectionRoundWithoutAssessment(1).subscribe((textSubmission) => {
-            expect(textSubmission.atheneTextAssessmentTrackingToken).to.equal('12345');
+            expect(textSubmission.atheneTextAssessmentTrackingToken).toBe('12345');
         });
 
         const mockRequest = httpMock.expectOne({ method: 'GET' });
@@ -113,13 +113,14 @@ describe('TextSubmission Service', () => {
         elemDefault.latestResult = undefined;
         const returnedFromService = [elemDefault];
         const expected = returnedFromService;
+        let response: any;
         service
             .getTextSubmissionsForExerciseByCorrectionRound(exerciseId, {})
             .pipe(take(1))
-            .subscribe((resp) => (mockResponse = resp));
+            .subscribe((resp) => (response = resp));
         const req = httpMock.expectOne({ method: 'GET' });
         req.flush(returnedFromService);
-        expect(mockResponse.body).to.deep.equal(expected);
+        expect(response.body).toEqual(expected);
         tick();
     }));
 
@@ -128,17 +129,14 @@ describe('TextSubmission Service', () => {
         elemDefault = new TextSubmission();
         const returnedFromService = { body: elemDefault };
         const expected = returnedFromService.body;
+        let response: any;
         service
             .getTextSubmission(exerciseId)
             .pipe(take(1))
-            .subscribe((resp) => (mockResponse = resp));
+            .subscribe((resp) => (response = resp));
         const req = httpMock.expectOne({ method: 'GET' });
         req.flush(returnedFromService);
-        expect(mockResponse.body).to.deep.equal(expected);
+        expect(response.body).toEqual(expected);
         tick();
     }));
-
-    afterEach(() => {
-        httpMock.verify();
-    });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
