### PR TITLE
`Development`:  Increase client test coverage for exercise update warning service

### DIFF
--- a/src/test/javascript/spec/component/shared/exercise-update-warning.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/exercise-update-warning.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ArtemisTestModule } from '../../test.module';
 import { ExerciseUpdateWarningComponent } from 'app/exercises/shared/exercise-update-warning/exercise-update-warning.component';
-import { MockDirective, MockProvider, MockPipe } from 'ng-mocks';
+import { MockDirective, MockPipe, MockProvider } from 'ng-mocks';
 import { NgModel } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
@@ -57,6 +57,7 @@ describe('Exercise Update Warning Component Tests', () => {
 
     it('should trigger clear once', () => {
         const clearSpy = jest.spyOn(comp, 'clear');
+        const cancelledEmitSpy = jest.spyOn(comp.canceled, 'emit');
 
         const button = fixture.debugElement.nativeElement.querySelector('#cancel-button');
         button.click();
@@ -64,6 +65,7 @@ describe('Exercise Update Warning Component Tests', () => {
         fixture.detectChanges();
 
         expect(clearSpy).toHaveBeenCalledTimes(1);
+        expect(cancelledEmitSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should toggle deleteFeedback', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Description
<!-- Describe your changes in detail -->
Add client tests to improve the test coverage of exercise-update-warning.service.ts

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
exercise-update-warning.service.ts 92.3% | 100%