### PR TITLE
`Exam mode`: Fix rounding of scores in the summary view

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -18,8 +18,8 @@
         {{ 'artemisApp.exam.studentReviewEnabled' | artemisTranslate }}
     </a>
 </div>
-<div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam">
-    <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam" [courseId]="courseId"></jhi-exam-points-summary>
+<div class="mb-4" *ngIf="studentExam && studentExam.exercises && studentExam.exam && course">
+    <jhi-exam-points-summary [exercises]="studentExam.exercises" [exam]="studentExam.exam" [course]="course"></jhi-exam-points-summary>
 </div>
 <div *ngIf="!resultsPublished" class="mb-0">
     <fa-icon [icon]="faInfoCircle" class="info-icon"></fa-icon>

--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.ts
@@ -10,6 +10,7 @@ import { SubmissionType } from 'app/entities/submission.model';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { faAngleDown, faAngleRight, faFolderOpen, faInfoCircle, faPrint } from '@fortawesome/free-solid-svg-icons';
+import { Course } from 'app/entities/course.model';
 
 @Component({
     selector: 'jhi-exam-participation-summary',
@@ -35,7 +36,8 @@ export class ExamParticipationSummaryComponent implements OnInit {
 
     collapsedExerciseIds: number[] = [];
 
-    courseId: number;
+    private courseId: number;
+    course: Course;
 
     isTestRun = false;
 
@@ -64,7 +66,9 @@ export class ExamParticipationSummaryComponent implements OnInit {
         this.setExamWithOnlyIdAndStudentReviewPeriod();
         // load course for the exercise
         this.courseManagementService.find(this.courseId).subscribe((courseResponse) => {
-            this.examWithOnlyIdAndStudentReviewPeriod.course = courseResponse.body!;
+            const course = courseResponse.body!;
+            this.examWithOnlyIdAndStudentReviewPeriod.course = course;
+            this.course = course;
         });
         for (const exercise of this.studentExam.exercises ?? []) {
             exercise.studentParticipations!.first()!.exercise = exercise;

--- a/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/points-summary/exam-points-summary.component.ts
@@ -7,6 +7,7 @@ import { roundValueSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { GradingSystemService } from 'app/grading-system/grading-system.service';
 import { GradeType } from 'app/entities/grading-scale.model';
+import { Course } from 'app/entities/course.model';
 import { faClipboard } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
@@ -18,7 +19,7 @@ export class ExamPointsSummaryComponent implements OnInit {
     readonly IncludedInOverallScore = IncludedInOverallScore;
     @Input() exercises: Exercise[];
     @Input() exam: Exam;
-    @Input() courseId: number;
+    @Input() course: Course;
 
     gradingScaleExists = false;
     isBonus = false;
@@ -56,9 +57,9 @@ export class ExamPointsSummaryComponent implements OnInit {
      */
     calculateExamGrade() {
         const achievedPointsRelative = (this.calculatePointsSum() / this.calculateMaxPointsSum()) * 100;
-        this.gradingSystemService.matchPercentageToGradeStepForExam(this.courseId, this.exam!.id!, achievedPointsRelative).subscribe((gradeObservable) => {
-            if (gradeObservable && gradeObservable!.body) {
-                const gradeDTO = gradeObservable!.body;
+        this.gradingSystemService.matchPercentageToGradeStepForExam(this.course.id!, this.exam.id!, achievedPointsRelative).subscribe((gradeObservable) => {
+            if (gradeObservable && gradeObservable.body) {
+                const gradeDTO = gradeObservable.body;
                 this.gradingScaleExists = true;
                 this.grade = gradeDTO.gradeName;
                 this.isBonus = gradeDTO.gradeType === GradeType.BONUS;
@@ -74,7 +75,7 @@ export class ExamPointsSummaryComponent implements OnInit {
      */
     calculateAchievedPoints(exercise: Exercise): number {
         if (ExamPointsSummaryComponent.hasResultScore(exercise)) {
-            return roundValueSpecifiedByCourseSettings(exercise.maxPoints! * (exercise.studentParticipations![0].results![0].score! / 100), this.exam.course);
+            return roundValueSpecifiedByCourseSettings(exercise.maxPoints! * (exercise.studentParticipations![0].results![0].score! / 100), this.course);
         }
         return 0;
     }
@@ -87,7 +88,7 @@ export class ExamPointsSummaryComponent implements OnInit {
             const exercisesIncluded = this.exercises?.filter((exercise) => exercise.includedInOverallScore !== IncludedInOverallScore.NOT_INCLUDED);
             return roundValueSpecifiedByCourseSettings(
                 exercisesIncluded.reduce((sum: number, nextExercise: Exercise) => sum + this.calculateAchievedPoints(nextExercise), 0),
-                this.exam.course,
+                this.course,
             );
         }
         return 0;
@@ -101,7 +102,7 @@ export class ExamPointsSummaryComponent implements OnInit {
             const exercisesIncluded = this.exercises?.filter((exercise) => exercise.includedInOverallScore === IncludedInOverallScore.INCLUDED_COMPLETELY);
             return roundValueSpecifiedByCourseSettings(
                 exercisesIncluded.reduce((sum: number, nextExercise: Exercise) => sum + ExamPointsSummaryComponent.getMaxScore(nextExercise), 0),
-                this.exam.course,
+                this.course,
             );
         }
         return 0;
@@ -115,7 +116,7 @@ export class ExamPointsSummaryComponent implements OnInit {
             const exercisesIncluded = this.exercises?.filter((exercise) => exercise.includedInOverallScore !== IncludedInOverallScore.NOT_INCLUDED);
             return roundValueSpecifiedByCourseSettings(
                 exercisesIncluded.reduce((sum: number, nextExercise: Exercise) => sum + ExamPointsSummaryComponent.getBonusPoints(nextExercise), 0),
-                this.exam.course,
+                this.course,
             );
         }
         return 0;

--- a/src/test/javascript/spec/component/exam/participate/summary/points-summary/exam-points-summary.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/points-summary/exam-points-summary.component.spec.ts
@@ -21,6 +21,7 @@ import { GradeDTO } from 'app/entities/grade-step.model';
 import { of, throwError } from 'rxjs';
 import { HttpResponse } from '@angular/common/http';
 import { GradeType } from 'app/entities/grading-scale.model';
+import { Course } from 'app/entities/course.model';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
 let fixture: ComponentFixture<ExamPointsSummaryComponent>;
@@ -134,9 +135,13 @@ describe('ExamPointsSummaryComponent', () => {
         })
             .compileComponents()
             .then(() => {
+                const course = new Course();
+                course.id = 1;
+                course.accuracyOfScores = 2;
+
                 fixture = TestBed.createComponent(ExamPointsSummaryComponent);
                 component = fixture.componentInstance;
-                component.courseId = 1;
+                component.course = course;
                 component.exam = exam;
                 component.exercises = exercises;
                 component.gradingScaleExists = false;
@@ -184,10 +189,10 @@ describe('ExamPointsSummaryComponent', () => {
         expect(component.calculateAchievedPoints(notIncludedTextExercise)).toEqual(10);
         expect(component.calculateAchievedPoints(bonusTextExercise)).toEqual(10);
         expect(component.calculateAchievedPoints(quizExercise)).toEqual(2);
-        expect(component.calculateAchievedPoints(modelingExercise)).toEqual(3.3);
+        expect(component.calculateAchievedPoints(modelingExercise)).toEqual(3.33);
         expect(component.calculateAchievedPoints(programmingExercise)).toEqual(0);
 
-        expect(component.calculatePointsSum()).toEqual(35.3);
+        expect(component.calculatePointsSum()).toEqual(35.33);
         expect(component.calculateMaxPointsSum()).toEqual(40);
         expect(component.calculateMaxBonusPointsSum()).toEqual(20);
     });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
Sentry issues https://sentry.ase.in.tum.de/organizations/artemis/issues/20270 and https://sentry.ase.in.tum.de/organizations/artemis/issues/20271.

### Description
The component that called the rounding did not have a course object to determine the rounding accuracy. This PR updates it to make sure a course is present when rounding.

### Steps for Testing
Prerequisites:
- 1 Finished exam for a student

1. Go to the student exam summary as instructor (Exam Management → Student Exams → View → Summary) or the student the exam belongs to.
2. The table titled ‘Overview’ with the scores of the exercises of the exam should be shown and the scores should be rounded according to the specified course accuracy.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
unchanged
