### PR TITLE
`Development`: Increase client test coverage for exercise hint components

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -47,7 +47,8 @@ module.exports = {
         'src/main/webapp/app/exam/participate/exam-participation.route.ts',
         'src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-management.route.ts',
         'src/main/webapp/app/exercises/modeling/manage/modeling-exercise.route.ts',
-        'src/main/webapp/app/exam/manage/exam-management.route.ts'
+        'src/main/webapp/app/exam/manage/exam-management.route.ts',
+        'src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint.route.ts',
     ],
     coverageThreshold: {
         global: {

--- a/src/test/javascript/spec/component/exercise-hint/exercise-hint-student-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/exercise-hint-student-dialog.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { of } from 'rxjs';
+import { HttpHeaders, HttpResponse } from '@angular/common/http';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+
+import { ExerciseHintUpdateComponent } from 'app/exercises/shared/exercise-hint/manage/exercise-hint-update.component';
+import { ArtemisTestModule } from '../../test.module';
+import { TranslateService } from '@ngx-translate/core';
+import { MockProvider } from 'ng-mocks';
+import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
+import { ExerciseHint } from 'app/entities/exercise-hint.model';
+import { MockExerciseService } from '../../helpers/mocks/service/mock-exercise.service';
+import { ExerciseHintStudentComponent, ExerciseHintStudentDialogComponent } from 'app/exercises/shared/exercise-hint/participate/exercise-hint-student-dialog.component';
+import { MockNgbModalService } from '../../helpers/mocks/service/mock-ngb-modal.service';
+
+describe('ExerciseHint Hint Student Component', () => {
+    let comp: ExerciseHintStudentComponent;
+    let fixture: ComponentFixture<ExerciseHintStudentComponent>;
+    let service: ExerciseHintService;
+    let modalService: NgbModal;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ArtemisTestModule],
+            declarations: [ExerciseHintUpdateComponent],
+            providers: [FormBuilder, MockExerciseService, MockProvider(TranslateService), { provide: NgbModal, useClass: MockNgbModalService }],
+        })
+            .overrideTemplate(ExerciseHintUpdateComponent, '')
+            .compileComponents();
+
+        fixture = TestBed.createComponent(ExerciseHintStudentComponent);
+        comp = fixture.componentInstance;
+        service = fixture.debugElement.injector.get(ExerciseHintService);
+        modalService = TestBed.inject(NgbModal);
+    });
+
+    it('should load all hints onInit', () => {
+        const exerciseHint = new ExerciseHint();
+        exerciseHint.id = 123;
+        comp.exerciseId = 15;
+        const headers = new HttpHeaders().append('link', 'link;link');
+        const findByExerciseIdSpy = jest.spyOn(service, 'findByExerciseId').mockReturnValue(
+            of(
+                new HttpResponse({
+                    body: [exerciseHint],
+                    headers,
+                }),
+            ),
+        );
+
+        comp.ngOnInit();
+
+        expect(findByExerciseIdSpy).toHaveBeenCalledTimes(1);
+        expect(findByExerciseIdSpy).toHaveBeenCalledWith(15);
+        expect(comp.exerciseHints).toEqual([exerciseHint]);
+    });
+
+    it('should open modal with exercise hints', () => {
+        const exerciseHint = new ExerciseHint();
+        exerciseHint.id = 123;
+        comp.exerciseHints = [exerciseHint];
+
+        const componentInstance = { exerciseHints: [] };
+        const result = new Promise((resolve) => resolve(true));
+        const openModalSpy = jest.spyOn(modalService, 'open').mockReturnValue(<NgbModalRef>{
+            componentInstance,
+            result,
+        });
+
+        comp.openModal();
+
+        expect(openModalSpy).toHaveBeenCalledTimes(1);
+        expect(openModalSpy).toHaveBeenCalledWith(ExerciseHintStudentDialogComponent, { size: 'lg', backdrop: 'static' });
+        expect(componentInstance.exerciseHints).toEqual([exerciseHint]);
+    });
+});

--- a/src/test/javascript/spec/component/exercise-hint/exercise-hint-update.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/exercise-hint-update.component.spec.ts
@@ -1,25 +1,32 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { HttpResponse } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { of } from 'rxjs';
+import { HttpHeaders, HttpResponse } from '@angular/common/http';
 
 import { ExerciseHintUpdateComponent } from 'app/exercises/shared/exercise-hint/manage/exercise-hint-update.component';
-import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
-import { ExerciseHint } from 'app/entities/exercise-hint.model';
 import { ArtemisTestModule } from '../../test.module';
 import { TranslateService } from '@ngx-translate/core';
 import { MockProvider } from 'ng-mocks';
