### PR TITLE
`Programming exercises`: Upgrade docker image for Java programming exercises to java17-5

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -34,9 +34,9 @@ artemis:
         # Defines the used docker images for certain programming languages
         build:
             images:
-                JAVA: "ls1tum/artemis-maven-template:java17-4"
-                KOTLIN: "ls1tum/artemis-maven-template:java17-4"
-                EMPTY: "ls1tum/artemis-maven-template:java17-4"
+                JAVA: "ls1tum/artemis-maven-template:java17-5"
+                KOTLIN: "ls1tum/artemis-maven-template:java17-5"
+                EMPTY: "ls1tum/artemis-maven-template:java17-5"
                 PYTHON: "ls1tum/artemis-python-docker:latest"
                 C: "ls1tum/artemis-c-docker:latest"
                 C_FACT: "sharingcodeability/fact:latest"

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -34,9 +34,9 @@ artemis:
         # Defines the used docker images for certain programming languages
         build:
             images:
-                JAVA: "ls1tum/artemis-maven-template:java17-3"
-                KOTLIN: "ls1tum/artemis-maven-template:java17-3"
-                EMPTY: "ls1tum/artemis-maven-template:java17-3"
+                JAVA: "ls1tum/artemis-maven-template:java17-4"
+                KOTLIN: "ls1tum/artemis-maven-template:java17-4"
+                EMPTY: "ls1tum/artemis-maven-template:java17-4"
                 PYTHON: "ls1tum/artemis-python-docker:latest"
                 C: "ls1tum/artemis-c-docker:latest"
                 C_FACT: "sharingcodeability/fact:latest"


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
Upgrade to the newest tag java17-5 of the "artemis-maven-template" Docker image. The main features are
- Caching the Gradle installation
- Native Image in arm64 (aside from the existing amd64)
- Upgrade of cached Ares version 1.9.2
- Caching the Teamscale JaCoCo-Agent


#### Code Review
- [ ] Review 1
- [ ] Review 2

