### PR TITLE
`General`: Fix an error in the participation page header

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.ts
@@ -20,7 +20,7 @@ export class HeaderParticipationPageComponent implements OnInit, OnChanges {
     @Input() participation: StudentParticipation;
 
     public exerciseStatusBadge = 'bg-success';
-    public exerciseCategories: ExerciseCategory[];
+    public exerciseCategories: ExerciseCategory[] = [];
 
     dueDate?: dayjs.Dayjs;
     getIcon = getIcon;
@@ -38,7 +38,7 @@ export class HeaderParticipationPageComponent implements OnInit, OnChanges {
      * Returns false if it is an exam exercise and the publishResultsDate is in the future, true otherwise
      */
     get resultsPublished(): boolean {
-        if (!!this.exercise.exerciseGroup && !!this.exercise.exerciseGroup.exam) {
+        if (this.exercise?.exerciseGroup?.exam) {
             if (this.exercise.exerciseGroup.exam.publishResultsDate) {
                 return dayjs().isAfter(this.exercise.exerciseGroup.exam.publishResultsDate);
             }
@@ -52,14 +52,10 @@ export class HeaderParticipationPageComponent implements OnInit, OnChanges {
      * Sets the status badge and categories of the exercise on changes
      */
     ngOnChanges(): void {
-        this.setExerciseStatusBadge();
-        this.exerciseCategories = this.exercise.categories || [];
-        this.dueDate = getExerciseDueDate(this.exercise, this.participation);
-    }
-
-    private setExerciseStatusBadge(): void {
         if (this.exercise) {
             this.exerciseStatusBadge = hasExerciseDueDatePassed(this.exercise, this.participation) ? 'bg-danger' : 'bg-success';
+            this.exerciseCategories = this.exercise.categories || [];
+            this.dueDate = getExerciseDueDate(this.exercise, this.participation);
         }
     }
 }

--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-participation-page.component.ts
@@ -20,7 +20,7 @@ export class HeaderParticipationPageComponent implements OnInit, OnChanges {
     @Input() participation: StudentParticipation;
 
     public exerciseStatusBadge = 'bg-success';
-    public exerciseCategories: ExerciseCategory[] = [];
+    public exerciseCategories: ExerciseCategory[];
 
     dueDate?: dayjs.Dayjs;
     getIcon = getIcon;

--- a/src/test/javascript/spec/component/exercises/shared/headers/header-participation-page.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/headers/header-participation-page.component.spec.ts
@@ -93,7 +93,7 @@ describe('HeaderParticipationPage', () => {
 
         // Expect default values
         expect(component.exerciseStatusBadge).toBe('bg-success');
-        expect(component.exerciseCategories).toEqual([]);
+        expect(component.exerciseCategories).toBe(undefined);
         expect(component.dueDate).toBe(undefined);
     });
 });

--- a/src/test/javascript/spec/component/exercises/shared/headers/header-participation-page.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/headers/header-participation-page.component.spec.ts
@@ -85,4 +85,15 @@ describe('HeaderParticipationPage', () => {
         exam.publishResultsDate = dayjs().add(1, 'day');
         expect(component.resultsPublished).toBe(false);
     });
+
+    it('should not apply changes if no exercise is set', () => {
+        // @ts-ignore
+        component.exercise = undefined;
+        component.ngOnChanges();
+
+        // Expect default values
+        expect(component.exerciseStatusBadge).toBe('bg-success');
+        expect(component.exerciseCategories).toEqual([]);
+        expect(component.dueDate).toBe(undefined);
+    });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Sentry spawns literally a million issues that are all related to this bug, see
https://sentry.ase.in.tum.de/organizations/artemis/issues/?project=-1&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D+categories&statsPeriod=14d

This bug seems to happen for file upload exercise when a student actually enters the submission view. The exercise is undefined at the beginning, but will be set correctly as soon as it's fetched. While the template already does nothing when the exercise is not yet set, ``ngOnChanges`` did try to access the exercise object in all cases.

### Description
<!-- Describe your changes in detail -->

All statements in ``ngOnChanges`` of this component are now appropriately guarded.
Additionally, I simplified a few other lines in the same file.

### Issue reproduction without this patch
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 open file upload exercise
- 1 Student

1. Open the exercise
2. Start the exercise
3. Go to the submission page where you can actually upload a file
 --> The issue will be logged in the console
 
 To verify the patch, deploy it onto the same node and reaccess the page. The error should not be logged anymore.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
header-participation-page.component.ts: 93% | 100%
