### PR TITLE
`Programming exercises`: Fix edge case in rendering of programming exercise problem statements

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise/exercise-details/exercise-details.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise-details/exercise-details.component.ts
@@ -33,6 +33,7 @@ export class ExerciseDetailsComponent implements OnInit {
         if (this.exercise.type === ExerciseType.PROGRAMMING) {
             this.programmingExercise = this.exercise as ProgrammingExercise;
         } else {
+            // Do not render the markdown here if it is a programming exercises, as ProgrammingExerciseInstructionComponent takes care of that
             this.formattedProblemStatement = this.artemisMarkdown.safeHtmlForMarkdown(this.exercise.problemStatement);
         }
         this.isExamExercise = !!this.exercise.exerciseGroup;

--- a/src/main/webapp/app/exercises/shared/exercise/exercise-details/exercise-details.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise-details/exercise-details.component.ts
@@ -30,9 +30,10 @@ export class ExerciseDetailsComponent implements OnInit {
      */
     ngOnInit() {
         this.formattedGradingInstructions = this.artemisMarkdown.safeHtmlForMarkdown(this.exercise.gradingInstructions);
-        this.formattedProblemStatement = this.artemisMarkdown.safeHtmlForMarkdown(this.exercise.problemStatement);
         if (this.exercise.type === ExerciseType.PROGRAMMING) {
             this.programmingExercise = this.exercise as ProgrammingExercise;
+        } else {
+            this.formattedProblemStatement = this.artemisMarkdown.safeHtmlForMarkdown(this.exercise.problemStatement);
         }
         this.isExamExercise = !!this.exercise.exerciseGroup;
         this.exercise.isAtLeastTutor = this.accountService.isAtLeastTutorForExercise(this.exercise);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In a current exam programming exercise it was the case that the problem statement was not rendered in the editor detail view of the exercise. The console showed an error that q.replace was not a function.
This issue was only occurring within this specific view and not within the actual editing view and the student detail view.

This was caused by an apparently very rare edge case in how the Markdown renderer detects links.
The task `[task][Constructor](xyz)` was interpreted as a link.
The task `[task][Constructo](xyz)` was however interpreted as a link.
The underlying issue here is that the problem statement gets rendered without the task markdown extension, which is present in every other view. This was the case, as it was rendered in the exercise-details-component ngOnInit method, which is the responsible component for rendering the common details of the different exercise types. However, if the exercise is a programming exercise the problem statement that is rendered in the ngOnInit method is not used, but instead the programming-exercise-instruction component is used. 

### Description
<!-- Describe your changes in detail -->
The easy fix was to simply only render the problem statement in the ngOnInit method, when the exercise is not a programming exercise.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Editor

1. Log in to Artemis
2. Create a programming exercise containing `[task][Constructor](xyz)`
3. Go to the detail view of the exercise
4. Check that the problem statement is rendered

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
