### PR TITLE
`Development`: Fix automatic inference of Artemis version for docker deployments

### DIFF
--- a/webpack/environment.js
+++ b/webpack/environment.js
@@ -1,7 +1,7 @@
 module.exports = {
     I18N_HASH: 'generated_hash',
     SERVER_API_URL: '',
-    __VERSION__: process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : inferVersion(),
+    __VERSION__: process.env.APP_VERSION || inferVersion(),
     __DEBUG_INFO_ENABLED__: false,
 };
 
@@ -21,11 +21,7 @@ function inferVersion() {
 
         version = data.match(/\nversion\s=\s"(.*)"/);
 
-        if (version) {
-            version = version[1];
-        } else {
-            version = 'DEV';
-        }
+        version = version[1] ?? 'DEV';
     } catch (error) {
         console.log("Error while retrieving 'APP_VERSION' property");
     }

--- a/webpack/environment.js
+++ b/webpack/environment.js
@@ -1,6 +1,35 @@
 module.exports = {
     I18N_HASH: 'generated_hash',
     SERVER_API_URL: '',
-    __VERSION__: process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'DEV',
+    __VERSION__: process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : inferVersion(),
     __DEBUG_INFO_ENABLED__: false,
 };
+
+/*
+ * Needed for client compilations with docker-compose, where the 'APP_VERSION' property isn't injected by gradle.
+ *
+ * Returns the inferred APP_VERSION from 'build.gradle', or 'DEV' if this couldn't be retrieved
+ */
+function inferVersion() {
+    let version = 'DEV';
+
+    try {
+        const fs = require('fs');
+        const buildGradleFile = 'build.gradle';
+
+        let data = fs.readFileSync(buildGradleFile, 'UTF-8');
+
+        version = data.match(/\nversion\s=\s"(.*)"/);
+
+        if (version) {
+            version = version[1];
+        } else {
+            version = 'DEV';
+        }
+    } catch (error) {
+        console.log("Error while retrieving 'APP_VERSION' property");
+    }
+
+    console.log(version);
+    return version;
+}

--- a/webpack/environment.js
+++ b/webpack/environment.js
@@ -30,6 +30,5 @@ function inferVersion() {
         console.log("Error while retrieving 'APP_VERSION' property");
     }
 
-    console.log(version);
     return version;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Compiling Artemis client using Docker-compose, or calling the npm script "webapp:prod", results in an Artemis version like "DEV". (see screenshot)

### Description
<!-- Describe your changes in detail -->
This is because the `APP_VERSION` is not injected by Gradle in this case, leading to the fallback version "DEV". As the version is specified in `build.gradle`, we can directly infer it, if this hasn't been previously injected by Gradle itself.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:

* Compatible Node.js version installed

1. Compile Artemis client using Docker-compose (or directly calling `npm run start-docker` or `npm run webapp:prod`)
2. Deploy it.
3. The Artemis version displayed on the top left side should be the correct one

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Before:**
![Screenshot 2022-02-21 175649](https://user-images.githubusercontent.com/45761921/155001915-b81377f5-285b-4f5d-bc78-f83a775bfdf3.png)

**After:**
![Screenshot 2022-02-21 175723](https://user-images.githubusercontent.com/45761921/155001960-1f530a4f-8c3e-428a-8028-5699ee05986b.png)
