### PR TITLE
`General`: Fix an issue with the autocomplete of exercise categories

### DIFF
--- a/src/main/webapp/app/shared/category-selector/category-selector.component.ts
+++ b/src/main/webapp/app/shared/category-selector/category-selector.component.ts
@@ -139,7 +139,7 @@ export class CategorySelectorComponent implements OnInit, OnChanges {
 
     // only invoked for autocomplete
     onItemSelect(event: MatAutocompleteSelectedEvent): void {
-        const categoryString = (event.option.viewValue || '').trim();
+        const categoryString = (event.option.value || '').trim();
         // check if there is an existing category and reuse the same color
         let category = this.findExistingCategory(categoryString);
         if (!category) {
@@ -147,6 +147,7 @@ export class CategorySelectorComponent implements OnInit, OnChanges {
         }
 
         this.categories.push(category);
+        this.selectedCategories.emit(this.categories);
         this.categoryInput.nativeElement.value = '';
         this.categoryCtrl.setValue(null);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The exercise categories were not saved / updated if they were chose from the Autocomplete list.

### Description
<!-- Describe your changes in detail -->
Also emit the new categories if one is added using the autocomplete list

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Exercise (one of each type ideally)

1. Log in to Artemis
2. Navigate to the exam detail page
3. Play around with the exercise categories (adding/ deleting them, especially using the autocomplete)
4. Verify that the categories are saved correctly

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
