### PR TITLE
`Programming exercises`: Show feedback details in overview again when result is clicked

### DIFF
--- a/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
+++ b/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
@@ -20,7 +20,7 @@
                 [exercise]="exercise"
                 [short]="true"
                 [triggerLastGraded]="false"
-                style="width: unset"
+                class="result"
             ></jhi-submission-result-status>
         </div>
         <div class="row" style="justify-content: space-between">

--- a/src/main/webapp/app/overview/course-exercises/course-exercise-row.scss
+++ b/src/main/webapp/app/overview/course-exercises/course-exercise-row.scss
@@ -30,6 +30,11 @@
         align-items: center;
         min-width: 40px;
     }
+
+    .result {
+        width: unset;
+        z-index: 2;
+    }
 }
 
 .raised-actions {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After reworking the exercise rows and declaring them as link to the corresponding exercise detail page, the link handled all click events. This leads to the situation that the feedback modal is not shown anymore if the user clicks on a programming exercise score. Instead, the user is delegated to the corresponding exercise detail page.
The modal should be accessible by clicking on the programming exercise score.
### Description
<!-- Describe your changes in detail -->
I increased the `z-index` of `jhi-submission-result-status`. This way, the click on the programming exercise results can be handled again.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
-  1 Student
- 1 Programming Exercise the student participated on and feedback is shown

1. Log in to Artemis
2. Navigate to Exercises tab of the course
3. Click on the underlined part of the score and make sure the feedback details popup is shown
4. Click on an arbitrary spot besides the exercise score on the exercise row. Make sure that you are delegated to the corresponding exercise detail page

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
Nothing changed
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Currently, the feedback popup is not accessible:

https://user-images.githubusercontent.com/80622272/150762904-2886be7b-241b-46a1-9303-a6db92306e8c.mp4

With these changes it is possible again:

https://user-images.githubusercontent.com/80622272/150763111-7057a34b-d82b-439e-acce-eca7bce77864.mp4


