### PR TITLE
`Programming exercises`: Fix problem statement for plain gradle exercises

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -295,6 +295,13 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
         } else {
             this.programmingExercise.projectType = ProjectType.PLAIN_GRADLE;
         }
+
+        // Don't override the problem statement with the template in edit mode.
+        if (this.programmingExercise.id === undefined) {
+            this.loadProgrammingLanguageTemplate(this.programmingExercise.programmingLanguage!, this.programmingExercise.projectType);
+            // Rerender the instructions as the template has changed.
+            this.rerenderSubject.next();
+        }
     }
 
     get selectedTestRepositoryProjectType() {

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.ts
@@ -238,7 +238,7 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
         // Automatically enable the checkout of the solution repository for Haskell exercises
         this.programmingExercise.checkoutSolutionRepository = this.checkoutSolutionRepositoryAllowed && language === ProgrammingLanguage.HASKELL;
 
-        // Don't override the problem statement with the template in edit mode.
+        // Only load problem statement template when creating a new exercise and not when importing an existing exercise
         if (this.programmingExercise.id === undefined) {
             this.loadProgrammingLanguageTemplate(language, this.programmingExercise.projectType!);
             // Rerender the instructions as the template has changed.
@@ -266,7 +266,7 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
             this.selectedTestRepositoryProjectType = JavaTestRepositoryProjectType.GRADLE;
         }
 
-        // Don't override the problem statement with the template in edit mode.
+        // Only load problem statement template when creating a new exercise and not when importing an existing exercise
         if (this.programmingExercise.id === undefined) {
             this.loadProgrammingLanguageTemplate(this.programmingExercise.programmingLanguage!, type);
             // Rerender the instructions as the template has changed.
@@ -296,7 +296,7 @@ export class ProgrammingExerciseUpdateComponent implements OnInit {
             this.programmingExercise.projectType = ProjectType.PLAIN_GRADLE;
         }
 
-        // Don't override the problem statement with the template in edit mode.
+        // Only load problem statement template when creating a new exercise and not when importing an existing exercise
         if (this.programmingExercise.id === undefined) {
             this.loadProgrammingLanguageTemplate(this.programmingExercise.programmingLanguage!, this.programmingExercise.projectType);
             // Rerender the instructions as the template has changed.


### PR DESCRIPTION
### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
When selecting the project type Plain Java - Gradle for Java exercises, the problem statement does not update accordingly. The test cases for Gradle exercises have a different name than those for Maven exercises.

### Description
The problem statement only reloads when changing the Solution & Template Repository project type, but not when changing the Test Repository project type. This is changed within this PR.

### Steps for Testing
Prerequisites:
- 1 Instructor
- Testserver with Atlassian (Prelive) Setup: TS0, TS1, TS5

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a new Programming Exercise
4. Select "Plain Java" as the Template & Solution Repository Project Type and "Gradle" as the Test Repository project type. After selecting the test repository project type, the problem statement should update accordingly and the tests should be referenced with an appended `()` after the actual test case name.
5. Play around a little bit with the different project types. Verify that the problem statements update accordingly.

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2