### PR TITLE
`General`: Forward changes to internal users to Bitbucket

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
@@ -397,7 +397,7 @@ public class Exam extends DomainObject {
      */
     @JsonIgnore
     public boolean isAfterLatestStudentExamEnd() {
-        return ZonedDateTime.now().isAfter(getStartDate().plusMinutes(getStudentExams().stream().mapToInt(StudentExam::getWorkingTime).max().orElse(0)));
+        return ZonedDateTime.now().isAfter(getStartDate().plusSeconds(getStudentExams().stream().mapToInt(StudentExam::getWorkingTime).max().orElse(0)));
     }
 
     public boolean hasExamArchive() {

--- a/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/exam/Exam.java
@@ -1,7 +1,10 @@
 package de.tum.in.www1.artemis.domain.exam;
 
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -9,6 +12,7 @@ import javax.validation.constraints.NotNull;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -384,6 +388,16 @@ public class Exam extends DomainObject {
             return false;
         }
         return publishResultsDate.isBefore(ZonedDateTime.now());
+    }
+
+    /**
+     * Checks if the exam has completely ended even for students with time extensions
+     *
+     * @return true if the exam writing time of the student with the longest extension has been exceeded
+     */
+    @JsonIgnore
+    public boolean isAfterLatestStudentExamEnd() {
+        return ZonedDateTime.now().isAfter(getStartDate().plusMinutes(getStudentExams().stream().mapToInt(StudentExam::getWorkingTime).max().orElse(0)));
     }
 
     public boolean hasExamArchive() {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -49,27 +49,27 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
      */
     @Override
     public void createVcsUser(User user) throws VersionControlException {
-        if (user.isInternal()) {
-            // User
-            if (!bitbucketService.userExists(user.getLogin())) {
-                log.debug("Bitbucket user {} does not exist yet", user.getLogin());
-                String displayName = user.getName().trim();
-                bitbucketService.createUser(user.getLogin(), passwordService.decryptPasswordByLogin(user.getLogin()).get(), user.getEmail(), displayName);
+        if (!user.isInternal()) {
+            return;
+        }
+        if (bitbucketService.userExists(user.getLogin())) {
+            log.debug("Bitbucket user {} already exists", user.getLogin());
+            return;
+        }
 
-                try {
-                    // NOTE: we need to fetch the user here again to make sure that the groups are not lazy loaded.
-                    User repoUser = userRepository.getUserWithGroupsAndAuthorities(user.getLogin());
-                    bitbucketService.addUserToGroups(repoUser.getLogin(), repoUser.getGroups());
-                }
-                catch (BitbucketException e) {
-                    /*
-                     * This might throw exceptions, for example if the group does not exist on Bitbucket. We can safely ignore them.
-                     */
-                }
-            }
-            else {
-                log.debug("Bitbucket user {} already exists", user.getLogin());
-            }
+        log.debug("Bitbucket user {} does not exist yet", user.getLogin());
+        String displayName = user.getName().trim();
+        bitbucketService.createUser(user.getLogin(), passwordService.decryptPasswordByLogin(user.getLogin()).get(), user.getEmail(), displayName);
+
+        try {
+            // NOTE: we need to fetch the user here again to make sure that the groups are not lazy loaded.
+            User repoUser = userRepository.getUserWithGroupsAndAuthorities(user.getLogin());
+            bitbucketService.addUserToGroups(repoUser.getLogin(), repoUser.getGroups());
+        }
+        catch (BitbucketException e) {
+            /*
+             * This might throw exceptions, for example if the group does not exist on Bitbucket. We can safely ignore them.
+             */
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -80,8 +80,8 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
      *     <li>Update the password of the user</li>
      *     <li>Update the groups the user belongs to, i.e. removing him from exercises that reference old groups</li>
      * </ul>
-     * @param vcsLogin                  The username of the user in the VCS
      *
+     * @param vcsLogin                  The username of the user in the VCS
      * @param user                      The updated user in Artemis
      * @param removedGroups             groups that the user does not belong to any longer
      * @param addedGroups               The new groups the Artemis user got added to
@@ -90,7 +90,10 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
     @Override
     public void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, boolean shouldSynchronizePassword) {
         bitbucketService.updateUserDetails(vcsLogin, user.getEmail(), user.getName());
-        if (user.isInternal() && shouldSynchronizePassword) {
+        if (!user.isInternal()) {
+            return;
+        }
+        if (shouldSynchronizePassword) {
             bitbucketService.updateUserPassword(vcsLogin, passwordService.decryptPassword(user));
         }
         if (addedGroups != null && !addedGroups.isEmpty()) {
@@ -108,6 +111,9 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
      */
     @Override
     public void deleteVcsUser(String login) throws VersionControlException {
+        if (!userRepository.findOneByLogin(login).orElseThrow().isInternal()) {
+            return;
+        }
         bitbucketService.deleteAndEraseUser(login);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -160,14 +160,15 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
             }
             if (!oldEditorGroup.equals(updatedCourse.getEditorGroupName())) {
                 bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), oldEditorGroup, null);
-                bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), updatedCourse.getEditorGroupName(), BitbucketPermission.PROJECT_READ);
+                bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), updatedCourse.getEditorGroupName(), BitbucketPermission.PROJECT_WRITE);
             }
-            ZonedDateTime examEndDate = programmingExercise.getExerciseGroup().getExam().getStartDate()
-                    .plusMinutes(programmingExercise.getExerciseGroup().getExam().getStudentExams().stream().mapToInt(StudentExam::getWorkingTime).max().orElse(0));
+            boolean isCourseOrAfterExam = programmingExercise.isCourseExercise() || ZonedDateTime.now().isAfter(programmingExercise.getExerciseGroup().getExam().getStartDate()
+                    .plusMinutes(programmingExercise.getExerciseGroup().getExam().getStudentExams().stream().mapToInt(StudentExam::getWorkingTime).max().orElse(0)));
             if (!oldEditorGroup.equals(updatedCourse.getTeachingAssistantGroupName())) {
-                bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), oldEditorGroup, null);
-                if ((!programmingExercise.isExamExercise() || ZonedDateTime.now().isAfter(examEndDate))) {
-                    bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), updatedCourse.getEditorGroupName(), BitbucketPermission.PROJECT_READ);
+                bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), oldTeachingAssistantGroup, null);
+                if (isCourseOrAfterExam) {
+                    bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), updatedCourse.getTeachingAssistantGroupName(),
+                            BitbucketPermission.PROJECT_READ);
                 }
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -60,8 +60,8 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
 
                 try {
                     // NOTE: we need to fetch the user here again to make sure that the groups are not lazy loaded.
-                    user = userRepository.getUserWithGroupsAndAuthorities(user.getLogin());
-                    bitbucketService.addUserToGroups(user.getLogin(), user.getGroups());
+                    User repoUser = userRepository.getUserWithGroupsAndAuthorities(user.getLogin());
+                    bitbucketService.addUserToGroups(repoUser.getLogin(), repoUser.getGroups());
                 }
                 catch (BitbucketException e) {
                     /*
@@ -91,7 +91,10 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
      */
     @Override
     public void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, boolean shouldSynchronizePassword) {
-        bitbucketService.updateUser(vcsLogin, user.isInternal() && shouldSynchronizePassword ? passwordService.decryptPassword(user) : null, user.getEmail(), user.getName());
+        bitbucketService.updateUserDetails(vcsLogin, user.getEmail(), user.getName());
+        if (user.isInternal() && shouldSynchronizePassword) {
+            bitbucketService.updateUserPassword(vcsLogin, passwordService.decryptPassword(user));
+        }
         if (addedGroups != null && !addedGroups.isEmpty()) {
             bitbucketService.addUserToGroups(user.getLogin(), addedGroups);
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -89,10 +89,10 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
      */
     @Override
     public void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, boolean shouldSynchronizePassword) {
-        bitbucketService.updateUserDetails(vcsLogin, user.getEmail(), user.getName());
         if (!user.isInternal()) {
             return;
         }
+        bitbucketService.updateUserDetails(vcsLogin, user.getEmail(), user.getName());
         if (shouldSynchronizePassword) {
             bitbucketService.updateUserPassword(vcsLogin, passwordService.decryptPassword(user));
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -1,0 +1,175 @@
+package de.tum.in.www1.artemis.service.connectors;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import de.tum.in.www1.artemis.domain.Course;
+import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.domain.exam.StudentExam;
+import de.tum.in.www1.artemis.exception.BitbucketException;
+import de.tum.in.www1.artemis.exception.VersionControlException;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.repository.UserRepository;
+import de.tum.in.www1.artemis.service.connectors.bitbucket.BitbucketPermission;
+import de.tum.in.www1.artemis.service.connectors.bitbucket.BitbucketService;
+import de.tum.in.www1.artemis.service.user.PasswordService;
+
+@Service
+@Profile("bitbucket")
+public class BitbucketUserManagementService implements VcsUserManagementService {
+
+    private final Logger log = LoggerFactory.getLogger(BitbucketUserManagementService.class);
+
+    private final BitbucketService bitbucketService;
+
+    private final UserRepository userRepository;
+
+    private final PasswordService passwordService;
+
+    private final ProgrammingExerciseRepository programmingExerciseRepository;
+
+    public BitbucketUserManagementService(BitbucketService bitbucketService, UserRepository userRepository, PasswordService passwordService,
+            ProgrammingExerciseRepository programmingExerciseRepository) {
+        this.bitbucketService = bitbucketService;
+        this.userRepository = userRepository;
+        this.passwordService = passwordService;
+        this.programmingExerciseRepository = programmingExerciseRepository;
+    }
+
+    /**
+     * Creates a new user in the VCS based on a local Artemis user. Should be called if Artemis handles user creation
+     * and management
+     *
+     * @param user The local Artemis user, which will be available in the VCS after invoking this method
+     */
+    @Override
+    public void createVcsUser(User user) throws VersionControlException {
+        if (user.isInternal()) {
+            // User
+            if (!bitbucketService.userExists(user.getLogin())) {
+                log.debug("Bitbucket user {} does not exist yet", user.getLogin());
+                String displayName = (user.getFirstName() + " " + user.getLastName()).trim();
+                bitbucketService.createUser(user.getLogin(), passwordService.decryptPasswordByLogin(user.getLogin()).get(), user.getEmail(), displayName);
+
+                try {
+                    // NOTE: we need to fetch the user here again to make sure that the groups are not lazy loaded.
+                    user = userRepository.getUserWithGroupsAndAuthorities(user.getLogin());
+                    bitbucketService.addUserToGroups(user.getLogin(), user.getGroups());
+                }
+                catch (BitbucketException e) {
+                    /*
+                     * This might throw exceptions, for example if the group does not exist on Bitbucket. We can safely ignore them.
+                     */
+                }
+            }
+            else {
+                log.debug("Bitbucket user {} already exists", user.getLogin());
+            }
+        }
+    }
+
+    /**
+     * Updates a new user in the VCS based on a local Artemis user. Should be called if Artemis handles user management.
+     * This will change the following:
+     * <ul>
+     *     <li>Update the password of the user</li>
+     *     <li>Update the groups the user belongs to, i.e. removing him from exercises that reference old groups</li>
+     * </ul>
+     *  @param vcsLogin                  The username of the user in the VCS
+     *
+     * @param user                      The updated user in Artemis
+     * @param removedGroups             groups that the user does not belong to any longer
+     * @param addedGroups               The new groups the Artemis user got added to
+     * @param shouldSynchronizePassword whether the password should be synchronized between Artemis and the VcsUserManagementService
+     */
+    @Override
+    public void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, boolean shouldSynchronizePassword) {
+        bitbucketService.updateUser(vcsLogin, user.isInternal() && shouldSynchronizePassword ? passwordService.decryptPassword(user) : null, user.getEmail(), user.getName());
+        if (addedGroups != null && !addedGroups.isEmpty()) {
+            bitbucketService.addUserToGroups(user.getLogin(), addedGroups);
+        }
+        if (removedGroups != null && !removedGroups.isEmpty()) {
+            bitbucketService.removeUserFromGroups(user.getLogin(), removedGroups);
+        }
+    }
+
+    /**
+     * Deletes the user under the specified login from the VCS
+     *
+     * @param login The login of the user that should get deleted
+     */
+    @Override
+    public void deleteVcsUser(String login) throws VersionControlException {
+        bitbucketService.deleteAndEraseUser(login);
+    }
+
+    /**
+     * Activates the VCS user.
+     *
+     * @param login The username of the user in the VCS
+     * @throws VersionControlException if an exception occurred
+     */
+    @Override
+    public void activateUser(String login) throws VersionControlException {
+        // Not supported by Bitbucket
+    }
+
+    /**
+     * Deactivates the VCS user.
+     *
+     * @param login The username of the user in the VCS
+     * @throws VersionControlException if an exception occurred
+     */
+    @Override
+    public void deactivateUser(String login) throws VersionControlException {
+        // Not supported by Bitbucket
+    }
+
+    /**
+     * Updates all exercises in a course based on the new instructors, editors and teaching assistant groups. This entails removing
+     * all users from exercises, that are no longer part of any relevant group and adding all users to exercises in the course
+     * that are part of the updated groups.
+     *
+     * @param updatedCourse             The updated course with the new permissions
+     * @param oldInstructorGroup        The old instructor group name
+     * @param oldEditorGroup            The old editor group name
+     * @param oldTeachingAssistantGroup The old teaching assistant group name
+     */
+    @Override
+    public void updateCoursePermissions(Course updatedCourse, String oldInstructorGroup, String oldEditorGroup, String oldTeachingAssistantGroup) {
+        if (oldInstructorGroup.equals(updatedCourse.getInstructorGroupName()) && oldEditorGroup.equals(updatedCourse.getEditorGroupName())
+                && oldTeachingAssistantGroup.equals(updatedCourse.getTeachingAssistantGroupName())) {
+            // Do nothing if the group names didn't change
+            return;
+        }
+
+        final List<ProgrammingExercise> programmingExercises = programmingExerciseRepository.findAllProgrammingExercisesInCourseOrInExamsOfCourse(updatedCourse);
+        log.info("Update Bitbucket permissions for programming exercises: " + programmingExercises.stream().map(ProgrammingExercise::getProjectKey).toList());
+
+        for (ProgrammingExercise programmingExercise : programmingExercises) {
+            if (!oldInstructorGroup.equals(updatedCourse.getInstructorGroupName())) {
+                bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), oldInstructorGroup, null);
+                bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), updatedCourse.getInstructorGroupName(), BitbucketPermission.PROJECT_ADMIN);
+            }
+            if (!oldEditorGroup.equals(updatedCourse.getEditorGroupName())) {
+                bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), oldEditorGroup, null);
+                bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), updatedCourse.getEditorGroupName(), BitbucketPermission.PROJECT_READ);
+            }
+            ZonedDateTime examEndDate = programmingExercise.getExerciseGroup().getExam().getStartDate()
+                    .plusMinutes(programmingExercise.getExerciseGroup().getExam().getStudentExams().stream().mapToInt(StudentExam::getWorkingTime).max().orElse(0));
+            if (!oldEditorGroup.equals(updatedCourse.getTeachingAssistantGroupName())) {
+                bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), oldEditorGroup, null);
+                if ((!programmingExercise.isExamExercise() || ZonedDateTime.now().isAfter(examEndDate))) {
+                    bitbucketService.grantGroupPermissionToProject(programmingExercise.getProjectKey(), updatedCourse.getEditorGroupName(), BitbucketPermission.PROJECT_READ);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/VersionControlRepositoryPermission.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/VersionControlRepositoryPermission.java
@@ -1,5 +1,5 @@
 package de.tum.in.www1.artemis.service.connectors;
 
 public enum VersionControlRepositoryPermission {
-    READ_ONLY, WRITE
+    REPO_READ, REPO_WRITE
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketAuthorizationInterceptor.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketAuthorizationInterceptor.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.service.connectors.bitbucket;
 
+import static org.springframework.http.HttpMethod.*;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Optional;
@@ -8,7 +10,6 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestExecution;
@@ -50,18 +51,19 @@ public class BitbucketAuthorizationInterceptor implements ClientHttpRequestInter
     }
 
     private static boolean needsBasicAuth(HttpRequest request) {
-        return isCreateProjectRequest(request) || isCreateUserRequest(request) || isAddUserToGroupsRequest(request);
+        return isCreateProjectRequest(request) || isCreateOrEditOrDeleteUserRequest(request) || isAddUserToGroupsRequest(request);
     }
 
     private static boolean isCreateProjectRequest(HttpRequest request) {
-        return request.getURI().toString().endsWith("latest/projects") && HttpMethod.POST.equals(request.getMethod());
+        return request.getURI().toString().endsWith("latest/projects") && POST.equals(request.getMethod());
     }
 
-    private static boolean isCreateUserRequest(HttpRequest request) {
-        return request.getURI().toString().contains("latest/admin/users") && HttpMethod.POST.equals(request.getMethod());
+    private static boolean isCreateOrEditOrDeleteUserRequest(HttpRequest request) {
+        return request.getURI().toString().contains("latest/admin/users")
+                && (POST.equals(request.getMethod()) || PUT.equals(request.getMethod()) || DELETE.equals(request.getMethod()));
     }
 
     private static boolean isAddUserToGroupsRequest(HttpRequest request) {
-        return request.getURI().toString().endsWith("latest/admin/users/add-groups") && HttpMethod.POST.equals(request.getMethod());
+        return request.getURI().toString().endsWith("latest/admin/users/add-groups") && POST.equals(request.getMethod());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
@@ -258,7 +258,7 @@ public class BitbucketService extends AbstractVersionControlService {
         }
         catch (HttpClientErrorException e) {
             if (isUserNotFoundException(e)) {
-                log.warn("Bitbucket user " + username + " does not exist.");
+                log.warn("Bitbucket user {} does not exist.", username);
                 return;
             }
             log.error("Could not update Bitbucket user " + username, e);
@@ -281,17 +281,17 @@ public class BitbucketService extends AbstractVersionControlService {
         passwordBody.put("passwordConfirm", password);
         HttpEntity<Map<String, Object>> passwordEntity = new HttpEntity<>(passwordBody, null);
 
-        log.debug("Updating Bitbucket user password {}", username);
+        log.debug("Updating Bitbucket user password for user {}", username);
 
         try {
             restTemplate.exchange(passwordBuilder.build().encode().toUri(), HttpMethod.PUT, passwordEntity, Void.class);
         }
         catch (HttpClientErrorException e) {
             if (isUserNotFoundException(e)) {
-                log.warn("Bitbucket user " + username + " does not exist.");
+                log.warn("Bitbucket user {} does not exist.", username);
                 return;
             }
-            log.error("Could not update Bitbucket user password for " + username, e);
+            log.error("Could not update Bitbucket user password for user " + username, e);
             throw new BitbucketException("Error while updating user", e);
         }
     }
@@ -312,7 +312,7 @@ public class BitbucketService extends AbstractVersionControlService {
         }
         catch (HttpClientErrorException e) {
             if (isUserNotFoundException(e)) {
-                log.warn("Bitbucket user " + username + " has already been deleted.");
+                log.warn("Bitbucket user {} has already been deleted.", username);
                 return;
             }
             log.error("Could not delete Bitbucket user " + username, e);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
@@ -255,8 +255,16 @@ public class BitbucketService extends AbstractVersionControlService {
             restTemplate.exchange(userDetailsBuilder.build().encode().toUri(), HttpMethod.PUT, userDetailsEntity, Void.class);
         }
         catch (HttpClientErrorException e) {
-            log.error("Could not update Bitbucket user " + username, e);
-            throw new BitbucketException("Error while updating user", e);
+            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+                // TODO: check the error message in this case for something like "No user named 'testuser123' was found" and/or
+                // "exceptionName":"com.atlassian.bitbucket.user.NoSuchUserException"
+                // nothing to do, the Bitbucket user simply does not exist which is ok.
+                log.warn("Could not update Bitbucket user " + username);
+            }
+            else {
+                log.error("Could not update Bitbucket user " + username, e);
+                throw new BitbucketException("Error while updating user", e);
+            }
         }
     }
 
@@ -279,8 +287,16 @@ public class BitbucketService extends AbstractVersionControlService {
             restTemplate.exchange(passwordBuilder.build().encode().toUri(), HttpMethod.PUT, passwordEntity, Void.class);
         }
         catch (HttpClientErrorException e) {
-            log.error("Could not update Bitbucket user " + username, e);
-            throw new BitbucketException("Error while updating user", e);
+            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+                // TODO: check the error message in this case for something like "No user named 'testuser123' was found" and/or
+                // "exceptionName":"com.atlassian.bitbucket.user.NoSuchUserException"
+                // nothing to do, the Bitbucket user simply does not exist which is ok.
+                log.warn("Could not update Bitbucket user password for " + username);
+            }
+            else {
+                log.error("Could not update Bitbucket user password for " + username, e);
+                throw new BitbucketException("Error while updating user", e);
+            }
         }
     }
 
@@ -299,8 +315,17 @@ public class BitbucketService extends AbstractVersionControlService {
             restTemplate.exchange(eraseBuilder.build().encode().toUri(), HttpMethod.POST, null, Void.class);
         }
         catch (HttpClientErrorException e) {
-            log.error("Could not update Bitbucket user " + username, e);
-            throw new BitbucketException("Error while updating user", e);
+
+            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+                // TODO: check the error message in this case for something like "No user named 'testuser123' was found" and/or
+                // "exceptionName":"com.atlassian.bitbucket.user.NoSuchUserException"
+                // nothing to do, the Bitbucket user simply does not exist which is ok.
+                log.warn("Could not delete Bitbucket user " + username);
+            }
+            else {
+                log.error("Could not delete Bitbucket user " + username, e);
+                throw new BitbucketException("Error while updating user", e);
+            }
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
@@ -3,6 +3,7 @@ package de.tum.in.www1.artemis.service.connectors.bitbucket;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,7 +27,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.JsonObject;
 
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.exception.BitbucketException;
@@ -244,24 +244,23 @@ public class BitbucketService extends AbstractVersionControlService {
      */
     public void updateUser(String username, String password, String emailAddress, String displayName) throws BitbucketException {
         UriComponentsBuilder userDetailsBuilder = UriComponentsBuilder.fromHttpUrl(bitbucketServerUrl + "/rest/api/latest/admin/users");
-        JsonObject userDetailsBody = new JsonObject();
-        userDetailsBody.addProperty("name", username);
-        userDetailsBody.addProperty("email", emailAddress);
-        userDetailsBody.addProperty("displayName", displayName);
-        HttpEntity<Object> userDetailsEntity = new HttpEntity<>(userDetailsBody, null);
-
-        UriComponentsBuilder passwordBuilder = UriComponentsBuilder.fromHttpUrl(bitbucketServerUrl + "/rest/api/latest/admin/users/credentials");
-        JsonObject passwordBody = new JsonObject();
-        passwordBody.addProperty("name", username);
-        passwordBody.addProperty("password", password);
-        passwordBody.addProperty("passwordConfirm", password);
-        HttpEntity<JsonObject> passwordEntity = new HttpEntity<>(passwordBody, null);
+        Map<String, Object> userDetailsBody = new HashMap<>();
+        userDetailsBody.put("name", username);
+        userDetailsBody.put("email", emailAddress);
+        userDetailsBody.put("displayName", displayName);
+        HttpEntity<Map<String, Object>> userDetailsEntity = new HttpEntity<>(userDetailsBody, null);
 
         log.debug("Updating Bitbucket user {} ({})", username, emailAddress);
 
         try {
             restTemplate.exchange(userDetailsBuilder.build().encode().toUri(), HttpMethod.PUT, userDetailsEntity, Void.class);
             if (password != null) {
+                UriComponentsBuilder passwordBuilder = UriComponentsBuilder.fromHttpUrl(bitbucketServerUrl + "/rest/api/latest/admin/users/credentials");
+                Map<String, Object> passwordBody = new HashMap<>();
+                passwordBody.put("name", username);
+                passwordBody.put("password", password);
+                passwordBody.put("passwordConfirm", password);
+                HttpEntity<Map<String, Object>> passwordEntity = new HttpEntity<>(passwordBody, null);
                 restTemplate.exchange(passwordBuilder.build().encode().toUri(), HttpMethod.PUT, passwordEntity, Void.class);
             }
         }
@@ -324,11 +323,11 @@ public class BitbucketService extends AbstractVersionControlService {
 
         try {
             for (String group : groups) {
-                JsonObject jsonObject = new JsonObject();
-                jsonObject.addProperty("context", username);
-                jsonObject.addProperty("itemName", group);
+                Map<String, Object> jsonObject = new HashMap<>();
+                jsonObject.put("context", username);
+                jsonObject.put("itemName", group);
 
-                HttpEntity<JsonObject> entity = new HttpEntity<>(jsonObject, null);
+                HttpEntity<Map<String, Object>> entity = new HttpEntity<>(jsonObject, null);
                 UriComponentsBuilder userDetailsBuilder = UriComponentsBuilder.fromHttpUrl(bitbucketServerUrl + "/rest/api/latest/admin/users/remove-group")
                         .queryParam("context", username).queryParam("itemName", group);
                 restTemplate.exchange(userDetailsBuilder.build().toUri(), HttpMethod.POST, entity, Void.class);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
@@ -403,7 +403,7 @@ public class BitbucketService extends AbstractVersionControlService {
 
     @Override
     public void setRepositoryPermissionsToReadOnly(VcsRepositoryUrl repositoryUrl, String projectKey, Set<User> users) throws BitbucketException {
-        users.forEach(user -> setStudentRepositoryPermission(repositoryUrl, projectKey, user.getLogin(), VersionControlRepositoryPermission.READ_ONLY));
+        users.forEach(user -> setStudentRepositoryPermission(repositoryUrl, projectKey, user.getLogin(), VersionControlRepositoryPermission.REPO_READ));
     }
 
     /**
@@ -471,10 +471,9 @@ public class BitbucketService extends AbstractVersionControlService {
      */
     private void setStudentRepositoryPermission(VcsRepositoryUrl repositoryUrl, String projectKey, String username, VersionControlRepositoryPermission repositoryPermission)
             throws BitbucketException {
-        String permissionString = repositoryPermission == VersionControlRepositoryPermission.READ_ONLY ? "READ" : "WRITE";
         String repositorySlug = getRepositoryName(repositoryUrl);
         String baseUrl = bitbucketServerUrl + "/rest/api/latest/projects/" + projectKey + "/repos/" + repositorySlug + "/permissions/users?name="; // NAME&PERMISSION
-        String url = baseUrl + username + "&permission=REPO_" + permissionString;
+        String url = baseUrl + username + "&permission=" + repositoryPermission;
         try {
             restTemplate.exchange(url, HttpMethod.PUT, null, Void.class);
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
@@ -365,6 +365,11 @@ public class BitbucketService extends AbstractVersionControlService {
             }
         }
         catch (HttpClientErrorException e) {
+            if (HttpStatus.NOT_FOUND.equals(e.getStatusCode())) {
+                log.warn("Could not remove Bitbucket user {} from groups {}. Either the user or the groups were not found or the user is not assigned to a group.", username,
+                        groups);
+                return;
+            }
             log.error("Could not remove Bitbucket user " + username + " from groups" + groups, e);
             throw new BitbucketException("Error while removing Bitbucket user from groups");
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
@@ -236,7 +236,7 @@ public class BitbucketService extends AbstractVersionControlService {
     }
 
     /**
-     * Updates an user on Bitbucket
+     * Updates a user on Bitbucket
      *
      * @param username     The username of the user
      * @param emailAddress The new email address
@@ -297,7 +297,7 @@ public class BitbucketService extends AbstractVersionControlService {
     }
 
     /**
-     * Deletes an user from Bitbucket. It also updates all previous occurrences of the username to a non-identifying username.
+     * Deletes a user from Bitbucket. It also updates all previous occurrences of the username to a non-identifying username.
      *
      * @param username The user to delete
      */

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bitbucket/BitbucketService.java
@@ -269,6 +269,8 @@ public class BitbucketService extends AbstractVersionControlService {
     }
 
     /**
+     * Updates the password of a user on Bitbucket
+     *
      * @param username The username of the user to update
      * @param password The new password
      * @throws BitbucketException

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabService.java
@@ -78,14 +78,11 @@ public class GitLabService extends AbstractVersionControlService {
         for (User user : users) {
             String username = user.getLogin();
 
-            // TODO: does it really make sense to potentially create a user here? Should we not rather create this user when the user is created in the internal Artemis database?
-
-            // Automatically created users
-            if ((userPrefixEdx.isPresent() && username.startsWith(userPrefixEdx.get())) || (userPrefixU4I.isPresent() && username.startsWith((userPrefixU4I.get())))) {
-                if (!userExists(username)) {
-                    gitLabUserManagementService.createUser(user);
-                }
+            // This is a failsafe in case a user was not created in VCS on registration
+            if (!userExists(username)) {
+                throw new GitLabException("The user was not created in GitLab and has to be manually added.");
             }
+
             if (allowAccess && !Boolean.FALSE.equals(exercise.isAllowOfflineIde())) {
                 // only add access to the repository if the offline IDE usage is NOT explicitly disallowed
                 // NOTE: null values are interpreted as offline IDE is allowed

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/jobs/JenkinsJobService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/jobs/JenkinsJobService.java
@@ -198,7 +198,7 @@ public class JenkinsJobService {
     }
 
     /**
-     * Updates the xml desription of the folder job.
+     * Updates the xml description of the folder job.
      *
      * @param folderName the name of the folder
      * @param folderConfig the xml document of the folder

--- a/src/main/java/de/tum/in/www1/artemis/service/dto/UserDTO.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/dto/UserDTO.java
@@ -53,6 +53,8 @@ public class UserDTO extends AuditingEntityDTO {
     @Size(min = 2, max = 6)
     private String langKey;
 
+    private boolean isInternal;
+
     private ZonedDateTime lastNotificationRead;
 
     private Set<String> authorities = new HashSet<>();
@@ -69,13 +71,13 @@ public class UserDTO extends AuditingEntityDTO {
 
     public UserDTO(User user) {
         this(user.getId(), user.getLogin(), user.getName(), user.getFirstName(), user.getLastName(), user.getEmail(), user.getVisibleRegistrationNumber(), user.getActivated(),
-                user.getImageUrl(), user.getLangKey(), user.getCreatedBy(), user.getCreatedDate(), user.getLastModifiedBy(), user.getLastModifiedDate(),
+                user.getImageUrl(), user.getLangKey(), user.isInternal(), user.getCreatedBy(), user.getCreatedDate(), user.getLastModifiedBy(), user.getLastModifiedDate(),
                 user.getLastNotificationRead(), user.getAuthorities(), user.getGroups(), user.getGuidedTourSettings(), user.getOrganizations());
     }
 
     public UserDTO(Long id, String login, String name, String firstName, String lastName, String email, String visibleRegistrationNumber, boolean activated, String imageUrl,
-            String langKey, String createdBy, Instant createdDate, String lastModifiedBy, Instant lastModifiedDate, ZonedDateTime lastNotificationRead, Set<Authority> authorities,
-            Set<String> groups, Set<GuidedTourSetting> guidedTourSettings, Set<Organization> organizations) {
+            String langKey, boolean isInternal, String createdBy, Instant createdDate, String lastModifiedBy, Instant lastModifiedDate, ZonedDateTime lastNotificationRead,
+            Set<Authority> authorities, Set<String> groups, Set<GuidedTourSetting> guidedTourSettings, Set<Organization> organizations) {
 
         this.id = id;
         this.login = login;
@@ -87,6 +89,7 @@ public class UserDTO extends AuditingEntityDTO {
         this.activated = activated;
         this.imageUrl = imageUrl;
         this.langKey = langKey;
+        this.isInternal = isInternal;
         this.setCreatedBy(createdBy);
         this.setCreatedDate(createdDate);
         this.setLastModifiedBy(lastModifiedBy);
@@ -226,5 +229,13 @@ public class UserDTO extends AuditingEntityDTO {
                 + imageUrl + '\'' + ", activated=" + activated + ", langKey='" + langKey + '\'' + ", createdBy=" + getCreatedBy() + ", createdDate=" + getCreatedDate()
                 + ", lastModifiedBy='" + getLastModifiedBy() + '\'' + ", lastModifiedDate=" + getLastModifiedDate() + ", lastNotificationRead=" + lastNotificationRead
                 + ", authorities=" + authorities + "}";
+    }
+
+    public boolean isInternal() {
+        return isInternal;
+    }
+
+    public void setInternal(boolean internal) {
+        isInternal = internal;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
@@ -245,10 +245,9 @@ public class UserCreationService {
         Set<Authority> managedAuthorities = user.getAuthorities();
         managedAuthorities.clear();
         updatedUserDTO.getAuthorities().stream().map(authorityRepository::findById).filter(Optional::isPresent).map(Optional::get).forEach(managedAuthorities::add);
-        user = saveUser(user);
-
         log.debug("Changed Information for User: {}", user);
-        return user;
+
+        return saveUser(user);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AccountResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AccountResource.java
@@ -191,8 +191,9 @@ public class AccountResource {
      */
     @PostMapping(path = "/account/change-password")
     public void changePassword(@RequestBody PasswordChangeDTO passwordChangeDto) {
-        if (isRegistrationDisabled() && isSAML2Disabled()) {
-            throw new AccessForbiddenException("User Registration is disabled");
+        User user = userRepository.getUser();
+        if (!user.isInternal()) {
+            throw new AccessForbiddenException("Only users with internally saved credentials can change their password.");
         }
         if (isPasswordLengthInvalid(passwordChangeDto.getNewPassword())) {
             throw new InvalidPasswordException();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AccountResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AccountResource.java
@@ -53,8 +53,6 @@ public class AccountResource {
 
     private final UserCreationService userCreationService;
 
-    private final PasswordService passwordService;
-
     private final MailService mailService;
 
     public AccountResource(UserRepository userRepository, UserService userService, UserCreationService userCreationService, MailService mailService,
@@ -63,7 +61,6 @@ public class AccountResource {
         this.userService = userService;
         this.userCreationService = userCreationService;
         this.mailService = mailService;
-        this.passwordService = passwordService;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -1025,17 +1025,15 @@ public class CourseResource {
      */
     @NotNull
     public ResponseEntity<Void> removeUserFromCourseGroup(String userLogin, User instructorOrAdmin, Course course, String group, Role role) {
-        if (authCheckService.isAtLeastInstructorInCourse(course, instructorOrAdmin)) {
-            Optional<User> userToRemoveFromGroup = userRepository.findOneWithGroupsAndAuthoritiesByLogin(userLogin);
-            if (userToRemoveFromGroup.isEmpty()) {
-                throw new EntityNotFoundException("User", userLogin);
-            }
-            courseService.removeUserFromGroup(userToRemoveFromGroup.get(), group, role);
-            return ResponseEntity.ok().body(null);
-        }
-        else {
+        if (!authCheckService.isAtLeastInstructorInCourse(course, instructorOrAdmin)) {
             throw new AccessForbiddenException();
         }
+        Optional<User> userToRemoveFromGroup = userRepository.findOneWithGroupsAndAuthoritiesByLogin(userLogin);
+        if (userToRemoveFromGroup.isEmpty()) {
+            throw new EntityNotFoundException("User", userLogin);
+        }
+        courseService.removeUserFromGroup(userToRemoveFromGroup.get(), group, role);
+        return ResponseEntity.ok().body(null);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
@@ -187,7 +187,7 @@ public class UserResource {
         final var oldUserLogin = existingUser.getLogin();
         final var oldGroups = existingUser.getGroups();
         var updatedUser = userCreationService.updateInternalUser(existingUser, managedUserVM);
-        userService.updateUserInConnectorsAndAuthProvider(existingUser, oldUserLogin, oldGroups);
+        userService.updateUserInConnectorsAndAuthProvider(updatedUser, oldUserLogin, oldGroups);
 
         if (shouldActivateUser) {
             userService.activateUser(updatedUser);

--- a/src/main/webapp/app/account/password/password.component.ts
+++ b/src/main/webapp/app/account/password/password.component.ts
@@ -29,15 +29,9 @@ export class PasswordComponent implements OnInit {
     constructor(private passwordService: PasswordService, private accountService: AccountService, private profileService: ProfileService, private fb: FormBuilder) {}
 
     ngOnInit() {
-        this.profileService.getProfileInfo().subscribe((profileInfo) => {
-            if (profileInfo) {
-                this.passwordResetEnabled = profileInfo.registrationEnabled || false;
-                this.passwordResetEnabled ||= profileInfo.saml2?.enablePassword || false;
-            }
-        });
-
         this.accountService.identity().then((user) => {
             this.user = user;
+            this.passwordResetEnabled = user?.internal || false;
         });
     }
 

--- a/src/main/webapp/app/core/user/account.model.ts
+++ b/src/main/webapp/app/core/user/account.model.ts
@@ -6,7 +6,7 @@ export class Account {
     public login?: string;
     public email?: string;
     public name?: string;
-    public isInternal: boolean;
+    public internal: boolean;
     public firstName?: string;
     public lastName?: string;
     public langKey?: string;

--- a/src/main/webapp/app/core/user/account.model.ts
+++ b/src/main/webapp/app/core/user/account.model.ts
@@ -6,6 +6,7 @@ export class Account {
     public login?: string;
     public email?: string;
     public name?: string;
+    public isInternal: boolean;
     public firstName?: string;
     public lastName?: string;
     public langKey?: string;

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -144,7 +144,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
             .pipe(
                 tap((user: User) => {
                     this.currAccount = user;
-                    this.passwordResetEnabled = user.isInternal;
+                    this.passwordResetEnabled = user.internal;
                 }),
             )
             .subscribe();

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -133,8 +133,6 @@ export class NavbarComponent implements OnInit, OnDestroy {
             if (profileInfo) {
                 this.inProduction = profileInfo.inProduction;
                 this.openApiEnabled = profileInfo.openApiEnabled;
-                this.isRegistrationEnabled = profileInfo.registrationEnabled || false;
-                this.passwordResetEnabled = this.isRegistrationEnabled || profileInfo.saml2?.enablePassword || false;
             }
         });
 
@@ -143,7 +141,12 @@ export class NavbarComponent implements OnInit, OnDestroy {
         // The current user is needed to hide menu items for not logged in users.
         this.authStateSubscription = this.accountService
             .getAuthenticationState()
-            .pipe(tap((user: User) => (this.currAccount = user)))
+            .pipe(
+                tap((user: User) => {
+                    this.currAccount = user;
+                    this.passwordResetEnabled = user.isInternal;
+                }),
+            )
             .subscribe();
 
         this.examParticipationService.currentlyLoadedStudentExam.subscribe((studentExam) => {

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -144,7 +144,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
             .pipe(
                 tap((user: User) => {
                     this.currAccount = user;
-                    this.passwordResetEnabled = user.internal;
+                    this.passwordResetEnabled = user?.internal || false;
                 }),
             )
             .subscribe();

--- a/src/test/cypress/integration/CourseManagement.spec.ts
+++ b/src/test/cypress/integration/CourseManagement.spec.ts
@@ -1,6 +1,6 @@
 import { Interception } from 'cypress/types/net-stubbing';
-import { COURSE_BASE } from './../support/requests/CourseManagementRequests';
-import { GET, BASE_API, POST } from './../support/constants';
+import { COURSE_BASE } from '../support/requests/CourseManagementRequests';
+import { GET, BASE_API, POST } from '../support/constants';
 import { artemis } from '../support/ArtemisTesting';
 import { CourseManagementPage } from '../support/pageobjects/course/CourseManagementPage';
 import { NavigationBar } from '../support/pageobjects/NavigationBar';

--- a/src/test/cypress/integration/exam/ExamAssessment.spec.ts
+++ b/src/test/cypress/integration/exam/ExamAssessment.spec.ts
@@ -9,7 +9,6 @@ import dayjs, { Dayjs } from 'dayjs/esm';
 import textSubmission from '../../fixtures/text_exercise_submission/text_exercise_submission.json';
 import multipleChoiceQuizTemplate from '../../fixtures/quiz_exercise_fixtures/multipleChoiceQuiz_template.json';
 import { makeSubmissionAndVerifyResults } from '../../support/pageobjects/exercises/programming/OnlineEditorPage';
-import { Interception } from 'cypress/types/net-stubbing';
 
 // requests
 const courseManagementRequests = artemis.requests.courseManagement;

--- a/src/test/cypress/support/index.ts
+++ b/src/test/cypress/support/index.ts
@@ -48,4 +48,12 @@ Cypress.on('window:before:load', (win) => {
 Cypress.on('window:before:load', (win) => {
     delete win.navigator.__proto__.serviceWorker;
 });
+
+/**
+ * On development environments (i.e. local environments) sentry is disabled and produces error messages in the console that cause cypress to fail.
+ * This call tells cypress to ignore errors related to sentry
+ */
+Cypress.on('uncaught:exception', (err, runnable) => {
+    return err.name === 'TypeError' && err?.stack?.includes('sentry');
+});
 /*eslint-enable */

--- a/src/test/cypress/support/pageobjects/exam/ExamCreationPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamCreationPage.ts
@@ -97,6 +97,8 @@ export class ExamCreationPage {
     }
 
     private enterDate(selector: string, date: dayjs.Dayjs) {
-        cy.get(selector).find('#date-input-field').clear().type(dayjsToString(date), { force: true });
+        const dateInputField = cy.get(selector).find('#date-input-field');
+        dateInputField.should('not.be.disabled');
+        dateInputField.clear().type(dayjsToString(date), { force: true });
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
@@ -515,8 +515,8 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
     }
 
     @Override
-    public void mockConfigureRepository(ProgrammingExercise exercise, String participantIdentifier, Set<User> students, boolean ltiUserExists) throws Exception {
-        bitbucketRequestMockProvider.mockConfigureRepository(exercise, participantIdentifier, students, ltiUserExists);
+    public void mockConfigureRepository(ProgrammingExercise exercise, String participantIdentifier, Set<User> students, boolean userExists) throws Exception {
+        bitbucketRequestMockProvider.mockConfigureRepository(exercise, participantIdentifier, students, userExists);
     }
 
     @Override

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
@@ -411,6 +411,9 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
     public void mockDeleteUserInUserManagement(User user, boolean userExistsInUserManagement, boolean failInVcs, boolean failInCi) {
         // User management and CI not needed here
         bitbucketRequestMockProvider.mockDeleteUser(user.getLogin(), failInVcs);
+        if (!failInVcs) {
+            bitbucketRequestMockProvider.mockEraseDeletedUser(user.getLogin());
+        }
     }
 
     @Override

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
@@ -389,7 +389,7 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
     public void mockUpdateUserInUserManagement(String oldLogin, User user, Set<String> oldGroups) throws JsonProcessingException {
         var managedUserVM = new ManagedUserVM(user);
         jiraRequestMockProvider.mockIsGroupAvailableForMultiple(managedUserVM.getGroups());
-        jiraRequestMockProvider.mockRemoveUserFromGroup(oldGroups, managedUserVM.getLogin(), false);
+        jiraRequestMockProvider.mockRemoveUserFromGroup(oldGroups, managedUserVM.getLogin(), false, true);
         jiraRequestMockProvider.mockAddUserToGroupForMultipleGroups(managedUserVM.getGroups());
 
         bitbucketRequestMockProvider.mockUpdateUserDetails(oldLogin, user.getEmail(), user.getFirstName() + " " + user.getLastName());
@@ -461,7 +461,7 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
 
     @Override
     public void mockRemoveUserFromGroup(User user, String group, boolean failInCi) {
-        jiraRequestMockProvider.mockRemoveUserFromGroup(Set.of(group), user.getLogin(), failInCi);
+        jiraRequestMockProvider.mockRemoveUserFromGroup(Set.of(group), user.getLogin(), failInCi, true);
     }
 
     @Override

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
@@ -1,10 +1,11 @@
 package de.tum.in.www1.artemis;
 
 import static de.tum.in.www1.artemis.config.Constants.*;
-import static de.tum.in.www1.artemis.domain.enumeration.BuildPlanType.*;
+import static de.tum.in.www1.artemis.domain.enumeration.BuildPlanType.SOLUTION;
+import static de.tum.in.www1.artemis.domain.enumeration.BuildPlanType.TEMPLATE;
 import static de.tum.in.www1.artemis.util.TestConstants.COMMIT_HASH_OBJECT_ID;
 import static org.mockito.Mockito.*;
-import static tech.jhipster.config.JHipsterConstants.*;
+import static tech.jhipster.config.JHipsterConstants.SPRING_PROFILE_TEST;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -38,7 +39,10 @@ import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentPar
 import de.tum.in.www1.artemis.service.TimeService;
 import de.tum.in.www1.artemis.service.connectors.BitbucketBambooUpdateService;
 import de.tum.in.www1.artemis.service.connectors.bamboo.BambooService;
-import de.tum.in.www1.artemis.service.connectors.bamboo.dto.*;
+import de.tum.in.www1.artemis.service.connectors.bamboo.dto.BambooBuildPlanDTO;
+import de.tum.in.www1.artemis.service.connectors.bamboo.dto.BambooBuildResultDTO;
+import de.tum.in.www1.artemis.service.connectors.bamboo.dto.BambooRepositoryDTO;
+import de.tum.in.www1.artemis.service.connectors.bamboo.dto.BambooTriggerDTO;
 import de.tum.in.www1.artemis.service.connectors.bitbucket.BitbucketService;
 import de.tum.in.www1.artemis.service.connectors.bitbucket.dto.BitbucketRepositoryDTO;
 import de.tum.in.www1.artemis.service.ldap.LdapUserService;
@@ -382,15 +386,17 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
     }
 
     @Override
-    public void mockUpdateUserInUserManagement(String oldLogin, User user, Set<String> oldGroups) throws URISyntaxException {
+    public void mockUpdateUserInUserManagement(String oldLogin, User user, Set<String> oldGroups) throws JsonProcessingException {
         var managedUserVM = new ManagedUserVM(user);
         jiraRequestMockProvider.mockIsGroupAvailableForMultiple(managedUserVM.getGroups());
         jiraRequestMockProvider.mockRemoveUserFromGroup(oldGroups, managedUserVM.getLogin(), false);
         jiraRequestMockProvider.mockAddUserToGroupForMultipleGroups(managedUserVM.getGroups());
+
+        bitbucketRequestMockProvider.mockUpdateUserDetails(oldLogin, user.getEmail(), user.getFirstName() + " " + user.getLastName());
     }
 
     @Override
-    public void mockCreateUserInUserManagement(User user, boolean userExistsInCi) throws URISyntaxException {
+    public void mockCreateUserInUserManagement(User user, boolean userExistsInCi) {
         var managedUserVM = new ManagedUserVM(user);
         jiraRequestMockProvider.mockIsGroupAvailableForMultiple(managedUserVM.getGroups());
         jiraRequestMockProvider.mockAddUserToGroupForMultipleGroups(managedUserVM.getGroups());
@@ -403,7 +409,8 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
 
     @Override
     public void mockDeleteUserInUserManagement(User user, boolean userExistsInUserManagement, boolean failInVcs, boolean failInCi) {
-        // Not needed here
+        // User management and CI not needed here
+        bitbucketRequestMockProvider.mockDeleteUser(user.getLogin(), failInVcs);
     }
 
     @Override

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationJenkinsGitlabTest.java
@@ -431,8 +431,8 @@ public abstract class AbstractSpringIntegrationJenkinsGitlabTest extends Abstrac
     }
 
     @Override
-    public void mockConfigureRepository(ProgrammingExercise exercise, String participantIdentifier, Set<User> students, boolean ltiUserExists) throws Exception {
-        gitlabRequestMockProvider.mockConfigureRepository(exercise, participantIdentifier, students, ltiUserExists);
+    public void mockConfigureRepository(ProgrammingExercise exercise, String participantIdentifier, Set<User> students, boolean userExists) throws Exception {
+        gitlabRequestMockProvider.mockConfigureRepository(exercise, participantIdentifier, students, userExists);
     }
 
     @Override

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationJenkinsGitlabTest.java
@@ -301,7 +301,7 @@ public abstract class AbstractSpringIntegrationJenkinsGitlabTest extends Abstrac
     }
 
     @Override
-    public void mockUpdateUserInUserManagement(String oldLogin, User user, Set<String> oldGroups) throws Exception {
+    public void mockUpdateUserInUserManagement(String oldLogin, User user, String password, Set<String> oldGroups) throws Exception {
         jenkinsRequestMockProvider.mockUpdateUserAndGroups(oldLogin, user, user.getGroups(), oldGroups, true);
         gitlabRequestMockProvider.mockUpdateVcsUser(oldLogin, user, oldGroups, user.getGroups(), true);
     }

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationJenkinsGitlabTest.java
@@ -320,7 +320,7 @@ public abstract class AbstractSpringIntegrationJenkinsGitlabTest extends Abstrac
 
     @Override
     public void mockDeleteUserInUserManagement(User user, boolean userExistsInUserManagement, boolean failInVcs, boolean failInCi) throws Exception {
-        gitlabRequestMockProvider.mockDeleteVcsUser(user.getLogin(), failInVcs);
+        gitlabRequestMockProvider.mockDeleteVcsUser(user.getLogin(), userExistsInUserManagement, failInVcs);
         jenkinsRequestMockProvider.mockDeleteUser(user, userExistsInUserManagement, failInCi);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
@@ -454,6 +454,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         assertThat(resetKey).isNotEqualTo(resetKeyBefore);
 
         // finish password reset
+        String newPassword = getValidPassword();
         KeyAndPasswordVM finishResetData = new KeyAndPasswordVM();
         finishResetData.setKey(resetKey);
         finishResetData.setNewPassword(newPassword);

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
@@ -332,57 +332,23 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
 
     @Test
     @WithMockUser(username = "authenticateduser")
-    public void changePasswordRegistrationDisabled() throws Throwable {
-        testWithRegistrationDisabled(() -> {
-            // create user in repo
-            User user = ModelFactory.generateActivatedUser("authenticateduser");
-            bitbucketRequestMockProvider.mockUserExists("authenticateduser");
-            User createdUser = userCreationService.createUser(new ManagedUserVM(user));
-            // Password Data
-            String updatedPassword = "12345678password-reset-init.component.spec.ts";
+    public void changePasswordExternalUser() throws Throwable {
+        String newPassword = getValidPassword();
+        // create user in repo
+        User user = ModelFactory.generateActivatedUser("authenticateduser");
+        bitbucketRequestMockProvider.mockUserExists("authenticateduser");
+        bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), user.getName());
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword, true);
+        User createdUser = userCreationService.createUser(new ManagedUserVM(user));
+        createdUser.setInternal(false);
+        userRepository.save(createdUser);
 
-            PasswordChangeDTO pwChange = new PasswordChangeDTO(passwordService.decryptPassword(createdUser.getPassword()), updatedPassword);
-            // make request
-            request.postWithoutLocation("/api/account/change-password", pwChange, HttpStatus.FORBIDDEN, null);
-        });
-    }
+        // Password Data
+        String updatedPassword = "12345678password-reset-init.component.spec.ts";
 
-    @Test
-    @WithMockUser(username = "authenticateduser")
-    public void changePasswordSaml2Disabled() throws Throwable {
-        testWithRegistrationDisabled(() -> {
-            ConfigUtil.testWithChangedConfig(accountResource, "saml2EnablePassword", Optional.of(Boolean.FALSE), () -> {
-                // create user in repo
-                User user = ModelFactory.generateActivatedUser("authenticateduser");
-                bitbucketRequestMockProvider.mockUserExists("authenticateduser");
-                User createdUser = userCreationService.createUser(new ManagedUserVM(user));
-                // Password Data
-                String updatedPassword = "12345678password-reset-init.component.spec.ts";
-
-                PasswordChangeDTO pwChange = new PasswordChangeDTO(passwordService.decryptPassword(createdUser.getPassword()), updatedPassword);
-                // make request
-                request.postWithoutLocation("/api/account/change-password", pwChange, HttpStatus.FORBIDDEN, null);
-            });
-        });
-    }
-
-    @Test
-    @WithMockUser(username = "authenticateduser")
-    public void changePasswordSaml2ConfigEmpty() throws Throwable {
-        testWithRegistrationDisabled(() -> {
-            ConfigUtil.testWithChangedConfig(accountResource, "saml2EnablePassword", Optional.empty(), () -> {
-                // create user in repo
-                User user = ModelFactory.generateActivatedUser("authenticateduser");
-                bitbucketRequestMockProvider.mockUserExists("authenticateduser");
-                User createdUser = userCreationService.createUser(new ManagedUserVM(user));
-                // Password Data
-                String updatedPassword = "12345678password-reset-init.component.spec.ts";
-
-                PasswordChangeDTO pwChange = new PasswordChangeDTO(passwordService.decryptPassword(createdUser.getPassword()), updatedPassword);
-                // make request
-                request.postWithoutLocation("/api/account/change-password", pwChange, HttpStatus.FORBIDDEN, null);
-            });
-        });
+        PasswordChangeDTO pwChange = new PasswordChangeDTO(passwordService.decryptPassword(createdUser.getPassword()), updatedPassword);
+        // make request
+        request.postWithoutLocation("/api/account/change-password", pwChange, HttpStatus.FORBIDDEN, null);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
@@ -412,10 +412,6 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         assertThat(userBefore).isPresent();
         String resetKeyBefore = userBefore.get().getResetKey();
 
-        // init password reset
-        // no helper method from request can be used since the String needs to be transferred unaltered; The helpers would add quotes around it
-        // previous, faulty call:
-        // request.postWithoutLocation("/api/account/reset-password/init", createdUser.getEmail(), HttpStatus.OK, null);
         var req = MockMvcRequestBuilders.post(new URI("/api/account/reset-password/init")).contentType(MediaType.APPLICATION_JSON).content(createdUser.getEmail());
         request.getMvc().perform(req).andExpect(status().is(HttpStatus.OK.value())).andReturn();
         ReflectionTestUtils.invokeMethod(request, "restoreSecurityContext");
@@ -425,18 +421,18 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
 
     @Test
     public void passwordResetByUsername() throws Exception {
+        String newPassword = getValidPassword();
         // create user in repo
         User user = ModelFactory.generateActivatedUser("authenticateduser");
+        bitbucketRequestMockProvider.mockUserExists("authenticateduser");
+        bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), user.getName());
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword, true);
         User createdUser = userCreationService.createUser(new ManagedUserVM(user));
 
         Optional<User> userBefore = userRepository.findOneByEmailIgnoreCase(createdUser.getEmail());
         assertThat(userBefore).isPresent();
         String resetKeyBefore = userBefore.get().getResetKey();
 
-        // init password reset
-        // no helper method from request can be used since the String needs to be transferred unaltered; The helpers would add quotes around it
-        // previous, faulty call:
-        // request.postWithoutLocation("/api/account/reset-password/init", createdUser.getEmail(), HttpStatus.OK, null);
         var req = MockMvcRequestBuilders.post(new URI("/api/account/reset-password/init")).contentType(MediaType.APPLICATION_JSON).content(createdUser.getLogin());
         request.getMvc().perform(req).andExpect(status().is(HttpStatus.OK.value())).andReturn();
         ReflectionTestUtils.invokeMethod(request, "restoreSecurityContext");

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
@@ -259,7 +259,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         User user = ModelFactory.generateActivatedUser("authenticateduser");
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), updatedFirstName + " " + user.getLastName());
-        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), ModelFactory.USER_PASSWORD, true);
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), ModelFactory.USER_PASSWORD, true, true);
         User createdUser = userCreationService.createUser(new ManagedUserVM(user, user.getPassword()));
 
         // update FirstName
@@ -317,7 +317,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         User user = ModelFactory.generateActivatedUser("authenticateduser");
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), user.getName());
-        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), updatedPassword, true);
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), updatedPassword, true, true);
         User createdUser = userCreationService.createUser(new ManagedUserVM(user));
 
         PasswordChangeDTO pwChange = new PasswordChangeDTO(passwordService.decryptPassword(createdUser.getPassword()), updatedPassword);
@@ -338,7 +338,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         User user = ModelFactory.generateActivatedUser("authenticateduser");
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), user.getName());
-        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword, true);
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword, true, true);
         User createdUser = userCreationService.createUser(new ManagedUserVM(user));
         createdUser.setInternal(false);
         userRepository.save(createdUser);
@@ -371,7 +371,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         User user = ModelFactory.generateActivatedUser("authenticateduser");
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), user.getName());
-        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword, true);
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword, true, true);
         User createdUser = userCreationService.createUser(new ManagedUserVM(user));
 
         Optional<User> userBefore = userRepository.findOneByEmailIgnoreCase(createdUser.getEmail());
@@ -392,7 +392,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         User user = ModelFactory.generateActivatedUser("authenticateduser");
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), user.getName());
-        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword, true);
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword, true, true);
         User createdUser = userCreationService.createUser(new ManagedUserVM(user));
 
         Optional<User> userBefore = userRepository.findOneByEmailIgnoreCase(createdUser.getEmail());

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
@@ -21,7 +21,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 
 import de.tum.in.www1.artemis.config.Constants;
-import de.tum.in.www1.artemis.connector.BitbucketRequestMockProvider;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.dto.PasswordChangeDTO;
@@ -50,9 +49,6 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
 
     @Autowired
     private PasswordService passwordService;
-
-    @Autowired
-    private BitbucketRequestMockProvider bitbucketRequestMockProvider;
 
     @BeforeEach
     public void setup() {
@@ -263,7 +259,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         User user = ModelFactory.generateActivatedUser("authenticateduser");
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), updatedFirstName + " " + user.getLastName());
-        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), ModelFactory.USER_PASSWORD);
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), ModelFactory.USER_PASSWORD, true);
         User createdUser = userCreationService.createUser(new ManagedUserVM(user, user.getPassword()));
 
         // update FirstName
