### PR TITLE
`Exam mode`: Make sure to use the correct amount of decimal places (setting in a course) when rounding scores in the quiz summary view

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -94,6 +94,7 @@
                     <ng-container *ngIf="exercise.type === QUIZ">
                         <jhi-quiz-exam-summary
                             [exercise]="exercise"
+                            [course]="course"
                             [exam]="studentExam.exam!"
                             [submission]="getSubmissionForExercise(exercise)!"
                             [resultsPublished]="!!resultsPublished"

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.html
@@ -1,4 +1,4 @@
-<div class="quiz-content container" *ngIf="exercise.quizQuestions && exercise.quizQuestions.length > 0">
+<div class="quiz-content container" *ngIf="exercise.quizQuestions && exercise.quizQuestions.length > 0 && course">
     <div class="alert alert-info mb-2" *ngIf="showMissingResultsNotice">
         {{ 'artemisApp.exam.examSummary.missingResultNotice' | artemisTranslate }}
     </div>

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
@@ -15,6 +15,7 @@ import { ArtemisServerDateService } from 'app/shared/server-date.service';
 import { Result } from 'app/entities/result.model';
 import { roundValueSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { getCourseFromExercise } from 'app/entities/exercise.model';
+import { Course } from 'app/entities/course.model';
 
 @Component({
     selector: 'jhi-quiz-exam-summary',
@@ -34,6 +35,9 @@ export class QuizExamSummaryComponent implements OnInit {
 
     @Input()
     submission: QuizSubmission;
+
+    @Input()
+    course: Course;
 
     @Input()
     resultsPublished: boolean;
@@ -119,7 +123,7 @@ export class QuizExamSummaryComponent implements OnInit {
                 return answer && answer.quizQuestion ? answer.quizQuestion.id === quizQuestionId : false;
             });
             if (submittedAnswer && submittedAnswer.scoreInPoints !== undefined) {
-                return roundValueSpecifiedByCourseSettings(submittedAnswer.scoreInPoints, getCourseFromExercise(this.exercise));
+                return roundValueSpecifiedByCourseSettings(submittedAnswer.scoreInPoints, this.course);
             }
         }
         return 0;

--- a/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
+++ b/src/main/webapp/app/exam/participate/summary/exercises/quiz-exam-summary/quiz-exam-summary.component.ts
@@ -14,7 +14,6 @@ import { Exam } from 'app/entities/exam.model';
 import { ArtemisServerDateService } from 'app/shared/server-date.service';
 import { Result } from 'app/entities/result.model';
 import { roundValueSpecifiedByCourseSettings } from 'app/shared/util/utils';
-import { getCourseFromExercise } from 'app/entities/exercise.model';
 import { Course } from 'app/entities/course.model';
 
 @Component({


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This is basically a follow up fix of #4703. That PR didn't fully fix the issue as the same calculation was attempted by a subcomponent handling the quiz summary view, and it did not have the course object available either.

This issue spawned over **two million** events in Sentry (https://sentry.ase.in.tum.de/organizations/artemis/issues/20508), caused by just 8 users. I'm not exactly sure why it happened exactly (like in #4703) but with this PR we make sure that the course object is available.

### Description
<!-- Describe your changes in detail -->
The course object that was introduced in #4703 will now be passed on to the quiz summary component as well.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Finished, graded exam for a student with a quiz exercise with a few questions

1. Go to the student exam summary as instructor (Exam Management → Student Exams → View → Summary) or the student the exam belongs to.
2. The individual questions should display their score correctly according to the specified course accuracy.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
