### PR TITLE
`Assessment`: Fix invalid links in team participation table

### DIFF
--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
@@ -76,7 +76,7 @@
                 <ng-template ngx-datatable-cell-template let-value="row">
                     <ng-container *ngIf="value.participation; else participationIdUnavailable">
                         <div *ngIf="exercise.isAtLeastInstructor; else displayId">
-                            <a [routerLink]="['/course-management', course.id, exercise.type + '-exercises', value.id, 'participations', value.participation.id, 'submissions']">
+                            <a [routerLink]="['/course-management', course.id, value.type + '-exercises', value.id, 'participations', value.participation.id, 'submissions']">
                                 {{ value.participation.id }}
                             </a>
                         </div>
@@ -123,7 +123,7 @@
                         >
                             <a
                                 [class.disabled]="isAssessmentButtonDisabled(value, value.submission)"
-                                [routerLink]="getAssessmentLink(exercise, value.participation, value.submission)"
+                                [routerLink]="getAssessmentLink(value, value.participation, value.submission)"
                                 class="btn btn-warning btn-sm"
                                 ><fa-icon [icon]="faFolderOpen" [fixedWidth]="true"></fa-icon>
                                 {{ 'artemisApp.exerciseAssessmentDashboard.' + assessmentAction(value.submission) + 'Assessment' | artemisTranslate }}</a


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally ~~and was confirmed by another developer on a test server~~.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

If a course has multiple team exercise, parts of the link to the exercise assessment would refer to the selected (green background) exercise instead of the one where Start Assessment was clicked. The same would happen for the participation Id column.

If the selected and actual exercise have the same type the only consequence appears to be that on the assessment page the breadcrumbs are wrong. But if they have a different type then assessing the submission would fail.

### Description
<!-- Describe your changes in detail -->
Changes two reference from the selected exercise to the exercise of the current row.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Tutor
- 1 Team
- At least 2 team exercises with different type where the team has participated
- (1 Admin)

1. Log in to Artemis
2. Navigate to the team page for the prepared team
3. Check that for all rows
   1. The Assessment link contains the id and type of the exercise of that row
   2. (if admin) Check that the exercise type in the participation id column matches the exercise type of the row

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
No change

### Screenshots
No change