### PR TITLE
`Development`: Increase client code coverage for programming exercise actions components

### DIFF
--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-trigger-build-button.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-trigger-build-button.component.spec.ts
@@ -1,0 +1,78 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ArtemisTestModule } from '../../test.module';
+import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
+import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
+import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
+import { Course } from 'app/entities/course.model';
+import { MockDirective, MockPipe } from 'ng-mocks';
+import { NgModel } from '@angular/forms';
+import { ButtonComponent } from 'app/shared/components/button.component';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { ProgrammingExerciseInstructorTriggerBuildButtonComponent } from 'app/exercises/programming/shared/actions/programming-exercise-instructor-trigger-build-button.component';
+import { MockNgbModalService } from '../../helpers/mocks/service/mock-ngb-modal.service';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { ConfirmAutofocusModalComponent } from 'app/shared/components/confirm-autofocus-button.component';
+import { of } from 'rxjs';
+import { ParticipationType } from 'app/entities/participation/participation.model';
+import { StudentParticipation } from 'app/entities/participation/student-participation.model';
+import { ProgrammingSubmissionService } from 'app/exercises/programming/participate/programming-submission.service';
+import { SubmissionType } from 'app/entities/submission.model';
+
+describe('ProgrammingExercise Instructor Trigger Build Component', () => {
+    const course = { id: 123 } as Course;
+    const programmingExercise = new ProgrammingExercise(course, undefined);
+    programmingExercise.id = 456;
+    programmingExercise.title = 'Exercise 1';
+    const participation = new StudentParticipation(ParticipationType.PROGRAMMING);
+    participation.id = 567;
+
+    let comp: ProgrammingExerciseInstructorTriggerBuildButtonComponent;
+    let fixture: ComponentFixture<ProgrammingExerciseInstructorTriggerBuildButtonComponent>;
+    let submissionService: ProgrammingSubmissionService;
+    let modalService: NgbModal;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [ProgrammingExerciseInstructorTriggerBuildButtonComponent, ButtonComponent, MockPipe(ArtemisTranslatePipe), MockDirective(NgModel)],
+            providers: [
+                { provide: NgbModal, useClass: MockNgbModalService },
+                { provide: LocalStorageService, useClass: MockSyncStorage },
+                { provide: SessionStorageService, useClass: MockSyncStorage },
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ProgrammingExerciseInstructorTriggerBuildButtonComponent);
+        comp = fixture.componentInstance;
+        submissionService = fixture.debugElement.injector.get(ProgrammingSubmissionService);
+        modalService = fixture.debugElement.injector.get(NgbModal);
+
+        comp.exercise = programmingExercise;
+        comp.participation = participation;
+        comp.lastResultIsManual = true;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('Should trigger build', () => {
+        const mockReturnValue = {
+            result: Promise.resolve(),
+            componentInstance: {},
+        } as NgbModalRef;
+        jest.spyOn(modalService, 'open').mockReturnValue(mockReturnValue);
+        jest.spyOn(submissionService, 'triggerBuild').mockReturnValue(of());
+
+        comp.triggerBuild({ stopPropagation: jest.fn() });
+
+        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledWith(ConfirmAutofocusModalComponent, {
+            size: 'lg',
+            keyboard: true,
+        });
+
+        expect(submissionService.triggerBuild).toHaveBeenCalledTimes(1);
+        expect(submissionService.triggerBuild).toHaveBeenCalledWith(participation.id, SubmissionType.INSTRUCTOR);
+    });
+});

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-re-evaluate-button.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-re-evaluate-button.component.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ArtemisTestModule } from '../../test.module';
+import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
+import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
+import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
+import { Course } from 'app/entities/course.model';
+import { MockDirective, MockPipe } from 'ng-mocks';
+import { NgModel } from '@angular/forms';
+import { ButtonComponent } from 'app/shared/components/button.component';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { ProgrammingExerciseReEvaluateButtonComponent } from 'app/exercises/programming/shared/actions/programming-exercise-re-evaluate-button.component';
+import { ProgrammingExerciseGradingService } from 'app/exercises/programming/manage/services/programming-exercise-grading.service';
+
+describe('ProgrammingExercise Re-Evaluate Button Component', () => {
+    const course = { id: 123 } as Course;
+    const programmingExercise = new ProgrammingExercise(course, undefined);
+    programmingExercise.id = 456;
+    programmingExercise.title = 'Exercise 1';
+
+    let comp: ProgrammingExerciseReEvaluateButtonComponent;
+    let fixture: ComponentFixture<ProgrammingExerciseReEvaluateButtonComponent>;
+    let gradingService: ProgrammingExerciseGradingService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [ProgrammingExerciseReEvaluateButtonComponent, ButtonComponent, MockPipe(ArtemisTranslatePipe), MockDirective(NgModel)],
+            providers: [
+                { provide: LocalStorageService, useClass: MockSyncStorage },
+                { provide: SessionStorageService, useClass: MockSyncStorage },
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ProgrammingExerciseReEvaluateButtonComponent);
+        comp = fixture.componentInstance;
+        gradingService = fixture.debugElement.injector.get(ProgrammingExerciseGradingService);
+
+        comp.exercise = programmingExercise;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('Should reEvaluate exercise', () => {
+        jest.spyOn(gradingService, 'reEvaluate');
+
+        const button = fixture.debugElement.nativeElement.querySelector('#re-evaluate-button button');
+        button.click();
+
+        expect(gradingService.reEvaluate).toHaveBeenCalledTimes(1);
+        expect(gradingService.reEvaluate).toHaveBeenCalledWith(programmingExercise.id);
+    });
+});

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-all-button.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-all-button.component.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ArtemisTestModule } from '../../test.module';
+import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
+import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
+import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
+import { Course } from 'app/entities/course.model';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { MockNgbModalService } from '../../helpers/mocks/service/mock-ngb-modal.service';
+import {
+    ProgrammingExerciseInstructorTriggerAllDialogComponent,
+    ProgrammingExerciseTriggerAllButtonComponent,
+} from 'app/exercises/programming/shared/actions/programming-exercise-trigger-all-button.component';
+import { ProgrammingSubmissionService } from 'app/exercises/programming/participate/programming-submission.service';
+import { of } from 'rxjs';
+import { MockDirective, MockPipe } from 'ng-mocks';
+import { NgModel } from '@angular/forms';
+import { ButtonComponent } from 'app/shared/components/button.component';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+
+describe('ProgrammingExercise Trigger All Button Component', () => {
+    const course = { id: 123 } as Course;
+    const programmingExercise = new ProgrammingExercise(course, undefined);
+    programmingExercise.id = 456;
+    programmingExercise.title = 'Exercise 1';
+
+    let comp: ProgrammingExerciseTriggerAllButtonComponent;
+    let fixture: ComponentFixture<ProgrammingExerciseTriggerAllButtonComponent>;
+    let submissionService: ProgrammingSubmissionService;
+    let modalService: NgbModal;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [ProgrammingExerciseTriggerAllButtonComponent, ButtonComponent, MockPipe(ArtemisTranslatePipe), MockDirective(NgModel)],
+            providers: [
+                { provide: NgbModal, useClass: MockNgbModalService },
+                { provide: LocalStorageService, useClass: MockSyncStorage },
+                { provide: SessionStorageService, useClass: MockSyncStorage },
+            ],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ProgrammingExerciseTriggerAllButtonComponent);
+        comp = fixture.componentInstance;
+        submissionService = fixture.debugElement.injector.get(ProgrammingSubmissionService);
+        modalService = fixture.debugElement.injector.get(NgbModal);
+
+        comp.exercise = programmingExercise;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('Should trigger builds for all participants on confirmation', () => {
+        const mockReturnValue = {
+            result: Promise.resolve(),
+            componentInstance: {},
+        } as NgbModalRef;
+        jest.spyOn(modalService, 'open').mockReturnValue(mockReturnValue);
+        jest.spyOn(submissionService, 'triggerInstructorBuildForAllParticipationsOfExercise').mockReturnValue(of());
+
+        const button = fixture.debugElement.nativeElement.querySelector('#trigger-all-button button');
+        button.click();
+
+        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledWith(ProgrammingExerciseInstructorTriggerAllDialogComponent, {
+            size: 'lg',
+            backdrop: 'static',
+        });
+
+        expect(submissionService.triggerInstructorBuildForAllParticipationsOfExercise).toHaveBeenCalledTimes(1);
+        expect(submissionService.triggerInstructorBuildForAllParticipationsOfExercise).toHaveBeenCalledWith(programmingExercise.id);
+    });
+});


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation
Increase the code coverage for components in `app/exercises/programming/shared/actions`.

### Description
Added test cases for three programming exercise action button components (Line-Cov):
- `programming-exercise-re-evaluate-button.component.ts`: 80%
- `programming-exercise-trigger-all-button.component.ts `: 80%
- `programming-exercise-instructor-trigger-build-button.component.ts`: 90%

Overall (`app/exercises/programming/shared/lifecycle`): 91%

#### Code Review
- [x] Review 1
- [x] Review 2