### PR TITLE
`Development`: Increase client test coverage of date time picker

### DIFF
--- a/src/test/javascript/spec/component/shared/date-time-picker.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/date-time-picker.component.spec.ts
@@ -1,0 +1,96 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NgModel } from '@angular/forms';
+import { OwlDateTimeModule } from '@danielmoncada/angular-datetime-picker';
+import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';
+import dayjs from 'dayjs/esm';
+import { MockDirective, MockModule } from 'ng-mocks';
+import { ArtemisTestModule } from '../../test.module';
+
+describe('FormDateTimePickerComponent', () => {
+    let component: FormDateTimePickerComponent;
+    let fixture: ComponentFixture<FormDateTimePickerComponent>;
+
+    const normalDate = dayjs('2022-01-02T22:15+00:00');
+    const normalDateAsDateObject = new Date('2022-01-02T22:15+00:00');
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule, MockModule(OwlDateTimeModule)],
+            declarations: [FormDateTimePickerComponent, MockDirective(NgModel)],
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(FormDateTimePickerComponent);
+                component = fixture.componentInstance;
+            });
+    });
+
+    it('should emit if a value is changed', () => {
+        const emitStub = jest.spyOn(component.valueChange, 'emit').mockImplementation();
+
+        component.valueChanged();
+
+        expect(emitStub).toHaveBeenCalledTimes(1);
+    });
+
+    describe('test date conversion', () => {
+        let convertedDate: Date | null;
+        it('should convert the dayjs if it is not undefined', () => {
+            convertedDate = component.convert(normalDate);
+
+            expect(convertedDate).toEqual(normalDateAsDateObject);
+        });
+
+        it('should return null if dayjs is undefined', () => {
+            convertedDate = component.convert();
+
+            expect(convertedDate).toBe(null);
+        });
+
+        it('should return null if dayjs is invalid', () => {
+            const unconvertedDate = dayjs('2022-31-02T00:00+00:00');
+
+            expect(unconvertedDate.isValid()).toBe(false);
+
+            convertedDate = component.convert(unconvertedDate);
+
+            expect(convertedDate).toBe(null);
+        });
+    });
+
+    describe('test date writing', () => {
+        it('should write the correct date if date is dayjs', () => {
+            component.writeValue(normalDate);
+
+            expect(component.value).toEqual(normalDateAsDateObject);
+        });
+
+        it('should write the correct date if date is date object', () => {
+            component.writeValue(normalDateAsDateObject);
+
+            expect(component.value).toEqual(normalDateAsDateObject);
+        });
+    });
+
+    it('should register callback function', () => {
+        const testCallBackFunction = (date: dayjs.Dayjs) => 'I am a test callbackFunction: ' + date.toDate();
+
+        component.registerOnChange(testCallBackFunction);
+
+        expect(component._onChange(normalDate)).toBe(testCallBackFunction(normalDate));
+    });
+
+    it('should update field', () => {
+        const valueChangedStub = jest.spyOn(component, 'valueChanged').mockImplementation();
+        const onChangeSpy = jest.spyOn(component, '_onChange');
+        const newDate = normalDate.add(2, 'days');
+        component.value = normalDate;
+
+        component.updateField(newDate);
+
+        expect(component.value).toEqual(newDate);
+        expect(onChangeSpy).toHaveBeenCalledTimes(1);
+        expect(onChangeSpy).toHaveBeenCalledWith(newDate);
+        expect(valueChangedStub).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR increases the test coverage of `date-time-picker.component.ts`
### Description
<!-- Describe your changes in detail -->
I introduced a dedicated test suite `date-time-picker.component.spec.ts`

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Only code review

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
`date-time-picker.component.ts`: 100% | 91.3%
