### PR TITLE
`Development`: Increase client test coverage for submission export

### DIFF
--- a/src/test/javascript/spec/component/exercises/shared/submission-export-button.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/submission-export-button.component.spec.ts
@@ -1,0 +1,74 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ArtemisTestModule } from '../../../test.module';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { MockDirective, MockPipe } from 'ng-mocks';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
+import { ExerciseType } from 'app/entities/exercise.model';
+import { SubmissionExportDialogComponent } from 'app/exercises/shared/submission-export/submission-export-dialog.component';
+import { SubmissionExportButtonComponent } from 'app/exercises/shared/submission-export/submission-export-button.component';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { MockNgbModalService } from '../../../helpers/mocks/service/mock-ngb-modal.service';
+
+export class MockNgbModalRef {
+    componentInstance = {
+        exerciseId: undefined,
+        exerciseType: undefined,
+    };
+    result: Promise<any> = new Promise((resolve, reject) => resolve(true));
+}
+
+describe('Submission Export Button Component', () => {
+    let fixture: ComponentFixture<SubmissionExportButtonComponent>;
+    let component: SubmissionExportButtonComponent;
+    let modalService: NgbModal;
+    let mouseEvent: MouseEvent;
+
+    const exerciseId = 1;
+    const exerciseType = ExerciseType.TEXT;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [SubmissionExportDialogComponent, MockDirective(NgbTooltip), MockPipe(ArtemisTranslatePipe), MockPipe(ArtemisTimeAgoPipe)],
+            providers: [{ provide: NgbModal, useClass: MockNgbModalService }],
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(SubmissionExportButtonComponent);
+                component = fixture.componentInstance;
+
+                modalService = TestBed.inject(NgbModal);
+
+                component.exerciseId = exerciseId;
+                component.exerciseType = exerciseType;
+
+                mouseEvent = new MouseEvent('mouseEvent');
+            });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should open export submission dialog', () => {
+        const mouseEventSpy = jest.spyOn(mouseEvent, 'stopPropagation');
+        const openSpy = jest.spyOn(modalService, 'open');
+
+        component.openSubmissionExportDialog(mouseEvent);
+
+        expect(mouseEventSpy).toHaveBeenCalledTimes(1);
+        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(openSpy).toHaveBeenCalledWith(SubmissionExportDialogComponent, { keyboard: true, size: 'lg' });
+    });
+
+    it('should set input values for dialog', () => {
+        const mockModalRef = new MockNgbModalRef();
+        modalService.open = jest.fn().mockReturnValue(mockModalRef);
+
+        component.openSubmissionExportDialog(mouseEvent);
+
+        expect(mockModalRef.componentInstance.exerciseId).toBe(exerciseId);
+        expect(mockModalRef.componentInstance.exerciseType).toBe(exerciseType);
+    });
+});

--- a/src/test/javascript/spec/component/exercises/shared/submission-export-button.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/submission-export-button.component.spec.ts
@@ -15,7 +15,7 @@ export class MockNgbModalRef {
         exerciseId: undefined,
         exerciseType: undefined,
     };
