### PR TITLE
`Programming exercises`: Fix a missing translation when running plagiarism checks

### DIFF
--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.ts
@@ -175,7 +175,7 @@ export class PlagiarismInspectorComponent implements OnInit {
         this.detectionInProgressMessage = state === 'RUNNING' ? messages : this.translateService.instant('artemisApp.plagiarism.loading');
 
         if (state === 'COMPLETED') {
-            this.detectionInProgressMessage = this.translateService.instant('artemisApp.plagiarism.fetching-results');
+            this.detectionInProgressMessage = this.translateService.instant('artemisApp.plagiarism.fetchingResults');
             this.getLatestPlagiarismResult();
         }
     }


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest)
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
When running plagiarism checks, a missing translation message is shown shortly.

### Description
I replaced the wrong key (`fetching-results`) with the key used in the translations ([`fetchingResults`](https://github.com/ls1intum/Artemis/blob/develop/src/main/webapp/i18n/en/plagiarism.json#L43)).

### Steps for Testing

1. Run plagiarism check for a programming exercise
2. Make sure no "missing translation" message is shown while fetching the results.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
