### PR TITLE
`General`: Set registered users automatically to internal

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/user/UserService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/user/UserService.java
@@ -239,6 +239,8 @@ public class UserService {
         newUser.setLangKey(userDTO.getLangKey());
         // new user is not active
         newUser.setActivated(false);
+        // registered users are always internal
+        newUser.setInternal(true);
         // new user gets registration key
         newUser.setActivationKey(RandomUtil.generateActivationKey());
         Set<Authority> authorities = new HashSet<>();

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceIntegrationTest.java
@@ -34,7 +34,8 @@ import de.tum.in.www1.artemis.web.rest.vm.KeyAndPasswordVM;
 import de.tum.in.www1.artemis.web.rest.vm.ManagedUserVM;
 
 /**
- * Tests {@link AccountResource}. Several Tests rely on overwriting AccountResource.registrationEnabled and other attributes with reflections. Any changes to the internal structure will cause these tests to fail.
+ * Tests {@link AccountResource}. Several Tests rely on overwriting AccountResource.registrationEnabled and other attributes with reflections. Any changes to the internal
+ * structure will cause these tests to fail.
  */
 public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
@@ -76,10 +77,16 @@ public class AccountResourceIntegrationTest extends AbstractSpringIntegrationBam
 
     @Test
     public void registerAccount() throws Exception {
+        String login = "abd123cd";
+        String password = getValidPassword();
         // setup user
-        User user = ModelFactory.generateActivatedUser("ab123cd");
+        User user = ModelFactory.generateActivatedUser(login);
         ManagedUserVM userVM = new ManagedUserVM(user);
-        userVM.setPassword(getValidPassword());
+        userVM.setPassword(password);
+
+        bitbucketRequestMockProvider.mockUserDoesNotExist(login);
+        bitbucketRequestMockProvider.mockCreateUser(login, password, login + "@test.de", login + "First " + login + "Last");
+        bitbucketRequestMockProvider.mockAddUserToGroups();
 
         // make request
         request.postWithoutLocation("/api/register", userVM, HttpStatus.CREATED, null);

--- a/src/test/java/de/tum/in/www1/artemis/AccountResourceWithGitLabIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AccountResourceWithGitLabIntegrationTest.java
@@ -47,6 +47,23 @@ public class AccountResourceWithGitLabIntegrationTest extends AbstractSpringInte
         gitlabRequestMockProvider.reset();
     }
 
+    @Test
+    public void registerAccount() throws Exception {
+        String login = "abd123cd";
+        String password = "this is a password";
+        // setup user
+        User user = ModelFactory.generateActivatedUser(login);
+        ManagedUserVM userVM = new ManagedUserVM(user);
+        userVM.setPassword(password);
+
+        gitlabRequestMockProvider.mockCreateVcsUser(user, false);
+        gitlabRequestMockProvider.mockGetUserId(login, true, false);
+        gitlabRequestMockProvider.mockDeactivateUser(login, false);
+
+        // make request
+        request.postWithoutLocation("/api/register", userVM, HttpStatus.CREATED, null);
+    }
+
     /**
      * Tests the registration of a user when an old unactivated User existed.
      * Also tries to verify that the inability to delete such user in GitLab does not hinder the operation.


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
@b-fein informed me that registered users are not set to internal

### Description
<!-- Describe your changes in detail -->
I set the property accordingly on user registration.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Not really to test as the user shouldn't really know about this distinction anyway.
However, I think this change is trivial enough

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
