### PR TITLE
`Programming exercises`: Fix edge case when generating diff reports

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
@@ -156,7 +156,7 @@ public class ProgrammingExerciseGitDiffReportService {
     public ProgrammingExerciseGitDiffReport updateReport(ProgrammingExercise programmingExercise) {
         // Synchronized to prevent multiple git-diffs to be generated for the same exercise at the same time
         // This happens e.g. when creating an exercise
-        synchronized (programmingExercise) {
+        synchronized (programmingExercise.getId().toString().intern()) {
             var templateParticipationOptional = templateProgrammingExerciseParticipationRepository.findByProgrammingExerciseId(programmingExercise.getId());
             var solutionParticipationOptional = solutionProgrammingExerciseParticipationRepository.findByProgrammingExerciseId(programmingExercise.getId());
             if (templateParticipationOptional.isEmpty() || solutionParticipationOptional.isEmpty()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
@@ -79,7 +79,12 @@ public class ProgrammingExerciseGitDiffReportService {
         try {
             var report = programmingExerciseGitDiffReportRepository.findByProgrammingExerciseId(programmingExercise.getId());
             if (report == null) {
-                return null;
+                // Generate the report if it does not exist yet
+                report = updateReport(programmingExercise);
+                if (report == null) {
+                    // Report could not be generated
+                    return null;
+                }
             }
             var templateParticipationOptional = templateProgrammingExerciseParticipationRepository.findByProgrammingExerciseId(programmingExercise.getId());
             var solutionParticipationOptional = solutionProgrammingExerciseParticipationRepository.findByProgrammingExerciseId(programmingExercise.getId());
@@ -183,7 +188,9 @@ public class ProgrammingExerciseGitDiffReportService {
             newReport.setSolutionRepositoryCommitHash(solutionHash);
             newReport.setProgrammingExercise(programmingExercise);
             // Delete any old report first
-            programmingExerciseGitDiffReportRepository.deleteByProgrammingExerciseId(programmingExercise.getId());
+            if (existingReport != null) {
+                programmingExerciseGitDiffReportRepository.delete(existingReport);
+            }
             newReport = programmingExerciseGitDiffReportRepository.save(newReport);
             programmingExercise.setGitDiffReport(newReport);
             programmingExerciseRepository.save(programmingExercise);

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
@@ -156,7 +156,7 @@ public class ProgrammingExerciseGitDiffReportService {
     public ProgrammingExerciseGitDiffReport updateReport(ProgrammingExercise programmingExercise) {
         // Synchronized to prevent multiple git-diffs to be generated for the same exercise at the same time
         // This happens e.g. when creating an exercise
-        synchronized (programmingExercise.getId().toString().intern()) {
+        synchronized (("ProgrammingExerciseGitDiffReport-" + programmingExercise.getId()).intern()) {
             var templateParticipationOptional = templateProgrammingExerciseParticipationRepository.findByProgrammingExerciseId(programmingExercise.getId());
             var solutionParticipationOptional = solutionProgrammingExerciseParticipationRepository.findByProgrammingExerciseId(programmingExercise.getId());
             if (templateParticipationOptional.isEmpty() || solutionParticipationOptional.isEmpty()) {

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
@@ -71,6 +71,7 @@ public class ProgrammingExerciseGitDiffReportService {
     /**
      * Gets the full git-diff report of a programming exercise. A full git-diff report is created from the normal git-diff report
      * but contains the actual code blocks of the template and solution.
+     * If the git-diff report does not exist yet it will generate it first.
      *
      * @param programmingExercise The programming exercise
      * @return The full git-diff report for the given programming exercise
@@ -119,6 +120,8 @@ public class ProgrammingExerciseGitDiffReportService {
 
     /**
      * Converts a normal git-diff entry to a full git-diff entry containing the actual code block of the change it represents.
+     * This method should not be called twice for the same programming exercise at the same time, as this will result in
+     * the creation of 2 reports. See https://github.com/ls1intum/Artemis/pull/4893 for more information about it.
      *
      * @param entry The normal git-diff entry
      * @param templateRepoFiles The files of the solution repository

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -197,17 +197,6 @@ public class ProgrammingExerciseGradingService {
         programmingSubmission.addResult(processedResult);
         programmingSubmissionRepository.save(programmingSubmission);
 
-        // Update the git-diff of the programming exercise when the push was to the solution repository and
-        // no git-diff report exists yet. This will be the case when a new exercise is created or imported
-        if ((isSolutionParticipation || isTemplateParticipation) && programmingExerciseGitDiffReportRepository.findByProgrammingExerciseId(programmingExercise.getId()) == null) {
-            try {
-                programmingExerciseGitDiffReportService.updateReport(programmingExercise);
-            }
-            catch (Exception e) {
-                log.error("Unable to update git-diff for programming exercise " + programmingExercise.getId(), e);
-            }
-        }
-
         return processedResult;
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
@@ -16,8 +16,6 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffEntry;
-import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
-import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseGitDiffReportRepository;
 import de.tum.in.www1.artemis.service.hestia.ProgrammingExerciseGitDiffReportService;
 import de.tum.in.www1.artemis.util.HestiaUtilTestService;
 import de.tum.in.www1.artemis.util.LocalRepository;
@@ -41,13 +39,7 @@ public class ProgrammingExerciseGitDiffReportServiceTest extends AbstractSpringI
     private HestiaUtilTestService hestiaUtilTestService;
 
     @Autowired
-    private ProgrammingExerciseRepository exerciseRepository;
-
-    @Autowired
     private ProgrammingExerciseGitDiffReportService reportService;
-
-    @Autowired
-    private ProgrammingExerciseGitDiffReportRepository reportRepository;
 
     @BeforeEach
     public void initTestCase() throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
@@ -55,11 +55,11 @@ public class ProgrammingExerciseGitDiffReportServiceTest extends AbstractSpringI
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    public void getNonExistingGitDiff() throws Exception {
+    public void getFullDiffNonExistingDiffShouldGenerateDiff() throws Exception {
         exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, "Line 1\nLine 2", exercise, templateRepo);
         exercise = hestiaUtilTestService.setupSolution(FILE_NAME, "Line 1\nLine 2", exercise, solutionRepo);
         var report = reportService.getFullReport(exercise);
-        assertThat(report).isNull();
+        assertThat(report).isNotNull();
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
@@ -72,28 +72,6 @@ public class ProgrammingExerciseGitDiffReportServiceTest extends AbstractSpringI
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    public void updateGitDiffParallel() throws Exception {
-        exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, "Line 1\nLine 2", exercise, templateRepo);
-        exercise = hestiaUtilTestService.setupSolution(FILE_NAME, "Line 1\nLine 2\nLine 3\n", exercise, solutionRepo);
-        var thread1 = new Thread(() -> reportService.updateReport(exerciseRepository.getById(exercise.getId())));
-        var thread2 = new Thread(() -> reportService.updateReport(exercise));
-        thread1.start();
-        thread2.start();
-        thread1.join();
-        thread2.join();
-        var reports = reportRepository.findAll();
-        assertThat(reports).hasSize(1);
-        var report = reports.get(0);
-        assertThat(report.getEntries()).hasSize(1);
-        var entry = report.getEntries().stream().findFirst().orElseThrow();
-        assertThat(entry.getPreviousStartLine()).isEqualTo(2);
-        assertThat(entry.getStartLine()).isEqualTo(2);
-        assertThat(entry.getPreviousLineCount()).isEqualTo(1);
-        assertThat(entry.getLineCount()).isEqualTo(2);
-    }
-
-    @Test
-    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateGitDiffNoChanges() throws Exception {
         exercise = hestiaUtilTestService.setupTemplate(FILE_NAME, "Line 1\nLine 2", exercise, templateRepo);
         exercise = hestiaUtilTestService.setupSolution(FILE_NAME, "Line 1\nLine 2", exercise, solutionRepo);

--- a/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
@@ -109,7 +109,7 @@ public class HestiaUtilTestService {
                 eq(false), any());
 
         bitbucketRequestMockProvider.enableMockingOfRequests(true);
-        bitbucketRequestMockProvider.mockDefaultBranch("master", urlService.getProjectKeyFromRepositoryUrl(templateRepoUrl));
+        bitbucketRequestMockProvider.mockDefaultBranch("main", urlService.getProjectKeyFromRepositoryUrl(templateRepoUrl));
 
         var savedExercise = exerciseRepository.save(exercise);
         database.addTemplateParticipationForProgrammingExercise(savedExercise);
@@ -170,7 +170,7 @@ public class HestiaUtilTestService {
                 eq(false), any());
 
         bitbucketRequestMockProvider.enableMockingOfRequests(true);
-        bitbucketRequestMockProvider.mockDefaultBranch("master", urlService.getProjectKeyFromRepositoryUrl(solutionRepoUrl));
+        bitbucketRequestMockProvider.mockDefaultBranch("main", urlService.getProjectKeyFromRepositoryUrl(solutionRepoUrl));
 
         var savedExercise = exerciseRepository.save(exercise);
         database.addSolutionParticipationForProgrammingExercise(savedExercise);
@@ -231,7 +231,7 @@ public class HestiaUtilTestService {
                 any());
 
         bitbucketRequestMockProvider.enableMockingOfRequests(true);
-        bitbucketRequestMockProvider.mockDefaultBranch("master", urlService.getProjectKeyFromRepositoryUrl(testRepoUrl));
+        bitbucketRequestMockProvider.mockDefaultBranch("main", urlService.getProjectKeyFromRepositoryUrl(testRepoUrl));
 
         return exerciseRepository.save(exercise);
     }

--- a/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import de.tum.in.www1.artemis.connector.BitbucketRequestMockProvider;
@@ -37,6 +38,9 @@ import de.tum.in.www1.artemis.service.connectors.GitService;
  */
 @Service
 public class HestiaUtilTestService {
+
+    @Value("${artemis.version-control.default-branch:main}")
+    private String defaultBranch;
 
     @Autowired
     private GitService gitService;
@@ -109,7 +113,7 @@ public class HestiaUtilTestService {
                 eq(false), any());
 
         bitbucketRequestMockProvider.enableMockingOfRequests(true);
-        bitbucketRequestMockProvider.mockDefaultBranch("main", urlService.getProjectKeyFromRepositoryUrl(templateRepoUrl));
+        bitbucketRequestMockProvider.mockDefaultBranch(defaultBranch, urlService.getProjectKeyFromRepositoryUrl(templateRepoUrl));
 
         var savedExercise = exerciseRepository.save(exercise);
         database.addTemplateParticipationForProgrammingExercise(savedExercise);
@@ -170,7 +174,7 @@ public class HestiaUtilTestService {
                 eq(false), any());
 
         bitbucketRequestMockProvider.enableMockingOfRequests(true);
-        bitbucketRequestMockProvider.mockDefaultBranch("main", urlService.getProjectKeyFromRepositoryUrl(solutionRepoUrl));
+        bitbucketRequestMockProvider.mockDefaultBranch(defaultBranch, urlService.getProjectKeyFromRepositoryUrl(solutionRepoUrl));
 
         var savedExercise = exerciseRepository.save(exercise);
         database.addSolutionParticipationForProgrammingExercise(savedExercise);
@@ -231,7 +235,7 @@ public class HestiaUtilTestService {
                 any());
 
         bitbucketRequestMockProvider.enableMockingOfRequests(true);
-        bitbucketRequestMockProvider.mockDefaultBranch("main", urlService.getProjectKeyFromRepositoryUrl(testRepoUrl));
+        bitbucketRequestMockProvider.mockDefaultBranch(defaultBranch, urlService.getProjectKeyFromRepositoryUrl(testRepoUrl));
 
         return exerciseRepository.save(exercise);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
A follow-up to #4732.
In rare cases it is possible that when creating an exercise Artemis tries to generate two reports at the same time for the new exercise. This would lead to both reports being saved and would then cause exceptions when trying to retrieve the report, as it is supposed to be a OneToOne relationship.
To prevent this I used a synchronized block.
However, the value this block would synchronize on was the programming exercise itself, which is not always the same. I realized on Hibernates caching system here, which apparently does not behave consistently.

### Description
<!-- Describe your changes in detail -->
After talking with Stephan I removed both the synchronized block and the creation of the git-diff report when the exercise is created. This fixes the issue in most cases unless someone manages to commit to both repositories within one second. As this edge case is highly unlikely I chose to ignore it, as a fix for this would be to complicated for such a small issue.
I also added a statement to the getFullReport method to generate the git-diff report if it does not exist yet. This also means that you can now see the report for exercises that were created before the feature was introduced.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Create a new programming exercise
4. Click on the show diff button
4. The git diff report should not exist
3. Wait for the builds to finish
4. Click on the show diff button
5. The git diff report should exist

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
