### PR TITLE
`Exam mode`: Fix back button fallback url on grading key overview

### DIFF
--- a/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
+++ b/src/main/webapp/app/grading-system/grading-key-overview/grading-key-overview.component.ts
@@ -72,7 +72,13 @@ export class GradingKeyOverviewComponent implements OnInit {
      * Navigates to the previous page (back button on the browser)
      */
     previousState() {
-        this.navigationUtilService.navigateBack(['courses', this.courseId!.toString(), 'statistics']);
+        const fallbackUrl = ['courses', this.courseId!.toString()];
+        if (this.isExam) {
+            fallbackUrl.push('exams', this.examId!.toString());
+        } else {
+            fallbackUrl.push('statistics');
+        }
+        this.navigationUtilService.navigateBack(fallbackUrl);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
This bug was found during today's exam mode testing session. If a fallback url is needed, the back button takes you always to the statistics page of the course, not the exam overview.

### Description
When calculating the fallback url, we now take into account whether or not we are in the context of an exam.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 finished exam with a grading key

1. Go to the exam overview
2. Click on "Show grading key"
3. Reload the page (to make sure the fallback url gets used)
4. Press the back-button
5. Make sure you end up on the exam overview again.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2