### PR TITLE
`Quiz exercises`: Fix automatic update of quiz lifecycle buttons

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.ts
@@ -169,15 +169,16 @@ export class QuizExerciseComponent extends ExerciseComponent {
 
     private handleNewQuizExercise(newQuizExercise: QuizExercise) {
         const index = this.quizExercises.findIndex((quizExercise) => quizExercise.id === newQuizExercise.id);
-        newQuizExercise.isAtLeastTutor = this.accountService.isAtLeastTutorInCourse(newQuizExercise.course!);
-        newQuizExercise.isAtLeastEditor = this.accountService.isAtLeastEditorInCourse(newQuizExercise.course!);
-        newQuizExercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(newQuizExercise.course!);
+        newQuizExercise.isAtLeastTutor = this.accountService.isAtLeastTutorInCourse(newQuizExercise.course);
+        newQuizExercise.isAtLeastEditor = this.accountService.isAtLeastEditorInCourse(newQuizExercise.course);
+        newQuizExercise.isAtLeastInstructor = this.accountService.isAtLeastInstructorInCourse(newQuizExercise.course);
         newQuizExercise.status = this.quizExerciseService.getStatus(newQuizExercise);
         if (index === -1) {
             this.quizExercises.push(newQuizExercise);
         } else {
             this.quizExercises[index] = newQuizExercise;
         }
+        this.applyFilter();
     }
 
     /**


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
While testing #4821 I noted that the quiz lifecycle buttons did not update the status automatically after pressing them. 

### Description
#4205 introduced another array `filteredQuizExercises` which is used in the template. When pressing the lifecycle buttons, the method `handleNewQuizExercise()` gets called. This only changes the `quizExercises`, but not the `filteredQuizExercises`. Therefore I added a call to `applyFilter()`, now both arrays are updated correctly. 

### Steps for Testing

1. Create a new quiz exercise
2. Press the Lifecycle buttons ("Set Visible", "Start", "Open for Practice")
3. Make sure that the state is directly updated, i.e. the next button is shown and clickable. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
