### PR TITLE
`Assessment`: Fix course scores export if user information is not set

### DIFF
--- a/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
@@ -67,10 +67,10 @@ export class CourseScoresCsvRowBuilder {
      * @param student A student of which the data should be saved.
      */
     setUserInformation(student: CourseScoresStudentStatistics) {
-        this.set(NAME_KEY, student.user.name!.trim());
-        this.set(USERNAME_KEY, student.user.login!.trim());
-        this.set(EMAIL_KEY, student.user.email!.trim());
-        this.set(REGISTRATION_NUMBER_KEY, student.user.visibleRegistrationNumber?.trim() ?? '');
+        this.set(NAME_KEY, student.user.name?.trim());
+        this.set(USERNAME_KEY, student.user.login?.trim());
+        this.set(EMAIL_KEY, student.user.email?.trim());
+        this.set(REGISTRATION_NUMBER_KEY, student.user.visibleRegistrationNumber?.trim());
     }
 
     /**

--- a/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
@@ -50,9 +50,18 @@ describe('The CourseScoresCsvRowBuilder', () => {
         expect(row[USERNAME_KEY]).toBe('login');
         expect(row[EMAIL_KEY]).toBe('mail@example.com');
         expect(row[REGISTRATION_NUMBER_KEY]).toBe('123456789');
+    });
 
-        user.visibleRegistrationNumber = undefined;
+    it('should allow for empty student information', () => {
+        const user = new User();
+        const student = new CourseScoresStudentStatistics(user);
+
         csvRow.setUserInformation(student);
+
+        const row = csvRow.build();
+        expect(row[NAME_KEY]).toBe('');
+        expect(row[USERNAME_KEY]).toBe('');
+        expect(row[EMAIL_KEY]).toBe('');
         expect(row[REGISTRATION_NUMBER_KEY]).toBe('');
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
https://github.com/ls1intum/Artemis/issues/4815#issuecomment-1078875569
Closes #4815

### Description
Allow for user information that is not required to be empty. Allows the login name to be empty for consistency as well, even if that shouldn’t really happen.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Course with student participations

1. Edit the user information of a student so that the name or email is missing.
2. Go to Course -> Scores and click on Export Results. The results should be exported with empty fields in the CSV where the user information should be. No error should be shown.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
Optional, fix should be clear from a code review.
- [ ] Test 1
- [ ] Test 2

### Test Coverage
All new code is tested by adding a unit test specifically for this case.

### Screenshots
n/a
