### PR TITLE
`Programming exercises`: Fix gradle project test source set for package names starting with "test"

### DIFF
--- a/src/main/resources/templates/java/gradle_gradle/exercise/build.gradle
+++ b/src/main/resources/templates/java/gradle_gradle/exercise/build.gradle
@@ -22,4 +22,9 @@ sourceSets {
             srcDir assignmentSrcDir
         }
     }
+    test {
+        java {
+            srcDirs = []
+        }
+    }
 }

--- a/src/main/resources/templates/java/gradle_gradle/solution/build.gradle
+++ b/src/main/resources/templates/java/gradle_gradle/solution/build.gradle
@@ -22,4 +22,9 @@ sourceSets {
             srcDir assignmentSrcDir
         }
     }
+    test {
+        java {
+            srcDirs = []
+        }
+    }
 }


### PR DESCRIPTION
### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab). (Gradle is not supported on this setup)

### Motivation and Context
When creating a Java programming exercise with Gradle as a project type for the template & solution repository with a package name starting with 'test', these source files are interpreted as a test location in the local IDE.

### Description
This happens because the folder `src/test/...` is interpreted as a test source set by default. Therefore, the test source set is overridden to contain no classes. In case the template & solution repository should contain tests, the source set for the test case has simply to be defined in the `build.gradle`.

### Steps for Testing

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a new Programming Exercise with the following configuration:
- Template & Solution Repository Project Type: Gradle
- Test Repository Project Type: Gradle
- Package name: A name starting with "test." (e.g. test.de.tum.in.ase)
4. Clone the template or solution repository and open it in your local IDE. Check that the location the classes are contained is interpreted as the main source set.

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2