### PR TITLE
`Exam mode`: Fix changing between programming exercises in exams shows wrong files on refresh

### DIFF
--- a/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.ts
+++ b/src/main/webapp/app/exam/participate/exercises/programming/programming-exam-submission.component.ts
@@ -76,14 +76,21 @@ export class ProgrammingExamSubmissionComponent extends ExamSubmissionComponent 
         // We lock the repository when the buildAndTestAfterDueDate is set and the due date has passed.
         const dueDateHasPassed = !this.exercise.dueDate || dayjs(this.exercise.dueDate).isBefore(dayjs());
         this.repositoryIsLocked = !!this.exercise.buildAndTestStudentSubmissionsAfterDueDate && !!this.exercise.dueDate && dueDateHasPassed;
-
-        const participation = { ...this.studentParticipation, exercise: this.exercise } as StudentParticipation;
-        this.domainService.setDomain([DomainType.PARTICIPATION, participation]);
+        this.updateDomain();
     }
 
     onActivate() {
         super.onActivate();
         this.instructions.updateMarkdown();
+        this.updateDomain();
+    }
+
+    /**
+     * Updates the domain to set the active student participation
+     */
+    updateDomain() {
+        const participation = { ...this.studentParticipation, exercise: this.exercise } as StudentParticipation;
+        this.domainService.setDomain([DomainType.PARTICIPATION, participation]);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This issue was reported on Confluence here (point 3):
https://confluence.ase.in.tum.de/display/ArTEMiS/Issues+Student+Subteam?preview=/90547586/115642047/2022-02-07%2015-12-16.mp4
This PR is linked to the following issue in an exam with two (or more) programming exercises as a student:
When opening the exam, the first programming exercise (1) is selected. When selecting the second programming exercise (2) and press the button “Refresh files”, switching back to the first exercise (1) and also press the button “Refresh files”, the files of the second exercise (2) were shown in the code editor. This should not be the case since exercise 1 is selected. At this stage, submitting files were pushed to the repository of exercise 2.


### Description
<!-- Describe your changes in detail -->
Once a programming exercise is opened for the first time (in the student’s exam), the method ngOnInit is invoked that sets the domain from which the participation (including the code from the repository for this respective exercise) is loaded.
Because of Angular component caching, once the code editor has been opened for an exercise for the first time, the ngOnInit method is not invoked when reopening the code editor for this exercise.
Since the domain change is called in the ngOnInit method, the domain only updates when a programming exercise has been for the first time, but not when “revisiting” the code editor for this exercise.
This PR fixes this problem by calling the method that changes the domain every time the component is reopened. This reopening triggers the Angular method onActivate, in which the domain change is called now.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student

1. Create an exam with two programming exercises
2. Open Programming Exercise 1 and then Exercise 2
3. Press "Refresh Files" on Exercise 2
4. Navigate back to Exercise 1 and also press "Refresh Files"
5. The files of Exercise 1 should now be visible
6. Check that after the previous testing steps that when submitting to an exercise, the files are submitted to the correct repository.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
