### PR TITLE
`General`: Fix user settings menu position

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -158,7 +158,7 @@
                 ngbDropdown
                 class="nav-item dropdown pointer"
                 display="dynamic"
-                placement="bottom-end"
+                placement="bottom-right"
                 routerLinkActive="active"
                 [routerLinkActiveOptions]="{ exact: true }"
                 [autoClose]="true"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Fixes #4542.

### Description
The user settings menu overflowed to the right of the page for short usernames (see screenshots in #4542). This has been fixed by updating the placement.

Grepping for `placement.*end` only showed one other similar possible issue. That one has already been fixed in #4567.

### Steps for Testing
1. Log in to Artemis
2. Click on your username in the top-right corner.
3. The settings menu dropdown should not overflow past the right side of the page.

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
n/a

### Screenshots
Right edge of the settings menu is now correctly aligned again:
![Screenshot 2022-01-03 at 09-17-06 Course overview](https://user-images.githubusercontent.com/64250573/147910995-23603d31-39b2-4066-83a8-b17b2c4fe7ae.png)

