### PR TITLE
`General`: Fix an edge case issue in the active students charts on course management

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.IsoFields;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -424,7 +425,9 @@ public class CourseService {
             ZonedDateTime date = LocalDateTime.parse(dateOfElement, formatter).atZone(zone);
             int index = statisticsRepository.getWeekOfDate(date);
             // the database stores entries in UTC, so it can happen that entries have a date one date before the startDate
-            index = index == startIndex - 1 ? startIndex : index;
+            var unifiedDateWeekBeforeStartIndex = startIndex == 1 ? Math.toIntExact(IsoFields.WEEK_OF_WEEK_BASED_YEAR.rangeRefinedBy(startDate.minusWeeks(1)).getMaximum())
+                    : startIndex - 1;
+            index = index == unifiedDateWeekBeforeStartIndex ? startIndex : index;
             statisticsRepository.addUserToTimeslot(usersByDate, listElement, index);
         }
         List<StatisticsEntry> returnList = new ArrayList<>();

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -424,7 +424,12 @@ public class CourseService {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
             ZonedDateTime date = LocalDateTime.parse(dateOfElement, formatter).atZone(zone);
             int index = statisticsRepository.getWeekOfDate(date);
-            // the database stores entries in UTC, so it can happen that entries have a date one date before the startDate
+            /*
+             * The database stores entries in UTC, so it can happen that entries lay in the calendar week one week before the calendar week of the startDate If startDate lays in a
+             * calendar week other than the first one, we simply check whether the calendar week of the entry equals to the calendar week of startDate - 1. If startDate lays in the
+             * first calendar week, we check whether the calendar week of the entry equals the last calendar week of the prior year. In either case, if the condition resolves to
+             * true, we shift the index the submission is sorted in to the calendar week of startDate, as this is the first bucket in the timeframe of interest.
+             */
             var unifiedDateWeekBeforeStartIndex = startIndex == 1 ? Math.toIntExact(IsoFields.WEEK_OF_WEEK_BASED_YEAR.rangeRefinedBy(startDate.minusWeeks(1)).getMaximum())
                     : startIndex - 1;
             index = index == unifiedDateWeekBeforeStartIndex ? startIndex : index;

--- a/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
@@ -117,6 +117,39 @@ public class CourseServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
     }
 
     @Test
+    public void testGetActiveStudents_UTCConversion() {
+        ZonedDateTime date = ZonedDateTime.of(2022, 1, 2, 0, 0, 0, 0, ZonedDateTime.now().getZone());
+        SecurityUtils.setAuthorizationObject();
+        var course = database.addEmptyCourse();
+        var exercise = ModelFactory.generateTextExercise(date, date, date, course);
+        course.addExercises(exercise);
+        exercise = exerciseRepo.save(exercise);
+
+        var users = database.addUsers(2, 0, 0, 0);
+        var student1 = users.get(0);
+        var participation1 = new StudentParticipation();
+        participation1.setParticipant(student1);
+        participation1.exercise(exercise);
+
+        studentParticipationRepo.save(participation1);
+
+        var submission1 = new TextSubmission();
+        submission1.text("text of text submission1");
+        submission1.setLanguage(Language.ENGLISH);
+        submission1.setSubmitted(true);
+        submission1.setParticipation(participation1);
+        submission1.setSubmissionDate(date.plusDays(1).plusMinutes(59).plusSeconds(59).plusNanos(59));
+
+        submissionRepository.save(submission1);
+
+        var exerciseList = new HashSet<Long>();
+        exerciseList.add(exercise.getId());
+        var activeStudents = courseService.getActiveStudents(exerciseList, 0, 4, ZonedDateTime.now());
+        assertThat(activeStudents.size()).isEqualTo(4);
+        assertThat(activeStudents).containsExactly(1, 0, 0, 0);
+    }
+
+    @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void testGetOverviewAsAdmin() {
         // Minimal testcase: Admins always see all courses


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Currently, the active students charts on course management page on the TUM instance are not working. The server-side statistic calculation throws an out of bounds exception. This PR should resolves this bug.
### Description
<!-- Describe your changes in detail -->
As far as I can tell, there is one edge case not covered properly. As index for sorting the submission in weekly buckets, the server uses the date week of the submission date. This submission time is stored in UTC in the database. The original author of the implementation took into account that this way there might occur dates that are in the date week right before the date week of the start date of the time frame of interest (in our case starting on Monday 3 weeks ago until upcoming Sunday).
The edge case was the following: If a student submitted between 03.01. 00:00 and 03.01. 00:059 in Germany, the server converted it to 02.01. 23:00 UTC or 23:59 UTC respectively. 03.01. is the first day in calendar week 1 in 2022, therefore 02.01. lays in calendar week 52 of 2021. As already said, the author was aware of the potential of such occurrence. But he did not take into account that the prior calendar week could lay in a prior year. Therefore he only checked whether the calendar week of the submission is equal to the calendar week of the start date (in our case 03.01.) - 1. If this was the case, the index got shifted to the calendar week of the start date. In the edge case, the system checked 52 == 1-1 and therefore proceeded with index 52.
Later on, this index was used in order to determine the index in the array returned to the client for representation of the active users. The index is calculated by subtracting the date week of the start date from the (shifted) date week of the submission date, adding the number of calendar weeks of the year of start date and finally taking the modulo of this term. In our case this leads to the calculation: (52 - 1 + 52) % 52 = 51. Since the array only has length 4, index 51 was out of bounds.
I changed the shifting of the submission date week in that way, that in the explained edge case it checks the date against the last date week of the prior year instead of 0 as it was before.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Testing is quite tricky here since there is no possibility to simulate a submission on Monday 3 weeks ago on a test server. I wrote a server test that covers exactly this edge case. If you like to, you can check out the branch and replace my changes with the prior implementation again, execute the additional test case and make sure that the test throws exactly this index out of bounds exception described above. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
The exception that is thrown on production:

![image (5)](https://user-images.githubusercontent.com/80622272/150835544-7ce0e15e-393c-496b-8f76-3725bf0add4c.png)