@@ -321,7 +317,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         User user = ModelFactory.generateActivatedUser("authenticateduser");
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), user.getName());
-        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), updatedPassword);
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), updatedPassword, true);
         User createdUser = userCreationService.createUser(new ManagedUserVM(user));
 
         PasswordChangeDTO pwChange = new PasswordChangeDTO(passwordService.decryptPassword(createdUser.getPassword()), updatedPassword);
@@ -409,7 +405,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         User user = ModelFactory.generateActivatedUser("authenticateduser");
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), user.getName());
-        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword);
+        bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), newPassword, true);
         User createdUser = userCreationService.createUser(new ManagedUserVM(user));
 
         Optional<User> userBefore = userRepository.findOneByEmailIgnoreCase(createdUser.getEmail());

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceWithGitLabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceWithGitLabIntegrationTest.java
@@ -68,7 +68,7 @@ public class AccountResourceWithGitLabIntegrationTest extends AbstractSpringInte
         userVM.setPassword("password");
 
         // Simulate failure to delete GitLab user, this should not keep Artemis from creating a new user
-        gitlabRequestMockProvider.mockDeleteVcsUser(user.getLogin(), true);
+        gitlabRequestMockProvider.mockDeleteVcsUser(user.getLogin(), true, true);
 
         // Simulate creation of GitLab user
         gitlabRequestMockProvider.mockCreateVcsUser(user, false);

