### PR TITLE
`Development`: Replace usages of deprecated TestBed.get with TestBed.inject

### DIFF
--- a/src/test/javascript/spec/component/account/activate.component.spec.ts
+++ b/src/test/javascript/spec/component/account/activate.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
 
@@ -14,7 +14,7 @@ import { MockProfileService } from '../../helpers/mocks/service/mock-profile.ser
 describe('ActivateComponent', () => {
     let comp: ActivateComponent;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [ActivateComponent],
@@ -27,7 +27,7 @@ describe('ActivateComponent', () => {
         })
             .overrideTemplate(ActivateComponent, '')
             .compileComponents();
-    }));
+    });
 
     beforeEach(() => {
         const fixture = TestBed.createComponent(ActivateComponent);

--- a/src/test/javascript/spec/component/account/password-strength-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/account/password-strength-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PasswordStrengthBarComponent } from 'app/account/password/password-strength-bar.component';
 
@@ -7,13 +7,13 @@ describe('Component Tests', () => {
         let comp: PasswordStrengthBarComponent;
         let fixture: ComponentFixture<PasswordStrengthBarComponent>;
 
-        beforeEach(async(() => {
+        beforeEach(() => {
             TestBed.configureTestingModule({
                 declarations: [PasswordStrengthBarComponent],
             })
                 .overrideTemplate(PasswordStrengthBarComponent, '')
                 .compileComponents();
-        }));
+        });
 
         beforeEach(() => {
             fixture = TestBed.createComponent(PasswordStrengthBarComponent);

--- a/src/test/javascript/spec/component/account/password.component.spec.ts
+++ b/src/test/javascript/spec/component/account/password.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpResponse } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
@@ -17,7 +17,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<PasswordComponent>;
         let service: PasswordService;
 
-        beforeEach(async(() => {
+        beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [ArtemisTestModule],
                 declarations: [PasswordComponent],
@@ -30,7 +30,7 @@ describe('Component Tests', () => {
             })
                 .overrideTemplate(PasswordComponent, '')
                 .compileComponents();
-        }));
+        });
 
         beforeEach(() => {
             fixture = TestBed.createComponent(PasswordComponent);

--- a/src/test/javascript/spec/component/account/register.component.spec.ts
+++ b/src/test/javascript/spec/component/account/register.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, async, inject, tick, fakeAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, inject, tick, fakeAsync } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 
@@ -20,7 +20,7 @@ describe('Component Tests', () => {
         let comp: RegisterComponent;
         let translateService: TranslateService;
 
-        beforeEach(async(() => {
+        beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [ArtemisTestModule],
                 declarations: [RegisterComponent],
@@ -34,7 +34,7 @@ describe('Component Tests', () => {
             })
                 .overrideTemplate(RegisterComponent, '')
                 .compileComponents();
-        }));
+        });
 
         beforeEach(() => {
             fixture = TestBed.createComponent(RegisterComponent);

--- a/src/test/javascript/spec/component/account/settings.component.spec.ts
+++ b/src/test/javascript/spec/component/account/settings.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, async, tick, fakeAsync, inject } from '@angular/core/testing';
+import { TestBed, tick, fakeAsync, inject } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
 import { throwError, of } from 'rxjs';
 
@@ -29,7 +29,7 @@ describe('SettingsComponent', () => {
         imageUrl: '',
     };
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [SettingsComponent],
@@ -43,7 +43,7 @@ describe('SettingsComponent', () => {
         })
             .overrideTemplate(SettingsComponent, '')
             .compileComponents();
-    }));
+    });
 
     beforeEach(() => {
         const fixture = TestBed.createComponent(SettingsComponent);

--- a/src/test/javascript/spec/component/admin/health.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/health.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { of, throwError } from 'rxjs';
 
@@ -12,14 +12,14 @@ describe('HealthComponent', () => {
     let fixture: ComponentFixture<HealthComponent>;
     let service: HealthService;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [HealthComponent],
         })
             .overrideTemplate(HealthComponent, '')
             .compileComponents();
-    }));
+    });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(HealthComponent);

--- a/src/test/javascript/spec/component/admin/user-management-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/user-management-detail.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 
@@ -15,7 +15,7 @@ describe('User Management Detail Component', () => {
         children: [],
     } as any as ActivatedRoute;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [UserManagementDetailComponent],
@@ -28,7 +28,7 @@ describe('User Management Detail Component', () => {
         })
             .overrideTemplate(UserManagementDetailComponent, '')
             .compileComponents();
-    }));
+    });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(UserManagementDetailComponent);

--- a/src/test/javascript/spec/component/complaints-for-tutor/complaints-for-tutor.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints-for-tutor/complaints-for-tutor.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ComplaintService } from 'app/complaints/complaint.service';
 import { ComplaintResponseService } from 'app/complaints/complaint-response.service';
 import { ComplaintsForTutorComponent } from 'app/complaints/complaints-for-tutor/complaints-for-tutor.component';
