### PR TITLE
`Development`: Fix properties for programming exercise tasks to break cycles in serialization

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
@@ -48,7 +48,7 @@ public class ProgrammingExerciseTestCase extends DomainObject {
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "programming_exercise_task_test_case", joinColumns = @JoinColumn(name = "test_case_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "task_id", referencedColumnName = "id"))
-    @JsonIgnoreProperties("testCases")
+    @JsonIgnoreProperties({ "testCases", "exercise" })
     private Set<ProgrammingExerciseTask> tasks = new HashSet<>();
 
     @OneToMany(mappedBy = "testCase", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExerciseTestCase.java
@@ -52,11 +52,11 @@ public class ProgrammingExerciseTestCase extends DomainObject {
     private Set<ProgrammingExerciseTask> tasks = new HashSet<>();
 
     @OneToMany(mappedBy = "testCase", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    @JsonIgnoreProperties("programmingExerciseTestCase")
+    @JsonIgnoreProperties("testCase")
     private Set<ProgrammingExerciseSolutionEntry> solutionEntries = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JsonIgnoreProperties("programmingExerciseTestCase")
+    @JsonIgnoreProperties("testCases")
     private ProgrammingExercise exercise;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/de/tum/in/www1/artemis/domain/hestia/ProgrammingExerciseTask.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/hestia/ProgrammingExerciseTask.java
@@ -35,7 +35,7 @@ public class ProgrammingExerciseTask extends DomainObject {
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "programming_exercise_task_test_case", joinColumns = @JoinColumn(name = "task_id", referencedColumnName = "id"), inverseJoinColumns = @JoinColumn(name = "test_case_id", referencedColumnName = "id"))
-    @JsonIgnoreProperties("tasks")
+    @JsonIgnoreProperties({ "tasks", "exercise" })
     private Set<ProgrammingExerciseTestCase> testCases = new HashSet<>();
 
     @ManyToOne

--- a/src/main/java/de/tum/in/www1/artemis/domain/hestia/ProgrammingExerciseTask.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/hestia/ProgrammingExerciseTask.java
@@ -30,7 +30,7 @@ public class ProgrammingExerciseTask extends DomainObject {
 
     // No orphanRemoval here, as there should only be one parent-child relationship (which is ProgrammingExercise -> CodeHint)
     @OneToMany(mappedBy = "task", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
-    @JsonIgnoreProperties("programmingExerciseTask")
+    @JsonIgnoreProperties("task")
     private Set<CodeHint> codeHints = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.LAZY)
@@ -39,7 +39,7 @@ public class ProgrammingExerciseTask extends DomainObject {
     private Set<ProgrammingExerciseTestCase> testCases = new HashSet<>();
 
     @ManyToOne
-    @JsonIgnoreProperties("programmingExerciseTask")
+    @JsonIgnoreProperties("tasks")
     private ProgrammingExercise exercise;
 
     public String getTaskName() {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Description
<!-- Describe your changes in detail -->
Updating the identifiers in some JsonIgnoreProperties annotations as they haven't been updated accordingly.
Additionally, this PR breaks some reference cycles using the annoation.

There's no changed behaviour to test. Code reviews should be enough.

#### Code Review
- [x] Review 1
- [x] Review 2

Thank you to @ole-ve and @Hialus for your collaboration on this one. :) 