### PR TITLE
`General`: Fix edit selected buttons still showing after deleting an exercise

### DIFF
--- a/src/main/webapp/app/course/manage/detail/course-detail-line-chart.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail-line-chart.component.html
@@ -35,7 +35,9 @@
                     <b class="tooltip-header">{{ findAbsoluteValue(model) }} ({{ model.value }}%)</b>
                 </ng-template>
                 <ng-template #seriesTooltipTemplate let-model="model">
-                    <span> {{ model[0].name }}: {{ findAbsoluteValue(model[0]) }} </span>
+                    <ng-container *ngIf="model.length">
+                        <span> {{ model[0].name }}: {{ findAbsoluteValue(model[0]) }} </span>
+                    </ng-container>
                 </ng-template>
             </ngx-charts-line-chart>
         </div>

--- a/src/main/webapp/app/course/manage/overview/course-management-overview-statistics.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-overview-statistics.component.html
@@ -25,7 +25,9 @@
             <span>{{ model.name }}</span>
         </ng-template>
         <ng-template #seriesTooltipTemplate let-model="model">
-            <span> {{ model[0].name }}: {{ model[0].absoluteValue }} </span>
+            <ng-container *ngIf="model.length">
+                <span> {{ model[0].name }}: {{ model[0].absoluteValue }} </span>
+            </ng-container>
         </ng-template>
     </ngx-charts-line-chart>
     <div *ngIf="loading" class="overview-spinner">

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
@@ -2,7 +2,9 @@
     <h4 class="d-flex mb-3 flex-wrap justify-content-end">
         <span class="mb-1 me-auto">
             <span *ngIf="course && !showHeading">{{ course.title }} - </span>
-            <span *ngIf="fileUploadExercises && showHeading && !filter.isEmpty()">{{ getAmountOfExercisesString(filteredFileUploadExercises) }} / </span>
+            <span *ngIf="fileUploadExercises && showHeading && !filter.isEmpty() && fileUploadExercises.length"
+                >{{ getAmountOfExercisesString(filteredFileUploadExercises) }} /
+            </span>
             <span *ngIf="fileUploadExercises && showHeading">{{ getAmountOfExercisesString(fileUploadExercises) }} </span>
             <span jhiTranslate="artemisApp.fileUploadExercise.home.title">File Upload Exercises</span>
         </span>

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
@@ -2,8 +2,8 @@
     <h4 class="d-flex mb-3 flex-wrap justify-content-end">
         <span class="mb-1 me-auto">
             <span *ngIf="course && !showHeading">{{ course.title }} - </span>
-            <span *ngIf="fileUploadExercises && showHeading && !filter.isEmpty() && fileUploadExercises.length"
-                >{{ getAmountOfExercisesString(filteredFileUploadExercises) }} /
+            <span *ngIf="fileUploadExercises && showHeading && !filter.isEmpty() && fileUploadExercises.length">
+                {{ getAmountOfExercisesString(filteredFileUploadExercises) }} /
             </span>
             <span *ngIf="fileUploadExercises && showHeading">{{ getAmountOfExercisesString(fileUploadExercises) }} </span>
             <span jhiTranslate="artemisApp.fileUploadExercise.home.title">File Upload Exercises</span>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
@@ -2,7 +2,7 @@
     <h4 class="d-flex mb-3 flex-wrap justify-content-end">
         <span class="mb-1 me-auto">
             <span *ngIf="course && !showHeading">{{ course.title }} - </span>
-            <span *ngIf="modelingExercises && showHeading && !filter.isEmpty()">{{ getAmountOfExercisesString(filteredModelingExercises) }} / </span>
+            <span *ngIf="modelingExercises && showHeading && !filter.isEmpty() && modelingExercises.length">{{ getAmountOfExercisesString(filteredModelingExercises) }} / </span>
             <span *ngIf="modelingExercises && showHeading">{{ getAmountOfExercisesString(modelingExercises) }} </span>
             <span jhiTranslate="artemisApp.modelingExercise.home.title">Modeling Exercises</span>
         </span>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -2,8 +2,8 @@
     <h4 class="d-flex mb-3 flex-wrap justify-content-end">
         <span class="mb-1 me-auto">
             <span *ngIf="course && !showHeading"> {{ course.title }} - </span>
-            <span *ngIf="programmingExercises && showHeading && !filter.isEmpty() && programmingExercises.length"
-                >{{ getAmountOfExercisesString(filteredProgrammingExercises) }} /
+            <span *ngIf="programmingExercises && showHeading && !filter.isEmpty() && programmingExercises.length">
+                {{ getAmountOfExercisesString(filteredProgrammingExercises) }} /
             </span>
             <span *ngIf="programmingExercises && showHeading">{{ getAmountOfExercisesString(programmingExercises) }} </span>
             <span jhiTranslate="artemisApp.programmingExercise.home.title">Programming Exercises</span>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -2,7 +2,9 @@
     <h4 class="d-flex mb-3 flex-wrap justify-content-end">
         <span class="mb-1 me-auto">
             <span *ngIf="course && !showHeading"> {{ course.title }} - </span>
