### PR TITLE
`General`: Show line breaks in manual feedback

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -71,6 +71,7 @@ module.exports = {
     testMatch: [
         '<rootDir>/src/test/javascript/spec/component/**/*.spec.ts',
         '<rootDir>/src/test/javascript/spec/directive/**/*.spec.ts',
+        '<rootDir>/src/test/javascript/spec/entities/**/*.spec.ts',
         '<rootDir>/src/test/javascript/spec/integration/**/*.spec.ts',
         '<rootDir>/src/test/javascript/spec/pipe/**/*.spec.ts',
         '<rootDir>/src/test/javascript/spec/service/**/*.spec.ts',

--- a/src/main/webapp/app/entities/feedback.model.ts
+++ b/src/main/webapp/app/entities/feedback.model.ts
@@ -195,15 +195,13 @@ export const buildFeedbackTextForReview = (feedback: Feedback): string => {
         if (feedback.text) {
             feedbackText = feedbackText + '\n' + feedback.text;
         }
-        return convertToHtmlLinebreaks(feedbackText);
+    } else if (feedback.detailText) {
+        feedbackText = feedback.detailText;
+    } else if (feedback.text) {
+        feedbackText = feedback.text;
     }
-    if (feedback.detailText) {
-        return feedback.detailText;
-    }
-    if (feedback.text) {
-        return feedback.text;
-    }
-    return feedbackText;
+
+    return convertToHtmlLinebreaks(feedbackText);
 };
 
 /**

--- a/src/main/webapp/app/entities/feedback.model.ts
+++ b/src/main/webapp/app/entities/feedback.model.ts
@@ -180,24 +180,26 @@ export class Feedback implements BaseEntity {
 /**
  * Helper method to build the feedback text for the review. When the feedback has a link with grading instruction
  * it merges the feedback of the grading instruction with the feedback text provided by the assessor. Otherwise,
- * it return detail_text or text property of the feedback depending on the submission element.
+ * it returns the detailed text and/or text properties of the feedback depending on the submission element.
  *
  * @param feedback that contains feedback text and grading instruction
- * @returns {string} formatted string representing the feedback text ready to display
+ * @param addFeedbackText if the text of the feedback should be part of the resulting text. Defaults to true.
+ *                        The detailText of the feedback is always added if present.
+ * @returns formatted string representing the feedback text ready to display
  */
-export const buildFeedbackTextForReview = (feedback: Feedback): string => {
+export const buildFeedbackTextForReview = (feedback: Feedback, addFeedbackText = true): string => {
     let feedbackText = '';
     if (feedback.gradingInstruction && feedback.gradingInstruction.feedback) {
         feedbackText = feedback.gradingInstruction.feedback;
         if (feedback.detailText) {
             feedbackText = feedbackText + '\n' + feedback.detailText;
         }
-        if (feedback.text) {
+        if (addFeedbackText && feedback.text) {
             feedbackText = feedbackText + '\n' + feedback.text;
         }
     } else if (feedback.detailText) {
         feedbackText = feedback.detailText;
-    } else if (feedback.text) {
+    } else if (addFeedbackText && feedback.text) {
         feedbackText = feedback.text;
     }
 

--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
@@ -44,6 +44,8 @@ import { faListAlt } from '@fortawesome/free-regular-svg-icons';
 })
 export class ModelingSubmissionComponent implements OnInit, OnDestroy, ComponentCanDeactivate {
     readonly addParticipationToResult = addParticipationToResult;
+    readonly buildFeedbackTextForReview = buildFeedbackTextForReview;
+
     @ViewChild(ModelingEditorComponent, { static: false })
     modelingEditor: ModelingEditorComponent;
     ButtonType = ButtonType;
@@ -587,9 +589,5 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         }
 
         return 'entity.action.submitDeadlineMissedTooltip';
-    }
-
-    public buildFeedbackTextForReview(feedback: Feedback): string {
-        return buildFeedbackTextForReview(feedback);
     }
 }

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.ts
@@ -128,11 +128,10 @@ export class CodeEditorTutorAssessmentInlineFeedbackComponent {
             if (feedback.detailText) {
                 feedbackText = feedbackText + '\n' + feedback.detailText;
             }
-            return convertToHtmlLinebreaks(feedbackText);
+        } else if (feedback.detailText) {
+            feedbackText = feedback.detailText;
         }
