### PR TITLE
`Exam mode`: Fix an issue when using structured grading instructions during the second correction round

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Feedback.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Feedback.java
@@ -369,7 +369,8 @@ public class Feedback extends DomainObject {
         feedback.setText(getText());
         feedback.setPositive(isPositive());
         feedback.setReference(getReference());
-        feedback.setVisibility(visibility);
+        feedback.setVisibility(getVisibility());
+        feedback.setGradingInstruction(getGradingInstruction());
         return feedback;
     }
 


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
Closes #4754

### Description
When preparing the assessment of the second correction round, the existing feedback gets copied. In this process, the `copyFeedback()`-method gets called. Here the gradingIstruction-field is now copied as well so that the connection doesn't get lost.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Exam with different exercises (preferably every type), each exercise with grading instructions.
- Second correction enabled for the exam
- 2 Tutors
- 1 Student

1. Tutor 1: Use Grading instructions during the first correction round
2. Tutor 2: Make sure the grading instructions are visible during the second correction round. Change the assessment.
3. Student: Make sure the grading instructions used in the second correction round are visible in the feedback.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

