### PR TITLE
`Quiz exercises`: Improve animations for drag and drop questions

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
@@ -288,7 +288,7 @@
                             <div title="Move">
                                 <fa-icon [icon]="faBars" size="lg"></fa-icon>
                             </div>
-                            <div *ngIf="dragItem.pictureFilePath" style="max-height: 100%">
+                            <div *ngIf="dragItem.pictureFilePath">
                                 <jhi-secured-image [src]="dragItem.pictureFilePath"></jhi-secured-image>
                             </div>
                             <div *ngIf="!dragItem.pictureFilePath">

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
@@ -188,7 +188,7 @@
                             cdkDropList
                         >
                             <div class="dimensions">{{ dropLocation.width }}x{{ dropLocation.height }}</div>
-                            <div class="d-inline-flex drop-location-buttons">
+                            <div class="drop-location-buttons">
                                 <div class="re-evaluate-button" title="Set invalid" *ngIf="reEvaluationInProgress && !dropLocation.invalid" (click)="dropLocation.invalid = true">
                                     <fa-icon [icon]="faBan" size="lg"></fa-icon>
                                 </div>
@@ -289,7 +289,7 @@
                                 <fa-icon [icon]="faBars" size="lg"></fa-icon>
                             </div>
                             <div *ngIf="dragItem.pictureFilePath" style="max-height: 100%">
-                                <jhi-secured-image style="max-height: 100%" [src]="dragItem.pictureFilePath"></jhi-secured-image>
+                                <jhi-secured-image [src]="dragItem.pictureFilePath"></jhi-secured-image>
                             </div>
                             <div *ngIf="!dragItem.pictureFilePath">
                                 <textarea

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.html
@@ -188,17 +188,19 @@
                             cdkDropList
                         >
                             <div class="dimensions">{{ dropLocation.width }}x{{ dropLocation.height }}</div>
-                            <div class="re-evaluate-button" title="Set invalid" *ngIf="reEvaluationInProgress && !dropLocation.invalid" (click)="dropLocation.invalid = true">
-                                <fa-icon [icon]="faBan" size="lg"></fa-icon>
-                            </div>
-                            <div class="re-evaluate-button" title="Reset" (click)="resetDropLocation(dropLocation)" *ngIf="reEvaluationInProgress">
-                                <fa-icon [icon]="faUndo" size="lg"></fa-icon>
-                            </div>
-                            <div class="duplicate-button" title="Duplicate" (click)="duplicateDropLocation(dropLocation)" *ngIf="!reEvaluationInProgress">
-                                <fa-icon [icon]="faCopy" size="lg"></fa-icon>
-                            </div>
-                            <div [ngClass]="reEvaluationInProgress ? 're-evaluate-button' : 'delete-button'" title="Delete" (click)="deleteDropLocation(dropLocation)">
-                                <fa-icon [icon]="faTrash" size="lg"></fa-icon>
+                            <div class="d-inline-flex drop-location-buttons">
+                                <div class="re-evaluate-button" title="Set invalid" *ngIf="reEvaluationInProgress && !dropLocation.invalid" (click)="dropLocation.invalid = true">
+                                    <fa-icon [icon]="faBan" size="lg"></fa-icon>
+                                </div>
+                                <div class="re-evaluate-button" title="Reset" (click)="resetDropLocation(dropLocation)" *ngIf="reEvaluationInProgress">
+                                    <fa-icon [icon]="faUndo" size="lg"></fa-icon>
+                                </div>
+                                <div class="duplicate-button" title="Duplicate" (click)="duplicateDropLocation(dropLocation)" *ngIf="!reEvaluationInProgress">
+                                    <fa-icon [icon]="faCopy" size="lg"></fa-icon>
+                                </div>
+                                <div [ngClass]="reEvaluationInProgress ? 're-evaluate-button' : 'delete-button'" title="Delete" (click)="deleteDropLocation(dropLocation)">
+                                    <fa-icon [icon]="faTrash" size="lg"></fa-icon>
+                                </div>
                             </div>
                             <div class="resize top left" (mousedown)="resizeMouseDown(dropLocation, 'top', 'left')"></div>
                             <div class="resize top center" (mousedown)="resizeMouseDown(dropLocation, 'top', 'center')"></div>
@@ -228,7 +230,7 @@
             <div *ngIf="question.dragItems && question.dragItems.length" class="dnd-instructions">
                 <span jhiTranslate="artemisApp.dragAndDropQuestion.addMappingsInstructions"></span>
             </div>
-            <div cdkDropList class="drag-items" *ngIf="question.dragItems && question.dragItems.length">
+            <div cdkDropList cdkDropListOrientation="horizontal" class="drag-items" *ngIf="question.dragItems && question.dragItems.length">
                 <div class="drag-item" id="drag-item-{{ i }}" *ngFor="let dragItem of question.dragItems; let i = index" cdkDrag [cdkDragDisabled]="false" [cdkDragData]="dragItem">
                     <div *ngIf="dragItem.pictureFilePath">
                         <jhi-secured-image [src]="dragItem.pictureFilePath"></jhi-secured-image>
