### PR TITLE
`Quiz exercises`: Fix Short Answer spots marked as invalid not showing up for students

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.html
@@ -48,18 +48,22 @@
                         value="{{ getSubmittedTextForSpotAsString(element) }}"
                         size="{{ getSubmittedTextSizeForSpot(element) }}"
                     />
-                    <div
-                        *ngIf="shortAnswerQuestionUtil.getSpot(shortAnswerQuestionUtil.getSpotNr(element), shortAnswerQuestion).invalid"
-                        [ngbTooltip]="'artemisApp.shortAnswerSpot.invalidSpot' | artemisTranslate"
-                    >
-                        <input
-                            class="short-answer-question-container__input"
-                            style="background: grey"
-                            disabled
-                            value="{{ getSubmittedTextForSpotAsString(element) }}"
-                            size="{{ getSubmittedTextSizeForSpot(element) }}"
-                        />
-                    </div>
+                </div>
+                <div
+                    *ngIf="
+                        shortAnswerQuestionUtil.isInputField(element) &&
+                        !showingSampleSolution &&
+                        shortAnswerQuestionUtil.getSpot(shortAnswerQuestionUtil.getSpotNr(element), shortAnswerQuestion).invalid
+                    "
+                    [ngbTooltip]="'artemisApp.shortAnswerSpot.invalidSpot' | artemisTranslate"
+                >
+                    <input
+                        class="short-answer-question-container__input"
+                        style="background: grey"
+                        disabled
+                        value="{{ getSubmittedTextForSpotAsString(element) }}"
+                        size="{{ getSubmittedTextSizeForSpot(element) }}"
+                    />
                 </div>
                 <div class="short-answer-question-container" id="sa-question-container-C" *ngIf="shortAnswerQuestionUtil.isInputField(element) && showingSampleSolution">
                     <input


### PR DESCRIPTION


<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally ~~and was confirmed by another developer on a test server~~.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
The HTML fragment for invalid answer spots in the student view of short answer quiz questions was incorrectly nested inside an other case and thus could never show up and instead invalid spots would just be missing.

### Description
In addition to putting that fragment into the correct parent I had extend the condition to match the one for regular spots as otherwise evaluating the condition would lead to exceptions.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Quiz with a Short Answer question

1. Start the Quiz
2. Participate as the student
3. Re-evaluate the quiz after it ended and mark one spot of the question as invalid
4. Reload the submission overview as the student, the invalid spot should still show up and have gray background and a helpful tooltip.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

