### PR TITLE
`General`: Change password handling for internal users

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ jacocoTestCoverageVerification {
                 counter = "CLASS"
                 value = "MISSEDCOUNT"
                 // TODO: in the future the following value should become less than 20
-                maximum = 22
+                maximum = 23
             }
         }
     }

--- a/docs/admin/knownIssues.rst
+++ b/docs/admin/knownIssues.rst
@@ -1,0 +1,17 @@
+Known Issues
+============
+
+No user updates with Jenkins without password
+---------------------------------------------
+Currently, Jenkins doesn't allow to update the user details. We would have to delete and create the user with the new information.
+We can only do this if we have the password, which we don't have unless the admin provides a new password as the passwords are hashed in our database.
+If you update the user details in Artemis you have the following options if you use Jenkins:
+
+a) Update the user manually in Jenkins. As admins rarely update the users themselves, this wouldn't be too much work.
+b) Leave it as it is. You have to decide for yourself whether the user details in Jenkins are important.
+c) Provide a password. **Not recommended!** You would need to provide the user with the new password which is itself a security issue and then the user has to change the password which might not be done reliably.
+
+Important to know:
+
+- Group/Permission updates get always delegated. They are separate from user details.
+- If users change their password after a not delegated user change, the user change gets automatically applied when recreating the Jenkins user.

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -95,7 +95,7 @@ You can override the following configuration options in this file.
    artemis:
        repo-clone-path: ./repos/
        repo-download-clone-path: ./repos-download/
-       encryption-password: <encrypt-password>     # arbitrary password for encrypting database values
+       encryption-password: <encrypt-password>      # LEGACY: arbitrary password for encrypting database values
        user-management:
            use-external: true
            password-reset:

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -96,6 +96,8 @@ You can override the following configuration options in this file.
        repo-clone-path: ./repos/
        repo-download-clone-path: ./repos-download/
        encryption-password: <encrypt-password>      # LEGACY: arbitrary password for encrypting database values
+       bcrypt-salt-rounds: 11   # The number of salt rounds for the bcrypt password hashing. Lower numbers make it faster but more unsecure and vice versa.
+                                # Please use the bcrypt benchmark tool to determine the best number of rounds for your system. https://github.com/ls1intum/bcrypt-Benchmark
        user-management:
            use-external: true
            password-reset:

--- a/docs/dev/setup/bamboo-bitbucket-jira.rst
+++ b/docs/dev/setup/bamboo-bitbucket-jira.rst
@@ -294,6 +294,8 @@ Configure Artemis
            repo-clone-path: ./repos/
            repo-download-clone-path: ./repos-download/
            encryption-password: artemis-encrypt         # LEGACY: arbitrary password for encrypting database values
+           bcrypt-salt-rounds: 11   # The number of salt rounds for the bcrypt password hashing. Lower numbers make it faster but more unsecure and vice versa.
+                                    # Please use the bcrypt benchmark tool to determine the best number of rounds for your system. https://github.com/ls1intum/bcrypt-Benchmark
            user-management:
                use-external: true
                external:

--- a/docs/dev/setup/bamboo-bitbucket-jira.rst
+++ b/docs/dev/setup/bamboo-bitbucket-jira.rst
@@ -293,7 +293,7 @@ Configure Artemis
 
            repo-clone-path: ./repos/
            repo-download-clone-path: ./repos-download/
-           encryption-password: artemis-encrypt   # arbitrary password for encrypting database values
+           encryption-password: artemis-encrypt         # LEGACY: arbitrary password for encrypting database values
            user-management:
                use-external: true
                external:

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -96,13 +96,7 @@ communication, you have to append it to the ``server.url`` value,
 e.g. \ ``127.0.0.1:8080``.
 
 When you start Artemis for the first time, it will automatically create
