### PR TITLE
`Development`: Fix flaky client test in external submission service

### DIFF
--- a/src/test/javascript/spec/service/external-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/external-submission.service.spec.ts
@@ -47,7 +47,8 @@ describe('External Submission Service', () => {
         const result = service.generateInitialManualResult();
         expect(result).toBeInstanceOf(Result);
         expect(result.completionDate).not.toBe(undefined);
-        expect(Math.abs(dayjs().diff(result.completionDate, 'ms'))).toBeLessThan(10);
+        // a maximum delay of 1s between creation and assertion is unlikely but accurate enough for an assertion of ‘approximately now’ here
+        expect(dayjs().diff(result.completionDate, 'ms')).toBeLessThan(1000);
         expect(result.successful).toBe(true);
         expect(result.score).toBe(100);
         expect(result.rated).toBe(true);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
The asserted delay of less than 10ms was sometimes too short when running the test in GitHub Actions, thereby causing the test to fail randomly. The highest observed actual delay was about 50ms.

### Description
The assertion only needs to test for ‘approximately now’. Therefore, using a higher delay is fine and also fixes the flakiness of the test.

### Steps for Testing
n/a

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
unchanged

### Screenshots
n/a
