### PR TITLE
`Development`: Remove explicit Hamcrest dependency from server tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -282,7 +282,6 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${mockito_version}"
     testImplementation "org.mockito:mockito-inline:${mockito_version}"
     testImplementation "org.mockito:mockito-junit-jupiter:${mockito_version}"
-    testImplementation "org.hamcrest:hamcrest-library:2.2"
     testImplementation "com.h2database:h2:1.4.200"
     testImplementation "org.awaitility:awaitility:4.2.0"
     testImplementation "org.apache.maven.shared:maven-invoker:3.1.0"

--- a/src/test/java/de/tum/in/www1/artemis/AtheneIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AtheneIntegrationTest.java
@@ -110,8 +110,7 @@ public class AtheneIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
                 assertThat(block.getAddedDistance()).isGreaterThan(1.65);
                 Segment segment = atheneResponse.getClusters(clusterIndex).getSegmentsList().get(blockIndex);
                 assertThat(block.getId()).isEqualTo(segment.getId());
-                var positionInCluster = ReflectionTestUtils.getField(block, "positionInCluster");
-                assertThat(positionInCluster).isEqualTo(blockIndex);
+                assertThat(block).hasFieldOrPropertyWithValue("positionInCluster", blockIndex);
             }
         }
 

--- a/src/test/java/de/tum/in/www1/artemis/AtheneIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AtheneIntegrationTest.java
@@ -1,8 +1,7 @@
 package de.tum.in.www1.artemis;
 
 import static de.tum.in.www1.artemis.config.Constants.ATHENE_RESULT_API_PATH;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -102,17 +101,17 @@ public class AtheneIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
 
         for (int clusterIndex = 0; clusterIndex < clusters.size(); clusterIndex++) {
             TextCluster cluster = clusters.get(clusterIndex);
-            assertThat(cluster.size(), equalTo(3));
-            assertThat(cluster.getBlocks(), hasSize(3));
+            assertThat(cluster.size()).isEqualTo(3);
+            assertThat(cluster.getBlocks()).hasSize(3);
 
             List<TextBlock> blocks = cluster.getBlocks();
             for (int blockIndex = 0; blockIndex < blocks.size(); blockIndex++) {
                 TextBlock block = blocks.get(blockIndex);
-                assertThat(block.getAddedDistance(), greaterThan(1.65));
+                assertThat(block.getAddedDistance()).isGreaterThan(1.65);
                 Segment segment = atheneResponse.getClusters(clusterIndex).getSegmentsList().get(blockIndex);
-                assertThat(block.getId(), is(equalTo(segment.getId())));
+                assertThat(block.getId()).isEqualTo(segment.getId());
                 var positionInCluster = ReflectionTestUtils.getField(block, "positionInCluster");
-                assertThat(positionInCluster, is(equalTo(blockIndex)));
+                assertThat(positionInCluster).isEqualTo(blockIndex);
             }
         }
 

--- a/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextSubmissionIntegrationTest.java
@@ -1,8 +1,6 @@
 package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.ZoneId;
@@ -289,10 +287,10 @@ public class TextSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
 
         StudentParticipation participation = request.get("/api/text-editor/" + participationId, HttpStatus.OK, StudentParticipation.class);
 
-        assertThat(participation.getResults(), is(notNullValue()));
-        assertThat(participation.getResults(), hasSize(1));
+        assertThat(participation.getResults()).isNotNull();
+        assertThat(participation.getResults()).hasSize(1);
 
-        assertThat(participation.getSubmissions(), is(notNullValue()));
+        assertThat(participation.getSubmissions()).isNotNull();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/service/AutomaticFeedbackConflictServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/AutomaticFeedbackConflictServiceTest.java
@@ -1,8 +1,7 @@
 package de.tum.in.www1.artemis.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 
 import java.util.*;
 
@@ -99,9 +98,9 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
 
         await().until(() -> feedbackConflictRepository.count() >= 0);
 