--- a/src/test/java/de/tum/in/www1/artemis/CourseBitbucketBambooJiraIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/CourseBitbucketBambooJiraIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.repository.CourseRepository;
+import de.tum.in.www1.artemis.service.connectors.bitbucket.BitbucketPermission;
 import de.tum.in.www1.artemis.util.CourseTestService;
 import de.tum.in.www1.artemis.util.ModelFactory;
 
@@ -144,6 +145,12 @@ public class CourseBitbucketBambooJiraIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void testUpdateCourseGroups() throws Exception {
+        bitbucketRequestMockProvider.mockRevokeGroupPermissionFromAnyProject("instructor");
+        bitbucketRequestMockProvider.mockGrantGroupPermissionToAnyProject("new-instructor-group", BitbucketPermission.PROJECT_ADMIN);
+        bitbucketRequestMockProvider.mockRevokeGroupPermissionFromAnyProject("editor");
+        bitbucketRequestMockProvider.mockGrantGroupPermissionToAnyProject("new-editor-group", BitbucketPermission.PROJECT_WRITE);
+        bitbucketRequestMockProvider.mockRevokeGroupPermissionFromAnyProject("tutor");
+        bitbucketRequestMockProvider.mockGrantGroupPermissionToAnyProject("new-ta-group", BitbucketPermission.PROJECT_READ);
         courseTestService.testUpdateCourseGroups();
     }
 