@@ -275,6 +277,31 @@
                             </div>
                         </div>
                     </div>
+                    <div class="placeholder-dnd" *cdkDragPreview matchSize>
+                        <ng-template *ngTemplateOutlet="preview"></ng-template>
+                    </div>
+                    <div class="placeholder-dnd" *cdkDragPlaceholder>
+                        <ng-template *ngTemplateOutlet="preview"></ng-template>
+                    </div>
+                    <ng-template #preview>
+                        <div style="border: 1px solid; background: #fafafa; padding: 4px 2px 2px 2px">
+                            <div title="Move">
+                                <fa-icon [icon]="faBars" size="lg"></fa-icon>
+                            </div>
+                            <div *ngIf="dragItem.pictureFilePath" style="max-height: 100%">
+                                <jhi-secured-image style="max-height: 100%" [src]="dragItem.pictureFilePath"></jhi-secured-image>
+                            </div>
+                            <div *ngIf="!dragItem.pictureFilePath">
+                                <textarea
+                                    disabled
+                                    style="text-align: center; border: none; resize: none"
+                                    id="drag-item-{{ i }}-text-preview"
+                                    [(ngModel)]="dragItem.text"
+                                    (ngModelChange)="questionUpdated.emit()"
+                                ></textarea>
+                            </div>
+                        </div>
+                    </ng-template>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.scss
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.scss
@@ -139,10 +139,4 @@
             width: 100%;
         }
     }
-
-    .cdk-drop-list-dragging {
-        display: flex;
-        align-content: center;
-        justify-content: center;
-    }
 }

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.scss
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.scss
@@ -132,6 +132,7 @@
     .placeholder-dnd {
         max-height: 160px;
         max-width: 160px;
+
         img {
             max-height: 100%;
             max-width: 100%;

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.scss
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.scss
@@ -102,13 +102,13 @@
 
             /* medium-purple dotted drop-location */
             .drop-location {
-                align-items: flex-start;
+                align-items: center;
                 border: 1px dashed mediumpurple;
                 background: rgba(255, 255, 255, 0.5);
                 cursor: move !important;
                 display: flex;
                 flex-direction: row;
-                justify-content: flex-end;
+                justify-content: center;
                 position: absolute;
                 background: white;
 
@@ -121,5 +121,30 @@
                 cursor: not-allowed !important;
             }
         }
+    }
+
+    .drop-location-buttons {
+        position: absolute;
+        top: 1%;
+        right: 1%;
+    }
+
+    .placeholder-dnd {
+        max-height: 160px;
+        max-width: 160px;
+        height: 100%;
+        width: 100%;
+        img {
+            max-height: 100%;
+            max-width: 100%;
+            height: 100%;
+            width: 100%;
+        }
+    }
+
+    .cdk-drop-list-dragging {
+        display: flex;
+        align-content: center;
+        justify-content: center;
     }
 }

--- a/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.scss
+++ b/src/main/webapp/app/exercises/quiz/manage/drag-and-drop-question/drag-and-drop-question-edit.component.scss
@@ -132,8 +132,6 @@
     .placeholder-dnd {
         max-height: 160px;
         max-width: 160px;
-        height: 100%;
-        width: 100%;
         img {
             max-height: 100%;
             max-width: 100%;

--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.scss
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.scss
@@ -44,8 +44,8 @@
                     position: absolute;
                     display: flex;
                     flex-direction: row;
-                    align-items: flex-start;
-                    justify-content: flex-end;
+                    align-items: center;
+                    justify-content: center;
                     background: white;
                     border: 1px dashed black;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, the drag and drop animations are a bit distorted. This is fixed by this PR.
### Description
<!-- Describe your changes in detail -->
CDK needed some additional definition in order to produce smooth previews and placeholders for the drag items. 
**Note**: There is some styling within the HTML-template. This should normally be moved into CSS classes. But due to CDK, no CSS classes are applied to the placeholders or previews of the drag items, therefore only direct styling works here.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students

1. Log in to Artemis as instructor
2. Navigate to Course Administration
3. Create a Quiz exercise and there a DnD question. Define mappings between drag items and drop locations and make sure that the appearance is better now.
4. Start the quiz and participate as student
5. Here, drag drag items into drop locations and again, check that the animations are more convenient than before.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
Nothing changed
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<details>
<summary>The current situation</summary>

https://user-images.githubusercontent.com/80622272/148253957-0337bc7d-f92f-4f88-a70d-93bf277a763e.mp4


https://user-images.githubusercontent.com/80622272/148253973-ff6601e9-64c1-4916-995a-dc7c12eb8738.mp4


</details>
<details>
<summary>How it looks now</summary>

https://user-images.githubusercontent.com/80622272/148254129-5333b182-f938-4a08-ad53-f9319244df74.mp4


https://user-images.githubusercontent.com/80622272/148254144-3b9da85a-b1b4-440a-9f11-dfb69e99b929.mp4


</details>