-    result: Promise<any> = new Promise((resolve, reject) => resolve(true));
+    result: Promise<boolean> = Promise.resolve(true);
 }
 
 describe('Submission Export Button Component', () => {

--- a/src/test/javascript/spec/component/exercises/shared/submission-export-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/submission-export-dialog.component.spec.ts
@@ -1,0 +1,142 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ArtemisTestModule } from '../../../test.module';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { MockDirective, MockPipe, MockProvider } from 'ng-mocks';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
+import { Exercise, ExerciseType } from 'app/entities/exercise.model';
+import { SubmissionExportDialogComponent } from 'app/exercises/shared/submission-export/submission-export-dialog.component';
+import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
+import { MockExerciseService } from '../../../helpers/mocks/service/mock-exercise.service';
+import { SubmissionExportService } from 'app/exercises/shared/submission-export/submission-export.service';
+import { HttpResponse } from '@angular/common/http';
+import { AlertService } from 'app/core/util/alert.service';
+import * as DownloadUtil from 'app/shared/util/download.util';
+import { of } from 'rxjs';
+
+describe('Submission Export Dialog Component', () => {
+    let fixture: ComponentFixture<SubmissionExportDialogComponent>;
+    let component: SubmissionExportDialogComponent;
+
+    let alertService: AlertService;
+    let submissionExportService: SubmissionExportService;
+    let exerciseService: ExerciseService;
+
+    const exerciseId = 1;
+    const validExerciseType = ExerciseType.TEXT;
+    const invalidExerciseType = ExerciseType.PROGRAMMING;
+    const submissionExportOptions = {
+        exportAllParticipants: false,
+        filterLateSubmissions: false,
+        filterLateSubmissionsDate: null,
+        participantIdentifierList: '',
+    };
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [SubmissionExportDialogComponent, MockDirective(NgbTooltip), MockPipe(ArtemisTranslatePipe), MockPipe(ArtemisTimeAgoPipe)],
+            providers: [
+                { provide: SubmissionExportService, useValue: MockProvider(SubmissionExportService) },
+                { provide: ExerciseService, useClass: MockExerciseService },
+            ],
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(SubmissionExportDialogComponent);
+                component = fixture.componentInstance;
+
+                alertService = TestBed.inject(AlertService);
+                submissionExportService = TestBed.inject(SubmissionExportService);
+                exerciseService = TestBed.inject(ExerciseService);
+
+                component.exerciseId = exerciseId;
+                component.exerciseType = validExerciseType;
+                component.submissionExportOptions = submissionExportOptions;
+            });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should initialize', () => {
+        const findSpy = jest.spyOn(exerciseService, 'find');
+        component.ngOnInit();
+
+        expect(component.isLoading).toBe(false);
+        expect(component.exportInProgress).toBe(false);
+        expect(component.submissionExportOptions).toEqual(submissionExportOptions);
+        expect(component.exercise).toEqual({ id: exerciseId } as Exercise);
+        expect(findSpy).toHaveBeenCalledTimes(1);
+        expect(findSpy).toHaveBeenCalledWith(exerciseId);
+    });
+
+    it('should handle export response', () => {
+        const response: HttpResponse<Blob> = new HttpResponse();
+        const alertSpy = jest.spyOn(alertService, 'success');
+        const modalSpy = jest.spyOn(component.activeModal, 'dismiss');
+        const downloadSpy = jest.spyOn(DownloadUtil, 'downloadZipFileFromResponse');
+
+        component.handleExportResponse(response);
+
+        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledWith('instructorDashboard.exportSubmissions.successMessage');
+        expect(modalSpy).toHaveBeenCalledTimes(1);
+        expect(modalSpy).toHaveBeenCalledWith(true);
+        expect(component.exportInProgress).toBe(false);
+        expect(downloadSpy).toHaveBeenCalledTimes(1);
+        expect(downloadSpy).toHaveBeenCalledWith(response);
+    });
+
+    it('should clear dialog', () => {
+        const modalSpy = jest.spyOn(component.activeModal, 'dismiss');
+        component.clear();
+
+        expect(modalSpy).toHaveBeenCalledTimes(1);
+        expect(modalSpy).toHaveBeenCalledWith('cancel');
+    });
+
+    describe('Exporting Submission', () => {
+        let exportSubmissionServiceMock: jest.Mock;
+        let handleExportResponseMock: jest.Mock;
+
+        beforeEach(() => {
+            handleExportResponseMock = jest.fn().mockReturnValue(of());
+            component.handleExportResponse = handleExportResponseMock;
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('should export submission', () => {
+            exportSubmissionServiceMock = jest.fn().mockReturnValue(of({ body: {} } as HttpResponse<Blob>));
+            submissionExportService.exportSubmissions = exportSubmissionServiceMock;
+
+            component.exportSubmissions(exerciseId);
+
+            expect(exportSubmissionServiceMock).toHaveBeenCalledTimes(1);
+            expect(exportSubmissionServiceMock).toHaveBeenCalledWith(exerciseId, validExerciseType, submissionExportOptions);
+            expect(component.exportInProgress).toBe(true);
+            expect(handleExportResponseMock).toHaveBeenCalledTimes(1);
+            expect(handleExportResponseMock).toHaveBeenCalledWith({ body: {} });
+        });
+
+        it('should handle error exporting submission for unsupported exercise types', () => {
+            exportSubmissionServiceMock = jest.fn().mockImplementation(() => {
+                throw Error('Export not implemented for exercise type ' + invalidExerciseType);
+            });
+            submissionExportService.exportSubmissions = exportSubmissionServiceMock;
+            component.exerciseType = invalidExerciseType;
+
+            expect(() => {
+                component.exportSubmissions(exerciseId);
+            }).toThrow('Export not implemented for exercise type ' + invalidExerciseType);
+
+            expect(exportSubmissionServiceMock).toHaveBeenCalledTimes(1);
+            expect(exportSubmissionServiceMock).toHaveBeenCalledWith(exerciseId, invalidExerciseType, submissionExportOptions);
+            expect(handleExportResponseMock).toHaveBeenCalledTimes(0);
+        });
+    });
+});

