### PR TITLE
`Assessment`: Fix an issue in the student grade key view

### DIFF
--- a/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
+++ b/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
@@ -38,6 +38,7 @@ export class GradingKeyOverviewComponent implements OnInit {
 
     ngOnInit(): void {
         this.route.params.subscribe((params) => {
+            console.log(params);
             this.courseId = Number(params['courseId']);
             if (params['examId']) {
                 this.examId = Number(params['examId']);

--- a/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
+++ b/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
@@ -63,7 +63,7 @@ export class GradingKeyOverviewComponent implements OnInit {
                 }
             });
         });
-        this.route.queryParams.subscribe((queryParams) => {
+        this.route.parent?.parent?.queryParams.subscribe((queryParams) => {
             this.studentGrade = queryParams['grade'];
         });
     }

--- a/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
+++ b/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
@@ -37,8 +37,7 @@ export class GradingKeyOverviewComponent implements OnInit {
     isBonus = false;
 
     ngOnInit(): void {
-        this.route.params.subscribe((params) => {
-            console.log(params);
+        this.route.parent?.parent?.params.subscribe((params) => {
             this.courseId = Number(params['courseId']);
             if (params['examId']) {
                 this.examId = Number(params['examId']);

--- a/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
+++ b/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
@@ -37,6 +37,7 @@ export class GradingKeyOverviewComponent implements OnInit {
     isBonus = false;
 
     ngOnInit(): void {
+        // Note: due to lazy loading and router outlet, we use parent 2x here
         this.route.parent?.parent?.params.subscribe((params) => {
             this.courseId = Number(params['courseId']);
             if (params['examId']) {

--- a/src/main/webapp/app/overview/course-statistics/course-statistics.module.ts
+++ b/src/main/webapp/app/overview/course-statistics/course-statistics.module.ts
@@ -9,6 +9,7 @@ import { CourseLearningGoalsComponent } from 'app/overview/course-learning-goals
 import { ArtemisLearningGoalsModule } from 'app/course/learning-goals/learning-goal.module';
 import { ArtemisExerciseScoresChartModule } from 'app/overview/visualizations/exercise-scores-chart.module';
 import { NgxChartsModule } from '@swimlane/ngx-charts';
+import { GradingKeyOverviewComponent } from 'app/grading-system/grading-key-overview/grading-key-overview.component';
 
 const routes: Routes = [
     {
@@ -17,6 +18,15 @@ const routes: Routes = [
         data: {
             authorities: [Authority.USER],
             pageTitle: 'overview.statistics',
+        },
+        canActivate: [UserRouteAccessService],
+    },
+    {
+        path: 'grading-key',
+        component: GradingKeyOverviewComponent,
+        data: {
+            authorities: [Authority.USER],
+            pageTitle: 'artemisApp.gradingSystem.title',
         },
         canActivate: [UserRouteAccessService],
     },

--- a/src/main/webapp/app/overview/courses-routing.module.ts
+++ b/src/main/webapp/app/overview/courses-routing.module.ts
@@ -6,7 +6,6 @@ import { CourseLecturesComponent } from 'app/overview/course-lectures/course-lec
 import { CourseExamsComponent } from 'app/overview/course-exams/course-exams.component';
 import { NgModule } from '@angular/core';
 import { Authority } from 'app/shared/constants/authority.constants';
-import { GradingKeyOverviewComponent } from 'app/grading-system/grading-key-overview/grading-key-overview.component';
 import { CourseExercisesComponent } from 'app/overview/course-exercises/course-exercises.component';
 
 const routes: Routes = [

--- a/src/main/webapp/app/overview/courses-routing.module.ts
+++ b/src/main/webapp/app/overview/courses-routing.module.ts
@@ -75,15 +75,6 @@ const routes: Routes = [
         ],
     },
     {
-        path: 'courses/:courseId/statistics/grading-key',
-        component: GradingKeyOverviewComponent,
-        data: {
-            authorities: [Authority.USER],
-            pageTitle: 'artemisApp.gradingSystem.title',
-        },
-        canActivate: [UserRouteAccessService],
-    },
-    {
         path: 'courses/:courseId/plagiarism',
         loadChildren: () => import('app/course/plagiarism-cases/plagiarism-cases.module').then((m) => m.PlagiarismCasesModule),
     },

--- a/src/test/javascript/spec/component/grading-system/grading-key-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/grading-key-overview.component.spec.ts
@@ -47,7 +47,7 @@ describe('GradeKeyOverviewComponent', () => {
             imports: [MockModule(NgbModule)],
             declarations: [GradingKeyOverviewComponent, MockComponent(FaIconComponent), MockPipe(ArtemisTranslatePipe), MockDirective(TranslateDirective)],
             providers: [
-                { provide: ActivatedRoute, useValue: { params: of({ courseId: 345, examId: 123 }), queryParams: of({ grade: '2.0' }) } },
+                { provide: ActivatedRoute, useValue: { parent: { parent: { params: of({ courseId: 345, examId: 123 }), queryParams: of({ grade: '2.0' }) } } } },
                 { provide: Router, useClass: MockRouter },
                 MockProvider(GradingSystemService),
                 MockProvider(ArtemisNavigationUtilService),


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
Sentry reports a missing course object in the student grading key view (see [ARTEMIS-MEF](https://sentry.ase.in.tum.de/organizations/artemis/issues/21376/events/92305ecd89c4483386e7a332f20c1a6e/?project=2)).

### Description
The course object is retrieved by calling `courseCalculationService.getCourse()`. This method works by having a local array of courses which is initialized in the `CoursesComponent`. But because the initial routing had the grading key page as a sperate route, this component never gets initialized.

This PR moves the /grading-key route to be a child of the CourseStatisticsModule. Now these parent modules are initialized properly. 

This requires the call to `parent?.parent?` when receiving the request params. Thanks to @bassner for helping me solve this problem.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Course with a grading key active
- 1 Student 

1. Go to the course statistics -> view grading key.
2. Reload the page (to ensure the components get initialized again)
3. Make sure there are no errors present in the console.
4. Make sure the `Interval (Points)` column is shown next to the percentages and the points are calculated correctly based on the max points of the course.

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2