### PR TITLE
`General`: Fix SAML2 login not possible when privacy terms don’t need to be accepted

### DIFF
--- a/src/main/webapp/app/home/home.component.html
+++ b/src/main/webapp/app/home/home.component.html
@@ -66,7 +66,7 @@
                             </div>
                             <div class="form-check" *ngIf="needsToAcceptTerms">
                                 <label class="form-check-label" for="acceptTerms">
-                                    <input class="form-check-input" type="checkbox" name="acceptTerms" id="acceptTerms" [(ngModel)]="userAcceptTerms" checked />
+                                    <input class="form-check-input" type="checkbox" name="acceptTerms" id="acceptTerms" [(ngModel)]="userAcceptedTerms" checked />
                                     <a [routerLink]="['privacy']" jhiTranslate="login.form.acceptTerms">Accept terms</a>
                                 </label>
                             </div>
@@ -77,7 +77,7 @@
                                 id="login-button"
                                 [disabled]="
                                     isSubmittingLogin ||
-                                    (!userAcceptTerms && needsToAcceptTerms) ||
+                                    (!userAcceptedTerms && needsToAcceptTerms) ||
                                     !password ||
                                     password.length < PASSWORD_MIN_LENGTH ||
                                     !username ||
@@ -89,7 +89,8 @@
                                 <span jhiTranslate="login.form.button"> Sign in </span>
                             </button>
                             <div *ngIf="profileInfo && profileInfo.saml2">
-                                <jhi-saml2-login [acceptTerms]="userAcceptTerms" [rememberMe]="rememberMe" [saml2Profile]="profileInfo.saml2"> </jhi-saml2-login>
+                                <jhi-saml2-login [acceptedTerms]="!needsToAcceptTerms || userAcceptedTerms" [rememberMe]="rememberMe" [saml2Profile]="profileInfo.saml2">
+                                </jhi-saml2-login>
                             </div>
                         </div>
                     </form>

--- a/src/main/webapp/app/home/home.component.ts
+++ b/src/main/webapp/app/home/home.component.ts
@@ -114,8 +114,8 @@ export class HomeComponent implements OnInit, AfterViewChecked {
             this.errorMessageUsername = 'home.errors.tumWarning';
         }
 
-        this.isRegistrationEnabled = profileInfo.registrationEnabled || false;
-        this.needsToAcceptTerms = profileInfo.needsToAcceptTerms || false;
+        this.isRegistrationEnabled = !!profileInfo.registrationEnabled;
+        this.needsToAcceptTerms = !!profileInfo.needsToAcceptTerms;
     }
 
     registerAuthenticationSuccess() {

--- a/src/main/webapp/app/home/saml2-login/saml2-login.component.html
+++ b/src/main/webapp/app/home/saml2-login/saml2-login.component.html
@@ -1,3 +1,3 @@
-<button type="button" [disabled]="!acceptTerms" class="btn btn-primary" (click)="loginSAML2()">
+<button type="button" [disabled]="!acceptedTerms" class="btn btn-primary" (click)="loginSAML2()">
     <span>{{ saml2Profile.buttonLabel || 'SAML2 Login' }}</span>
 </button>

--- a/src/main/webapp/app/home/saml2-login/saml2-login.component.ts
+++ b/src/main/webapp/app/home/saml2-login/saml2-login.component.ts
@@ -14,7 +14,7 @@ export class Saml2LoginComponent implements OnInit {
     @Input()
     rememberMe = true;
     @Input()
-    acceptTerms = false;
+    acceptedTerms = false;
     @Input()
     saml2Profile: Saml2Config;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
When setting `accept-terms: false` in the server configuration, i.e., users do not have to accept the privacy statement before they are allowed to log in, the login via SAML2 button was always disabled on the login page. It required the user to click the ‘Accept Terms’ button before the SAML2 login became active. However, this button was not shown if the mentioned server setting was applied.

### Description
This change enables the button either when the user is not required to accept the terms or the user is required to accept the terms and has accepted them.

### Steps for Testing
Prerequisites:
- 1 Setup with SAML2 logins enabled and access to the configuration.

1. With `accept-terms: false` in the configuration the login via SAML2 button is enabled on the login-page.

### Review Progress
#### Code Review
The only actual proper code change in this PR is line 92 of `src/main/webapp/app/home/home.component.html` where condition for ‘user has accepted the terms’ given to the SAML2-button changed from `userAcceptTerms` to `!needsToAcceptTerms || userAcceptedTerms`. The remaining changes are only some housekeeping where bigger methods are split up into smaller ones without changes to their behaviour.
- [x] Review 1
- [x] Review 2
#### Manual Tests
Probably not really needed, as the change is minimal. From the code changes it should be clear that it works as intended.
- [x] Test 1
- [x] Test 2

### Test Coverage
unchanged