@@ -306,6 +313,8 @@ public class CourseBitbucketBambooJiraIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = "ab12cde")
     public void testRegisterForCourse() throws Exception {
+        bitbucketRequestMockProvider.mockUpdateUserDetails("ab12cde", "ab12cde@test.de", "ab12cdeFirst ab12cdeLast");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
         courseTestService.testRegisterForCourse();
     }
 
@@ -318,6 +327,12 @@ public class CourseBitbucketBambooJiraIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testAddTutorAndInstructorToCourse_failsToAddUserToGroup() throws Exception {
+        bitbucketRequestMockProvider.mockUpdateUserDetails("tutor1", "tutor1@test.de", "tutor1First tutor1Last");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
+        bitbucketRequestMockProvider.mockUpdateUserDetails("editor1", "editor1@test.de", "editor1First editor1Last");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
+        bitbucketRequestMockProvider.mockUpdateUserDetails("instructor1", "instructor1@test.de", "instructor1First instructor1Last");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
         courseTestService.testAddTutorAndEditorAndInstructorToCourse_failsToAddUserToGroup(HttpStatus.OK);
     }
 
@@ -365,6 +380,14 @@ public class CourseBitbucketBambooJiraIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testAddStudentOrTutorOrEditorOrInstructorToCourse() throws Exception {
+        bitbucketRequestMockProvider.mockUpdateUserDetails("student1", "student1@test.de", "student1First student1Last");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
+        bitbucketRequestMockProvider.mockUpdateUserDetails("tutor1", "tutor1@test.de", "tutor1First tutor1Last");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
+        bitbucketRequestMockProvider.mockUpdateUserDetails("editor1", "editor1@test.de", "editor1First editor1Last");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
+        bitbucketRequestMockProvider.mockUpdateUserDetails("instructor1", "instructor1@test.de", "instructor1First instructor1Last");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
         courseTestService.testAddStudentOrTutorOrEditorOrInstructorToCourse();
     }
 
