### PR TITLE
`Development`: Fix charts on course management and course detail page

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -443,7 +443,12 @@ public class CourseService {
             int dateWeek = getWeekOfDate(date);
             int startDateWeek = getWeekOfDate(startDate);
             int weeksDifference;
-            weeksDifference = dateWeek < startDateWeek ? dateWeek == startDateWeek - 1 ? 0 : dateWeek + 53 - startDateWeek : dateWeek - startDateWeek;
+            // we need to take into account that years can have 53 or 52 calendar weeks
+            ZonedDateTime firstDateOfStartYear = ZonedDateTime.of(startDate.getYear(), 1, 1, 0, 0, 0, 0, startDate.getZone());
+            ZonedDateTime lastDateOfStartYear = ZonedDateTime.of(startDate.getYear(), 12, 31, 0, 0, 0, 0, startDate.getZone());
+            boolean beginsOrEndsOnThursday = firstDateOfStartYear.getDayOfWeek() == DayOfWeek.THURSDAY || lastDateOfStartYear.getDayOfWeek() == DayOfWeek.THURSDAY;
+            int lastCalendarWeek = beginsOrEndsOnThursday ? 53 : 52;
+            weeksDifference = dateWeek < startDateWeek ? dateWeek == startDateWeek - 1 ? 0 : dateWeek + lastCalendarWeek - startDateWeek : dateWeek - startDateWeek;
             result[weeksDifference] += amount;
         }
         return result;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR fixes #4574 
### Description
<!-- Describe your changes in detail -->
So far, the aggregation of active users for different weeks did not take into account the following edge case appropriately:
The displayed timespan includes two different years and the most recent week has active users > 0.
The current implementation handles this case somehow by applying an offset to the displayed weeks of the most recent year in order to allocate the correct array position. The problem is, that the offset is hardcoded to 53 calendar weeks which does not necessarily hold for every year (if you are interested, read more about this on e.g. [Wikipedia](https://de.wikipedia.org/wiki/Woche#:~:text=Z%C3%A4hlweise%20nach%20ISO%208601%5BBearbeiten%20%7C%20Quelltext%20bearbeiten%5D)).
This leads currently to internal server errors as the server tries to access an array position that is out of bounds.
I changed the implementation so that it identifies the amount of calendar weeks for the prior year and applies the appropriate offset in case of such a situation as described above.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course with activity in the most recent week

1. Log in to Artemis
2. Navigate to Course Administration
3. Make sure no internal server error is thrown and the charts are filled with data
4. Click on the course card and check the same for the chart on the course detail page.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Screenshots documenting the current state are provided by the connected issue. The diagrams should now work again:
![image](https://user-images.githubusercontent.com/80622272/147961385-30c62b55-be71-4c47-89c8-74cdd887dba5.png)
![image](https://user-images.githubusercontent.com/80622272/147961532-377d0908-6cf1-4f40-bbba-b315863c1de3.png)