@@ -19,7 +19,7 @@ describe('ComplaintsForTutorComponent', () => {
     let complaintForTutorComponentFixture: ComponentFixture<ComplaintsForTutorComponent>;
     let injectedComplaintResponseService: ComplaintResponseService;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [RouterTestingModule.withRoutes([]), FormsModule],
             declarations: [ComplaintsForTutorComponent, MockPipe(ArtemisTranslatePipe), MockPipe(ArtemisDatePipe)],
@@ -31,7 +31,7 @@ describe('ComplaintsForTutorComponent', () => {
                 complaintsForTutorComponent = complaintForTutorComponentFixture.componentInstance;
                 injectedComplaintResponseService = complaintForTutorComponentFixture.debugElement.injector.get(ComplaintResponseService);
             });
-    }));
+    });
 
     afterEach(() => {
         jest.restoreAllMocks();

--- a/src/test/javascript/spec/component/complaints/complaint-response.service.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint-response.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { ComplaintResponseService } from 'app/complaints/complaint-response.service';
 import { ComplaintResponse } from 'app/entities/complaint-response.model';
@@ -12,7 +12,6 @@ import { User } from 'app/core/user/user.model';
 import { TextExercise } from 'app/entities/text-exercise.model';
 
 describe('ComplaintResponseService', () => {
-    let testBed: TestBed;
     let complaintResponseService: ComplaintResponseService;
     let httpTestingController: HttpTestingController;
     let defaultComplaintResponse: ComplaintResponse;
@@ -25,9 +24,8 @@ describe('ComplaintResponseService', () => {
         });
         expectedComplaintResponse = {} as HttpResponse<ComplaintResponse>;
 
-        testBed = getTestBed();
-        complaintResponseService = testBed.get(ComplaintResponseService);
-        httpTestingController = testBed.get(HttpTestingController);
+        complaintResponseService = TestBed.inject(ComplaintResponseService);
+        httpTestingController = TestBed.inject(HttpTestingController);
 
         defaultComplaintResponse = new ComplaintResponse();
         defaultComplaintResponse.id = 1;
@@ -43,7 +41,7 @@ describe('ComplaintResponseService', () => {
     });
 
     function setupLockTest(loginOfLoggedInUser: string, loggedInUserIsInstructor: boolean, loginOfReviewer: string, lockActive: boolean) {
-        const accountService = testBed.get(AccountService);
+        const accountService = TestBed.inject(AccountService);
         jest.spyOn(accountService, 'userIdentity', 'get').mockImplementation(function getterFn() {
             const user = new User();
             user.login = loginOfLoggedInUser;

--- a/src/test/javascript/spec/component/course/course-exercise-submission-result-simulation.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-exercise-submission-result-simulation.service.spec.ts
@@ -1,11 +1,10 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Result } from 'app/entities/result.model';
 import { CourseExerciseSubmissionResultSimulationService } from 'app/course/manage/course-exercise-submission-result-simulation.service';
 import { ProgrammingSubmission } from 'app/entities/programming-submission.model';
 
 describe('Participation Service', () => {
-    let injector: TestBed;
     let service: CourseExerciseSubmissionResultSimulationService;
     let httpMock: HttpTestingController;
     let exerciseId: number;
@@ -13,9 +12,8 @@ describe('Participation Service', () => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
         });
-        injector = getTestBed();
-        service = injector.get(CourseExerciseSubmissionResultSimulationService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(CourseExerciseSubmissionResultSimulationService);
+        httpMock = TestBed.inject(HttpTestingController);
         exerciseId = 123;
     });
 

--- a/src/test/javascript/spec/component/course/course-management.service.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { AccountService } from 'app/core/auth/account.service';
@@ -22,7 +22,6 @@ import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.s
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
 
 describe('Course Management Service', () => {
-    let injector: TestBed;
     let courseManagementService: CourseManagementService;
     let accountService: AccountService;
     let exerciseService: ExerciseService;
@@ -39,6 +38,7 @@ describe('Course Management Service', () => {
     let exercises: Exercise[];
     let returnedFromService: any;
     let participations: StudentParticipation[];
+
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
@@ -49,12 +49,11 @@ describe('Course Management Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        courseManagementService = injector.get(CourseManagementService);
-        httpMock = injector.get(HttpTestingController);
-        accountService = injector.get(AccountService);
-        exerciseService = injector.get(ExerciseService);
-        lectureService = injector.get(LectureService);
+        courseManagementService = TestBed.inject(CourseManagementService);
+        httpMock = TestBed.inject(HttpTestingController);
+        accountService = TestBed.inject(AccountService);
+        exerciseService = TestBed.inject(ExerciseService);
+        lectureService = TestBed.inject(LectureService);
 
         isAtLeastTutorInCourseSpy = jest.spyOn(accountService, 'isAtLeastTutorInCourse').mockReturnValue(false);
         isAtLeastEditorInCourseSpy = jest.spyOn(accountService, 'isAtLeastEditorInCourse').mockReturnValue(false);

--- a/src/test/javascript/spec/component/course/course.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course.component.spec.ts
@@ -78,7 +78,7 @@ describe('CoursesComponent', () => {
 
     const route = { data: of({ courseId: course1.id }), children: [] } as any as ActivatedRoute;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, RouterTestingModule.withRoutes([{ path: 'courses/:courseId/exams/:examId', component: DummyComponent }])],
             declarations: [

--- a/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
@@ -104,7 +104,7 @@ describe('ExamParticipationComponent', () => {
                 courseExerciseService = TestBed.inject(CourseExerciseService);
                 textSubmissionService = TestBed.inject(TextSubmissionService);
                 modelingSubmissionService = TestBed.inject(ModelingSubmissionService);
-                alertService = fixture.debugElement.injector.get(AlertService);
+                alertService = TestBed.inject(AlertService);
                 artemisServerDateService = TestBed.inject(ArtemisServerDateService);
                 fixture.detectChanges();
             });
@@ -129,7 +129,7 @@ describe('ExamParticipationComponent', () => {
             expect(testRunRibbon).toBeDefined();
         });
         it('should initialize and not display test run ribbon', () => {
-            TestBed.get(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
+            TestBed.inject(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
             comp.ngOnInit();
             fixture.detectChanges();
             expect(fixture).toBeTruthy();
@@ -185,7 +185,7 @@ describe('ExamParticipationComponent', () => {
         studentExam.exam.startDate = dayjs().subtract(2000, 'seconds');
         studentExam.workingTime = 100;
         const studentExamWithExercises = new StudentExam();
-        TestBed.get(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
+        TestBed.inject(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
         const loadStudentExamSpy = jest.spyOn(examParticipationService, 'loadStudentExam').mockReturnValue(of(studentExam));
         const loadStudentExamWithExercisesForSummary = jest.spyOn(examParticipationService, 'loadStudentExamWithExercisesForSummary').mockReturnValue(of(studentExamWithExercises));
         comp.ngOnInit();
@@ -214,7 +214,7 @@ describe('ExamParticipationComponent', () => {
         const lastSaveFailedStub = jest.spyOn(examParticipationService, 'lastSaveFailed').mockReturnValue(true);
         const loadLocalStudentExamStub = jest.spyOn(examParticipationService, 'loadStudentExamWithExercisesForConductionFromLocalStorage').mockReturnValue(of(localStudentExam));
 
-        TestBed.get(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
+        TestBed.inject(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
 
         comp.ngOnInit();
 
@@ -286,7 +286,7 @@ describe('ExamParticipationComponent', () => {
 
     it('should initialize exercise without test run', () => {
         // Should calculate time from exam start date when no test run, rest does not get effected
-        TestBed.get(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
+        TestBed.inject(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
         comp.ngOnInit();
         const startDate = dayjs();
         comp.exam = new Exam();
@@ -460,7 +460,7 @@ describe('ExamParticipationComponent', () => {
     });
 
     const setComponentWithoutTestRun = () => {
-        TestBed.get(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
+        TestBed.inject(ActivatedRoute).params = of({ courseId: '1', examId: '2' });
         comp.ngOnInit();
         comp.exam = new Exam();
     };

--- a/src/test/javascript/spec/component/exercises/quiz/quiz-participation.service.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/quiz-participation.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { QuizParticipationService } from 'app/exercises/quiz/participate/quiz-participation.service';
 import { QuizSubmission } from 'app/entities/quiz/quiz-submission.model';
 import { Result } from 'app/entities/result.model';
@@ -7,7 +7,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../../../helpers/mocks/service/mock-account.service';
 
 describe('Quiz Participation Service', () => {
-    let injector: TestBed;
     let service: QuizParticipationService;
     let httpMock: HttpTestingController;
     let exerciseId: number;
@@ -16,9 +15,8 @@ describe('Quiz Participation Service', () => {
             imports: [HttpClientTestingModule],
             providers: [{ provide: AccountService, useClass: MockAccountService }],
         });
-        injector = getTestBed();
-        service = injector.get(QuizParticipationService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(QuizParticipationService);
+        httpMock = TestBed.inject(HttpTestingController);
         exerciseId = 123;
     });
 

--- a/src/test/javascript/spec/component/file-upload-exercise/file-upload-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-exercise/file-upload-exercise.component.spec.ts
@@ -43,8 +43,8 @@ describe('FileUploadExercise Management Component', () => {
 
         fixture = TestBed.createComponent(FileUploadExerciseComponent);
         comp = fixture.componentInstance;
-        service = fixture.debugElement.injector.get(CourseExerciseService);
-        fileUploadExerciseService = fixture.debugElement.injector.get(FileUploadExerciseService);
+        service = TestBed.inject(CourseExerciseService);
+        fileUploadExerciseService = TestBed.inject(FileUploadExerciseService);
 
         comp.fileUploadExercises = [fileUploadExercise];
     });

--- a/src/test/javascript/spec/component/learning-goals/course-learning-goals.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-goals/course-learning-goals.component.spec.ts
@@ -61,7 +61,7 @@ describe('CourseLearningGoals', () => {
             .then(() => {
                 courseLearningGoalsComponentFixture = TestBed.createComponent(CourseLearningGoalsComponent);
                 courseLearningGoalsComponent = courseLearningGoalsComponentFixture.componentInstance;
-                const accountService = TestBed.get(AccountService);
+                const accountService = TestBed.inject(AccountService);
                 const user = new User();
                 user.login = 'testUser';
                 jest.spyOn(accountService, 'userIdentity', 'get').mockReturnValue(user);
@@ -79,7 +79,7 @@ describe('CourseLearningGoals', () => {
     });
 
     it('should load learning goal and associated progress and display a card for each of them', () => {
-        const learningGoalService = TestBed.get(LearningGoalService);
+        const learningGoalService = TestBed.inject(LearningGoalService);
         const learningGoal = new LearningGoal();
         const textUnit = new TextUnit();
         learningGoal.id = 1;

--- a/src/test/javascript/spec/component/learning-goals/learning-goal.service.spec.ts
+++ b/src/test/javascript/spec/component/learning-goals/learning-goal.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
 import { take } from 'rxjs/operators';
@@ -10,7 +10,6 @@ import { IndividualLearningGoalProgress } from 'app/course/learning-goals/learni
 import { LearningGoal } from 'app/entities/learningGoal.model';
 
 describe('LearningGoalService', () => {
-    let testBed: TestBed;
     let learningGoalService: LearningGoalService;
     let httpTestingController: HttpTestingController;
     let defaultLearningGoal: LearningGoal;
@@ -35,9 +34,8 @@ describe('LearningGoalService', () => {
         expectedResultLearningGoal = {} as HttpResponse<LearningGoal>;
         expectedResultLearningGoalProgress = {} as HttpResponse<IndividualLearningGoalProgress>;
 
-        testBed = getTestBed();
-        learningGoalService = testBed.get(LearningGoalService);
-        httpTestingController = testBed.get(HttpTestingController);
+        learningGoalService = TestBed.inject(LearningGoalService);
+        httpTestingController = TestBed.inject(HttpTestingController);
 
         defaultLearningGoal = new LearningGoal();
         defaultLearningGoal.id = 0;

--- a/src/test/javascript/spec/component/lecture-unit/attachment-unit/attachment-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/attachment-unit/attachment-unit.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
 import { take } from 'rxjs/operators';
@@ -11,7 +11,6 @@ import { Attachment, AttachmentType } from 'app/entities/attachment.model';
 import { AttachmentUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/attachmentUnit.service';
 
 describe('AttachmentUnitService', () => {
-    let injector: TestBed;
     let service: AttachmentUnitService;
     let httpMock: HttpTestingController;
     let elemDefault: AttachmentUnit;
@@ -29,9 +28,8 @@ describe('AttachmentUnitService', () => {
             ],
         });
         expectedResult = {} as HttpResponse<AttachmentUnit>;
-        injector = getTestBed();
-        service = injector.get(AttachmentUnitService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(AttachmentUnitService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         const attachment = new Attachment();
         attachment.id = 0;

--- a/src/test/javascript/spec/component/lecture-unit/exercise-unit/exercise-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/exercise-unit/exercise-unit.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
 import { take } from 'rxjs/operators';
@@ -12,7 +12,6 @@ import { Course } from 'app/entities/course.model';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 
 describe('ExerciseUnitService', () => {
-    let injector: TestBed;
     let service: ExerciseUnitService;
     let httpMock: HttpTestingController;
     let elemDefault: ExerciseUnit;
@@ -36,9 +35,8 @@ describe('ExerciseUnitService', () => {
         });
         expectedResult = {} as HttpResponse<ExerciseUnit>;
         expectedResultArray = {} as HttpResponse<ExerciseUnit[]>;
-        injector = getTestBed();
-        service = injector.get(ExerciseUnitService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(ExerciseUnitService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         const course = new Course();
         const exercise = new TextExercise(course, undefined);

--- a/src/test/javascript/spec/component/lecture-unit/text-unit/text-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/text-unit/text-unit.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
 import { TextUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/textUnit.service';
@@ -10,7 +10,6 @@ import { LectureUnit } from 'app/entities/lecture-unit/lectureUnit.model';
 import dayjs from 'dayjs/esm';
 
 describe('TextUnitService', () => {
-    let injector: TestBed;
     let service: TextUnitService;
     let httpMock: HttpTestingController;
     let elemDefault: TextUnit;
@@ -31,9 +30,8 @@ describe('TextUnitService', () => {
             ],
         });
         expectedResult = {} as HttpResponse<TextUnit>;
-        injector = getTestBed();
-        service = injector.get(TextUnitService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(TextUnitService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new TextUnit();
         elemDefault.id = 0;

--- a/src/test/javascript/spec/component/lecture-unit/video-unit/video-unit.service.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/video-unit/video-unit.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed } from '@angular/core/testing';
 import { LectureUnitService } from 'app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service';
 import { MockProvider } from 'ng-mocks';
 import { take } from 'rxjs/operators';
@@ -10,7 +10,6 @@ import { VideoUnitService } from 'app/lecture/lecture-unit/lecture-unit-manageme
 import { VideoUnit } from 'app/entities/lecture-unit/videoUnit.model';
 
 describe('VideoUnitService', () => {
-    let injector: TestBed;
     let service: VideoUnitService;
     let httpMock: HttpTestingController;
     let elemDefault: VideoUnit;
@@ -31,9 +30,8 @@ describe('VideoUnitService', () => {
             ],
         });
         expectedResult = {} as HttpResponse<VideoUnit>;
-        injector = getTestBed();
-        service = injector.get(VideoUnitService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(VideoUnitService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new VideoUnit();
         elemDefault.id = 0;

--- a/src/test/javascript/spec/component/lecture/lecture-attachments.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture/lecture-attachments.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick, getTestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import dayjs from 'dayjs/esm';
 import { ArtemisTestModule } from '../../test.module';
 import { ActivatedRoute } from '@angular/router';
@@ -24,7 +24,6 @@ import { HttpResponse } from '@angular/common/http';
 describe('LectureAttachmentsComponent', () => {
     let comp: LectureAttachmentsComponent;
     let fixture: ComponentFixture<LectureAttachmentsComponent>;
-    let injector: TestBed;
     let fileUploaderService: FileUploaderService;
     let attachmentService: AttachmentService;
     let attachmentServiceFindAllByLectureIdStub: jest.SpyInstance;
@@ -104,9 +103,8 @@ describe('LectureAttachmentsComponent', () => {
             .then(() => {
                 fixture = TestBed.createComponent(LectureAttachmentsComponent);
                 comp = fixture.componentInstance;
-                injector = getTestBed();
-                fileUploaderService = injector.get(FileUploaderService);
-                attachmentService = injector.get(AttachmentService);
+                fileUploaderService = TestBed.inject(FileUploaderService);
+                attachmentService = TestBed.inject(AttachmentService);
                 attachmentServiceFindAllByLectureIdStub = jest.spyOn(attachmentService, 'findAllByLectureId').mockReturnValue(of(new HttpResponse({ body: [...attachments] })));
             });
     });

--- a/src/test/javascript/spec/component/markdown-editor/bold-command.spec.ts
+++ b/src/test/javascript/spec/component/markdown-editor/bold-command.spec.ts
@@ -11,7 +11,7 @@ describe('BoldCommand', () => {
     let comp: MarkdownEditorComponent;
     let fixture: ComponentFixture<MarkdownEditorComponent>;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [ArtemisTestModule, TranslateModule.forRoot(), AceEditorModule, ArtemisMarkdownEditorModule],
         })

--- a/src/test/javascript/spec/component/markdown-editor/headingCommands.spec.ts
+++ b/src/test/javascript/spec/component/markdown-editor/headingCommands.spec.ts
@@ -20,7 +20,7 @@ describe('HeadingOneCommand', () => {
         jest.restoreAllMocks();
     });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [ArtemisTestModule, TranslateModule.forRoot(), AceEditorModule, ArtemisMarkdownEditorModule],
         })

--- a/src/test/javascript/spec/component/markdown-editor/italic-command.spec.ts
+++ b/src/test/javascript/spec/component/markdown-editor/italic-command.spec.ts
@@ -11,7 +11,7 @@ describe('ItalicCommand', () => {
     let comp: MarkdownEditorComponent;
     let fixture: ComponentFixture<MarkdownEditorComponent>;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [ArtemisTestModule, TranslateModule.forRoot(), AceEditorModule, ArtemisMarkdownEditorModule],
         })

--- a/src/test/javascript/spec/component/markdown-editor/katex-command.spec.ts
+++ b/src/test/javascript/spec/component/markdown-editor/katex-command.spec.ts
@@ -11,7 +11,7 @@ describe('KatexCommand', () => {
     let comp: MarkdownEditorComponent;
     let fixture: ComponentFixture<MarkdownEditorComponent>;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [ArtemisTestModule, TranslateModule.forRoot(), AceEditorModule, ArtemisMarkdownEditorModule],
         })

--- a/src/test/javascript/spec/component/markdown-editor/reference-command.spec.ts
+++ b/src/test/javascript/spec/component/markdown-editor/reference-command.spec.ts
@@ -16,7 +16,7 @@ describe('ReferenceCommand', () => {
         jest.restoreAllMocks();
     });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [ArtemisTestModule, TranslateModule.forRoot(), AceEditorModule, ArtemisMarkdownEditorModule],
         })

--- a/src/test/javascript/spec/component/markdown-editor/underline-command.spec.ts
+++ b/src/test/javascript/spec/component/markdown-editor/underline-command.spec.ts
@@ -16,7 +16,7 @@ describe('Underline Command', () => {
         jest.restoreAllMocks();
     });
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [ArtemisTestModule, TranslateModule.forRoot(), AceEditorModule, ArtemisMarkdownEditorModule],
         })

--- a/src/test/javascript/spec/component/organization/organization-management-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/organization/organization-management-detail.component.spec.ts
@@ -53,7 +53,7 @@ describe('OrganizationManagementDetailComponent', () => {
         userService = TestBed.inject(UserService);
     });
 
-    afterEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks();
     });
 

--- a/src/test/javascript/spec/component/organization/organization-management-update.component.spec.ts
+++ b/src/test/javascript/spec/component/organization/organization-management-update.component.spec.ts
@@ -35,7 +35,7 @@ describe('OrganizationManagementUpdateComponent', () => {
         organizationService = TestBed.inject(OrganizationManagementService);
     });
 
-    afterEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks();
     });
 

--- a/src/test/javascript/spec/component/organization/organization-management.component.spec.ts
+++ b/src/test/javascript/spec/component/organization/organization-management.component.spec.ts
@@ -38,7 +38,7 @@ describe('OrganizationManagementComponent', () => {
         organizationService = TestBed.inject(OrganizationManagementService);
     });
 
-    afterEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks();
     });
 

--- a/src/test/javascript/spec/component/organization/organization-management.service.spec.ts
+++ b/src/test/javascript/spec/component/organization/organization-management.service.spec.ts
@@ -3,7 +3,7 @@ import { Organization } from 'app/entities/organization.model';
 import { MockRouter } from '../../helpers/mocks/mock-router';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { MockTranslateService } from '../../helpers/mocks/service/mock-translate.service';
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -13,7 +13,6 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { OrganizationCountDto } from 'app/admin/organization-management/organization-count-dto.model';
 
 describe('Organization Service', () => {
-    let injector: TestBed;
     let service: OrganizationManagementService;
     let httpMock: HttpTestingController;
     let elemDefault: Organization;
@@ -28,9 +27,8 @@ describe('Organization Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(OrganizationManagementService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(OrganizationManagementService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new Organization();
         elemDefault.id = 0;

--- a/src/test/javascript/spec/component/organization/organization-selector/organization-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/organization/organization-selector/organization-selector.component.spec.ts
@@ -29,7 +29,7 @@ describe('OrganizationSelectorComponent', () => {
             });
     });
 
-    afterEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks();
     });
 

--- a/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
@@ -191,8 +191,8 @@ describe('ParticipationSubmissionComponent', () => {
     }));
 
     it('Template Submission is correctly loaded', fakeAsync(() => {
-        TestBed.get(ActivatedRoute).params = of({ participationId: 2, exerciseId: 42 });
-        TestBed.get(ActivatedRoute).queryParams = of({ isTmpOrSolutionProgrParticipation: 'true' });
+        TestBed.inject(ActivatedRoute).params = of({ participationId: 2, exerciseId: 42 });
+        TestBed.inject(ActivatedRoute).queryParams = of({ isTmpOrSolutionProgrParticipation: 'true' });
         const templateParticipation = new TemplateProgrammingExerciseParticipation();
         templateParticipation.id = 2;
         templateParticipation.submissions = [
@@ -228,8 +228,8 @@ describe('ParticipationSubmissionComponent', () => {
     }));
 
     it('Solution Submission is correctly loaded', fakeAsync(() => {
-        TestBed.get(ActivatedRoute).params = of({ participationId: 3, exerciseId: 42 });
-        TestBed.get(ActivatedRoute).queryParams = of({ isTmpOrSolutionProgrParticipation: 'true' });
+        TestBed.inject(ActivatedRoute).params = of({ participationId: 3, exerciseId: 42 });
+        TestBed.inject(ActivatedRoute).queryParams = of({ isTmpOrSolutionProgrParticipation: 'true' });
         const solutionParticipation = new SolutionProgrammingExerciseParticipation();
         solutionParticipation.id = 3;
         solutionParticipation.submissions = [

--- a/src/test/javascript/spec/component/presentation-score/presentation-score.component.spec.ts
+++ b/src/test/javascript/spec/component/presentation-score/presentation-score.component.spec.ts
@@ -33,7 +33,7 @@ describe('PresentationScoreComponent', () => {
         isAtLeastInstructor: true,
     } as Exercise;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             declarations: [PresentationScoreComponent],
         })

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-build-button.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-build-button.component.spec.ts
@@ -44,7 +44,7 @@ describe('TriggerBuildButtonSpec', () => {
 
     const submission = { id: 1 } as any;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), ArtemisTestModule, ArtemisProgrammingExerciseActionsModule],
             providers: [

--- a/src/test/javascript/spec/component/rating/star-rating.component.spec.ts
+++ b/src/test/javascript/spec/component/rating/star-rating.component.spec.ts
@@ -1,15 +1,15 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { StarRatingComponent } from 'app/exercises/shared/rating/star-rating/star-rating.component';
 
 describe('StarRatingComponent', () => {
     let component: StarRatingComponent;
     let fixture: ComponentFixture<StarRatingComponent>;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [StarRatingComponent],
         }).compileComponents();
-    }));
+    });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(StarRatingComponent);

--- a/src/test/javascript/spec/component/shared/alert-error.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/alert-error.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 
 import { ArtemisTestModule } from '../../test.module';
@@ -13,7 +13,7 @@ describe('Alert Error Component', () => {
     let eventManager: EventManager;
     let alertService: AlertService;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, TranslateModule.forRoot()],
             declarations: [AlertErrorComponent],
@@ -21,7 +21,7 @@ describe('Alert Error Component', () => {
         })
             .overrideTemplate(AlertErrorComponent, '')
             .compileComponents();
-    }));
+    });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(AlertErrorComponent);

--- a/src/test/javascript/spec/component/shared/alert.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/alert.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AlertService } from 'app/core/util/alert.service';
 import { ArtemisTestModule } from '../../test.module';
 import { AlertComponent } from 'app/shared/alert/alert.component';
@@ -8,14 +8,14 @@ describe('Alert Component Tests', () => {
     let fixture: ComponentFixture<AlertComponent>;
     let alertService: AlertService;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [AlertComponent],
         })
             .overrideTemplate(AlertComponent, '')
             .compileComponents();
-    }));
+    });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(AlertComponent);

--- a/src/test/javascript/spec/component/shared/delete-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/delete-dialog.component.spec.ts
@@ -21,7 +21,7 @@ describe('DeleteDialogComponent', () => {
     let debugElement: DebugElement;
     let ngbActiveModal: NgbActiveModal;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), ArtemisTestModule, FormsModule, NgbModule],
             declarations: [DeleteDialogComponent, AlertComponent, MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)],

--- a/src/test/javascript/spec/component/shared/exercise-scores-export-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/exercise-scores-export-button.component.spec.ts
@@ -103,7 +103,7 @@ describe('ExerciseScoresExportButtonComponent', () => {
         resultService = TestBed.inject(ResultService);
     });
 
-    afterEach(async () => {
+    beforeEach(() => {
         jest.restoreAllMocks();
     });
 

--- a/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/answer-post-reactions-bar/answer-post-reactions-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, getTestBed, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MetisService } from 'app/shared/metis/metis.service';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
@@ -26,7 +26,6 @@ import { metisCourse, metisUser1 } from '../../../../../helpers/sample/metis-sam
 
 describe('AnswerPostReactionsBarComponent', () => {
     let component: AnswerPostReactionsBarComponent;
-    let injector: TestBed;
     let fixture: ComponentFixture<AnswerPostReactionsBarComponent>;
     let metisService: MetisService;
     let answerPost: AnswerPost;
@@ -56,8 +55,7 @@ describe('AnswerPostReactionsBarComponent', () => {
             .compileComponents()
             .then(() => {
                 fixture = TestBed.createComponent(AnswerPostReactionsBarComponent);
-                injector = getTestBed();
-                metisService = injector.get(MetisService);
+                metisService = TestBed.inject(MetisService);
                 component = fixture.componentInstance;
                 answerPost = new AnswerPost();
                 answerPost.id = 1;

--- a/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/post-reactions-bar/post-reactions-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-reactions-bar/post-reactions-bar/post-reactions-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, getTestBed, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MetisService } from 'app/shared/metis/metis.service';
 import { DebugElement } from '@angular/core';
 import { Post } from 'app/entities/metis/post.model';
@@ -29,7 +29,6 @@ import { metisCourse, metisUser1 } from '../../../../../helpers/sample/metis-sam
 
 describe('PostReactionsBarComponent', () => {
     let component: PostReactionsBarComponent;
-    let injector: TestBed;
     let fixture: ComponentFixture<PostReactionsBarComponent>;
     let debugElement: DebugElement;
     let metisService: MetisService;
@@ -61,8 +60,7 @@ describe('PostReactionsBarComponent', () => {
             .compileComponents()
             .then(() => {
                 fixture = TestBed.createComponent(PostReactionsBarComponent);
-                injector = getTestBed();
-                metisService = injector.get(MetisService);
+                metisService = TestBed.inject(MetisService);
                 debugElement = fixture.debugElement;
                 component = fixture.componentInstance;
                 metisServiceUpdateDisplayPriorityMock = jest.spyOn(metisService, 'updatePostDisplayPriority');

--- a/src/test/javascript/spec/component/shared/notification/notification-popup.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/notification/notification-popup.component.spec.ts
@@ -64,7 +64,7 @@ describe('Notification Popup Component', () => {
                 notificationService = TestBed.inject(NotificationService);
                 accountService = TestBed.inject(AccountService);
                 examExerciseUpdateService = TestBed.inject(ExamExerciseUpdateService);
-                router = TestBed.get(Router);
+                router = TestBed.inject(Router);
             });
     });
 

--- a/src/test/javascript/spec/component/shared/resizeable-container.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/resizeable-container.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ResizeableContainerComponent } from 'app/shared/resizeable-container/resizeable-container.component';
 import { ArtemisTestModule } from '../../test.module';
 
@@ -6,12 +6,12 @@ describe('ResizeableContainerComponent', () => {
     let component: ResizeableContainerComponent;
     let fixture: ComponentFixture<ResizeableContainerComponent>;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [ResizeableContainerComponent],
         }).compileComponents();
-    }));
+    });
 
     beforeEach(() => {
         fixture = TestBed.createComponent(ResizeableContainerComponent);

--- a/src/test/javascript/spec/component/statistics/statistics-graph.component.spec.ts
+++ b/src/test/javascript/spec/component/statistics/statistics-graph.component.spec.ts
@@ -31,7 +31,7 @@ describe('StatisticsGraphComponent', () => {
                 fixture = TestBed.createComponent(StatisticsGraphComponent);
                 component = fixture.componentInstance;
                 service = TestBed.inject(StatisticsService);
-                httpMock = TestBed.get(HttpTestingController);
+                httpMock = TestBed.inject(HttpTestingController);
             });
     });
 

--- a/src/test/javascript/spec/component/table/table-editable-checkbox.component.spec.ts
+++ b/src/test/javascript/spec/component/table/table-editable-checkbox.component.spec.ts
@@ -13,7 +13,7 @@ describe('TableEditableFieldComponent', () => {
 
     const tableCheckbox = '.table-editable-field__checkbox';
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), ArtemisTestModule, ArtemisTableModule],
         })

--- a/src/test/javascript/spec/component/table/table-editable-field.component.spec.ts
+++ b/src/test/javascript/spec/component/table/table-editable-field.component.spec.ts
@@ -13,7 +13,7 @@ describe('TableEditableFieldComponent', () => {
 
     const tableInputValue = '.table-editable-field__input';
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), ArtemisTestModule, ArtemisTableModule],
             declarations: [TableEditableFieldComponent],

--- a/src/test/javascript/spec/component/team/team-update-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team-update-dialog.component.spec.ts
@@ -29,7 +29,7 @@ describe('TeamUpdateDialogComponent', () => {
     let debugElement: DebugElement;
     let ngbActiveModal: NgbActiveModal;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         return TestBed.configureTestingModule({
             imports: [ArtemisTestModule, FormsModule],
             declarations: [

--- a/src/test/javascript/spec/service/attachment.service.spec.ts
+++ b/src/test/javascript/spec/service/attachment.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HttpResponse } from '@angular/common/http';
 import { take } from 'rxjs/operators';
@@ -13,7 +13,6 @@ import { AttachmentService } from 'app/lecture/attachment.service';
 import { Attachment, AttachmentType } from 'app/entities/attachment.model';
 
 describe('Attachment Service', () => {
-    let injector: TestBed;
     let httpMock: HttpTestingController;
     let service: AttachmentService;
     const resourceUrl = SERVER_API_URL + 'api/attachments';
@@ -29,9 +28,8 @@ describe('Attachment Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(AttachmentService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(AttachmentService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         expectedResult = {} as HttpResponse<Attachment>;
         elemDefault = new Attachment();

--- a/src/test/javascript/spec/service/course-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/course-exercise.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { Course } from 'app/entities/course.model';
@@ -18,7 +18,6 @@ import { MockTranslateService } from '../helpers/mocks/service/mock-translate.se
 import { CourseExerciseService } from 'app/exercises/shared/course-exercises/course-exercise.service';
 
 describe('Course Management Service', () => {
-    let injector: TestBed;
     let service: CourseExerciseService;
     let httpMock: HttpTestingController;
     let exerciseId: number;
@@ -50,9 +49,8 @@ describe('Course Management Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(CourseExerciseService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(CourseExerciseService);
+        httpMock = TestBed.inject(HttpTestingController);
         exerciseId = 123;
 
         course = new Course();

--- a/src/test/javascript/spec/service/course.service.spec.ts
+++ b/src/test/javascript/spec/service/course.service.spec.ts
@@ -1,5 +1,5 @@
 import { TranslateService } from '@ngx-translate/core';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { map, take } from 'rxjs/operators';
@@ -13,7 +13,6 @@ import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.serv
 import { MockRouter } from '../helpers/mocks/mock-router';
 
 describe('Course Service', () => {
-    let injector: TestBed;
     let service: CourseManagementService;
     let httpMock: HttpTestingController;
     let elemDefault: Course;
@@ -28,9 +27,8 @@ describe('Course Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(CourseManagementService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(CourseManagementService);
+        httpMock = TestBed.inject(HttpTestingController);
         currentDate = dayjs();
 
         elemDefault = new Course();

--- a/src/test/javascript/spec/service/exam-participation.service.spec.ts
+++ b/src/test/javascript/spec/service/exam-participation.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import dayjs from 'dayjs/esm';
@@ -19,7 +19,6 @@ import { Result } from 'app/entities/result.model';
 import { getLatestSubmissionResult } from 'app/entities/submission.model';
 
 describe('Exam Participation Service', () => {
-    let injector: TestBed;
     let service: ExamParticipationService;
     let httpMock: HttpTestingController;
     let exam: Exam;
@@ -36,10 +35,9 @@ describe('Exam Participation Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(ExamParticipationService);
-        httpMock = injector.get(HttpTestingController);
-        localStorage = injector.get(LocalStorageService);
+        service = TestBed.inject(ExamParticipationService);
+        httpMock = TestBed.inject(HttpTestingController);
+        localStorage = TestBed.inject(LocalStorageService);
 
         exam = new Exam();
         studentExam = new StudentExam();

--- a/src/test/javascript/spec/service/example-submission-import-paging.service.spec.ts
+++ b/src/test/javascript/spec/service/example-submission-import-paging.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { SortingOrder } from 'app/shared/table/pageable-table';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -11,7 +11,6 @@ import { Exercise } from 'app/entities/exercise.model';
 import { TextSubmission } from 'app/entities/text-submission.model';
 
 describe('Example Submission Import Paging Service', () => {
-    let injector: TestBed;
     let service: ExampleSubmissionImportPagingService;
     let httpMock: HttpTestingController;
 
@@ -24,9 +23,8 @@ describe('Example Submission Import Paging Service', () => {
                 { provide: LocalStorageService, useClass: MockSyncStorage },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(ExampleSubmissionImportPagingService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(ExampleSubmissionImportPagingService);
+        httpMock = TestBed.inject(HttpTestingController);
     });
 
     afterEach(() => {

--- a/src/test/javascript/spec/service/example-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/example-submission.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HttpResponse } from '@angular/common/http';
 import { take } from 'rxjs/operators';
@@ -16,7 +16,6 @@ import { MockExerciseService } from '../helpers/mocks/service/mock-exercise.serv
 import { MockProvider } from 'ng-mocks';
 
 describe('Example Submission Service', () => {
-    let injector: TestBed;
     let httpMock: HttpTestingController;
     let service: ExampleSubmissionService;
     let expectedResult: any;
@@ -28,9 +27,8 @@ describe('Example Submission Service', () => {
             imports: [ArtemisTestModule, HttpClientTestingModule],
             providers: [{ provide: ExerciseService, useClass: MockExerciseService }, MockProvider(StringCountService)],
         });
-        injector = getTestBed();
-        service = injector.get(ExampleSubmissionService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(ExampleSubmissionService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         expectedResult = {} as HttpResponse<ExampleSubmission[]>;
         elemDefault = new ExampleSubmission();

--- a/src/test/javascript/spec/service/exercise-hint.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-hint.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HttpResponse } from '@angular/common/http';
 import { take } from 'rxjs/operators';
@@ -10,7 +10,6 @@ import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { Exercise } from 'app/entities/exercise.model';
 
 describe('ExerciseHint Service', () => {
-    let injector: TestBed;
     let service: ExerciseHintService;
     let httpMock: HttpTestingController;
     let elemDefault: ExerciseHint;
@@ -29,9 +28,8 @@ describe('ExerciseHint Service', () => {
             ],
         });
         expectedResult = {} as HttpResponse<ExerciseHint>;
-        injector = getTestBed();
-        service = injector.get(ExerciseHintService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(ExerciseHintService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         const exercise = new ProgrammingExercise(undefined, undefined);
         exercise.id = 1;

--- a/src/test/javascript/spec/service/exercise-scores-chart.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-scores-chart.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ArtemisTestModule } from '../test.module';
 import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.service';
@@ -9,7 +9,6 @@ import { take } from 'rxjs/operators';
 import { ExerciseScoresChartService, ExerciseScoresDTO } from 'app/overview/visualizations/exercise-scores-chart.service';
 
 describe('Exercise Scores Chart Service', () => {
-    let injector: TestBed;
     let service: ExerciseScoresChartService;
     let httpMock: HttpTestingController;
     let elemDefault: ExerciseScoresDTO;
@@ -22,9 +21,8 @@ describe('Exercise Scores Chart Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(ExerciseScoresChartService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(ExerciseScoresChartService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new ExerciseScoresDTO();
     });

--- a/src/test/javascript/spec/service/exercise-update-warning.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-update-warning.service.spec.ts
@@ -1,5 +1,5 @@
 import { ExerciseUpdateWarningService } from 'app/exercises/shared/exercise-update-warning/exercise-update-warning.service';
-import { getTestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { GradingInstruction } from 'app/exercises/shared/structured-grading-criterion/grading-instruction.model';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
 import { Exercise } from 'app/entities/exercise.model';
@@ -18,8 +18,7 @@ describe('Exercise Update Warning Service', () => {
     const backupExercise = { id: 1 } as Exercise;
 
     beforeEach(() => {
-        const injector = getTestBed();
-        updateWarningService = injector.get(ExerciseUpdateWarningService);
+        updateWarningService = TestBed.inject(ExerciseUpdateWarningService);
 
         updateWarningService.instructionDeleted = false;
         updateWarningService.creditChanged = false;

--- a/src/test/javascript/spec/service/file-upload-assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/file-upload-assessment.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import dayjs from 'dayjs/esm';
@@ -10,7 +10,6 @@ import { ComplaintResponse } from 'app/entities/complaint-response.model';
 import { HttpResponse } from '@angular/common/http';
 
 describe('Modeling Assessment Service', () => {
-    let injector: TestBed;
     let httpMock: HttpTestingController;
     let service: FileUploadAssessmentService;
     let expectedResult: any;
@@ -21,9 +20,8 @@ describe('Modeling Assessment Service', () => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, HttpClientTestingModule],
         });
-        injector = getTestBed();
-        service = injector.get(FileUploadAssessmentService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(FileUploadAssessmentService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         expectedResult = {} as Result;
         httpExpectedResult = {} as HttpResponse<Result>;

--- a/src/test/javascript/spec/service/file-upload-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/file-upload-exercise.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { map, take } from 'rxjs/operators';
 
@@ -14,7 +14,6 @@ import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service'
 import { MockExerciseService } from '../helpers/mocks/service/mock-exercise.service';
 
 describe('FileUploadExercise Service', () => {
-    let injector: TestBed;
     let service: FileUploadExerciseService;
     let httpMock: HttpTestingController;
     let elemDefault: FileUploadExercise;
@@ -34,9 +33,8 @@ describe('FileUploadExercise Service', () => {
                 { provide: ExerciseService, useClass: MockExerciseService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(FileUploadExerciseService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(FileUploadExerciseService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new FileUploadExercise(undefined, undefined);
     });

--- a/src/test/javascript/spec/service/file-upload-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/file-upload-submission.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { map, take } from 'rxjs/operators';
 import { FileUploadSubmissionService } from 'app/exercises/file-upload/participate/file-upload-submission.service';
@@ -7,7 +7,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 
 describe('FileUploadSubmission Service', () => {
-    let injector: TestBed;
     let service: FileUploadSubmissionService;
     let httpMock: HttpTestingController;
     let elemDefault: FileUploadSubmission;
@@ -17,9 +16,8 @@ describe('FileUploadSubmission Service', () => {
             imports: [HttpClientTestingModule],
             providers: [{ provide: AccountService, useClass: MockAccountService }],
         });
-        injector = getTestBed();
-        service = injector.get(FileUploadSubmissionService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(FileUploadSubmissionService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new FileUploadSubmission();
     });

--- a/src/test/javascript/spec/service/grading-system.service.spec.ts
+++ b/src/test/javascript/spec/service/grading-system.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
 import { GradeType, GradingScale } from 'app/entities/grading-scale.model';
@@ -9,7 +9,6 @@ import { of } from 'rxjs';
 import { HttpResponse } from '@angular/common/http';
 
 describe('Grading System Service', () => {
-    let injector: TestBed;
     let service: GradingSystemService;
     let httpMock: HttpTestingController;
     let elemDefault: GradingScale;
@@ -44,9 +43,8 @@ describe('Grading System Service', () => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule, RouterTestingModule],
         });
-        injector = getTestBed();
-        service = injector.get(GradingSystemService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(GradingSystemService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new GradingScale();
     });

--- a/src/test/javascript/spec/service/guided-tour.service.spec.ts
+++ b/src/test/javascript/spec/service/guided-tour.service.spec.ts
@@ -206,7 +206,7 @@ describe('GuidedTourService', () => {
             jest.spyOn<any, any>(guidedTourComponent, 'subscribeToDotChanges').mockImplementation(() => {});
         }
 
-        async function startCourseOverviewTour(guidedTour: GuidedTour) {
+        function startCourseOverviewTour(guidedTour: GuidedTour) {
             guidedTourComponent.ngAfterViewInit();
 
             guidedTourComponentFixture.ngZone!.run(() => {
@@ -225,9 +225,9 @@ describe('GuidedTourService', () => {
         }
 
         describe('Tours without user interaction', () => {
-            beforeEach(async () => {
+            beforeEach(() => {
                 prepareGuidedTour(tour);
-                await startCourseOverviewTour(tour);
+                startCourseOverviewTour(tour);
             });
 
             it('should start and finish the course overview guided tour', async () => {
@@ -265,9 +265,9 @@ describe('GuidedTourService', () => {
         });
 
         describe('Tours with user interaction', () => {
-            beforeEach(async () => {
+            beforeEach(() => {
                 prepareGuidedTour(tourWithUserInteraction);
-                await startCourseOverviewTour(tourWithUserInteraction);
+                startCourseOverviewTour(tourWithUserInteraction);
             });
 
             it('should disable the next button', () => {

--- a/src/test/javascript/spec/service/lecture.service.spec.ts
+++ b/src/test/javascript/spec/service/lecture.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HttpResponse } from '@angular/common/http';
 import { take } from 'rxjs/operators';
@@ -13,7 +13,6 @@ import { Course } from 'app/entities/course.model';
 import dayjs from 'dayjs/esm';
 
 describe('Lecture Service', () => {
-    let injector: TestBed;
     let httpMock: HttpTestingController;
     let service: LectureService;
     const resourceUrl = SERVER_API_URL + 'api/lectures';
@@ -29,9 +28,8 @@ describe('Lecture Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(LectureService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(LectureService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         expectedResult = {} as HttpResponse<Lecture>;
         elemDefault = new Lecture();

--- a/src/test/javascript/spec/service/metis/answer-post.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/answer-post.service.spec.ts
@@ -1,11 +1,10 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { AnswerPostService } from 'app/shared/metis/answer-post.service';
 import { metisAnswerPostToCreateUser1, metisResolvingAnswerPostUser1 } from '../../helpers/sample/metis-sample-data';
 
 describe('AnswerPost Service', () => {
-    let injector: TestBed;
     let service: AnswerPostService;
     let httpMock: HttpTestingController;
 
@@ -13,9 +12,8 @@ describe('AnswerPost Service', () => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
         });
-        injector = getTestBed();
-        service = injector.get(AnswerPostService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(AnswerPostService);
+        httpMock = TestBed.inject(HttpTestingController);
     });
 
     describe('Service methods', () => {

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Post } from 'app/entities/metis/post.model';
 import { Course } from 'app/entities/course.model';
@@ -39,7 +39,6 @@ import {
 } from '../../helpers/sample/metis-sample-data';
 
 describe('Metis Service', () => {
-    let injector: TestBed;
     let metisService: MetisService;
     let metisServiceUserStub: jest.SpyInstance;
     let metisServiceGetFilteredPostsSpy: jest.SpyInstance;
@@ -47,8 +46,8 @@ describe('Metis Service', () => {
     let websocketServiceSubscribeSpy: jest.SpyInstance;
     let websocketServiceReceiveStub: jest.SpyInstance;
     let websocketService: JhiWebsocketService;
-    let reactionService: MockReactionService;
-    let postService: MockPostService;
+    let reactionService: ReactionService;
+    let postService: PostService;
     let answerPostService: AnswerPostService;
     let post: Post;
     let answerPost: AnswerPost;
@@ -70,12 +69,11 @@ describe('Metis Service', () => {
                 { provide: LocalStorageService, useClass: MockLocalStorageService },
             ],
         });
-        injector = getTestBed();
-        metisService = injector.get(MetisService);
-        websocketService = injector.get(JhiWebsocketService);
-        reactionService = injector.get(ReactionService);
-        postService = injector.get(PostService);
-        answerPostService = injector.get(AnswerPostService);
+        metisService = TestBed.inject(MetisService);
+        websocketService = TestBed.inject(JhiWebsocketService);
+        reactionService = TestBed.inject(ReactionService);
+        postService = TestBed.inject(PostService);
+        answerPostService = TestBed.inject(AnswerPostService);
         metisServiceGetFilteredPostsSpy = jest.spyOn(metisService, 'getFilteredPosts');
         metisServiceCreateWebsocketSubscriptionSpy = jest.spyOn(metisService, 'createWebsocketSubscription');
         metisServiceUserStub = jest.spyOn(metisService, 'getUser');

--- a/src/test/javascript/spec/service/metis/post.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/post.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { Post } from 'app/entities/metis/post.model';
@@ -18,7 +18,6 @@ import {
 } from '../../helpers/sample/metis-sample-data';
 
 describe('Post Service', () => {
-    let injector: TestBed;
     let service: PostService;
     let httpMock: HttpTestingController;
 
@@ -26,9 +25,8 @@ describe('Post Service', () => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
         });
-        injector = getTestBed();
-        service = injector.get(PostService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(PostService);
+        httpMock = TestBed.inject(HttpTestingController);
     });
 
     describe('Service methods', () => {

--- a/src/test/javascript/spec/service/metis/reaction.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/reaction.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { Reaction } from 'app/entities/metis/reaction.model';
@@ -6,7 +6,6 @@ import { ReactionService } from 'app/shared/metis/reaction.service';
 import { metisReactionToCreate, metisReactionUser2 } from '../../helpers/sample/metis-sample-data';
 
 describe('Reaction Service', () => {
-    let injector: TestBed;
     let service: ReactionService;
     let httpMock: HttpTestingController;
 
@@ -14,9 +13,8 @@ describe('Reaction Service', () => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
         });
-        injector = getTestBed();
-        service = injector.get(ReactionService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(ReactionService);
+        httpMock = TestBed.inject(HttpTestingController);
     });
 
     describe('Service methods', () => {

--- a/src/test/javascript/spec/service/modeling-assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/modeling-assessment.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HttpResponse } from '@angular/common/http';
 import { take } from 'rxjs/operators';
@@ -15,7 +15,6 @@ import { UMLElementType, UMLModel, UMLRelationshipType } from '@ls1intum/apollon
 import { getNamesForAssessments } from 'app/exercises/modeling/assess/modeling-assessment.util';
 
 describe('Modeling Assessment Service', () => {
-    let injector: TestBed;
     let httpMock: HttpTestingController;
     let service: ModelingAssessmentService;
     let expectedResult: any;
@@ -31,9 +30,8 @@ describe('Modeling Assessment Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(ModelingAssessmentService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(ModelingAssessmentService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         expectedResult = {} as Result;
         httpExpectedResult = {} as HttpResponse<Result>;

--- a/src/test/javascript/spec/service/modeling-exercise-paging.service.spec.ts
+++ b/src/test/javascript/spec/service/modeling-exercise-paging.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { ModelingExercise, UMLDiagramType } from 'app/entities/modeling-exercise.model';
 import { ModelingExercisePagingService } from 'app/exercises/modeling/manage/modeling-exercise-paging.service';
@@ -10,7 +10,6 @@ import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.serv
 import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
 
 describe('ModelingExercise Service', () => {
-    let injector: TestBed;
     let service: ModelingExercisePagingService;
     let httpMock: HttpTestingController;
 
@@ -23,10 +22,9 @@ describe('ModelingExercise Service', () => {
                 { provide: LocalStorageService, useClass: MockSyncStorage },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(ModelingExercisePagingService);
+        service = TestBed.inject(ModelingExercisePagingService);
         service.resourceUrl = 'resourceUrl';
-        httpMock = injector.get(HttpTestingController);
+        httpMock = TestBed.inject(HttpTestingController);
     });
 
     it('should find an element', fakeAsync(() => {

--- a/src/test/javascript/spec/service/modeling-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/modeling-exercise.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { ModelingExerciseService } from 'app/exercises/modeling/manage/modeling-exercise.service';
@@ -16,7 +16,6 @@ import { Router } from '@angular/router';
 import { MockRouter } from '../helpers/mocks/mock-router';
 
 describe('ModelingExercise Service', () => {
-    let injector: TestBed;
     let service: ModelingExerciseService;
     let httpMock: HttpTestingController;
     let elemDefault: ModelingExercise;
@@ -33,10 +32,9 @@ describe('ModelingExercise Service', () => {
                 { provide: Router, useClass: MockRouter },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(ModelingExerciseService);
+        service = TestBed.inject(ModelingExerciseService);
         service.resourceUrl = 'resourceUrl';
-        httpMock = injector.get(HttpTestingController);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new ModelingExercise(UMLDiagramType.ComponentDiagram, undefined, undefined);
         elemDefault.dueDate = dayjs();

--- a/src/test/javascript/spec/service/modeling-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/modeling-submission.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { getTestBed, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ModelingSubmission } from 'app/entities/modeling-submission.model';
 import { ModelingSubmissionService } from 'app/exercises/modeling/participate/modeling-submission.service';
 import { take } from 'rxjs/operators';
@@ -7,7 +7,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 
 describe('ModelingSubmission Service', () => {
-    let injector: TestBed;
     let service: ModelingSubmissionService;
     let httpMock: HttpTestingController;
     let elemDefault: ModelingSubmission;
@@ -17,9 +16,8 @@ describe('ModelingSubmission Service', () => {
             imports: [HttpClientTestingModule],
             providers: [{ provide: AccountService, useClass: MockAccountService }],
         });
-        injector = getTestBed();
-        service = injector.get(ModelingSubmissionService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(ModelingSubmissionService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new ModelingSubmission();
     });

--- a/src/test/javascript/spec/service/notification.service.spec.ts
+++ b/src/test/javascript/spec/service/notification.service.spec.ts
@@ -83,7 +83,7 @@ describe('Notification Service', () => {
             .then(() => {
                 notificationService = TestBed.inject(NotificationService);
                 httpMock = TestBed.inject(HttpTestingController);
-                router = TestBed.get(Router);
+                router = TestBed.inject(Router);
 
                 websocketService = TestBed.inject(JhiWebsocketService);
                 wsSubscribeStub = jest.spyOn(websocketService, 'subscribe');

--- a/src/test/javascript/spec/service/participation.service.spec.ts
+++ b/src/test/javascript/spec/service/participation.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { map, take } from 'rxjs/operators';
@@ -17,7 +17,6 @@ import { TextExercise } from 'app/entities/text-exercise.model';
 import { Course } from 'app/entities/course.model';
 
 describe('Participation Service', () => {
-    let injector: TestBed;
     let service: ParticipationService;
     let httpMock: HttpTestingController;
     let participationDefault: Participation;
@@ -32,9 +31,8 @@ describe('Participation Service', () => {
                 { provide: SessionStorageService, useClass: MockSyncStorage },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(ParticipationService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(ParticipationService);
+        httpMock = TestBed.inject(HttpTestingController);
         currentDate = dayjs();
 
         participationDefault = new StudentParticipation();

--- a/src/test/javascript/spec/service/plagiarism-cases.service.spec.ts
+++ b/src/test/javascript/spec/service/plagiarism-cases.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { PlagiarismCasesService } from 'app/course/plagiarism-cases/plagiarism-cases.service';
 import { take } from 'rxjs/operators';
 import { ExerciseType } from 'app/entities/exercise.model';
@@ -11,7 +11,6 @@ import { ModelingSubmissionElement } from 'app/exercises/shared/plagiarism/types
 import { PlagiarismCase } from 'app/exercises/shared/plagiarism/types/PlagiarismCase';
 
 describe('Plagiarism Cases Service', () => {
-    let injector: TestBed;
     let service: PlagiarismCasesService;
     let httpMock: HttpTestingController;
 
@@ -44,9 +43,8 @@ describe('Plagiarism Cases Service', () => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
         });
-        injector = getTestBed();
-        service = injector.get(PlagiarismCasesService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(PlagiarismCasesService);
+        httpMock = TestBed.inject(HttpTestingController);
     });
 
     afterEach(() => {

--- a/src/test/javascript/spec/service/programming-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { ProgrammingExerciseService } from 'app/exercises/programming/manage/services/programming-exercise.service';
@@ -16,7 +16,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 
 describe('ProgrammingExercise Service', () => {
-    let injector: TestBed;
     let service: ProgrammingExerciseService;
     let httpMock: HttpTestingController;
     let defaultProgrammingExercise: ProgrammingExercise;
@@ -34,9 +33,8 @@ describe('ProgrammingExercise Service', () => {
         })
             .compileComponents()
             .then(() => {
-                injector = getTestBed();
-                service = injector.get(ProgrammingExerciseService);
-                httpMock = injector.get(HttpTestingController);
+                service = TestBed.inject(ProgrammingExerciseService);
+                httpMock = TestBed.inject(HttpTestingController);
 
                 defaultProgrammingExercise = new ProgrammingExercise(undefined, undefined);
             });

--- a/src/test/javascript/spec/service/quiz-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/quiz-exercise.service.spec.ts
@@ -1,5 +1,5 @@
 import { TranslateService } from '@ngx-translate/core';
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { map, take } from 'rxjs/operators';
 import { SessionStorageService } from 'ngx-webstorage';
@@ -11,7 +11,6 @@ import { MockSyncStorage } from '../helpers/mocks/service/mock-sync-storage.serv
 import { ArtemisTestModule } from '../test.module';
 
 describe('QuizExercise Service', () => {
-    let injector: TestBed;
     let service: QuizExerciseService;
     let httpMock: HttpTestingController;
     let elemDefault: QuizExercise;
@@ -23,9 +22,8 @@ describe('QuizExercise Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(QuizExerciseService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(QuizExerciseService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new QuizExercise(new Course(), undefined);
     });

--- a/src/test/javascript/spec/service/quiz.service.spec.ts
+++ b/src/test/javascript/spec/service/quiz.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { ArtemisQuizService } from 'app/shared/quiz/quiz.service';
 import { QuizQuestionType, ScoringType } from 'app/entities/quiz/quiz-question.model';
 import { ExerciseMode, ExerciseType, IncludedInOverallScore } from 'app/entities/exercise.model';
@@ -6,7 +6,6 @@ import { ShortAnswerQuestion } from 'app/entities/quiz/short-answer-question.mod
 import { MultipleChoiceQuestion } from 'app/entities/quiz/multiple-choice-question.model';
 
 describe('Quiz Service', () => {
-    let injector: TestBed;
     let service: ArtemisQuizService;
     const quiz = {
         mode: ExerciseMode.INDIVIDUAL,
@@ -175,8 +174,7 @@ describe('Quiz Service', () => {
         },
     ];
     beforeEach(() => {
-        injector = getTestBed();
-        service = injector.get(ArtemisQuizService);
+        service = TestBed.inject(ArtemisQuizService);
         jest.spyOn(global.Math, 'random').mockReturnValue(0.2);
     });
 

--- a/src/test/javascript/spec/service/rating.service.spec.ts
+++ b/src/test/javascript/spec/service/rating.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { TestBed, tick, fakeAsync } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
@@ -7,7 +7,6 @@ import { Rating } from 'app/entities/rating.model';
 import { Result } from 'app/entities/result.model';
 
 describe('Rating Service', () => {
-    let injector: TestBed;
     let service: RatingService;
     let httpMock: HttpTestingController;
     let elemDefault: Rating;
@@ -15,9 +14,8 @@ describe('Rating Service', () => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, HttpClientTestingModule],
         });
-        injector = getTestBed();
-        service = injector.get(RatingService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(RatingService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new Rating(new Result(), 3);
     });

--- a/src/test/javascript/spec/service/result.service.spec.ts
+++ b/src/test/javascript/spec/service/result.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { HttpClient } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
@@ -36,8 +36,8 @@ describe('ResultService', () => {
             ],
         });
 
-        resultService = getTestBed().get(ResultService);
-        http = getTestBed().get(HttpClient);
+        resultService = TestBed.inject(ResultService);
+        http = TestBed.inject(HttpClient);
     });
 
     const rawExerciseReleaseDate = '2020-03-30T12:00:00Z';

--- a/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
+++ b/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, getTestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { ShortAnswerQuestionUtil } from 'app/exercises/quiz/shared/short-answer-question-util.service';
 import { ArtemisTestModule } from '../test.module';
@@ -9,7 +9,6 @@ import { ShortAnswerSolution } from 'app/entities/quiz/short-answer-solution.mod
 import { cloneDeep } from 'lodash-es';
 
 describe('ShortAnswerQuestionUtil', () => {
-    let injector: TestBed;
     let service: ShortAnswerQuestionUtil;
 
     const spot = new ShortAnswerSpot();
@@ -49,8 +48,7 @@ describe('ShortAnswerQuestionUtil', () => {
             imports: [TranslateModule.forRoot(), ArtemisTestModule],
         });
 
-        injector = getTestBed();
-        service = injector.get(ShortAnswerQuestionUtil);
+        service = TestBed.inject(ShortAnswerQuestionUtil);
     });
     it('should return correct getter', () => {
         const solutions = service.getAllSolutionsForSpot(shortAnswerQuestion.correctMappings, spot);

--- a/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
+++ b/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
@@ -43,7 +43,7 @@ describe('ShortAnswerQuestionUtil', () => {
         }
     };
 
-    beforeEach(async () => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), ArtemisTestModule],
         });

--- a/src/test/javascript/spec/service/sort.service.spec.ts
+++ b/src/test/javascript/spec/service/sort.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import dayjs from 'dayjs/esm';
 import { SortService } from 'app/shared/service/sort.service';
 
@@ -11,14 +11,12 @@ type TestObject = {
 };
 
 describe('Sort Service', () => {
-    let injector: TestBed;
     let service: SortService;
     let e1: TestObject, e2: TestObject, e3: TestObject, e4: TestObject, e5: TestObject, e6: TestObject;
 
     beforeEach(() => {
         TestBed.configureTestingModule({});
-        injector = getTestBed();
-        service = injector.get(SortService);
+        service = TestBed.inject(SortService);
 
         e1 = {
             a: 10,

--- a/src/test/javascript/spec/service/structured-grading-criterion.service.spec.ts
+++ b/src/test/javascript/spec/service/structured-grading-criterion.service.spec.ts
@@ -1,11 +1,10 @@
-import { getTestBed, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { TestBed, tick, fakeAsync } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { StructuredGradingCriterionService } from 'app/exercises/shared/structured-grading-criterion/structured-grading-criterion.service';
 import { Feedback } from 'app/entities/feedback.model';
 import { GradingInstruction } from 'app/exercises/shared/structured-grading-criterion/grading-instruction.model';
 
 describe('Structured Grading Criteria Service', () => {
-    let injector: TestBed;
     let service: StructuredGradingCriterionService;
     let httpMock: HttpTestingController;
     let feedbacks: Feedback[];
@@ -14,9 +13,8 @@ describe('Structured Grading Criteria Service', () => {
         TestBed.configureTestingModule({
             imports: [HttpClientTestingModule],
         });
-        injector = getTestBed();
-        service = injector.get(StructuredGradingCriterionService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(StructuredGradingCriterionService);
+        httpMock = TestBed.inject(HttpTestingController);
     });
 
     describe('Service methods', () => {

--- a/src/test/javascript/spec/service/submission-policy.service.spec.ts
+++ b/src/test/javascript/spec/service/submission-policy.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { SubmissionPolicyService } from 'app/exercises/programming/manage/services/submission-policy.service';
 import { LockRepositoryPolicy, SubmissionPolicyType } from 'app/entities/submission-policy.model';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
@@ -6,7 +6,6 @@ import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { take } from 'rxjs/operators';
 
 describe('Submission Policy Service', () => {
-    let injector: TestBed;
     let httpMock: HttpTestingController;
     let submissionPolicyService: SubmissionPolicyService;
     let lockRepositoryPolicy: LockRepositoryPolicy;
@@ -19,9 +18,8 @@ describe('Submission Policy Service', () => {
             imports: [HttpClientTestingModule],
             providers: [{ provide: SubmissionPolicyService, useClass: SubmissionPolicyService }],
         });
-        injector = getTestBed();
-        httpMock = injector.get(HttpTestingController);
-        submissionPolicyService = injector.get(SubmissionPolicyService);
+        httpMock = TestBed.inject(HttpTestingController);
+        submissionPolicyService = TestBed.inject(SubmissionPolicyService);
         lockRepositoryPolicy = { type: SubmissionPolicyType.LOCK_REPOSITORY, submissionLimit: 5 } as LockRepositoryPolicy;
         programmingExercise = new ProgrammingExercise(undefined, undefined);
         programmingExercise.id = 1;

--- a/src/test/javascript/spec/service/submission.service.spec.ts
+++ b/src/test/javascript/spec/service/submission.service.spec.ts
@@ -1,5 +1,5 @@
 import { SubmissionService } from 'app/exercises/shared/submission/submission.service';
-import { getTestBed, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { TestBed, tick, fakeAsync } from '@angular/core/testing';
 import { take } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
@@ -13,7 +13,6 @@ import { Feedback } from 'app/entities/feedback.model';
 import { HttpResponse } from '@angular/common/http';
 import { getLatestSubmissionResult, Submission } from 'app/entities/submission.model';
 describe('Submission Service', () => {
-    let injector: TestBed;
     let service: SubmissionService;
     let httpMock: HttpTestingController;
     let expectedResult: any;
@@ -43,9 +42,8 @@ describe('Submission Service', () => {
                 { provide: TranslateService, useClass: MockTranslateService },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(SubmissionService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(SubmissionService);
+        httpMock = TestBed.inject(HttpTestingController);
         expectedResult = {} as HttpResponse<Submission[]>;
     });
 

--- a/src/test/javascript/spec/service/text-assessment-analytics.service.spec.ts
+++ b/src/test/javascript/spec/service/text-assessment-analytics.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed, fakeAsync } from '@angular/core/testing';
+import { TestBed, fakeAsync } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TextAssessmentEventType } from 'app/entities/text-assesment-event.model';
 import { TextAssessmentAnalytics } from 'app/exercises/text/assess/analytics/text-assesment-analytics.service';
@@ -13,7 +13,6 @@ import { Router } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 
 describe('TextAssessmentAnalytics Service', () => {
-    let injector: TestBed;
     let service: TextAssessmentAnalytics;
     let httpMock: HttpTestingController;
 
@@ -27,9 +26,8 @@ describe('TextAssessmentAnalytics Service', () => {
                 { provide: LocalStorageService, useClass: MockSyncStorage },
             ],
         });
-        injector = getTestBed();
-        service = injector.get(TextAssessmentAnalytics);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(TextAssessmentAnalytics);
+        httpMock = TestBed.inject(HttpTestingController);
         httpMock.expectOne({ url: `${SERVER_API_URL}management/info`, method: 'GET' });
     });
 

--- a/src/test/javascript/spec/service/text-assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/text-assessment.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { TestBed, tick, fakeAsync } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { TextSubmission } from 'app/entities/text-submission.model';
@@ -12,7 +12,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 
 describe('TextAssessment Service', () => {
-    let injector: TestBed;
     let service: TextAssessmentService;
     let httpMock: HttpTestingController;
     let textSubmission: TextSubmission;
@@ -23,9 +22,8 @@ describe('TextAssessment Service', () => {
             imports: [HttpClientTestingModule],
             providers: [{ provide: AccountService, useClass: MockAccountService }],
         });
-        injector = getTestBed();
-        service = injector.get(TextAssessmentService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(TextAssessmentService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         textSubmission = new TextSubmission();
 

--- a/src/test/javascript/spec/service/text-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/text-exercise.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { TextExerciseService } from 'app/exercises/text/manage/text-exercise/text-exercise.service';
@@ -19,7 +19,6 @@ import { TutorEffort } from 'app/entities/tutor-effort.model';
 import { TextPlagiarismResult } from 'app/exercises/shared/plagiarism/types/text/TextPlagiarismResult';
 
 describe('TextExercise Service', () => {
-    let injector: TestBed;
     let service: TextExerciseService;
     let httpMock: HttpTestingController;
     let elemDefault: TextExercise;
@@ -37,9 +36,8 @@ describe('TextExercise Service', () => {
             ],
         });
         requestResult = {} as HttpResponse<TextExercise>;
-        injector = getTestBed();
-        service = injector.get(TextExerciseService);
-        httpMock = injector.get(HttpTestingController);
+        service = TestBed.inject(TextExerciseService);
+        httpMock = TestBed.inject(HttpTestingController);
 
         elemDefault = new TextExercise(new Course(), undefined);
         elemDefault.assessmentDueDate = dayjs();

--- a/src/test/javascript/spec/service/text-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/text-submission.service.spec.ts
@@ -1,4 +1,4 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take } from 'rxjs/operators';
 import { TextSubmissionService } from 'app/exercises/text/participate/text-submission.service';
@@ -7,7 +7,6 @@ import { AccountService } from 'app/core/auth/account.service';
 import { MockAccountService } from '../helpers/mocks/service/mock-account.service';
 
 describe('TextSubmission Service', () => {
-    let injector: TestBed;
     let service: TextSubmissionService;
     let httpMock: HttpTestingController;
     let elemDefault: TextSubmission;
@@ -44,9 +43,8 @@ describe('TextSubmission Service', () => {
         })
             .compileComponents()
             .then(() => {
-                injector = getTestBed();
-                service = injector.get(TextSubmissionService);
-                httpMock = injector.get(HttpTestingController);
+                service = TestBed.inject(TextSubmissionService);
+                httpMock = TestBed.inject(HttpTestingController);
 
                 elemDefault = new TextSubmission();
             });

--- a/src/test/javascript/spec/service/tutor-participation.service.spec.ts
+++ b/src/test/javascript/spec/service/tutor-participation.service.spec.ts
@@ -1,4 +1,4 @@
-import { getTestBed, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { TestBed, tick, fakeAsync } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { take, isEmpty } from 'rxjs/operators';
 import { ArtemisTestModule } from '../test.module';
@@ -11,7 +11,6 @@ import { MockAccountService } from '../helpers/mocks/service/mock-account.servic
 import { AccountService } from 'app/core/auth/account.service';
 
 describe('Rating Service', () => {
-    let injector: TestBed;
     let service: TutorParticipationService;
     let httpMock: HttpTestingController;
     let accountServiceMock: AccountService;
@@ -23,10 +22,9 @@ describe('Rating Service', () => {
             imports: [ArtemisTestModule, HttpClientTestingModule],
             providers: [{ provide: AccountService, useClass: MockAccountService }],
         });
-        injector = getTestBed();
-        service = injector.get(TutorParticipationService);
-        httpMock = injector.get(HttpTestingController);
-        accountServiceMock = injector.get(AccountService);
+        service = TestBed.inject(TutorParticipationService);
+        httpMock = TestBed.inject(HttpTestingController);
+        accountServiceMock = TestBed.inject(AccountService);
     });
 
     it('should create a TutorParticipation for an exercise', fakeAsync(() => {

--- a/src/test/javascript/spec/service/user-route-access.service.spec.ts
+++ b/src/test/javascript/spec/service/user-route-access.service.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 import { ActivatedRouteSnapshot, Route } from '@angular/router';
 import { ArtemisTestModule } from '../test.module';
@@ -22,7 +22,7 @@ describe('UserRouteAccessService', () => {
     let fixture: ComponentFixture<CourseExerciseDetailsComponent>;
     let service: UserRouteAccessService;
 
-    beforeEach(async(() => {
+    beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
                 ArtemisTestModule,
@@ -50,7 +50,7 @@ describe('UserRouteAccessService', () => {
                 service = TestBed.inject(UserRouteAccessService);
                 fixture = TestBed.createComponent(CourseExerciseDetailsComponent);
             });
-    }));
+    });
 
     it('should store the JWT token for LTI users', () => {
         const snapshot = fixture.debugElement.injector.get(ActivatedRouteSnapshot) as Mutable<ActivatedRouteSnapshot>;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
`TestBed.get` [is deprecated](https://angular.io/api/core/testing/TestBed#get). The recommended direct replacement for it is `TestBed.inject`.

### Description
Replaces all usages of the deprecated method with the recommended replacement. Also removes deprecated `async` from `beforeEach` methods.

### Steps for Testing
Only test code changed ⇒ Code-review is enough.

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
unchanged
