### PR TITLE
`Development`: Consistently use try with resources for file operations

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -550,18 +550,20 @@ public class FileService implements DisposableBean {
         log.debug("Replacing {} with {} in directory {}", targetString, replacementString, startPath);
         File directory = new File(startPath);
         if (!directory.exists() || !directory.isDirectory()) {
-            throw new RuntimeException("Files in the directory " + startPath + " should be replaced but it does not exist.");
+            throw new FileNotFoundException("Files in the directory " + startPath + " should be replaced but it does not exist.");
         }
 
         // rename all files in the file tree
-        Files.find(Paths.get(startPath), Integer.MAX_VALUE, (filePath, fileAttr) -> fileAttr.isRegularFile() && filePath.toString().contains(targetString)).forEach(filePath -> {
-            try {
-                Files.move(new File(filePath.toString()).toPath(), new File(filePath.toString().replace(targetString, replacementString)).toPath());
-            }
-            catch (IOException e) {
-                throw new RuntimeException("File " + filePath + " should be replaced but does not exist.");
-            }
-        });
+        try (var files = Files.find(Path.of(startPath), Integer.MAX_VALUE, (filePath, fileAttr) -> fileAttr.isRegularFile() && filePath.toString().contains(targetString))) {
+            files.forEach(filePath -> {
+                try {
+                    Files.move(filePath, Path.of(filePath.toString().replace(targetString, replacementString)));
+                }
+                catch (IOException e) {
+                    throw new RuntimeException("File " + filePath + " should be replaced but does not exist.");
+                }
+            });
+        }
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ZipFileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ZipFileService.java
@@ -60,8 +60,8 @@ public class ZipFileService {
      * @throws IOException if an error occurred while zipping
      */
     public Path createZipFileWithFolderContent(Path zipFilePath, Path contentRootPath) throws IOException {
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFilePath))) {
-            Files.walk(contentRootPath).filter(path -> Files.isReadable(path) && !Files.isDirectory(path)).forEach(path -> {
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(zipFilePath)); var files = Files.walk(contentRootPath)) {
+            files.filter(path -> Files.isReadable(path) && !Files.isDirectory(path)).forEach(path -> {
                 ZipEntry zipEntry = new ZipEntry(contentRootPath.relativize(path).toString());
                 copyToZipFile(zipOutputStream, path, zipEntry);
             });

--- a/src/main/java/de/tum/in/www1/artemis/service/util/structureoraclegenerator/OracleGenerator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/util/structureoraclegenerator/OracleGenerator.java
@@ -178,8 +178,8 @@ public class OracleGenerator {
 
     private static List<Path> retrieveJavaSourceFiles(Path start) {
         var matcher = FileSystems.getDefault().getPathMatcher("glob:**/*.java");
-        try {
-            return Files.walk(start).filter(Files::isRegularFile).filter(matcher::matches).toList();
+        try (var files = Files.walk(start)) {
+            return files.filter(Files::isRegularFile).filter(matcher::matches).toList();
         }
         catch (IOException e) {
             var error = "Could not retrieve the project files to generate the oracle";

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -1978,7 +1978,10 @@ public class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         String extractedArchiveDir = archive.getPath().substring(0, archive.getPath().length() - 4);
 
         // Check that the dummy files we created exist in the archive.
-        var filenames = Files.walk(Path.of(extractedArchiveDir)).filter(Files::isRegularFile).map(Path::getFileName).collect(Collectors.toList());
+        List<Path> filenames;
+        try (var files = Files.walk(Path.of(extractedArchiveDir))) {
+            filenames = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
+        }
 
         var submissions = submissionRepository.findAll();
 

--- a/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
@@ -330,8 +330,9 @@ public class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         byte[] receivedFile = request.get("/api/files/attachments/lecture/" + lecture.getId() + "/merge-pdf" + "?access_token=" + accessToken, HttpStatus.OK, byte[].class);
 
         assertThat(receivedFile).isNotEmpty();
-        PDDocument mergedDoc = PDDocument.load(receivedFile);
-        assertEquals(5, mergedDoc.getNumberOfPages());
+        try (PDDocument mergedDoc = PDDocument.load(receivedFile)) {
+            assertEquals(5, mergedDoc.getNumberOfPages());
+        }
     }
 
     public Lecture createLectureWithLectureUnits(HttpStatus expectedStatus) throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/SubmissionExportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/SubmissionExportIntegrationTest.java
@@ -229,8 +229,7 @@ public class SubmissionExportIntegrationTest extends AbstractSpringIntegrationBa
     }
 
     private void assertZipContains(File file, Submission... submissions) {
-        try {
-            ZipFile zip = new ZipFile(file);
+        try (ZipFile zip = new ZipFile(file)) {
             for (Submission s : submissions) {
                 assertThat(zip.getEntry(getSubmissionFileName(s))).isNotNull();
             }

--- a/src/test/java/de/tum/in/www1/artemis/connector/JenkinsRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/JenkinsRequestMockProvider.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.http.client.HttpResponseException;
 import org.mockito.InjectMocks;
@@ -298,14 +299,10 @@ public class JenkinsRequestMockProvider {
         }
         else {
             File file = ResourceUtils.getFile("classpath:test-data/jenkins-response/failed-build-log.txt");
-            StringBuilder builder = new StringBuilder();
             try (var lines = Files.lines(file.toPath())) {
-                lines.forEach(line -> {
-                    builder.append(line);
-                    builder.append("\n");
-                });
+                String result = lines.collect(Collectors.joining("\n"));
+                doReturn(result).when(buildWithDetails).getConsoleOutputText();
             }
-            doReturn(builder.toString()).when(buildWithDetails).getConsoleOutputText();
         }
         return buildWithDetails;
 

--- a/src/test/java/de/tum/in/www1/artemis/connector/JenkinsRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/JenkinsRequestMockProvider.java
@@ -299,10 +299,12 @@ public class JenkinsRequestMockProvider {
         else {
             File file = ResourceUtils.getFile("classpath:test-data/jenkins-response/failed-build-log.txt");
             StringBuilder builder = new StringBuilder();
-            Files.lines(file.toPath()).forEach(line -> {
-                builder.append(line);
-                builder.append("\n");
-            });
+            try (var lines = Files.lines(file.toPath())) {
+                lines.forEach(line -> {
+                    builder.append(line);
+                    builder.append("\n");
+                });
+            }
             doReturn(builder.toString()).when(buildWithDetails).getConsoleOutputText();
         }
         return buildWithDetails;

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -1003,12 +1003,13 @@ public class ProgrammingExerciseTestService {
         String extractedZipDir = zipFile.getPath().substring(0, zipFile.getPath().length() - 4);
 
         // Check that the contents we created exist in the unzipped exported folder
-        var listOfIncludedFiles = Files.walk(Path.of(extractedZipDir)).filter(Files::isRegularFile).map(Path::getFileName).toList();
-        assertThat(listOfIncludedFiles.stream().anyMatch((filename) -> filename.toString().matches(".*-exercise.zip"))).isTrue();
-        assertThat(listOfIncludedFiles.stream().anyMatch((filename) -> filename.toString().matches(".*-solution.zip"))).isTrue();
-        assertThat(listOfIncludedFiles.stream().anyMatch((filename) -> filename.toString().matches(".*-tests.zip"))).isTrue();
-        assertThat(listOfIncludedFiles.stream().anyMatch((filename) -> filename.toString().matches(EXPORTED_EXERCISE_PROBLEM_STATEMENT_FILE_PREFIX + ".*.md"))).isTrue();
-        assertThat(listOfIncludedFiles.stream().anyMatch((filename) -> filename.toString().matches(EXPORTED_EXERCISE_DETAILS_FILE_PREFIX + ".*.json"))).isTrue();
+        try (var files = Files.walk(Path.of(extractedZipDir))) {
+            List<Path> listOfIncludedFiles = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
+            assertThat(listOfIncludedFiles).anyMatch((filename) -> filename.toString().matches(".*-exercise.zip"))
+                    .anyMatch((filename) -> filename.toString().matches(".*-solution.zip")).anyMatch((filename) -> filename.toString().matches(".*-tests.zip"))
+                    .anyMatch((filename) -> filename.toString().matches(EXPORTED_EXERCISE_PROBLEM_STATEMENT_FILE_PREFIX + ".*.md"))
+                    .anyMatch((filename) -> filename.toString().matches(EXPORTED_EXERCISE_DETAILS_FILE_PREFIX + ".*.json"));
+        }
     }
 
     // Test
@@ -1132,11 +1133,10 @@ public class ProgrammingExerciseTestService {
         String extractedArchiveDir = archivePath.toString().substring(0, archivePath.toString().length() - 4);
 
         // Check that the dummy files we created exist in the archive
-        var filenames = Files.walk(Path.of(extractedArchiveDir)).filter(Files::isRegularFile).map(Path::getFileName).collect(Collectors.toList());
-        assertThat(filenames).contains(Path.of("Template.java"));
-        assertThat(filenames).contains(Path.of("Solution.java"));
-        assertThat(filenames).contains(Path.of("Tests.java"));
-        assertThat(filenames).contains(Path.of("HelloWorld.java"));
+        try (var files = Files.walk(Path.of(extractedArchiveDir))) {
+            var filenames = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
+            assertThat(filenames).contains(Path.of("Template.java"), Path.of("Solution.java"), Path.of("Tests.java"), Path.of("HelloWorld.java"));
+        }
     }
 
     private Course createCourseWithProgrammingExerciseAndParticipationWithFiles() throws GitAPIException, IOException, InterruptedException {
@@ -1227,11 +1227,10 @@ public class ProgrammingExerciseTestService {
         String extractedArchiveDir = archive.getPath().substring(0, archive.getPath().length() - 4);
 
         // Check that the dummy files we created exist in the archive
-        var filenames = Files.walk(Path.of(extractedArchiveDir)).filter(Files::isRegularFile).map(Path::getFileName).collect(Collectors.toList());
-        assertThat(filenames).contains(Path.of("HelloWorld.java"));
-        assertThat(filenames).contains(Path.of("Template.java"));
-        assertThat(filenames).contains(Path.of("Solution.java"));
-        assertThat(filenames).contains(Path.of("Tests.java"));
+        try (var files = Files.walk(Path.of(extractedArchiveDir))) {
+            var filenames = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
+            assertThat(filenames).contains(Path.of("HelloWorld.java"), Path.of("Template.java"), Path.of("Solution.java"), Path.of("Tests.java"));
+        }
     }
 
     private ProgrammingExerciseStudentParticipation createStudentParticipationWithSubmission(ExerciseMode exerciseMode) throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/service/JenkinsAuthorizationInterceptorTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/JenkinsAuthorizationInterceptorTest.java
@@ -73,12 +73,12 @@ public class JenkinsAuthorizationInterceptorTest extends AbstractSpringIntegrati
         var responseBody = objectMapper.writeValueAsString(crumbJson);
 
         mockGetCrumb(responseBody, HttpStatus.OK);
-        jenkinsAuthorizationInterceptor.intercept(request, new byte[] {}, mock(ClientHttpRequestExecution.class));
-
-        assertThat(request.getHeaders()).containsKeys("some-header", "Jenkins-Crumb", "Cookie");
-        assertThat(request.getHeaders().get("some-header")).contains("true");
-        assertThat(request.getHeaders().get("Jenkins-Crumb")).contains("some-crumb");
-        assertThat(request.getHeaders().get("Cookie")).contains("some-session");
+        try (var response = jenkinsAuthorizationInterceptor.intercept(request, new byte[] {}, mock(ClientHttpRequestExecution.class))) {
+            assertThat(request.getHeaders()).containsKeys("some-header", "Jenkins-Crumb", "Cookie");
+            assertThat(request.getHeaders().get("some-header")).contains("true");
+            assertThat(request.getHeaders().get("Jenkins-Crumb")).contains("some-crumb");
+            assertThat(request.getHeaders().get("Cookie")).contains("some-session");
+        }
 
     }
 
@@ -89,13 +89,14 @@ public class JenkinsAuthorizationInterceptorTest extends AbstractSpringIntegrati
         var request = mockHttpRequestWithHeaders();
 
         ReflectionTestUtils.setField(jenkinsAuthorizationInterceptor, "useCrumb", false);
-        jenkinsAuthorizationInterceptor.intercept(request, new byte[] {}, mock(ClientHttpRequestExecution.class));
-        ReflectionTestUtils.setField(jenkinsAuthorizationInterceptor, "useCrumb", true);
+        try (var response = jenkinsAuthorizationInterceptor.intercept(request, new byte[] {}, mock(ClientHttpRequestExecution.class))) {
+            ReflectionTestUtils.setField(jenkinsAuthorizationInterceptor, "useCrumb", true);
 
-        assertThat(request.getHeaders()).containsKey("some-header");
-        assertThat(request.getHeaders().get("some-header")).contains("true");
+            assertThat(request.getHeaders()).containsKey("some-header");
+            assertThat(request.getHeaders().get("some-header")).contains("true");
 
-        assertThat(request.getHeaders()).doesNotContainKeys("Jenkins-Crumb", "Cookie");
+            assertThat(request.getHeaders()).doesNotContainKeys("Jenkins-Crumb", "Cookie");
+        }
     }
 
     @Test
@@ -105,12 +106,13 @@ public class JenkinsAuthorizationInterceptorTest extends AbstractSpringIntegrati
         var request = mockHttpRequestWithHeaders();
 
         mockGetCrumb("", HttpStatus.NOT_FOUND);
-        jenkinsAuthorizationInterceptor.intercept(request, new byte[] {}, mock(ClientHttpRequestExecution.class));
+        try (var response = jenkinsAuthorizationInterceptor.intercept(request, new byte[] {}, mock(ClientHttpRequestExecution.class))) {
 
-        assertThat(request.getHeaders()).containsKey("some-header");
-        assertThat(request.getHeaders().get("some-header")).contains("true");
+            assertThat(request.getHeaders()).containsKey("some-header");
+            assertThat(request.getHeaders().get("some-header")).contains("true");
 
-        assertThat(request.getHeaders()).doesNotContainKeys("Jenkins-Crumb", "Cookie");
+            assertThat(request.getHeaders()).doesNotContainKeys("Jenkins-Crumb", "Cookie");
+        }
 
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/service/compass/controller/UMLModelParserTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/compass/controller/UMLModelParserTest.java
@@ -6,12 +6,10 @@ import static de.tum.in.www1.artemis.service.compass.umlmodel.classdiagram.UMLRe
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.util.ResourceUtils;
 
 import com.google.gson.JsonObject;
 
@@ -23,6 +21,7 @@ import de.tum.in.www1.artemis.service.compass.umlmodel.activity.UMLControlFlow;
 import de.tum.in.www1.artemis.service.compass.umlmodel.classdiagram.*;
 import de.tum.in.www1.artemis.service.compass.umlmodel.classdiagram.UMLClass.UMLClassType;
 import de.tum.in.www1.artemis.service.compass.umlmodel.parsers.UMLModelParser;
+import de.tum.in.www1.artemis.util.FileUtils;
 
 public class UMLModelParserTest {
 
@@ -129,11 +128,7 @@ public class UMLModelParserTest {
     }
 
     private JsonObject loadFileFromResources(String path) throws Exception {
-        java.io.File file = ResourceUtils.getFile("classpath:" + path);
-        StringBuilder builder = new StringBuilder();
-        Files.lines(file.toPath()).forEach(builder::append);
-        assertThat(builder.toString()).as("model has been correctly read from file").isNotEqualTo("");
-        return parseString(builder.toString()).getAsJsonObject();
+        return parseString(FileUtils.loadFileFromResources(path)).getAsJsonObject();
     }
 
     private List<UMLElement> createExampleClassDiagramElements() {

--- a/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
@@ -1315,8 +1314,9 @@ public class CourseTestService {
         zipFileTestUtilService.extractZipFileRecursively(archivePath.toString());
         String extractedArchiveDir = archivePath.toString().substring(0, archivePath.toString().length() - 4);
 
-        return Files.walk(Path.of(extractedArchiveDir)).filter(Files::isRegularFile).map(Path::getFileName).filter(path -> !path.toString().endsWith(".zip"))
-                .collect(Collectors.toList());
+        try (var files = Files.walk(Path.of(extractedArchiveDir))) {
+            return files.filter(Files::isRegularFile).map(Path::getFileName).filter(path -> !path.toString().endsWith(".zip")).toList();
+        }
     }
 
     public void testExportCourse_cannotCreateTmpDir() throws Exception {
@@ -1416,7 +1416,10 @@ public class CourseTestService {
 
         // We test for the filenames of the submissions since it's the easiest way.
         // We don't test the directory structure
-        var filenames = Files.walk(Path.of(extractedArchiveDir)).filter(Files::isRegularFile).map(Path::getFileName).collect(Collectors.toList());
+        List<Path> filenames;
+        try (var files = Files.walk(Path.of(extractedArchiveDir))) {
+            filenames = files.filter(Files::isRegularFile).map(Path::getFileName).toList();
+        }
 
         var submissions = submissionRepository.findAll();
 

--- a/src/test/java/de/tum/in/www1/artemis/util/FileUtils.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/FileUtils.java
@@ -17,8 +17,11 @@ public class FileUtils {
     public static String loadFileFromResources(String path) throws IOException {
         java.io.File file = ResourceUtils.getFile("classpath:" + path);
         StringBuilder builder = new StringBuilder();
-        Files.lines(file.toPath()).forEach(builder::append);
-        assertThat(builder.toString()).as("file has been correctly read from file").isNotBlank();
-        return builder.toString();
+        try (var lines = Files.lines(file.toPath())) {
+            lines.forEach(builder::append);
+        }
+        String result = builder.toString();
+        assertThat(result).as("file has been correctly read from file").isNotBlank();
+        return result;
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/util/FileUtils.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/FileUtils.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.stream.Collectors;
 
 import org.springframework.util.ResourceUtils;
 
@@ -16,12 +17,10 @@ public class FileUtils {
      */
     public static String loadFileFromResources(String path) throws IOException {
         java.io.File file = ResourceUtils.getFile("classpath:" + path);
-        StringBuilder builder = new StringBuilder();
         try (var lines = Files.lines(file.toPath())) {
-            lines.forEach(builder::append);
+            String result = lines.collect(Collectors.joining());
+            assertThat(result).as("file has been correctly read from file").isNotBlank();
+            return result;
         }
-        String result = builder.toString();
-        assertThat(result).as("file has been correctly read from file").isNotBlank();
-        return result;
     }
 }


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
This is basically a followup of #4837. I looked for more places where try with resources should be applied and changed it accordingly. 

### Description
File operations like Files.walk() are now inside a try with resources block.

### Steps for Testing
Code Review should be enough, if you want you can test that the changed services still work.

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