-        assertThat(feedbackConflictRepository.findAll(), hasSize(1));
-        assertThat(feedbackConflictRepository.findAll().get(0).getFirstFeedback(), either(is(feedback1)).or(is(feedback2)));
-        assertThat(feedbackConflictRepository.findAll().get(0).getSecondFeedback(), either(is(feedback1)).or(is(feedback2)));
+        assertThat(feedbackConflictRepository.findAll()).hasSize(1);
+        assertThat(feedbackConflictRepository.findAll().get(0).getFirstFeedback()).isIn(feedback1, feedback2);
+        assertThat(feedbackConflictRepository.findAll().get(0).getSecondFeedback()).isIn(feedback1, feedback2);
     }
 
     /**
@@ -137,10 +136,10 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
 
         await().until(() -> feedbackConflictRepository.count() >= 0);
 
-        assertThat(feedbackConflictRepository.findAll(), hasSize(1));
-        assertThat(feedbackConflictRepository.findAll().get(0).getFirstFeedback(), is(feedback1));
-        assertThat(feedbackConflictRepository.findAll().get(0).getSecondFeedback(), is(feedback2));
-        assertThat(feedbackConflictRepository.findAll().get(0).getType(), is(FeedbackConflictType.INCONSISTENT_SCORE));
+        assertThat(feedbackConflictRepository.findAll()).hasSize(1);
+        assertThat(feedbackConflictRepository.findAll().get(0).getFirstFeedback()).isEqualTo(feedback1);
+        assertThat(feedbackConflictRepository.findAll().get(0).getSecondFeedback()).isEqualTo(feedback2);
+        assertThat(feedbackConflictRepository.findAll().get(0).getType()).isEqualTo(FeedbackConflictType.INCONSISTENT_SCORE);
     }
 
     /**
@@ -176,11 +175,11 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
 
         await().until(() -> feedbackConflictRepository.count() >= 0);
 
-        assertThat(feedbackConflictRepository.findAll(), hasSize(1));
-        assertThat(feedbackConflictRepository.findAll().get(0).getFirstFeedback(), is(feedback1));
-        assertThat(feedbackConflictRepository.findAll().get(0).getSecondFeedback(), is(feedback2));
-        assertThat(feedbackConflictRepository.findAll().get(0).getConflict(), is(Boolean.FALSE));
-        assertThat(feedbackConflictRepository.findAll().get(0).getSolvedAt(), is(notNullValue()));
+        assertThat(feedbackConflictRepository.findAll()).hasSize(1);
+        assertThat(feedbackConflictRepository.findAll().get(0).getFirstFeedback()).isEqualTo(feedback1);
+        assertThat(feedbackConflictRepository.findAll().get(0).getSecondFeedback()).isEqualTo(feedback2);
+        assertThat(feedbackConflictRepository.findAll().get(0).getConflict()).isFalse();
+        assertThat(feedbackConflictRepository.findAll().get(0).getSolvedAt()).isNotNull();
     }
 
     /**
@@ -191,7 +190,7 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
     public void testSubmissionDelete() {
         TextSubmission textSubmission = createTextSubmissionWithResultFeedbackAndConflicts();
         textSubmissionRepository.deleteById(textSubmission.getId());
-        assertThat(feedbackConflictRepository.findAll(), hasSize(0));
+        assertThat(feedbackConflictRepository.findAll()).isEmpty();
     }
 
     /**
@@ -202,7 +201,7 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
     public void testResultDelete() {
         TextSubmission textSubmission = createTextSubmissionWithResultFeedbackAndConflicts();
         resultRepository.deleteById(textSubmission.getLatestResult().getId());
-        assertThat(feedbackConflictRepository.findAll(), hasSize(0));
+        assertThat(feedbackConflictRepository.findAll()).isEmpty();
     }
 
     /**
@@ -213,7 +212,7 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
     public void testFeedbackDelete() {
         this.createTextSubmissionWithResultFeedbackAndConflicts();
         feedbackRepository.deleteAll();
-        assertThat(feedbackConflictRepository.findAll(), hasSize(0));
+        assertThat(feedbackConflictRepository.findAll()).isEmpty();
     }
 
     /**
@@ -224,7 +223,7 @@ public class AutomaticFeedbackConflictServiceTest extends AbstractSpringIntegrat
     public void testFeedbackConflictDelete() {
         createTextSubmissionWithResultFeedbackAndConflicts();
         feedbackConflictRepository.deleteAll();
-        assertThat(feedbackRepository.findAll(), hasSize(2));
+        assertThat(feedbackRepository.findAll()).hasSize(2);
     }
 
     private List<FeedbackConflictResponseDTO> createRemoteServiceResponse(Feedback firstFeedback, Feedback secondFeedback) {

--- a/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExerciseLifecycleServiceTest.java
@@ -1,8 +1,7 @@
 package de.tum.in.www1.artemis.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.ZonedDateTime;
@@ -107,6 +106,6 @@ public class ExerciseLifecycleServiceTest extends AbstractSpringIntegrationBambo
     }
 
     private void assertEqual(MutableBoolean testBoolean, boolean expected) {
-        assertThat(testBoolean.toBoolean(), is(equalTo(expected)));
+        assertThat(testBoolean.toBoolean()).isEqualTo(expected);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/service/HttpRequestUtilsTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/HttpRequestUtilsTest.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.service;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -16,67 +15,67 @@ public class HttpRequestUtilsTest {
     public void testIPv4String() {
         HttpServletRequest request = httpRequestMockWithIp("192.0.2.235");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
-        assertThat(ipAddress.toFullString(), is(equalTo("192.000.002.235")));
+        assertThat(ipAddress.toFullString()).isEqualTo("192.000.002.235");
     }
 
     @Test
     void testIPv6String() {
         HttpServletRequest request = httpRequestMockWithIp("2001:db8:0:0:0:8a2e:370:7334");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
-        assertThat(ipAddress.toFullString(), is(equalTo("2001:0db8:0000:0000:0000:8a2e:0370:7334")));
+        assertThat(ipAddress.toFullString()).isEqualTo("2001:0db8:0000:0000:0000:8a2e:0370:7334");
     }
 
     @Test
     void testIPv6ShortString() {
         HttpServletRequest request = httpRequestMockWithIp("2001:db8::8a2e:370:7334");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
-        assertThat(ipAddress.isIPv6(), is(true));
-        assertThat(ipAddress.toFullString(), is(equalTo("2001:0db8:0000:0000:0000:8a2e:0370:7334")));
+        assertThat(ipAddress.isIPv6()).isTrue();
+        assertThat(ipAddress.toFullString()).isEqualTo("2001:0db8:0000:0000:0000:8a2e:0370:7334");
     }
 
     @Test
     void testIPv4Lopback() {
         HttpServletRequest request = httpRequestMockWithIp("127.0.0.1");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
-        assertThat(ipAddress.isIPv4(), is(true));
-        assertThat(ipAddress.toFullString(), is(equalTo("127.000.000.001")));
+        assertThat(ipAddress.isIPv4()).isTrue();
+        assertThat(ipAddress.toFullString()).isEqualTo("127.000.000.001");
     }
 
     @Test
     void testIPv6Loopback() {
         HttpServletRequest request = httpRequestMockWithIp("0:0:0:0:0:0:0:1");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
-        assertThat(ipAddress.isIPv6(), is(true));
-        assertThat(ipAddress.toFullString(), is(equalTo("0000:0000:0000:0000:0000:0000:0000:0001")));
+        assertThat(ipAddress.isIPv6()).isTrue();
+        assertThat(ipAddress.toFullString()).isEqualTo("0000:0000:0000:0000:0000:0000:0000:0001");
     }
 
     @Test
     void testIPv6ShortLoopback() {
         HttpServletRequest request = httpRequestMockWithIp("::1");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
-        assertThat(ipAddress.isIPv6(), is(true));
-        assertThat(ipAddress.toFullString(), is(equalTo("0000:0000:0000:0000:0000:0000:0000:0001")));
+        assertThat(ipAddress.isIPv6()).isTrue();
+        assertThat(ipAddress.toFullString()).isEqualTo("0000:0000:0000:0000:0000:0000:0000:0001");
     }
 
     @Test()
     void testInvalidIPv4String() {
         HttpServletRequest request = httpRequestMockWithIp("192.256.2.235");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request);
-        assertThat(ipAddress.isEmpty(), is(true));
+        assertThat(ipAddress).isEmpty();
     }
 
     @Test
     void testRandomString() {
         HttpServletRequest request = httpRequestMockWithIp("foo.example");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request);
-        assertThat(ipAddress.isEmpty(), is(true));
+        assertThat(ipAddress).isEmpty();
     }
 
     @Test
     void testIpInRemoteAddr() {
         HttpServletRequest request = httpRequestMockWithIp("REMOTE_ADDR", "224.14.7.42");
         final var ipAddress = HttpRequestUtils.getIpAddressFromRequest(request).get();
-        assertThat(ipAddress.toFullString(), is(equalTo("224.014.007.042")));
+        assertThat(ipAddress.toFullString()).isEqualTo("224.014.007.042");
     }
 
     private HttpServletRequest httpRequestMockWithIp(String ipAddress) {

--- a/src/test/java/de/tum/in/www1/artemis/service/TextBlockServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/TextBlockServiceTest.java
@@ -1,13 +1,11 @@
 package de.tum.in.www1.artemis.service;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collection;
 import java.util.Objects;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,19 +25,19 @@ public class TextBlockServiceTest {
     public void splitSubmissionIntoBlocksForEmptyText() {
         TextSubmission submission = new TextSubmission(0L);
         var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
-        assertThat(textBlocks, hasSize(0));
+        assertThat(textBlocks).isEmpty();
 
         submission = new TextSubmission(0L).text("");
         textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
-        assertThat(textBlocks, hasSize(0));
+        assertThat(textBlocks).isEmpty();
 
         submission = new TextSubmission(0L).text("\n");
         textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
-        assertThat(textBlocks, hasSize(0));
+        assertThat(textBlocks).isEmpty();
 
         submission = new TextSubmission(0L).text("\n\n\n\n");
         textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
-        assertThat(textBlocks, hasSize(0));
+        assertThat(textBlocks).isEmpty();
     }
 
     @Test
@@ -47,8 +45,8 @@ public class TextBlockServiceTest {
         final TextSubmission submission = new TextSubmission(0L).text("Hello World.");
         final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
 
-        assertThat(textBlocks, hasSize(1));
-        assertThat(textBlocks.iterator().next().getText(), is(equalTo("Hello World.")));
+        assertThat(textBlocks).hasSize(1);
+        assertThat(textBlocks.iterator().next().getText()).isEqualTo("Hello World.");
     }
 
     @Test
@@ -56,9 +54,7 @@ public class TextBlockServiceTest {
         final TextSubmission submission = new TextSubmission(0L).text("Hello World. This is a Test.");
         final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
 
-        assertThat(textBlocks, hasSize(2));
-        assertThat(textBlocks, hasItem(textBlock("Hello World.")));
-        assertThat(textBlocks, hasItem(textBlock("This is a Test.")));
+        assertThat(textBlocks).hasSize(2).has(textBlock("Hello World.")).has(textBlock("This is a Test."));
     }
 
     @Test
@@ -66,10 +62,7 @@ public class TextBlockServiceTest {
         final TextSubmission submission = new TextSubmission(0L).text("Hello World. This is a Test\n\n\nAnother Test");
         final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
 
-        assertThat(textBlocks, hasSize(3));
-        assertThat(textBlocks, hasItem(textBlock("Hello World.")));
-        assertThat(textBlocks, hasItem(textBlock("This is a Test")));
-        assertThat(textBlocks, hasItem(textBlock("Another Test")));
+        assertThat(textBlocks).hasSize(3).has(textBlock("Hello World.")).has(textBlock("This is a Test")).has(textBlock("Another Test"));
     }
 
     @Test
@@ -78,9 +71,9 @@ public class TextBlockServiceTest {
         final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
 
         String[] sections = new String[] { "Example:", "This is the first example", "Section 2:", "- Here is a list", "- Of many bullet  points" };
-        assertThat(textBlocks, hasSize(sections.length));
+        assertThat(textBlocks).hasSize(sections.length);
         for (String section : sections) {
-            assertThat(textBlocks, hasItem(textBlock(section)));
+            assertThat(textBlocks).has(textBlock(section));
         }
     }
 
@@ -89,12 +82,11 @@ public class TextBlockServiceTest {
         final var submission = new TextSubmission(0L).text("   Test.");
         final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
 
-        assertThat(textBlocks, hasSize(1));
-        assertThat(textBlocks, hasItem(textBlock("Test.")));
+        assertThat(textBlocks).hasSize(1).has(textBlock("Test."));
 
         final TextBlock textBlock = textBlocks.iterator().next();
-        assertThat(textBlock.getStartIndex(), equalTo(3));
-        assertThat(textBlock.getEndIndex(), equalTo(8));
+        assertThat(textBlock.getStartIndex()).isEqualTo(3);
+        assertThat(textBlock.getEndIndex()).isEqualTo(8);
     }
 
     @Test
@@ -102,12 +94,11 @@ public class TextBlockServiceTest {
         final var submission = new TextSubmission(0L).text("\t\t\tTest.");
         final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
 
-        assertThat(textBlocks, hasSize(1));
-        assertThat(textBlocks, hasItem(textBlock("Test.")));
+        assertThat(textBlocks).hasSize(1).has(textBlock("Test."));
 
         final TextBlock textBlock = textBlocks.iterator().next();
-        assertThat(textBlock.getStartIndex(), equalTo(3));
-        assertThat(textBlock.getEndIndex(), equalTo(8));
+        assertThat(textBlock.getStartIndex()).isEqualTo(3);
+        assertThat(textBlock.getEndIndex()).isEqualTo(8);
     }
 
     @Test
@@ -138,57 +129,47 @@ public class TextBlockServiceTest {
                 """);
         final var textBlocks = textBlockService.splitSubmissionIntoBlocks(submission);
 
-        assertThat(textBlocks, hasSize(21));
-        assertThat(textBlocks, hasItem(textBlock(3, 23, "ALLOC 3\t\t\t\t\t\t\tLOAD 0")));
-        assertThat(textBlocks, hasItem(textBlock(27, 44, "READ\t\t\t\t\t\t\tLOAD 2")));
-        assertThat(textBlocks, hasItem(textBlock(48, 65, "STORE 0\t\t\t\t\t\t\tMUL")));
-        assertThat(textBlocks, hasItem(textBlock(69, 89, "CONST 1\t\t\t\t\t\t\tLOAD 1")));
-        assertThat(textBlocks, hasItem(textBlock(93, 110, "STORE 1\t\t\t\t\t\t\tADD")));
-        assertThat(textBlocks, hasItem(textBlock(114, 135, "CONST 0\t\t\t\t\t\t\tSTORE 1")));
-        assertThat(textBlocks, hasItem(textBlock(139, 169, "STORE 2\t\t\t\t\t\t\tJUMP if_else_end")));
-        assertThat(textBlocks, hasItem(textBlock(178, 215, "while_start:\tLOAD 2\t\t\telse:\t\t\t\tLOAD 1")));
-        assertThat(textBlocks, hasItem(textBlock(219, 236, "CONST 1\t\t\t\t\t\t\tNEG")));
-        assertThat(textBlocks, hasItem(textBlock(240, 258, "ADD\t\t\t\t\t\t\t\tSTORE 1")));
-        assertThat(textBlocks, hasItem(textBlock(262, 268, "LOAD 0")));
-        assertThat(textBlocks, hasItem(textBlock(272, 299, "LEQ\t\t\t\tif_else_end:\t\tLOAD 2")));
-        assertThat(textBlocks, hasItem(textBlock(303, 332, "FJUMP after_while\t\t\t\t\tCONST 1")));
-        assertThat(textBlocks, hasItem(textBlock(345, 352, "STORE 2")));
-        assertThat(textBlocks, hasItem(textBlock(356, 385, "LOAD 1\t\t\t\t\t\t\tJUMP while_start")));
-        assertThat(textBlocks, hasItem(textBlock(389, 396, "CONST 2")));
-        assertThat(textBlocks, hasItem(textBlock(400, 426, "MOD\t\t\tafter_while:\t\tLOAD 1")));
-        assertThat(textBlocks, hasItem(textBlock(430, 450, "CONST 1\t\t\t\t\t\t\tLOAD 2")));
-        assertThat(textBlocks, hasItem(textBlock(454, 467, "EQ\t\t\t\t\t\t\t\tDIV")));
-        assertThat(textBlocks, hasItem(textBlock(471, 492, "FJUMP else\t\t\t\t\t\tWRITE")));
-        assertThat(textBlocks, hasItem(textBlock(504, 508, "HALT")));
+        assertThat(textBlocks).hasSize(21);
+        assertThat(textBlocks).has(textBlock(3, 23, "ALLOC 3\t\t\t\t\t\t\tLOAD 0"));
+        assertThat(textBlocks).has(textBlock(27, 44, "READ\t\t\t\t\t\t\tLOAD 2"));
+        assertThat(textBlocks).has(textBlock(48, 65, "STORE 0\t\t\t\t\t\t\tMUL"));
+        assertThat(textBlocks).has(textBlock(69, 89, "CONST 1\t\t\t\t\t\t\tLOAD 1"));
+        assertThat(textBlocks).has(textBlock(93, 110, "STORE 1\t\t\t\t\t\t\tADD"));
+        assertThat(textBlocks).has(textBlock(114, 135, "CONST 0\t\t\t\t\t\t\tSTORE 1"));
+        assertThat(textBlocks).has(textBlock(139, 169, "STORE 2\t\t\t\t\t\t\tJUMP if_else_end"));
+        assertThat(textBlocks).has(textBlock(178, 215, "while_start:\tLOAD 2\t\t\telse:\t\t\t\tLOAD 1"));
+        assertThat(textBlocks).has(textBlock(219, 236, "CONST 1\t\t\t\t\t\t\tNEG"));
+        assertThat(textBlocks).has(textBlock(240, 258, "ADD\t\t\t\t\t\t\t\tSTORE 1"));
+        assertThat(textBlocks).has(textBlock(262, 268, "LOAD 0"));
+        assertThat(textBlocks).has(textBlock(272, 299, "LEQ\t\t\t\tif_else_end:\t\tLOAD 2"));
+        assertThat(textBlocks).has(textBlock(303, 332, "FJUMP after_while\t\t\t\t\tCONST 1"));
+        assertThat(textBlocks).has(textBlock(345, 352, "STORE 2"));
+        assertThat(textBlocks).has(textBlock(356, 385, "LOAD 1\t\t\t\t\t\t\tJUMP while_start"));
+        assertThat(textBlocks).has(textBlock(389, 396, "CONST 2"));
+        assertThat(textBlocks).has(textBlock(400, 426, "MOD\t\t\tafter_while:\t\tLOAD 1"));
+        assertThat(textBlocks).has(textBlock(430, 450, "CONST 1\t\t\t\t\t\t\tLOAD 2"));
+        assertThat(textBlocks).has(textBlock(454, 467, "EQ\t\t\t\t\t\t\t\tDIV"));
+        assertThat(textBlocks).has(textBlock(471, 492, "FJUMP else\t\t\t\t\t\tWRITE"));
+        assertThat(textBlocks).has(textBlock(504, 508, "HALT"));
     }
 
-    private Matcher<TextBlock> textBlock(String expectedText) {
-        return new TypeSafeMatcher<>() {
+    private Condition<? super Collection<? extends TextBlock>> textBlock(String expectedText) {
+        return new Condition<>(String.format("a text block with text=\"%s\"", expectedText)) {
 
             @Override
-            public void describeTo(Description description) {
-                description.appendText("text block with \"text\" property set to").appendValue(expectedText);
-            }
-
-            @Override
-            protected boolean matchesSafely(TextBlock item) {
-                return Objects.equals(item.getText(), expectedText);
+            public boolean matches(Collection<? extends TextBlock> value) {
+                return value.stream().anyMatch(textBlock -> Objects.equals(textBlock.getText(), expectedText));
             }
         };
     }
 
-    private Matcher<TextBlock> textBlock(int expectedStartIndex, int expextedEndIndex, String expectedText) {
-        return new TypeSafeMatcher<>() {
+    private Condition<? super Collection<? extends TextBlock>> textBlock(int expectedStartIndex, int expectedEndIndex, String expectedText) {
+        return new Condition<>(String.format("a text block with startIndex=%d, endIndex=%d, and text=\"%s\"", expectedStartIndex, expectedEndIndex, expectedText)) {
 
             @Override
-            public void describeTo(Description description) {
-                description.appendText("text block with \"startIndex\" ").appendValue(expectedStartIndex).appendText(", \"endIndex\" ").appendValue(expextedEndIndex)
-                        .appendText(", \"text\" property ").appendValue(expectedText);
-            }
-
-            @Override
-            protected boolean matchesSafely(TextBlock item) {
-                return item.getStartIndex() == expectedStartIndex && item.getEndIndex() == expextedEndIndex && Objects.equals(item.getText(), expectedText);
+            public boolean matches(Collection<? extends TextBlock> value) {
+                return value.stream().anyMatch(textBlock -> textBlock.getStartIndex() == expectedStartIndex && textBlock.getEndIndex() == expectedEndIndex
+                        && Objects.equals(textBlock.getText(), expectedText));
             }
         };
     }

--- a/src/test/java/de/tum/in/www1/artemis/service/connectors/AtheneServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/connectors/AtheneServiceTest.java
@@ -3,8 +3,6 @@ package de.tum.in.www1.artemis.service.connectors;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.codec.digest.DigestUtils.sha1Hex;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 
 import java.util.*;
 
@@ -118,7 +116,6 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
      */
     @Test
     public void parseTextBlocks() {
-
         int size = 10;
         var textSubmissions = generateTextSubmissions(size);
 
@@ -130,7 +127,7 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
             assertThat(textBlock.getType()).isEqualTo(TextBlockType.AUTOMATIC);
             assertThat(textBlock.getSubmission()).isNotNull();
         }
