### PR TITLE
`General` Enhance course/exam archive button alignment

### DIFF
--- a/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
@@ -57,7 +57,7 @@
                 >
                     <fa-icon [icon]="faUndo"></fa-icon>
                 </button>
-                <div *ngIf="exam && isExamOver && exam.course" class="my-2 me-1 mt-1">
+                <div *ngIf="exam && isExamOver && exam.course" class="mt-1 d-inline">
                     <jhi-course-exam-archive-button [archiveMode]="'Exam'" [exam]="exam" [course]="exam.course"></jhi-course-exam-archive-button>
                 </div>
             </div>

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.html
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.html
@@ -77,7 +77,15 @@
             <button type="button" class="btn btn-success" [jhiTranslate]="'global.generic.no'" (click)="modal.dismiss()">No</button>
         </div>
     </ng-template>
-    <button *ngIf="canArchive()" [disabled]="isBeingArchived" type="button" [attr.data-mode]="archiveMode" id="archiveButton" class="btn btn-warning mb-1" (click)="openModal(archiveWarningPopup)">
+    <button
+        *ngIf="canArchive()"
+        [disabled]="isBeingArchived"
+        type="button"
+        [attr.data-mode]="archiveMode"
+        id="archiveButton"
+        class="btn btn-warning mb-1"
+        (click)="openModal(archiveWarningPopup)"
+    >
         <fa-icon [hidden]="!isBeingArchived" [spin]="true" [icon]="faCircleNotch"></fa-icon>
         <fa-icon [hidden]="isBeingArchived" [icon]="faArchive"></fa-icon>&nbsp;
         <span>{{ archiveButtonText }}</span>

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.html
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.html
@@ -77,7 +77,7 @@
             <button type="button" class="btn btn-success" [jhiTranslate]="'global.generic.no'" (click)="modal.dismiss()">No</button>
         </div>
     </ng-template>
-    <button *ngIf="canArchive()" [disabled]="isBeingArchived" type="button" [attr.data-mode]="archiveMode" class="btn btn-warning mb-1" (click)="openModal(archiveWarningPopup)">
+    <button *ngIf="canArchive()" [disabled]="isBeingArchived" type="button" [attr.data-mode]="archiveMode" id="archiveButton" class="btn btn-warning mb-1" (click)="openModal(archiveWarningPopup)">
         <fa-icon [hidden]="!isBeingArchived" [spin]="true" [icon]="faCircleNotch"></fa-icon>
         <fa-icon [hidden]="isBeingArchived" [icon]="faArchive"></fa-icon>&nbsp;
         <span>{{ archiveButtonText }}</span>

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.html
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.html
@@ -77,7 +77,7 @@
             <button type="button" class="btn btn-success" [jhiTranslate]="'global.generic.no'" (click)="modal.dismiss()">No</button>
         </div>
     </ng-template>
-    <button *ngIf="canArchive()" [disabled]="isBeingArchived" type="button" class="btn btn-warning me-1 mb-1" (click)="openModal(archiveWarningPopup)">
+    <button *ngIf="canArchive()" [disabled]="isBeingArchived" type="button" [attr.data-mode]="archiveMode" class="btn btn-warning mb-1" (click)="openModal(archiveWarningPopup)">
         <fa-icon [hidden]="!isBeingArchived" [spin]="true" [icon]="faCircleNotch"></fa-icon>
         <fa-icon [hidden]="isBeingArchived" [icon]="faArchive"></fa-icon>&nbsp;
         <span>{{ archiveButtonText }}</span>

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.scss
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.scss
@@ -1,8 +1,8 @@
-button[data-mode='Course'] {
+#archiveButton[data-mode='Course'] {
     margin-bottom: 11px !important;
 }
 
-button[data-mode='Exam'] {
+#archiveButton[data-mode='Exam'] {
     margin-top: 0.25rem !important;
     margin-bottom: 0 !important;
 }

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.scss
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.scss
@@ -1,0 +1,8 @@
+button[data-mode='Course'] {
+    margin-bottom: 11px !important;
+}
+
+button[data-mode='Exam'] {
+    margin-top: 0.25rem !important;
+    margin-bottom: 0 !important;
+}

--- a/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
+++ b/src/main/webapp/app/shared/components/course-exam-archive-button/course-exam-archive-button.component.ts
@@ -24,7 +24,7 @@ export type CourseExamArchiveState = {
 @Component({
     selector: 'jhi-course-exam-archive-button',
     templateUrl: './course-exam-archive-button.component.html',
-    styles: [],
+    styleUrls: ['./course-exam-archive-button.component.scss'],
 })
 export class CourseExamArchiveButtonComponent implements OnInit, OnDestroy {
     ButtonSize = ButtonSize;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #4457 

### Description
<!-- Describe your changes in detail -->

Currently the archive button is not aligned with the rest of the buttons. This is caused by the fact, that all other buttons are placed within the same div as a parent and the archive button is nested within some more divs (because it's a separate component). 
But since the button is used in the course and the exam view and both require a different alignment, my suggested solution is, to use a html data attribute, to give the button context in which view it is displayed. This allows to use specific css, that only applies to the current context. Additionally the archive button on the exam view is inlined with the other buttons (with a little space to the left to separate it from the others), since it was placed within another row before. The before and after state can be examined in the screenshots below. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

For the course view:
1. Log in to Artemis
2. Navigate to Course Administration
3. Create a course with an end date before today
4. Disable the "Show only active courses" checkbox
4. Go to the course detail page
5. An archive button should be displayed

For the exam view:
1. Log in to Artemis
2. Navigate to Course Administration
3. Create an exam with an end time before today
4. Go to the exam detail page
5. An archive button should be displayed

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Course view**
Before:
![9VIr8](https://user-images.githubusercontent.com/1368405/153661504-390dba15-ef5e-4845-bc78-38773a5233f7.png)
After:
![Screenshot from 2022-02-11 20-23-29](https://user-images.githubusercontent.com/1368405/153661928-57692a00-65f9-4c04-8b0d-62b61322b89d.png)

**Exam view**
Before:
![i5N7Z](https://user-images.githubusercontent.com/1368405/153661500-6938958e-2ce0-47eb-8603-a8ff8d770fed.png)

After:
![Screenshot from 2022-02-11 20-24-08](https://user-images.githubusercontent.com/1368405/153661926-01f2b3fd-b2fd-4ed8-9cb3-2dff03f487af.png)



