### PR TITLE
`Programming exercises`: Fix sorting by submission count on the submission dashboard

### DIFF
--- a/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-exercise-submissions.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/programming-assessment-dashboard/programming-exercise-submissions.component.html
@@ -25,7 +25,7 @@
                         <a class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.result">Result</a>
                         <fa-icon [icon]="faSort"></fa-icon>
                     </th>
-                    <th jhiSortBy="participation.submissions.length">
+                    <th jhiSortBy="participation.submissionCount">
                         <a class="th-link" jhiTranslate="artemisApp.assessment.dashboard.columns.submissionCount">Submission count</a>
                         <fa-icon [icon]="faSort"></fa-icon>
                     </th>


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
After #4772 the number of submissions are now tracked using the `submissionCount` attribute instread of the lengh of the `submissions` array. This change broke sorting by the submissions.

### Description
I changed the `jhiSortBy` key to now also use `submissionCount`.

### Steps for Testing
Prerequisites:
- 1 Programming Exercise with multiple participations / submissions

1. Go to Course Management -> Exercises -> select a programming exercise -> Submissions
2. Make sure you can sort the table by the number of submissions. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