--- a/src/test/javascript/spec/component/exercises/shared/submission-export-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/submission-export-dialog.component.spec.ts
@@ -106,10 +106,6 @@ describe('Submission Export Dialog Component', () => {
             component.handleExportResponse = handleExportResponseMock;
         });
 
-        afterEach(() => {
-            jest.restoreAllMocks();
-        });
-
         it('should export submission', () => {
             exportSubmissionServiceMock = jest.fn().mockReturnValue(of({ body: {} } as HttpResponse<Blob>));
             submissionExportService.exportSubmissions = exportSubmissionServiceMock;

--- a/src/test/javascript/spec/service/submission-export.service.spec.ts
+++ b/src/test/javascript/spec/service/submission-export.service.spec.ts
@@ -1,0 +1,70 @@
+import { TestBed } from '@angular/core/testing';
+import { ArtemisTestModule } from '../test.module';
+import { SubmissionExportService } from 'app/exercises/shared/submission-export/submission-export.service';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ExerciseType } from 'app/entities/exercise.model';
+
+describe('Submission Export Service', () => {
+    let service: SubmissionExportService;
+    let httpMock: HttpTestingController;
+    let expectedResult: any;
+    const exerciseId = 1;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule, HttpClientTestingModule],
+        });
+        service = TestBed.inject(SubmissionExportService);
+        httpMock = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => {
+        httpMock.verify();
+        jest.restoreAllMocks();
+    });
+
+    it('check exercise url for text exercise', () => {
+        const exerciseType = ExerciseType.TEXT;
+        const result = service.getExerciseUrl(exerciseType, exerciseId);
+
+        expect(result).toBe('text-exercises/' + exerciseId);
+    });
+
+    it('check exercise url for modeling exercise', () => {
+        const exerciseType = ExerciseType.MODELING;
+        const result = service.getExerciseUrl(exerciseType, exerciseId);
+
+        expect(result).toBe('modeling-exercises/' + exerciseId);
+    });
+
+    it('check exercise url for file upload exercise', () => {
+        const exerciseType = ExerciseType.FILE_UPLOAD;
+        const result = service.getExerciseUrl(exerciseType, exerciseId);
+
+        expect(result).toBe('file-upload-exercises/' + exerciseId);
+    });
+
+    it('check exercise url for unsupported exercise types', () => {
+        const exerciseTypes = [ExerciseType.QUIZ, ExerciseType.PROGRAMMING];
+
+        for (const exerciseType of exerciseTypes) {
+            expect(() => {
+                service.getExerciseUrl(exerciseType, exerciseId);
+            }).toThrow('Export not implemented for exercise type ' + exerciseType);
+        }
+    });
+
+    it('should export submissions', () => {
+        service
+            .exportSubmissions(exerciseId, ExerciseType.TEXT, {
+                exportAllParticipants: true,
+                filterLateSubmissions: true,
+                filterLateSubmissionsDate: null,
+                participantIdentifierList: 'participant1,participant2,participant3',
+            })
+            .subscribe((resp) => (expectedResult = resp.ok));
+        const req = httpMock.expectOne({ method: 'POST' });
+        req.flush(new Blob());
+        expect(expectedResult).toBe(true);
+    });
+});


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation
Increase the code coverage for service and components in `app/exercises/shared/submission-export`.

### Description
Added test cases for both submission export files (name: Branch-Cov, Line-Cov):
- `submission-export-button.component.ts`: 75%, 100%
- `submission-export-dialog.component.ts`: 75%, 88.57%
- `submission-export.service.ts`: 87.5%, 100%

Overall (`app/exercises/shared/submission-export`): 78.57%, 93.54%

#### Code Review
- [x] Review 1
- [x] Review 2