### PR TITLE
`Development`: Add hint about the authorization object in the Java migration tool documentation

### DIFF
--- a/docs/dev/migration/data.rst
+++ b/docs/dev/migration/data.rst
@@ -18,4 +18,4 @@ The changelog can be found in :code:`src/main/java/config/migration/MigrationReg
 - All executed entries are saved in the table :code:`migration_changelog`. If you delete entries, they get executed again.
 - Test your changes locally first, and only commit changes you are confident that work.
 - Before deploying any database changes to a test server, ask for official permission from the project lead. If the changes don’t get approved, manual rollbacks can be necessary, which are avoidable.
-- Do not use repository methods that execute custom SQL/JPQL queries as this leads to problems.
+- If queries fail due to the authorization object being null, call `SecurityUtils.setAuthorizationObject()` beforehand to set a dummy object.

--- a/docs/dev/migration/data.rst
+++ b/docs/dev/migration/data.rst
@@ -18,4 +18,4 @@ The changelog can be found in :code:`src/main/java/config/migration/MigrationReg
 - All executed entries are saved in the table :code:`migration_changelog`. If you delete entries, they get executed again.
 - Test your changes locally first, and only commit changes you are confident that work.
 - Before deploying any database changes to a test server, ask for official permission from the project lead. If the changes don’t get approved, manual rollbacks can be necessary, which are avoidable.
-- It is suggested to not use repository methods that execute custom SQL queries as this may lead to problems with the authentication to the database.
+- Do not use repository methods that execute custom SQL/JPQL queries as this leads to problems.

--- a/docs/dev/migration/data.rst
+++ b/docs/dev/migration/data.rst
@@ -18,3 +18,4 @@ The changelog can be found in :code:`src/main/java/config/migration/MigrationReg
 - All executed entries are saved in the table :code:`migration_changelog`. If you delete entries, they get executed again.
 - Test your changes locally first, and only commit changes you are confident that work.
 - Before deploying any database changes to a test server, ask for official permission from the project lead. If the changes don’t get approved, manual rollbacks can be necessary, which are avoidable.
+- It is suggested to not use repository methods that execute custom SQL queries as this may lead to problems with the authentication to the database.


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
I encountered an issue when using a custom SQL query inside of a changeset with the Java Migration Tool from @julian-christl.

### Description
There seems to be a problem with the tool connecting to the database when using some custom SQL queries from a Spring repository. I encountered the following error:
`java.lang.IllegalArgumentException: Authentication object cannot be null`