@@ -389,6 +412,14 @@ public class CourseBitbucketBambooJiraIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testRemoveStudentOrTutorOrInstructorFromCourse() throws Exception {
+        bitbucketRequestMockProvider.mockUpdateUserDetails("student1", "student1@test.de", "student1First student1Last");
+        bitbucketRequestMockProvider.mockRemoveUserFromGroup("student1", "tumuser");
+        bitbucketRequestMockProvider.mockUpdateUserDetails("tutor1", "tutor1@test.de", "tutor1First tutor1Last");
+        bitbucketRequestMockProvider.mockRemoveUserFromGroup("tutor1", "tutor");
+        bitbucketRequestMockProvider.mockUpdateUserDetails("editor1", "editor1@test.de", "editor1First editor1Last");
+        bitbucketRequestMockProvider.mockRemoveUserFromGroup("editor1", "editor");
+        bitbucketRequestMockProvider.mockUpdateUserDetails("instructor1", "instructor1@test.de", "instructor1First instructor1Last");
+        bitbucketRequestMockProvider.mockRemoveUserFromGroup("instructor1", "instructor");
         courseTestService.testRemoveStudentOrTutorOrInstructorFromCourse();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -1314,6 +1314,7 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void unlockAllRepositories() throws Exception {
+        bitbucketRequestMockProvider.enableMockingOfRequests(true);
         assertThat(studentExamRepository.findStudentExam(new ProgrammingExercise(), null)).isEmpty();
 
         ExerciseGroup exerciseGroup1 = new ExerciseGroup();

--- a/src/test/java/de/tum/in/www1/artemis/OrganizationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/OrganizationIntegrationTest.java
@@ -45,6 +45,8 @@ public class OrganizationIntegrationTest extends AbstractSpringIntegrationBamboo
 
     @AfterEach
     public void resetDatabase() {
+        bitbucketRequestMockProvider.reset();
+        bambooRequestMockProvider.reset();
         database.resetDatabase();
     }
 
@@ -122,6 +124,12 @@ public class OrganizationIntegrationTest extends AbstractSpringIntegrationBamboo
         jiraRequestMockProvider.mockAddUserToGroupForMultipleGroups(Set.of(course1.getStudentGroupName()));
         jiraRequestMockProvider.mockAddUserToGroupForMultipleGroups(Set.of(course2.getStudentGroupName()));
         jiraRequestMockProvider.mockAddUserToGroupForMultipleGroups(Set.of(course3.getStudentGroupName()));
+        bitbucketRequestMockProvider.mockUpdateUserDetails(student.getLogin(), student.getEmail(), student.getName());
+        bitbucketRequestMockProvider.mockAddUserToGroups();
+        bitbucketRequestMockProvider.mockUpdateUserDetails(student.getLogin(), student.getEmail(), student.getName());
+        bitbucketRequestMockProvider.mockAddUserToGroups();
+        bitbucketRequestMockProvider.mockUpdateUserDetails(student.getLogin(), student.getEmail(), student.getName());
+        bitbucketRequestMockProvider.mockAddUserToGroups();
 
         User updatedStudent = request.postWithResponseBody("/api/courses/" + course1.getId() + "/register", null, User.class, HttpStatus.OK);
         assertThat(updatedStudent.getGroups()).as("User is registered for course").contains(course1.getStudentGroupName());

--- a/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ResultServiceIntegrationTest.java
@@ -37,6 +37,7 @@ import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.service.connectors.VersionControlRepositoryPermission;
 import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.web.rest.dto.ResultWithPointsPerGradingCriterionDTO;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
@@ -702,13 +703,14 @@ public class ResultServiceIntegrationTest extends AbstractSpringIntegrationBambo
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createResultForExternalSubmission_programmingExercise() throws Exception {
-        bitbucketRequestMockProvider.enableMockingOfRequests(true);
-        bambooRequestMockProvider.enableMockingOfRequests(true);
+        bitbucketRequestMockProvider.enableMockingOfRequests();
+        bambooRequestMockProvider.enableMockingOfRequests();
         var studentLogin = "student1";
         User user = userRepository.findOneByLogin(studentLogin).orElseThrow();
-        mockConnectorRequestsForStartParticipation(programmingExercise, user.getParticipantIdentifier(), Set.of(user), true, HttpStatus.CREATED);
         final var repositorySlug = (programmingExercise.getProjectKey() + "-" + studentLogin).toLowerCase();
-        bitbucketRequestMockProvider.mockSetRepositoryPermissionsToReadOnly(repositorySlug, programmingExercise.getProjectKey(), Set.of(user));
+        bitbucketRequestMockProvider.mockSetStudentRepositoryPermission(repositorySlug, programmingExercise.getProjectKey(), studentLogin,
+                VersionControlRepositoryPermission.REPO_READ);
+        mockConnectorRequestsForStartParticipation(programmingExercise, user.getParticipantIdentifier(), Set.of(user), true, HttpStatus.CREATED);
         Result result = new Result().rated(false);
         programmingExercise.setDueDate(ZonedDateTime.now().minusMinutes(5));
         programmingExerciseRepository.save(programmingExercise);

--- a/src/test/java/de/tum/in/www1/artemis/SubmissionPolicyIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/SubmissionPolicyIntegrationTest.java
@@ -237,6 +237,7 @@ public class SubmissionPolicyIntegrationTest extends AbstractSpringIntegrationBa
         database.addProgrammingSubmissionToResultAndParticipation(new Result().score(30.0), participation2, "commit3");
         String repositoryName = programmingExercise.getProjectKey().toLowerCase() + "-student2";
         bitbucketRequestMockProvider.enableMockingOfRequests();
+        bitbucketRequestMockProvider.mockUserExists("student2");
         bitbucketRequestMockProvider.mockGiveWritePermission(programmingExercise, repositoryName, "student2", HttpStatus.OK);
         bitbucketRequestMockProvider.mockProtectBranches(programmingExercise, repositoryName);
         request.patch(requestUrl(), SubmissionPolicyBuilder.lockRepo().active(true).limit(3).policy(), HttpStatus.OK);

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.authentication;
 
-import static org.mockito.Mockito.verifyNoInteractions;
-
 import java.io.IOException;
 
 import org.junit.jupiter.api.AfterEach;
@@ -24,6 +22,7 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     public void setUp() throws Exception {
         userTestService.setup(this);
         jiraRequestMockProvider.enableMockingOfRequests();
+        bitbucketRequestMockProvider.enableMockingOfRequests();
     }
 
     @AfterEach
@@ -34,6 +33,10 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void updateUser_asAdmin_isSuccessful() throws Exception {
+        bitbucketRequestMockProvider.mockUpdateUserDetails(userTestService.student.getLogin(), "bonobo42@tum.com", "Bruce Wayne");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
+        bitbucketRequestMockProvider.mockRemoveUserFromGroup(userTestService.student.getLogin(), "testgroup");
+        bitbucketRequestMockProvider.mockRemoveUserFromGroup(userTestService.student.getLogin(), "tumuser");
         userTestService.updateUser_asAdmin_isSuccessful();
     }
 
@@ -52,6 +55,7 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void updateUser_withNullPassword_oldPasswordNotChanged() throws Exception {
+        bitbucketRequestMockProvider.mockUpdateUserDetails(userTestService.student.getLogin(), userTestService.student.getEmail(), userTestService.student.getName());
         userTestService.updateUser_withNullPassword_oldPasswordNotChanged();
     }
 
@@ -70,13 +74,15 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void updateUser_withExternalUserManagement_vcsManagementHasNotBeenCalled() throws Exception {
+        bitbucketRequestMockProvider.mockUpdateUserDetails(userTestService.student.getLogin(), userTestService.student.getEmail(),
+                "changed " + userTestService.student.getLastName());
         userTestService.updateUser_withExternalUserManagement();
-        verifyNoInteractions(versionControlService);
     }
 
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void createUser_asAdmin_isSuccessful() throws Exception {
+        bitbucketRequestMockProvider.mockUserExists("batman");
         userTestService.createUser_asAdmin_isSuccessful();
     }
 
@@ -89,6 +95,7 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void createUser_asAdmin_existingLogin() throws Exception {
+        bitbucketRequestMockProvider.mockUserExists("batman");
         userTestService.createUser_asAdmin_existingLogin();
     }
 
@@ -101,32 +108,38 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void createUser_withNullAsPassword_generatesRandomPassword() throws Exception {
+        bitbucketRequestMockProvider.mockUserExists("batman");
         userTestService.createUser_withNullAsPassword_generatesRandomPassword();
     }
 
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void createUser_withExternalUserManagement_vcsManagementHasNotBeenCalled() throws Exception {
+        bitbucketRequestMockProvider.mockUserExists("batman");
         userTestService.createUser_withExternalUserManagement();
-        verifyNoInteractions(versionControlService);
     }
 
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void deleteUser_withExternalUserManagement_vcsManagementHasNotBeenCalled() throws Exception {
+        bitbucketRequestMockProvider.mockDeleteUser(userTestService.getStudent().getLogin());
+        bitbucketRequestMockProvider.mockEraseDeletedUser(userTestService.getStudent().getLogin());
         request.delete("/api/users/" + userTestService.getStudent().getLogin(), HttpStatus.OK);
-        verifyNoInteractions(versionControlService);
     }
 
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void deleteUser_isSuccessful() throws Exception {
+        bitbucketRequestMockProvider.mockDeleteUser("student1");
+        bitbucketRequestMockProvider.mockEraseDeletedUser("student1");
         userTestService.deleteUser_isSuccessful();
     }
 
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void deleteUser_doesntExistInUserManagement_isSuccessful() throws Exception {
+        bitbucketRequestMockProvider.mockDeleteUser(userTestService.getStudent().getLogin());
+        bitbucketRequestMockProvider.mockEraseDeletedUser(userTestService.getStudent().getLogin());
         userTestService.deleteUser_doesntExistInUserManagement_isSuccessful();
     }
 
@@ -211,6 +224,9 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "student1", roles = "USER")
     public void initializeUser() throws Exception {
+        bitbucketRequestMockProvider.mockUserExists(userTestService.student.getLogin());
+        bitbucketRequestMockProvider.mockUpdateUserDetails(userTestService.student.getLogin(), userTestService.student.getEmail(), userTestService.student.getName());
+        bitbucketRequestMockProvider.mockUpdateUserPassword(userTestService.student.getLogin(), "ThisIsAPassword", false);
         userTestService.initializeUser(false);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
@@ -81,9 +81,18 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
 
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
-    public void createUser_asAdmin_isSuccessful() throws Exception {
+    public void createExternalUser_asAdmin_isSuccessful() throws Exception {
         bitbucketRequestMockProvider.mockUserExists("batman");
-        userTestService.createUser_asAdmin_isSuccessful();
+        userTestService.createExternalUser_asAdmin_isSuccessful();
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    public void createInternalUser_asAdmin_isSuccessful() throws Exception {
+        bitbucketRequestMockProvider.mockUserExists("batman");
+        bitbucketRequestMockProvider.mockCreateUser("batman", "foobar", "batman@secret.invalid", "Bruce Wayne");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
+        userTestService.createInternalUser_asAdmin_isSuccessful();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
@@ -131,7 +131,7 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void deleteUser_withExternalUserManagement_vcsManagementHasNotBeenCalled() throws Exception {
-        bitbucketRequestMockProvider.mockDeleteUser(userTestService.getStudent().getLogin());
+        bitbucketRequestMockProvider.mockDeleteUser(userTestService.getStudent().getLogin(), false);
         bitbucketRequestMockProvider.mockEraseDeletedUser(userTestService.getStudent().getLogin());
         request.delete("/api/users/" + userTestService.getStudent().getLogin(), HttpStatus.OK);
     }
@@ -139,7 +139,7 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void deleteUser_isSuccessful() throws Exception {
-        bitbucketRequestMockProvider.mockDeleteUser("student1");
+        bitbucketRequestMockProvider.mockDeleteUser("student1", false);
         bitbucketRequestMockProvider.mockEraseDeletedUser("student1");
         userTestService.deleteUser_isSuccessful();
     }
@@ -147,8 +147,6 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void deleteUser_doesntExistInUserManagement_isSuccessful() throws Exception {
-        bitbucketRequestMockProvider.mockDeleteUser(userTestService.getStudent().getLogin());
-        bitbucketRequestMockProvider.mockEraseDeletedUser(userTestService.getStudent().getLogin());
         userTestService.deleteUser_doesntExistInUserManagement_isSuccessful();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
@@ -44,10 +44,6 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void updateUser_asAdmin_isSuccessful() throws Exception {
-        bitbucketRequestMockProvider.mockUpdateUserDetails(userTestService.student.getLogin(), "bonobo42@tum.com", "Bruce Wayne");
-        bitbucketRequestMockProvider.mockAddUserToGroups();
-        bitbucketRequestMockProvider.mockRemoveUserFromGroup(userTestService.student.getLogin(), "testgroup");
-        bitbucketRequestMockProvider.mockRemoveUserFromGroup(userTestService.student.getLogin(), "tumuser");
         userTestService.updateUser_asAdmin_isSuccessful();
     }
 
@@ -94,11 +90,13 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void updateUser_withVcsUserNotExisting_isSuccessful() throws Exception {
         var student = userTestService.student;
+        student.setInternal(true);
+        student = userRepository.save(student);
+        student.setFirstName("changed");
         jiraRequestMockProvider.mockIsGroupAvailable("testgroup");
         jiraRequestMockProvider.mockIsGroupAvailable("tumuser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(student.getLogin(), student.getEmail(), student.getName(), false);
         bitbucketRequestMockProvider.mockUpdateUserPassword(student.getLogin(), "newPassword", true, false);
-        student.setFirstName("changed");
 
         request.put("/api/users", new ManagedUserVM(student, "newPassword"), HttpStatus.OK);
 

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserBambooBitbucketJiraIntegrationTest.java
@@ -89,8 +89,8 @@ public class UserBambooBitbucketJiraIntegrationTest extends AbstractSpringIntegr
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void createInternalUser_asAdmin_isSuccessful() throws Exception {
-        bitbucketRequestMockProvider.mockUserExists("batman");
-        bitbucketRequestMockProvider.mockCreateUser("batman", "foobar", "batman@secret.invalid", "Bruce Wayne");
+        bitbucketRequestMockProvider.mockUserDoesNotExist("batman");
+        bitbucketRequestMockProvider.mockCreateUser("batman", "foobar1234", "batman@secret.invalid", "student1First student1Last");
         bitbucketRequestMockProvider.mockAddUserToGroups();
         userTestService.createInternalUser_asAdmin_isSuccessful();
     }

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
@@ -101,17 +101,24 @@ public class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJ
     public void createUserWithPseudonymsIsSuccessful() throws Exception {
         ReflectionTestUtils.setField(jenkinsUserManagementService, "usePseudonyms", true);
         ReflectionTestUtils.setField(gitLabUserManagementService, "usePseudonyms", true);
-        userTestService.createUser_asAdmin_isSuccessful();
+        userTestService.createExternalUser_asAdmin_isSuccessful();
         ReflectionTestUtils.setField(jenkinsUserManagementService, "usePseudonyms", usePseudonymsJenkins);
         ReflectionTestUtils.setField(gitLabUserManagementService, "usePseudonyms", usePseudonymsGitlab);
-
     }
 
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void createAdminUserSkippedInJenkins() throws Exception {
         ReflectionTestUtils.setField(jenkinsUserManagementService, "jenkinsAdminUsername", "batman");
-        userTestService.createUser_asAdmin_isSuccessful();
+        userTestService.createExternalUser_asAdmin_isSuccessful();
+        ReflectionTestUtils.setField(jenkinsUserManagementService, "jenkinsAdminUsername", jenkinsAdminUsername);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    public void createAdminInternalUserSkippedInJenkins() throws Exception {
+        ReflectionTestUtils.setField(jenkinsUserManagementService, "jenkinsAdminUsername", "batman");
+        userTestService.createInternalUser_asAdmin_isSuccessful();
         ReflectionTestUtils.setField(jenkinsUserManagementService, "jenkinsAdminUsername", jenkinsAdminUsername);
     }
 
@@ -134,7 +141,7 @@ public class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJ
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void createUser_asAdmin_isSuccessful() throws Exception {
-        userTestService.createUser_asAdmin_isSuccessful();
+        userTestService.createExternalUser_asAdmin_isSuccessful();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
@@ -271,10 +271,16 @@ public class BitbucketRequestMockProvider {
         })).andRespond(withStatus(HttpStatus.NO_CONTENT));
     }
 
-    public void mockDeleteUser(String username) {
+    public void mockDeleteUser(String username, boolean fail) {
         final var path = UriComponentsBuilder.fromHttpUrl(bitbucketServerUrl + "/rest/api/latest/admin/users").queryParam("name", username).build().toUri();
 
-        mockServer.expect(requestTo(path)).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(HttpStatus.NO_CONTENT));
+        if (fail) {
+            mockServer.expect(requestTo(path)).andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withStatus(HttpStatus.NOT_FOUND).body("404 : \"{\"errors:[{\"exceptionName\":\"com.atlassian.bitbucket.user.NoSuchUserException\"}]}\""));
+        }
+        else {
+            mockServer.expect(requestTo(path)).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(HttpStatus.NO_CONTENT));
+        }
     }
 
     public void mockEraseDeletedUser(String username) {

--- a/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
@@ -423,7 +423,7 @@ public class BitbucketRequestMockProvider {
 
     public void mockSetRepositoryPermissionsToReadOnly(String repositorySlug, String projectKey, Set<User> users) throws URISyntaxException {
         for (User user : users) {
-            mockSetStudentRepositoryPermission(repositorySlug, projectKey, user.getLogin(), VersionControlRepositoryPermission.READ_ONLY);
+            mockSetStudentRepositoryPermission(repositorySlug, projectKey, user.getLogin(), VersionControlRepositoryPermission.REPO_READ);
         }
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
@@ -36,6 +36,7 @@ import de.tum.in.www1.artemis.service.UrlService;
 import de.tum.in.www1.artemis.service.connectors.bitbucket.BitbucketPermission;
 import de.tum.in.www1.artemis.service.connectors.bitbucket.dto.*;
 import de.tum.in.www1.artemis.service.user.PasswordService;
+import net.sf.json.JSONObject;
 
 @Component
 @Profile("bitbucket")
@@ -193,6 +194,27 @@ public class BitbucketRequestMockProvider {
                 .queryParam("emailAddress", emailAddress).queryParam("password", password).queryParam("displayName", displayName).queryParam("addToDefaultGroup", "true")
                 .queryParam("notify", "false").build().toUri();
         mockServer.expect(requestTo(path)).andExpect(method(HttpMethod.POST)).andRespond(withStatus(HttpStatus.OK));
+    }
+
+    public void mockUpdateUserDetails(String userName, String emailAddress, String displayName) throws JsonProcessingException {
+        final var path = UriComponentsBuilder.fromHttpUrl(bitbucketServerUrl + "/rest/api/latest/admin/users").build().toUri();
+        JSONObject body = new JSONObject();
+        body.put("name", userName);
+        body.put("email", emailAddress);
+        body.put("displayName", displayName);
+
+        mockServer.expect(requestTo(path)).andExpect(method(HttpMethod.PUT)).andExpect(content().json(mapper.writeValueAsString(body))).andRespond(withStatus(HttpStatus.OK));
+    }
+
+    public void mockUpdateUserPassword(String userName, String password) throws JsonProcessingException {
+        final var path = UriComponentsBuilder.fromHttpUrl(bitbucketServerUrl + "/rest/api/latest/admin/users/credentials").build().toUri();
+        JSONObject body = new JSONObject();
+        body.put("name", userName);
+        body.put("password", password);
+        body.put("passwordConfirm", password);
+
+        mockServer.expect(requestTo(path)).andExpect(method(HttpMethod.PUT)).andExpect(content().json(mapper.writeValueAsString(body)))
+                .andRespond(withStatus(HttpStatus.NO_CONTENT));
     }
 
     public void mockAddUserToGroups() throws URISyntaxException {

--- a/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
@@ -121,15 +121,15 @@ public class BitbucketRequestMockProvider {
 
     public void mockGrantGroupPermissionToProject(ProgrammingExercise exercise, String groupName, BitbucketPermission permission) throws URISyntaxException {
         final var projectKey = exercise.getProjectKey();
-        final var permissionPath = UriComponentsBuilder.fromUri(bitbucketServerUrl.toURI()).path("/rest/api/latest/projects/").pathSegment(projectKey).path("/permissions/groups/")
+        final var permissionPath = UriComponentsBuilder.fromUri(bitbucketServerUrl.toURI()).path("/rest/api/latest/projects/").pathSegment(projectKey).path("/permissions/groups")
                 .queryParam("name", groupName).queryParam("permission", permission);
 
         mockServer.expect(ExpectedCount.once(), requestTo(permissionPath.build().toUri())).andExpect(method(HttpMethod.PUT)).andRespond(withStatus(HttpStatus.OK));
     }
 
-    public void mockrevokeGroupPermissionFromProject(ProgrammingExercise exercise, String groupName) throws URISyntaxException {
+    public void mockRevokeGroupPermissionFromProject(ProgrammingExercise exercise, String groupName) throws URISyntaxException {
         final var projectKey = exercise.getProjectKey();
-        final var permissionPath = UriComponentsBuilder.fromUri(bitbucketServerUrl.toURI()).path("/rest/api/latest/projects/").pathSegment(projectKey).path("/permissions/groups/")
+        final var permissionPath = UriComponentsBuilder.fromUri(bitbucketServerUrl.toURI()).path("/rest/api/latest/projects/").pathSegment(projectKey).path("/permissions/groups")
                 .queryParam("name", groupName);
 
         mockServer.expect(ExpectedCount.once(), requestTo(permissionPath.build().toUri())).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(HttpStatus.OK));

--- a/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
@@ -209,19 +209,15 @@ public class GitlabRequestMockProvider {
         mockCreateRepository(exercise, clonedRepoName);
     }
 
-    public void mockConfigureRepository(ProgrammingExercise exercise, String username, Set<de.tum.in.www1.artemis.domain.User> users, boolean ltiUserExists)
+    public void mockConfigureRepository(ProgrammingExercise exercise, String username, Set<de.tum.in.www1.artemis.domain.User> users, boolean userExists)
             throws GitLabApiException {
         var repositoryUrl = exercise.getVcsTemplateRepositoryUrl();
         for (var user : users) {
             String loginName = user.getLogin();
-            if ((userPrefixEdx.isPresent() && loginName.startsWith(userPrefixEdx.get())) || (userPrefixU4I.isPresent() && loginName.startsWith((userPrefixU4I.get())))) {
-                mockUserExists(loginName, ltiUserExists);
-                if (!ltiUserExists) {
-                    mockImportUser(user, false);
-                }
+            mockUserExists(loginName, userExists);
+            if (userExists) {
+                mockAddMemberToRepository(repositoryUrl, user.getLogin());
             }
-
-            mockAddMemberToRepository(repositoryUrl, user.getLogin());
         }
         var defaultBranch = "main";
         mockGetDefaultBranch(defaultBranch, repositoryUrl);

--- a/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
@@ -2,7 +2,8 @@ package de.tum.in.www1.artemis.connector;
 
 import static org.gitlab4j.api.models.AccessLevel.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 
 import java.net.URISyntaxException;
@@ -353,9 +354,12 @@ public class GitlabRequestMockProvider {
         }
     }
 
-    public void mockDeleteVcsUser(String login, boolean shouldFailToDelete) throws GitLabApiException {
+    public void mockDeleteVcsUser(String login, boolean userExists, boolean shouldFailToDelete) throws GitLabApiException {
         mockGetUserId(login, true, false);
-        if (shouldFailToDelete) {
+        if (!userExists) {
+            doThrow(GitLabUserDoesNotExistException.class).when(userApi).deleteUser(anyInt(), eq(true));
+        }
+        else if (shouldFailToDelete) {
             doThrow(GitLabApiException.class).when(userApi).deleteUser(anyInt(), eq(true));
         }
         else {

--- a/src/test/java/de/tum/in/www1/artemis/connector/JiraRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/JiraRequestMockProvider.java
@@ -78,10 +78,10 @@ public class JiraRequestMockProvider {
                 .andRespond(withStatus(HttpStatus.OK));
     }
 
-    public void mockRemoveUserFromGroup(Set<String> groups, String username, boolean shouldFail) {
+    public void mockRemoveUserFromGroup(Set<String> groups, String username, boolean shouldFail, boolean found) {
         final var regexGroups = String.join("|", groups);
         final var uriPattern = Pattern.compile(JIRA_URL + "/rest/api/2/group/user\\?groupname=(" + regexGroups + ")&username=" + username);
-        var status = shouldFail ? HttpStatus.NOT_FOUND : HttpStatus.OK;
+        var status = shouldFail ? HttpStatus.INTERNAL_SERVER_ERROR : (found ? HttpStatus.OK : HttpStatus.NOT_FOUND);
         mockServer.expect(ExpectedCount.twice(), requestTo(MatchesPattern.matchesPattern(uriPattern))).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(status));
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/MockDelegate.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/MockDelegate.java
@@ -118,7 +118,7 @@ public interface MockDelegate {
 
     void mockSetRepositoryPermissionsToReadOnly(VcsRepositoryUrl repositoryUrl, String projectKey, Set<User> users) throws Exception;
 
-    void mockConfigureRepository(ProgrammingExercise exercise, String participantIdentifier, Set<User> students, boolean ltiUserExists) throws Exception;
+    void mockConfigureRepository(ProgrammingExercise exercise, String participantIdentifier, Set<User> students, boolean userExists) throws Exception;
 
     void mockDefaultBranch(ProgrammingExercise programmingExercise) throws IOException, GitLabApiException;
 }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/MockDelegate.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/MockDelegate.java
@@ -71,7 +71,7 @@ public interface MockDelegate {
 
     void resetMockProvider();
 
-    void mockUpdateUserInUserManagement(String oldLogin, User user, Set<String> oldGroups) throws Exception;
+    void mockUpdateUserInUserManagement(String oldLogin, User user, String password, Set<String> oldGroups) throws Exception;
 
     void mockUpdateCoursePermissions(Course updatedCourse, String oldInstructorGroup, String oldEditorGroup, String oldTeachingAssistantGroup) throws Exception;
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseBitbucketBambooIntegrationTest.java
@@ -160,6 +160,9 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
     @EnumSource(ExerciseMode.class)
     @WithMockUser(username = studentLogin, roles = "USER")
     public void startProgrammingExercise_correctInitializationState(ExerciseMode exerciseMode) throws Exception {
+        for (int i = 1; i <= 12; i++) {
+            bitbucketRequestMockProvider.mockUserExists("student" + i);
+        }
         programmingExerciseTestService.startProgrammingExercise_correctInitializationState(exerciseMode);
     }
 
@@ -225,24 +228,36 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
     @Test
     @WithMockUser(username = studentLogin, roles = "USER")
     public void startProgrammingExerciseStudentSubmissionFailedWithBuildlog() throws Exception {
+        for (int i = 1; i <= 12; i++) {
+            bitbucketRequestMockProvider.mockUserExists("student" + i);
+        }
         programmingExerciseTestService.startProgrammingExerciseStudentSubmissionFailedWithBuildlog();
     }
 
     @Test
     @WithMockUser(username = studentLogin, roles = "USER")
     public void startProgrammingExerciseStudentRetrieveEmptyArtifactPage() throws Exception {
+        for (int i = 1; i <= 12; i++) {
+            bitbucketRequestMockProvider.mockUserExists("student" + i);
+        }
         programmingExerciseTestService.startProgrammingExerciseStudentRetrieveEmptyArtifactPage();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void repositoryAccessIsAdded_whenStudentIsAddedToTeam() throws Exception {
+        for (int i = 1; i <= 12; i++) {
+            bitbucketRequestMockProvider.mockUserExists("student" + i);
+        }
         programmingExerciseTestService.repositoryAccessIsAdded_whenStudentIsAddedToTeam();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void repositoryAccessIsRemoved_whenStudentIsRemovedFromTeam() throws Exception {
+        for (int i = 1; i <= 12; i++) {
+            bitbucketRequestMockProvider.mockUserExists("student" + i);
+        }
         programmingExerciseTestService.repositoryAccessIsRemoved_whenStudentIsRemovedFromTeam();
     }
 
@@ -260,13 +275,10 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    public void configureRepository_createTeamUserWhenLtiUserIsNotExistent() throws Exception {
-        programmingExerciseTestService.configureRepository_createTeamUserWhenLtiUserIsNotExistent();
-    }
-
-    @Test
-    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void copyRepository_testConflictError() throws Exception {
+        for (int i = 1; i <= 12; i++) {
+            bitbucketRequestMockProvider.mockUserExists("student" + i);
+        }
         programmingExerciseTestService.copyRepository_testConflictError();
     }
 
@@ -279,6 +291,9 @@ public class ProgrammingExerciseBitbucketBambooIntegrationTest extends AbstractS
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void configureRepository_testBadRequestError() throws Exception {
+        for (int i = 1; i <= 12; i++) {
+            bitbucketRequestMockProvider.mockUserExists("student" + i);
+        }
         programmingExerciseTestService.configureRepository_testBadRequestError();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
@@ -262,8 +262,8 @@ class ProgrammingExerciseGitlabJenkinsIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    public void configureRepository_createTeamUserWhenLtiUserIsNotExistent() throws Exception {
-        programmingExerciseTestService.configureRepository_createTeamUserWhenLtiUserIsNotExistent();
+    public void configureRepository_throwExceptionWhenLtiUserIsNotExistent() throws Exception {
+        programmingExerciseTestService.configureRepository_throwExceptionWhenLtiUserIsNotExistent();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitlabJenkinsIntegrationTest.java
@@ -170,7 +170,7 @@ class ProgrammingExerciseGitlabJenkinsIntegrationTest extends AbstractSpringInte
     @Test
     @WithMockUser(username = "edx_student1", roles = "USER")
     public void startProgrammingExerciseEdxUser_correctInitializationState() throws Exception {
-        programmingExerciseTestService.startProgrammingExerciseAutomaticallyCreateEdxUser_correctInitializationState();
+        programmingExerciseTestService.startProgrammingExercise_correctInitializationState();
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
@@ -739,8 +739,6 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void unlockAllRepositories() throws Exception {
-        bitbucketRequestMockProvider.mockUserExists("student1");
-        bitbucketRequestMockProvider.mockUserExists("student2");
         programmingExerciseIntegrationTestService.unlockAllRepositories();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
@@ -739,6 +739,8 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void unlockAllRepositories() throws Exception {
+        bitbucketRequestMockProvider.mockUserExists("student1");
+        bitbucketRequestMockProvider.mockUserExists("student2");
         programmingExerciseIntegrationTestService.unlockAllRepositories();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -1505,8 +1505,8 @@ public class ProgrammingExerciseIntegrationTestService {
     }
 
     public void unlockAllRepositories() throws Exception {
-        mockDelegate.mockConfigureRepository(programmingExercise, participation1.getParticipantIdentifier(), participation1.getStudents(), false);
-        mockDelegate.mockConfigureRepository(programmingExercise, participation2.getParticipantIdentifier(), participation2.getStudents(), false);
+        mockDelegate.mockConfigureRepository(programmingExercise, participation1.getParticipantIdentifier(), participation1.getStudents(), true);
+        mockDelegate.mockConfigureRepository(programmingExercise, participation2.getParticipantIdentifier(), participation2.getStudents(), true);
         mockDelegate.mockDefaultBranch(programmingExercise);
 
         final var endpoint = ProgrammingExerciseResourceEndpoints.UNLOCK_ALL_REPOSITORIES.replace("{exerciseId}", String.valueOf(programmingExercise.getId()));

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -57,6 +57,7 @@ import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
 import de.tum.in.www1.artemis.service.connectors.bamboo.dto.BambooBuildResultDTO;
+import de.tum.in.www1.artemis.service.connectors.gitlab.GitLabException;
 import de.tum.in.www1.artemis.service.programming.JavaTemplateUpgradeService;
 import de.tum.in.www1.artemis.service.programming.ProgrammingLanguageFeature;
 import de.tum.in.www1.artemis.service.scheduled.AutomaticProgrammingExerciseCleanupService;
@@ -1383,7 +1384,7 @@ public class ProgrammingExerciseTestService {
     }
 
     // TEST
-    public void configureRepository_createTeamUserWhenLtiUserIsNotExistent() throws Exception {
+    public void configureRepository_throwExceptionWhenLtiUserIsNotExistent() throws Exception {
         setupTeamExercise();
 
         // create a team for the user (necessary condition before starting an exercise)
@@ -1398,7 +1399,7 @@ public class ProgrammingExerciseTestService {
         mockDelegate.mockConnectorRequestsForStartParticipation(exercise, team.getParticipantIdentifier(), team.getStudents(), ltiUserExists, HttpStatus.CREATED);
 
         // Start participation with original team
-        participationService.startExercise(exercise, team, false);
+        assertThrows(GitLabException.class, () -> participationService.startExercise(exercise, team, false));
     }
 
     // TEST

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -782,7 +782,7 @@ public class ProgrammingExerciseTestService {
     }
 
     // TEST
-    public void startProgrammingExerciseAutomaticallyCreateEdxUser_correctInitializationState() throws Exception {
+    public void startProgrammingExercise_correctInitializationState() throws Exception {
         var user = userRepo.findOneByLogin(studentLogin).orElseThrow();
         user.setLogin("edx_student1");
         user = userRepo.save(user);
@@ -790,7 +790,7 @@ public class ProgrammingExerciseTestService {
         final Course course = setupCourseWithProgrammingExercise(ExerciseMode.INDIVIDUAL);
         Participant participant = user;
 
-        mockDelegate.mockConnectorRequestsForStartParticipation(exercise, participant.getParticipantIdentifier(), participant.getParticipants(), false, HttpStatus.CREATED);
+        mockDelegate.mockConnectorRequestsForStartParticipation(exercise, participant.getParticipantIdentifier(), participant.getParticipants(), true, HttpStatus.CREATED);
 
         final var path = ParticipationResource.Endpoints.ROOT + ParticipationResource.Endpoints.START_PARTICIPATION.replace("{courseId}", String.valueOf(course.getId()))
                 .replace("{exerciseId}", String.valueOf(exercise.getId()));

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
@@ -218,10 +218,10 @@ public class ModelFactory {
         return exercise;
     }
 
-    public static List<User> generateActivatedUsers(String loginPrefix, String[] groups, Set<Authority> authorities, int amount) {
+    public static List<User> generateActivatedUsers(String loginPrefix, String commonEncryptedPassword, String[] groups, Set<Authority> authorities, int amount) {
         List<User> generatedUsers = new ArrayList<>();
         for (int i = 1; i <= amount; i++) {
-            User user = ModelFactory.generateActivatedUser(loginPrefix + i);
+            User user = ModelFactory.generateActivatedUser(loginPrefix + i, commonEncryptedPassword);
             if (groups != null) {
                 user.setGroups(Set.of(groups));
                 user.setAuthorities(authorities);
@@ -229,6 +229,10 @@ public class ModelFactory {
             generatedUsers.add(user);
         }
         return generatedUsers;
+    }
+
+    public static List<User> generateActivatedUsers(String loginPrefix, String[] groups, Set<Authority> authorities, int amount) {
+        return generateActivatedUsers(loginPrefix, USER_PASSWORD, groups, authorities, amount);
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
@@ -263,11 +263,32 @@ public class UserTestService {
     }
 
     // Test
-    public void createUser_asAdmin_isSuccessful() throws Exception {
+    public void createExternalUser_asAdmin_isSuccessful() throws Exception {
         student.setId(null);
         student.setLogin("batman");
         student.setPassword("foobar");
         student.setEmail("batman@secret.invalid");
+
+        mockDelegate.mockCreateUserInUserManagement(student, false);
+
+        final var response = request.postWithResponseBody("/api/users", new ManagedUserVM(student), User.class, HttpStatus.CREATED);
+        assertThat(response).isNotNull();
+        final var userInDB = userRepository.findById(response.getId()).get();
+        userInDB.setPassword(passwordService.decryptPasswordByLogin(userInDB.getLogin()).get());
+        student.setId(response.getId());
+        response.setPassword("foobar");
+
+        assertThat(student).as("New user is equal to request response").isEqualTo(response);
+        assertThat(student).as("New user is equal to new user in DB").isEqualTo(userInDB);
+    }
+
+    // Test
+    public void createInternalUser_asAdmin_isSuccessful() throws Exception {
+        student.setId(null);
+        student.setLogin("batman");
+        student.setPassword("foobar");
+        student.setEmail("batman@secret.invalid");
+        student.setInternal(true);
 
         mockDelegate.mockCreateUserInUserManagement(student, false);
 

--- a/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
@@ -286,18 +286,18 @@ public class UserTestService {
     public void createInternalUser_asAdmin_isSuccessful() throws Exception {
         student.setId(null);
         student.setLogin("batman");
-        student.setPassword("foobar");
+        student.setPassword("foobar1234");
         student.setEmail("batman@secret.invalid");
         student.setInternal(true);
 
         mockDelegate.mockCreateUserInUserManagement(student, false);
 
-        final var response = request.postWithResponseBody("/api/users", new ManagedUserVM(student), User.class, HttpStatus.CREATED);
+        final var response = request.postWithResponseBody("/api/users", new ManagedUserVM(student, student.getPassword()), User.class, HttpStatus.CREATED);
         assertThat(response).isNotNull();
         final var userInDB = userRepository.findById(response.getId()).get();
         userInDB.setPassword(passwordService.decryptPasswordByLogin(userInDB.getLogin()).get());
         student.setId(response.getId());
-        response.setPassword("foobar");
+        response.setPassword("foobar1234");
 
         assertThat(student).as("New user is equal to request response").isEqualTo(response);
         assertThat(student).as("New user is equal to new user in DB").isEqualTo(userInDB);

--- a/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
@@ -112,7 +112,7 @@ public class UserTestService {
 
     // Test
     public void deleteUser_doesntExistInUserManagement_isSuccessful() throws Exception {
-        mockDelegate.mockDeleteUserInUserManagement(student, false, false, false);
+        mockDelegate.mockDeleteUserInUserManagement(student, false, true, true);
 
         request.delete("/api/users/" + student.getLogin(), HttpStatus.OK);
 
@@ -132,7 +132,7 @@ public class UserTestService {
 
     // Test
     public void deleteUser_FailsInExternalVcsUserManagement_isNotSuccessful() throws Exception {
-        mockDelegate.mockDeleteUserInUserManagement(student, false, true, false);
+        mockDelegate.mockDeleteUserInUserManagement(student, true, true, false);
 
         request.delete("/api/users/" + student.getLogin(), HttpStatus.INTERNAL_SERVER_ERROR);
 

--- a/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
@@ -102,6 +102,8 @@ public class UserTestService {
 
     // Test
     public void deleteUser_isSuccessful() throws Exception {
+        student.setInternal(true);
+        userRepository.save(student);
         mockDelegate.mockDeleteUserInUserManagement(student, true, false, false);
 
         request.delete("/api/users/" + student.getLogin(), HttpStatus.OK);

--- a/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
@@ -52,7 +52,7 @@ public class UserTestService {
     private UserRepository userRepository;
 
     @Autowired
-    PasswordService passwordService;
+    private PasswordService passwordService;
 
     @Autowired
     private CacheManager cacheManager;

--- a/src/test/javascript/spec/component/account/settings.component.spec.ts
+++ b/src/test/javascript/spec/component/account/settings.component.spec.ts
@@ -17,7 +17,7 @@ describe('SettingsComponent', () => {
     let comp: SettingsComponent;
 
     const accountValues: User = {
-        isInternal: true,
+        internal: true,
         guidedTourSettings: [],
         name: 'John Doe',
         firstName: 'John',

--- a/src/test/javascript/spec/component/account/settings.component.spec.ts
+++ b/src/test/javascript/spec/component/account/settings.component.spec.ts
@@ -17,6 +17,7 @@ describe('SettingsComponent', () => {
     let comp: SettingsComponent;
 
     const accountValues: User = {
+        isInternal: true,
         guidedTourSettings: [],
         name: 'John Doe',
         firstName: 'John',

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
@@ -53,6 +53,7 @@ describe('StudentExamDetailComponent', () => {
         course = { id: 1 };
 
         student = {
+            isInternal: true,
             guidedTourSettings: [],
             name: 'name',
             login: 'login',

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
@@ -53,7 +53,7 @@ describe('StudentExamDetailComponent', () => {
         course = { id: 1 };
 
         student = {
-            isInternal: true,
+            internal: true,
             guidedTourSettings: [],
             name: 'name',
             login: 'login',

--- a/src/test/javascript/spec/component/exam/participate/information/exam-information.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/information/exam-information.component.spec.ts
@@ -16,8 +16,8 @@ let component: ExamInformationComponent;
 
 const user = { id: 1, name: 'Test User' } as User;
 
-const startDate = dayjs().subtract(5, 'hours');
-const endDate = dayjs().subtract(4, 'hours');
+const startDate = dayjs('2022-02-06 02:00:00');
+const endDate = dayjs(startDate).add(1, 'hours');
 
 let exam = {
     id: 1,

--- a/src/test/javascript/spec/component/exercises/shared/exercise-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/exercise-scores.component.spec.ts
@@ -60,11 +60,13 @@ describe('Exercise Scores Component', () => {
             {
                 login: 'login1',
                 name: 'name1',
+                isInternal: true,
                 guidedTourSettings: [],
             },
             {
                 login: 'login2',
                 name: 'name2',
+                isInternal: true,
                 guidedTourSettings: [],
             },
         ],
@@ -248,6 +250,7 @@ describe('Exercise Scores Component', () => {
         participation.student = {
             login: 'login',
             name: 'name',
+            isInternal: true,
             guidedTourSettings: [],
         };
 

--- a/src/test/javascript/spec/component/exercises/shared/exercise-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/exercise-scores.component.spec.ts
@@ -60,13 +60,13 @@ describe('Exercise Scores Component', () => {
             {
                 login: 'login1',
                 name: 'name1',
-                isInternal: true,
+                internal: true,
                 guidedTourSettings: [],
             },
             {
                 login: 'login2',
                 name: 'name2',
-                isInternal: true,
+                internal: true,
                 guidedTourSettings: [],
             },
         ],
@@ -250,7 +250,7 @@ describe('Exercise Scores Component', () => {
         participation.student = {
             login: 'login',
             name: 'name',
-            isInternal: true,
+            internal: true,
             guidedTourSettings: [],
         };
 

--- a/src/test/javascript/spec/component/file-upload-assessment-dashboard/file-upload-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-assessment-dashboard/file-upload-assessment-dashboard.component.spec.ts
@@ -38,13 +38,13 @@ const fileUploadExercise2 = {
 const fileUploadSubmission1 = {
     id: 1,
     submitted: true,
-    results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], isInternal: true } }],
+    results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], internal: true } }],
     participation: { id: 41, exercise: fileUploadExercise1 },
 };
 const fileUploadSubmission2 = {
     id: 2,
     submitted: true,
-    results: [{ id: 20, assessor: { id: 30, guidedTourSettings: [], isInternal: true } }],
+    results: [{ id: 20, assessor: { id: 30, guidedTourSettings: [], internal: true } }],
     participation: { id: 41, exercise: fileUploadExercise2 },
 };
 

--- a/src/test/javascript/spec/component/file-upload-assessment-dashboard/file-upload-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-assessment-dashboard/file-upload-assessment-dashboard.component.spec.ts
@@ -38,13 +38,13 @@ const fileUploadExercise2 = {
 const fileUploadSubmission1 = {
     id: 1,
     submitted: true,
-    results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [] } }],
+    results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], isInternal: true } }],
     participation: { id: 41, exercise: fileUploadExercise1 },
 };
 const fileUploadSubmission2 = {
     id: 2,
     submitted: true,
-    results: [{ id: 20, assessor: { id: 30, guidedTourSettings: [] } }],
+    results: [{ id: 20, assessor: { id: 30, guidedTourSettings: [], isInternal: true } }],
     participation: { id: 41, exercise: fileUploadExercise2 },
 };
 

--- a/src/test/javascript/spec/component/modeling-assessment-dashboard/modeling-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-dashboard/modeling-assessment-dashboard.component.spec.ts
@@ -43,7 +43,7 @@ const modelingExerciseOfExam = {
     numberOfAssessmentsOfCorrectionRounds: [],
     secondCorrectionEnabled: true,
 };
-const modelingSubmission = { id: 1, submitted: true, results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [] } }] };
+const modelingSubmission = { id: 1, submitted: true, results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], isInternal: true } }] };
 
 describe('ModelingAssessmentDashboardComponent', () => {
     let component: ModelingAssessmentDashboardComponent;

--- a/src/test/javascript/spec/component/modeling-assessment-dashboard/modeling-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-dashboard/modeling-assessment-dashboard.component.spec.ts
@@ -43,7 +43,7 @@ const modelingExerciseOfExam = {
     numberOfAssessmentsOfCorrectionRounds: [],
     secondCorrectionEnabled: true,
 };
-const modelingSubmission = { id: 1, submitted: true, results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], isInternal: true } }] };
+const modelingSubmission = { id: 1, submitted: true, results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], internal: true } }] };
 
 describe('ModelingAssessmentDashboardComponent', () => {
     let component: ModelingAssessmentDashboardComponent;

--- a/src/test/javascript/spec/component/participation/participation.component.spec.ts
+++ b/src/test/javascript/spec/component/participation/participation.component.spec.ts
@@ -88,7 +88,7 @@ describe('ParticipationComponent', () => {
         const theExercise = { ...exercise, type: ExerciseType.FILE_UPLOAD };
         const exerciseFindStub = jest.spyOn(exerciseService, 'find').mockReturnValue(of(new HttpResponse({ body: theExercise })));
 
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', internal: true };
         const participation: StudentParticipation = { id: 1, student };
         const participationFindStub = jest.spyOn(participationService, 'findAllParticipationsByExercise').mockReturnValue(of(new HttpResponse({ body: [participation] })));
 
@@ -111,7 +111,7 @@ describe('ParticipationComponent', () => {
         const theExercise = { ...exercise, type: ExerciseType.PROGRAMMING };
         const exerciseFindStub = jest.spyOn(exerciseService, 'find').mockReturnValue(of(new HttpResponse({ body: theExercise })));
 
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', internal: true };
         const participation: StudentParticipation = { id: 1, student };
         const participationFindStub = jest.spyOn(participationService, 'findAllParticipationsByExercise').mockReturnValue(of(new HttpResponse({ body: [participation] })));
 
@@ -148,7 +148,7 @@ describe('ParticipationComponent', () => {
     });
 
     it('should format student login or team name from participation', () => {
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', internal: true };
         const participation: StudentParticipation = { id: 123, student };
         expect(component.searchResultFormatter(participation)).toBe(`${student.login} (${student.name})`);
 
@@ -164,7 +164,7 @@ describe('ParticipationComponent', () => {
     });
 
     it('should return student login, team short name, or empty from participation', () => {
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', internal: true };
         const team: Team = { name: 'Team', shortName: 'T', students: [student] };
         const participation: StudentParticipation = { id: 123, student, team };
 
@@ -178,7 +178,7 @@ describe('ParticipationComponent', () => {
     });
 
     it('should filter participation by prop', () => {
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', internal: true };
         const team: Team = { name: 'Team', shortName: 'T', students: [student] };
         const participation: StudentParticipation = { id: 1, student, team };
 

--- a/src/test/javascript/spec/component/participation/participation.component.spec.ts
+++ b/src/test/javascript/spec/component/participation/participation.component.spec.ts
@@ -88,7 +88,7 @@ describe('ParticipationComponent', () => {
         const theExercise = { ...exercise, type: ExerciseType.FILE_UPLOAD };
         const exerciseFindStub = jest.spyOn(exerciseService, 'find').mockReturnValue(of(new HttpResponse({ body: theExercise })));
 
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max' };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
         const participation: StudentParticipation = { id: 1, student };
         const participationFindStub = jest.spyOn(participationService, 'findAllParticipationsByExercise').mockReturnValue(of(new HttpResponse({ body: [participation] })));
 
@@ -111,7 +111,7 @@ describe('ParticipationComponent', () => {
         const theExercise = { ...exercise, type: ExerciseType.PROGRAMMING };
         const exerciseFindStub = jest.spyOn(exerciseService, 'find').mockReturnValue(of(new HttpResponse({ body: theExercise })));
 
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max' };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
         const participation: StudentParticipation = { id: 1, student };
         const participationFindStub = jest.spyOn(participationService, 'findAllParticipationsByExercise').mockReturnValue(of(new HttpResponse({ body: [participation] })));
 
@@ -148,7 +148,7 @@ describe('ParticipationComponent', () => {
     });
 
     it('should format student login or team name from participation', () => {
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max' };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
         const participation: StudentParticipation = { id: 123, student };
         expect(component.searchResultFormatter(participation)).toBe(`${student.login} (${student.name})`);
 
@@ -164,7 +164,7 @@ describe('ParticipationComponent', () => {
     });
 
     it('should return student login, team short name, or empty from participation', () => {
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max' };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
         const team: Team = { name: 'Team', shortName: 'T', students: [student] };
         const participation: StudentParticipation = { id: 123, student, team };
 
@@ -178,7 +178,7 @@ describe('ParticipationComponent', () => {
     });
 
     it('should filter participation by prop', () => {
-        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max' };
+        const student: User = { guidedTourSettings: [], id: 1, login: 'student', name: 'Max', isInternal: true };
         const team: Team = { name: 'Team', shortName: 'T', students: [student] };
         const participation: StudentParticipation = { id: 1, student, team };
 

--- a/src/test/javascript/spec/component/programming-assessment-dashboard/programming-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment-dashboard/programming-assessment-dashboard.component.spec.ts
@@ -38,13 +38,13 @@ const programmingExercise2 = {
 const programmingSubmission1 = {
     id: 1,
     submitted: true,
-    results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], isInternal: true } }],
+    results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], internal: true } }],
     participation: { id: 41, exercise: programmingExercise1 },
 };
 const programmingSubmission2 = {
     id: 2,
     submitted: true,
-    results: [{ id: 20, assessor: { id: 30, guidedTourSettings: [], isInternal: true } }],
+    results: [{ id: 20, assessor: { id: 30, guidedTourSettings: [], internal: true } }],
     participation: { id: 41, exercise: programmingExercise2 },
 };
 

--- a/src/test/javascript/spec/component/programming-assessment-dashboard/programming-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment-dashboard/programming-assessment-dashboard.component.spec.ts
@@ -38,13 +38,13 @@ const programmingExercise2 = {
 const programmingSubmission1 = {
     id: 1,
     submitted: true,
-    results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [] } }],
+    results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], isInternal: true } }],
     participation: { id: 41, exercise: programmingExercise1 },
 };
 const programmingSubmission2 = {
     id: 2,
     submitted: true,
-    results: [{ id: 20, assessor: { id: 30, guidedTourSettings: [] } }],
+    results: [{ id: 20, assessor: { id: 30, guidedTourSettings: [], isInternal: true } }],
     participation: { id: 41, exercise: programmingExercise2 },
 };
 

--- a/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
@@ -190,7 +190,7 @@ describe('JhiCloneRepoButtonComponent', () => {
 
     function stubServices() {
         const identityStub = jest.spyOn(accountService, 'identity');
-        identityStub.mockReturnValue(Promise.resolve({ guidedTourSettings: [], login: 'edx_userLogin', isInternal: true }));
+        identityStub.mockReturnValue(Promise.resolve({ guidedTourSettings: [], login: 'edx_userLogin', internal: true }));
 
         const getProfileInfoStub = jest.spyOn(profileService, 'getProfileInfo');
         getProfileInfoStub.mockReturnValue(new BehaviorSubject(info));

--- a/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
@@ -131,7 +131,7 @@ describe('JhiCloneRepoButtonComponent', () => {
         component.sshTemplateUrl = 'ssh://git@bitbucket.ase.in.tum.de:7999/';
         component.useSsh = false;
 
-        component.user = { login: 'user1', guidedTourSettings: [], isInternal: true };
+        component.user = { login: 'user1', guidedTourSettings: [], internal: true };
         component.isTeamParticipation = true;
         let url = component.getHttpOrSshRepositoryUrl();
         expect(url).toEqual(`https://${component.user.login}@bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise-team1.git`);
@@ -145,7 +145,7 @@ describe('JhiCloneRepoButtonComponent', () => {
         component.repositoryUrl = info.versionControlUrl!;
         component.useSsh = false;
 
-        component.user = { login: 'user1', guidedTourSettings: [], isInternal: true };
+        component.user = { login: 'user1', guidedTourSettings: [], internal: true };
         component.isTeamParticipation = true;
         let url = component.getHttpOrSshRepositoryUrl();
         expect(url).toEqual(`https://${component.user.login}@bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise-team1.git`);

--- a/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
@@ -131,7 +131,7 @@ describe('JhiCloneRepoButtonComponent', () => {
         component.sshTemplateUrl = 'ssh://git@bitbucket.ase.in.tum.de:7999/';
         component.useSsh = false;
 
-        component.user = { login: 'user1', guidedTourSettings: [] };
+        component.user = { login: 'user1', guidedTourSettings: [], isInternal: true };
         component.isTeamParticipation = true;
         let url = component.getHttpOrSshRepositoryUrl();
         expect(url).toEqual(`https://${component.user.login}@bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise-team1.git`);
@@ -145,7 +145,7 @@ describe('JhiCloneRepoButtonComponent', () => {
         component.repositoryUrl = info.versionControlUrl!;
         component.useSsh = false;
 
-        component.user = { login: 'user1', guidedTourSettings: [] };
+        component.user = { login: 'user1', guidedTourSettings: [], isInternal: true };
         component.isTeamParticipation = true;
         let url = component.getHttpOrSshRepositoryUrl();
         expect(url).toEqual(`https://${component.user.login}@bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise-team1.git`);
@@ -190,7 +190,7 @@ describe('JhiCloneRepoButtonComponent', () => {
 
     function stubServices() {
         const identityStub = jest.spyOn(accountService, 'identity');
-        identityStub.mockReturnValue(Promise.resolve({ guidedTourSettings: [], login: 'edx_userLogin' }));
+        identityStub.mockReturnValue(Promise.resolve({ guidedTourSettings: [], login: 'edx_userLogin', isInternal: true }));
 
         const getProfileInfoStub = jest.spyOn(profileService, 'getProfileInfo');
         getProfileInfoStub.mockReturnValue(new BehaviorSubject(info));

--- a/src/test/javascript/spec/component/text-assessment-dashboard/text-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/text-assessment-dashboard/text-assessment-dashboard.component.spec.ts
@@ -43,7 +43,7 @@ const textExerciseOfExam = {
     numberOfAssessmentsOfCorrectionRounds: [],
     secondCorrectionEnabled: true,
 };
-const textSubmission = { id: 1, submitted: true, results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [] } }], participation: { id: 1 } };
+const textSubmission = { id: 1, submitted: true, results: [{ id: 10, assessor: { id: 20, guidedTourSettings: [], internal: true } }], participation: { id: 1 } };
 
 describe('TextAssessmentDashboardComponent', () => {
     let component: TextAssessmentDashboardComponent;

--- a/src/test/javascript/spec/service/participation.service.spec.ts
+++ b/src/test/javascript/spec/service/participation.service.spec.ts
@@ -113,7 +113,7 @@ describe('Participation Service', () => {
             type: ParticipationType.PROGRAMMING,
             repositoryUrl: 'repo-url',
             buildPlanId: 'build-plan-id',
-            student: { id: 1, login: 'student1', guidedTourSettings: [] },
+            student: { id: 1, login: 'student1', guidedTourSettings: [], isInternal: true },
             team: { id: 1, name: 'team1' },
             results: [{ id: 3 }],
             submissions: [{ id: 1 }],
@@ -124,7 +124,7 @@ describe('Participation Service', () => {
             type: ParticipationType.PROGRAMMING,
             repositoryUrl: 'repo-url-1',
             buildPlanId: 'build-plan-id-1',
-            student: { id: 2, login: 'student2', guidedTourSettings: [] },
+            student: { id: 2, login: 'student2', guidedTourSettings: [], isInternal: true },
             results: [{ id: 1 }, { id: 2 }],
             submissions: [{ id: 2 }, { id: 3 }],
         };
@@ -143,7 +143,7 @@ describe('Participation Service', () => {
         const participation1: StudentParticipation = {
             id: 1,
             type: ParticipationType.STUDENT,
-            student: { id: 1, login: 'student1', guidedTourSettings: [] },
+            student: { id: 1, login: 'student1', guidedTourSettings: [], isInternal: true },
             results: [{ id: 3 }],
             submissions: [{ id: 1 }],
         };
@@ -151,7 +151,7 @@ describe('Participation Service', () => {
         const participation2: StudentParticipation = {
             id: 2,
             type: ParticipationType.STUDENT,
-            student: { id: 2, login: 'student2', guidedTourSettings: [] },
+            student: { id: 2, login: 'student2', guidedTourSettings: [], isInternal: true },
             results: [{ id: 1 }, { id: 2 }],
             submissions: [{ id: 2 }, { id: 3 }],
         };
@@ -168,7 +168,7 @@ describe('Participation Service', () => {
         const participation: StudentParticipation = {
             id: 1,
             type: ParticipationType.SOLUTION,
-            student: { id: 1, login: 'student1', guidedTourSettings: [] },
+            student: { id: 1, login: 'student1', guidedTourSettings: [], isInternal: true },
             results: [{ id: 3 }],
             submissions: [{ id: 1 }],
         };

--- a/src/test/javascript/spec/service/participation.service.spec.ts
+++ b/src/test/javascript/spec/service/participation.service.spec.ts
@@ -113,7 +113,7 @@ describe('Participation Service', () => {
             type: ParticipationType.PROGRAMMING,
             repositoryUrl: 'repo-url',
             buildPlanId: 'build-plan-id',
-            student: { id: 1, login: 'student1', guidedTourSettings: [], isInternal: true },
+            student: { id: 1, login: 'student1', guidedTourSettings: [], internal: true },
             team: { id: 1, name: 'team1' },
             results: [{ id: 3 }],
             submissions: [{ id: 1 }],
@@ -124,7 +124,7 @@ describe('Participation Service', () => {
             type: ParticipationType.PROGRAMMING,
             repositoryUrl: 'repo-url-1',
             buildPlanId: 'build-plan-id-1',
-            student: { id: 2, login: 'student2', guidedTourSettings: [], isInternal: true },
+            student: { id: 2, login: 'student2', guidedTourSettings: [], internal: true },
             results: [{ id: 1 }, { id: 2 }],
             submissions: [{ id: 2 }, { id: 3 }],
         };
@@ -143,7 +143,7 @@ describe('Participation Service', () => {
         const participation1: StudentParticipation = {
             id: 1,
             type: ParticipationType.STUDENT,
-            student: { id: 1, login: 'student1', guidedTourSettings: [], isInternal: true },
+            student: { id: 1, login: 'student1', guidedTourSettings: [], internal: true },
             results: [{ id: 3 }],
             submissions: [{ id: 1 }],
         };
@@ -151,7 +151,7 @@ describe('Participation Service', () => {
         const participation2: StudentParticipation = {
             id: 2,
             type: ParticipationType.STUDENT,
-            student: { id: 2, login: 'student2', guidedTourSettings: [], isInternal: true },
+            student: { id: 2, login: 'student2', guidedTourSettings: [], internal: true },
             results: [{ id: 1 }, { id: 2 }],
             submissions: [{ id: 2 }, { id: 3 }],
         };
@@ -168,7 +168,7 @@ describe('Participation Service', () => {
         const participation: StudentParticipation = {
             id: 1,
             type: ParticipationType.SOLUTION,
-            student: { id: 1, login: 'student1', guidedTourSettings: [], isInternal: true },
+            student: { id: 1, login: 'student1', guidedTourSettings: [], internal: true },
             results: [{ id: 3 }],
             submissions: [{ id: 1 }],
         };


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.(https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [X] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [X] I implemented the changes with a good performance and prevented too many database calls.
- [X] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
If a password gets changed, changes only get delegated to GitLab/Jenkins but not Bitbucket so the password change only affects Artemis.

### Description
<!-- Describe your changes in detail -->
I implemented the BitbucketUser ManagementService and moved the Bitbucket user creation from participation initialisation to Artemis user creation as also suggested by a TODO.
I also changed it so all internal users can access the password reset.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Testserver with Atlassian connected
- 1 Student with a local user Account
- 1 Programming Exercise 
**You need a local user for this. If you already have one, please use it, if you need one, please let me know.**

1. Log in to Artemis
2. Start your participation to the exercise
3. Download the repository with the students credentials and push changes
4. Change your password using the change password function in the top-right menu
5. Make sure you can't do any changes to the repository with your old password but you can with your new password.
6. Log out and reset the password using the password reset function
7. Make sure you can't do any changes to the repository with your old password but you can with your new password.
8. Change the password back to the default

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
BitbucketUserManagementService: 69.44% | 94.44%
BitbucketService: 44.19% | 66.39%
BitbucketAuthorizationInterceptor.java: 73.33% | 92.86%
GitLabService.java: 45.65% | 83.60%
JiraAuthenticationProvider.java: 37.50% | 66.67%
UserCreationService.java: 69.64% | 94.04%
AccountResource.java: 77.08% | 95.65%
CourseResource.java: 73.08% | 95.42%