### PR TITLE
`Development`: Refactor exercise scores CSV export

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores-export-button.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores-export-button.component.ts
@@ -64,7 +64,7 @@ export class ExerciseScoresExportButtonComponent {
             });
 
             const fileNamePrefix = exercise.shortName ?? exercise.title?.split(/\s+/).join('_');
-            ExerciseScoresExportButtonComponent.exportAsCsv(`${fileNamePrefix}-results-scores.csv`, keys, rows);
+            ExerciseScoresExportButtonComponent.exportAsCsv(`${fileNamePrefix}-results-scores`, keys, rows);
         });
     }
 

--- a/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores-export-button.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-scores/exercise-scores-export-button.component.ts
@@ -9,6 +9,7 @@ import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
 import { ResultWithPointsPerGradingCriterion } from 'app/entities/result-with-points-per-grading-criterion.model';
 import { faDownload } from '@fortawesome/free-solid-svg-icons';
+import { ExportToCsv } from 'export-to-csv';
 
 @Component({
     selector: 'jhi-exercise-scores-export-button',
@@ -31,16 +32,6 @@ export class ExerciseScoresExportButtonComponent {
 
     /**
      * Exports the exercise results as a CSV file.
-     *
-     * CSV columns [alternative column name for team exercises]:
-     * - Name [Team Name]
-     * - Username [Team Short Name]
-     * - Score
-     * - Points
-     * - for each grading criterion `c` of the exercise: `c.title`
-     *   (sorted by title, contains the total points given in this grading category)
-     * - Repo Link (only for programming exercises)
-     * - Students (only for team exercises; comma-separated list of students in the team)
      */
     exportResults() {
         if (this.exercises.length === 0 && this.exercise !== undefined) {
@@ -57,90 +48,48 @@ export class ExerciseScoresExportButtonComponent {
      */
     private constructCSV(exercise: Exercise) {
         this.resultService.getResultsWithPointsPerGradingCriterion(exercise).subscribe((data) => {
-            const rows: string[] = [];
             const results: ResultWithPointsPerGradingCriterion[] = data.body || [];
             if (results.length === 0) {
                 this.alertService.warning(`artemisApp.exercise.exportResultsEmptyError`, { exercise: exercise.title });
                 window.scroll(0, 0);
                 return;
             }
+            const isTeamExercise = !!(results[0].result.participation! as StudentParticipation).team;
             const gradingCriteria: GradingCriterion[] = ExerciseScoresExportButtonComponent.sortedGradingCriteria(exercise);
 
-            results.forEach((resultWithPoints, index) => {
+            const keys = ExerciseScoresRowBuilder.keys(exercise, isTeamExercise, gradingCriteria);
+            const rows = results.map((resultWithPoints) => {
                 const studentParticipation = resultWithPoints.result.participation! as StudentParticipation;
-                if (index === 0) {
-                    rows.push(this.formatHeaderRow(exercise, studentParticipation, gradingCriteria));
-                }
-                rows.push(this.formatCsvRow(exercise, gradingCriteria, studentParticipation, resultWithPoints));
+                return new ExerciseScoresRowBuilder(exercise, gradingCriteria, studentParticipation, resultWithPoints).build();
             });
 
             const fileNamePrefix = exercise.shortName ?? exercise.title?.split(/\s+/).join('_');
-            this.resultService.triggerDownloadCSV(rows, `${fileNamePrefix}-results-scores.csv`);
+            ExerciseScoresExportButtonComponent.exportAsCsv(`${fileNamePrefix}-results-scores.csv`, keys, rows);
         });
     }
 
     /**
-     * Utility method used to retrieve the headers row for CSV creation
-     * @param exercise the exercise the participation belongs to
-     * @param studentParticipation to create headers for
-     * @param gradingCriteria the list of grading criteria for which the points should be included in the CSV
-     */
-    private formatHeaderRow(exercise: Exercise, studentParticipation: StudentParticipation, gradingCriteria: GradingCriterion[]) {
-        const columns = [];
-
-        if (studentParticipation.team) {
-            columns.push('Team Name', 'Team Short Name');
-        } else {
-            columns.push('Name', 'Username');
-        }
-        columns.push('Score', 'Points');
-
-        gradingCriteria.forEach((criterion) => columns.push(`"${criterion.title ?? 'Unnamed Criterion'}"`));
-
-        if (exercise.type === ExerciseType.PROGRAMMING) {
-            columns.push('Repo Link');
-        }
-
-        if (studentParticipation.team) {
-            columns.push('Students');
-        }
-
-        return 'data:text/csv;charset=utf-8,' + columns.join(',');
-    }
-
-    /**
-     * Formats a single row of the CSV file
-     * @param exercise of which the results are processed
-     * @param gradingCriteria sorted in the same order as they appear in the header of the CSV
-     * @param participation of the student in this exercise
-     * @param resultWithPoints the result together with the points per grading criterion
+     * Triggers the download as CSV for the exercise results.
+     * @param filename The filename the results should be downloaded as.
+     * @param keys The column names in the CSV.
+     * @param rows The actual data rows in the CSV.
      * @private
      */
-    private formatCsvRow(
-        exercise: Exercise,
-        gradingCriteria: GradingCriterion[],
-        participation: StudentParticipation,
-        resultWithPoints: ResultWithPointsPerGradingCriterion,
-    ): string {
-        const result = resultWithPoints.result;
-        const { participantName, participantIdentifier } = participation;
-        const score = roundValueSpecifiedByCourseSettings(result.score, getCourseFromExercise(exercise));
+    private static exportAsCsv(filename: string, keys: string[], rows: ExerciseScoresRow[]) {
+        const options = {
+            fieldSeparator: ';',
+            quoteStrings: '"',
+            decimalSeparator: 'locale',
+            showLabels: true,
+            showTitle: false,
+            filename,
+            useTextFile: false,
+            useBom: true,
+            headers: keys,
+        };
 
-        const columns = [`"${participantName}"`, participantIdentifier, score, resultWithPoints.totalPoints];
-
-        gradingCriteria.map((criterion) => resultWithPoints.pointsPerCriterion.get(criterion.id!) || 0).forEach((criterionPoints) => columns.push(criterionPoints));
-
-        if (exercise.type === ExerciseType.PROGRAMMING) {
-            const repoLink = (participation as ProgrammingExerciseStudentParticipation).repositoryUrl;
-            columns.push(repoLink);
-        }
-
-        if (participation.team) {
-            const students = `"${participation.team?.students?.map((s) => s.name).join(', ')}"`;
-            columns.push(students);
-        }
-
-        return columns.join(',');
+        const csvExporter = new ExportToCsv(options);
+        csvExporter.generateCsv(rows); // includes download
     }
 
     /**
@@ -160,5 +109,154 @@ export class ExerciseScoresExportButtonComponent {
                 }
             }) || []
         );
+    }
+}
+
+/**
+ * A data row in the CSV file.
+ *
+ * For a list of all possible keys see {@link ExerciseScoresRowBuilder.keys}.
+ */
+type ExerciseScoresRow = any;
+
+class ExerciseScoresRowBuilder {
+    private readonly exercise: Exercise;
+    private readonly gradingCriteria: GradingCriterion[];
+    private readonly participation: StudentParticipation;
+    private readonly resultWithPoints: ResultWithPointsPerGradingCriterion;
+
+    private csvRow: ExerciseScoresRow = {};
+
+    constructor(exercise: Exercise, gradingCriteria: GradingCriterion[], participation: StudentParticipation, resultWithPoints: ResultWithPointsPerGradingCriterion) {
+        this.exercise = exercise;
+        this.gradingCriteria = gradingCriteria;
+        this.participation = participation;
+        this.resultWithPoints = resultWithPoints;
+    }
+
+    /**
+     * Builds the actual data row that should be exported as part of the CSV.
+     */
+    public build(): ExerciseScoresRow {
+        this.setName();
+
+        const score = roundValueSpecifiedByCourseSettings(this.resultWithPoints.result.score, getCourseFromExercise(this.exercise));
+        this.set('Score', score);
+        this.set('Points', this.resultWithPoints.totalPoints);
+
+        this.setGradingCriteriaPoints();
+        this.setProgrammingExerciseInformation();
+        this.setTeamInformation();
+
+        return this.csvRow;
+    }
+
+    /**
+     * Stores the given value under the key in the row.
+     * @param key Which should be associated with the given value.
+     * @param value That should be placed in the row. Replaced by the empty string if undefined.
+     */
+    private set<T>(key: string, value: T) {
+        this.csvRow[key] = value ?? '';
+    }
+
+    /**
+     * Sets the student or team name information in the row.
+     * @private
+     */
+    private setName() {
+        if (this.participation.team) {
+            this.set('Team Name', this.participation.participantName);
+            this.set('Team Short Name', this.participation.participantIdentifier);
+        } else {
+            this.set('Name', this.participation.participantName);
+            this.set('Username', this.participation.participantIdentifier);
+        }
+    }
+
+    /**
+     * Sets the points for each grading criterion in the row.
+     * @private
+     */
+    private setGradingCriteriaPoints() {
+        let unnamedCriterionIndex = 1;
+        this.gradingCriteria.forEach((criterion) => {
+            const points = this.resultWithPoints.pointsPerCriterion.get(criterion.id!) || 0;
+            if (criterion.title) {
+                this.set(criterion.title, points);
+            } else {
+                this.set(`Unnamed Criterion ${unnamedCriterionIndex}`, points);
+                unnamedCriterionIndex += 1;
+            }
+        });
+    }
+
+    /**
+     * Adds information specific to programming exercises to the row.
+     * @private
+     */
+    private setProgrammingExerciseInformation() {
+        if (this.exercise.type === ExerciseType.PROGRAMMING) {
+            const repoLink = (this.participation as ProgrammingExerciseStudentParticipation).repositoryUrl;
+            this.set('Repo Link', repoLink);
+        }
+    }
+
+    /**
+     * Adds information specific to a team participation to the row.
+     * @private
+     */
+    private setTeamInformation() {
+        if (this.participation.team) {
+            const students = `${this.participation.team?.students?.map((s) => s.name).join(', ')}`;
+            this.set('Students', students);
+        }
+    }
+
+    /**
+     * CSV columns [alternative column name for team exercises]:
+     * - Name [Team Name]
+     * - Username [Team Short Name]
+     * - Score
+     * - Points
+     * - for each grading criterion `c` of the exercise: `c.title`
+     *   (sorted by title, contains the total points given in this grading category)
+     * - Repo Link (only for programming exercises)
+     * - Students (only for team exercises; comma-separated list of students in the team)
+     *
+     * @param exercise The exercise for which results should be exported.
+     * @param isTeamExercise True, if the students participate in teams in this exercise.
+     * @param gradingCriteria The grading criteria that can be used in this exercise.
+     */
+    public static keys(exercise: Exercise, isTeamExercise: boolean, gradingCriteria: GradingCriterion[]): Array<string> {
+        const columns = [];
+
+        if (isTeamExercise) {
+            columns.push('Team Name', 'Team Short Name');
+        } else {
+            columns.push('Name', 'Username');
+        }
+
+        columns.push('Score', 'Points');
+
+        let unnamedCriterionIndex = 1;
+        gradingCriteria.forEach((criterion) => {
+            if (criterion.title) {
+                columns.push(criterion.title);
+            } else {
+                columns.push(`Unnamed Criterion ${unnamedCriterionIndex}`);
+                unnamedCriterionIndex += 1;
+            }
+        });
+
+        if (exercise.type === ExerciseType.PROGRAMMING) {
+            columns.push('Repo Link');
+        }
+
+        if (isTeamExercise) {
+            columns.push('Students');
+        }
+
+        return columns;
     }
 }

--- a/src/test/javascript/spec/component/shared/exercise-scores-export-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/exercise-scores-export-button.component.spec.ts
@@ -156,7 +156,7 @@ describe('ExerciseScoresExportButtonComponent', () => {
     });
 
     it('should export results for one exercise', () => {
-        testCsvExport(exercise1, [resultWithPoints1, resultWithPoints2], 'ex1-results-scores.csv', expectedColumnsWithCriteria, expectedRowsWithCriteria);
+        testCsvExport(exercise1, [resultWithPoints1, resultWithPoints2], 'ex1-results-scores', expectedColumnsWithCriteria, expectedRowsWithCriteria);
     });
 
     it('should export results for a team exercise', () => {
@@ -192,7 +192,7 @@ describe('ExerciseScoresExportButtonComponent', () => {
             Students: 'Student 1, Student 2, Student 3, Student 4',
         };
 
-        testCsvExport(exerciseTeam, [teamResultWithPoints], 'ex1-results-scores.csv', expectedTeamColumns, [expectedRow]);
+        testCsvExport(exerciseTeam, [teamResultWithPoints], 'ex1-results-scores', expectedTeamColumns, [expectedRow]);
     });
 
     it('should export results for multiple exercises', () => {
@@ -211,8 +211,8 @@ describe('ExerciseScoresExportButtonComponent', () => {
         // THEN
         expect(getResultsStub).toHaveBeenCalledTimes(2);
         expect(exportAsCsvStub).toHaveBeenCalledTimes(2);
-        expect(exportAsCsvStub).toHaveBeenNthCalledWith(1, 'ex1-results-scores.csv', expectedColumnsWithCriteria, expectedRowsWithCriteria);
-        expect(exportAsCsvStub).toHaveBeenNthCalledWith(2, 'Exercise_title_with_spaces-results-scores.csv', expectedColumnsNoCriteria, expectedRowsNoCriteria);
+        expect(exportAsCsvStub).toHaveBeenNthCalledWith(1, 'ex1-results-scores', expectedColumnsWithCriteria, expectedRowsWithCriteria);
+        expect(exportAsCsvStub).toHaveBeenNthCalledWith(2, 'Exercise_title_with_spaces-results-scores', expectedColumnsNoCriteria, expectedRowsNoCriteria);
     });
 
     function testCsvExport(exercise: Exercise, results: ResultWithPointsPerGradingCriterion[], expectedCsvFilename: string, expectedCsvColumns: string[], expectedCsvRows: any[]) {


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
The CSV file was manually assembled before this PR. This is error-prone in case of special characters in the team names and grading criteria. Therefore, using a library to build the CSV that automatically handles required character-escapes is useful.

### Description
This PR refactors the export to no longer manually assemble the CSV but instead uses a library for this task.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- Exercises with student submissions: at least some combination of various exercise features should be tested, the exercise can have multiple features at the same time
    - programming exercise: repo link should be part of the CSV
    - grading criteria: the points per grading criterion should be in the CSV
    - team exercise: the team name should be in the CSV instead of the student names, there should be a special column listing all student names in the CSV

1. Go to the ‘Scores’ page of an exercise.
2. Use the ‘Export Results’ button in the top-right-hand corner.
3. The data in the CSV should match the one you can see in the table. The columns as described above should be part of the CSV.

### Review Progress

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
| File/Class | Branch | Statement |
| --- | --- | --- |
| `exercise-scores-export-button.component.ts` | 84.5% | 94.4% |

### Screenshots
n/a