+import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
+import { ExerciseHint } from 'app/entities/exercise-hint.model';
+import { ActivatedRoute } from '@angular/router';
+import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
+import { MockExerciseService } from '../../helpers/mocks/service/mock-exercise.service';
+import { ProgrammingExercise, ProgrammingLanguage } from 'app/entities/programming-exercise.model';
 
 describe('ExerciseHint Management Update Component', () => {
     let comp: ExerciseHintUpdateComponent;
     let fixture: ComponentFixture<ExerciseHintUpdateComponent>;
     let service: ExerciseHintService;
+    let exerciseService: ExerciseService;
+    const exerciseHint = new ExerciseHint();
+    const route = { data: of({ exerciseHint }), params: of({ courseId: 12, exerciseId: 15 }) } as any as ActivatedRoute;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [ExerciseHintUpdateComponent],
-            providers: [FormBuilder, MockProvider(TranslateService)],
+            providers: [FormBuilder, MockExerciseService, MockProvider(TranslateService), { provide: ActivatedRoute, useValue: route }],
         })
             .overrideTemplate(ExerciseHintUpdateComponent, '')
             .compileComponents();
@@ -27,6 +34,31 @@ describe('ExerciseHint Management Update Component', () => {
         fixture = TestBed.createComponent(ExerciseHintUpdateComponent);
         comp = fixture.componentInstance;
         service = fixture.debugElement.injector.get(ExerciseHintService);
+        exerciseService = fixture.debugElement.injector.get(ExerciseService);
+    });
+
+    it('should load params and data onInit', () => {
+        const exercise = new ProgrammingExercise(undefined, undefined);
+        exercise.programmingLanguage = ProgrammingLanguage.JAVA;
+        exercise.id = 15;
+        const headers = new HttpHeaders().append('link', 'link;link');
+        const findByExerciseIdSpy = jest.spyOn(exerciseService, 'find').mockReturnValue(
+            of(
+                new HttpResponse({
+                    body: exercise,
+                    headers,
+                }),
+            ),
+        );
+
+        comp.ngOnInit();
+
+        expect(findByExerciseIdSpy).toHaveBeenCalledTimes(1);
+        expect(findByExerciseIdSpy).toHaveBeenCalledWith(15);
+        expect(comp.exerciseHint.exercise).toEqual(exercise);
+        expect(comp.exerciseHint).toEqual(exerciseHint);
+        expect(comp.courseId).toBe(12);
+        expect(comp.exerciseId).toBe(15);
     });
 
     describe('save', () => {

--- a/src/test/javascript/spec/component/exercise-hint/exercise-hint.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/exercise-hint.component.spec.ts
@@ -1,11 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
+import { ActivatedRoute } from '@angular/router';
 
 import { ExerciseHintComponent } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.component';
-import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
-import { ExerciseHint } from 'app/entities/exercise-hint.model';
 import { ArtemisTestModule } from '../../test.module';
+import { ExerciseHint } from 'app/entities/exercise-hint.model';
+import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
+import { MockActivatedRoute } from '../../helpers/mocks/activated-route/mock-activated-route';
 
 describe('ExerciseHint Management Component', () => {
     let comp: ExerciseHintComponent;
@@ -16,7 +18,7 @@ describe('ExerciseHint Management Component', () => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
             declarations: [ExerciseHintComponent],
-            providers: [],
+            providers: [{ provide: ActivatedRoute, useValue: new MockActivatedRoute({ exerciseId: 15 }) }],
         })
             .overrideTemplate(ExerciseHintComponent, '')
             .compileComponents();
@@ -26,7 +28,7 @@ describe('ExerciseHint Management Component', () => {
         service = fixture.debugElement.injector.get(ExerciseHintService);
     });
 
-    it('Should call load all on init', () => {
+    it('Should call load all on init with exerciseId from route', () => {
         // GIVEN
         const headers = new HttpHeaders().append('link', 'link;link');
         const hint = new ExerciseHint();
@@ -45,7 +47,21 @@ describe('ExerciseHint Management Component', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(service.findByExerciseId).toHaveBeenCalled();
+        expect(service.findByExerciseId).toHaveBeenCalledTimes(1);
+        expect(service.findByExerciseId).toHaveBeenCalledWith(15);
         expect(comp.exerciseHints[0]).toEqual(expect.objectContaining({ id: 123 }));
+    });
+
+    it('should invoke hint deletion', () => {
+        const deleteHintMock = jest.spyOn(service, 'delete');
+        const exerciseHint = new ExerciseHint();
+        exerciseHint.id = 123;
+        comp.exerciseHints = [exerciseHint];
+        comp.exerciseId = 15;
+
+        comp.deleteExerciseHint(123);
+
+        expect(deleteHintMock).toHaveBeenCalledTimes(1);
+        expect(deleteHintMock).toHaveBeenCalledWith(123);
     });
 });


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test 

### Motivation and Context
We would like to have a reasonably high test coverage percentage aimed to catch potential bugs before deployment.

### Description
Increase client test coverage of exercise hint components over 80%.

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2

### Test Coverage
|  File | Branches % | Lines % |
| --- | --- | --- |
| **manage/** | 64.06% → 75.43% | 63.75% → 88% |
| exercise-hint-detail.component.ts (unchanged) | 80% → 80% | 100% → 100% |
| exercise-hint-update.component.ts | 72.41% → 79.31% | 63.15% → 87.71% |
| exercise-hint.component.ts | 72.22% → 72.22% | 81.57% → 84.21% |
| **participate/** | 71.42% → 76.19% | 37.5% → 83.33% |
| exercise-hint-student-dialog.component.ts | 71.42% → 76.19% | 37.5% → 83.33% |