### PR TITLE
`General`: Align the style of the included in overall score choice

### DIFF
--- a/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.html
+++ b/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
     <div
-        class="btn btn-default"
+        class="btn"
         [ngClass]="{
             'btn-primary': includedInOverallScore === IncludedInOverallScore.INCLUDED_COMPLETELY,
             'btn-default': includedInOverallScore !== IncludedInOverallScore.INCLUDED_COMPLETELY

--- a/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.html
+++ b/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.html
@@ -1,29 +1,32 @@
-<div class="btn-group" name="includeInOverallScorePicker">
+<div class="btn-group">
     <div
         class="btn"
         [ngClass]="{
             'btn-primary': includedInOverallScore === IncludedInOverallScore.INCLUDED_COMPLETELY,
-            'btn-default': includedInOverallScore != IncludedInOverallScore.INCLUDED_COMPLETELY
+            'btn-default': includedInOverallScore !== IncludedInOverallScore.INCLUDED_COMPLETELY
         }"
-        (click)="setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY)"
+        (click)="change(IncludedInOverallScore.INCLUDED_COMPLETELY)"
     >
         {{ 'artemisApp.exercise.yes' | artemisTranslate }}
     </div>
     <div
-        class="btn"
+        class="btn btn-default"
         [ngClass]="{
             'btn-primary': includedInOverallScore === IncludedInOverallScore.INCLUDED_AS_BONUS,
-            'btn-default': includedInOverallScore != IncludedInOverallScore.INCLUDED_AS_BONUS
+            'btn-default': includedInOverallScore !== IncludedInOverallScore.INCLUDED_AS_BONUS
         }"
-        (click)="setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_AS_BONUS)"
+        (click)="change(IncludedInOverallScore.INCLUDED_AS_BONUS)"
     >
         {{ 'artemisApp.exercise.bonus' | artemisTranslate }}
     </div>
     <div
-        class="btn"
         *ngIf="allowNotIncluded"
-        [ngClass]="{ 'btn-primary': includedInOverallScore === IncludedInOverallScore.NOT_INCLUDED, 'btn-default': includedInOverallScore != IncludedInOverallScore.NOT_INCLUDED }"
-        (click)="setIncludedInOverallScore(IncludedInOverallScore.NOT_INCLUDED)"
+        class="btn"
+        [ngClass]="{
+            'btn-primary': includedInOverallScore === IncludedInOverallScore.NOT_INCLUDED,
+            'btn-default': includedInOverallScore !== IncludedInOverallScore.NOT_INCLUDED
+        }"
+        (click)="change(IncludedInOverallScore.NOT_INCLUDED)"
     >
         {{ 'artemisApp.exercise.no' | artemisTranslate }}
     </div>

--- a/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.html
+++ b/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.html
@@ -1,6 +1,6 @@
 <div class="btn-group">
     <div
-        class="btn"
+        class="btn btn-default"
         [ngClass]="{
             'btn-primary': includedInOverallScore === IncludedInOverallScore.INCLUDED_COMPLETELY,
             'btn-default': includedInOverallScore !== IncludedInOverallScore.INCLUDED_COMPLETELY
@@ -21,7 +21,7 @@
     </div>
     <div
         *ngIf="allowNotIncluded"
-        class="btn"
+        class="btn btn-default"
         [ngClass]="{
             'btn-primary': includedInOverallScore === IncludedInOverallScore.NOT_INCLUDED,
             'btn-default': includedInOverallScore !== IncludedInOverallScore.NOT_INCLUDED

