### PR TITLE
`Assessment`: Display warning when using grading criterion without feedback

### DIFF
--- a/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
+++ b/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
@@ -47,11 +47,11 @@
                     [readOnly]="readOnly"
                     [disabled]="readOnly"
                     [placeholder]="
-                        assessment.gradingInstruction!
+                        assessment.gradingInstruction! && assessment.gradingInstruction!.feedback!
                             ? ('artemisApp.assessment.additionalFeedbackCommentPlaceholder' | artemisTranslate)
                             : ('artemisApp.assessment.feedbackCommentPlaceholder' | artemisTranslate)
                     "
-                    [required]="!assessment.gradingInstruction"
+                    [required]="!assessment.gradingInstruction || !assessment.gradingInstruction!.feedback"
                 ></textarea>
             </div>
         </div>

--- a/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
+++ b/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
@@ -1,6 +1,6 @@
 <div (drop)="updateAssessmentOnDrop($event)" (dragover)="$event.preventDefault()" class="card mb-3" id="assessment-detail">
     <div class="card-header" [class.color-cyan]="assessment.type == FeedbackType_AUTOMATIC">
-        <jhi-grading-instruction-link-icon *ngIf="assessment.gradingInstruction!" [assessment]="assessment"></jhi-grading-instruction-link-icon>
+        <jhi-grading-instruction-link-icon *ngIf="assessment?.gradingInstruction" [assessment]="assessment"></jhi-grading-instruction-link-icon>
         <fa-icon [icon]="faTrashAlt" class="float-end" (click)="delete()" *ngIf="!readOnly"></fa-icon>
         <span class="badge bg-secondary float-end" *ngIf="assessment.type == FeedbackType_AUTOMATIC" title="{{ 'artemisApp.assessment.automaticGenerated' | artemisTranslate }}">
             <fa-icon [icon]="faRobot"></fa-icon>
@@ -25,7 +25,7 @@
         <div class="form-group row">
             <div class="col-4 assessment-label">
                 <label class="pe-0" style="float: left" jhiTranslate="artemisApp.assessment.detail.feedback"></label>
-                <div *ngIf="assessment.gradingInstruction!">
+                <div *ngIf="assessment?.gradingInstruction">
                     <fa-icon
                         [icon]="faQuestionCircle"
                         class="text-secondary ps-1"
@@ -35,7 +35,7 @@
                 </div>
             </div>
             <div class="col p-0">
-                <div *ngIf="assessment.gradingInstruction!">
+                <div *ngIf="assessment?.gradingInstruction">
                     <span>{{ assessment.gradingInstruction!.feedback }}</span>
                 </div>
                 <textarea
@@ -47,11 +47,11 @@
                     [readOnly]="readOnly"
                     [disabled]="readOnly"
                     [placeholder]="
-                        assessment.gradingInstruction! && assessment.gradingInstruction!.feedback!
+                        assessment.gradingInstruction?.feedback
                             ? ('artemisApp.assessment.additionalFeedbackCommentPlaceholder' | artemisTranslate)
                             : ('artemisApp.assessment.feedbackCommentPlaceholder' | artemisTranslate)
                     "
-                    [required]="!assessment.gradingInstruction || !assessment.gradingInstruction!.feedback"
+                    [required]="!assessment.gradingInstruction?.feedback"
                 ></textarea>
             </div>
         </div>

--- a/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
+++ b/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
@@ -1,6 +1,6 @@
 <div (drop)="updateAssessmentOnDrop($event)" (dragover)="$event.preventDefault()" class="card mb-3" id="assessment-detail">
     <div class="card-header" [class.color-cyan]="assessment.type == FeedbackType_AUTOMATIC">
-        <jhi-grading-instruction-link-icon *ngIf="assessment?.gradingInstruction" [assessment]="assessment"></jhi-grading-instruction-link-icon>
+        <jhi-grading-instruction-link-icon *ngIf="assessment.gradingInstruction" [assessment]="assessment"></jhi-grading-instruction-link-icon>
         <fa-icon [icon]="faTrashAlt" class="float-end" (click)="delete()" *ngIf="!readOnly"></fa-icon>
         <span class="badge bg-secondary float-end" *ngIf="assessment.type == FeedbackType_AUTOMATIC" title="{{ 'artemisApp.assessment.automaticGenerated' | artemisTranslate }}">
             <fa-icon [icon]="faRobot"></fa-icon>
@@ -25,7 +25,7 @@
         <div class="form-group row">
             <div class="col-4 assessment-label">
                 <label class="pe-0" style="float: left" jhiTranslate="artemisApp.assessment.detail.feedback"></label>
-                <div *ngIf="assessment?.gradingInstruction">
+                <div *ngIf="assessment.gradingInstruction">
                     <fa-icon
                         [icon]="faQuestionCircle"
                         class="text-secondary ps-1"
@@ -35,7 +35,7 @@
                 </div>
             </div>
             <div class="col p-0">
-                <div *ngIf="assessment?.gradingInstruction">
+                <div *ngIf="assessment.gradingInstruction">
                     <span>{{ assessment.gradingInstruction!.feedback }}</span>
                 </div>
                 <textarea


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
The additional Feedback component requires textual feedback to submit the assessment. While a visual warning is shown to the TA when the textual feedback is missing, when using a grading criterion without feedback the warning is currently missing. Because of this, the TA cannot submit the assessment, but also has no indication about the reason for this.

### Description
The additional Feedback component now also displays a visual warning when the TA used a Grading Criterion without Feedback. 

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Exercise with 1 Grading Criterion without Feedback to the students

1. Participate and submit the exercise as student
2. Assess the exercise
3. Drag & Drop the Grading Criterion without Feedback into the additional feedback
4. Make sure the red warning is shown
5. (Add some textual description and submit the assessment)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
https://user-images.githubusercontent.com/94070506/161821774-d0fd099b-2614-4850-95f9-b1869861beba.mp4


