### PR TITLE
`Exam mode`: Fix course access rights initialization on the student exam view

### DIFF
--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
@@ -15,6 +15,7 @@ import { GradingSystemService } from 'app/grading-system/grading-system.service'
 import { faSave } from '@fortawesome/free-solid-svg-icons';
 import { getRelativeWorkingTimeExtension, normalWorkingTime } from 'app/exam/participate/exam.utils';
 import { Exercise } from 'app/entities/exercise.model';
+import { AccountService } from 'app/core/auth/account.service';
 
 @Component({
     selector: 'jhi-student-exam-detail',
@@ -53,6 +54,7 @@ export class StudentExamDetailComponent implements OnInit {
 
     constructor(
         private route: ActivatedRoute,
+        private accountService: AccountService,
         private studentExamService: StudentExamService,
         private artemisDurationFromSecondsPipe: ArtemisDurationFromSecondsPipe,
         private alertService: AlertService,
@@ -130,6 +132,7 @@ export class StudentExamDetailComponent implements OnInit {
 
         this.student = this.studentExam.user!;
         this.course = this.studentExam.exam!.course!;
+        this.accountService.setAccessRightsForCourse(this.course);
 
         studentExam.exercises!.forEach((exercise) => this.initExercise(exercise));
     }


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
Fixes a bug where an instructor could not edit a student exam on its respective student exam detail view.

### Description
#4783 changed how the course object gets retrived. In this case the `isAtLeastRole`-attributes are not initialized. I added the call to `setAccessRightsForCourse()` to now initialize these attributes.

### Steps for Testing
1. Go to the student exam detail view as an instructor (exam -> student exam -> view)
2. Make sure that the features to edit the student exam are availible.

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots

old:
![grafik](https://user-images.githubusercontent.com/26540346/161387426-447fefc9-5590-4461-abeb-ed9ea525a987.png)

new:
![grafik](https://user-images.githubusercontent.com/26540346/161387419-70d0e078-ad5a-45a8-999a-ecc5fc6339ff.png)
