### PR TITLE
`Development`: Debounce sentry events in the client to avoid overloading sentry with too many errors

### DIFF
--- a/src/main/webapp/app/core/sentry/deduplicate.sentry-integration.ts
+++ b/src/main/webapp/app/core/sentry/deduplicate.sentry-integration.ts
@@ -1,5 +1,4 @@
-import { Exception } from '@sentry/browser';
-import { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
+import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
 import { sha1Hex } from 'app/shared/util/crypto.utils';
 
 export class ArtemisDeduplicate implements Integration {

--- a/src/main/webapp/app/core/sentry/deduplicate.sentry-integration.ts
+++ b/src/main/webapp/app/core/sentry/deduplicate.sentry-integration.ts
@@ -53,29 +53,11 @@ function computeEventHash(event: Event): string {
     }
 
     // If event has stack trace, add filename and line of each frame
-    const frames = getFramesFromEvent(exception, event);
+    const frames = (exception && exception.stacktrace?.frames) || event.stacktrace?.frames;
     if (frames) {
         frames.forEach((frame) => (valueSequence += frame.filename ?? ''));
         frames.forEach((frame) => (valueSequence += frame.lineno ?? ''));
     }
 
     return sha1Hex(valueSequence);
-}
-
-/**
- * Return the stack trace frames of the event exception or the event itself
- * @param exception the previously extracted exception, if present
- * @param event the event to get frames from alternatively
- */
-function getFramesFromEvent(exception: Exception | false | undefined, event: Event): StackFrame[] | undefined {
-    if (exception) {
-        try {
-            return exception.stacktrace?.frames;
-        } catch (_oO) {
-            return undefined;
-        }
-    } else if (event.stacktrace) {
-        return event.stacktrace.frames;
-    }
-    return undefined;
 }

--- a/src/main/webapp/app/core/sentry/deduplicate.sentry-integration.ts
+++ b/src/main/webapp/app/core/sentry/deduplicate.sentry-integration.ts
@@ -1,0 +1,81 @@
+import { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
+import { sha1Hex } from 'app/shared/util/crypto.utils';
+
+export class ArtemisDeduplicate implements Integration {
+    public static id = 'ArtemisDeduplicate';
+    public name: string = ArtemisDeduplicate.id;
+
+    private observedEventHashes: string[] = [];
+
+    public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+        addGlobalEventProcessor((currentEvent: Event) => {
+            const self = getCurrentHub().getIntegration(ArtemisDeduplicate);
+            if (self) {
+                // Try-catch to make sure that we submit the event if something goes wrong during deduplication
+                try {
+                    // Hash the current event and check if hash is present in already seen event hashes
+                    const eventHash = computeEventHash(currentEvent);
+                    if (this.observedEventHashes.includes(eventHash)) {
+                        return null; // Drop event
+                    } else {
+                        // Add event to seen events and schedule removal in 5 minutes (throttle)
+                        this.observedEventHashes.push(eventHash);
+                        setTimeout(() => {
+                            const index = this.observedEventHashes.indexOf(eventHash);
+                            if (index >= 0) {
+                                this.observedEventHashes.splice(index, 1);
+                            }
+                        }, 5 * 60 * 1000);
+                    }
+                } catch (e) {
+                    console.error(e);
+                }
+            }
+            return currentEvent;
+        });
+    }
+}
+
+/**
+ * Sticks together a simple string with important values of the event and hashes it to produce an easily comparable value
+ * @param event the sentry event to hash
+ */
+function computeEventHash(event: Event): string {
+    // Add the message
+    let valueSequence = event.message ?? '';
+
+    // If the event has an exception, add type, value and for each frame, filename and line
+    const exception = event.exception?.values && event.exception!.values.length > 0 && event.exception!.values[0];
+    if (exception) {
+        valueSequence += exception.type ?? '';
+        valueSequence += exception.value ?? '';
+
+        const frames = getFramesFromEvent(event);
+        if (frames) {
+            frames.forEach((frame) => (valueSequence += frame.filename ?? ''));
+            frames.forEach((frame) => (valueSequence += frame.lineno ?? ''));
+        }
+    }
+
+    return sha1Hex(valueSequence);
+}
+
+/**
+ * Return the stack trace frames of the event exception or the event itself
+ * @param event the event to get frames from
+ */
+function getFramesFromEvent(event: Event): StackFrame[] | undefined {
+    const exception = event.exception;
+
+    if (exception) {
+        try {
+            // @ts-ignore Object is possibly undefined
+            return exception.values[0].stacktrace?.frames;
+        } catch (_oO) {
+            return undefined;
+        }
+    } else if (event.stacktrace) {
+        return event.stacktrace.frames;
+    }
+    return undefined;
+}

--- a/src/main/webapp/app/core/sentry/sentry.error-handler.ts
+++ b/src/main/webapp/app/core/sentry/sentry.error-handler.ts
@@ -2,6 +2,7 @@ import { ErrorHandler, Injectable } from '@angular/core';
 import { captureException, init } from '@sentry/browser';
 import { VERSION } from 'app/app.constants';
 import { ProfileInfo } from 'app/shared/layouts/profiles/profile-info.model';
+import { ArtemisDeduplicate } from 'app/core/sentry/deduplicate.sentry-integration';
 
 @Injectable({ providedIn: 'root' })
 export class SentryErrorHandler extends ErrorHandler {
@@ -30,7 +31,15 @@ export class SentryErrorHandler extends ErrorHandler {
             dsn: profileInfo.sentry.dsn,
             release: VERSION,
             environment: this.environment,
+            integrations: [new ArtemisDeduplicate()],
         });
+
+        setTimeout(() => {
+            setInterval(() => {
+                captureException(new Error('Test 123'));
+                captureException(new Error('Test 124'));
+            }, 100);
+        }, 5000);
     }
 
     constructor() {

--- a/src/main/webapp/app/core/sentry/sentry.error-handler.ts
+++ b/src/main/webapp/app/core/sentry/sentry.error-handler.ts
@@ -33,13 +33,6 @@ export class SentryErrorHandler extends ErrorHandler {
             environment: this.environment,
             integrations: [new ArtemisDeduplicate()],
         });
