### PR TITLE
`Assessment`: Fix filter for finished exercises with complaints for automatic assessment

### DIFF
--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.ts
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.ts
@@ -316,8 +316,9 @@ export class AssessmentDashboardComponent implements OnInit {
     private getUnfinishedExercises(exercises?: Exercise[]) {
         const filteredExercises = exercises?.filter(
             (exercise) =>
-                exercise.numberOfAssessmentsOfCorrectionRounds?.map((round) => round.inTime !== exercise.numberOfSubmissions?.inTime).reduce((acc, current) => acc || current) ||
-                exercise.totalNumberOfAssessments?.inTime !== exercise.numberOfSubmissions?.inTime ||
+                (!exercise.allowComplaintsForAutomaticAssessments &&
+                    (exercise.numberOfAssessmentsOfCorrectionRounds?.map((round) => round.inTime !== exercise.numberOfSubmissions?.inTime).reduce((acc, cur) => acc || cur) ||
+                        exercise.totalNumberOfAssessments?.inTime !== exercise.numberOfSubmissions?.inTime)) ||
                 exercise.numberOfOpenComplaints !== 0 ||
                 exercise.numberOfOpenMoreFeedbackRequests !== 0,
         );

--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.ts
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.ts
@@ -324,7 +324,7 @@ export class AssessmentDashboardComponent implements OnInit {
         return filteredExercises ? filteredExercises : [];
     }
 
-    private hasUnfinishedAssessments(exercise: Exercise) {
+    private hasUnfinishedAssessments(exercise: Exercise): boolean {
         return (
             exercise.numberOfAssessmentsOfCorrectionRounds?.map((round) => round.inTime !== exercise.numberOfSubmissions?.inTime).reduce((acc, cur) => acc || cur) ||
             exercise.totalNumberOfAssessments?.inTime !== exercise.numberOfSubmissions?.inTime

--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.ts
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.ts
@@ -316,14 +316,19 @@ export class AssessmentDashboardComponent implements OnInit {
     private getUnfinishedExercises(exercises?: Exercise[]) {
         const filteredExercises = exercises?.filter(
             (exercise) =>
-                (!exercise.allowComplaintsForAutomaticAssessments &&
-                    (exercise.numberOfAssessmentsOfCorrectionRounds?.map((round) => round.inTime !== exercise.numberOfSubmissions?.inTime).reduce((acc, cur) => acc || cur) ||
-                        exercise.totalNumberOfAssessments?.inTime !== exercise.numberOfSubmissions?.inTime)) ||
+                (!exercise.allowComplaintsForAutomaticAssessments && this.hasUnfinishedAssessments(exercise)) ||
                 exercise.numberOfOpenComplaints !== 0 ||
                 exercise.numberOfOpenMoreFeedbackRequests !== 0,
         );
 
         return filteredExercises ? filteredExercises : [];
+    }
+
+    private hasUnfinishedAssessments(exercise: Exercise) {
+        return (
+            exercise.numberOfAssessmentsOfCorrectionRounds?.map((round) => round.inTime !== exercise.numberOfSubmissions?.inTime).reduce((acc, cur) => acc || cur) ||
+            exercise.totalNumberOfAssessments?.inTime !== exercise.numberOfSubmissions?.inTime
+        );
     }
 
     /**

--- a/src/test/javascript/spec/component/assessment-dashboard/assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/assessment-dashboard.component.spec.ts
@@ -67,6 +67,24 @@ describe('AssessmentDashboardInformationComponent', () => {
         tutorParticipations: [{ status: TutorParticipationStatus.TRAINED }],
         secondCorrectionEnabled: false,
     } as ProgrammingExercise;
+    const programmingExerciseComplaintsOnAutomaticAssessment = {
+        id: 21,
+        type: ExerciseType.PROGRAMMING,
+        tutorParticipations: [{ status: TutorParticipationStatus.TRAINED }],
+        allowComplaintsForAutomaticAssessments: true,
+        secondCorrectionEnabled: false,
+        numberOfOpenComplaints: 0,
+        numberOfOpenMoreFeedbackRequests: 0,
+        // Normally only a small fraction of submissions is assessed by hand and accounted
+        numberOfSubmissions: {
+            inTime: 1234,
+            late: 0,
+        },
+        totalNumberOfAssessments: {
+            inTime: 12,
+            late: 0,
+        },
+    } as ProgrammingExercise;
     const modelingExercise = {
         id: 17,
         type: ExerciseType.MODELING,
@@ -92,8 +110,8 @@ describe('AssessmentDashboardInformationComponent', () => {
         includedInOverallScore: IncludedInOverallScore.INCLUDED_AS_BONUS,
     } as FileUploadExercise;
 
-    const course = { id: 10, exercises: [programmingExercise, modelingExercise, textExercise, modelingExercise] } as Course;
-    const exercises = [programmingExercise, fileUploadExercise, modelingExercise, textExercise];
+    const course = { id: 10, exercises: [programmingExercise, programmingExerciseComplaintsOnAutomaticAssessment, modelingExercise, textExercise, modelingExercise] } as Course;
+    const exercises = [programmingExercise, programmingExerciseComplaintsOnAutomaticAssessment, fileUploadExercise, modelingExercise, textExercise];
     const exerciseGroup1 = { id: 141, exercises: [programmingExercise, modelingExercise] } as ExerciseGroup;
     const exerciseGroup2 = { id: 142, exercises: [textExercise, fileUploadExercise] } as ExerciseGroup;
     const exam = { id: 20, exerciseGroups: [exerciseGroup1, exerciseGroup2], course: { id: 10 } } as Exam;
@@ -224,7 +242,7 @@ describe('AssessmentDashboardInformationComponent', () => {
         expect(getCourseWithInterestingExercisesForTutorsStub).toHaveBeenCalledTimes(1);
         expect(getStatsForTutorsStub).toHaveBeenCalledTimes(1);
         expect(comp.course).toEqual(Course.from(course));
-        expect(comp.allExercises).toHaveLength(4);
+        expect(comp.allExercises).toHaveLength(5);
         expect(comp.currentlyShownExercises).toHaveLength(4);
     }));
 
@@ -241,16 +259,16 @@ describe('AssessmentDashboardInformationComponent', () => {
     });
 
     it('should update exercises when finished exercises are filtered', () => {
-        comp.allExercises = [programmingExercise, textExercise, modelingExercise, fileUploadExercise];
+        comp.allExercises = [programmingExercise, programmingExerciseComplaintsOnAutomaticAssessment, textExercise, modelingExercise, fileUploadExercise];
         comp.currentlyShownExercises = [programmingExercise, textExercise, modelingExercise];
         comp.triggerFinishedExercises(); // should now show all exercises
-        expect(comp.currentlyShownExercises).toEqual([programmingExercise, textExercise, modelingExercise, fileUploadExercise]);
+        expect(comp.currentlyShownExercises).toEqual([programmingExercise, programmingExerciseComplaintsOnAutomaticAssessment, textExercise, modelingExercise, fileUploadExercise]);
         comp.triggerFinishedExercises(); // should no longer show fileUploadExercise
         expect(comp.currentlyShownExercises).toEqual([programmingExercise, textExercise, modelingExercise]);
     });
 
     it('should update exercises when optional exercises are filtered', () => {
-        comp.allExercises = [programmingExercise, textExercise, modelingExercise, fileUploadExercise];
+        comp.allExercises = [programmingExercise, programmingExerciseComplaintsOnAutomaticAssessment, textExercise, modelingExercise, fileUploadExercise];
         comp.currentlyShownExercises = [programmingExercise, textExercise, modelingExercise];
         comp.triggerOptionalExercises();
         expect(comp.currentlyShownExercises).toEqual([programmingExercise, modelingExercise]);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation, Context and Description
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix a bug where exercises with complaints on automated assessments would still be shown in the tutor assessment dashboard even though they were finished.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise with Complaints on automatic assessments enabled

1. Create the exercise, participate as a student and complain after the deadline on the automatic assessment
2. Check that the exercise appears correctly on the assessment dashboard
3. Respond to the complaint
4. Check that the finished exercise is correctly filtered

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2