### PR TITLE
`General`: Fix tooltip in student statistics if exercise is only started

### DIFF
--- a/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
+++ b/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
@@ -334,7 +334,13 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy, AfterViewIn
                                 this.pushToData(exercise, series);
                             } else {
                                 series[5].value = 100;
-                                series[5].afterDueDate = true;
+                                // If the user only presses "start exercise", there is still no participation
+                                if (participation.initializationState === InitializationState.INITIALIZED) {
+                                    series[5].afterDueDate = false;
+                                    series[5].notParticipated = true;
+                                } else {
+                                    series[5].afterDueDate = true;
+                                }
                                 series[5].exerciseTitle = exercise.title;
                                 series[5].exerciseId = exercise.id;
                                 this.pushToData(exercise, series);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Given the situation that the user only presses "start exercises", the corresponding bar in the horizontal bar chart of the respective exercise type currently shows an incorrect tooltip indicating that the user participated on the exercise but after the due date.
This is tooltip is fixed in this PR.
### Description
<!-- Describe your changes in detail -->
I added an additional check that triggers the correct tooltip if the situation explained above occurs.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Exercise (the type can be arbitrary)

1. Log in to Artemis
2. Press "Start exercise" of the corresponding exercise
3. Navigate to the statistics tab
4. Hover over the corresponding bar. Make sure that the tooltip displays that you did not participate on the exercise yet.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
Nothing changed
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
The current tooltip:
![image](https://user-images.githubusercontent.com/80622272/151968524-11682f31-74c9-4756-b3c8-bd9fa9d36173.png)

The correct tooltip:
![image](https://user-images.githubusercontent.com/80622272/151968071-211743b9-daf3-4a2b-a20c-d17e9dbe76e5.png)