-        assertThat(textBlocks, hasSize(size));
+        assertThat(textBlocks).hasSize(size);
     }
 
     /**
@@ -146,7 +143,7 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
             assertThat(textCluster.getBlocks()).isNotEmpty();
             assertThat(textCluster.getDistanceMatrix()).isNotNull();
         }
-        assertThat(textClusters, hasSize(clusters.size()));
+        assertThat(textClusters).hasSameSizeAs(clusters);
     }
 
     /**
@@ -171,8 +168,8 @@ public class AtheneServiceTest extends AbstractSpringIntegrationBambooBitbucketJ
     private List<Cluster> generateClusters() {
         int size = 10;
         List<Cluster> clusters = new ArrayList<>();
-        // Generate 10 clusters
-        for (int i = 0; i < 10; i++) {
+        // Generate clusters
+        for (int i = 0; i < size; i++) {
             List<Segment> segments = new ArrayList<>();
             // First generate 5 segments for each cluster
             for (int j = 0; j < 5; j++) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
Most Java unit tests are using AssertJ assertions as described in the coding guidelines. Only very few used Hamcrest assertions instead.

### Description
This PR changes the seven test classes that used Hamcrest to AssertJ, thereby removing the explicit dependency.

The `BitbucketRequestMockProvider` and `JiraRequestMockProvider` still use Hamcrest to match paths on mocked requests. This is required by the Spring request mocking framework. However, it also comes with a bundled dependency on the required Hamcrest classes. Therefore, it no longer has to be part of our `build.gradle`.

### Steps for Testing
n/a

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
