### PR TITLE
`General`: Fix an issue when sorting exercises by dates in course management

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-test-schedule-date-picker.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-test-schedule-date-picker.component.ts
@@ -44,7 +44,8 @@ export class ProgrammingExerciseTestScheduleDatePickerComponent implements Contr
 
     writeValue(obj: any): void {
         if (obj !== undefined && this.selectedDate !== obj) {
-            this.selectedDate = !obj ? null : isDate(obj) ? obj.setSeconds(0, 0) : obj.toDate().setSeconds(0, 0);
+            this.selectedDate = !obj ? null : isDate(obj) ? obj : obj.toDate();
+            this.selectedDate?.setSeconds(0, 0);
             this._onChange(obj);
         }
     }

--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-test-schedule-date-picker.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-test-schedule-date-picker.component.ts
@@ -44,7 +44,7 @@ export class ProgrammingExerciseTestScheduleDatePickerComponent implements Contr
 
     writeValue(obj: any): void {
         if (obj !== undefined && this.selectedDate !== obj) {
-            this.selectedDate = !obj ? null : isDate(obj) ? obj : obj.toDate();
+            this.selectedDate = !obj ? null : isDate(obj) ? obj.setSeconds(0, 0) : obj.toDate().setSeconds(0, 0);
             this._onChange(obj);
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

An instructor reported about problems when sorting exercises in `course-management-exercises` view by `Release Date` or `Due Date`. The exercises were sorted correctly by date, but for exercises with the same `Release Date` or `Due Date`, no secondary key is used.

### Description
<!-- Describe your changes in detail -->
It emerged that dates are stored including the current time seconds, which aren't visible to the user. Sorting the exercises by some key and subsequently by a date didn't work, as the dates differ. Setting seconds and milliseconds to zero in the `date-picker` component fixes this issue.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course

1. Log in to Artemis
2. Navigate to Course Administration
3. Generate two exercise (of the same type) with the same `Release Date` or `Due Date`
4. Sort the exercises by `title` and subsequently by date
5. Check if the exercises are sorted correctly by `title`

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/45761921/154994459-49dd32b6-9748-4489-823e-45112beb1bc4.png)

![image](https://user-images.githubusercontent.com/45761921/154993618-84bfd9d7-81fd-488f-b07b-bce737668d44.png)

