### PR TITLE
`Development`: Remove deprecations in server code

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/FileUploadExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/FileUploadExerciseRepository.java
@@ -40,7 +40,7 @@ public interface FileUploadExerciseRepository extends JpaRepository<FileUploadEx
      * @return the entity
      */
     @NotNull
-    default FileUploadExercise findOneByIdElseThrow(Long exerciseId) {
+    default FileUploadExercise findByIdElseThrow(Long exerciseId) {
         return findById(exerciseId).orElseThrow(() -> new EntityNotFoundException("File Upload Exercise", exerciseId));
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/GradeStepRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/GradeStepRepository.java
@@ -1,13 +1,10 @@
 package de.tum.in.www1.artemis.repository;
 
-import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import de.tum.in.www1.artemis.domain.GradeStep;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 /**
  * Spring Data JPA Repository for the GradeStep entity
@@ -15,17 +12,7 @@ import de.tum.in.www1.artemis.domain.GradeStep;
 @Repository
 public interface GradeStepRepository extends JpaRepository<GradeStep, Long> {
 
-    /**
-     * Find all grade steps for a grading scale by id
-     *
-     * @param gradingScaleId the id of the grading scale
-     * @return a List of all grade steps for the grading scale
-     */
-    @Query("""
-                SELECT gradeStep
-                FROM GradeStep gradeStep
-                WHERE gradeStep.gradingScale.id = :#{#gradingScaleId}
-            """)
-    List<GradeStep> findByGradingScaleId(@Param("gradingScaleId") Long gradingScaleId);
-
+    default GradeStep findByIdElseThrow(long gradeStepId) {
+        return findById(gradeStepId).orElseThrow(() -> new EntityNotFoundException("GradeStep", gradeStepId));
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/LearningGoalRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/LearningGoalRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import de.tum.in.www1.artemis.domain.LearningGoal;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 /**
  * Spring Data JPA repository for the Learning Goal entity.
@@ -31,6 +32,10 @@ public interface LearningGoalRepository extends JpaRepository<LearningGoal, Long
             LEFT JOIN FETCH lu.learningGoals
             WHERE learningGoal.id = :#{#learningGoalId}
             """)
-    Optional<LearningGoal> findByIdWithLectureUnitsBidirectional(@Param("learningGoalId") Long learningGoalId);
+    Optional<LearningGoal> findByIdWithLectureUnitsBidirectional(@Param("learningGoalId") long learningGoalId);
+
+    default LearningGoal findByIdWithLectureUnitsBidirectionalElseThrow(long learningGoalId) {
+        return findByIdWithLectureUnitsBidirectional(learningGoalId).orElseThrow(() -> new EntityNotFoundException("LearningGoal", learningGoalId));
+    }
 
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/LectureUnitRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/LectureUnitRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 /**
  * Spring Data JPA repository for the Lecture Unit entity.
@@ -30,6 +31,9 @@ public interface LectureUnitRepository extends JpaRepository<LectureUnit, Long> 
             LEFT JOIN FETCH lg.lectureUnits
             WHERE lectureUnit.id = :#{#lectureUnitId}
             """)
-    Optional<LectureUnit> findByIdWithLearningGoalsBidirectional(@Param("lectureUnitId") Long lectureUnitId);
+    Optional<LectureUnit> findByIdWithLearningGoalsBidirectional(@Param("lectureUnitId") long lectureUnitId);
 
+    default LectureUnit findByIdWithLearningGoalsBidirectionalElseThrow(long lectureUnitId) {
+        return findByIdWithLearningGoalsBidirectional(lectureUnitId).orElseThrow(() -> new EntityNotFoundException("LectureUnit", lectureUnitId));
+    }
 }

--- a/src/main/java/de/tum/in/www1/artemis/repository/TeamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/TeamRepository.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 import de.tum.in.www1.artemis.domain.Exercise;
 import de.tum.in.www1.artemis.domain.Team;
 import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import de.tum.in.www1.artemis.web.rest.errors.StudentsAlreadyAssignedException;
 
 /**
@@ -115,5 +116,9 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             }
         });
         return conflicts;
+    }
+
+    default Team findByIdElseThrow(long teamId) throws EntityNotFoundException {
+        return findById(teamId).orElseThrow(() -> new EntityNotFoundException("Team", teamId));
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ApollonDiagramResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ApollonDiagramResource.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.conflict;
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
@@ -230,7 +230,7 @@ public abstract class AssessmentResource {
         Result result = resultRepository.findByIdWithEagerFeedbacksElseThrow(resultId);
         Participation participation = submission.getParticipation();
         if (!participation.getId().equals(participationId)) {
-            throw new BadRequestAlertException("participationId in path does not match the id of the participation to submission " + submissionId + " !", "Participation", "400");
+            throw new BadRequestAlertException("participationId in path does not match the id of the participation to submission " + submissionId + "!", "Participation", "400");
         }
         Exercise exercise = exerciseRepository.findByIdElseThrow(participation.getExercise().getId());
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, exercise, null);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
@@ -166,18 +166,18 @@ public abstract class AssessmentResource {
      * @param submissionId the id of the example submission
      * @return the result linked to the example submission
      */
-    ResponseEntity<Result> getExampleAssessment(long exerciseId, long submissionId) {
+    protected ResponseEntity<Result> getExampleAssessment(long exerciseId, long submissionId) {
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         final var exampleSubmission = exampleSubmissionRepository.findBySubmissionIdWithResultsElseThrow(submissionId);
 
         var user = userRepository.getUserWithGroupsAndAuthorities();
-        var isInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
-        var isTutor = authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user);
+        var isAtLeastInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
+        var isAtLeastTutor = authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user);
         // It is allowed to get the example assessment, if the user is an instructor or
         // if the user is a tutor and the submission is not used for tutorial in the assessment dashboard
         // The reason is that example submissions with isTutorial = false should be shown immediately (with the assessment) to the tutor and
         // for example submission with isTutorial = true, the assessment should not be shown to the tutor. Instead, the tutor should try to assess it him/herself
-        if (!(isInstructor || isTutor && !exampleSubmission.isUsedForTutorial())) {
+        if (!(isAtLeastInstructor || (isAtLeastTutor && !exampleSubmission.isUsedForTutorial()))) {
             throw new AccessForbiddenException();
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AssessmentResource.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
-
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -20,7 +18,9 @@ import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.exam.ExamService;
 import de.tum.in.www1.artemis.service.notifications.SingleUserNotificationService;
+import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 public abstract class AssessmentResource {
 
@@ -79,11 +79,11 @@ public abstract class AssessmentResource {
 
         Result result = submission.getLatestResult();
         if (result == null) {
-            return notFound();
+            throw new EntityNotFoundException("Result with submission", submissionId);
         }
 
         if (!authCheckService.isUserAllowedToGetResult(exercise, participation, result)) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
 
         // remove sensitive information for students
@@ -114,7 +114,7 @@ public abstract class AssessmentResource {
         final var isAtLeastInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
         if (!assessmentService.isAllowedToCreateOrOverrideResult(submission.getLatestResult(), exercise, studentParticipation, user, isAtLeastInstructor)) {
             log.debug("The user {} is not allowed to override the assessment for the submission {}", user.getLogin(), submission.getId());
-            return forbidden("assessment", "assessmentSaveNotAllowed", "The user is not allowed to override the assessment");
+            throw new AccessForbiddenException("The user is not allowed to override the assessment");
         }
 
         Result result = assessmentService.saveManualAssessment(submission, feedbackList, resultId);
@@ -170,12 +170,15 @@ public abstract class AssessmentResource {
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         final var exampleSubmission = exampleSubmissionRepository.findBySubmissionIdWithResultsElseThrow(submissionId);
 
+        var user = userRepository.getUserWithGroupsAndAuthorities();
+        var isInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
+        var isTutor = authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user);
         // It is allowed to get the example assessment, if the user is an instructor or
         // if the user is a tutor and the submission is not used for tutorial in the assessment dashboard
-        boolean isAllowed = authCheckService.isAtLeastInstructorForExercise(exercise)
-                || authCheckService.isAtLeastTeachingAssistantForExercise(exercise) && !Boolean.TRUE.equals(exampleSubmission.isUsedForTutorial());
-        if (!isAllowed) {
-            forbidden();
+        // The reason is that example submissions with isTutorial = false should be shown immediately (with the assessment) to the tutor and
+        // for example submission with isTutorial = true, the assessment should not be shown to the tutor. Instead, the tutor should try to assess it him/herself
+        if (!(isInstructor || isTutor && !exampleSubmission.isUsedForTutorial())) {
+            throw new AccessForbiddenException();
         }
 
         return ResponseEntity.ok(assessmentService.getExampleAssessment(submissionId));
@@ -214,7 +217,7 @@ public abstract class AssessmentResource {
         boolean isAtLeastInstructor = authCheckService.isAtLeastInstructorForExercise(exercise, user);
         if (!(isAtLeastInstructor || userRepository.getUser().getId().equals(submission.getLatestResult().getAssessor().getId()))) {
             // tutors cannot cancel the assessment of other tutors (only instructors can)
-            return forbidden();
+            throw new AccessForbiddenException();
         }
         assessmentService.cancelAssessmentOfSubmission(submission);
         return ResponseEntity.ok().build();
@@ -227,7 +230,7 @@ public abstract class AssessmentResource {
         Result result = resultRepository.findByIdWithEagerFeedbacksElseThrow(resultId);
         Participation participation = submission.getParticipation();
         if (!participation.getId().equals(participationId)) {
-            return badRequest("participationId", "400", "participationId in path does not match the id of the participation to submission " + submissionId + " !");
+            throw new BadRequestAlertException("participationId in path does not match the id of the participation to submission " + submissionId + " !", "Participation", "400");
         }
         Exercise exercise = exerciseRepository.findByIdElseThrow(participation.getExercise().getId());
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, exercise, null);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.badRequest;
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
 
 import java.time.ZonedDateTime;
 import java.util.*;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseResource.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.badRequest;
 
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -27,7 +27,7 @@ import de.tum.in.www1.artemis.service.exam.ExamDateService;
 import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggle;
 import de.tum.in.www1.artemis.web.rest.dto.StatsForDashboardDTO;
-import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
+import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 import tech.jhipster.web.util.ResponseUtil;
 
@@ -110,18 +110,18 @@ public class ExerciseResource {
                 ZonedDateTime latestIndividualExamEndDate = examDateService.getLatestIndividualExamEndDate(exam);
                 if (latestIndividualExamEndDate == null || latestIndividualExamEndDate.isAfter(ZonedDateTime.now())) {
                     // When there is no due date or the due date is in the future, we return forbidden here
-                    return forbidden();
+                    throw new AccessForbiddenException();
                 }
             }
             else {
                 // Students should never access exercises
-                return forbidden();
+                throw new AccessForbiddenException();
             }
         }
         // Normal exercise
         else {
             if (!authCheckService.isAllowedToSeeExercise(exercise, user)) {
-                return forbidden();
+                throw new AccessForbiddenException();
             }
             if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user)) {
                 exercise.filterSensitiveInformation();
@@ -180,11 +180,7 @@ public class ExerciseResource {
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Set<Exercise>> getUpcomingExercises() {
         log.debug("REST request to get all upcoming exercises");
-
-        if (!authCheckService.isAdmin()) {
-            return forbidden();
-        }
-
+        authCheckService.checkIsAdminElseThrow(null);
         Set<Exercise> upcomingExercises = exerciseRepository.findAllExercisesWithCurrentOrUpcomingDueDate();
         return ResponseEntity.ok(upcomingExercises);
     }
@@ -212,13 +208,8 @@ public class ExerciseResource {
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<StatsForDashboardDTO> getStatsForExerciseAssessmentDashboard(@PathVariable Long exerciseId) {
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
-
-        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise)) {
-            return forbidden();
-        }
-
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, exercise, null);
         StatsForDashboardDTO stats = exerciseService.populateCommonStatistics(exercise, exercise.isExamExercise());
-
         return ResponseEntity.ok(stats);
     }
 
@@ -250,10 +241,8 @@ public class ExerciseResource {
     @FeatureToggle(Feature.ProgrammingExercises)
     public ResponseEntity<Resource> cleanup(@PathVariable Long exerciseId, @RequestParam(defaultValue = "false") boolean deleteRepositories) {
         log.info("Start to cleanup build plans for Exercise: {}, delete repositories: {}", exerciseId, deleteRepositories);
-        Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
-        if (!authCheckService.isAtLeastInstructorForExercise(exercise)) {
-            return forbidden();
-        }
+        var exercise = exerciseRepository.findByIdElseThrow(exerciseId);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, exercise, null);
         exerciseDeletionService.cleanup(exerciseId, deleteRepositories);
         log.info("Cleanup build plans was successful for Exercise : {}", exerciseId);
         return ResponseEntity.ok().build();
@@ -275,12 +264,12 @@ public class ExerciseResource {
         // TODO: Create alternative route so that instructors and admins can access the exercise details
         // The users are not allowed to access the exercise details over this route if the exercise belongs to an exam
         if (exercise.isExamExercise()) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
 
         // if exercise is not yet released to the students they should not have any access to it
         if (!authCheckService.isAllowedToSeeExercise(exercise, user)) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
 
         List<StudentParticipation> participations = participationService.findByExerciseAndStudentIdWithEagerResultsAndSubmissions(exercise, user.getId());
@@ -322,12 +311,7 @@ public class ExerciseResource {
     public ResponseEntity<Boolean> toggleSecondCorrectionEnabled(@PathVariable Long exerciseId) {
         log.debug("toggleSecondCorrectionEnabled for exercise with id: {}", exerciseId);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
-        if (exercise == null) {
-            throw new EntityNotFoundException("Exercise not found with id " + exerciseId);
-        }
-        if (!authCheckService.isAtLeastInstructorForExercise(exercise)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, exercise, null);
         return ResponseEntity.ok(exerciseRepository.toggleSecondCorrection(exercise));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -525,15 +525,9 @@ public class FileResource {
 
             HttpHeaders headers = new HttpHeaders();
 
-            ContentDisposition contentDisposition;
-            if (filename.endsWith("htm") || filename.endsWith("html") || filename.endsWith("svg") || filename.endsWith("svgz")) {
-                // attachment will force the user to download the file
-                contentDisposition = ContentDisposition.builder("attachment").filename(filename).build();
-            }
-            else {
-                contentDisposition = ContentDisposition.builder("inline").filename(filename).build();
-            }
-            headers.setContentDisposition(contentDisposition);
+            // attachment will force the user to download the file
+            String contentType = filename.endsWith("htm") || filename.endsWith("html") || filename.endsWith("svg") || filename.endsWith("svgz") ? "attachment" : "inline";
+            headers.setContentDisposition(ContentDisposition.builder(contentType).filename(filename).build());
 
             FileNameMap fileNameMap = URLConnection.getFileNameMap();
             String mimeType = fileNameMap.getContentTypeFor(filename);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -1,10 +1,11 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
-
 import java.io.File;
 import java.io.IOException;
-import java.net.*;
+import java.net.FileNameMap;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -43,6 +44,7 @@ import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.FilePathService;
 import de.tum.in.www1.artemis.service.FileService;
 import de.tum.in.www1.artemis.service.ResourceLoaderService;
+import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 
 /**
  * REST controller for managing Course.
@@ -278,7 +280,7 @@ public class FileResource {
             return ResponseEntity.ok(temporaryAccessToken);
         }
         catch (IllegalAccessException e) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
     }
 
@@ -299,7 +301,7 @@ public class FileResource {
             return ResponseEntity.ok(temporaryAccessToken);
         }
         catch (IllegalAccessException e) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
     }
 
@@ -523,15 +525,15 @@ public class FileResource {
 
             HttpHeaders headers = new HttpHeaders();
 
+            ContentDisposition contentDisposition;
             if (filename.endsWith("htm") || filename.endsWith("html") || filename.endsWith("svg") || filename.endsWith("svgz")) {
                 // attachment will force the user to download the file
-                ContentDisposition contentDisposition = ContentDisposition.builder("attachment").filename(filename).build();
-                headers.setContentDisposition(contentDisposition);
+                contentDisposition = ContentDisposition.builder("attachment").filename(filename).build();
             }
             else {
-                ContentDisposition contentDisposition = ContentDisposition.builder("inline").filename(filename).build();
-                headers.setContentDisposition(contentDisposition);
+                contentDisposition = ContentDisposition.builder("inline").filename(filename).build();
             }
+            headers.setContentDisposition(contentDisposition);
 
             FileNameMap fileNameMap = URLConnection.getFileNameMap();
             String mimeType = fileNameMap.getContentTypeFor(filename);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadAssessmentResource.java
@@ -90,7 +90,7 @@ public class FileUploadAssessmentResource extends AssessmentResource {
         FileUploadSubmission fileUploadSubmission = fileUploadSubmissionRepository.findByIdWithEagerResultAndAssessorAndFeedbackElseThrow(submissionId);
         StudentParticipation studentParticipation = (StudentParticipation) fileUploadSubmission.getParticipation();
         long exerciseId = studentParticipation.getExercise().getId();
-        FileUploadExercise fileUploadExercise = fileUploadExerciseRepository.findOneByIdElseThrow(exerciseId);
+        FileUploadExercise fileUploadExercise = fileUploadExerciseRepository.findByIdElseThrow(exerciseId);
         checkAuthorization(fileUploadExercise, user);
 
         Result result = assessmentService.updateAssessmentAfterComplaint(fileUploadSubmission.getLatestResult(), fileUploadExercise, assessmentUpdate);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -219,7 +219,7 @@ public class FileUploadExerciseResource {
         log.debug("REST request to get FileUploadExercise : {}", exerciseId);
         var exercise = fileUploadExerciseRepository.findWithEagerTeamAssignmentConfigAndCategoriesById(exerciseId)
                 .orElseThrow(() -> new EntityNotFoundException("FileUploadExercise", exerciseId));
-        // If the exercise belongs to an exam, only instructors and admins are allowed to access it, otherwise also TA have access
+        // If the exercise belongs to an exam, only editors or above are allowed to access it, otherwise also TA have access
         if (exercise.isExamExercise()) {
             authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, exercise, null);
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -1,13 +1,11 @@
 package de.tum.in.www1.artemis.web.rest;
 
 import static de.tum.in.www1.artemis.config.Constants.FILE_ENDING_PATTERN;
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
 
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +16,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.*;
@@ -26,6 +23,7 @@ import de.tum.in.www1.artemis.service.messaging.InstanceMessageSendService;
 import de.tum.in.www1.artemis.service.notifications.GroupNotificationService;
 import de.tum.in.www1.artemis.web.rest.dto.SubmissionExportOptionsDTO;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 import de.tum.in.www1.artemis.web.rest.util.ResponseUtil;
 
@@ -61,17 +59,14 @@ public class FileUploadExerciseResource {
 
     private final GradingCriterionRepository gradingCriterionRepository;
 
-    private final ExerciseGroupRepository exerciseGroupRepository;
-
     private final FileUploadSubmissionExportService fileUploadSubmissionExportService;
 
     private final InstanceMessageSendService instanceMessageSendService;
 
     public FileUploadExerciseResource(FileUploadExerciseRepository fileUploadExerciseRepository, UserRepository userRepository, AuthorizationCheckService authCheckService,
             CourseService courseService, GroupNotificationService groupNotificationService, ExerciseService exerciseService, ExerciseDeletionService exerciseDeletionService,
-            FileUploadSubmissionExportService fileUploadSubmissionExportService, GradingCriterionRepository gradingCriterionRepository,
-            ExerciseGroupRepository exerciseGroupRepository, CourseRepository courseRepository, ParticipationRepository participationRepository,
-            InstanceMessageSendService instanceMessageSendService) {
+            FileUploadSubmissionExportService fileUploadSubmissionExportService, GradingCriterionRepository gradingCriterionRepository, CourseRepository courseRepository,
+            ParticipationRepository participationRepository, InstanceMessageSendService instanceMessageSendService) {
         this.fileUploadExerciseRepository = fileUploadExerciseRepository;
         this.userRepository = userRepository;
         this.courseService = courseService;
@@ -80,7 +75,6 @@ public class FileUploadExerciseResource {
         this.exerciseService = exerciseService;
         this.exerciseDeletionService = exerciseDeletionService;
         this.gradingCriterionRepository = gradingCriterionRepository;
-        this.exerciseGroupRepository = exerciseGroupRepository;
         this.fileUploadSubmissionExportService = fileUploadSubmissionExportService;
         this.courseRepository = courseRepository;
         this.participationRepository = participationRepository;
@@ -101,26 +95,17 @@ public class FileUploadExerciseResource {
         if (fileUploadExercise.getId() != null) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createAlert(applicationName, "A new fileUploadExercise cannot already have an ID", "idexists")).body(null);
         }
-
         // validates general settings: points, dates
         fileUploadExercise.validateGeneralSettings();
-
         // Validate the new file upload exercise
         validateNewOrUpdatedFileUploadExercise(fileUploadExercise);
-
         // Retrieve the course over the exerciseGroup or the given courseId
         Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(fileUploadExercise);
-
         // Check that the user is authorized to create the exercise
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastEditorInCourse(course, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
 
         FileUploadExercise result = fileUploadExerciseRepository.save(fileUploadExercise);
-
         groupNotificationService.checkNotificationsForNewExercise(fileUploadExercise, instanceMessageSendService);
-
         return ResponseEntity.created(new URI("/api/file-upload-exercises/" + result.getId()))
                 .headers(HeaderUtil.createEntityCreationAlert(applicationName, true, ENTITY_NAME, result.getId().toString())).body(result);
     }
@@ -170,7 +155,6 @@ public class FileUploadExerciseResource {
     public ResponseEntity<FileUploadExercise> updateFileUploadExercise(@RequestBody FileUploadExercise fileUploadExercise,
             @RequestParam(value = "notificationText", required = false) String notificationText, @PathVariable Long exerciseId) {
         log.debug("REST request to update FileUploadExercise : {}", fileUploadExercise);
-
         // TODO: The route has an exerciseId but we don't do anything useful with it. Change route and client requests?
 
         // Validate the updated file upload exercise
@@ -183,15 +167,13 @@ public class FileUploadExerciseResource {
 
         // Check that the user is authorized to update the exercise
         User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastEditorInCourse(course, user)) {
-            return forbidden();
-        }
-        final FileUploadExercise fileUploadExerciseBeforeUpdate = fileUploadExerciseRepository.findOneByIdElseThrow(fileUploadExercise.getId());
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, user);
+        final var fileUploadExerciseBeforeUpdate = fileUploadExerciseRepository.findByIdElseThrow(fileUploadExercise.getId());
 
         // Forbid conversion between normal course exercise and exam exercise
         exerciseService.checkForConversionBetweenExamAndCourseExercise(fileUploadExercise, fileUploadExerciseBeforeUpdate, ENTITY_NAME);
 
-        FileUploadExercise updatedExercise = fileUploadExerciseRepository.save(fileUploadExercise);
+        var updatedExercise = fileUploadExerciseRepository.save(fileUploadExercise);
         exerciseService.logUpdate(updatedExercise, updatedExercise.getCourseViaExerciseGroupOrCourseMember(), user);
         exerciseService.updatePointsInRelatedParticipantScores(fileUploadExerciseBeforeUpdate, updatedExercise);
 
@@ -214,10 +196,7 @@ public class FileUploadExerciseResource {
     public ResponseEntity<List<FileUploadExercise>> getFileUploadExercisesForCourse(@PathVariable Long courseId) {
         log.debug("REST request to get all ProgrammingExercises for the course with id : {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastTeachingAssistantInCourse(course, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
         List<FileUploadExercise> exercises = fileUploadExerciseRepository.findByCourseIdWithCategories(courseId);
         for (Exercise exercise : exercises) {
             // not required in the returned json body
@@ -238,35 +217,19 @@ public class FileUploadExerciseResource {
     public ResponseEntity<FileUploadExercise> getFileUploadExercise(@PathVariable Long exerciseId) {
         // TODO: Split this route in two: One for normal and one for exam exercises
         log.debug("REST request to get FileUploadExercise : {}", exerciseId);
-        Optional<FileUploadExercise> optionalFileUploadExercise = fileUploadExerciseRepository.findWithEagerTeamAssignmentConfigAndCategoriesById(exerciseId);
-
-        if (optionalFileUploadExercise.isEmpty()) {
-            return notFound();
-        }
-        FileUploadExercise fileUploadExercise = optionalFileUploadExercise.get();
-
+        var exercise = fileUploadExerciseRepository.findWithEagerTeamAssignmentConfigAndCategoriesById(exerciseId)
+                .orElseThrow(() -> new EntityNotFoundException("FileUploadExercise", exerciseId));
         // If the exercise belongs to an exam, only instructors and admins are allowed to access it, otherwise also TA have access
-        if (fileUploadExercise.isExamExercise()) {
-            // Get the course over the exercise group
-            ExerciseGroup exerciseGroup = exerciseGroupRepository.findByIdElseThrow(fileUploadExercise.getExerciseGroup().getId());
-            Course course = exerciseGroup.getExam().getCourse();
-
-            if (!authCheckService.isAtLeastEditorInCourse(course, null)) {
-                return forbidden();
-            }
-            // Set the exerciseGroup, exam and course so that the client can work with those ids
-            fileUploadExercise.setExerciseGroup(exerciseGroup);
+        if (exercise.isExamExercise()) {
+            authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, exercise, null);
         }
-        else if (!authCheckService.isAtLeastTeachingAssistantForExercise(fileUploadExercise)) {
-            return forbidden();
+        else {
+            authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, exercise, null);
         }
-
         List<GradingCriterion> gradingCriteria = gradingCriterionRepository.findByExerciseIdWithEagerGradingCriteria(exerciseId);
-        fileUploadExercise.setGradingCriteria(gradingCriteria);
-
-        exerciseService.checkExerciseIfStructuredGradingInstructionFeedbackUsed(gradingCriteria, fileUploadExercise);
-
-        return ResponseEntity.ok().body(fileUploadExercise);
+        exercise.setGradingCriteria(gradingCriteria);
+        exerciseService.checkExerciseIfStructuredGradingInstructionFeedbackUsed(gradingCriteria, exercise);
+        return ResponseEntity.ok().body(exercise);
     }
 
     /**
@@ -279,29 +242,13 @@ public class FileUploadExerciseResource {
     @PreAuthorize("hasRole('INSTRUCTOR')")
     public ResponseEntity<Void> deleteFileUploadExercise(@PathVariable Long exerciseId) {
         log.info("REST request to delete FileUploadExercise : {}", exerciseId);
-        Optional<FileUploadExercise> optionalFileUploadExercise = fileUploadExerciseRepository.findById(exerciseId);
-        if (optionalFileUploadExercise.isEmpty()) {
-            return notFound();
-        }
-        FileUploadExercise fileUploadExercise = optionalFileUploadExercise.get();
-
-        // If the exercise belongs to an exam, the course must be retrieved over the exerciseGroup
-        Course course;
-        if (fileUploadExercise.isExamExercise()) {
-            course = exerciseGroupRepository.retrieveCourseOverExerciseGroup(fileUploadExercise.getExerciseGroup().getId());
-        }
-        else {
-            course = fileUploadExercise.getCourseViaExerciseGroupOrCourseMember();
-        }
-
+        var exercise = fileUploadExerciseRepository.findByIdElseThrow(exerciseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastInstructorInCourse(course, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, exercise, user);
         // note: we use the exercise service here, because this one makes sure to clean up all lazy references correctly.
-        exerciseService.logDeletion(fileUploadExercise, course, user);
+        exerciseService.logDeletion(exercise, exercise.getCourseViaExerciseGroupOrCourseMember(), user);
         exerciseDeletionService.delete(exerciseId, false, false);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, fileUploadExercise.getTitle())).build();
+        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, exercise.getTitle())).build();
     }
 
     /**
@@ -314,14 +261,12 @@ public class FileUploadExerciseResource {
     @PostMapping("/file-upload-exercises/{exerciseId}/export-submissions")
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<Resource> exportSubmissions(@PathVariable long exerciseId, @RequestBody SubmissionExportOptionsDTO submissionExportOptions) {
-
-        FileUploadExercise fileUploadExercise = fileUploadExerciseRepository.findOneByIdElseThrow(exerciseId);
-
-        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, fileUploadExercise, null);
+        var exercise = fileUploadExerciseRepository.findByIdElseThrow(exerciseId);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, exercise, null);
 
         // TAs are not allowed to download all participations
         if (submissionExportOptions.isExportAllParticipants()) {
-            authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, fileUploadExercise.getCourseViaExerciseGroupOrCourseMember(), null);
+            authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, exercise.getCourseViaExerciseGroupOrCourseMember(), null);
         }
 
         File zipFile = fileUploadSubmissionExportService.exportStudentSubmissionsElseThrow(exerciseId, submissionExportOptions);
@@ -339,7 +284,6 @@ public class FileUploadExerciseResource {
      * with status 400 (Bad Request) if the fileUploadExercise is not valid, or with status 409 (Conflict)
      * if given exerciseId is not same as in the object of the request body, or with status 500 (Internal
      * Server Error) if the fileUploadExercise couldn't be updated
-     * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PutMapping(Endpoints.REEVALUATE_EXERCISE)
     @PreAuthorize("hasRole('EDITOR')")
@@ -348,18 +292,14 @@ public class FileUploadExerciseResource {
         log.debug("REST request to re-evaluate FileUploadExercise : {}", fileUploadExercise);
 
         // check that the exercise is exist for given id
-        fileUploadExerciseRepository.findOneByIdElseThrow(exerciseId);
-
+        fileUploadExerciseRepository.findByIdElseThrow(exerciseId);
         authCheckService.checkGivenExerciseIdSameForExerciseInRequestBodyElseThrow(exerciseId, fileUploadExercise);
 
         Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(fileUploadExercise);
 
         // Check that the user is authorized to update the exercise
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, user);
-
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
         exerciseService.reEvaluateExercise(fileUploadExercise, deleteFeedbackAfterGradingInstructionUpdate);
-
         return updateFileUploadExercise(fileUploadExercise, null, fileUploadExercise.getId());
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadSubmissionResource.java
@@ -88,7 +88,7 @@ public class FileUploadSubmissionResource extends AbstractSubmissionResource {
         log.debug("REST request to submit new FileUploadSubmission : {}", fileUploadSubmission);
         long start = System.currentTimeMillis();
 
-        final var exercise = fileUploadExerciseRepository.findOneByIdElseThrow(exerciseId);
+        final var exercise = fileUploadExerciseRepository.findByIdElseThrow(exerciseId);
         final User user = userRepository.getUserWithGroupsAndAuthorities();
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.STUDENT, exercise, user);
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingAssessmentResource.java
@@ -97,9 +97,7 @@ public class ModelingAssessmentResource extends AssessmentResource {
     public ResponseEntity<Result> saveModelingAssessment(@PathVariable long submissionId, @PathVariable long resultId,
             @RequestParam(value = "submit", defaultValue = "false") boolean submit, @RequestBody List<Feedback> feedbacks) {
         Submission submission = submissionRepository.findOneWithEagerResultAndFeedback(submissionId);
-        ResponseEntity<Result> response = super.saveAssessment(submission, submit, feedbacks, resultId);
-
-        return response;
+        return super.saveAssessment(submission, submit, feedbacks, resultId);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/NotificationSettingsResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/NotificationSettingsResource.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.badRequest;
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,6 +21,7 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.NotificationSettingRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.notifications.NotificationSettingsService;
+import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
 /**
@@ -79,14 +80,14 @@ public class NotificationSettingsResource {
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<NotificationSetting[]> saveNotificationSettingsForCurrentUser(@NotNull @RequestBody NotificationSetting[] notificationSettings) {
         if (notificationSettings.length == 0) {
-            return badRequest("notificationSettings", "400", "Can not save non existing Notification Settings");
+            throw new BadRequestAlertException("Can not save non existing Notification Settings", "NotificationSettings", "notificationSettingsEmpty");
         }
         User currentUser = userRepository.getUserWithGroupsAndAuthorities();
         log.debug("REST request to save NotificationSettings : {} for current user {}", notificationSettings, currentUser);
         notificationSettingsService.setCurrentUser(notificationSettings, currentUser);
         List<NotificationSetting> resultAsList = notificationSettingRepository.saveAll(Arrays.stream(notificationSettings).toList());
         if (resultAsList.isEmpty()) {
-            return badRequest("notificationSettings", "500", "Error occurred during saving of Notification Settings");
+            throw new BadRequestAlertException("Error occurred during saving of Notification Settings", "NotificationSettings", "notificationSettingsEmptyAfterSave");
         }
         NotificationSetting[] resultAsArray = resultAsList.toArray(new NotificationSetting[0]);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, "notificationSetting", "test")).body(resultAsArray);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/NotificationSettingsResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/NotificationSettingsResource.java
@@ -80,7 +80,7 @@ public class NotificationSettingsResource {
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<NotificationSetting[]> saveNotificationSettingsForCurrentUser(@NotNull @RequestBody NotificationSetting[] notificationSettings) {
         if (notificationSettings.length == 0) {
-            throw new BadRequestAlertException("Can not save non existing Notification Settings", "NotificationSettings", "notificationSettingsEmpty");
+            throw new BadRequestAlertException("Cannot save non existing Notification Settings", "NotificationSettings", "notificationSettingsEmpty");
         }
         User currentUser = userRepository.getUserWithGroupsAndAuthorities();
         log.debug("REST request to save NotificationSettings : {} for current user {}", notificationSettings, currentUser);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/OrganizationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/OrganizationResource.java
@@ -1,8 +1,8 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.badRequest;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +19,7 @@ import de.tum.in.www1.artemis.repository.OrganizationRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.OrganizationService;
 import de.tum.in.www1.artemis.web.rest.dto.OrganizationCountDTO;
+import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
 /**
@@ -88,7 +89,7 @@ public class OrganizationResource {
     }
 
     /**
-     * POST organizations/:organizationId/users/:userlogin :
+     * POST organizations/:organizationId/users/:userLogin :
      * Add a user to an organization
      *
      * @param userLogin the login of the user to add
@@ -154,10 +155,10 @@ public class OrganizationResource {
     public ResponseEntity<Organization> updateOrganization(@PathVariable Long organizationId, @RequestBody Organization organization) {
         log.debug("REST request to update organization : {}", organization);
         if (organization.getId() == null) {
-            return badRequest("organization.Id", "400", "The ID of the organization in the RequestBody isn't set!");
+            throw new BadRequestAlertException("The ID of the organization in the RequestBody isn't set!", ENTITY_NAME, "noId");
         }
         if (!organization.getId().equals(organizationId)) {
-            return badRequest("organizationId", "400", "organizationId in path doesn't match the one in the RequestBody!");
+            throw new BadRequestAlertException("organizationId in path doesn't match the one in the RequestBody!", ENTITY_NAME, "organizationIdDoesNotMatch");
         }
         organizationRepository.findByIdElseThrow(organization.getId());
         Organization updated = organizationService.update(organization);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ParticipationResource.java
@@ -124,7 +124,7 @@ public class ParticipationResource {
     }
 
     /**
-     * POST /courses/:courseId/exercises/:exerciseId/participations : start the "participationId" exercise for the current user.
+     * POST /exercises/:exerciseId/participations : start the "participationId" exercise for the current user.
      *
      * @param exerciseId the participationId of the exercise for which to init a participation
      * @return the ResponseEntity with status 201 (Created) and the participation within the body, or with status 404 (Not Found)
@@ -163,6 +163,16 @@ public class ParticipationResource {
         }
 
         StudentParticipation participation = participationService.startExercise(exercise, participant, true);
+
+        if (exercise.isExamExercise() && exercise instanceof ProgrammingExercise) {
+            // TODO: this programming exercise was started during an exam (the instructor did not invoke "prepare exercise start" before the exam or it failed in this case)
+            // 1) check that now is between exam start and individual exam end
+            // 2) create a scheduled lock operation (see ProgrammingExerciseScheduleService)
+            // var task = programmingExerciseScheduleService.lockStudentRepository(participation);
+            // 3) add the task to the schedule service
+            // scheduleService.scheduleTask(exercise, ExerciseLifecycle.DUE, task);
+        }
+
         // remove sensitive information before sending participation to the client
         participation.getExercise().filterSensitiveInformation();
         return ResponseEntity.created(new URI("/api/participations/" + participation.getId())).body(participation);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseSimulationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseSimulationResource.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -12,13 +10,15 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
-import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.CourseRepository;
-import de.tum.in.www1.artemis.repository.UserRepository;
+import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.feature.Feature;
 import de.tum.in.www1.artemis.service.feature.FeatureToggle;
@@ -47,15 +47,12 @@ public class ProgrammingExerciseSimulationResource {
 
     private final ProgrammingExerciseSimulationService programmingExerciseSimulationService;
 
-    private final UserRepository userRepository;
-
     private final AuthorizationCheckService authCheckService;
 
     public ProgrammingExerciseSimulationResource(CourseRepository courseRepository, ProgrammingExerciseSimulationService programmingExerciseSimulationService,
-            UserRepository userRepository, AuthorizationCheckService authCheckService) {
+            AuthorizationCheckService authCheckService) {
         this.courseRepository = courseRepository;
         this.programmingExerciseSimulationService = programmingExerciseSimulationService;
-        this.userRepository = userRepository;
         this.authCheckService = authCheckService;
     }
 
@@ -76,13 +73,9 @@ public class ProgrammingExerciseSimulationResource {
 
         // fetch course from database to make sure client didn't change groups
         Course course = courseRepository.findByIdElseThrow(programmingExercise.getCourseViaExerciseGroupOrCourseMember().getId());
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastEditorInCourse(course, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
 
         programmingExercise.setCourse(course);
-
         programmingExercise.generateAndSetProjectKey();
         try {
             ProgrammingExercise newProgrammingExercise = programmingExerciseSimulationService

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
@@ -114,18 +112,11 @@ public class QuizExerciseResource {
         }
 
         quizExercise.validateScoreSettings();
-
         // Valid exercises have set either a course or an exerciseGroup
         quizExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
-
         // Retrieve the course over the exerciseGroup or the given courseId
         Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(quizExercise);
-
-        // Check that the user is authorized to create the exercise
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastEditorInCourse(course, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, null);
 
         quizExercise = quizExerciseService.save(quizExercise);
 
@@ -161,15 +152,10 @@ public class QuizExerciseResource {
 
         // Valid exercises have set either a course or an exerciseGroup
         quizExercise.checkCourseAndExerciseGroupExclusivity(ENTITY_NAME);
-
         // Retrieve the course over the exerciseGroup or the given courseId
         Course course = courseService.retrieveCourseOverExerciseGroupOrCourseId(quizExercise);
-
-        // Check that the user is authorized to update the exercise
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastEditorInCourse(course, user)) {
-            return forbidden();
-        }
+        var user = userRepository.getUserWithGroupsAndAuthorities();
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, course, user);
 
         // Forbid conversion between normal course exercise and exam exercise
         final var originalQuiz = quizExerciseRepository.findByIdElseThrow(quizExercise.getId());
@@ -250,19 +236,13 @@ public class QuizExerciseResource {
     public ResponseEntity<QuizExercise> getQuizExercise(@PathVariable Long quizExerciseId) {
         // TODO: Split this route in two: One for normal and one for exam exercises
         log.debug("REST request to get QuizExercise : {}", quizExerciseId);
-        QuizExercise quizExercise = quizExerciseRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExerciseId);
-
+        var quizExercise = quizExerciseRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExerciseId);
         if (quizExercise.isExamExercise()) {
-            // Get the course over the exercise group
-            Course course = quizExercise.getExerciseGroup().getExam().getCourse();
-
-            if (!authCheckService.isAtLeastEditorInCourse(course, null)) {
-                return forbidden();
-            }
+            authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, quizExercise, null);
             studentParticipationRepository.checkTestRunsExist(quizExercise);
         }
         else if (!authCheckService.isAllowedToSeeExercise(quizExercise, null)) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
         return ResponseEntity.ok(quizExercise);
     }
@@ -279,7 +259,7 @@ public class QuizExerciseResource {
         log.debug("REST request to get QuizExercise : {}", quizExerciseId);
         QuizExercise quizExercise = quizExerciseRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExerciseId);
         if (!authCheckService.isAllowedToSeeExercise(quizExercise, null)) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
         quizStatisticService.recalculateStatistics(quizExercise);
         // fetch the quiz exercise again to make sure the latest changes are included
@@ -296,11 +276,9 @@ public class QuizExerciseResource {
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<QuizExercise> getQuizExerciseForStudent(@PathVariable Long quizExerciseId) {
         log.debug("REST request to get QuizExercise : {}", quizExerciseId);
-
         QuizExercise quizExercise = quizExerciseRepository.findByIdWithQuestionsElseThrow(quizExerciseId);
-
         if (!authCheckService.isAllowedToSeeExercise(quizExercise, null)) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
         quizExercise.applyAppropriateFilterForStudents();
 
@@ -320,14 +298,8 @@ public class QuizExerciseResource {
     @PreAuthorize("hasRole('EDITOR')")
     public ResponseEntity<QuizExercise> performActionForQuizExercise(@PathVariable Long quizExerciseId, @PathVariable String action) {
         log.debug("REST request to immediately start QuizExercise : {}", quizExerciseId);
-
-        QuizExercise quizExercise = quizExerciseRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExerciseId);
-
-        // check permissions
-        Course course = quizExercise.getCourseViaExerciseGroupOrCourseMember();
-        if (!authCheckService.isAtLeastEditorInCourse(course, null)) {
-            return forbidden();
-        }
+        var quizExercise = quizExerciseRepository.findByIdWithQuestionsAndStatisticsElseThrow(quizExerciseId);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, quizExercise, null);
 
         switch (action) {
             case "start-now" -> {
@@ -396,13 +368,11 @@ public class QuizExerciseResource {
     public ResponseEntity<Void> deleteQuizExercise(@PathVariable Long quizExerciseId) {
         log.info("REST request to delete QuizExercise : {}", quizExerciseId);
         var quizExercise = quizExerciseRepository.findByIdElseThrow(quizExerciseId);
-        Course course = quizExercise.getCourseViaExerciseGroupOrCourseMember();
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastInstructorInCourse(course, user)) {
-            return forbidden();
-        }
+        var user = userRepository.getUserWithGroupsAndAuthorities();
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, quizExercise, user);
+
         // note: we use the exercise service here, because this one makes sure to clean up all lazy references correctly.
-        exerciseService.logDeletion(quizExercise, course, user);
+        exerciseService.logDeletion(quizExercise, quizExercise.getCourseViaExerciseGroupOrCourseMember(), user);
         exerciseDeletionService.delete(quizExerciseId, false, false);
         quizExerciseService.cancelScheduledQuiz(quizExerciseId);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, quizExercise.getTitle())).build();
@@ -440,15 +410,12 @@ public class QuizExerciseResource {
         }
 
         var user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastInstructorForExercise(originalQuizExercise, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, quizExercise, user);
 
         quizExercise = quizExerciseService.reEvaluate(quizExercise, originalQuizExercise);
         exerciseService.logUpdate(quizExercise, quizExercise.getCourseViaExerciseGroupOrCourseMember(), user);
 
         quizExercise.validateScoreSettings();
-
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, quizExercise.getId().toString())).body(quizExercise);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizSubmissionResource.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
-
 import java.security.Principal;
 import java.time.ZonedDateTime;
 
@@ -25,7 +23,11 @@ import de.tum.in.www1.artemis.exception.QuizSubmissionException;
 import de.tum.in.www1.artemis.repository.QuizExerciseRepository;
 import de.tum.in.www1.artemis.repository.StudentParticipationRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.security.Role;
+import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.ParticipationService;
+import de.tum.in.www1.artemis.service.QuizSubmissionService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.exam.ExamSubmissionService;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
@@ -176,10 +178,7 @@ public class QuizSubmissionResource {
         }
 
         QuizExercise quizExercise = quizExerciseRepository.findByIdWithQuestionsElseThrow(exerciseId);
-
-        if (!authCheckService.isAtLeastTeachingAssistantForExercise(quizExercise, null)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, quizExercise, null);
 
         // update submission
         quizSubmission.setSubmitted(true);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/RatingResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/RatingResource.java
@@ -1,7 +1,5 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -14,13 +12,18 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import de.tum.in.www1.artemis.domain.*;
+import de.tum.in.www1.artemis.domain.Course;
+import de.tum.in.www1.artemis.domain.Rating;
+import de.tum.in.www1.artemis.domain.Result;
+import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
+import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.RatingService;
+import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 
 /**
@@ -64,8 +67,8 @@ public class RatingResource {
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Optional<Rating>> getRatingForResult(@PathVariable Long resultId) {
         // TODO allow for Instructors
-        if (!checkIfUserIsOwnerOfSubmission(resultId) && !authCheckService.isAdmin()) {
-            return forbidden();
+        if (!authCheckService.isAdmin()) {
+            checkIfUserIsOwnerOfSubmissionElseThrow(resultId);
         }
         Optional<Rating> rating = ratingService.findRatingByResultId(resultId);
         return ResponseEntity.ok(rating);
@@ -83,10 +86,7 @@ public class RatingResource {
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Rating> createRatingForResult(@PathVariable long resultId, @PathVariable int ratingValue) throws URISyntaxException {
         checkRating(ratingValue);
-        if (!checkIfUserIsOwnerOfSubmission(resultId)) {
-            return forbidden();
-        }
-
+        checkIfUserIsOwnerOfSubmissionElseThrow(resultId);
         Rating savedRating = ratingService.saveRating(resultId, ratingValue);
         return ResponseEntity.created(new URI("/api/results/" + savedRating.getId() + "/rating")).body(savedRating);
     }
@@ -108,10 +108,7 @@ public class RatingResource {
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Rating> updateRatingForResult(@PathVariable long resultId, @PathVariable int ratingValue) {
         checkRating(ratingValue);
-        if (!checkIfUserIsOwnerOfSubmission(resultId)) {
-            return forbidden();
-        }
-
+        checkIfUserIsOwnerOfSubmissionElseThrow(resultId);
         Rating savedRating = ratingService.updateRating(resultId, ratingValue);
         return ResponseEntity.ok(savedRating);
     }
@@ -125,27 +122,23 @@ public class RatingResource {
     @GetMapping("/course/{courseId}/rating")
     @PreAuthorize("hasRole('INSTRUCTOR')")
     public ResponseEntity<List<Rating>> getRatingForInstructorDashboard(@PathVariable Long courseId) {
-        User user = userRepository.getUserWithGroupsAndAuthorities();
         Course course = courseRepository.findByIdElseThrow(courseId);
-
-        if (!authCheckService.isAtLeastInstructorInCourse(course, user)) {
-            return forbidden();
-        }
-
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
         List<Rating> responseRatings = ratingService.getAllRatingsByCourse(courseId);
-
         return ResponseEntity.ok(responseRatings);
     }
 
     /**
-     * Check if currently logged in user in the owner of the participation
+     * Check if currently logged in user in the owner of the participation, if this is not the case throw an AccessForbiddenException
      *
      * @param resultId - Id of the result that the participation belongs to
-     * @return False if User is not Owner, True otherwise
      */
-    private boolean checkIfUserIsOwnerOfSubmission(Long resultId) {
+    private void checkIfUserIsOwnerOfSubmissionElseThrow(Long resultId) {
         User user = userRepository.getUser();
         Result result = resultRepository.findByIdElseThrow(resultId);
-        return authCheckService.isOwnerOfParticipation((StudentParticipation) result.getParticipation(), user);
+        if (!authCheckService.isOwnerOfParticipation((StudentParticipation) result.getParticipation(), user)) {
+            log.warn("User {} has tried to access rating for result {}", user.getLogin(), resultId);
+            throw new AccessForbiddenException();
+        }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
@@ -1,11 +1,13 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.badRequest;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -19,15 +21,22 @@ import org.springframework.web.bind.annotation.*;
 
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.enumeration.*;
+import de.tum.in.www1.artemis.domain.enumeration.BuildPlanType;
+import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
 import de.tum.in.www1.artemis.domain.exam.Exam;
-import de.tum.in.www1.artemis.domain.participation.*;
+import de.tum.in.www1.artemis.domain.participation.Participation;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
+import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
+import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.exception.ContinuousIntegrationException;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.SecurityUtils;
-import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.ParticipationService;
+import de.tum.in.www1.artemis.service.ResultService;
+import de.tum.in.www1.artemis.service.WebsocketMessagingService;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.LtiService;
 import de.tum.in.www1.artemis.service.exam.ExamDateService;
@@ -36,6 +45,7 @@ import de.tum.in.www1.artemis.service.programming.ProgrammingExerciseParticipati
 import de.tum.in.www1.artemis.web.rest.dto.ResultWithPointsPerGradingCriterionDTO;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
 /**
@@ -136,7 +146,7 @@ public class ResultResource {
         log.debug("Received result notify (NEW)");
         if (token == null || !token.equals(artemisAuthenticationTokenValue)) {
             log.info("Cancelling request with invalid token {}", token);
-            return forbidden(); // Only allow endpoint when using correct token
+            throw new AccessForbiddenException(); // Only allow endpoint when using correct token
         }
 
         // No 'user' is properly logged into Artemis, this leads to an issue when accessing custom repository methods.
@@ -159,7 +169,7 @@ public class ResultResource {
         var participation = getParticipationWithResults(planKey);
         if (participation == null) {
             log.warn("Participation is missing for notifyResultNew (PlanKey: {}).", planKey);
-            return notFound();
+            throw new EntityNotFoundException("Participation for build plan" + planKey + " does not exist");
         }
 
         // Process the new result from the build result.
@@ -319,15 +329,20 @@ public class ResultResource {
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<Result> getResult(@PathVariable Long participationId, @PathVariable Long resultId) {
         log.debug("REST request to get Result : {}", resultId);
+        Result result = getResultForParticipationAndCheckAccess(participationId, resultId, Role.TEACHING_ASSISTANT);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    private Result getResultForParticipationAndCheckAccess(Long participationId, Long resultId, Role role) {
         Result result = resultRepository.findByIdElseThrow(resultId);
         Participation participation = result.getParticipation();
         if (!participation.getId().equals(participationId)) {
-            return badRequest("participationId", "400",
-                    "participationId of the path doesnt match the participationId of the participation corresponding to the result " + resultId + " !");
+            throw new BadRequestAlertException("participationId of the path doesnt match the participationId of the participation corresponding to the result " + resultId + " !",
+                    "Participation", "400");
         }
         Course course = participation.getExercise().getCourseViaExerciseGroupOrCourseMember();
-        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(role, course, null);
+        return result;
     }
 
     /**
@@ -346,7 +361,7 @@ public class ResultResource {
         if (participation instanceof StudentParticipation && !authCheckService.canAccessParticipation((StudentParticipation) participation)
                 || participation instanceof ProgrammingExerciseParticipation
                         && !programmingExerciseParticipationService.canAccessParticipation((ProgrammingExerciseParticipation) participation)) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
 
         Result result = resultRepository.findFirstWithFeedbacksByParticipationIdOrderByCompletionDateDescElseThrow(participation.getId());
@@ -402,14 +417,7 @@ public class ResultResource {
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<Void> deleteResult(@PathVariable Long participationId, @PathVariable Long resultId) {
         log.debug("REST request to delete Result : {}", resultId);
-        Result result = resultRepository.findByIdElseThrow(resultId);
-        Participation participation = result.getParticipation();
-        if (!participation.getId().equals(participationId)) {
-            return badRequest("participationId", "400",
-                    "participationId of the path doesnt match the participationId of the participation corresponding to the result " + resultId + " !");
-        }
-        Course course = participation.getExercise().getCourseViaExerciseGroupOrCourseMember();
-        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
+        Result result = getResultForParticipationAndCheckAccess(participationId, resultId, Role.TEACHING_ASSISTANT);
         resultRepository.deleteById(resultId);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, true, ENTITY_NAME, resultId.toString())).build();
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ResultResource.java
@@ -169,7 +169,7 @@ public class ResultResource {
         var participation = getParticipationWithResults(planKey);
         if (participation == null) {
             log.warn("Participation is missing for notifyResultNew (PlanKey: {}).", planKey);
-            throw new EntityNotFoundException("Participation for build plan" + planKey + " does not exist");
+            throw new EntityNotFoundException("Participation for build plan " + planKey + " does not exist");
         }
 
         // Process the new result from the build result.
@@ -337,7 +337,7 @@ public class ResultResource {
         Result result = resultRepository.findByIdElseThrow(resultId);
         Participation participation = result.getParticipation();
         if (!participation.getId().equals(participationId)) {
-            throw new BadRequestAlertException("participationId of the path doesnt match the participationId of the participation corresponding to the result " + resultId + " !",
+            throw new BadRequestAlertException("participationId of the path doesnt match the participationId of the participation corresponding to the result " + resultId + "!",
                     "Participation", "400");
         }
         Course course = participation.getExercise().getCourseViaExerciseGroupOrCourseMember();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/StatisticsResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/StatisticsResource.java
@@ -1,14 +1,15 @@
 package de.tum.in.www1.artemis.web.rest;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
-
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.Exercise;
@@ -18,7 +19,8 @@ import de.tum.in.www1.artemis.domain.enumeration.StatisticsView;
 import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.ExerciseRepository;
 import de.tum.in.www1.artemis.security.Role;
-import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.StatisticsService;
 import de.tum.in.www1.artemis.web.rest.dto.CourseManagementStatisticsDTO;
 import de.tum.in.www1.artemis.web.rest.dto.ExerciseManagementStatisticsDTO;
 
@@ -85,9 +87,7 @@ public class StatisticsResource {
             case ARTEMIS -> throw new UnsupportedOperationException("Unsupported view: " + view);
         }
         Course course = courseRepository.findByIdElseThrow(courseId);
-        if (!authorizationCheckService.isAtLeastTeachingAssistantInCourse(course, null)) {
-            return forbidden();
-        }
+        authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
         return ResponseEntity.ok(this.service.getChartData(span, periodIndex, graphType, view, entityId));
     }
 
@@ -115,9 +115,7 @@ public class StatisticsResource {
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<ExerciseManagementStatisticsDTO> getExerciseStatistics(@RequestParam Long exerciseId) {
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
-        if (!authorizationCheckService.isAtLeastTeachingAssistantForExercise(exercise, null)) {
-            return forbidden();
-        }
+        authorizationCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, exercise, null);
         var exerciseManagementStatisticsDTO = service.getExerciseStatistics(exercise);
         return ResponseEntity.ok(exerciseManagementStatisticsDTO);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TeamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TeamResource.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.web.rest;
 
 import static de.tum.in.www1.artemis.config.Constants.SHORT_NAME_PATTERN;
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.forbidden;
 import static de.tum.in.www1.artemis.web.rest.util.StringUtil.stripIllegalCharacters;
 
 import java.net.URI;
@@ -28,7 +27,10 @@ import de.tum.in.www1.artemis.domain.enumeration.TeamImportStrategyType;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.security.Role;
-import de.tum.in.www1.artemis.service.*;
+import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.service.ParticipationService;
+import de.tum.in.www1.artemis.service.SubmissionService;
+import de.tum.in.www1.artemis.service.TeamService;
 import de.tum.in.www1.artemis.service.dto.TeamSearchUserDTO;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
@@ -162,7 +164,7 @@ public class TeamResource {
             throw new BadRequestAlertException("The team does not belong to the specified exercise id.", ENTITY_NAME, "wrongExerciseId");
         }
         if (!team.getShortName().equals(existingTeam.get().getShortName())) {
-            return forbidden(ENTITY_NAME, "shortNameChangeForbidden", "The team's short name cannot be changed after the team has been created.");
+            throw new BadRequestAlertException("The team's short name cannot be changed after the team has been created.", ENTITY_NAME, "shortNameChangeNotAllowed");
         }
         // Remove illegal characters from the long name
         team.setName(stripIllegalCharacters(team.getName()));
@@ -176,13 +178,13 @@ public class TeamResource {
 
         // User must be (1) at least instructor or (2) TA but the owner of the team
         if (!isAtLeastInstructor && !isAtLeastTeachingAssistantAndOwner) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
 
         // The team owner can only be changed by instructors
         final boolean ownerWasChanged = !Objects.equals(existingTeam.get().getOwner(), team.getOwner());
         if (!isAtLeastInstructor && ownerWasChanged) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
 
         // Save team (includes check for conflicts that no student is assigned to multiple teams for an exercise)
@@ -229,7 +231,7 @@ public class TeamResource {
         User user = userRepository.getUserWithGroupsAndAuthorities();
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user) && !team.hasStudent(user)) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
         team.filterSensitiveInformation();
         return ResponseEntity.ok().body(team);
@@ -246,11 +248,8 @@ public class TeamResource {
     @PreAuthorize("hasRole('TA')")
     public ResponseEntity<List<Team>> getTeamsForExercise(@PathVariable long exerciseId, @RequestParam(value = "teamOwnerId", required = false) Long teamOwnerId) {
         log.debug("REST request to get all Teams for the exercise with id : {}", exerciseId);
-        User user = userRepository.getUserWithGroupsAndAuthorities();
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
-        if (!authCheckService.isAtLeastTeachingAssistantForExercise(exercise, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, exercise, null);
         List<Team> teams = teamRepository.findAllByExerciseIdWithEagerStudents(exercise, teamOwnerId);
         teams.forEach(Team::filterSensitiveInformation);
         teams.forEach(team -> team.getStudents().forEach(student -> student.setVisibleRegistrationNumber(student.getRegistrationNumber())));
@@ -269,18 +268,12 @@ public class TeamResource {
     public ResponseEntity<Void> deleteTeam(@PathVariable long exerciseId, @PathVariable long teamId) {
         log.info("REST request to delete Team with id {} in exercise with id {}", teamId, exerciseId);
         User user = userRepository.getUserWithGroupsAndAuthorities();
-        Optional<Team> optionalTeam = teamRepository.findById(teamId);
-        if (optionalTeam.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
-        Team team = optionalTeam.get();
+        Team team = teamRepository.findByIdElseThrow(teamId);
         if (team.getExercise() != null && !team.getExercise().getId().equals(exerciseId)) {
             throw new BadRequestAlertException("The team does not belong to the specified exercise id.", ENTITY_NAME, "wrongExerciseId");
         }
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
-        if (!authCheckService.isAtLeastInstructorForExercise(exercise, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.INSTRUCTOR, exercise, user);
         // Create audit event for team delete action
         var logMessage = "Delete Team with id " + teamId + " in exercise with id " + exerciseId;
         var auditEvent = new AuditEvent(user.getLogin(), Constants.DELETE_TEAM, logMessage);
@@ -308,10 +301,7 @@ public class TeamResource {
     public ResponseEntity<Boolean> existsTeamByShortName(@PathVariable long courseId, @RequestParam("shortName") String shortName) {
         log.debug("REST request to check Team existence for course with id {} for shortName : {}", courseId, shortName);
         Course course = courseRepository.findByIdElseThrow(courseId);
-        User user = userRepository.getUserWithGroupsAndAuthorities();
-        if (!authCheckService.isAtLeastTeachingAssistantInCourse(course, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
         return ResponseEntity.ok().body(teamRepository.existsByExerciseCourseIdAndShortName(courseId, shortName));
     }
 
@@ -332,11 +322,8 @@ public class TeamResource {
         if (loginOrName.length() < 3) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Query param 'loginOrName' must be three characters or longer.");
         }
-        User user = userRepository.getUserWithGroupsAndAuthorities();
         Course course = courseRepository.findByIdElseThrow(courseId);
-        if (!authCheckService.isAtLeastTeachingAssistantInCourse(course, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
         return ResponseEntity.ok().body(teamService.searchByLoginOrNameInCourseForExerciseTeam(course, exercise, loginOrName));
     }
@@ -356,10 +343,7 @@ public class TeamResource {
 
         User user = userRepository.getUserWithGroupsAndAuthorities();
         Exercise exercise = exerciseRepository.findByIdElseThrow(exerciseId);
-
-        if (!authCheckService.isAtLeastEditorForExercise(exercise, user)) {
-            return forbidden();
-        }
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, exercise, user);
 
         if (!exercise.isTeamMode()) {
             throw new BadRequestAlertException("The exercise must be a team-based exercise.", ENTITY_NAME, "destinationExerciseNotTeamBased");
@@ -399,10 +383,8 @@ public class TeamResource {
 
         User user = userRepository.getUserWithGroupsAndAuthorities();
         Exercise destinationExercise = exerciseRepository.findByIdElseThrow(destinationExerciseId);
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, destinationExercise, user);
 
-        if (!authCheckService.isAtLeastEditorForExercise(destinationExercise, user)) {
-            return forbidden();
-        }
         if (destinationExerciseId == sourceExerciseId) {
             throw new BadRequestAlertException("The source and destination exercise must be different.", ENTITY_NAME, "sourceDestinationExerciseNotDifferent");
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/AttachmentUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/AttachmentUnitResource.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.web.rest.lecture;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.badRequest;
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.conflict;
+import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/ExerciseUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/ExerciseUnitResource.java
@@ -5,7 +5,6 @@ import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +17,7 @@ import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.lecture.ExerciseUnit;
 import de.tum.in.www1.artemis.repository.ExerciseUnitRepository;
 import de.tum.in.www1.artemis.repository.LectureRepository;
+import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
@@ -59,17 +59,11 @@ public class ExerciseUnitResource {
         if (exerciseUnit.getId() != null) {
             return badRequest();
         }
-        Optional<Lecture> lectureOptional = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lectureId);
-        if (lectureOptional.isEmpty()) {
-            return badRequest();
-        }
-        Lecture lecture = lectureOptional.get();
+        Lecture lecture = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoalsElseThrow(lectureId);
         if (lecture.getCourse() == null) {
             return conflict();
         }
-        if (!authorizationCheckService.isAtLeastEditorInCourse(lecture.getCourse(), null)) {
-            return forbidden();
-        }
+        authorizationCheckService.checkHasAtLeastRoleForLectureElseThrow(Role.EDITOR, lecture, null);
 
         // persist lecture unit before lecture to prevent "null index column for collection" error
         exerciseUnit.setLecture(null);
@@ -94,22 +88,12 @@ public class ExerciseUnitResource {
     @PreAuthorize("hasRole('EDITOR')")
     public ResponseEntity<List<ExerciseUnit>> getAllExerciseUnitsOfLecture(@PathVariable Long lectureId) {
         log.debug("REST request to get all exercise units for lecture : {}", lectureId);
-        Optional<Lecture> lectureOptional = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lectureId);
-        if (lectureOptional.isEmpty()) {
-            return badRequest();
-        }
-        Lecture lecture = lectureOptional.get();
+        Lecture lecture = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoalsElseThrow(lectureId);
         if (lecture.getCourse() == null) {
             return conflict();
         }
-        if (!authorizationCheckService.isAtLeastEditorInCourse(lecture.getCourse(), null)) {
-            return forbidden();
-        }
-
+        authorizationCheckService.checkHasAtLeastRoleForLectureElseThrow(Role.EDITOR, lecture, null);
         List<ExerciseUnit> exerciseUnitsOfLecture = exerciseUnitRepository.findByLectureId(lectureId);
-
         return ResponseEntity.ok().body(exerciseUnitsOfLecture);
-
     }
-
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/LectureUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/LectureUnitResource.java
@@ -110,12 +110,7 @@ public class LectureUnitResource {
     @PreAuthorize("hasRole('INSTRUCTOR')")
     public ResponseEntity<Void> deleteLectureUnit(@PathVariable Long lectureUnitId, @PathVariable Long lectureId) {
         log.info("REST request to delete lecture unit: {}", lectureUnitId);
-        Optional<LectureUnit> lectureUnitOptional = lectureUnitRepository.findByIdWithLearningGoalsBidirectional(lectureUnitId);
-        if (lectureUnitOptional.isEmpty()) {
-            throw new EntityNotFoundException("LectureUnit", lectureUnitId);
-        }
-        LectureUnit lectureUnit = lectureUnitOptional.get();
-
+        LectureUnit lectureUnit = lectureUnitRepository.findByIdWithLearningGoalsBidirectionalElseThrow(lectureUnitId);
         if (lectureUnit.getLecture() == null || lectureUnit.getLecture().getCourse() == null) {
             return conflict();
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
@@ -92,7 +92,7 @@ public class VideoUnitResource {
             new URL(videoUnit.getSource());
         }
         catch (MalformedURLException exception) {
-            badRequest();
+            return badRequest();
         }
 
         authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, videoUnit.getLecture().getCourse(), null);
@@ -126,7 +126,7 @@ public class VideoUnitResource {
             new URL(videoUnit.getSource());
         }
         catch (MalformedURLException exception) {
-            badRequest();
+            return badRequest();
         }
 
         Lecture lecture = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoalsElseThrow(lectureId);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
@@ -6,7 +6,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +18,9 @@ import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.lecture.VideoUnit;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.VideoUnitRepository;
+import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
 @RestController
@@ -56,20 +57,14 @@ public class VideoUnitResource {
     @PreAuthorize("hasRole('EDITOR')")
     public ResponseEntity<VideoUnit> getVideoUnit(@PathVariable Long videoUnitId, @PathVariable Long lectureId) {
         log.debug("REST request to get VideoUnit : {}", videoUnitId);
-        Optional<VideoUnit> optionalVideoUnit = videoUnitRepository.findById(videoUnitId);
-        if (optionalVideoUnit.isEmpty()) {
-            return notFound();
-        }
-        VideoUnit videoUnit = optionalVideoUnit.get();
+        var videoUnit = videoUnitRepository.findById(videoUnitId).orElseThrow(() -> new EntityNotFoundException("VideoUnit", videoUnitId));
         if (videoUnit.getLecture() == null || videoUnit.getLecture().getCourse() == null) {
             return conflict();
         }
         if (!videoUnit.getLecture().getId().equals(lectureId)) {
             return conflict();
         }
-        if (!authorizationCheckService.isAtLeastEditorInCourse(videoUnit.getLecture().getCourse(), null)) {
-            return forbidden();
-        }
+        authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, videoUnit.getLecture().getCourse(), null);
         return ResponseEntity.ok().body(videoUnit);
     }
 
@@ -79,11 +74,10 @@ public class VideoUnitResource {
      * @param lectureId      the id of the lecture to which the video unit belongs to update
      * @param videoUnit the video unit to update
      * @return the ResponseEntity with status 200 (OK) and with body the updated videoUnit
-     * @throws URISyntaxException if the Location URI syntax is incorrect
      */
     @PutMapping("/lectures/{lectureId}/video-units")
     @PreAuthorize("hasRole('EDITOR')")
-    public ResponseEntity<VideoUnit> updateVideoUnit(@PathVariable Long lectureId, @RequestBody VideoUnit videoUnit) throws URISyntaxException {
+    public ResponseEntity<VideoUnit> updateVideoUnit(@PathVariable Long lectureId, @RequestBody VideoUnit videoUnit) {
         log.debug("REST request to update an video unit : {}", videoUnit);
         if (videoUnit.getId() == null) {
             return badRequest();
@@ -101,9 +95,7 @@ public class VideoUnitResource {
             badRequest();
         }
 
-        if (!authorizationCheckService.isAtLeastEditorInCourse(videoUnit.getLecture().getCourse(), null)) {
-            return forbidden();
-        }
+        authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, videoUnit.getLecture().getCourse(), null);
 
         if (!videoUnit.getLecture().getId().equals(lectureId)) {
             return conflict();
@@ -137,17 +129,11 @@ public class VideoUnitResource {
             badRequest();
         }
 
-        Optional<Lecture> lectureOptional = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lectureId);
-        if (lectureOptional.isEmpty()) {
-            return badRequest();
-        }
-        Lecture lecture = lectureOptional.get();
+        Lecture lecture = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoalsElseThrow(lectureId);
         if (lecture.getCourse() == null) {
             return conflict();
         }
-        if (!authorizationCheckService.isAtLeastEditorInCourse(lecture.getCourse(), null)) {
-            return forbidden();
-        }
+        authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.EDITOR, lecture.getCourse(), null);
 
         // persist lecture unit before lecture to prevent "null index column for collection" error
         videoUnit.setLecture(null);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
@@ -31,6 +31,8 @@ import de.tum.in.www1.artemis.web.rest.ParticipationResource;
 import de.tum.in.www1.artemis.web.rest.dto.FileMove;
 import de.tum.in.www1.artemis.web.rest.dto.RepositoryStatusDTO;
 import de.tum.in.www1.artemis.web.rest.dto.RepositoryStatusDTOType;
+import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import de.tum.in.www1.artemis.web.rest.repository.util.RepositoryExecutor;
 
 /**
@@ -306,13 +308,13 @@ public abstract class RepositoryResource {
             return badRequest();
         }
         catch (IllegalAccessException ex) {
-            return forbidden();
+            throw new AccessForbiddenException();
         }
         catch (CheckoutConflictException | WrongRepositoryStateException ex) {
             return new ResponseEntity<>(HttpStatus.CONFLICT);
         }
         catch (FileNotFoundException ex) {
-            return notFound();
+            throw new EntityNotFoundException("File not found");
         }
         catch (GitAPIException | IOException | InterruptedException ex) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/repository/RepositoryResource.java
@@ -1,13 +1,17 @@
 package de.tum.in.www1.artemis.web.rest.repository;
 
-import static de.tum.in.www1.artemis.web.rest.util.ResponseUtil.*;
-
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -16,10 +20,11 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.WrongRepositoryStateException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import de.tum.in.www1.artemis.domain.*;
-import de.tum.in.www1.artemis.domain.File;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
@@ -32,6 +37,7 @@ import de.tum.in.www1.artemis.web.rest.dto.FileMove;
 import de.tum.in.www1.artemis.web.rest.dto.RepositoryStatusDTO;
 import de.tum.in.www1.artemis.web.rest.dto.RepositoryStatusDTOType;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
+import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 import de.tum.in.www1.artemis.web.rest.repository.util.RepositoryExecutor;
 
@@ -264,10 +270,8 @@ public abstract class RepositoryResource {
     public ResponseEntity<RepositoryStatusDTO> getStatus(Long domainId) throws GitAPIException, InterruptedException {
         log.debug("REST request to get clean status for Repository for domainId : {}", domainId);
 
-        boolean hasPermissions = canAccessRepository(domainId);
-
-        if (!hasPermissions) {
-            return forbidden();
+        if (!canAccessRepository(domainId)) {
+            throw new AccessForbiddenException();
         }
 
         RepositoryStatusDTO repositoryStatus = new RepositoryStatusDTO();
@@ -305,7 +309,7 @@ public abstract class RepositoryResource {
             responseEntitySuccess = executor.exec();
         }
         catch (IllegalArgumentException | FileAlreadyExistsException ex) {
-            return badRequest();
+            throw new BadRequestAlertException("Illegal argument during operation or file already exists", "Repository", "illegalArgumentFileAlreadyExists");
         }
         catch (IllegalAccessException ex) {
             throw new AccessForbiddenException();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/util/ResponseUtil.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/util/ResponseUtil.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
+import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
+
 /**
  * Deprecation: please throw exceptions instead of using the below methods,
  * use e.g. AccessForbiddenException, EntityNotFoundException, BadRequestAlertException, ConflictException
@@ -17,12 +19,6 @@ import org.springframework.http.ResponseEntity;
 public final class ResponseUtil implements tech.jhipster.web.util.ResponseUtil {
 
     private static final String applicationName = "artemisApp";
-
-    // Replace with EntityNotFoundException
-    @Deprecated(forRemoval = true, since = "5.2.0")
-    public static <X> ResponseEntity<X> notFound() {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-    }
 
     // Replace with AccessForbiddenException
     @Deprecated(forRemoval = true, since = "5.2.0")
@@ -66,7 +62,7 @@ public final class ResponseUtil implements tech.jhipster.web.util.ResponseUtil {
             return ResponseEntity.ok().contentLength(file.length()).contentType(MediaType.APPLICATION_OCTET_STREAM).header("filename", file.getName()).body(resource);
         }
         catch (FileNotFoundException e) {
-            return notFound();
+            throw new EntityNotFoundException("File not found");
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/util/ResponseUtil.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/util/ResponseUtil.java
@@ -20,18 +20,6 @@ public final class ResponseUtil implements tech.jhipster.web.util.ResponseUtil {
 
     private static final String applicationName = "artemisApp";
 
-    // Replace with AccessForbiddenException
-    @Deprecated(forRemoval = true, since = "5.2.0")
-    public static <X> ResponseEntity<X> forbidden() {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-    }
-
-    // Replace with AccessForbiddenException
-    @Deprecated(forRemoval = true, since = "5.2.0")
-    public static <X> ResponseEntity<X> forbidden(String entityName, String errorKey, String message) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).headers(HeaderUtil.createFailureAlert(applicationName, true, entityName, errorKey, message)).build();
-    }
-
     // Replace with BadRequestAlertException
     @Deprecated(forRemoval = true, since = "5.2.0")
     public static <X> ResponseEntity<X> badRequest() {

--- a/src/test/java/de/tum/in/www1/artemis/ExerciseUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExerciseUnitIntegrationTest.java
@@ -148,11 +148,11 @@ public class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationBamboo
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    public void createExerciseUnit_notExistingLectureId_shouldReturnBadRequest() throws Exception {
+    public void createExerciseUnit_notExistingLectureId_shouldReturnNotFound() throws Exception {
         Exercise exercise = course1.getExercises().stream().findFirst().get();
         ExerciseUnit exerciseUnit = new ExerciseUnit();
         exerciseUnit.setExercise(exercise);
-        ExerciseUnit persistedExerciseUnit = request.postWithResponseBody("/api/lectures/" + 0 + "/exercise-units", exerciseUnit, ExerciseUnit.class, HttpStatus.BAD_REQUEST);
+        request.postWithResponseBody("/api/lectures/" + 0 + "/exercise-units", exerciseUnit, ExerciseUnit.class, HttpStatus.NOT_FOUND);
     }
 
     @Test
@@ -161,8 +161,7 @@ public class ExerciseUnitIntegrationTest extends AbstractSpringIntegrationBamboo
         Exercise exercise = course1.getExercises().stream().findFirst().get();
         ExerciseUnit exerciseUnit = new ExerciseUnit();
         exerciseUnit.setExercise(exercise);
-        ExerciseUnit persistedExerciseUnit = request.postWithResponseBody("/api/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnit, ExerciseUnit.class,
-                HttpStatus.FORBIDDEN);
+        request.postWithResponseBody("/api/lectures/" + lecture1.getId() + "/exercise-units", exerciseUnit, ExerciseUnit.class, HttpStatus.FORBIDDEN);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/FileUploadExerciseIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadExerciseIntegrationTest.java
@@ -555,7 +555,7 @@ public class FileUploadExerciseIntegrationTest extends AbstractSpringIntegration
     public void testReEvaluateAndUpdateFileUploadExercise_isNotSameGivenExerciseIdInRequestBody_conflict() throws Exception {
         Course course = database.addCourseWithThreeFileUploadExercise();
         FileUploadExercise fileUploadExercise = database.findFileUploadExerciseWithTitle(course.getExercises(), "released");
-        FileUploadExercise fileUploadExerciseToBeConflicted = fileUploadExerciseRepository.findOneByIdElseThrow(fileUploadExercise.getId());
+        FileUploadExercise fileUploadExerciseToBeConflicted = fileUploadExerciseRepository.findByIdElseThrow(fileUploadExercise.getId());
         fileUploadExerciseToBeConflicted.setId(123456789L);
         fileUploadExerciseRepository.save(fileUploadExerciseToBeConflicted);
 

--- a/src/test/java/de/tum/in/www1/artemis/LearningGoalIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LearningGoalIntegrationTest.java
@@ -568,8 +568,8 @@ public class LearningGoalIntegrationTest extends AbstractSpringIntegrationBamboo
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateLearningGoal_asInstructor_shouldUpdateLearningGoal() throws Exception {
-        LearningGoal existingLearningGoal = learningGoalRepository.findByIdWithLectureUnitsBidirectional(idOfLearningGoal).get();
-        LectureUnit textLectureUnit = lectureUnitRepository.findByIdWithLearningGoalsBidirectional(idOfTextUnitOfLectureOne).get();
+        LearningGoal existingLearningGoal = learningGoalRepository.findByIdWithLectureUnitsBidirectionalElseThrow(idOfLearningGoal);
+        LectureUnit textLectureUnit = lectureUnitRepository.findByIdWithLearningGoalsBidirectionalElseThrow(idOfTextUnitOfLectureOne);
         existingLearningGoal.setTitle("Updated");
         existingLearningGoal.removeLectureUnit(textLectureUnit);
         existingLearningGoal.setDescription("Updated Description");

--- a/src/test/java/de/tum/in/www1/artemis/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingAssessmentIntegrationTest.java
@@ -183,14 +183,39 @@ public class ModelingAssessmentIntegrationTest extends AbstractSpringIntegration
 
     @Test()
     @WithMockUser(username = "tutor1", roles = "TA")
-    public void testGetExampleAssessment() throws Exception {
+    public void testGetExampleAssessmentAsTutor() throws Exception {
         ExampleSubmission storedExampleSubmission = database.addExampleSubmission(database.generateExampleSubmission(validModel, classExercise, true, true));
         List<Feedback> feedbackList = database.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
         Result storedResult = request.putWithResponseBody("/api/modeling-submissions/" + storedExampleSubmission.getId() + "/example-assessment", feedbackList, Result.class,
                 HttpStatus.OK);
         assertThat(storedResult.isExampleResult()).as("stored result is flagged as example result").isTrue();
         assertThat(exampleSubmissionRepository.findById(storedExampleSubmission.getId())).isPresent();
-        // NOTE: for some reason this test fails in IntelliJ but works fine on the command line
+        request.get("/api/exercise/" + classExercise.getId() + "/modeling-submissions/" + storedExampleSubmission.getSubmission().getId() + "/example-assessment",
+                HttpStatus.FORBIDDEN, Result.class);
+    }
+
+    @Test()
+    @WithMockUser(username = "tutor1", roles = "TA")
+    public void testGetExampleAssessmentAsTutorNoTutorial() throws Exception {
+        ExampleSubmission storedExampleSubmission = database.addExampleSubmission(database.generateExampleSubmission(validModel, classExercise, true, false));
+        List<Feedback> feedbackList = database.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
+        Result storedResult = request.putWithResponseBody("/api/modeling-submissions/" + storedExampleSubmission.getId() + "/example-assessment", feedbackList, Result.class,
+                HttpStatus.OK);
+        assertThat(storedResult.isExampleResult()).as("stored result is flagged as example result").isTrue();
+        assertThat(exampleSubmissionRepository.findById(storedExampleSubmission.getId())).isPresent();
+        request.get("/api/exercise/" + classExercise.getId() + "/modeling-submissions/" + storedExampleSubmission.getSubmission().getId() + "/example-assessment", HttpStatus.OK,
+                Result.class);
+    }
+
+    @Test()
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void testGetExampleAssessmentAsInstructor() throws Exception {
+        ExampleSubmission storedExampleSubmission = database.addExampleSubmission(database.generateExampleSubmission(validModel, classExercise, true, true));
+        List<Feedback> feedbackList = database.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
+        Result storedResult = request.putWithResponseBody("/api/modeling-submissions/" + storedExampleSubmission.getId() + "/example-assessment", feedbackList, Result.class,
+                HttpStatus.OK);
+        assertThat(storedResult.isExampleResult()).as("stored result is flagged as example result").isTrue();
+        assertThat(exampleSubmissionRepository.findById(storedExampleSubmission.getId())).isPresent();
         request.get("/api/exercise/" + classExercise.getId() + "/modeling-submissions/" + storedExampleSubmission.getSubmission().getId() + "/example-assessment", HttpStatus.OK,
                 Result.class);
     }
@@ -199,11 +224,8 @@ public class ModelingAssessmentIntegrationTest extends AbstractSpringIntegration
     @WithMockUser(username = "student1")
     public void testManualAssessmentSubmitAsStudent() throws Exception {
         ModelingSubmission submission = database.addModelingSubmissionFromResources(classExercise, "test-data/model-submission/model.54727.json", "student1");
-
         List<Feedback> feedbacks = database.loadAssessmentFomResources("test-data/model-assessment/assessment.54727.json");
-
         createAssessment(submission, feedbacks, "/assessment?submit=true", HttpStatus.FORBIDDEN);
-
         Optional<Result> storedResult = resultRepo.findDistinctBySubmissionId(submission.getId());
         assertThat(storedResult).as("result is not saved").isNotPresent();
     }

--- a/src/test/java/de/tum/in/www1/artemis/TeamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TeamIntegrationTest.java
@@ -94,7 +94,7 @@ public class TeamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         var teamAssignmentConfig = new TeamAssignmentConfig();
         teamAssignmentConfig.setExercise(exercise);
         assertThat(teamAssignmentConfig.getExercise()).isEqualTo(exercise);
-        System.out.println(teamAssignmentConfig.toString());
+        System.out.println(teamAssignmentConfig);
         teamAssignmentConfig.setMinTeamSize(1);
         teamAssignmentConfig.setMaxTeamSize(10);
         exercise.setTeamAssignmentConfig(teamAssignmentConfig);
@@ -222,7 +222,7 @@ public class TeamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         // It should not be allowed to change a team's short name (unique identifier) after creation
         Team team = database.addTeamForExercise(exercise, tutor);
         team.setShortName(team.getShortName() + " Updated");
-        request.putWithResponseBody(resourceUrl() + "/" + team.getId(), team, Team.class, HttpStatus.FORBIDDEN);
+        request.putWithResponseBody(resourceUrl() + "/" + team.getId(), team, Team.class, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -465,9 +465,9 @@ public class TeamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         Team team2a = database.addTeamsForExercise(programmingExercise, shortNamePrefix2, "team2astudent", 1, null).get(0);
         Team team2b = database.addTeamsForExercise(textExercise, shortNamePrefix2, "team2bstudent", 1, null).get(0);
 
-        assertThat(List.of(team1a, team1b, team1c).stream().map(Team::getShortName).distinct()).as("Teams 1 need the same short name for this test").hasSize(1);
-        assertThat(List.of(team2a, team2b).stream().map(Team::getShortName).distinct()).as("Teams 2 need the same short name for this test").hasSize(1);
-        assertThat(List.of(team1a, team1b, team1c, team2a, team2b).stream().map(Team::getShortName).distinct()).as("Teams 1 and Teams 2 need different short names").hasSize(2);
+        assertThat(Stream.of(team1a, team1b, team1c).map(Team::getShortName).distinct()).as("Teams 1 need the same short name for this test").hasSize(1);
+        assertThat(Stream.of(team2a, team2b).map(Team::getShortName).distinct()).as("Teams 2 need the same short name for this test").hasSize(1);
+        assertThat(Stream.of(team1a, team1b, team1c, team2a, team2b).map(Team::getShortName).distinct()).as("Teams 1 and Teams 2 need different short names").hasSize(2);
 
         database.addTeamParticipationForExercise(programmingExercise, team1a.getId());
         database.addTeamParticipationForExercise(textExercise, team1b.getId());

--- a/src/test/java/de/tum/in/www1/artemis/VideoUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/VideoUnitIntegrationTest.java
@@ -72,6 +72,7 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void createVideoUnit_asInstructor_shouldCreateVideoUnit() throws Exception {
+        videoUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");
         var persistedVideoUnit = request.postWithResponseBody("/api/lectures/" + this.lecture1.getId() + "/video-units", videoUnit, VideoUnit.class, HttpStatus.CREATED);
         assertThat(persistedVideoUnit.getId()).isNotNull();
     }
@@ -79,6 +80,7 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
     @Test
     @WithMockUser(username = "instructor42", roles = "INSTRUCTOR")
     public void createVideoUnit_InstructorNotInCourse_shouldReturnForbidden() throws Exception {
+        videoUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");
         request.postWithResponseBody("/api/lectures/" + this.lecture1.getId() + "/video-units", videoUnit, VideoUnit.class, HttpStatus.FORBIDDEN);
     }
 
@@ -91,6 +93,7 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
         lecture1 = lectureRepository.save(lecture1);
 
         this.videoUnit = (VideoUnit) lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get().getLectureUnits().stream().findFirst().get();
+        this.videoUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");
         this.videoUnit.setDescription("Changed");
         this.videoUnit = request.putWithResponseBody("/api/lectures/" + lecture1.getId() + "/video-units", this.videoUnit, VideoUnit.class, HttpStatus.OK);
         assertThat(this.videoUnit.getDescription()).isEqualTo("Changed");
@@ -106,6 +109,7 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
 
         this.videoUnit = (VideoUnit) lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get().getLectureUnits().stream().findFirst().get();
         this.videoUnit.setDescription("Changed");
+        this.videoUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");
         this.videoUnit = request.putWithResponseBody("/api/lectures/" + lecture1.getId() + "/video-units", this.videoUnit, VideoUnit.class, HttpStatus.FORBIDDEN);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/simulation/ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/simulation/ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest.java
@@ -33,19 +33,16 @@ public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest ext
 
     private Long exerciseId;
 
-    private ProgrammingExercise exercise;
-
     @BeforeEach
     void setUp() {
         database.addUsers(3, 2, 1, 2);
         database.addCourseWithOneProgrammingExerciseAndTestCases();
 
-        exercise = programmingExerciseRepository.findAllWithEagerParticipationsAndLegalSubmissions().get(0);
+        ProgrammingExercise exercise = programmingExerciseRepository.findAllWithEagerParticipationsAndLegalSubmissions().get(0);
         database.addStudentParticipationForProgrammingExercise(exercise, "student1");
         database.addStudentParticipationForProgrammingExercise(exercise, "student2");
 
         exerciseId = exercise.getId();
-        exercise = programmingExerciseRepository.findAllWithEagerParticipationsAndLegalSubmissions().get(0);
     }
 
     @AfterEach
@@ -100,6 +97,6 @@ public class ProgrammingExerciseSubmissionAndResultSimulationIntegrationTest ext
     @Test
     @WithMockUser(username = "tutor1", roles = "EDITOR")
     void shouldCreateResultWithoutConnectionToVCSandCI_forbidden() throws Exception {
-        request.post(ROOT + RESULTS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null, HttpStatus.FORBIDDEN);
+        request.post(ROOT + RESULTS_SIMULATION.replace("{exerciseId}", String.valueOf(exerciseId)), null, HttpStatus.NOT_FOUND);
     }
 }


### PR DESCRIPTION
This PR migrates deprecations in server code to the now preferred use, in particular used of `notFound()` and `forbidden()` are changed to the corresponding exceptions.


### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