-an admin user based on the default encryption password specified in the
-yml file above. In case you want to use a different encryption password,
-you can insert users manually into the ``jhi_user`` table. You can use
-`Jasypt Online Encryption
-Tool <https://www.devglan.com/online-tools/jasypt-online-encryption-decryption>`__
-to generate encryption strings. Use Two Way Encryption (With Secret
-Text).
+an admin user.
 
 **Note:** Sometimes Artemis does not generate the admin user which may lead to a startup
 error. You will have to create the user manually in the MySQL database and in Gitlab. Make sure

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -42,6 +42,8 @@ below into your ``application-artemis.yml`` or ``application-local.yml`` file (t
     repo-clone-path: ./repos
     repo-download-clone-path: ./repos-download
     encryption-password: artemis_admin           # LEGACY: arbitrary password for encrypting database values
+    bcrypt-salt-rounds: 11  # The number of salt rounds for the bcrypt password hashing. Lower numbers make it faster but more unsecure and vice versa.
+                            # Please use the bcrypt benchmark tool to determine the best number of rounds for your system. https://github.com/ls1intum/bcrypt-Benchmark
     user-management:
         use-external: false
         internal-admin:

--- a/docs/dev/setup/jenkins-gitlab.rst
+++ b/docs/dev/setup/jenkins-gitlab.rst
@@ -41,7 +41,7 @@ below into your ``application-artemis.yml`` or ``application-local.yml`` file (t
     course-archives-path: ./exports/courses
     repo-clone-path: ./repos
     repo-download-clone-path: ./repos-download
-    encryption-password: artemis_admin
+    encryption-password: artemis_admin           # LEGACY: arbitrary password for encrypting database values
     user-management:
         use-external: false
         internal-admin:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,3 +53,4 @@ All these exercises are supposed to be run either live in the lecture with insta
    admin/registration
    admin/accessRights
    admin/troubleshooting
+   admin/knownIssues

--- a/src/main/docker/cypress/application.yml
+++ b/src/main/docker/cypress/application.yml
@@ -39,7 +39,7 @@ artemis:
   repo-download-clone-path: repos-download
   file-upload-path: ./uploads
   submission-export-path: exports
-  encryption-password: cypressEncryptionPassword
+  encryption-password: cypressEncryptionPassword # LEGACY: arbitrary password for encrypting database values
   user-management:
     use-external: true
     external:

--- a/src/main/docker/cypress/application.yml
+++ b/src/main/docker/cypress/application.yml
@@ -40,8 +40,7 @@ artemis:
   file-upload-path: ./uploads
   submission-export-path: exports
   encryption-password: cypressEncryptionPassword # LEGACY: arbitrary password for encrypting database values
-  bcrypt-salt-rounds: 10    # The number of salt rounds for the bcrypt password hashing. Lower numbers make it faster but more unsecure and vice versa.
-                            # Please use the bcrypt benchmark tool to determine the best number of rounds for your system. https://github.com/ls1intum/bcrypt-Benchmark
+  bcrypt-salt-rounds: 4    # We don't need secure passwords for testing. Lower rounds will speed up tests. 4 ist the lowest
   user-management:
     use-external: true
     external:

--- a/src/main/docker/cypress/application.yml
+++ b/src/main/docker/cypress/application.yml
@@ -40,6 +40,8 @@ artemis:
   file-upload-path: ./uploads
   submission-export-path: exports
   encryption-password: cypressEncryptionPassword # LEGACY: arbitrary password for encrypting database values
+  bcrypt-salt-rounds: 10    # The number of salt rounds for the bcrypt password hashing. Lower numbers make it faster but more unsecure and vice versa.
+                            # Please use the bcrypt benchmark tool to determine the best number of rounds for your system. https://github.com/ls1intum/bcrypt-Benchmark
   user-management:
     use-external: true
     external:

--- a/src/main/java/de/tum/in/www1/artemis/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/SecurityConfiguration.java
@@ -73,7 +73,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     public void init() {
         try {
             // here we configure 2 authentication provider: 1) the user details service for internal authentication using the Artemis database...
-            authenticationManagerBuilder.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder());
+            authenticationManagerBuilder.userDetailsService(userDetailsService);
             // ... and 2), if specified a remote (or external) user authentication provider (e.g. JIRA)
             remoteUserAuthenticationProvider.ifPresent(authenticationManagerBuilder::authenticationProvider);
             // When users try to authenticate, Spring will always first ask the remote user authentication provider (e.g. JIRA) if available, and only if this one fails,
@@ -82,22 +82,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         catch (Exception e) {
             throw new BeanInitializationException("Security configuration failed", e);
         }
-    }
-
-    @Value("${artemis.encryption-password}")
-    private String encryptionPassword;
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new PBEPasswordEncoder(encryptor());
-    }
-
-    @Bean
-    public StandardPBEStringEncryptor encryptor() {
-        StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
-        encryptor.setAlgorithm("PBEWithMD5AndDES");
-        encryptor.setPassword(encryptionPassword);
-        return encryptor;
     }
 
     @Bean

--- a/src/main/java/de/tum/in/www1/artemis/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/SecurityConfiguration.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import javax.annotation.PostConstruct;
 
-import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import de.tum.in.www1.artemis.service.user.PasswordService;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -23,13 +23,13 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.web.filter.CorsFilter;
 import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 
-import de.tum.in.www1.artemis.security.PBEPasswordEncoder;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.jwt.JWTConfigurer;
 import de.tum.in.www1.artemis.security.jwt.TokenProvider;
@@ -50,18 +50,21 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final SecurityProblemSupport problemSupport;
 
+    private final PasswordService passwordService;
+
     private final Optional<AuthenticationProvider> remoteUserAuthenticationProvider;
 
     @Value("${spring.prometheus.monitoringIp:#{null}}")
     private Optional<String> monitoringIpAddress;
 
-    public SecurityConfiguration(AuthenticationManagerBuilder authenticationManagerBuilder, UserDetailsService userDetailsService, TokenProvider tokenProvider,
-                                 CorsFilter corsFilter, SecurityProblemSupport problemSupport, Optional<AuthenticationProvider> remoteUserAuthenticationProvider) {
+    public SecurityConfiguration(AuthenticationManagerBuilder authenticationManagerBuilder, UserDetailsService userDetailsService, TokenProvider tokenProvider, CorsFilter corsFilter, SecurityProblemSupport problemSupport,
+        PasswordService passwordService, Optional<AuthenticationProvider> remoteUserAuthenticationProvider) {
         this.authenticationManagerBuilder = authenticationManagerBuilder;
         this.userDetailsService = userDetailsService;
         this.tokenProvider = tokenProvider;
         this.corsFilter = corsFilter;
         this.problemSupport = problemSupport;
+        this.passwordService = passwordService;
         this.remoteUserAuthenticationProvider = remoteUserAuthenticationProvider;
     }
 
@@ -82,6 +85,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         catch (Exception e) {
             throw new BeanInitializationException("Security configuration failed", e);
         }
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return this.passwordService.getPasswordEncoder();
     }
 
     @Bean

--- a/src/main/java/de/tum/in/www1/artemis/config/auth/JiraAuthorizationInterceptor.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/auth/JiraAuthorizationInterceptor.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.config.auth;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.validation.constraints.NotNull;
 
@@ -27,7 +28,7 @@ public class JiraAuthorizationInterceptor implements ClientHttpRequestIntercepto
     @Override
     public ClientHttpResponse intercept(HttpRequest request, @NotNull byte[] body, @NotNull ClientHttpRequestExecution execution) throws IOException {
         if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
-            request.getHeaders().setBasicAuth(JIRA_USER, JIRA_PASSWORD);
+            request.getHeaders().setBasicAuth(JIRA_USER, JIRA_PASSWORD, StandardCharsets.UTF_8);
         }
         return execution.execute(request, body);
     }

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationRegistry.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/MigrationRegistry.java
@@ -26,6 +26,7 @@ public class MigrationRegistry {
         // Here we define the order of the ChangeEntries
         migrationEntryMap.put(0, MigrationEntry20211214_184200.class);
         migrationEntryMap.put(1, MigrationEntry20220210_160300.class);
+        migrationEntryMap.put(2, MigrationEntry20220302_164200.class);
         this.migrationService = migrationService;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20211214_184200.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20211214_184200.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import de.tum.in.www1.artemis.config.migration.MigrationEntry;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.service.user.PasswordService;
+import de.tum.in.www1.artemis.service.user.LegacyPasswordService;
 
 /**
  * This migration separates the users into internal and external users and sets the newly created attribute isInternal in {@link User}
@@ -17,9 +17,9 @@ public class MigrationEntry20211214_184200 extends MigrationEntry {
 
     private final UserRepository userRepository;
 
-    private final PasswordService passwordService;
+    private final LegacyPasswordService passwordService;
 
-    public MigrationEntry20211214_184200(UserRepository userRepository, PasswordService passwordService) {
+    public MigrationEntry20211214_184200(UserRepository userRepository, LegacyPasswordService passwordService) {
         this.userRepository = userRepository;
         this.passwordService = passwordService;
     }

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20211214_184200.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20211214_184200.java
@@ -18,7 +18,7 @@ import de.tum.in.www1.artemis.service.user.LegacyPasswordService;
 @Component
 public class MigrationEntry20211214_184200 extends MigrationEntry {
 
-    private static final Logger log = LoggerFactory.getLogger(MigrationEntry20211214_184200.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MigrationEntry20211214_184200.class);
 
     private final UserRepository userRepository;
 
@@ -37,7 +37,7 @@ public class MigrationEntry20211214_184200 extends MigrationEntry {
         int listSize = 100;
         // false is the default value so if they were already set to true, this migration probably runs on a fresh system
         List<User> users = userRepository.findAllByInternal(false);
-        log.info("Found {} users to process with `User.isInternal=false`.", users.size());
+        LOGGER.info("Found {} users to process with `User.isInternal=false`.", users.size());
         int remainder = users.size() % listSize;
         int listCount = (int) Math.floor(users.size() / 100f);
         for (int i = 0; i < listCount; i++) {

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import de.tum.in.www1.artemis.config.migration.MigrationEntry;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.UserRepository;
+import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.user.LegacyPasswordService;
 import de.tum.in.www1.artemis.service.user.PasswordService;
 
@@ -27,6 +28,7 @@ public class MigrationEntry20220302_164200 extends MigrationEntry {
 
     @Override
     public void execute() {
+        SecurityUtils.setAuthorizationObject();
         int listSize = 100;
         List<User> users = userRepository.findAllByInternal(true);
         // Cut list in parts to prevent any timeouts

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
@@ -31,7 +31,7 @@ public class MigrationEntry20220302_164200 extends MigrationEntry {
     public void execute() {
         List<User> users = userRepository.findAll();
         Lists.partition(users, 100).forEach(list -> {
-            list = list.stream().peek(this::processUser).toList();
+            list.forEach(this::processUser);
             userRepository.saveAll(list);
         });
     }

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
@@ -41,7 +41,7 @@ public class MigrationEntry20220302_164200 extends MigrationEntry {
 
         // Set internal state again due to an issue with setting the correct status during registration (PR #4806)
         // As the passwords of all external users were set to the encrypted empty string in Migration Entry 20211214_184200
-        user.setInternal(!password.equals(""));
+        user.setInternal(!"".equals(password));
 
         if (user.isInternal()) {
             String hash = passwordService.hashPassword(password);

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
@@ -2,6 +2,8 @@ package de.tum.in.www1.artemis.config.migration.entries;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
@@ -14,6 +16,8 @@ import de.tum.in.www1.artemis.service.user.PasswordService;
 
 @Component
 public class MigrationEntry20220302_164200 extends MigrationEntry {
+
+    private static final Logger log = LoggerFactory.getLogger(MigrationEntry20220302_164200.class);
 
     private final UserRepository userRepository;
 
@@ -30,6 +34,7 @@ public class MigrationEntry20220302_164200 extends MigrationEntry {
     @Override
     public void execute() {
         List<User> users = userRepository.findAll();
+        log.info("Found {} users to process.", users.size());
         Lists.partition(users, 100).forEach(list -> {
             list.forEach(this::processUser);
             userRepository.saveAll(list);
@@ -37,11 +42,28 @@ public class MigrationEntry20220302_164200 extends MigrationEntry {
     }
 
     private void processUser(User user) {
+        if (user.getPassword() == null) {
+            // If the password is null at this point, it has to be a proper external user we don't need to handle anymore.
+            // Just to be sure, we set the correct internal state
+            user.setInternal(false);
+            return;
+        }
+        // The admin gets created beforehand if the account doesn't exist yet. This would be captured here.
+        if (user.getPassword().matches("^\\$2[abxy]\\$\\d{2}\\$.*$")) {
+            // If the password is a Bcrypt password at this point, it has to be a proper internal user we don't need to handle anymore.
+            // Just to be sure, we set the correct internal state
+            user.setInternal(true);
+            return;
+        }
+
+        // In a previous migration we encrypted all relevant password so we don't need a fallback here
         String password = legacyPasswordService.decryptPassword(user);
 
-        // Set internal state again due to an issue with setting the correct status during registration (PR #4806)
-        // As the passwords of all external users were set to the encrypted empty string in Migration Entry 20211214_184200
-        user.setInternal(!"".equals(password));
+        if (!user.isInternal()) {
+            // Set internal state again due to an issue with setting the correct status during registration (PR #4806)
+            // As the passwords of all external users were set to the encrypted empty string in Migration Entry 20211214_184200
+            user.setInternal(!"".equals(password));
+        }
 
         if (user.isInternal()) {
             String hash = passwordService.hashPassword(password);

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
@@ -17,7 +17,7 @@ import de.tum.in.www1.artemis.service.user.PasswordService;
 @Component
 public class MigrationEntry20220302_164200 extends MigrationEntry {
 
-    private static final Logger log = LoggerFactory.getLogger(MigrationEntry20220302_164200.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MigrationEntry20220302_164200.class);
 
     private final UserRepository userRepository;
 
@@ -34,7 +34,7 @@ public class MigrationEntry20220302_164200 extends MigrationEntry {
     @Override
     public void execute() {
         List<User> users = userRepository.findAll();
-        log.info("Found {} users to process.", users.size());
+        LOGGER.info("Found {} users to process.", users.size());
         Lists.partition(users, 100).forEach(list -> {
             list.forEach(this::processUser);
             userRepository.saveAll(list);

--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20220302_164200.java
@@ -1,0 +1,83 @@
+package de.tum.in.www1.artemis.config.migration.entries;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import de.tum.in.www1.artemis.config.migration.MigrationEntry;
+import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.repository.UserRepository;
+import de.tum.in.www1.artemis.service.user.LegacyPasswordService;
+import de.tum.in.www1.artemis.service.user.PasswordService;
+
+@Component
+public class MigrationEntry20220302_164200 extends MigrationEntry {
+
+    private final UserRepository userRepository;
+
+    private final LegacyPasswordService legacyPasswordService;
+
+    private final PasswordService passwordService;
+
+    public MigrationEntry20220302_164200(UserRepository userRepository, LegacyPasswordService legacyPasswordService, PasswordService passwordService) {
+        this.userRepository = userRepository;
+        this.legacyPasswordService = legacyPasswordService;
+        this.passwordService = passwordService;
+    }
+
+    @Override
+    public void execute() {
+        int listSize = 100;
+        List<User> users = userRepository.findAllByInternal(true);
+        // Cut list in parts to prevent any timeouts
+        int remainder = users.size() % listSize;
+        int listCount = (int) Math.floor(users.size() / 100f);
+        for (int i = 0; i < listCount - 1; i++) {
+            List<User> sublist = users.subList(i * listSize, (i + 1) * listSize);
+            processInternalUsers(sublist);
+        }
+        if (remainder > 0) {
+            List<User> sublist = users.subList(listCount * listSize, (listCount * listSize) + remainder);
+            processInternalUsers(sublist);
+        }
+
+        processExternalUsers();
+    }
+
+    private void processInternalUsers(List<User> userList) {
+        userList = userList.stream().peek(user -> {
+            String password = legacyPasswordService.decryptPassword(user);
+            String hash = passwordService.hashPassword(password);
+            user.setPassword(hash);
+        }).toList();
+
+        userRepository.saveAll(userList);
+    }
+
+    private void processExternalUsers() {
+        List<User> userList = userRepository.findAllByInternal(false);
+        userList = userList.stream().peek(user -> {
+            user.setPassword(null);
+        }).toList();
+
+        userRepository.saveAll(userList);
+    }
+
+    /**
+     * @return Author of the entry. Either full name or GitHub name.
+     */
+    @Override
+    public String author() {
+        return "julian-christl";
+    }
+
+    /**
+     * Format YYYYMMDD_HHmmss
+     *
+     * @return Current time in given format
+     */
+    @Override
+    public String date() {
+        return "20220302_164200";
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -56,6 +56,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findOneWithGroupsAndAuthoritiesByLogin(String login);
 
     @EntityGraph(type = LOAD, attributePaths = { "groups", "authorities" })
+    Optional<User> findOneWithGroupsAndAuthoritiesByLoginAndIsInternal(String login, boolean isInternal);
+
+    @EntityGraph(type = LOAD, attributePaths = { "groups", "authorities" })
     Optional<User> findOneWithGroupsAndAuthoritiesById(Long id);
 
     @EntityGraph(type = LOAD, attributePaths = { "groups", "authorities", "organizations" })

--- a/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/UserRepository.java
@@ -83,6 +83,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("select user from User user where :#{#groupName} member of user.groups")
     List<User> findAllInGroup(@Param("groupName") String groupName);
 
+    @Query("select user from User user where user.isInternal = :#{#isInternal}")
+    List<User> findAllByInternal(boolean isInternal);
+
     /**
      * Searches for users in a group by their login or full name.
      *

--- a/src/main/java/de/tum/in/www1/artemis/security/ArtemisInternalAuthenticationProvider.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/ArtemisInternalAuthenticationProvider.java
@@ -33,8 +33,7 @@ public class ArtemisInternalAuthenticationProvider extends ArtemisAuthentication
         if (!user.get().getActivated()) {
             throw new UserNotActivatedException("User " + user.get().getLogin() + " was not activated");
         }
-        final var storedPassword = passwordService.decryptPassword(user.get());
-        if (!authentication.getCredentials().toString().equals(storedPassword)) {
+        if (!passwordService.checkPasswordMatch(authentication.getCredentials().toString(), user.get().getPassword())) {
             throw new AuthenticationServiceException("Invalid password for user " + user.get().getLogin());
         }
         return new UsernamePasswordAuthenticationToken(user.get().getLogin(), user.get().getPassword(), user.get().getGrantedAuthorities());
@@ -51,8 +50,7 @@ public class ArtemisInternalAuthenticationProvider extends ArtemisAuthentication
         else {
             user = optionalUser.get();
             if (!skipPasswordCheck) {
-                final var storedPassword = passwordService.decryptPassword(user);
-                if (!password.equals(storedPassword)) {
+                if (!passwordService.checkPasswordMatch(password, user.getPassword())) {
                     throw new InternalAuthenticationServiceException("Authentication failed for user " + user.getLogin());
                 }
             }

--- a/src/main/java/de/tum/in/www1/artemis/security/ArtemisInternalAuthenticationProvider.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/ArtemisInternalAuthenticationProvider.java
@@ -49,10 +49,8 @@ public class ArtemisInternalAuthenticationProvider extends ArtemisAuthentication
         }
         else {
             user = optionalUser.get();
-            if (!skipPasswordCheck) {
-                if (!passwordService.checkPasswordMatch(password, user.getPassword())) {
-                    throw new InternalAuthenticationServiceException("Authentication failed for user " + user.getLogin());
-                }
+            if (!skipPasswordCheck && !passwordService.checkPasswordMatch(password, user.getPassword())) {
+                throw new InternalAuthenticationServiceException("Authentication failed for user " + user.getLogin());
             }
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/security/DomainUserDetailsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/DomainUserDetailsService.java
@@ -30,7 +30,7 @@ public class DomainUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(final String login) {
         log.debug("Authenticating {}", login);
         String lowercaseLogin = login.toLowerCase(Locale.ENGLISH);
-        return userRepository.findOneWithGroupsAndAuthoritiesByLogin(lowercaseLogin).map(user -> createSpringSecurityUser(lowercaseLogin, user))
+        return userRepository.findOneWithGroupsAndAuthoritiesByLoginAndIsInternal(lowercaseLogin, true).map(user -> createSpringSecurityUser(lowercaseLogin, user))
                 .orElseThrow(() -> new UsernameNotFoundException("User " + lowercaseLogin + " was not found in the database"));
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/security/PBEPasswordEncoder.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/PBEPasswordEncoder.java
@@ -6,6 +6,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 /**
  * PBEPasswordEncoder for Spring, based on org.jasypt.spring.security3.PBEPasswordEncoder;
  */
+@Deprecated
 public class PBEPasswordEncoder implements PasswordEncoder {
 
     private final PBEStringEncryptor pbeStringEncryptor;

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -59,7 +59,7 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
         }
 
         log.debug("Bitbucket user {} does not exist yet", user.getLogin());
-        String displayName = user.getName().trim();
+        String displayName = user.getName() != null ? user.getName().trim() : user.getName();
         bitbucketService.createUser(user.getLogin(), password, user.getEmail(), displayName);
 
         try {
@@ -87,7 +87,7 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
      * @param user                      The updated user in Artemis
      * @param removedGroups             groups that the user does not belong to any longer
      * @param addedGroups               The new groups the Artemis user got added to
-     * @param shouldSynchronizePassword whether the password should be synchronized between Artemis and the VcsUserManagementService
+     * @param newPassword               The new password, null otherwise
      */
     @Override
     public void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, String newPassword) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -80,7 +80,6 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
      * </ul>
      *
      * @param vcsLogin                  The username of the user in the VCS
-     *
      * @param user                      The updated user in Artemis
      * @param removedGroups             groups that the user does not belong to any longer
      * @param addedGroups               The new groups the Artemis user got added to

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -56,7 +56,7 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
         }
 
         log.debug("Bitbucket user {} does not exist yet", user.getLogin());
-        String displayName = user.getName() != null ? user.getName().trim() : user.getName();
+        String displayName = user.getName() != null ? user.getName().trim() : null;
         bitbucketService.createUser(user.getLogin(), password, user.getEmail(), displayName);
 
         try {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -46,9 +46,10 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
      * and management
      *
      * @param user The local Artemis user, which will be available in the VCS after invoking this method
+     * @param password the password of the user to be set
      */
     @Override
-    public void createVcsUser(User user) throws VersionControlException {
+    public void createVcsUser(User user, String password) throws VersionControlException {
         if (!user.isInternal()) {
             return;
         }
@@ -59,7 +60,7 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
 
         log.debug("Bitbucket user {} does not exist yet", user.getLogin());
         String displayName = user.getName().trim();
-        bitbucketService.createUser(user.getLogin(), passwordService.decryptPasswordByLogin(user.getLogin()).get(), user.getEmail(), displayName);
+        bitbucketService.createUser(user.getLogin(), password, user.getEmail(), displayName);
 
         try {
             // NOTE: we need to fetch the user here again to make sure that the groups are not lazy loaded.
@@ -82,19 +83,20 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
      * </ul>
      *
      * @param vcsLogin                  The username of the user in the VCS
+     *
      * @param user                      The updated user in Artemis
      * @param removedGroups             groups that the user does not belong to any longer
      * @param addedGroups               The new groups the Artemis user got added to
      * @param shouldSynchronizePassword whether the password should be synchronized between Artemis and the VcsUserManagementService
      */
     @Override
-    public void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, boolean shouldSynchronizePassword) {
+    public void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, String newPassword) {
         if (!user.isInternal()) {
             return;
         }
         bitbucketService.updateUserDetails(vcsLogin, user.getEmail(), user.getName());
-        if (shouldSynchronizePassword) {
-            bitbucketService.updateUserPassword(vcsLogin, passwordService.decryptPassword(user));
+        if (newPassword != null) {
+            bitbucketService.updateUserPassword(vcsLogin, newPassword);
         }
         if (addedGroups != null && !addedGroups.isEmpty()) {
             bitbucketService.addUserToGroups(user.getLogin(), addedGroups);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/BitbucketUserManagementService.java
@@ -29,15 +29,12 @@ public class BitbucketUserManagementService implements VcsUserManagementService 
 
     private final UserRepository userRepository;
 
-    private final PasswordService passwordService;
-
     private final ProgrammingExerciseRepository programmingExerciseRepository;
 
     public BitbucketUserManagementService(BitbucketService bitbucketService, UserRepository userRepository, PasswordService passwordService,
             ProgrammingExerciseRepository programmingExerciseRepository) {
         this.bitbucketService = bitbucketService;
         this.userRepository = userRepository;
-        this.passwordService = passwordService;
         this.programmingExerciseRepository = programmingExerciseRepository;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/CIUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/CIUserManagementService.java
@@ -12,9 +12,10 @@ public interface CIUserManagementService {
      * Creates a new user in the CIS based the Artemis user.
      *
      * @param user The Artemis user
+     * @param password The user's password
      * @throws ContinuousIntegrationException thrown when a job cannot be fetched/updated
      */
-    void createUser(User user) throws ContinuousIntegrationException;
+    void createUser(User user, String password) throws ContinuousIntegrationException;
 
     /**
      * Deletes the user under the specified login from the CIS.
@@ -29,17 +30,19 @@ public interface CIUserManagementService {
      * an exceptions if the user doesn't exist in the CIS.
      *
      * @param user The Artemis user
+     * @param password The user's password
      * @throws ContinuousIntegrationException thrown when a job cannot be fetched/updated
      */
-    void updateUser(User user) throws ContinuousIntegrationException;
+    void updateUser(User user, String password) throws ContinuousIntegrationException;
 
     /**
      * Updates the user login of the user.
      *
      * @param oldLogin the old login
      * @param user The Artemis user with the new login
+     * @param password The user's password
      */
-    void updateUserLogin(String oldLogin, User user) throws ContinuousIntegrationException;
+    void updateUserLogin(String oldLogin, User user, String password) throws ContinuousIntegrationException;
 
     /**
      * Updates the user in the CIS with the data from the Artemis users. Also adds/removes
@@ -48,11 +51,12 @@ public interface CIUserManagementService {
      *
      * @param oldLogin the old login if it was updated
      * @param user the Artemis user
+     * @param password the user's password
      * @param groupsToAdd groups to add the user to
      * @param groupsToRemove groups to remove the user from
      * @throws ContinuousIntegrationException thrown when a job cannot be fetched/updated
      */
-    void updateUserAndGroups(String oldLogin, User user, Set<String> groupsToAdd, Set<String> groupsToRemove) throws ContinuousIntegrationException;
+    void updateUserAndGroups(String oldLogin, User user, String password, Set<String> groupsToAdd, Set<String> groupsToRemove) throws ContinuousIntegrationException;
 
     /**
      * Adds the user to the specified group in the CIS. Groups define who has access

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/VcsUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/VcsUserManagementService.java
@@ -12,9 +12,10 @@ public interface VcsUserManagementService {
      * Creates a new user in the VCS based on a local Artemis user. Should be called if Artemis handles user creation
      * and management
      *
-     * @param user The local Artemis user, which will be available in the VCS after invoking this method
+     * @param user     The local Artemis user, which will be available in the VCS after invoking this method
+     * @param password the password of the user to be set
      */
-    void createVcsUser(User user) throws VersionControlException;
+    void createVcsUser(User user, String password) throws VersionControlException;
 
     /**
      * Updates a new user in the VCS based on a local Artemis user. Should be called if Artemis handles user management.
@@ -24,13 +25,17 @@ public interface VcsUserManagementService {
      *     <li>Update the groups the user belongs to, i.e. removing him from exercises that reference old groups</li>
      * </ul>
      *
-     * @param vcsLogin                  The username of the user in the VCS
-     * @param user                      The updated user in Artemis
-     * @param removedGroups             groups that the user does not belong to any longer
-     * @param addedGroups               The new groups the Artemis user got added to
-     * @param shouldSynchronizePassword whether the password should be synchronized between Artemis and the VcsUserManagementService
+     * @param vcsLogin      The username of the user in the VCS
+     * @param user          The updated user in Artemis
+     * @param removedGroups groups that the user does not belong to any longer
+     * @param addedGroups   The new groups the Artemis user got added to
+     * @param newPassword   if set, the password gets updated
      */
-    void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, boolean shouldSynchronizePassword);
+    void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, String newPassword);
+
+    default void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups) {
+        updateVcsUser(vcsLogin, user, removedGroups, addedGroups, null);
+    }
 
     /**
      * Deletes the user under the specified login from the VCS

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabUserManagementService.java
@@ -29,8 +29,6 @@ public class GitLabUserManagementService implements VcsUserManagementService {
 
     private final Logger log = LoggerFactory.getLogger(GitLabUserManagementService.class);
 
-    private final PasswordService passwordService;
-
     private final UserRepository userRepository;
 
     private final ProgrammingExerciseRepository programmingExerciseRepository;
@@ -45,7 +43,6 @@ public class GitLabUserManagementService implements VcsUserManagementService {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.gitlabApi = gitlabApi;
         this.userRepository = userRepository;
-        this.passwordService = passwordService;
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/gitlab/GitLabUserManagementService.java
@@ -49,16 +49,16 @@ public class GitLabUserManagementService implements VcsUserManagementService {
     }
 
     @Override
-    public void createVcsUser(User user) throws VersionControlException {
-        final Long gitlabUserId = getUserIdCreateIfNotExists(user);
+    public void createVcsUser(User user, String password) throws VersionControlException {
+        final Long gitlabUserId = getUserIdCreateIfNotExists(user, password);
         // Add user to existing exercises
         addUserToGroups(gitlabUserId, user.getGroups());
     }
 
     @Override
-    public void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, boolean shouldUpdatePassword) {
+    public void updateVcsUser(String vcsLogin, User user, Set<String> removedGroups, Set<String> addedGroups, String newPassword) {
         try {
-            var gitlabUser = updateBasicUserInformation(vcsLogin, user, shouldUpdatePassword);
+            var gitlabUser = updateBasicUserInformation(vcsLogin, user, newPassword);
             if (gitlabUser == null) {
                 return;
             }
@@ -67,7 +67,7 @@ public class GitLabUserManagementService implements VcsUserManagementService {
 
             addUserToGroups(gitlabUser.getId(), addedGroups);
 
-            // Remove the user from groups or update it's permissions if the user belongs to multiple
+            // Remove the user from groups or update its permissions if the user belongs to multiple
             // groups of the same course.
             removeOrUpdateUserFromGroups(gitlabUser.getId(), user.getGroups(), removedGroups);
         }
@@ -81,11 +81,11 @@ public class GitLabUserManagementService implements VcsUserManagementService {
      *
      * @param userLogin the username of the user
      * @param user the Artemis user to update
-     * @param shouldUpdatePassword if the Gitlab password should be updated
+     * @param newPassword if provided the Gitlab password should be updated to the new value
      * @return the updated Gitlab user
      * @throws GitLabApiException if the user cannot be retrieved or cannot update the user
      */
-    private org.gitlab4j.api.models.User updateBasicUserInformation(String userLogin, User user, boolean shouldUpdatePassword) throws GitLabApiException {
+    private org.gitlab4j.api.models.User updateBasicUserInformation(String userLogin, User user, String newPassword) throws GitLabApiException {
         UserApi userApi = gitlabApi.getUserApi();
 
         final var gitlabUser = userApi.getUser(userLogin);
@@ -101,8 +101,7 @@ public class GitLabUserManagementService implements VcsUserManagementService {
         // Skip confirmation is necessary in order to update the email without user re-confirmation
         gitlabUser.setSkipConfirmation(true);
 
-        String password = shouldUpdatePassword ? passwordService.decryptPassword(user) : null;
-        return userApi.updateUser(gitlabUser, password);
+        return userApi.updateUser(gitlabUser, newPassword);
     }
 
     /**
@@ -310,13 +309,14 @@ public class GitLabUserManagementService implements VcsUserManagementService {
      * generated id.
      *
      * @param user the Artemis user
+     * @param password the user's password
      * @return the Gitlab user id
      */
-    private Long getUserIdCreateIfNotExists(User user) {
+    private Long getUserIdCreateIfNotExists(User user, String password) {
         try {
             var gitlabUser = gitlabApi.getUserApi().getUser(user.getLogin());
             if (gitlabUser == null) {
-                gitlabUser = createUser(user);
+                gitlabUser = createUser(user, password);
             }
             return gitlabUser.getId();
         }
@@ -469,13 +469,14 @@ public class GitLabUserManagementService implements VcsUserManagementService {
      * user account with the same email, login, name and password
      *
      * @param user The artemis user
+     * @param password The user's password
      * @return a Gitlab user
      */
-    public org.gitlab4j.api.models.User createUser(User user) {
+    public org.gitlab4j.api.models.User createUser(User user, String password) {
         try {
             final var gitlabUser = new org.gitlab4j.api.models.User().withEmail(user.getEmail()).withUsername(user.getLogin()).withName(getUsersName(user))
                     .withCanCreateGroup(false).withCanCreateProject(false).withSkipConfirmation(true);
-            return gitlabApi.getUserApi().createUser(gitlabUser, passwordService.decryptPassword(user), false);
+            return gitlabApi.getUserApi().createUser(gitlabUser, password, false);
         }
         catch (GitLabApiException e) {
             throw new GitLabException("Unable to create new user in GitLab " + user.getLogin(), e);

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsUserManagementService.java
@@ -199,7 +199,7 @@ public class JenkinsUserManagementService implements CIUserManagementService {
     }
 
     /**
-     * We only support updating the groups if no password is provided. See {@link #updateUserLogin(String, User, String)} for more information.
+     * We only support updating the groups if a password is provided. See {@link #updateUserLogin(String, User, String)} for more information.
      * If no password is provided we expect the frontend to show an automatic warning.
      *
      * @param oldLogin       the old login if it was updated

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsUserManagementService.java
@@ -199,7 +199,8 @@ public class JenkinsUserManagementService implements CIUserManagementService {
     }
 
     /**
-     * We only support updating the groups. See {@link #updateUserLogin(String, User, String)} for more information.
+     * We only support updating the groups if no password is provided. See {@link #updateUserLogin(String, User, String)} for more information.
+     * If no password is provided we expect the frontend to show an automatic warning.
      *
      * @param oldLogin       the old login if it was updated
      * @param user           the Artemis user
@@ -210,8 +211,15 @@ public class JenkinsUserManagementService implements CIUserManagementService {
      */
     @Override
     public void updateUserAndGroups(String oldLogin, User user, String password, Set<String> groupsToAdd, Set<String> groupsToRemove) throws ContinuousIntegrationException {
-        removeUserFromGroups(oldLogin, groupsToRemove);
-        addUserToGroups(oldLogin, groupsToAdd);
+        if (password != null) {
+            updateUser(user, password);
+            removeUserFromGroups(user.getLogin(), groupsToRemove);
+            addUserToGroups(user.getLogin(), groupsToAdd);
+        }
+        else {
+            removeUserFromGroups(oldLogin, groupsToRemove);
+            addUserToGroups(oldLogin, groupsToAdd);
+        }
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsUserManagementService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsUserManagementService.java
@@ -196,10 +196,11 @@ public class JenkinsUserManagementService implements CIUserManagementService {
      */
     @Override
     public void updateUserLogin(String oldLogin, User user, String password) throws ContinuousIntegrationException {
+        // Intentionally empty. See JavaDoc for details.
     }
 
     /**
-     * We only support updating the groups if a password is provided. See {@link #updateUserLogin(String, User, String)} for more information.
+     * We only support updating the user details if a password is provided. See {@link #updateUserLogin(String, User, String)} for more information.
      * If no password is provided we expect the frontend to show an automatic warning.
      *
      * @param oldLogin       the old login if it was updated

--- a/src/main/java/de/tum/in/www1/artemis/service/user/LegacyPasswordService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/LegacyPasswordService.java
@@ -1,0 +1,93 @@
+package de.tum.in.www1.artemis.service.user;
+
+import java.util.Optional;
+
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import de.tum.in.www1.artemis.domain.User;
+import de.tum.in.www1.artemis.repository.UserRepository;
+import de.tum.in.www1.artemis.security.PBEPasswordEncoder;
+
+@Service
+@Deprecated
+public class LegacyPasswordService {
+
+    @Value("${artemis.encryption-password}")
+    private String encryptionPassword;
+
+    private final UserRepository userRepository;
+
+    private PBEPasswordEncoder passwordEncoder;
+
+    private StandardPBEStringEncryptor encryptor;
+
+    public LegacyPasswordService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * Get the encoder for password encryption
+     *
+     * @return existing password encoder or newly created password encryptor
+     */
+    private PBEPasswordEncoder passwordEncoder() {
+        if (passwordEncoder != null) {
+            return passwordEncoder;
+        }
+        passwordEncoder = new PBEPasswordEncoder(encryptor());
+        return passwordEncoder;
+    }
+
+    /**
+     * Get the the password encryptor with MD5 and DES encryption algorithm
+     *
+     * @return existing encryptor or newly created encryptor
+     */
+    private StandardPBEStringEncryptor encryptor() {
+        if (encryptor != null) {
+            return encryptor;
+        }
+        encryptor = new StandardPBEStringEncryptor();
+        encryptor.setAlgorithm("PBEWithMD5AndDES");
+        encryptor.setPassword(encryptionPassword);
+        return encryptor;
+    }
+
+    /**
+     * Get decrypted password for given user
+     *
+     * @param user the user
+     * @return decrypted password or empty string
+     */
+    public String decryptPassword(User user) {
+        return encryptor().decrypt(user.getPassword());
+    }
+
+    public String decryptPassword(String encodedPassword) {
+        return encryptor().decrypt(encodedPassword);
+    }
+
+    public String encryptPassword(String rawPassword) {
+        return encryptor().encrypt(rawPassword);
+    }
+
+    public String encodePassword(CharSequence rawPassword) {
+        return passwordEncoder().encode(rawPassword);
+    }
+
+    public boolean checkPasswordMatch(CharSequence rawPassword, String encodedPassword) {
+        return passwordEncoder().matches(rawPassword, encodedPassword);
+    }
+
+    /**
+     * Get decrypted password for given user login
+     *
+     * @param login of a user
+     * @return decrypted password or empty string
+     */
+    public Optional<String> decryptPasswordByLogin(String login) {
+        return userRepository.findOneByLogin(login).map(user -> encryptor().decrypt(user.getPassword()));
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/user/PasswordService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/PasswordService.java
@@ -1,108 +1,21 @@
 package de.tum.in.www1.artemis.service.user;
 
-import java.util.Optional;
-
-import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.stereotype.Service;
-
-import de.tum.in.www1.artemis.domain.User;
-import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.security.PBEPasswordEncoder;
-import de.tum.in.www1.artemis.security.SecurityUtils;
 
 @Service
 public class PasswordService {
 
-    @Value("${artemis.encryption-password}")
-    private String encryptionPassword;
+    @Value("${artemis.bcrypt-salt-rounds}")
+    int bcryptSaltRounds;
 
-    private final UserRepository userRepository;
-
-    private PBEPasswordEncoder passwordEncoder;
-
-    private StandardPBEStringEncryptor encryptor;
-
-    public PasswordService(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
-
-    /**
-     * Get the encoder for password encryption
-     *
-     * @return existing password encoder or newly created password encryptor
-     */
-    private PBEPasswordEncoder passwordEncoder() {
-        if (passwordEncoder != null) {
-            return passwordEncoder;
-        }
-        passwordEncoder = new PBEPasswordEncoder(encryptor());
-        return passwordEncoder;
-    }
-
-    /**
-     * Get the the password encryptor with MD5 and DES encryption algorithm
-     *
-     * @return existing encryptor or newly created encryptor
-     */
-    private StandardPBEStringEncryptor encryptor() {
-        if (encryptor != null) {
-            return encryptor;
-        }
-        encryptor = new StandardPBEStringEncryptor();
-        encryptor.setAlgorithm("PBEWithMD5AndDES");
-        encryptor.setPassword(encryptionPassword);
-        return encryptor;
-    }
-
-    /**
-     * Get decrypted password for the current user
-     *
-     * @return decrypted password or empty string
-     */
-    public String decryptPasswordOfCurrentUser() {
-        User user = userRepository.findOneByLogin(SecurityUtils.getCurrentUserLogin().get()).get();
-        try {
-            return encryptor().decrypt(user.getPassword());
-        }
-        catch (Exception e) {
-            return "";
-        }
-    }
-
-    /**
-     * Get decrypted password for given user
-     *
-     * @param user the user
-     * @return decrypted password or empty string
-     */
-    public String decryptPassword(User user) {
-        return encryptor().decrypt(user.getPassword());
-    }
-
-    public String decryptPassword(String encodedPassword) {
-        return encryptor().decrypt(encodedPassword);
-    }
-
-    public String encryptPassword(String rawPassword) {
-        return encryptor().encrypt(rawPassword);
-    }
-
-    public String encodePassword(CharSequence rawPassword) {
-        return passwordEncoder().encode(rawPassword);
+    public String hashPassword(String rawPassword) {
+        String salt = BCrypt.gensalt(bcryptSaltRounds);
+        return BCrypt.hashpw(rawPassword, salt);
     }
 
     public boolean checkPasswordMatch(CharSequence rawPassword, String encodedPassword) {
-        return passwordEncoder().matches(rawPassword, encodedPassword);
-    }
-
-    /**
-     * Get decrypted password for given user login
-     *
-     * @param login of a user
-     * @return decrypted password or empty string
-     */
-    public Optional<String> decryptPasswordByLogin(String login) {
-        return userRepository.findOneByLogin(login).map(user -> encryptor().decrypt(user.getPassword()));
+        return BCrypt.checkpw(rawPassword.toString(), encodedPassword);
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/user/PasswordService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/PasswordService.java
@@ -1,21 +1,35 @@
 package de.tum.in.www1.artemis.service.user;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.crypto.bcrypt.BCrypt;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import de.tum.in.www1.artemis.config.SecurityConfiguration;
+
+/**
+ * This service is a simple delegate to break the circular structure we would get when defining
+ * a) {@link SecurityConfiguration#passwordEncoder()}
+ * b) The passwordEncoder in every other class using password hashing or matching
+ */
 @Service
 public class PasswordService {
 
-    @Value("${artemis.bcrypt-salt-rounds}")
-    int bcryptSaltRounds;
+    private final PasswordEncoder passwordEncoder;
+
+    public PasswordService(@Value("${artemis.bcrypt-salt-rounds}") int bcryptSaltRounds) {
+        this.passwordEncoder = new BCryptPasswordEncoder(bcryptSaltRounds);
+    }
 
     public String hashPassword(String rawPassword) {
-        String salt = BCrypt.gensalt(bcryptSaltRounds);
-        return BCrypt.hashpw(rawPassword, salt);
+        return passwordEncoder.encode(rawPassword);
     }
 
     public boolean checkPasswordMatch(CharSequence rawPassword, String encodedPassword) {
-        return BCrypt.checkpw(rawPassword.toString(), encodedPassword);
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+
+    public PasswordEncoder getPasswordEncoder() {
+        return this.passwordEncoder;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
@@ -220,12 +220,11 @@ public class UserCreationService {
     }
 
     /**
-     * Update all information for a specific user (incl. its password), and return the modified user.
+     * Update all information for a specific user (including its password), and return the modified user.
      * This method is typically invoked by the admin user
      *
      * @param user           The user that should get updated
      * @param updatedUserDTO The DTO containing the to be updated values
-     * @param isInternal     True if the updated user is an internal user
      * @return updated user
      */
     @NotNull

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
@@ -165,7 +165,8 @@ public class UserCreationService {
                     .collect(Collectors.toSet());
             user.setAuthorities(authorities);
         }
-        String encryptedPassword = passwordService.hashPassword(userDTO.getPassword() == null ? RandomUtil.generatePassword() : userDTO.getPassword());
+        String password = userDTO.getPassword() == null ? RandomUtil.generatePassword() : userDTO.getPassword();
+        String encryptedPassword = passwordService.hashPassword(password);
         user.setPassword(encryptedPassword);
         user.setResetKey(RandomUtil.generateResetKey());
         user.setResetDate(Instant.now());
@@ -185,8 +186,8 @@ public class UserCreationService {
         user.setRegistrationNumber(userDTO.getVisibleRegistrationNumber());
         saveUser(user);
 
-        optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.createVcsUser(user, userDTO.getPassword()));
-        optionalCIUserManagementService.ifPresent(ciUserManagementService -> ciUserManagementService.createUser(user, userDTO.getPassword()));
+        optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.createVcsUser(user, password));
+        optionalCIUserManagementService.ifPresent(ciUserManagementService -> ciUserManagementService.createUser(user, password));
 
         addUserToGroupsInternal(user, userDTO.getGroups());
 
@@ -228,7 +229,7 @@ public class UserCreationService {
      * @return updated user
      */
     @NotNull
-    public User updateUser(@NotNull User user, ManagedUserVM updatedUserDTO, boolean isInternal) {
+    public User updateUser(@NotNull User user, ManagedUserVM updatedUserDTO) {
         user.setLogin(updatedUserDTO.getLogin().toLowerCase());
         user.setFirstName(updatedUserDTO.getFirstName());
         user.setLastName(updatedUserDTO.getLastName());
@@ -238,7 +239,7 @@ public class UserCreationService {
         user.setActivated(updatedUserDTO.isActivated());
         user.setLangKey(updatedUserDTO.getLangKey());
         user.setGroups(updatedUserDTO.getGroups());
-        if (isInternal && updatedUserDTO.getPassword() != null) {
+        if (user.isInternal() && updatedUserDTO.getPassword() != null) {
             user.setPassword(passwordService.hashPassword(updatedUserDTO.getPassword()));
         }
         user.setOrganizations(updatedUserDTO.getOrganizations());

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
@@ -224,10 +224,11 @@ public class UserCreationService {
      *
      * @param user           The user that should get updated
      * @param updatedUserDTO The DTO containing the to be updated values
+     * @param isInternal     True if the updated user is an internal user
      * @return updated user
      */
     @NotNull
-    public User updateInternalUser(@NotNull User user, ManagedUserVM updatedUserDTO) {
+    public User updateUser(@NotNull User user, ManagedUserVM updatedUserDTO, boolean isInternal) {
         user.setLogin(updatedUserDTO.getLogin().toLowerCase());
         user.setFirstName(updatedUserDTO.getFirstName());
         user.setLastName(updatedUserDTO.getLastName());
@@ -237,7 +238,7 @@ public class UserCreationService {
         user.setActivated(updatedUserDTO.isActivated());
         user.setLangKey(updatedUserDTO.getLangKey());
         user.setGroups(updatedUserDTO.getGroups());
-        if (updatedUserDTO.getPassword() != null) {
+        if (isInternal && updatedUserDTO.getPassword() != null) {
             user.setPassword(passwordService.hashPassword(updatedUserDTO.getPassword()));
         }
         user.setOrganizations(updatedUserDTO.getOrganizations());

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
@@ -101,13 +101,15 @@ public class UserCreationService {
             String imageUrl, String langKey, boolean isInternal) {
         User newUser = new User();
 
-        // Set random password for null passwords
-        if (password == null) {
-            password = RandomUtil.generatePassword();
+        if (isInternal) {
+            // Set random password for null passwords
+            if (password == null) {
+                password = RandomUtil.generatePassword();
+            }
+            String encryptedPassword = passwordService.hashPassword(password);
+            // new user gets initially a generated password
+            newUser.setPassword(encryptedPassword);
         }
-        String encryptedPassword = passwordService.hashPassword(password);
-        // new user gets initially a generated password
-        newUser.setPassword(encryptedPassword);
 
         newUser.setLogin(login);
         newUser.setFirstName(firstName);

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserCreationService.java
@@ -106,9 +106,9 @@ public class UserCreationService {
             if (password == null) {
                 password = RandomUtil.generatePassword();
             }
-            String encryptedPassword = passwordService.hashPassword(password);
+            String passwordHash = passwordService.hashPassword(password);
             // new user gets initially a generated password
-            newUser.setPassword(encryptedPassword);
+            newUser.setPassword(passwordHash);
         }
 
         newUser.setLogin(login);
@@ -168,8 +168,8 @@ public class UserCreationService {
             user.setAuthorities(authorities);
         }
         String password = userDTO.getPassword() == null ? RandomUtil.generatePassword() : userDTO.getPassword();
-        String encryptedPassword = passwordService.hashPassword(password);
-        user.setPassword(encryptedPassword);
+        String passwordHash = passwordService.hashPassword(password);
+        user.setPassword(passwordHash);
         user.setResetKey(RandomUtil.generateResetKey());
         user.setResetDate(Instant.now());
         if (!useExternalUserManagement) {

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserService.java
@@ -229,10 +229,10 @@ public class UserService {
     public User registerUser(UserDTO userDTO, String password) {
         // Prepare the new user object.
         final var newUser = new User();
-        String encryptedPassword = passwordService.hashPassword(password);
+        String passwordHash = passwordService.hashPassword(password);
         newUser.setLogin(userDTO.getLogin().toLowerCase());
         // new user gets initially a generated password
-        newUser.setPassword(encryptedPassword);
+        newUser.setPassword(passwordHash);
         newUser.setFirstName(userDTO.getFirstName());
         newUser.setLastName(userDTO.getLastName());
         newUser.setEmail(userDTO.getEmail().toLowerCase());
@@ -445,12 +445,12 @@ public class UserService {
      */
     public void changePassword(String currentClearTextPassword, String newPassword) {
         SecurityUtils.getCurrentUserLogin().flatMap(userRepository::findOneByLogin).ifPresent(user -> {
-            String currentEncryptedPassword = user.getPassword();
-            if (!passwordService.checkPasswordMatch(currentClearTextPassword, currentEncryptedPassword)) {
+            String currentPasswordHash = user.getPassword();
+            if (!passwordService.checkPasswordMatch(currentClearTextPassword, currentPasswordHash)) {
                 throw new InvalidPasswordException();
             }
-            String encryptedPassword = passwordService.hashPassword(newPassword);
-            user.setPassword(encryptedPassword);
+            String newPasswordHash = passwordService.hashPassword(newPassword);
+            user.setPassword(newPasswordHash);
             saveUser(user);
             optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(user.getLogin(), user, null, null, newPassword));
             optionalCIUserManagementService.ifPresent(ciUserManagementService -> ciUserManagementService.updateUser(user, newPassword));

--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserService.java
@@ -113,11 +113,12 @@ public class UserService {
                 Optional<User> existingInternalAdmin = userRepository.findOneWithGroupsAndAuthoritiesByLogin(artemisInternalAdminUsername.get());
                 if (existingInternalAdmin.isPresent()) {
                     log.info("Update internal admin user {}", artemisInternalAdminUsername.get());
-                    existingInternalAdmin.get().setPassword(passwordService.encodePassword(artemisInternalAdminPassword.get()));
+                    existingInternalAdmin.get().setPassword(passwordService.hashPassword(artemisInternalAdminPassword.get()));
                     // needs to be mutable --> new HashSet<>(Set.of(...))
                     existingInternalAdmin.get().setAuthorities(new HashSet<>(Set.of(ADMIN_AUTHORITY, new Authority(STUDENT.getAuthority()))));
                     saveUser(existingInternalAdmin.get());
-                    updateUserInConnectorsAndAuthProvider(existingInternalAdmin.get(), existingInternalAdmin.get().getLogin(), existingInternalAdmin.get().getGroups());
+                    updateUserInConnectorsAndAuthProvider(existingInternalAdmin.get(), existingInternalAdmin.get().getLogin(), existingInternalAdmin.get().getGroups(),
+                            artemisInternalAdminPassword.get());
                 }
                 else {
                     log.info("Create internal admin user {}", artemisInternalAdminUsername.get());
@@ -180,12 +181,12 @@ public class UserService {
     public Optional<User> completePasswordReset(String newPassword, String key) {
         log.debug("Reset user password for reset key {}", key);
         return userRepository.findOneByResetKey(key).filter(user -> user.getResetDate().isAfter(Instant.now().minusSeconds(86400))).map(user -> {
-            user.setPassword(passwordService.encodePassword(newPassword));
+            user.setPassword(passwordService.hashPassword(newPassword));
             user.setResetKey(null);
             user.setResetDate(null);
             saveUser(user);
-            optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(user.getLogin(), user, null, null, true));
-            optionalCIUserManagementService.ifPresent(ciUserManagementService -> ciUserManagementService.updateUser(user));
+            optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(user.getLogin(), user, null, null, newPassword));
+            optionalCIUserManagementService.ifPresent(ciUserManagementService -> ciUserManagementService.updateUser(user, newPassword));
             return user;
         });
     }
@@ -228,7 +229,7 @@ public class UserService {
     public User registerUser(UserDTO userDTO, String password) {
         // Prepare the new user object.
         final var newUser = new User();
-        String encryptedPassword = passwordService.encodePassword(password);
+        String encryptedPassword = passwordService.hashPassword(password);
         newUser.setLogin(userDTO.getLogin().toLowerCase());
         // new user gets initially a generated password
         newUser.setPassword(encryptedPassword);
@@ -251,7 +252,7 @@ public class UserService {
         Optional<User> optionalExistingUser = userRepository.findOneWithGroupsByLogin(userDTO.getLogin().toLowerCase());
         if (optionalExistingUser.isPresent()) {
             User existingUser = optionalExistingUser.get();
-            return handleRegisterUserWithSameLoginAsExistingUser(newUser, existingUser);
+            return handleRegisterUserWithSameLoginAsExistingUser(newUser, existingUser, password);
         }
 
         // Find user that has the same email
@@ -275,7 +276,7 @@ public class UserService {
         // Create an account on the VCS. If it fails, abort registration.
         optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> {
             try {
-                vcsUserManagementService.createVcsUser(savedNonActivatedUser);
+                vcsUserManagementService.createVcsUser(savedNonActivatedUser, password);
                 vcsUserManagementService.deactivateUser(savedNonActivatedUser.getLogin());
             }
             catch (VersionControlException e) {
@@ -298,9 +299,10 @@ public class UserService {
      *
      * @param newUser the new user
      * @param existingUser the existing user
+     * @param password the entered raw password
      * @return the existing non-activated user in Artemis.
      */
-    private User handleRegisterUserWithSameLoginAsExistingUser(User newUser, User existingUser) {
+    private User handleRegisterUserWithSameLoginAsExistingUser(User newUser, User existingUser, String password) {
         // An account with the same login is already activated.
         if (existingUser.getActivated()) {
             throw new UsernameAlreadyUsedException();
@@ -314,7 +316,7 @@ public class UserService {
             newUser.setId(existingUser.getId());
             User updatedExistingUser = userRepository.save(newUser);
             optionalVcsUserManagementService
-                    .ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(existingUser.getLogin(), updatedExistingUser, Set.of(), Set.of(), true));
+                    .ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(existingUser.getLogin(), updatedExistingUser, Set.of(), Set.of(), password));
 
             // Post-pone the cleaning up of the account
             instanceMessageSendService.sendRemoveNonActivatedUserSchedule(updatedExistingUser.getId());
@@ -376,13 +378,17 @@ public class UserService {
      * @param oldUserLogin The username of the user. If the username is updated in the user object, it must be the one before the update in order to find the user in the VCS
      * @param user         The updated user in Artemis (this method assumes that the user including its groups was already saved to the Artemis database)
      * @param oldGroups    The old groups of the user before the update
+     * @param newPassword  If provided, the password gets updated
      */
-    public void updateUserInConnectorsAndAuthProvider(User user, String oldUserLogin, Set<String> oldGroups) {
+    // TODO: The password can be null but Jenkins requires it to be non null => How do we get the password on update?
+    // Or how do we get Jenkins to update the user without recreating it
+    public void updateUserInConnectorsAndAuthProvider(User user, String oldUserLogin, Set<String> oldGroups, String newPassword) {
         final var updatedGroups = user.getGroups();
         final var removedGroups = oldGroups.stream().filter(group -> !updatedGroups.contains(group)).collect(Collectors.toSet());
         final var addedGroups = updatedGroups.stream().filter(group -> !oldGroups.contains(group)).collect(Collectors.toSet());
-        optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(oldUserLogin, user, removedGroups, addedGroups, true));
-        optionalCIUserManagementService.ifPresent(ciUserManagementService -> ciUserManagementService.updateUserAndGroups(oldUserLogin, user, addedGroups, removedGroups));
+        optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(oldUserLogin, user, removedGroups, addedGroups, newPassword));
+        optionalCIUserManagementService
+                .ifPresent(ciUserManagementService -> ciUserManagementService.updateUserAndGroups(oldUserLogin, user, newPassword, addedGroups, removedGroups));
 
         removedGroups.forEach(group -> artemisAuthenticationProvider.removeUserFromGroup(user, group)); // e.g. Jira
         try {
@@ -443,11 +449,11 @@ public class UserService {
             if (!passwordService.checkPasswordMatch(currentClearTextPassword, currentEncryptedPassword)) {
                 throw new InvalidPasswordException();
             }
-            String encryptedPassword = passwordService.encodePassword(newPassword);
+            String encryptedPassword = passwordService.hashPassword(newPassword);
             user.setPassword(encryptedPassword);
             saveUser(user);
-            optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(user.getLogin(), user, null, null, true));
-            optionalCIUserManagementService.ifPresent(ciUserManagementService -> ciUserManagementService.updateUser(user));
+            optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(user.getLogin(), user, null, null, newPassword));
+            optionalCIUserManagementService.ifPresent(ciUserManagementService -> ciUserManagementService.updateUser(user, newPassword));
 
             log.debug("Changed password for User: {}", user);
         });
@@ -536,7 +542,7 @@ public class UserService {
             // This might throw exceptions, for example if the group does not exist on the authentication service. We can safely ignore it
         }
         // e.g. Gitlab: TODO: include the role to distinguish more cases
-        optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(user.getLogin(), user, Set.of(), Set.of(group), false));
+        optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(user.getLogin(), user, Set.of(), Set.of(group)));
         optionalCIUserManagementService.ifPresent(ciUserManagementService -> ciUserManagementService.addUserToGroups(user.getLogin(), Set.of(group)));
     }
 
@@ -566,7 +572,7 @@ public class UserService {
         removeUserFromGroupInternal(user, group); // internal Artemis database
         artemisAuthenticationProvider.removeUserFromGroup(user, group); // e.g. JIRA
         // e.g. Gitlab
-        optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(user.getLogin(), user, Set.of(group), Set.of(), false));
+        optionalVcsUserManagementService.ifPresent(vcsUserManagementService -> vcsUserManagementService.updateVcsUser(user.getLogin(), user, Set.of(group), Set.of()));
         optionalCIUserManagementService.ifPresent(ciUserManagementService -> {
             ciUserManagementService.removeUserFromGroups(user.getLogin(), Set.of(group));
             ciUserManagementService.addUserToGroups(user.getLogin(), user.getGroups());

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AccountResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AccountResource.java
@@ -22,7 +22,6 @@ import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.MailService;
 import de.tum.in.www1.artemis.service.dto.PasswordChangeDTO;
 import de.tum.in.www1.artemis.service.dto.UserDTO;
-import de.tum.in.www1.artemis.service.user.PasswordService;
 import de.tum.in.www1.artemis.service.user.UserCreationService;
 import de.tum.in.www1.artemis.service.user.UserService;
 import de.tum.in.www1.artemis.web.rest.errors.*;
@@ -55,8 +54,7 @@ public class AccountResource {
 
     private final MailService mailService;
 
-    public AccountResource(UserRepository userRepository, UserService userService, UserCreationService userCreationService, MailService mailService,
-            PasswordService passwordService) {
+    public AccountResource(UserRepository userRepository, UserService userService, UserCreationService userCreationService, MailService mailService) {
         this.userRepository = userRepository;
         this.userService = userService;
         this.userCreationService = userCreationService;

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
@@ -186,7 +186,7 @@ public class UserResource {
         final boolean shouldActivateUser = !existingUser.getActivated() && managedUserVM.isActivated();
         final var oldUserLogin = existingUser.getLogin();
         final var oldGroups = existingUser.getGroups();
-        var updatedUser = userCreationService.updateInternalUser(existingUser, managedUserVM);
+        var updatedUser = userCreationService.updateUser(existingUser, managedUserVM, false);
         userService.updateUserInConnectorsAndAuthProvider(updatedUser, oldUserLogin, oldGroups, managedUserVM.getPassword());
 
         if (shouldActivateUser) {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
@@ -187,7 +187,7 @@ public class UserResource {
         final var oldUserLogin = existingUser.getLogin();
         final var oldGroups = existingUser.getGroups();
         var updatedUser = userCreationService.updateInternalUser(existingUser, managedUserVM);
-        userService.updateUserInConnectorsAndAuthProvider(updatedUser, oldUserLogin, oldGroups);
+        userService.updateUserInConnectorsAndAuthProvider(updatedUser, oldUserLogin, oldGroups, managedUserVM.getPassword());
 
         if (shouldActivateUser) {
             userService.activateUser(updatedUser);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/UserResource.java
@@ -186,7 +186,7 @@ public class UserResource {
         final boolean shouldActivateUser = !existingUser.getActivated() && managedUserVM.isActivated();
         final var oldUserLogin = existingUser.getLogin();
         final var oldGroups = existingUser.getGroups();
-        var updatedUser = userCreationService.updateUser(existingUser, managedUserVM, false);
+        var updatedUser = userCreationService.updateUser(existingUser, managedUserVM);
         userService.updateUserInConnectorsAndAuthProvider(updatedUser, oldUserLogin, oldGroups, managedUserVM.getPassword());
 
         if (shouldActivateUser) {

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -6,7 +6,7 @@ artemis:
     course-archives-path: ./exports/courses         # a folder in which archived courses and exams are stored.
     repo-clone-path: ./repos                        # a folder in which git repos for the online code editor are stored. In a multi node setup, this folder should be in a shared file system area (e.g. based on NFS), so that user can access the same files over multiple nodes
     repo-download-clone-path: ./repos-download      # a temporary folder, in which git repos are downloaded that are immediately deleted afterwards (e.g. exports, plagiarism checks), should NOT be in a shared file system area
-    encryption-password: <encrypt-password>         # arbitrary password for encrypting database values
+    encryption-password: <encrypt-password>         # LEGACY: arbitrary password for encrypting database values
     user-management:
         use-external: true
         password-reset:

--- a/src/main/resources/config/application-artemis.yml
+++ b/src/main/resources/config/application-artemis.yml
@@ -7,6 +7,8 @@ artemis:
     repo-clone-path: ./repos                        # a folder in which git repos for the online code editor are stored. In a multi node setup, this folder should be in a shared file system area (e.g. based on NFS), so that user can access the same files over multiple nodes
     repo-download-clone-path: ./repos-download      # a temporary folder, in which git repos are downloaded that are immediately deleted afterwards (e.g. exports, plagiarism checks), should NOT be in a shared file system area
     encryption-password: <encrypt-password>         # LEGACY: arbitrary password for encrypting database values
+    bcrypt-salt-rounds: 11  # The number of salt rounds for the bcrypt password hashing. Lower numbers make it faster but more unsecure and vice versa.
+                            # Please use the bcrypt benchmark tool to determine the best number of rounds for your system. https://github.com/ls1intum/bcrypt-Benchmark
     user-management:
         use-external: true
         password-reset:

--- a/src/main/webapp/i18n/de/user-management.json
+++ b/src/main/webapp/i18n/de/user-management.json
@@ -38,6 +38,7 @@
         "searchForUser": "Suche nach Nutzer:innen: ",
         "search": "Suche",
         "loading": "Laden...",
-        "searchError": "Der Suchbegriff muss leer oder mindestens 3 Zeichen lang sein."
+        "searchError": "Der Suchbegriff muss leer oder mindestens 3 Zeichen lang sein.",
+        "jenkinsChange": "Die Änderung des Benutzernamens wird für dein aktuelles Setup (Jenkins) nicht unterstützt. Möglicherweise musst du den Benutzernamen in Jenkins manuell ändern.\nDu hast den Benutzer <i>{{ oldLogin }}</i> auf <i>{{ newLogin }}</i> aktualisiert."
     }
 }

--- a/src/main/webapp/i18n/en/user-management.json
+++ b/src/main/webapp/i18n/en/user-management.json
@@ -38,6 +38,7 @@
         "searchForUser": "Search for User: ",
         "search": "Search",
         "loading": "Loading...",
-        "searchError": "Search term must be empty or contain at least 3 characters."
+        "searchError": "Search term must be empty or contain at least 3 characters.",
+        "jenkinsChange": "Changing the user's login is not supported for your current setup (Jenkins). You may have to manually update the user's login in Jenkins.\nYou changed the user <i>{{ oldLogin }}</i> to <i>{{ newLogin }}</i>."
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
@@ -324,7 +324,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
         bitbucketRequestMockProvider.mockUpdateUserDetails(user.getLogin(), user.getEmail(), user.getName());
         bitbucketRequestMockProvider.mockUpdateUserPassword(user.getLogin(), updatedPassword, true, true);
-        User createdUser = userCreationService.createUser(new ManagedUserVM(user, ModelFactory.USER_PASSWORD));
+        userCreationService.createUser(new ManagedUserVM(user, ModelFactory.USER_PASSWORD));
 
         PasswordChangeDTO pwChange = new PasswordChangeDTO(ModelFactory.USER_PASSWORD, updatedPassword);
         // make request
@@ -362,7 +362,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
     public void changePasswordInvalidPassword() throws Exception {
         User user = ModelFactory.generateActivatedUser("authenticateduser");
         bitbucketRequestMockProvider.mockUserExists("authenticateduser");
-        User createdUser = userCreationService.createUser(new ManagedUserVM(user));
+        userCreationService.createUser(new ManagedUserVM(user));
         String updatedPassword = "";
 
         PasswordChangeDTO pwChange = new PasswordChangeDTO(ModelFactory.USER_PASSWORD, updatedPassword);

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -334,7 +333,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         // check if update successful
         Optional<User> updatedUser = userRepository.findOneByLogin("authenticateduser");
         assertThat(updatedUser).isPresent();
-        assertThat(BCrypt.checkpw(updatedPassword, updatedUser.get().getPassword())).isTrue();
+        assertThat(passwordService.checkPasswordMatch(updatedPassword, updatedUser.get().getPassword())).isTrue();
     }
 
     @Test
@@ -434,7 +433,7 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
         // get updated user
         Optional<User> userPasswordResetFinished = userRepository.findOneByLogin("authenticateduser");
         assertThat(userPasswordResetFinished).isPresent();
-        assertThat(BCrypt.checkpw(newPassword, userPasswordResetFinished.get().getPassword())).isTrue();
+        assertThat(passwordService.checkPasswordMatch(newPassword, userPasswordResetFinished.get().getPassword())).isTrue();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -131,9 +131,9 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         instructor = users.get(users.size() - 1);
 
         // Add users that are not in the course
-        userRepo.save(ModelFactory.generateActivatedUser("student42", passwordService.encryptPassword(ModelFactory.USER_PASSWORD)));
-        userRepo.save(ModelFactory.generateActivatedUser("tutor6", passwordService.encryptPassword(ModelFactory.USER_PASSWORD)));
-        userRepo.save(ModelFactory.generateActivatedUser("instructor6", passwordService.encryptPassword(ModelFactory.USER_PASSWORD)));
+        userRepo.save(ModelFactory.generateActivatedUser("student42", passwordService.hashPassword(ModelFactory.USER_PASSWORD)));
+        userRepo.save(ModelFactory.generateActivatedUser("tutor6", passwordService.hashPassword(ModelFactory.USER_PASSWORD)));
+        userRepo.save(ModelFactory.generateActivatedUser("instructor6", passwordService.hashPassword(ModelFactory.USER_PASSWORD)));
         bitbucketRequestMockProvider.enableMockingOfRequests();
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.TestingAuthenticationToken;
-import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 
@@ -110,6 +109,7 @@ public class InternalAuthenticationIntegrationTest extends AbstractSpringIntegra
         student = userRepository.findOneWithGroupsAndAuthoritiesByLogin(USERNAME).get();
         final var encodedPassword = passwordService.hashPassword(USER_PASSWORD);
         student.setPassword(encodedPassword);
+        student.setInternal(true);
         userRepository.save(student);
         ltiLaunchRequest.setLis_person_contact_email_primary(student.getEmail());
     }
@@ -277,7 +277,7 @@ public class InternalAuthenticationIntegrationTest extends AbstractSpringIntegra
         final var response = request.putWithResponseBody("/api/users", managedUserVM, User.class, HttpStatus.OK);
         final var updatedUserIndDB = userRepository.findOneWithGroupsAndAuthoritiesByLogin(student.getLogin()).get();
 
-        assertThat(BCrypt.checkpw(managedUserVM.getPassword(), updatedUserIndDB.getPassword())).isTrue();
+        assertThat(passwordService.checkPasswordMatch(managedUserVM.getPassword(), updatedUserIndDB.getPassword())).isTrue();
 
         // Skip passwords for comparison
         updatedUserIndDB.setPassword(null);

--- a/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/InternalAuthenticationIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
 
@@ -107,7 +108,7 @@ public class InternalAuthenticationIntegrationTest extends AbstractSpringIntegra
         authorityRepository.saveAll(List.of(userAuthority, instructorAuthority, adminAuthority, taAuthority));
 
         student = userRepository.findOneWithGroupsAndAuthoritiesByLogin(USERNAME).get();
-        final var encodedPassword = passwordService.encodePassword(USER_PASSWORD);
+        final var encodedPassword = passwordService.hashPassword(USER_PASSWORD);
         student.setPassword(encodedPassword);
         userRepository.save(student);
         ltiLaunchRequest.setLis_person_contact_email_primary(student.getEmail());
@@ -275,7 +276,12 @@ public class InternalAuthenticationIntegrationTest extends AbstractSpringIntegra
 
         final var response = request.putWithResponseBody("/api/users", managedUserVM, User.class, HttpStatus.OK);
         final var updatedUserIndDB = userRepository.findOneWithGroupsAndAuthoritiesByLogin(student.getLogin()).get();
-        updatedUserIndDB.setPassword(passwordService.decryptPasswordByLogin(updatedUserIndDB.getLogin()).get());
+
+        assertThat(BCrypt.checkpw(managedUserVM.getPassword(), updatedUserIndDB.getPassword())).isTrue();
+
+        // Skip passwords for comparison
+        updatedUserIndDB.setPassword(null);
+        student.setPassword(null);
 
         assertThat(response).isNotNull();
         assertThat(student).as("Returned user is equal to sent update").isEqualTo(response);

--- a/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegationTest.java
@@ -31,8 +31,6 @@ import de.tum.in.www1.artemis.security.ArtemisInternalAuthenticationProvider;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.jwt.TokenProvider;
 import de.tum.in.www1.artemis.service.connectors.jira.JiraAuthenticationProvider;
-import de.tum.in.www1.artemis.service.user.PasswordService;
-import de.tum.in.www1.artemis.service.user.UserService;
 import de.tum.in.www1.artemis.web.rest.UserJWTController;
 import de.tum.in.www1.artemis.web.rest.dto.LtiLaunchRequestDTO;
 import de.tum.in.www1.artemis.web.rest.vm.LoginVM;
@@ -59,12 +57,6 @@ public class JiraAuthenticationIntegationTest extends AbstractSpringIntegrationB
 
     @Autowired
     private TokenProvider tokenProvider;
-
-    @Autowired
-    private UserService userService;
-
-    @Autowired
-    private PasswordService passwordService;
 
     @Autowired
     protected ProgrammingExerciseRepository programmingExerciseRepository;

--- a/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegationTest.java
@@ -129,7 +129,7 @@ public class JiraAuthenticationIntegationTest extends AbstractSpringIntegrationB
 
         ltiLaunchRequest.setCustom_lookup_user_by_email(true);
         request.postForm("/api/lti/launch/" + programmingExercise.getId(), ltiLaunchRequest, HttpStatus.FOUND);
-        final var user = userRepository.findAll().get(0);
+        final var user = userRepository.findOneByLogin(username).orElseThrow();
         final var ltiUser = ltiUserIdRepository.findAll().get(0);
         final var ltiOutcome = ltiOutcomeUrlRepository.findAll().get(0);
         assertThat(ltiUser.getUser()).isEqualTo(user);
@@ -146,7 +146,7 @@ public class JiraAuthenticationIntegationTest extends AbstractSpringIntegrationB
         assertThat(mrrobotUser.getGroups()).contains(course.getStudentGroupName());
         assertThat(mrrobotUser.getAuthorities()).containsAll(authorityRepository.findAll());
 
-        final var auth = new TestingAuthenticationToken(username, mrrobotUser.getPassword());
+        final var auth = new TestingAuthenticationToken(username, "");
         final var responseAuth = jiraAuthenticationProvider.authenticate(auth);
 
         assertThat(responseAuth.getPrincipal()).isEqualTo(username);

--- a/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegationTest.java
@@ -146,8 +146,7 @@ public class JiraAuthenticationIntegationTest extends AbstractSpringIntegrationB
         assertThat(mrrobotUser.getGroups()).contains(course.getStudentGroupName());
         assertThat(mrrobotUser.getAuthorities()).containsAll(authorityRepository.findAll());
 
-        final var password = passwordService.decryptPassword(mrrobotUser.getPassword());
-        final var auth = new TestingAuthenticationToken(username, password);
+        final var auth = new TestingAuthenticationToken(username, mrrobotUser.getPassword());
         final var responseAuth = jiraAuthenticationProvider.authenticate(auth);
 
         assertThat(responseAuth.getPrincipal()).isEqualTo(username);

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserJenkinsGitlabIntegrationTest.java
@@ -24,6 +24,7 @@ import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.connectors.gitlab.GitLabUserManagementService;
 import de.tum.in.www1.artemis.service.connectors.jenkins.JenkinsUserManagementService;
+import de.tum.in.www1.artemis.service.user.PasswordService;
 import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.util.UserTestService;
 import de.tum.in.www1.artemis.web.rest.vm.ManagedUserVM;
@@ -41,6 +42,12 @@ public class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJ
 
     @Autowired
     private UserTestService userTestService;
+
+    @Autowired
+    private PasswordService passwordService;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Autowired
     private JenkinsUserManagementService jenkinsUserManagementService;
@@ -350,6 +357,8 @@ public class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJ
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void updateUserGroups() throws Exception {
+        userTestService.student.setPassword(passwordService.hashPassword("this is a password"));
+        userRepository.save(userTestService.student);
         userTestService.updateUserGroups();
     }
 
@@ -402,6 +411,9 @@ public class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJ
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
     public void shouldBlockUserInGitlabIfAccountNotActivated() throws Exception {
+        String password = "this is a password";
+        userTestService.student.setPassword(passwordService.hashPassword(password));
+        userRepository.save(userTestService.student);
         var oldLogin = userTestService.student.getLogin();
         User user = userTestService.student;
         user.setLogin("new-login");
@@ -410,7 +422,7 @@ public class UserJenkinsGitlabIntegrationTest extends AbstractSpringIntegrationJ
         jenkinsRequestMockProvider.mockUpdateUserAndGroups(oldLogin, user, user.getGroups(), Set.of(), true);
         gitlabRequestMockProvider.mockUpdateVcsUser(oldLogin, user, Set.of(), user.getGroups(), true);
 
-        request.put("/api/users", new ManagedUserVM(user, user.getPassword()), HttpStatus.OK);
+        request.put("/api/users", new ManagedUserVM(user, password), HttpStatus.OK);
 
         UserRepository userRepository = userTestService.getUserRepository();
         final var userInDB = userRepository.findById(user.getId());

--- a/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/UserSaml2IntegrationTest.java
@@ -150,7 +150,7 @@ public class UserSaml2IntegrationTest extends AbstractSpringIntegrationSaml2Test
 
         // Change Password
         User student = userRepository.findUserWithGroupsAndAuthoritiesByLogin(STUDENT_NAME).get();
-        student.setPassword(passwordService.encryptPassword(STUDENT_PASSWORD));
+        student.setPassword(passwordService.hashPassword(STUDENT_PASSWORD));
         userRepository.saveAndFlush(student);
 
         // Try to login ..

--- a/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/BitbucketRequestMockProvider.java
@@ -194,6 +194,7 @@ public class BitbucketRequestMockProvider {
             }
             else {
                 mockUserDoesNotExist(user.getLogin());
+                throw new BitbucketException("The user was not created in Bitbucket and has to be manually added.");
             }
         }
         mockProtectBranches(exercise, repoName);

--- a/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
@@ -35,13 +35,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUrl;
+import de.tum.in.www1.artemis.repository.LtiUserIdRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.UrlService;
 import de.tum.in.www1.artemis.service.connectors.gitlab.GitLabException;
 import de.tum.in.www1.artemis.service.connectors.gitlab.GitLabUserDoesNotExistException;
 import de.tum.in.www1.artemis.service.connectors.gitlab.GitLabUserManagementService;
-import de.tum.in.www1.artemis.service.user.PasswordService;
 
 @Component
 @Profile("gitlab")
@@ -81,13 +81,13 @@ public class GitlabRequestMockProvider {
     private ProtectedBranchesApi protectedBranchesApi;
 
     @SpyBean
-    private PasswordService passwordService;
-
-    @SpyBean
     private GitLabUserManagementService gitLabUserManagementService;
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
+
+    @Autowired
+    private LtiUserIdRepository ltiUserIdRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
@@ -226,8 +226,6 @@ public class GitlabRequestMockProvider {
     private void mockImportUser(de.tum.in.www1.artemis.domain.User user, boolean shouldFail) throws GitLabApiException {
         final var gitlabUser = new org.gitlab4j.api.models.User().withEmail(user.getEmail()).withUsername(user.getLogin()).withName(user.getName()).withCanCreateGroup(false)
                 .withCanCreateProject(false).withSkipConfirmation(true);
-        doReturn(user.getPassword()).when(passwordService).decryptPassword(user);
-
         if (!shouldFail) {
             var createdUser = gitlabUser.withId(1L);
             doReturn(createdUser).when(userApi).createUser(isA(User.class), anyString(), eq(false));
@@ -326,7 +324,7 @@ public class GitlabRequestMockProvider {
         var gitlabUser = new User().withUsername(login).withId(1L);
         doReturn(gitlabUser).when(userApi).getUser(login);
         if (shouldUpdatePassword) {
-            doReturn(gitlabUser).when(userApi).updateUser(gitlabUser, user.getPassword());
+            doReturn(gitlabUser).when(userApi).updateUser(eq(gitlabUser), any(CharSequence.class));
         }
         else {
             doReturn(gitlabUser).when(userApi).updateUser(gitlabUser, null);

--- a/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/GitlabRequestMockProvider.java
@@ -35,7 +35,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUrl;
-import de.tum.in.www1.artemis.repository.LtiUserIdRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.service.UrlService;
@@ -85,9 +84,6 @@ public class GitlabRequestMockProvider {
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
-
-    @Autowired
-    private LtiUserIdRepository ltiUserIdRepository;
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/connector/JenkinsRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/JenkinsRequestMockProvider.java
@@ -340,10 +340,6 @@ public class JenkinsRequestMockProvider {
 
     private void mockUpdateUser(User user, boolean userExists) throws URISyntaxException, IOException {
         mockGetUser(user.getLogin(), userExists, false);
-
-        doReturn(user.getPassword()).when(passwordService).decryptPassword(user);
-        doReturn(user.getPassword()).when(passwordService).decryptPassword(user);
-
         mockDeleteUser(user, userExists, false);
         mockCreateUser(user, false, false, false);
     }
@@ -410,9 +406,6 @@ public class JenkinsRequestMockProvider {
 
     public void mockCreateUser(User user, boolean userExistsInCi, boolean shouldFail, boolean shouldFailToGetUser) throws URISyntaxException, IOException {
         mockGetUser(user.getLogin(), userExistsInCi, shouldFailToGetUser);
-
-        doReturn(user.getPassword()).when(passwordService).decryptPassword(user);
-        doReturn(user.getPassword()).when(passwordService).decryptPassword(user);
 
         final var uri = UriComponentsBuilder.fromUri(jenkinsServerUrl.toURI()).pathSegment("securityRealm", "createAccountByAdmin").build().toUri();
         var status = shouldFail ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.FOUND;

--- a/src/test/java/de/tum/in/www1/artemis/connector/JenkinsRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/JenkinsRequestMockProvider.java
@@ -45,7 +45,6 @@ import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentPar
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.service.connectors.jenkins.dto.JenkinsUserDTO;
 import de.tum.in.www1.artemis.service.connectors.jenkins.jobs.JenkinsJobPermissionsService;
-import de.tum.in.www1.artemis.service.user.PasswordService;
 
 @Component
 @Profile("jenkins")
@@ -72,10 +71,6 @@ public class JenkinsRequestMockProvider {
     @SpyBean
     @InjectMocks
     private JenkinsJobPermissionsService jenkinsJobPermissionsService;
-
-    @SpyBean
-    @InjectMocks
-    private PasswordService passwordService;
 
     @Autowired
     private ObjectMapper mapper;

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -1399,7 +1399,7 @@ public class ProgrammingExerciseTestService {
         // create a team for the user (necessary condition before starting an exercise)
         final String edxUsername = userPrefixEdx.get() + "student";
         User edxStudent = ModelFactory.generateActivatedUsers(edxUsername, new String[] { "tumuser", "testgroup" }, Set.of(new Authority(Role.STUDENT.getAuthority())), 1).get(0);
-        edxStudent.setPassword(passwordService.encryptPassword(edxStudent.getPassword()));
+        edxStudent.setPassword(passwordService.hashPassword(edxStudent.getPassword()));
         edxStudent = userRepo.save(edxStudent);
         Team team = setupTeam(edxStudent);
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -796,6 +796,7 @@ public class ProgrammingExerciseTestService {
     public void startProgrammingExercise_correctInitializationState() throws Exception {
         var user = userRepo.findOneByLogin(studentLogin).orElseThrow();
         user.setLogin("edx_student1");
+        user.setInternal(true);
         user = userRepo.save(user);
 
         final Course course = setupCourseWithProgrammingExercise(ExerciseMode.INDIVIDUAL);
@@ -1399,6 +1400,7 @@ public class ProgrammingExerciseTestService {
         // create a team for the user (necessary condition before starting an exercise)
         final String edxUsername = userPrefixEdx.get() + "student";
         User edxStudent = ModelFactory.generateActivatedUsers(edxUsername, new String[] { "tumuser", "testgroup" }, Set.of(new Authority(Role.STUDENT.getAuthority())), 1).get(0);
+        edxStudent.setInternal(true);
         edxStudent.setPassword(passwordService.hashPassword(edxStudent.getPassword()));
         edxStudent = userRepo.save(edxStudent);
         Team team = setupTeam(edxStudent);

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -304,15 +304,15 @@ public class DatabaseUtilService {
 
         authorityRepository.saveAll(adminAuthorities);
 
-        List<User> students = ModelFactory.generateActivatedUsers("student", passwordService.encryptPassword(ModelFactory.USER_PASSWORD), new String[] { "tumuser", "testgroup" },
+        List<User> students = ModelFactory.generateActivatedUsers("student", passwordService.hashPassword(ModelFactory.USER_PASSWORD), new String[] { "tumuser", "testgroup" },
                 studentAuthorities, numberOfStudents);
-        List<User> tutors = ModelFactory.generateActivatedUsers("tutor", passwordService.encryptPassword(ModelFactory.USER_PASSWORD), new String[] { "tutor", "testgroup" },
+        List<User> tutors = ModelFactory.generateActivatedUsers("tutor", passwordService.hashPassword(ModelFactory.USER_PASSWORD), new String[] { "tutor", "testgroup" },
                 tutorAuthorities, numberOfTutors);
-        List<User> editors = ModelFactory.generateActivatedUsers("editor", passwordService.encryptPassword(ModelFactory.USER_PASSWORD), new String[] { "editor", "testgroup" },
+        List<User> editors = ModelFactory.generateActivatedUsers("editor", passwordService.hashPassword(ModelFactory.USER_PASSWORD), new String[] { "editor", "testgroup" },
                 editorAuthorities, numberOfEditors);
-        List<User> instructors = ModelFactory.generateActivatedUsers("instructor", passwordService.encryptPassword(ModelFactory.USER_PASSWORD),
+        List<User> instructors = ModelFactory.generateActivatedUsers("instructor", passwordService.hashPassword(ModelFactory.USER_PASSWORD),
                 new String[] { "instructor", "testgroup" }, instructorAuthorities, numberOfInstructors);
-        User admin = ModelFactory.generateActivatedUser("admin", passwordService.encryptPassword(ModelFactory.USER_PASSWORD));
+        User admin = ModelFactory.generateActivatedUser("admin", passwordService.hashPassword(ModelFactory.USER_PASSWORD));
         admin.setGroups(Set.of("admin"));
         admin.setAuthorities(adminAuthorities);
         List<User> usersToAdd = new ArrayList<>();

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
@@ -218,10 +218,10 @@ public class ModelFactory {
         return exercise;
     }
 
-    public static List<User> generateActivatedUsers(String loginPrefix, String commonEncryptedPassword, String[] groups, Set<Authority> authorities, int amount) {
+    public static List<User> generateActivatedUsers(String loginPrefix, String commonPasswordHash, String[] groups, Set<Authority> authorities, int amount) {
         List<User> generatedUsers = new ArrayList<>();
         for (int i = 1; i <= amount; i++) {
-            User user = ModelFactory.generateActivatedUser(loginPrefix + i, commonEncryptedPassword);
+            User user = ModelFactory.generateActivatedUser(loginPrefix + i, commonPasswordHash);
             if (groups != null) {
                 user.setGroups(Set.of(groups));
                 user.setAuthorities(authorities);

--- a/src/test/resources/config/application-artemis.yml
+++ b/src/test/resources/config/application-artemis.yml
@@ -7,6 +7,8 @@ artemis:
     repo-clone-path: ./repos/server-integration-test
     repo-download-clone-path: ./repos-download/server-integration-test
     encryption-password: fake-password                                     # LEGACY: arbitrary password for encrypting database values
+    bcrypt-salt-rounds: 11  # The number of salt rounds for the bcrypt password hashing. Lower numbers make it faster but more unsecure and vice versa.
+                            # Please use the bcrypt benchmark tool to determine the best number of rounds for your system. https://github.com/ls1intum/bcrypt-Benchmark
     user-management:
         use-external: true
         external:

--- a/src/test/resources/config/application-artemis.yml
+++ b/src/test/resources/config/application-artemis.yml
@@ -6,7 +6,7 @@ artemis:
     course-archives-path: ./exports/server-integration-test/courses         # a folder in which archived courses and exams are stored.
     repo-clone-path: ./repos/server-integration-test
     repo-download-clone-path: ./repos-download/server-integration-test
-    encryption-password: fake-password
+    encryption-password: fake-password                                     # LEGACY: arbitrary password for encrypting database values
     user-management:
         use-external: true
         external:

--- a/src/test/resources/config/application-artemis.yml
+++ b/src/test/resources/config/application-artemis.yml
@@ -7,8 +7,7 @@ artemis:
     repo-clone-path: ./repos/server-integration-test
     repo-download-clone-path: ./repos-download/server-integration-test
     encryption-password: fake-password                                     # LEGACY: arbitrary password for encrypting database values
-    bcrypt-salt-rounds: 11  # The number of salt rounds for the bcrypt password hashing. Lower numbers make it faster but more unsecure and vice versa.
-                            # Please use the bcrypt benchmark tool to determine the best number of rounds for your system. https://github.com/ls1intum/bcrypt-Benchmark
+    bcrypt-salt-rounds: 4  # We don't need secure passwords for testing. Lower rounds will speed up tests. 4 ist the lowest allowed round count.
     user-management:
         use-external: true
         external:


### PR DESCRIPTION
### Warning: Data Migration
All passwords of internal users will get hashed. Reverting the version will not be possible without resetting the database.
Before starting the application with the new version
- Create a database backup
- Configure `artemis.bcrypt-salt-rounds` in your Spring configuration with the help of https://github.com/ls1intum/bcrypt-Benchmark to use the most secure setting

<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I tested **all** changes and their related features with **all** corresponding user types **locally** as TS testing is not possible here.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [X] I implemented the changes with a good performance and prevented too many database calls.
- [X] I documented the Java code using JavaDoc style.
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [X] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types **locally** with the Atlassian Suite.
- [x] I tested **all** changes and their related features with **all** corresponding user types **locally** with Jenkins and Gitlab.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This is the final PR of my Password Migration to Bcrypt Hashing to finally switch the Password Service.

### Description
<!-- Describe your changes in detail -->
I deprecated the old PasswordService and added a new one supporting Bcrypt. A new Java Migration sets all passwords of external users to null and first decrypts and then hashes the other passwords to complete the transformation.
I then adapted all occurrences, especially all instances of creating and updating the user. Instead of decrypting the password at any given place I now pass the password along.
I also documented the new usage and current limitations of Jenkins.

I upped the maximum missable classes because by deprecating the password service I created another class that is, again, just a wrapper class for external functionality so nothing we need or want to write tests for.

**The cypress tests currently fail. I can't reproduce certain errors locally. Currently investigating if this PR requires the cypress setup to do some changes.**

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
You can only test this locally as this change would make any test server unusable until reset or this PR is merged.
For local testing:
1. SQL dump `jhi_user`
2. Do the testing
3. Drop `jhi_user` and import your SQL dump
4. Remove the entry from the `migragion_changelog` table

Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise with Complaints enabled

1. Start the application
2. Make sure that `jhi_users` was updated correctly
3. Log in with internal and external users
5. Do a password change with internal users (verify the password gets updated for the git repository)
6. Edit internal users with a password change and without. Verify that changes are correctly propagated. For Jenkins developers, please validate that the behaviour was correctly documented.
7. Test anything that seems reasonable to you in regards to the changes.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
SecurityConfiguration.java: n/a | 97.65%
JiraAuthorizationInterceptor.java: 100% | 100%
ArtemisInternalAuthenticationProvider.java: 41.67% | 74.07 %
DomainUserDetailsService.java: 0% | 36.36%
BitbucketUserManagementService.java: 71.05% | 94.34%
VcsUserManagementService.java: n/a | 100%
GitLabUserManagementService.java: 88.24% | 97.50%
JenkinsUserManagementService.java: 86.84% | 98.64%
PasswordService.java: n/a | 100%
UserCreationService.java: 68.97% | 94.12%
UserService.java: 78.33% | 93.25%
AccountResource.java: 77.08% | 95.71%
UserResource.java: 75% | 96.77%