### PR TITLE
`Programming exercises`: Fix folders with names including dots missing in the online editor file browser

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
@@ -508,11 +508,13 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
             rxMap((files) =>
                 fromPairs(
                     toPairs(files)
+                        // Remove hidden files
+                        .filter(([fileName]) => !fileName.startsWith('.'))
                         // Remove binary files as they can't be displayed in an editor
-                        .filter(([filename]) => {
-                            const fileSplit = filename.split('.');
-                            // Either the file has no ending or the file ending is allowed
-                            return fileSplit.length === 1 || supportedTextFileExtensions.includes(fileSplit.pop()!);
+                        .filter(([fileName, fileType]) => {
+                            const fileSplit = fileName.split('.');
+                            // Keep the file if it is either a folder, the file has no ending, or the file ending is allowed
+                            return fileType === FileType.FOLDER || fileSplit.length === 1 || supportedTextFileExtensions.includes(fileSplit.pop()!);
                         })
                         // Filter Readme file that was historically in the student's assignment repo
                         .filter(([value]) => !value.includes('README.md'))

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/file-browser/code-editor-file-browser.component.ts
@@ -415,7 +415,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
         if (Object.keys(this.repositoryFiles).includes(newFilePath)) {
             this.onError.emit('fileExists');
             return;
-        } else if (newFileName.split('.').length > 1 && !supportedTextFileExtensions.includes(newFileName.split('.').pop()!)) {
+        } else if (!CodeEditorFileBrowserComponent.shouldDisplayFile(newFileName, fileType)) {
             this.onError.emit('unsupportedFile');
             return;
         }
@@ -453,7 +453,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
         }
         const [folderPath, fileType] = this.creatingFile;
 
-        if (fileName.split('.').length > 1 && !supportedTextFileExtensions.includes(fileName.split('.').pop()!)) {
+        if (!CodeEditorFileBrowserComponent.shouldDisplayFile(fileName, fileType)) {
             this.onError.emit('unsupportedFile');
             return;
         } else if (Object.keys(this.repositoryFiles).includes(folderPath ? [folderPath, fileName].join('/') : fileName)) {
@@ -508,14 +508,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
             rxMap((files) =>
                 fromPairs(
                     toPairs(files)
-                        // Remove hidden files
-                        .filter(([fileName]) => !fileName.startsWith('.'))
-                        // Remove binary files as they can't be displayed in an editor
-                        .filter(([fileName, fileType]) => {
-                            const fileSplit = fileName.split('.');
-                            // Keep the file if it is either a folder, the file has no ending, or the file ending is allowed
-                            return fileType === FileType.FOLDER || fileSplit.length === 1 || supportedTextFileExtensions.includes(fileSplit.pop()!);
-                        })
+                        .filter(([fileName, fileType]) => CodeEditorFileBrowserComponent.shouldDisplayFile(fileName, fileType))
                         // Filter Readme file that was historically in the student's assignment repo
                         .filter(([value]) => !value.includes('README.md'))
                         // Filter root folder
@@ -531,12 +524,7 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
             rxMap((files) =>
                 fromPairs(
                     toPairs(files)
-                        // Remove binary files as they can't be displayed in an editor
-                        .filter(([filename]) => {
-                            const fileSplit = filename.split('.');
-                            // Either the file has no ending or the file ending is allowed
-                            return fileSplit.length === 1 || supportedTextFileExtensions.includes(fileSplit.pop()!);
-                        })
+                        .filter(([filename]) => CodeEditorFileBrowserComponent.shouldDisplayFile(filename, FileType.FILE))
                         // Filter Readme file that was historically in the student's assignment repo
                         .filter(([value]) => !value.includes('README.md')),
                 ),
@@ -570,5 +558,36 @@ export class CodeEditorFileBrowserComponent implements OnInit, OnChanges, AfterV
             modalRef.componentInstance.fileNameToDelete = filePath;
             modalRef.componentInstance.fileType = fileType;
         }
+    }
+
+    /**
+     * Determines if the given file or folder should be displayed.
+     *
+     * Folders are only hidden if their name starts with a `.`, files are additionally hidden
+     * based on their file extension (see {@link shouldDisplayFileBasedOnExtension}).
+     * @param fileName The name of the file or folder.
+     * @param fileType The type of the file or folder.
+     * @private
+     */
+    private static shouldDisplayFile(fileName: string, fileType: FileType): boolean {
+        if (fileName.startsWith('.')) {
+            return false;
+        } else if (fileType === FileType.FOLDER) {
+            return true;
+        } else {
+            return CodeEditorFileBrowserComponent.shouldDisplayFileBasedOnExtension(fileName);
+        }
+    }
+
+    /**
+     * Determines if the file should be shown based on its file extension.
+     *
+     * E.g., text files like `SomeClass.java` are shown, binary files like `document.pdf` are not.
+     * @param fileName
+     * @private
+     */
+    private static shouldDisplayFileBasedOnExtension(fileName: string): boolean {
+        const fileSplit = fileName.split('.');
+        return fileSplit.length === 1 || supportedTextFileExtensions.includes(fileSplit.pop()!);
     }
 }

--- a/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { MockComponent } from 'ng-mocks';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';
@@ -27,7 +27,7 @@ describe('CodeEditorFileBrowserComponent', () => {
     let codeEditorRepositoryFileService: CodeEditorRepositoryFileService;
     let codeEditorRepositoryService: CodeEditorRepositoryService;
     let conflictService: CodeEditorConflictStateService;
-    let getRepositoryContenStub: jest.SpyInstance;
+    let getRepositoryContentStub: jest.SpyInstance;
     let getStatusStub: jest.SpyInstance;
     let createFileStub: jest.SpyInstance;
     let renameFileStub: jest.SpyInstance;
@@ -62,7 +62,7 @@ describe('CodeEditorFileBrowserComponent', () => {
                 codeEditorRepositoryService = TestBed.inject(CodeEditorRepositoryService);
                 conflictService = TestBed.inject(CodeEditorConflictStateService);
                 getStatusStub = jest.spyOn(codeEditorRepositoryService, 'getStatus');
-                getRepositoryContenStub = jest.spyOn(codeEditorRepositoryFileService, 'getRepositoryContent');
+                getRepositoryContentStub = jest.spyOn(codeEditorRepositoryFileService, 'getRepositoryContent');
                 createFileStub = jest.spyOn(codeEditorRepositoryFileService, 'createFile').mockReturnValue(of(undefined));
                 renameFileStub = jest.spyOn(codeEditorRepositoryFileService, 'renameFile').mockReturnValue(of(undefined));
             });
@@ -75,7 +75,7 @@ describe('CodeEditorFileBrowserComponent', () => {
     it('should create no treeviewItems if getRepositoryContent returns an empty result', () => {
         const repositoryContent: { [fileName: string]: string } = {};
         const expectedFileTreeItems: TreeviewItem<string>[] = [];
-        getRepositoryContenStub.mockReturnValue(of(repositoryContent));
+        getRepositoryContentStub.mockReturnValue(of(repositoryContent));
         getStatusStub.mockReturnValue(of({ repositoryStatus: CommitState.CLEAN }));
         comp.commitState = CommitState.UNDEFINED;
 
@@ -93,7 +93,7 @@ describe('CodeEditorFileBrowserComponent', () => {
 
     it('should create treeviewItems if getRepositoryContent returns files', () => {
         const repositoryContent: { [fileName: string]: string } = { file: 'FILE', folder: 'FOLDER' };
-        getRepositoryContenStub.mockReturnValue(of(repositoryContent));
+        getRepositoryContentStub.mockReturnValue(of(repositoryContent));
         getStatusStub.mockReturnValue(of({ repositoryStatus: CommitState.CLEAN }));
         comp.commitState = CommitState.UNDEFINED;
 
@@ -194,7 +194,7 @@ describe('CodeEditorFileBrowserComponent', () => {
             'allowedFile.java': FileType.FILE,
         };
         const forbiddenFiles = {
-            'danger.bin': FileType.FOLDER,
+            'danger.bin': FileType.FILE,
             'README.md': FileType.FILE,
             '.hidden': FileType.FILE,
             '.': FileType.FOLDER,
@@ -212,7 +212,7 @@ describe('CodeEditorFileBrowserComponent', () => {
                 value: 'file1',
             } as any),
         ].map((x) => x.toString());
-        getRepositoryContenStub.mockReturnValue(of(repositoryContent));
+        getRepositoryContentStub.mockReturnValue(of(repositoryContent));
         getStatusStub.mockReturnValue(of({ repositoryStatus: CommitState.CLEAN }));
         comp.commitState = CommitState.UNDEFINED;
         triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
@@ -225,6 +225,30 @@ describe('CodeEditorFileBrowserComponent', () => {
         expect(renderedFolders).toHaveLength(0);
         expect(renderedFiles).toHaveLength(1);
     });
+
+    it('should show folders with dots in their names', fakeAsync(() => {
+        const allowedFolders = {
+            'dot.in.folderName': FileType.FOLDER,
+            'regular.folder': FileType.FOLDER,
+        };
+        const hiddenFolders = {
+            '.git': FileType.FOLDER,
+            '.other_hidden_folder': FileType.FOLDER,
+        };
+        const allFolders = {
+            ...allowedFolders,
+            ...hiddenFolders,
+        };
+        getRepositoryContentStub.mockReturnValue(of(allFolders));
+
+        comp.loadFiles().subscribe((filteredFiles) => {
+            const actualFiles = Object.keys(filteredFiles);
+            expect(actualFiles).toHaveLength(2);
+            expect(actualFiles).toEqual(Object.keys(allowedFolders));
+        });
+
+        flush();
+    }));
 
     it('should not load files if commitState could not be retrieved (possibly corrupt repository or server error)', () => {
         const isCleanSubject = new Subject<{ isClean: boolean }>();
@@ -256,7 +280,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         const getRepositoryContentSubject = new Subject<{ [fileName: string]: FileType }>();
         const onErrorSpy = jest.spyOn(comp.onError, 'emit');
         getStatusStub.mockReturnValue(isCleanSubject);
-        getRepositoryContenStub.mockReturnValue(getRepositoryContentSubject);
+        getRepositoryContentStub.mockReturnValue(getRepositoryContentSubject);
         comp.commitState = CommitState.UNDEFINED;
         triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
@@ -678,7 +702,7 @@ describe('CodeEditorFileBrowserComponent', () => {
     it('should disable action buttons if there is a git conflict', () => {
         const repositoryContent: { [fileName: string]: string } = {};
         getStatusStub.mockReturnValue(of({ repositoryStatus: CommitState.CONFLICT }));
-        getRepositoryContenStub.mockReturnValue(of(repositoryContent));
+        getRepositoryContentStub.mockReturnValue(of(repositoryContent));
         comp.commitState = CommitState.UNDEFINED;
 
         triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
@@ -705,7 +729,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         expect(debugElement.query(By.css(createFolderRoot)).nativeElement.disabled).toBe(false);
         expect(debugElement.query(By.css(compressTree)).nativeElement.disabled).toBe(false);
 
-        expect(getRepositoryContenStub).toHaveBeenCalledTimes(1);
+        expect(getRepositoryContentStub).toHaveBeenCalledTimes(1);
         expect(comp.selectedFile).toBe(undefined);
     });
 

--- a/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
@@ -458,6 +458,31 @@ describe('CodeEditorFileBrowserComponent', () => {
         expect(createFileStub).not.toHaveBeenCalled();
     });
 
+    it('should be able to create a folder with a name that contains dots', () => {
+        const onErrorSpy = jest.spyOn(comp.onError, 'emit');
+
+        const folderName = 'dot.in.folderName';
+        comp.creatingFile = ['', FileType.FOLDER];
+        comp.repositoryFiles = {};
+        comp.onCreateFile(folderName);
+        fixture.detectChanges();
+
+        expect(onErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([FileType.FILE, FileType.FOLDER])('should not be able to create a hidden %s', (fileType) => {
+        const onErrorSpy = jest.spyOn(comp.onError, 'emit');
+
+        const name = '.hidden_file_or_folder';
+        comp.creatingFile = ['', fileType];
+        comp.repositoryFiles = {};
+        comp.onCreateFile(name);
+        fixture.detectChanges();
+
+        expect(onErrorSpy).toHaveBeenCalledTimes(1);
+        expect(onErrorSpy).toHaveBeenCalledWith('unsupportedFile');
+    });
+
     it('should not be able to create node that already exists', () => {
         const fileName = 'file1';
         const repositoryFiles = { 'folder2/file1': FileType.FILE, folder2: FileType.FOLDER };
@@ -670,6 +695,33 @@ describe('CodeEditorFileBrowserComponent', () => {
         focusedElement = debugElement.query(By.css(':focus')).nativeElement;
         expect(renamingInput.nativeElement).toEqual(focusedElement);
     }));
+
+    it('should be able to rename a folder with a new  name that contains dots', () => {
+        const onErrorSpy = jest.spyOn(comp.onError, 'emit');
+
+        const newFolderName = 'dot.in.folderName';
+
+        comp.renamingFile = ['', 'oldFolderName', FileType.FOLDER];
+        comp.repositoryFiles = { oldFolderName: FileType.FOLDER };
+        comp.onRenameFile(newFolderName);
+        fixture.detectChanges();
+
+        expect(onErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([FileType.FILE, FileType.FOLDER])('should not be able to rename a %s so that is hidden', (fileType) => {
+        const onErrorSpy = jest.spyOn(comp.onError, 'emit');
+
+        const newName = '.hidden_file_or_folder';
+
+        comp.renamingFile = ['', 'oldName', fileType];
+        comp.repositoryFiles = { oldName: fileType };
+        comp.onRenameFile(newName);
+        fixture.detectChanges();
+
+        expect(onErrorSpy).toHaveBeenCalledTimes(1);
+        expect(onErrorSpy).toHaveBeenCalledWith('unsupportedFile');
+    });
 
     it('should leave rename state if renaming a file to the same file name', fakeAsync(() => {
         const fileName = 'file1';


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Closes #4867

### Description
The filter for file endings did not differentiate between folders and files. Therefore, it erroneously applied the file extension filter to folder names as well.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Open the online editor.
2. Create and rename folders in the online editor so that they contain dots in their new name.
     - This is not allowed only if the new name starts with a dot, otherwise the folder should be created/renamed.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| `code-editor-file-browser.component.ts` | 81.3% | 85% |

New code covered with additional test.

### Screenshots
Gitlab:
![Screenshot 2022-03-28 at 13-29-06 IDE](https://user-images.githubusercontent.com/64250573/160423198-7d29176f-0324-41fa-8980-a8e02cabda78.png)
Artemis before:
![Screenshot 2022-03-28 at 13-29-17 Code Editor](https://user-images.githubusercontent.com/64250573/160423206-4bf9ff58-85cb-4037-9e9c-f0e65b4948f7.png)
Artemis after:
![Screenshot 2022-03-28 at 16-31-44 Code Editor](https://user-images.githubusercontent.com/64250573/160423208-7055ed55-1de3-4858-8d55-e816b81e012b.png)

