### PR TITLE
`Documentation`: Update link of docker image configuration location

### DIFF
--- a/docs/dev/docker.rst
+++ b/docs/dev/docker.rst
@@ -45,7 +45,7 @@ Updating can only be done with access to the account on Dockerhub. If you need a
    - Click "Releases" on the right on the front page of that repository
    - Create a new release with the button called "Draft release" and give it the same name as in step 4
 6. Wait for the build in Dockerhub of the newly created Tag
-7. Change the docker image used in Artemis to the newly created tag: `application-artemis.yml <https://github.com/ls1intum/Artemis/blob/develop/src/main/resources/config/application-artemis.yml>`_
+7. Change the docker image used in Artemis to the newly created tag: `application.yml <https://github.com/ls1intum/Artemis/blob/develop/src/main/resources/config/application.yml>`_
 8. If the used docker container should also be changed for already created exercises you have to change the build plan of that exercise
 
    - Change the docker image used by following this path: Configure Buildplan > Default Job > Docker > Docker Image

--- a/docs/dev/docker.rst
+++ b/docs/dev/docker.rst
@@ -45,7 +45,7 @@ Updating can only be done with access to the account on Dockerhub. If you need a
    - Click "Releases" on the right on the front page of that repository
    - Create a new release with the button called "Draft release" and give it the same name as in step 4
 6. Wait for the build in Dockerhub of the newly created Tag
-7. Change the docker image used in Artemis to the newly created tag: `ContinuousIntegrationService.java <https://github.com/ls1intum/Artemis/blob/develop/src/main/java/de/tum/in/www1/artemis/service/connectors/ContinuousIntegrationService.java>`_
+7. Change the docker image used in Artemis to the newly created tag: `application-artemis.yml <https://github.com/ls1intum/Artemis/blob/develop/src/main/resources/config/application-artemis.yml>`_
 8. If the used docker container should also be changed for already created exercises you have to change the build plan of that exercise
 
    - Change the docker image used by following this path: Configure Buildplan > Default Job > Docker > Docker Image


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
#4455 changed the place where the use docker-image gets configured but did not change the documentation accordingly. 

### Description
I updated the link in the documentation

### Steps for Testing
Read the documentation / code changes, make sure that the link works correctly. You can check out the [Documentation build of this PR](https://artemis-platform--4832.org.readthedocs.build/en/4832/dev/docker/)

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
