### PR TITLE
`Development`: Fix server test concerning UTC conversion

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
@@ -144,7 +144,7 @@ public class CourseServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
 
         var exerciseList = new HashSet<Long>();
         exerciseList.add(exercise.getId());
-        var activeStudents = courseService.getActiveStudents(exerciseList, 0, 4, ZonedDateTime.now());
+        var activeStudents = courseService.getActiveStudents(exerciseList, 0, 4, ZonedDateTime.of(2022, 1, 25, 0, 0, 0, 0, ZonedDateTime.now().getZone()));
         assertThat(activeStudents.size()).isEqualTo(4);
         assertThat(activeStudents).containsExactly(1, 0, 0, 0);
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
@@ -144,7 +144,7 @@ public class CourseServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
 
         var exerciseList = new HashSet<Long>();
         exerciseList.add(exercise.getId());
-        var activeStudents = courseService.getActiveStudents(exerciseList, 0, 4, ZonedDateTime.of(2022, 1, 25, 0, 0, 0, 0, ZonedDateTime.now().getZone()));
+        var activeStudents = courseService.getActiveStudents(exerciseList, 0, 4, ZonedDateTime.of(2022, 1, 25, 0, 0, 0, 0, ZoneId.systemDefault()));
         assertThat(activeStudents.size()).isEqualTo(4);
         assertThat(activeStudents).containsExactly(1, 0, 0, 0);
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/CourseServiceTest.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.HashSet;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A couple of days ago, the active users chart was broken due to an edge case. I implemented a server test covering exactly this edge case. This test case is currently failing because I was using `ZonedDateTime.now()` as start date for the test. This made the test flaky after the end of last week as the day the submission was simulated on was not in scope of the chart anymore. 
### Description
<!-- Describe your changes in detail -->
I defined an explicit date now (25.01.22)
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Only code review

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
Nothing changed
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
