### PR TITLE
`Development`: Fix docker build issue with wget

### DIFF
--- a/src/main/docker/jenkins/Dockerfile
+++ b/src/main/docker/jenkins/Dockerfile
@@ -7,7 +7,7 @@ USER root
 RUN apt update
 
 # Install Java and Maven dependencies
-RUN apt-get install -y maven
+RUN apt-get install -y maven wget
 RUN cd /usr/lib/jvm && \
     wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz && \
     tar -zxf OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz \
@@ -22,7 +22,7 @@ RUN apt install -y gcc gdb make libubsan0 liblsan0 libtsan0
 
 # Some packages need to be installed to avoid some known problems for python3.6, see: https://github.com/pyenv/pyenv/wiki/Common-build-problems
 RUN apt install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
-    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+    libreadline-dev libsqlite3-dev curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev
 
  # Install Python3.8


### PR DESCRIPTION
### Checklist
#### General
- [X] This is a small issue that I tested locally.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
When building the Jenkins Docker image with `docker-compose -f src/main/docker/gitlab-jenkins-mysql.yml up --build -d`, the following error occures:
```
[+] Building 217.1s (16/27)
 => [docker_gitlab internal] load build definition from Dockerfile                                                                       0.0s
 => => transferring dockerfile: 531B                                                                                                     0.0s
 => [docker_jenkins internal] load build definition from Dockerfile                                                                      0.0s
 => => transferring dockerfile: 2.39kB                                                                                                   0.0s
 => [docker_gitlab internal] load .dockerignore                                                                                          0.0s
 => => transferring context: 2B                                                                                                          0.0s
 => [docker_jenkins internal] load .dockerignore                                                                                         0.0s
 => => transferring context: 2B                                                                                                          0.0s
 => [docker_gitlab internal] load metadata for docker.io/gitlab/gitlab-ce:latest                                                         4.9s
 => [docker_jenkins internal] load metadata for docker.io/jenkins/jenkins:lts                                                            4.8s
 => [docker_gitlab 1/4] FROM docker.io/gitlab/gitlab-ce:latest@sha256:28335217fa8ae7198bf27bad1707861acd27d839f7d49345e0c990bbc5d4cc83   0.0s
 => CACHED [docker_gitlab 2/4] RUN apt update                                                                                            0.0s
 => CACHED [docker_gitlab 3/4] RUN apt-get install --no-install-recommends -y jq                                                         0.0s
 => CACHED [docker_gitlab 4/4] RUN sed -i '/^.*user_params\[:password_expires_at\] = Time.current if admin_making_changes_for_another_u  0.0s
 => [docker_gitlab] exporting to image                                                                                                   0.1s
 => => exporting layers                                                                                                                  0.0s
 => => writing image sha256:9e76e117c3f634e250d87f039dcf28d109634760d7bc606d803cb84314d2642a                                             0.0s
 => => naming to docker.io/library/docker_gitlab                                                                                         0.0s
 => [docker_jenkins internal] load build context                                                                                         0.1s
 => => transferring context: 489B                                                                                                        0.0s
 => [docker_jenkins  1/15] FROM docker.io/jenkins/jenkins:lts@sha256:c9cc19190b123077b434dd9c77b7252c3c58c3dc1add149fa9f6e2fb490526e9    0.0s
 => CACHED [docker_jenkins  2/15] RUN apt update                                                                                         0.0s
 => [docker_jenkins  3/15] RUN apt-get install -y maven                                                                                 40.6s
 => ERROR [docker_jenkins  4/15] RUN cd /usr/lib/jvm &&     wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/j  0.8s
------
 > [docker_jenkins  4/15] RUN cd /usr/lib/jvm &&     wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz &&     tar -zxf OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz     && mv jdk-16+36 java-16-openjdk-amd64     && rm OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz:
#15 0.774 /bin/sh: 1: wget: not found
------
failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c cd /usr/lib/jvm &&     wget https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16%2B36/OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz &&     tar -zxf OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz     && mv jdk-16+36 java-16-openjdk-amd64     && rm OpenJDK16-jdk_x64_linux_hotspot_16_36.tar.gz]: exit code: 127
```


### Description
`wget` has been used, before it was installed. I have moved the installation before the first use of it.

### Steps for Testing
Prerequisites:
- Docker installation

1. Build the Jenkins Docker image `docker-compose -f src/main/docker/gitlab-jenkins-mysql.yml up --build -d` (according to [the documentation](https://docs.artemis.ase.in.tum.de/dev/setup/jenkins-gitlab/#gitlab)).

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2