### PR TITLE
`Development`:  Increase client test coverage for language helper

### DIFF
--- a/src/test/javascript/spec/component/admin/user-management-update.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/user-management-update.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, fakeAsync, inject, TestBed, tick } from '@angular/core/testing';
 import { HttpResponse } from '@angular/common/http';
-import { ActivatedRoute } from '@angular/router';
-import { of, Subject } from 'rxjs';
+import { ActivatedRoute, Router, RouterState } from '@angular/router';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 
 import { ArtemisTestModule } from '../../test.module';
 import { UserManagementUpdateComponent } from 'app/admin/user-management/user-management-update.component';
@@ -17,19 +17,36 @@ import { Organization } from 'app/entities/organization.model';
 import { OrganizationSelectorComponent } from 'app/shared/organization-selector/organization-selector.component';
 import { NgForm, NgModel } from '@angular/forms';
 import { MockDirective, MockModule } from 'ng-mocks';
-import { TranslatePipeMock } from '../../helpers/mocks/service/mock-translate.service';
+import { MockTranslateService, TranslatePipeMock } from '../../helpers/mocks/service/mock-translate.service';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
+import { TranslateService } from '@ngx-translate/core';
+import { MockRouter } from '../../helpers/mocks/mock-router';
+import { Title } from '@angular/platform-browser';
+
+import { LANGUAGES } from 'app/core/language/language.constants';
 
 describe('User Management Update Component', () => {
     let comp: UserManagementUpdateComponent;
     let fixture: ComponentFixture<UserManagementUpdateComponent>;
     let service: UserService;
+    let titleService: Title;
+
     const parentRoute = {
         data: of({ user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', [Authority.USER], ['admin'], undefined, undefined, undefined) }),
     } as any as ActivatedRoute;
     const route = { parent: parentRoute } as any as ActivatedRoute;
+
+    const mockRouterState = {
+        routerState: {
+            snapshot: {
+                root: { firstChild: {}, data: {} },
+            },
+        } as RouterState,
+    };
+
     let modalService: NgbModal;
+    let translateService: TranslateService;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -43,6 +60,7 @@ describe('User Management Update Component', () => {
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
                 { provide: NgbModal, useClass: MockNgbModalService },
+                { provide: TranslateService, useClass: MockTranslateService },
             ],
         })
             .compileComponents()
@@ -51,7 +69,13 @@ describe('User Management Update Component', () => {
                 comp = fixture.componentInstance;
                 service = TestBed.inject(UserService);
                 modalService = TestBed.inject(NgbModal);
+                titleService = TestBed.inject(Title);
+                translateService = TestBed.inject(TranslateService);
             });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     describe('OnInit', () => {
@@ -69,6 +93,56 @@ describe('User Management Update Component', () => {
                 expect(service.authorities).toHaveBeenCalled();
                 expect(comp.authorities).toEqual(['USER']);
                 expect(getAllSpy).toHaveBeenCalled();
+            }),
+        ));
+
+        it('should load available languages', inject(
+            [JhiLanguageHelper],
+            fakeAsync((languageHelper: JhiLanguageHelper) => {
+                // GIVEN
+                const getAllSpy = jest.spyOn(languageHelper, 'getAll');
+
+                // WHEN
+                comp.ngOnInit();
+
+                // THEN
+                expect(getAllSpy).toHaveBeenCalledTimes(1);
+                expect(comp.languages).toEqual(LANGUAGES);
+            }),
+        ));
+
+        it('should return current language', inject(
+            [JhiLanguageHelper],
+            fakeAsync((languageHelper: JhiLanguageHelper) => {
+                // GIVEN
+                const routerMock: MockRouter = TestBed.inject<MockRouter>(Router as any);
+                routerMock.setRouterState(mockRouterState.routerState);
+
+                // WHEN
+                translateService.use('en');
+
+                // THEN
+                expect(languageHelper.language).toStrictEqual(new BehaviorSubject<string>(translateService.currentLang).asObservable());
+            }),
+        ));
+
+        it('should set page title to default', inject(
+            [JhiLanguageHelper],
+            fakeAsync((languageHelper: JhiLanguageHelper) => {
+                // GIVEN
+                const routerMock: MockRouter = TestBed.inject<MockRouter>(Router as any);
+                routerMock.setRouterState(mockRouterState.routerState);
+
+                const updateTitleSpy = jest.spyOn(languageHelper, 'updateTitle');
+                const setTitleOnTitleServiceSpy = jest.spyOn(titleService, 'setTitle');
+
+                // WHEN
+                translateService.use('en');
+
+                // THEN
+                expect(updateTitleSpy).toHaveBeenCalledTimes(1);
+                expect(setTitleOnTitleServiceSpy).toHaveBeenCalledTimes(1);
+                expect(setTitleOnTitleServiceSpy).toHaveBeenCalledWith('artemisApp');
             }),
         ));
     });

--- a/src/test/javascript/spec/helpers/mocks/mock-router.ts
+++ b/src/test/javascript/spec/helpers/mocks/mock-router.ts
@@ -1,5 +1,5 @@
 import { EMPTY, Observable } from 'rxjs';
-import { RouterEvent } from '@angular/router';
+import { RouterEvent, RouterState } from '@angular/router';
 
 // When using the spies, bear in mind jest.resetAllMocks does not affect them, they need to be reset manually
 export class MockRouter {
@@ -8,4 +8,8 @@ export class MockRouter {
     navigateByUrl = jest.fn().mockReturnValue(true);
     navigate = jest.fn().mockReturnValue(true);
     events: Observable<RouterEvent> = EMPTY;
+    routerState: RouterState;
+    setRouterState(routerState: RouterState) {
+        this.routerState = routerState;
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Description
<!-- Describe your changes in detail -->
Added a client test to improve the test coverage of language.helper.ts.

#### Code Review
- [x] Review 1
- [x] Review 2


### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
language.helper.ts: 75% | 100% 
