### PR TITLE
`Assessment`: Fix type error in the course score calculation

### DIFF
--- a/src/main/webapp/app/overview/course-score-calculation.service.ts
+++ b/src/main/webapp/app/overview/course-score-calculation.service.ts
@@ -80,7 +80,7 @@ export class CourseScoreCalculationService {
 
     updateCourse(course: Course) {
         // filter out the old course object with the same id
-        this.courses = this.courses.filter((existingCourses) => existingCourses.id !== course.id);
+        this.courses = this.courses.filter((existingCourse) => existingCourse.id !== course.id);
         this.courses.push(course);
     }
 

--- a/src/main/webapp/app/overview/course-score-calculation.service.ts
+++ b/src/main/webapp/app/overview/course-score-calculation.service.ts
@@ -80,7 +80,7 @@ export class CourseScoreCalculationService {
 
     updateCourse(course: Course) {
         // filter out the old course object with the same id
-        this.courses = this.courses.filter((existingCourses) => existingCourses.id !== existingCourses.id);
+        this.courses = this.courses.filter((existingCourses) => existingCourses.id !== course.id);
         this.courses.push(course);
     }
 
@@ -208,7 +208,7 @@ export class CourseScoreCalculationService {
         return (
             this.isAssessedAutomatically(exercise) &&
             (!(exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate ||
-                (exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate!.isBefore(dayjs()))
+                dayjs().isSameOrAfter((exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate))
         );
     }
 }

--- a/src/main/webapp/app/overview/course-score-calculation.service.ts
+++ b/src/main/webapp/app/overview/course-score-calculation.service.ts
@@ -208,7 +208,7 @@ export class CourseScoreCalculationService {
         return (
             this.isAssessedAutomatically(exercise) &&
             (!(exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate ||
-                dayjs().isSameOrAfter((exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate))
+                dayjs().isAfter((exercise as ProgrammingExercise).buildAndTestStudentSubmissionsAfterDueDate))
         );
     }
 }


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
Closes [ARTEMIS-M27](https://sentry.ase.in.tum.de/organizations/artemis/issues/20984/events/e925aa5ff84c4c3680cc2026832a1a54/?project=2)

### Description
`buildAndTestStudentSubmissionsAfterDueDate` is not always correctly converted to a dayjs object. This is because calls to general exercise-apis only covert standard dates into dayjs()-objects, not dates specific to one exercise type. By changing the call order this conversion is done implicitly in the isAfter()-call.

I also changed a comparison that for certain was a small overlook. 

### Steps for Testing
Code Review is most important. You can:
1. Open the Artemis front page and the course statistic page
2. Make sure no errors are present in the console.

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