-            <span *ngIf="programmingExercises && showHeading && !filter.isEmpty()">{{ getAmountOfExercisesString(filteredProgrammingExercises) }} / </span>
+            <span *ngIf="programmingExercises && showHeading && !filter.isEmpty() && programmingExercises.length"
+                >{{ getAmountOfExercisesString(filteredProgrammingExercises) }} /
+            </span>
             <span *ngIf="programmingExercises && showHeading">{{ getAmountOfExercisesString(programmingExercises) }} </span>
             <span jhiTranslate="artemisApp.programmingExercise.home.title">Programming Exercises</span>
         </span>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.ts
@@ -33,9 +33,9 @@ import { CourseExerciseService } from 'app/exercises/shared/course-exercises/cou
 export class ProgrammingExerciseComponent extends ExerciseComponent implements OnInit, OnDestroy {
     @Input() programmingExercises: ProgrammingExercise[];
     filteredProgrammingExercises: ProgrammingExercise[];
+    selectedProgrammingExercises: ProgrammingExercise[];
     readonly ActionType = ActionType;
     FeatureToggle = FeatureToggle;
-    selectedProgrammingExercises: ProgrammingExercise[];
     solutionParticipationType = ProgrammingExerciseParticipationType.SOLUTION;
     templateParticipationType = ProgrammingExerciseParticipationType.TEMPLATE;
     allChecked = false;
@@ -112,6 +112,7 @@ export class ProgrammingExerciseComponent extends ExerciseComponent implements O
                             );
                         }
                     }
+                    this.selectedProgrammingExercises = [];
                 });
                 this.applyFilter();
                 this.emitExerciseCount(this.programmingExercises.length);

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
@@ -2,7 +2,7 @@
     <h4 class="d-flex mb-3 flex-wrap justify-content-end">
         <span class="mb-1 me-auto">
             <span *ngIf="course && !showHeading">{{ course.title }} - </span>
-            <span *ngIf="quizExercises && showHeading && !filter.isEmpty()">{{ getAmountOfExercisesString(filteredQuizExercises) }} / </span>
+            <span *ngIf="quizExercises && showHeading && !filter.isEmpty() && quizExercises.length">{{ getAmountOfExercisesString(filteredQuizExercises) }} / </span>
             <span *ngIf="quizExercises && showHeading">{{ getAmountOfExercisesString(quizExercises) }} </span>
             <span jhiTranslate="artemisApp.quizExercise.home.title">Quiz Exercises</span>
         </span>

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.html
@@ -2,7 +2,7 @@
     <h4 class="d-flex mb-3 flex-wrap justify-content-end">
         <span class="mb-1 me-auto">
             <span *ngIf="course && !showHeading">{{ course.title }} - </span>
-            <span *ngIf="textExercises && showHeading && !filter.isEmpty()">{{ getAmountOfExercisesString(filteredTextExercises) }} / </span>
+            <span *ngIf="textExercises && showHeading && !filter.isEmpty() && textExercises.length">{{ getAmountOfExercisesString(filteredTextExercises) }} / </span>
             <span *ngIf="textExercises && showHeading">{{ getAmountOfExercisesString(textExercises) }} </span>
             <span jhiTranslate="artemisApp.textExercise.home.title">Text Exercises</span>
         </span>


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
This PR fixes 3 smaller issues. I decided to put them together into one PR to not create PR-spam.

#### 1) Fix additional buttons appearing after deleting a programming exercise. 
Closes #4547 (see the issue for more)

#### 2) Fix "No / No exercises" text in the advanced search when no exercises exist
The advanced search shows e.g "3 / 20 exercises" when using the filter function. But if the course has no exercise of a specific type, the header changes to "No / No exercises".

#### 3) Fix a type error in charts
Sentry issuses: [ARTEMIS-M2E](https://sentry.ase.in.tum.de/organizations/artemis/issues/20991/events/402ac2dbfb864ba78d42f2cdd38d84dc/?project=2), [ARTEMIS-KTA](https://sentry.ase.in.tum.de/organizations/artemis/issues/20731/events/0d5112df1ae34d2695b0bc4887735fd6/?project=2).

### Description
#### 1)
I now reset the `selectedExercises` array after deleting an exercise. This means that an existing selection may be reset after deleting exercises. But his makes the whole process more fault resistant since there could also be other changes loaded from the server during this reload.

#### 2)
If there are no exercises of a specific type, now only "No exercises" is displayed when using the advanced search, just like when just using the dashboard without the search.

3) Before accessing `model[0]` we check the length of the array and make sure that this element is available. 

### Steps for Testing
#### 1)
1. Open the list of exercises
2. Select two existing programming exercises
3. Delete one of the selected programming exercises
4. Make sure that the selection is reset and no more selection-related buttons ("e.g. edit selected") are shown.

#### 2)
1. Open the list of exercises. Make sure that the used course has at least one exercise type with no exercises of this type.
2. Open the advanced search and filter for only exercises of this type
3. Make sure that "no exercises" is shown as the header

#### 3)

Code review should be enough. 

### Review Progress

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Screenshots
#### 2)
old:
![grafik](https://user-images.githubusercontent.com/26540346/160295502-a53e14ed-a004-40d9-8422-c0d4cfff6a02.png)

new:
![grafik](https://user-images.githubusercontent.com/26540346/160295413-349bea29-fb76-439d-b771-dda8cfc330c7.png)

