### PR TITLE
`Development`: Fix feature tag naming in the PR naming conventions

### DIFF
--- a/docs/dev/guidelines/development-process.rst
+++ b/docs/dev/guidelines/development-process.rst
@@ -11,7 +11,7 @@ Naming Conventions for GitHub Pull Requests
 
 1. The first term is a main feature of Artemis and is using code highlighting, e.g.  “``Programming exercises``:”.
 
-    1. Possible feature tags are: ``Programming exercises``, ``Modeling exercises``, ``Text exercises``, ``Quiz exercises``, ``File upload exercises``, ``Lectures``, ``Exam mode``, ``Assessments``, ``Discussion``, ``Notifications``. More tags are possible if they make sense.
+    1. Possible feature tags are: ``Programming exercises``, ``Modeling exercises``, ``Text exercises``, ``Quiz exercises``, ``File upload exercises``, ``Lectures``, ``Exam mode``, ``Assessment``, ``Discussion``, ``Notifications``. More tags are possible if they make sense.
     2. If no feature makes sense, and it is a pure development or test improvement, we use the term “``Development``:”. More tags are also possible if they make sense.
     3. Everything else belongs to the ``General`` category.
 


### PR DESCRIPTION
### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
We currently use `Assessment` as a PR feature tag name, but the documentation calls it `Assessments`.

### Description
Changed to `Assessment`.

### Review Progress
#### Code Review
- [x] Review 1
- [ ] Review 2
