### PR TITLE
`Programming exercises`: Fix creation of Swift exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -380,8 +380,9 @@ public class FileService implements DisposableBean {
             String oldName = replacementDirective.getKey();
             String newName = replacementDirective.getValue();
 
-            if (resultFilePath.endsWith(replacementDirective.getKey())) {
+            if (resultFilePath.endsWith(oldName)) {
                 resultFilePath = resultFilePath.replace(oldName, newName);
+                break;
             }
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -50,6 +50,28 @@ public class FileService implements DisposableBean {
 
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
 
+    /**
+     * Filenames for which the template filename differs from the filename it should have in the repository.
+     */
+    // @formatter:off
+    private static final Map<String, String> FILENAME_REPLACEMENTS = Map.ofEntries(
+        Map.entry("git.ignore.file", ".gitignore"),
+        Map.entry("git.attributes.file", ".gitattributes"),
+        Map.entry("Makefile.file", "Makefile"),
+        Map.entry("project.file", ".project"),
+        Map.entry("classpath.file", ".classpath"),
+        Map.entry("dune.file", "dune"),
+        Map.entry("Fast.file", "Fastfile"),
+        Map.entry("App.file", "Appfile"),
+        Map.entry("Scan.file", "Scanfile")
+    );
+    // @formatter:on
+
+    /**
+     * These directories get falsely marked as files and should be ignored during copying.
+     */
+    private static final List<String> IGNORED_DIRECTORIES = List.of(".xcassets/", ".colorset/", ".appiconset/", ".xcworkspace/", ".xcodeproj/", ".swiftpm/");
+
     @Override
     public void destroy() {
         futures.values().forEach(future -> future.cancel(true));
@@ -322,53 +344,16 @@ public class FileService implements DisposableBean {
      * @throws IOException if the copying operation fails.
      */
     public void copyResources(Resource[] resources, String prefix, String targetDirectoryPath, Boolean keepParentFolder) throws IOException {
-
         for (Resource resource : resources) {
-
             // Replace windows separator with "/"
             String fileUrl = java.net.URLDecoder.decode(resource.getURL().toString(), StandardCharsets.UTF_8).replaceAll("\\\\", "/");
             // cut the prefix (e.g. 'exercise', 'solution', 'test') from the actual path
             int index = fileUrl.indexOf(prefix);
+
             String targetFilePath = keepParentFolder ? fileUrl.substring(index + prefix.length()) : "/" + resource.getFilename();
-            // special case for '.git.ignore.file' file which would not be included in build otherwise
-            if (targetFilePath.endsWith("git.ignore.file")) {
-                targetFilePath = targetFilePath.replaceAll("git.ignore.file", ".gitignore");
-            }
-            // special case for '.gitattributes' file which would not be included in build otherwise
-            if (targetFilePath.endsWith("git.attributes.file")) {
-                targetFilePath = targetFilePath.replaceAll("git.attributes.file", ".gitattributes");
-            }
-            // special case for 'Makefile' files which would not be included in the build otherwise
-            if (targetFilePath.endsWith("Makefile.file")) {
-                targetFilePath = targetFilePath.replace("Makefile.file", "Makefile");
-            }
-            // special case for '.project' files which would not be included in the build otherwise
-            if (targetFilePath.endsWith("project.file")) {
-                targetFilePath = targetFilePath.replace("project.file", ".project");
-            }
-            // special case for '.classpath' files which would not be included in the build otherwise
-            if (targetFilePath.endsWith("classpath.file")) {
-                targetFilePath = targetFilePath.replace("classpath.file", ".classpath");
-            }
-            // special case for 'dune' files which would not be included in the build otherwise
-            if (targetFilePath.endsWith("dune.file")) {
-                targetFilePath = targetFilePath.replace("dune.file", "dune");
-            }
-            // special case for 'Fastfile' files which would not be included in the build otherwise
-            if (targetFilePath.endsWith("Fast.file")) {
-                targetFilePath = targetFilePath.replace("Fast.file", "Fastfile");
-            }
-            // special case for 'Appfile' files which would not be included in the build otherwise
-            if (targetFilePath.endsWith("App.file")) {
-                targetFilePath = targetFilePath.replace("App.file", "Appfile");
-            }
-            // special case for 'Scanfile' files which would not be included in the build otherwise
-            if (targetFilePath.endsWith("Scan.file")) {
-                targetFilePath = targetFilePath.replace("Scan.file", "Scanfile");
-            }
-            // special case for Xcode where directories get falsely scanned as files
-            if (targetFilePath.endsWith(".xcassets/") || targetFilePath.endsWith(".colorset/") || targetFilePath.endsWith(".appiconset/")
-                    || targetFilePath.endsWith(".xcworkspace/") || targetFilePath.endsWith(".xcodeproj/")) {
+            targetFilePath = applySpecialFilenameReplacements(targetFilePath);
+
+            if (isIgnoredDirectory(targetFilePath)) {
                 continue;
             }
 
@@ -380,6 +365,37 @@ public class FileService implements DisposableBean {
 
             Files.copy(resource.getInputStream(), copyPath, StandardCopyOption.REPLACE_EXISTING);
         }
+    }
+
+    /**
+     * Replaces filenames where the template name differs from the name the file should have in the repository.
+     *
+     * @param filePath The path to a file.
+     * @return The path with replacements applied where necessary.
+     */
+    private String applySpecialFilenameReplacements(final String filePath) {
+        String resultFilePath = filePath;
+
+        for (final Map.Entry<String, String> replacementDirective : FILENAME_REPLACEMENTS.entrySet()) {
+            String oldName = replacementDirective.getKey();
+            String newName = replacementDirective.getValue();
+
+            if (resultFilePath.endsWith(replacementDirective.getKey())) {
+                resultFilePath = resultFilePath.replace(oldName, newName);
+            }
+        }
+
+        return resultFilePath;
+    }
+
+    /**
+     * Checks if the given path has been identified as a file but it actually points to a directory.
+     *
+     * @param filePath The path to a file/directory.
+     * @return True, if the path is assumed to be a file but actually points to a directory.
+     */
+    private boolean isIgnoredDirectory(final String filePath) {
+        return IGNORED_DIRECTORIES.stream().anyMatch(filePath::endsWith);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsProgrammingLanguageFeatureService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsProgrammingLanguageFeatureService.java
@@ -22,7 +22,7 @@ public class JenkinsProgrammingLanguageFeatureService extends ProgrammingLanguag
         programmingLanguageFeatures.put(KOTLIN, new ProgrammingLanguageFeature(KOTLIN, true, false, false, true, false, List.of()));
         programmingLanguageFeatures.put(PYTHON, new ProgrammingLanguageFeature(PYTHON, false, false, true, false, false, List.of()));
         // Jenkins is not supporting XCODE at the moment
-        programmingLanguageFeatures.put(SWIFT, new ProgrammingLanguageFeature(SWIFT, false, true, false, true, false, List.of()));
+        programmingLanguageFeatures.put(SWIFT, new ProgrammingLanguageFeature(SWIFT, false, true, false, true, false, List.of(PLAIN)));
         programmingLanguageFeatures.put(C, new ProgrammingLanguageFeature(C, false, false, true, false, false, List.of(FACT, GCC)));
         // TODO: Should be re-enabled once Jenkins Pipelines are used
         // programmingLanguageFeatures.put(HASKELL, new ProgrammingLanguageFeature(HASKELL, false, false, false, false, false));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on ~~Test Server 2~~ a local setup (Jenkins and Gitlab).

### Motivation and Context
On Jenkins, Swift programming exercises could not be created because the `PLAIN` feature was not defined.

Additionally, in the `tests` repository a `.swiftpm` directory should be created. This directory is falsely recognized as a file in the `FileService` whereby the copy operation fails and the repository remains empty. This affects Bamboo setups, too.

### Description
This PR adds the `PLAIN` feature for Swift exercises in `JenkinsProgrammingLanguageFeatureService`.
Additionally, the `.swiftpm/` directory is added to the list of exclusion in the `FileService`.

### Steps for Testing
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Create a new Swift programming exercise.
3. Verify that the tests-Repository is not empty and contains a folder `.swiftpm/` with some files in it. This folder is hidden in the online editor within Artemis, you have to open the repository via the version control system.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
| Class/File | Branch | Line |
| --- | ---: | ---: |
| `FileService` | 86% | 91% | 

### Screenshots
n/a
