### PR TITLE
`Development`: Update project type name in request in K6 Test

### DIFF
--- a/src/test/k6/requests/programmingExercise.js
+++ b/src/test/k6/requests/programmingExercise.js
@@ -93,7 +93,7 @@ export function createProgrammingExercise(artemis, courseId, exerciseGroup = und
         staticCodeAnalysisEnabled: enableSCA,
         sequentialTestRuns: false,
         mode: 'INDIVIDUAL',
-        projectType: programmingLanguage === 'JAVA' ? 'ECLIPSE' : undefined,
+        projectType: programmingLanguage === 'JAVA' ? 'PLAIN_MAVEN' : undefined,
     };
 
     if (courseId) {


### PR DESCRIPTION
### Checklist
### Motivation and Context
Due to changing the project type names in #4785, the K6 Integration tests were failing since the new name was not updated in the request made within the tests.

#### Code Review
- [ ] Review 1
- [ ] Review 2