### PR TITLE
`Exam mode`: Fix that complaints are not possible for non programming exercises after participating in an exam as a student

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -525,15 +525,18 @@ public class CourseResource {
      * @return the ResponseEntity with status 200 (OK) and with body the course, or with status 404 (Not Found)
      */
     @GetMapping("/courses/{courseId}")
-    @PreAuthorize("hasRole('TA')")
+    @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Course> getCourse(@PathVariable Long courseId) {
         log.debug("REST request to get Course : {}", courseId);
         Course course = courseRepository.findByIdElseThrow(courseId);
-        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
-        course.setNumberOfInstructors(userRepository.countUserInGroup(course.getInstructorGroupName()));
-        course.setNumberOfTeachingAssistants(userRepository.countUserInGroup(course.getTeachingAssistantGroupName()));
-        course.setNumberOfEditors(userRepository.countUserInGroup(course.getEditorGroupName()));
-        course.setNumberOfStudents(userRepository.countUserInGroup(course.getStudentGroupName()));
+        authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.STUDENT, course, null);
+
+        if (authCheckService.isAtLeastTeachingAssistantInCourse(course, null)) {
+            course.setNumberOfInstructors(userRepository.countUserInGroup(course.getInstructorGroupName()));
+            course.setNumberOfTeachingAssistants(userRepository.countUserInGroup(course.getTeachingAssistantGroupName()));
+            course.setNumberOfEditors(userRepository.countUserInGroup(course.getEditorGroupName()));
+            course.setNumberOfStudents(userRepository.countUserInGroup(course.getStudentGroupName()));
+        }
         return ResponseUtil.wrapOrNotFound(Optional.of(course));
     }
 

--- a/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.html
+++ b/src/main/webapp/app/complaints/complaints-for-students/complaints-student-view.component.html
@@ -1,14 +1,14 @@
 <div *ngIf="complaint || showSection">
-    <p *ngIf="course!.complaintsEnabled">
+    <p *ngIf="course?.complaintsEnabled ?? false">
         <span
             *ngIf="!isExamMode && remainingNumberOfComplaints == undefined"
             [jhiTranslate]="'artemisApp.complaint.' + (exercise.teamMode ? 'descriptionTeam' : 'description')"
-            [translateValues]="{ maxComplaintNumber: course!.maxComplaints! }"
+            [translateValues]="{ maxComplaintNumber: course?.maxComplaints ?? 0 }"
         ></span>
         <span
             *ngIf="!isExamMode && remainingNumberOfComplaints >= 0"
             [jhiTranslate]="'artemisApp.complaint.' + (exercise.teamMode ? 'descriptionTeamExtended' : 'descriptionExtended')"
-            [translateValues]="{ maxComplaintNumber: course!.maxComplaints!, allowedComplaints: remainingNumberOfComplaints }"
+            [translateValues]="{ maxComplaintNumber: course?.maxComplaints ?? 0, allowedComplaints: remainingNumberOfComplaints }"
         ></span>
         <span *ngIf="isExamMode" [jhiTranslate]="'artemisApp.complaint.descriptionExam'"></span>
         <fa-icon *ngIf="!isExamMode" [icon]="faInfoCircle" title="{{ 'artemisApp.complaint.info' | artemisTranslate }}" class="info-icon"></fa-icon>

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
@@ -62,13 +62,14 @@ export class ExamParticipationSummaryComponent implements OnInit {
         // courseId is not part of the exam or the exercise
         this.courseId = Number(this.route.snapshot.paramMap.get('courseId'));
         this.setExamWithOnlyIdAndStudentReviewPeriod();
-        let course;
-        this.courseManagementService.find(this.courseId).subscribe((courseResponse) => (course = courseResponse.body!));
-        for (const exercise of this.studentExam.exercises!) {
+        // load course for the exercise
+        this.courseManagementService.find(this.courseId).subscribe((courseResponse) => {
+            this.examWithOnlyIdAndStudentReviewPeriod.course = courseResponse.body!;
+        });
+        for (const exercise of this.studentExam.exercises ?? []) {
             exercise.studentParticipations!.first()!.exercise = exercise;
             exercise.exerciseGroup!.exam = this.examWithOnlyIdAndStudentReviewPeriod;
         }
-        this.examWithOnlyIdAndStudentReviewPeriod.course = course;
     }
 
     getIcon(exerciseType: ExerciseType) {


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
This issue was reported on Confluence here (point 5):
This PR is linked to an issue where a student was not able to complain about non-programming exercises after participating in the exam.
The client invokes the REST endpoint `/courses/{courseId}` in order to check if and how many complaints are allowed. In order to call this endpoint, the caller must have at least tutor rights. A student does not have those rights and therefore multiple values in the client were undefined. Hence, the site was not usable anymore (screenshot below).
Additionally, while waiting for the response, the components are already built and produce errors because some values are undefined.

### Description
I changed the endpoint to be also callable for students. This should not be a security issue since there are other endpoints allowing this, too (e.g. for the course overview).
In addition, I added default values for those variables that are loaded asynchronously (contained in the response).


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam with at least one non-programming exercise

1. As Instructor: Create an exam with at least one non-programming exercise
2. As Student: Participate in this exam and submit anything to the exercise.
3. As Instructor: Open the assessment dashboard for the exercise(s) and submit feedback on every exercise.
4. As Student: Open the exam again. You should now be able to see every exercise, your submitted solution, the score and the 'Complain'-Button (see screenshot below).

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2


### Screenshots
Before:
<img width="1403" alt="Bildschirmfoto 2022-02-05 um 18 19 28" src="https://user-images.githubusercontent.com/73833780/152977828-6858e244-4f47-475d-a050-003dd81380ee.png">

After:
![Bildschirmfoto 2022-02-08 um 12 08 54](https://user-images.githubusercontent.com/73833780/152977851-74613930-396c-456d-90cc-022827ee87a3.png)