--- a/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.html
+++ b/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.html
@@ -1,11 +1,30 @@
-<div class="btn-group btn-group-toggle" ngbRadioGroup name="includeInOverallScorePicker" [ngModel]="includedInOverallScore" (ngModelChange)="change($event)">
-    <label ngbButtonLabel class="btn-primary">
-        <input ngbButton type="radio" [value]="IncludedInOverallScore.INCLUDED_COMPLETELY" /> {{ 'artemisApp.exercise.yes' | artemisTranslate }}
-    </label>
-    <label ngbButtonLabel class="btn-primary">
-        <input ngbButton type="radio" [value]="IncludedInOverallScore.INCLUDED_AS_BONUS" />{{ 'artemisApp.exercise.bonus' | artemisTranslate }}
-    </label>
-    <label ngbButtonLabel class="btn-primary" *ngIf="allowNotIncluded">
-        <input ngbButton type="radio" [value]="IncludedInOverallScore.NOT_INCLUDED" /> {{ 'artemisApp.exercise.no' | artemisTranslate }}
-    </label>
+<div class="btn-group" name="includeInOverallScorePicker">
+    <div
+        class="btn"
+        [ngClass]="{
+            'btn-primary': includedInOverallScore === IncludedInOverallScore.INCLUDED_COMPLETELY,
+            'btn-default': includedInOverallScore != IncludedInOverallScore.INCLUDED_COMPLETELY
+        }"
+        (click)="setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_COMPLETELY)"
+    >
+        {{ 'artemisApp.exercise.yes' | artemisTranslate }}
+    </div>
+    <div
+        class="btn"
+        [ngClass]="{
+            'btn-primary': includedInOverallScore === IncludedInOverallScore.INCLUDED_AS_BONUS,
+            'btn-default': includedInOverallScore != IncludedInOverallScore.INCLUDED_AS_BONUS
+        }"
+        (click)="setIncludedInOverallScore(IncludedInOverallScore.INCLUDED_AS_BONUS)"
+    >
+        {{ 'artemisApp.exercise.bonus' | artemisTranslate }}
+    </div>
+    <div
+        class="btn"
+        *ngIf="allowNotIncluded"
+        [ngClass]="{ 'btn-primary': includedInOverallScore === IncludedInOverallScore.NOT_INCLUDED, 'btn-default': includedInOverallScore != IncludedInOverallScore.NOT_INCLUDED }"
+        (click)="setIncludedInOverallScore(IncludedInOverallScore.NOT_INCLUDED)"
+    >
+        {{ 'artemisApp.exercise.no' | artemisTranslate }}
+    </div>
 </div>

--- a/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.ts
+++ b/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.ts
@@ -17,7 +17,11 @@ export class IncludedInOverallScorePickerComponent {
     @Output()
     includedInOverallScoreChange = new EventEmitter();
 
-    change(newValue: IncludedInOverallScore) {
+    /**
+     * Sets the Enum for the IncludedInOverallScore and emits the changes to the parent component to notice changes
+     * @param newValue chosen type of IncludedInOverallScore
+     */
+    setIncludedInOverallScore(newValue?: IncludedInOverallScore) {
         this.includedInOverallScore = newValue;
         this.includedInOverallScoreChange.emit(newValue);
     }

--- a/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.ts
+++ b/src/main/webapp/app/exercises/shared/included-in-overall-score-picker/included-in-overall-score-picker.component.ts
@@ -17,11 +17,7 @@ export class IncludedInOverallScorePickerComponent {
     @Output()
     includedInOverallScoreChange = new EventEmitter();
 
-    /**
-     * Sets the Enum for the IncludedInOverallScore and emits the changes to the parent component to notice changes
-     * @param newValue chosen type of IncludedInOverallScore
-     */
-    setIncludedInOverallScore(newValue?: IncludedInOverallScore) {
+    change(newValue: IncludedInOverallScore) {
         this.includedInOverallScore = newValue;
         this.includedInOverallScoreChange.emit(newValue);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Currently, the following color scheme is used for the `included-in-overall-score-picker` component: 
![image](https://user-images.githubusercontent.com/94070506/159716431-fcbd18af-0db6-4310-8d16-507bc1c6329c.png) if not selected and ![image](https://user-images.githubusercontent.com/94070506/159716308-892c50fa-778e-4779-b91d-2f7f8450b575.png) if selected.
The other pickers (Difficulty / Team), in contrast, use the following color scheme: 
![image](https://user-images.githubusercontent.com/94070506/159716147-6d8675f2-109a-40df-93f3-b5a1f19ff666.png) if not selected and ![image](https://user-images.githubusercontent.com/94070506/159716074-d3efa49c-3b16-4b09-b342-774d14873b37.png) if selected. 
(More details in attached screenshots)
This may cause some confusion as to which mode is actually selected. (@canberkanar thanks for pointing out the issue)
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
This PR aligns the `included-in-overall-score-picker` component with the color scheme of the other components
The radio button Implementation was changed to a button group, comparable to the 'difficulty-picker'. The selected option is displayed as a primary (blue) button, the other options are displayed as a default (white) button.
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor (or 1 Editor)

1. Log in to Artemis
2. Navigate to Course Administration -> Exercise
3. Try to create a new Exercise. 
4. Make sure that the buttons are displayed as shown in the screenshot below (dark blue if selected, white if not selected)
5. Check, if the variable `IncludedInOverallScore` is set correctly when creating an exercise 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
**Current situation:**
![image](https://user-images.githubusercontent.com/94070506/159715609-d3e07018-36b9-4e2b-b257-cad4976f5039.png)
**Enhancement with this PR:**
![image](https://user-images.githubusercontent.com/94070506/159715449-28724172-3aaf-45cd-95e0-7729cf53ac89.png)
![image](https://user-images.githubusercontent.com/94070506/159746120-1c30c98d-41aa-4c7a-95f1-559eafbe3bc0.png)

