### PR TITLE
`Development`: Fix repository call in Java migration

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20211214_184200.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/migration/entries/MigrationEntry20211214_184200.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import de.tum.in.www1.artemis.config.migration.MigrationEntry;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.repository.UserRepository;
+import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.service.user.LegacyPasswordService;
 
 /**
@@ -34,6 +35,7 @@ public class MigrationEntry20211214_184200 extends MigrationEntry {
      */
     @Override
     public void execute() {
+        SecurityUtils.setAuthorizationObject();
         int listSize = 100;
         // false is the default value so if they were already set to true, this migration probably runs on a fresh system
         List<User> users = userRepository.findAllByInternal(false);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
@bassner Informed me that he was not able to create the database from scratch. The first Migration throws an exception.
The reason is that in #4768 I fixed the migration due to a Cypress issue and limited the migration to internal users only.
The new method call requires setting the authentication object manually. But because I've already executed the migration in my environment, it didn't fail and apparently Cypress doesn't use a fully empty database otherwise, Cypress would've failed.

### Description
<!-- Describe your changes in detail -->
I simply set the authorization object and made sure that the error isn't reproducible anymore.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
Local environment

1. Change the database name in `applicaiton-dev.yml` in `spring.datasource.url` to anything
2. If you need to create the database manually, please make sure to use the correct collation `utf8mb4_unicode_ci`
3. Start the application
4. The application should start without errors

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
