### PR TITLE
`Assessment`: Fix page overflow for smaller screens when grading programming exercises

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
@@ -64,7 +64,7 @@
         <div class="grading-body-container mt-3">
             <div *ngIf="activeTab == 'test-cases'">
                 <div class="grading-table-layout">
-                    <div>
+                    <div class="col-7">
                         <div class="d-flex justify-content-between mb-3">
                             <div>
                                 <h2 class="mb-1 fw-medium" jhiTranslate="artemisApp.programmingExercise.configureGrading.testCases.title">Test Cases</h2>
@@ -239,7 +239,7 @@
                             </ngx-datatable-column>
                         </ngx-datatable>
                     </div>
-                    <div>
+                    <div class="col-5">
                         <h2 class="mb-5 fw-medium">
                             <span>{{ 'artemisApp.programmingExercise.configureGrading.charts.title' | artemisTranslate }}</span>
                             <span *ngIf="!!changedTestCaseIds.length" class="badge bg-primary" jhiTranslate="artemisApp.programmingExercise.configureGrading.charts.preview"></span>

--- a/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
@@ -258,7 +258,7 @@
             </div>
             <div *ngIf="activeTab == 'code-analysis' && programmingExercise.staticCodeAnalysisEnabled">
                 <div class="grading-table-layout">
-                    <div>
+                    <div class="col-7">
                         <div class="d-flex align-items-center justify-content-between mb-4">
                             <h2 class="fw-medium" jhiTranslate="artemisApp.programmingExercise.configureGrading.categories.title">Code Analysis Categories</h2>
                             <!-- TODO currently the reset button is permanently disabled -->
@@ -397,7 +397,7 @@
                             </ngx-datatable-column>
                         </ngx-datatable>
                     </div>
-                    <div>
+                    <div class="col-5">
                         <h2 class="mb-5 fw-medium">
                             <span>{{ 'artemisApp.programmingExercise.configureGrading.charts.title' | artemisTranslate }}</span>
                             <span *ngIf="!!changedCategoryIds.length" class="badge bg-primary" jhiTranslate="artemisApp.programmingExercise.configureGrading.charts.preview"></span>

--- a/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.scss
+++ b/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.scss
@@ -59,6 +59,7 @@ $border-color: #979797;
         & > div {
             width: 100% !important;
         }
+
         & > div:last-child {
             border-left: hidden;
             border-top: 1px solid #ddd;

--- a/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.scss
+++ b/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.scss
@@ -30,21 +30,14 @@ $border-color: #979797;
 
 .grading-table-layout {
     display: flex;
-    flex-flow: row;
+    flex-wrap: wrap;
 
     & > div {
         padding: 20px;
-        flex-shrink: 0;
-        flex-grow: 1;
-    }
-
-    & > div:first-child {
-        flex-basis: 800px;
     }
 
     & > div:last-child {
         border-left: 1px solid #ddd;
-        flex-basis: 400px;
     }
 }
 
@@ -64,7 +57,11 @@ $border-color: #979797;
         flex-flow: column;
 
         & > div {
-            flex-basis: auto;
+            width: 100% !important;
+        }
+        & > div:last-child {
+            border-left: hidden;
+            border-top: 1px solid #ddd;
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The programming grading page currently has the problem that the page overflows its maximum width if the screen size gets decreased to some value above 1200px. If this threshold is undercutted, the page restructures again by wrapping the prior two columns to rows.
This behavior is of course unpleasant and should be fixed by this PR.
### Description
<!-- Describe your changes in detail -->
I restructured the page styling a little bit so that the content aligns with the maximum screen width again. I additionally removed the left border for the right column if the columns wrap to rows since it is not needed anymore. For this situation, I introduced a top border to separate the two rows.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with SCA enabled

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to the exercise detail page and click 'Grading'
4. Play around with the screen dimensions on the test cases tab. Make sure everything aligns now
5. Switch to the SCA tab and do the same. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Please use the schema "Branches % | Lines %" -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- - ExerciseService.java: 85% | 77% -->
<!-- - programming-exercise.component.ts: 13% | 95% -->
Nothing changed
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
The current behavior:

https://user-images.githubusercontent.com/80622272/157881139-b2234b8b-ccc3-4e9e-a90c-823448630210.mp4

How it should look with this PR:

https://user-images.githubusercontent.com/80622272/157881968-ac3f8217-910d-4e4c-9bf3-42d1ad06512a.mp4


