### PR TITLE
`Assessment`: Show assessment dashboard links for instructors

### DIFF
--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
@@ -57,6 +57,7 @@
                 [moreFeedbackRequests]="moreFeedbackRequests"
                 [assessmentLocks]="assessmentLocks"
                 [ratings]="ratings"
+                [isAtLeastInstructor]="course.isAtLeastInstructor!"
             >
             </jhi-assessment-dashboard-information>
         </div>


### PR DESCRIPTION

### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Closes #4613

### Description
The input value of `isAtLeastInstructor` was not passed, leading to a falsy value in all checks afterward. 

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Tutor

1. Log in to Artemis
2. Navigate to Course Management -> Assessment Dashboard
3. Check that the Editor sees the additional links to the complaint and more feedback overview, the tutor can only see the links to his own complaints / requests. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
old:
![grafik](https://user-images.githubusercontent.com/26540346/151569574-d34bae5b-0926-46da-8a77-d739704d5ca4.png)

new:
![grafik](https://user-images.githubusercontent.com/26540346/151569585-438160cc-115d-49a3-9292-012cc790dc95.png)
