### PR TITLE
`Development`: Increase client test coverage of assessment filters

### DIFF
--- a/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
@@ -11,6 +11,8 @@ import { Result } from 'app/entities/result.model';
 describe('AssessmentFiltersComponent', () => {
     let component: AssessmentFiltersComponent;
     let fixture: ComponentFixture<AssessmentFiltersComponent>;
+    let textSubmission1: TextSubmission;
+    let textSubmission2: TextSubmission;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -22,15 +24,15 @@ describe('AssessmentFiltersComponent', () => {
                 fixture = TestBed.createComponent(AssessmentFiltersComponent);
                 component = fixture.componentInstance;
                 fixture.detectChanges();
+                textSubmission1 = { id: 23, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+                textSubmission2 = { id: 24, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
             });
     });
     afterEach(() => {
         jest.restoreAllMocks();
     });
 
-    it('should update fitler when being called', () => {
-        const textSubmission1 = { id: 23, participation: { exercise: { id: 1 }, id: 2 }, results: {}, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
-        const textSubmission2 = { id: 24, participation: { exercise: { id: 1 }, id: 2 }, results: {}, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+    it('should set filter properly when being called', () => {
         component.submissions = [textSubmission1, textSubmission2];
         const submissions = [textSubmission1, textSubmission2];
         component.submissions = submissions;
@@ -40,8 +42,6 @@ describe('AssessmentFiltersComponent', () => {
     });
 
     it('emitting the changes should not change the underlying submission list', () => {
-        const textSubmission1 = { id: 23, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
-        const textSubmission2 = { id: 24, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
         const submissions = [textSubmission1, textSubmission2];
         textSubmission1.results = [];
         textSubmission2.results = [];

--- a/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
@@ -5,14 +5,17 @@ import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockDirective, MockPipe } from 'ng-mocks';
 import { NgModel } from '@angular/forms';
 import { TextSubmission } from 'app/entities/text-submission.model';
-import { SubmissionExerciseType } from 'app/entities/submission.model';
+import { Submission, SubmissionExerciseType } from 'app/entities/submission.model';
 import { Result } from 'app/entities/result.model';
+import dayjs from 'dayjs/esm';
 
 describe('AssessmentFiltersComponent', () => {
     let component: AssessmentFiltersComponent;
     let fixture: ComponentFixture<AssessmentFiltersComponent>;
-    let textSubmission1: TextSubmission;
-    let textSubmission2: TextSubmission;
+    let textSubmissionWithLock: TextSubmission;
+    let textSubmissionWithoutResult: TextSubmission;
+    let textSubmissionWithResult: TextSubmission;
+    let submissions: Submission[];
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -24,8 +27,10 @@ describe('AssessmentFiltersComponent', () => {
                 fixture = TestBed.createComponent(AssessmentFiltersComponent);
                 component = fixture.componentInstance;
                 fixture.detectChanges();
-                textSubmission1 = { id: 23, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
-                textSubmission2 = { id: 24, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+                textSubmissionWithLock = { id: 23, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+                textSubmissionWithoutResult = { id: 24, participation: { exercise: { id: 1 }, id: 3 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+                textSubmissionWithResult = { id: 25, participation: { exercise: { id: 1 }, id: 4 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+                submissions = [textSubmissionWithLock, textSubmissionWithoutResult, textSubmissionWithResult];
             });
     });
     afterEach(() => {
@@ -33,24 +38,30 @@ describe('AssessmentFiltersComponent', () => {
     });
 
     it('should set filter properly when being called', () => {
-        component.submissions = [textSubmission1, textSubmission2];
-        const submissions = [textSubmission1, textSubmission2];
         component.submissions = submissions;
+        const emitSpy = jest.spyOn(component.filterChange, 'emit');
         component.updateFilter(component.FilterProp.ALL);
         expect(component.filterProp).toBe(component.FilterProp.ALL);
         expect(component.submissions).toBe(submissions);
+        expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledWith(submissions);
     });
 
-    it('emitting the changes should not change the underlying submission list', () => {
-        const submissions = [textSubmission1, textSubmission2];
-        textSubmission1.results = [];
-        textSubmission2.results = [];
-        textSubmission1.results = [new Result()];
+    it('should filter for the right submissions', () => {
+        textSubmissionWithLock.results = [];
+        textSubmissionWithoutResult.results = [];
+        textSubmissionWithResult.results = [];
+        textSubmissionWithLock.results = [new Result()];
+        const result3 = new Result();
+        result3.completionDate = dayjs().add(5, 'minutes');
+        textSubmissionWithResult.results.push(result3);
         component.submissions = submissions;
+        const expectedResult = [textSubmissionWithLock];
         const emitSpy = jest.spyOn(component.filterChange, 'emit');
         component.updateFilter(component.FilterProp.LOCKED);
         expect(component.filterProp).toBe(component.FilterProp.LOCKED);
         expect(component.submissions).toBe(submissions);
         expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledWith(expectedResult);
     });
 });

--- a/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
@@ -4,17 +4,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockDirective, MockPipe } from 'ng-mocks';
 import { NgModel } from '@angular/forms';
-import { TextSubmission } from 'app/entities/text-submission.model';
-import { Submission, SubmissionExerciseType } from 'app/entities/submission.model';
+import { Submission } from 'app/entities/submission.model';
 import { Result } from 'app/entities/result.model';
 import dayjs from 'dayjs/esm';
 
 describe('AssessmentFiltersComponent', () => {
     let component: AssessmentFiltersComponent;
     let fixture: ComponentFixture<AssessmentFiltersComponent>;
-    let textSubmissionWithLock: TextSubmission;
-    let textSubmissionWithoutResult: TextSubmission;
-    let textSubmissionWithResult: TextSubmission;
+
     let submissions: Submission[];
 
     beforeEach(() => {
@@ -27,10 +24,6 @@ describe('AssessmentFiltersComponent', () => {
                 fixture = TestBed.createComponent(AssessmentFiltersComponent);
                 component = fixture.componentInstance;
                 fixture.detectChanges();
-                textSubmissionWithLock = { id: 23, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
-                textSubmissionWithoutResult = { id: 24, participation: { exercise: { id: 1 }, id: 3 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
-                textSubmissionWithResult = { id: 25, participation: { exercise: { id: 1 }, id: 4 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
-                submissions = [textSubmissionWithLock, textSubmissionWithoutResult, textSubmissionWithResult];
             });
     });
     afterEach(() => {
@@ -38,25 +31,27 @@ describe('AssessmentFiltersComponent', () => {
     });
 
     it('should set filter properly when being called', () => {
+        submissions = [];
         component.submissions = submissions;
         const emitSpy = jest.spyOn(component.filterChange, 'emit');
+        component.updateFilter(component.FilterProp.LOCKED);
+        expect(component.filterProp).toBe(component.FilterProp.LOCKED);
         component.updateFilter(component.FilterProp.ALL);
         expect(component.filterProp).toBe(component.FilterProp.ALL);
         expect(component.submissions).toBe(submissions);
-        expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledTimes(2);
         expect(emitSpy).toHaveBeenCalledWith(submissions);
     });
 
     it('should filter for the right submissions', () => {
-        textSubmissionWithLock.results = [];
-        textSubmissionWithoutResult.results = [];
-        textSubmissionWithResult.results = [];
-        textSubmissionWithLock.results = [new Result()];
-        const result3 = new Result();
-        result3.completionDate = dayjs().add(5, 'minutes');
-        textSubmissionWithResult.results.push(result3);
+        const submissionWithLock = { results: [new Result()] } as Submission;
+        const resultWithCompletionDate = new Result();
+        resultWithCompletionDate.completionDate = dayjs();
+        const unlockedSubmissionWithResult = { results: [resultWithCompletionDate] } as Submission;
+        const submissionWithoutResult = {} as Submission;
+        submissions = [unlockedSubmissionWithResult, submissionWithLock, submissionWithoutResult];
         component.submissions = submissions;
-        const expectedResult = [textSubmissionWithLock];
+        const expectedResult = [submissionWithLock];
         const emitSpy = jest.spyOn(component.filterChange, 'emit');
         component.updateFilter(component.FilterProp.LOCKED);
         expect(component.filterProp).toBe(component.FilterProp.LOCKED);

--- a/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
@@ -1,0 +1,56 @@
+import { ArtemisTestModule } from '../../test.module';
+import { AssessmentFiltersComponent } from 'app/assessment/assessment-filters/assessment-filters.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
+import { MockDirective, MockPipe } from 'ng-mocks';
+import { NgModel } from '@angular/forms';
+import { TextSubmission } from 'app/entities/text-submission.model';
+import { SubmissionExerciseType } from 'app/entities/submission.model';
+import { Result } from 'app/entities/result.model';
+
+describe('AssessmentFiltersComponent', () => {
+    let component: AssessmentFiltersComponent;
+    let fixture: ComponentFixture<AssessmentFiltersComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [AssessmentFiltersComponent, MockPipe(ArtemisTranslatePipe), MockDirective(NgModel)],
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(AssessmentFiltersComponent);
+                component = fixture.componentInstance;
+                fixture.detectChanges();
+            });
+    });
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should update fitler when being called', () => {
+        const textSubmission1 = { id: 23, participation: { exercise: { id: 1 }, id: 2 }, results: {}, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+        const textSubmission2 = { id: 24, participation: { exercise: { id: 1 }, id: 2 }, results: {}, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+        component.submissions = [textSubmission1, textSubmission2];
+        const submissions = [textSubmission1, textSubmission2];
+        component.submissions = submissions;
+        component.updateFilter(component.FilterProp.ALL);
+        expect(component.filterProp).toBe(component.FilterProp.ALL);
+        expect(component.submissions).toBe(submissions);
+    });
+
+    it('emitting the changes should not change the underlying submission list', () => {
+        const textSubmission1 = { id: 23, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+        const textSubmission2 = { id: 24, participation: { exercise: { id: 1 }, id: 2 }, submissionExerciseType: SubmissionExerciseType.TEXT } as TextSubmission;
+        const submissions = [textSubmission1, textSubmission2];
+        textSubmission1.results = [];
+        textSubmission2.results = [];
+        textSubmission1.results = [new Result()];
+        component.submissions = submissions;
+        const emitSpy = jest.spyOn(component.filterChange, 'emit');
+        component.updateFilter(component.FilterProp.LOCKED);
+        expect(component.filterProp).toBe(component.FilterProp.LOCKED);
+        expect(component.submissions).toBe(submissions);
+        expect(emitSpy).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR increases the test coverage of `assessments-filters.component.ts`
### Description
<!-- Describe your changes in detail -->
I introduced a dedicated test suite `assessments-filters.component.spec.ts`

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Only code review

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
`assesment-filters.component.ts`: 100% | 91.3%