-
-        setTimeout(() => {
-            setInterval(() => {
-                captureException(new Error('Test 123'));
-                captureException(new Error('Test 124'));
-            }, 100);
-        }, 5000);
     }
 
     constructor() {

--- a/src/test/javascript/spec/integration/sentry/deduplicate.sentry-integration.spec.ts
+++ b/src/test/javascript/spec/integration/sentry/deduplicate.sentry-integration.spec.ts
@@ -1,0 +1,90 @@
+import { ArtemisDeduplicate } from 'app/core/sentry/deduplicate.sentry-integration';
+import { Event } from '@sentry/types';
+import dayjs from 'dayjs';
+import { fakeAsync, flush, tick } from '@angular/core/testing';
+
+// @ts-ignore
+
+describe('ArtemisDeduplicateSentryIntegration', () => {
+    let dedup: ArtemisDeduplicate;
+    let globalEventProcessor: (currentEvent: Event) => Event | null;
+
+    beforeEach(() => {
+        dedup = new ArtemisDeduplicate();
+        dedup.setupOnce(
+            (callback) => {
+                // @ts-ignore
+                globalEventProcessor = callback;
+            },
+            // @ts-ignore
+            () => ({ getIntegration: () => dedup }),
+        );
+    });
+
+    it.each([
+        // Test exceptions
+        (value: string) =>
+            ({
+                level: 'error',
+                timestamp: dayjs().valueOf(),
+                exception: {
+                    values: [
+                        {
+                            type: 'Error',
+                            value: value,
+                            stacktrace: [
+                                {
+                                    filename: 'a.ts',
+                                    lineno: 5,
+                                },
+                                {
+                                    filename: 'b.ts',
+                                    lineno: 10,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            } as any as Event),
+
+        // Test messages (no exception)
+        (value: string) =>
+            ({
+                level: 'error',
+                timestamp: dayjs().valueOf(),
+                message: value,
+                stacktrace: [
+                    {
+                        filename: 'a.ts',
+                        lineno: 5,
+                    },
+                    {
+                        filename: 'b.ts',
+                        lineno: 10,
+                    },
+                ],
+            } as any as Event),
+    ])(
+        'should ignore exceptions and error messages that happened already in the last 5 minutes',
+        fakeAsync((createEvent: (value: string) => Event) => {
+            const ev0 = createEvent('test0');
+            expect(globalEventProcessor(ev0)).toBe(ev0);
+
+            // Identical event should be ignored
+            const ev1 = createEvent('test0');
+            expect(globalEventProcessor(ev1)).toBe(null);
+
+            // An event with different value should go through
+            const ev2 = createEvent('test1');
+            expect(globalEventProcessor(ev2)).toBe(ev2);
+
+            tick(5 * 60 * 1000);
+
+            // Original event should work again after 5 minutes
+            const ev3 = createEvent('test0');
+            expect(globalEventProcessor(ev3)).toBe(ev3);
+
+            flush();
+        }),
+    );
+});

--- a/src/test/javascript/spec/integration/sentry/deduplicate.sentry-integration.spec.ts
+++ b/src/test/javascript/spec/integration/sentry/deduplicate.sentry-integration.spec.ts
@@ -3,8 +3,6 @@ import { Event } from '@sentry/types';
 import dayjs from 'dayjs';
 import { fakeAsync, flush, tick } from '@angular/core/testing';
 
-// @ts-ignore
-
 describe('ArtemisDeduplicateSentryIntegration', () => {
     let dedup: ArtemisDeduplicate;
     let globalEventProcessor: (currentEvent: Event) => Event | null;

--- a/src/test/javascript/spec/integration/sentry/deduplicate.sentry-integration.spec.ts
+++ b/src/test/javascript/spec/integration/sentry/deduplicate.sentry-integration.spec.ts
@@ -31,38 +31,50 @@ describe('ArtemisDeduplicateSentryIntegration', () => {
                     values: [
                         {
                             type: 'Error',
-                            value: value,
-                            stacktrace: [
-                                {
-                                    filename: 'a.ts',
-                                    lineno: 5,
-                                },
-                                {
-                                    filename: 'b.ts',
-                                    lineno: 10,
-                                },
-                            ],
+                            value,
+                            stacktrace: {
+                                frames: [
+                                    {
+                                        filename: 'a.ts',
+                                        lineno: 5,
+                                    },
+                                    {
+                                        filename: 'b.ts',
+                                        lineno: 10,
+                                    },
+                                ],
+                            },
                         },
                     ],
                 },
             } as any as Event),
 
-        // Test messages (no exception)
+        // Test messages (no exception, but stacktrace)
         (value: string) =>
             ({
                 level: 'error',
                 timestamp: dayjs().valueOf(),
                 message: value,
-                stacktrace: [
-                    {
-                        filename: 'a.ts',
-                        lineno: 5,
-                    },
-                    {
-                        filename: 'b.ts',
-                        lineno: 10,
-                    },
-                ],
+                stacktrace: {
+                    frames: [
+                        {
+                            filename: 'a.ts',
+                            lineno: 5,
+                        },
+                        {
+                            filename: 'b.ts',
+                            lineno: 10,
+                        },
+                    ],
+                },
+            } as any as Event),
+
+        // Test messages (no exception, no stacktrace)
+        (value: string) =>
+            ({
+                level: 'error',
+                timestamp: dayjs().valueOf(),
+                message: value,
             } as any as Event),
     ])(
         'should ignore exceptions and error messages that happened already in the last 5 minutes',


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In the past, we had issues with Sentry due to events that were sent hundreds of thousands of times by just a few users, causing our sentry instance to crash. Max. was an event that was sent over 2 million times

### Description
<!-- Describe your changes in detail -->

Add an event handler to sentry that stops the same event from being sent again within 5 minutes in the same session.

### Steps for Testing
You can add a section like this somewhere in the app:
```js
setTimeout(() => {
    setInterval(() => {
        captureException(new Error('Test 123'));
        captureException(new Error('Test 124'));
    }, 100);
}, 1000);
```
and then observe that the events are only sent once in dev tools, and maybe once again after 5 minutes.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| deduplicate.sentry-integration.ts | 88% | 95% |