### PR TITLE
`Programming exercises`: Fix building animation after submission

### DIFF
--- a/src/main/webapp/app/exercises/shared/result/updating-result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/updating-result.component.ts
@@ -131,6 +131,12 @@ export class UpdatingResultComponent implements OnChanges, OnDestroy {
         return MissingResultInfo.FAILED_PROGRAMMING_SUBMISSION_ONLINE_IDE;
     }
 
+    /**
+     * Checks if a status update should be shown for this submission.
+     *
+     * @param submission for which a status update should be shown.
+     * @private
+     */
     private shouldUpdateSubmissionState(submission?: Submission): boolean {
         // The updating result must ignore submissions that are ungraded if ungraded results should not be shown
         // (otherwise the building animation will be shown even though not relevant).
@@ -144,6 +150,12 @@ export class UpdatingResultComponent implements OnChanges, OnDestroy {
         );
     }
 
+    /**
+     * Updates the shown status based on the given state of a submission.
+     *
+     * @param submissionState the submission is currently in.
+     * @private
+     */
     private updateSubmissionState(submissionState: ProgrammingSubmissionState) {
         this.isBuilding = submissionState === ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION;
 

--- a/src/main/webapp/app/exercises/shared/result/updating-result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/updating-result.component.ts
@@ -9,11 +9,11 @@ import { ProgrammingSubmissionService, ProgrammingSubmissionState } from 'app/ex
 import { Exercise, ExerciseType } from 'app/entities/exercise.model';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { ResultService } from 'app/exercises/shared/result/result.service';
-import { SubmissionType } from 'app/entities/submission.model';
+import { Submission, SubmissionType } from 'app/entities/submission.model';
 import { StudentParticipation } from 'app/entities/participation/student-participation.model';
 import { Result } from 'app/entities/result.model';
 import { MissingResultInfo } from 'app/exercises/shared/result/result.component';
-import { hasExerciseDueDatePassed } from 'app/exercises/shared/exercise/exercise.utils';
+import { getExerciseDueDate } from 'app/exercises/shared/exercise/exercise.utils';
 import { hasParticipationChanged } from 'app/exercises/shared/participation/participation.utils';
 
 /**
@@ -117,27 +117,8 @@ export class UpdatingResultComponent implements OnChanges, OnDestroy {
         this.submissionSubscription = this.submissionService
             .getLatestPendingSubmissionByParticipationId(this.participation.id!, this.exercise.id!, this.personalParticipation)
             .pipe(
-                // The updating result must ignore submissions that are ungraded if ungraded results should not be shown
-                // (otherwise the building animation will be shown even though not relevant).
-                filter(
-                    ({ submission }) =>
-                        this.showUngradedResults ||
-                        !submission ||
-                        !this.exercise.dueDate ||
-                        submission.type === SubmissionType.INSTRUCTOR ||
-                        submission.type === SubmissionType.TEST ||
-                        !hasExerciseDueDatePassed(this.exercise, this.participation),
-                ),
-                tap(({ submissionState }) => {
-                    this.isBuilding = submissionState === ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION;
-
-                    if (submissionState === ProgrammingSubmissionState.HAS_FAILED_SUBMISSION) {
-                        this.missingResultInfo = this.generateMissingResultInfoForFailedProgrammingExerciseSubmission();
-                    } else {
-                        // everything ok, remove the warning
-                        this.missingResultInfo = MissingResultInfo.NONE;
-                    }
-                }),
+                filter(({ submission }) => this.shouldUpdateSubmissionState(submission)),
+                tap(({ submissionState }) => this.updateSubmissionState(submissionState)),
             )
             .subscribe();
     }
@@ -148,5 +129,29 @@ export class UpdatingResultComponent implements OnChanges, OnDestroy {
             return MissingResultInfo.FAILED_PROGRAMMING_SUBMISSION_OFFLINE_IDE;
         }
         return MissingResultInfo.FAILED_PROGRAMMING_SUBMISSION_ONLINE_IDE;
+    }
+
+    private shouldUpdateSubmissionState(submission?: Submission): boolean {
+        // The updating result must ignore submissions that are ungraded if ungraded results should not be shown
+        // (otherwise the building animation will be shown even though not relevant).
+        return (
+            this.showUngradedResults ||
+            !submission ||
+            !this.exercise.dueDate ||
+            submission.type === SubmissionType.INSTRUCTOR ||
+            submission.type === SubmissionType.TEST ||
+            dayjs(submission.submissionDate).isBefore(getExerciseDueDate(this.exercise, this.participation))
+        );
+    }
+
+    private updateSubmissionState(submissionState: ProgrammingSubmissionState) {
+        this.isBuilding = submissionState === ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION;
+
+        if (submissionState === ProgrammingSubmissionState.HAS_FAILED_SUBMISSION) {
+            this.missingResultInfo = this.generateMissingResultInfoForFailedProgrammingExerciseSubmission();
+        } else {
+            // everything ok, remove the warning
+            this.missingResultInfo = MissingResultInfo.NONE;
+        }
     }
 }

--- a/src/main/webapp/app/exercises/shared/result/updating-result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/updating-result.component.ts
@@ -126,7 +126,7 @@ export class UpdatingResultComponent implements OnChanges, OnDestroy {
                         !this.exercise.dueDate ||
                         submission.type === SubmissionType.INSTRUCTOR ||
                         submission.type === SubmissionType.TEST ||
-                        hasExerciseDueDatePassed(this.exercise, this.participation),
+                        !hasExerciseDueDatePassed(this.exercise, this.participation),
                 ),
                 tap(({ submissionState }) => {
                     this.isBuilding = submissionState === ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION;

--- a/src/test/javascript/spec/component/shared/updating-result.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/updating-result.component.spec.ts
@@ -14,6 +14,7 @@ import { MissingResultInfo, ResultComponent } from 'app/exercises/shared/result/
 import { Result } from 'app/entities/result.model';
 import { MockParticipationWebsocketService } from '../../helpers/mocks/service/mock-participation-websocket.service';
 import { MockComponent } from 'ng-mocks';
+import { Submission } from 'app/entities/submission.model';
 
 describe('UpdatingResultComponent', () => {
     let comp: UpdatingResultComponent;
@@ -38,7 +39,7 @@ describe('UpdatingResultComponent', () => {
     const newGradedResult = { id: 14, rated: true } as Result;
     const newUngradedResult = { id: 15, rated: false } as Result;
 
-    const submission = { id: 1 } as any;
+    const submission = { id: 1 } as Submission;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -194,6 +195,24 @@ describe('UpdatingResultComponent', () => {
         getLatestPendingSubmissionStub.mockReturnValue(of({ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission, participationId: 3 }));
         cleanInitializeGraded();
         expect(getLatestPendingSubmissionStub).not.toHaveBeenCalled();
+        expect(comp.isBuilding).toBe(undefined);
+        expect(comp.missingResultInfo).toBe(MissingResultInfo.NONE);
+    });
+
+    it('should update the building status if the submission was before the due date', () => {
+        submission.submissionDate = dayjs();
+        comp.exercise = { id: 99, type: ExerciseType.PROGRAMMING, dueDate: submission.submissionDate.add(1, 'hour') } as Exercise;
+        getLatestPendingSubmissionStub.mockReturnValue(of({ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission, participationId: 3 }));
+        cleanInitializeGraded();
+        expect(comp.isBuilding).toBe(true);
+        expect(comp.missingResultInfo).toBe(MissingResultInfo.NONE);
+    });
+
+    it('should not update the building status if the submission was after the due date', () => {
+        submission.submissionDate = dayjs();
+        comp.exercise = { id: 99, type: ExerciseType.PROGRAMMING, dueDate: submission.submissionDate.subtract(1, 'minute') } as Exercise;
+        getLatestPendingSubmissionStub.mockReturnValue(of({ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission, participationId: 3 }));
+        cleanInitializeGraded();
         expect(comp.isBuilding).toBe(undefined);
         expect(comp.missingResultInfo).toBe(MissingResultInfo.NONE);
     });


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
This PR is linked to #4591. No loading animation is shown after pushing code to a programming exercise that has a due date. 

### Description
Introduced in #4416, submissions that have been made **before** the due date has passed have been filtered out in the corresponding component. This PR changes that and submissions that have been made **after** the due date has passed are filtered out and all other submissions retain.

### Steps for Testing
- 1 Instructor
- 1 Programming Exercise with a due date in the future

1. Log in to Artemis
2. Navigate to Course Overview
3. Start a programming exercise and clone the repository locallly
4. Push code from the local IDE and confirm that a loading animation is displayed while the submission is being built

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
