### PR TITLE
`Development`: Improve cypress e2e test stability for programming exercises

### DIFF
--- a/src/test/cypress/support/pageobjects/exercises/programming/OnlineEditorPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/programming/OnlineEditorPage.ts
@@ -33,7 +33,7 @@ export class OnlineEditorPage {
             this.createFileInRootPackage(newFile.name, packageName);
             cy.fixture(newFile.path).then(($fileContent) => {
                 const sanitizedContent = this.sanitizeInput($fileContent, packageName);
-                this.focusCodeEditor().type(sanitizedContent, { delay: 3 });
+                this.focusCodeEditor().type(sanitizedContent, { delay: 8 });
                 // Delete the remaining content which has been automatically added by the code editor.
                 // We simply send as many {del} keystrokes as the file has characters. This shouldn't increase the test runtime by too long since we set the delay to 0.
                 const deleteRemainingContent = '{del}'.repeat(sanitizedContent.length);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some of the cypress tests for programming exercises, where cypress has to type in a submission via the online editor, fail because the result is not as expected ([like in this build](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETG-DA-81/test/case/491488734)). It seems like the stability of those tests diminished with the new setup (Github integration). We should improve the stability of those tests again.

### Description
<!-- Describe your changes in detail -->
I think cypress is typing too fast for the Artemis Client in the docker container, so I simply increased the delay between each keystroke a bit.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
[I triggered the execution of the cypress build plan multiple times and in more than the last 10 builds the tests did not fail without any issue.](https://bamboo.ase.in.tum.de/browse/ARTEMIS-AETG189)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
