### PR TITLE
`General`: Fix internal server error displaying active students chart

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -444,6 +444,9 @@ public class CourseService {
             int startDateWeek = getWeekOfDate(startDate);
             int weeksDifference;
             weeksDifference = dateWeek < startDateWeek ? dateWeek == startDateWeek - 1 ? 0 : dateWeek + 53 - startDateWeek : dateWeek - startDateWeek;
+            if (result.length == weeksDifference) {
+                weeksDifference -= 1;
+            }
             result[weeksDifference] += amount;
         }
         return result;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
An **Internal server error** is thrown when the active students chart is displayed in the UI (see screenshots).

The error originates from a potential edge case (noticed on 03/01/2022) when calling `/api/courses/stats-for-management-overview?onlyActive=true` returning a `Index 4 out of bounds for length 4` exception.

### Description
<!-- Describe your changes in detail -->
This small fix inserts the statistical data into the previous week, avoiding the exception to be thrown.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course with 1 Exercise 

1. Log in to Artemis
2. Navigate to a course
3. Add the instructor in the 'students group'
4. Start and submit an exercise
5. Navigate to 'Course Management' view
6. Make sure no 'internal server error' is displayed

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![Screenshot 2022-01-03 155829](https://user-images.githubusercontent.com/45761921/147953948-18f55dee-e75a-4f64-a253-daa656ff8360.png)
![Screenshot 2022-01-03 155853](https://user-images.githubusercontent.com/45761921/147953951-a25a72a5-b21e-42e7-9ad0-c0d6bbe0ebe5.png)

