### PR TITLE
`General`: Prevent unnecessary calls to external authentication services for internal users

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/security/DomainUserDetailsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/security/DomainUserDetailsService.java
@@ -30,8 +30,12 @@ public class DomainUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(final String login) {
         log.debug("Authenticating {}", login);
         String lowercaseLogin = login.toLowerCase(Locale.ENGLISH);
-        return userRepository.findOneWithGroupsAndAuthoritiesByLoginAndIsInternal(lowercaseLogin, true).map(user -> createSpringSecurityUser(lowercaseLogin, user))
+        User user = userRepository.findOneWithGroupsAndAuthoritiesByLoginAndIsInternal(lowercaseLogin, true)
                 .orElseThrow(() -> new UsernameNotFoundException("User " + lowercaseLogin + " was not found in the database"));
+        if (!user.isInternal()) {
+            throw new UsernameNotFoundException("User " + lowercaseLogin + " is an external user and thus was not found as an internal user.");
+        }
+        return createSpringSecurityUser(lowercaseLogin, user);
     }
 
     private org.springframework.security.core.userdetails.User createSpringSecurityUser(String lowercaseLogin, User user) {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jira/JiraAuthenticationProvider.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jira/JiraAuthenticationProvider.java
@@ -100,7 +100,10 @@ public class JiraAuthenticationProvider extends ArtemisAuthenticationProviderImp
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         User user = getOrCreateUser(authentication, false);
-        return new UsernamePasswordAuthenticationToken(user.getLogin(), user.getPassword(), user.getGrantedAuthorities());
+        if (user != null) {
+            return new UsernamePasswordAuthenticationToken(user.getLogin(), user.getPassword(), user.getGrantedAuthorities());
+        }
+        return null;
     }
 
     @Override
@@ -112,6 +115,15 @@ public class JiraAuthenticationProvider extends ArtemisAuthenticationProviderImp
     private User getOrCreateUser(Authentication authentication, Boolean skipPasswordCheck) {
         String username = authentication.getName().toLowerCase();
         String password = authentication.getCredentials().toString();
+
+        final var optionalUser = userRepository.findOneWithGroupsAndAuthoritiesByLogin(username);
+        if (optionalUser.isPresent() && optionalUser.get().isInternal()) {
+            // User found but is internal. Skip external authentication.
+            return null;
+        }
+
+        // User is either not yet existent or an external user
+
         ResponseEntity<JiraUserDTO> authenticationResponse = null;
         try {
             final var path = jiraUrl + "/rest/api/2/user?username=" + username + "&expand=groups";
@@ -148,17 +160,10 @@ public class JiraAuthenticationProvider extends ArtemisAuthenticationProviderImp
 
         if (authenticationResponse != null && authenticationResponse.getBody() != null) {
             final var jiraUserDTO = authenticationResponse.getBody();
-            username = jiraUserDTO.getName();
-            User user;
-            final var optionalUser = userRepository.findOneWithGroupsAndAuthoritiesByLogin(username);
-            if (optionalUser.isPresent()) {
-                user = optionalUser.get();
-            }
-            else {
-                // the user does not exist yet, we have to create it in the Artemis database
-                // Note: we use an empty password, so that we don't store the credentials of Jira users in the Artemis DB (Spring enforces a non null password)
-                user = userCreationService.createUser(username, "", null, jiraUserDTO.getDisplayName(), "", jiraUserDTO.getEmailAddress(), null, null, "en", false);
-            }
+            // If the user has already existed, the check has already been completed and we can continue
+            // Otherwise, we have to create it in the Artemis database
+            User user = optionalUser.orElseGet(() -> userCreationService.createUser(jiraUserDTO.getName(), null, null, jiraUserDTO.getDisplayName(), "",
+                    jiraUserDTO.getEmailAddress(), null, null, "en", false));
             // load additional details if the ldap service is available and the user follows the allowed username pattern (if specified)
             ldapUserService.ifPresent(service -> service.loadUserDetailsFromLdap(user));
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [X] I implemented the changes with a good performance and prevented too many database calls.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Whenever an internal users tries to authenticate themselves a call to Jira gets triggered if the user is internal.
For obvious reasons this is unnecessary and should be prevented.

### Description
<!-- Describe your changes in detail -->
I made sure that the whole `JiraAuthenticationProvider` only does its calls if the user either doesn't exist or is external.
Otherwise, the Provider returns null during Authentication and the next Provider gets called (here the `DomainUserDetailsService`).

I tested this by setting breakpoints at appropriate places and logging in with an internal, an external user and a non-existing one.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
To test all paths, I suggest you test it the same way with breakpoints. Otherwise:

Prerequisites:
- 1 System with Jira(!)
- 1 Internal user (e.g. the internal admin, if applicable)
- 1 External user

1. Try to log in with a non-existent username
2. It should fail
3. Try to log in as the internal user
4. You should log in. Log out
5. Try to log in as the external user
6. You should log in.

Prerequisites:
- 1 System with Gitlab(!)

1. Try to log in with a non-existent username
2. It should fail
3. Try to log in with an existing user.
4. You should log in.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| JiraAuthenticationProvider.java | 38% | 65.63% |
| DomainUserDetailsService.java | 0% | 28% |