### PR TITLE
`General`: Align complaint and complaint response

### DIFF
--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
@@ -27,7 +27,7 @@
         </button>
     </div>
     <div class="row">
-        <div class="col-12 col-md-6">
+        <div class="col-12 col-md-6 complaint-block">
             <h4>
                 <span
                     >{{
@@ -50,7 +50,7 @@
             <textarea id="complaintTextArea" class="col-12 px-1" rows="4" [(ngModel)]="complaintText" [readonly]="true" [disabled]="true"></textarea>
         </div>
 
-        <div *ngIf="handled || isAllowedToRespond" class="col-12 col-md-6">
+        <div *ngIf="handled || isAllowedToRespond" class="col-12 col-md-6 complaint-response-block">
             <h3>
                 {{
                     complaint.complaintType === ComplaintType.MORE_FEEDBACK

--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.ts
@@ -15,6 +15,7 @@ import { isAllowedToRespondToComplaintAction } from 'app/assessment/assessment.s
 @Component({
     selector: 'jhi-complaints-for-tutor-form',
     templateUrl: './complaints-for-tutor.component.html',
+    styleUrls: ['../complaints.scss'],
     providers: [],
 })
 export class ComplaintsForTutorComponent implements OnInit {

--- a/src/main/webapp/app/complaints/complaints.scss
+++ b/src/main/webapp/app/complaints/complaints.scss
@@ -7,9 +7,8 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-}
 
-.complaint-response-block textarea,
-.complaint-block textarea {
-    margin-top: auto;
+    & textarea {
+        margin-top: auto;
+    }
 }

--- a/src/main/webapp/app/complaints/complaints.scss
+++ b/src/main/webapp/app/complaints/complaints.scss
@@ -1,3 +1,15 @@
 .info-icon {
     color: #ffc107;
 }
+
+.complaint-response-block,
+.complaint-block {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.complaint-response-block textarea,
+.complaint-block textarea {
+    margin-top: auto;
+}

--- a/src/main/webapp/app/complaints/request/complaint-request.component.html
+++ b/src/main/webapp/app/complaints/request/complaint-request.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="complaint-block h-100">
     <p class="mt-4">
         {{
             complaint.complaintType === ComplaintType.COMPLAINT

--- a/src/main/webapp/app/complaints/request/complaint-request.component.ts
+++ b/src/main/webapp/app/complaints/request/complaint-request.component.ts
@@ -4,6 +4,7 @@ import { Complaint, ComplaintType } from 'app/entities/complaint.model';
 @Component({
     selector: 'jhi-complaint-request',
     templateUrl: './complaint-request.component.html',
+    styleUrls: ['../complaints.scss'],
 })
 export class ComplaintRequestComponent {
     @Input() complaint: Complaint;

--- a/src/main/webapp/app/complaints/response/complaint-response.component.html
+++ b/src/main/webapp/app/complaints/response/complaint-response.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="complaint.accepted != undefined && complaint.complaintResponse">
+<div *ngIf="complaint.accepted != undefined && complaint.complaintResponse" class="complaint-response-block h-100">
     <p class="col-12 mt-4">
         {{
             complaint.complaintType === ComplaintType.COMPLAINT

--- a/src/main/webapp/app/complaints/response/complaint-response.component.ts
+++ b/src/main/webapp/app/complaints/response/complaint-response.component.ts
@@ -4,6 +4,7 @@ import { Complaint, ComplaintType } from 'app/entities/complaint.model';
 @Component({
     selector: 'jhi-complaint-response',
     templateUrl: './complaint-response.component.html',
+    styleUrls: ['../complaints.scss'],
 })
 export class ComplaintResponseComponent {
     @Input() complaint: Complaint;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

In particular, if your browser fills only half of the screen, the complaint and the complaint response area are not aligned. To avoid this behavior, this PR aligns both text areas.

### Description
<!-- Describe your changes in detail -->

Edit: This will not work as expected, as aligning text areas at the bottom will not work in this context -> needs more refactoring (to avoid workarounds)

- Created css class `complaint-block` and `complaint-response-block`
- Added `display: flex;` to allow the use of flex properties
- Added `flex-direction: column;` to align the paragraph and the textarea in a column
- Added `justify-content: space-between;` to align the paragraph on the start and the textarea on the end of this div
- Finally added ` margin-top: auto;` to apply the content space.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exercise with Complaints enabled

1. Participate as a student in an exercise
2. Evaluate the assignment of this student
3. Complaint/Request more feedback as a student
4. Verify complaint view of the instructor
5. Respond to that complaint/request
6. Verify view of the student

-> Screenshots below
### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

<details>
<summary>Tutor view</summary>

old:
![tutor_old](https://user-images.githubusercontent.com/60005702/161035196-f4500a01-7126-4f2d-a2aa-448d04be9eb1.png)
new:
![tutor_new](https://user-images.githubusercontent.com/60005702/161035208-02908973-2645-4800-9bf1-c2901e3c71ac.png)
</details>

<details>
<summary>Student view</summary>

old:
![old](https://user-images.githubusercontent.com/60005702/161035286-9c415571-d241-401f-9c21-66877ce9a529.png)
new:
![new](https://user-images.githubusercontent.com/60005702/161035296-c29b9638-967b-4bc9-b19a-28995993afab.png)
</details>