-        if (feedback.detailText) {
-            return feedback.detailText;
-        }
-        return feedbackText;
+
+        return convertToHtmlLinebreaks(feedbackText);
     }
 }

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.ts
@@ -5,7 +5,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { StructuredGradingCriterionService } from 'app/exercises/shared/structured-grading-criterion/structured-grading-criterion.service';
 import { roundValueSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { Course } from 'app/entities/course.model';
-import { convertToHtmlLinebreaks } from 'app/utils/text.utils';
 import { faBan, faPencilAlt, faQuestionCircle, faSave, faTrashAlt, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 
 @Component({

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { Feedback, FeedbackType } from 'app/entities/feedback.model';
+import { buildFeedbackTextForReview, Feedback, FeedbackType } from 'app/entities/feedback.model';
 import { cloneDeep } from 'lodash-es';
 import { TranslateService } from '@ngx-translate/core';
 import { StructuredGradingCriterionService } from 'app/exercises/shared/structured-grading-criterion/structured-grading-criterion.service';
@@ -116,22 +116,12 @@ export class CodeEditorTutorAssessmentInlineFeedbackComponent {
 
     /**
      * Builds the feedback text. When the feedback has a link with grading instruction it merges the feedback of
-     * the grading instruction with the feedback text provided by the assessor. Otherwise, it returns detail_text.
+     * the grading instruction with the feedback text provided by the assessor.
      *
-     * @param feedback that contains feedback detail_text and grading instruction
-     * @returns {string} formatted string representing the feedback text ready to display
+     * @param feedback The feedback for which the text visible to the user should be created.
+     * @returns The formatted string representing the feedback text ready to display.
      */
     public buildFeedbackTextForCodeEditor(feedback: Feedback): string {
-        let feedbackText = '';
-        if (feedback.gradingInstruction && feedback.gradingInstruction.feedback) {
-            feedbackText = feedback.gradingInstruction.feedback;
-            if (feedback.detailText) {
-                feedbackText = feedbackText + '\n' + feedback.detailText;
-            }
-        } else if (feedback.detailText) {
-            feedbackText = feedback.detailText;
-        }
-
-        return convertToHtmlLinebreaks(feedbackText);
+        return buildFeedbackTextForReview(feedback, false);
     }
 }

--- a/src/main/webapp/app/exercises/text/participate/text-result/text-result.component.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-result/text-result.component.ts
@@ -21,6 +21,8 @@ export class TextResultComponent {
     // Icons
     faExclamationTriangle = faExclamationTriangle;
 
+    readonly buildFeedbackTextForReview = buildFeedbackTextForReview;
+
     private readonly sha1Regex = /^[a-f0-9]{40}$/i;
 
     @Input()
@@ -112,9 +114,5 @@ export class TextResultComponent {
         const singular = Math.abs(textResultBlock.feedback!.credits || 0) === 1;
 
         return this.translateService.instant(`artemisApp.textAssessment.detail.credits.${singular ? 'one' : 'many'}`, { credits: textResultBlock.feedback!.credits });
-    }
-
-    public buildFeedbackTextForReview(feedback: Feedback): string {
-        return buildFeedbackTextForReview(feedback);
     }
 }

--- a/src/main/webapp/app/shared/additional-feedback/additional-feedback.component.ts
+++ b/src/main/webapp/app/shared/additional-feedback/additional-feedback.component.ts
@@ -26,8 +26,5 @@ export class AdditionalFeedbackComponent {
     // Expose the function to the template
     readonly roundScoreSpecifiedByCourseSettings = roundValueSpecifiedByCourseSettings;
     readonly getCourseFromExercise = getCourseFromExercise;
-
-    public buildFeedbackTextForReview(feedback: Feedback): string {
-        return buildFeedbackTextForReview(feedback);
-    }
+    readonly buildFeedbackTextForReview = buildFeedbackTextForReview;
 }

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-inline-feedback.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-inline-feedback.component.spec.ts
@@ -126,6 +126,7 @@ describe('CodeEditorTutorAssessmentInlineFeedbackComponent', () => {
         const feedback = {
             id: 1,
             detailText: 'feedback1',
+            text: 'File src/sorting/BubbleSort.java at line 4',
             credits: 1.5,
         } as Feedback;
 

--- a/src/test/javascript/spec/entities/feedback.model.spec.ts
+++ b/src/test/javascript/spec/entities/feedback.model.spec.ts
@@ -2,7 +2,7 @@ import { GradingInstruction } from 'app/exercises/shared/structured-grading-crit
 import { buildFeedbackTextForReview, Feedback } from 'app/entities/feedback.model';
 
 describe('Feedback', () => {
-    describe('buildFeedbackTextForReview', function () {
+    describe('buildFeedbackTextForReview', () => {
         const gradingInstruction = new GradingInstruction();
         gradingInstruction.feedback = 'Grading instruction feedback';
 

--- a/src/test/javascript/spec/entities/feedback.model.spec.ts
+++ b/src/test/javascript/spec/entities/feedback.model.spec.ts
@@ -22,6 +22,13 @@ describe('Feedback', () => {
             expect(buildFeedbackTextForReview(feedback)).toBe(expectedText);
         });
 
+        it('should ignore the simple text if requested and no grading instruction is set', () => {
+            const feedback = new Feedback();
+            feedback.text = 'simple text\nline2';
+
+            expect(buildFeedbackTextForReview(feedback, false)).toBe('');
+        });
+
         it('should only return the the grading instruction feedback if no other text is set', () => {
             const feedback = new Feedback();
             feedback.gradingInstruction = gradingInstruction;
@@ -37,6 +44,9 @@ describe('Feedback', () => {
 
             const expectedText = 'Grading instruction feedback<br>multi<br>line<br>detail<br>simple text';
             expect(buildFeedbackTextForReview(feedback)).toBe(expectedText);
+
+            const expectedTextIgnoreSimpleText = 'Grading instruction feedback<br>multi<br>line<br>detail';
+            expect(buildFeedbackTextForReview(feedback, false)).toBe(expectedTextIgnoreSimpleText);
         });
     });
 });

--- a/src/test/javascript/spec/entities/feedback.model.spec.ts
+++ b/src/test/javascript/spec/entities/feedback.model.spec.ts
@@ -1,0 +1,42 @@
+import { GradingInstruction } from 'app/exercises/shared/structured-grading-criterion/grading-instruction.model';
+import { buildFeedbackTextForReview, Feedback } from 'app/entities/feedback.model';
+
+describe('Feedback', () => {
+    describe('buildFeedbackTextForReview', function () {
+        const gradingInstruction = new GradingInstruction();
+        gradingInstruction.feedback = 'Grading instruction feedback';
+
+        it('should return the detailed text if no grading instruction is connected to the feedback', () => {
+            const feedback = new Feedback();
+            feedback.detailText = 'detail\nline2';
+
+            const expectedText = 'detail<br>line2';
+            expect(buildFeedbackTextForReview(feedback)).toBe(expectedText);
+        });
+
+        it('should return the text if no detail text and no grading instruction is connected to the feedback', () => {
+            const feedback = new Feedback();
+            feedback.text = 'simple text\nline2';
+
+            const expectedText = 'simple text<br>line2';
+            expect(buildFeedbackTextForReview(feedback)).toBe(expectedText);
+        });
+
+        it('should only return the the grading instruction feedback if no other text is set', () => {
+            const feedback = new Feedback();
+            feedback.gradingInstruction = gradingInstruction;
+
+            expect(buildFeedbackTextForReview(feedback)).toBe(gradingInstruction.feedback);
+        });
+
+        it('should add grading instruction feedback and detail text and text if all are available', () => {
+            const feedback = new Feedback();
+            feedback.gradingInstruction = gradingInstruction;
+            feedback.detailText = 'multi\nline\ndetail';
+            feedback.text = 'simple text';
+
+            const expectedText = 'Grading instruction feedback<br>multi<br>line<br>detail<br>simple text';
+            expect(buildFeedbackTextForReview(feedback)).toBe(expectedText);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Closes #3035
Closes #3854 
Closes kit-sdq/Artemis#15

### Description
Manual comments by tutors could contain multiple lines. Those were not always shown to the student, however. This PR makes sure that the newlines are always kept when displaying the feedback to students.

The first line of the feedback is in the same line as the ‘Feedback’ text. I think this only looks a bit odd because I used very short lines in the screenshots. In practice and in my experience I think that most tutors will give a longer/full-sentence explanation in the first line and only then add some more lines with additional context/bullet-points. Therefore, I think keeping the first line of the feedback text on the same line as ‘Feedback’ is fine.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise with manual feedbacks
- 1 Text Exercise with manual feedbacks

1. Submit as the student to the programming exercise and the text exercise.
2. As instructor, create manual feedbacks (both inline and additional ones) containing one or multiple lines for those submissions.
3. Log in as student again and look at your results. The feedback should still contain multiple lines. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
unchanged; relevant method in `feedback.model.ts`: 2x 100%

### Screenshots
Additional feedback:
![Screenshot 2022-02-18 at 14-37-39 Code Editor](https://user-images.githubusercontent.com/64250573/154693031-16b48312-3145-4261-90ea-7dff2300f8ed.png)

Inline code feedback:
![Screenshot 2022-02-18 at 14-38-25 Code Editor](https://user-images.githubusercontent.com/64250573/154693058-d50eb50c-b85d-4ccd-a7c8-12f08d270e95.png)

Inline text feedback:
![Screenshot 2022-02-18 at 14-37-56 Text Exercises](https://user-images.githubusercontent.com/64250573/154693078-1c0d0088-56b4-492e-9d5b-f2fe1d9f2826.png)

Modeling exercises:
![Screenshot 2022-02-18 at 14-30-22 Modelling Exercises](https://user-images.githubusercontent.com/64250573/154691704-2bfbd730-a8ca-4bfc-aa50-f69ddb7ce3aa.png)
