### PR TITLE
`Assessment`: Allow instructors to select a decimal separator before downloading course scores as csv

### DIFF
--- a/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
@@ -2,31 +2,18 @@ import { ExerciseType } from 'app/entities/exercise.model';
 import { EMAIL_KEY, NAME_KEY, POINTS_KEY, REGISTRATION_NUMBER_KEY, SCORE_KEY, USERNAME_KEY } from 'app/course/course-scores/course-scores.component';
 import { CourseScoresStudentStatistics } from 'app/course/course-scores/course-scores-student-statistics';
 
-/**
- * A function that converts a number into the localized representation for the user.
- */
-type Localizer = (value: number) => string;
-
 export type CourseScoresCsvRow = any;
 
 /**
  * Builds CSV rows for the course scores export.
  */
 export class CourseScoresCsvRowBuilder {
-    private readonly localizer: Localizer;
-    private readonly percentLocalizer: Localizer;
-
     private csvRow = {};
 
     /**
      * Creates a new empty CSV row.
-     * @param localizer The function that should be used to convert numbers into their localized representations.
-     * @param percentLocalizer The function that should be used to convert percentage values into their localized representations.
      */
-    constructor(localizer: Localizer, percentLocalizer: Localizer) {
-        this.localizer = localizer;
-        this.percentLocalizer = percentLocalizer;
-    }
+    constructor() {}
 
     /**
      * Constructs and returns the actual CSV row data.
@@ -46,24 +33,6 @@ export class CourseScoresCsvRowBuilder {
         } else {
             this.csvRow[key] = value ?? '';
         }
-    }
-
-    /**
-     * Stores the given value under the key in the row after converting it to the localized format.
-     * @param key Which should be associated with the given value.
-     * @param value That should be placed in the row.
-     */
-    setLocalized(key: string, value: number) {
-        this.set(key, this.localizer(value));
-    }
-
-    /**
-     * Stores the given value under the key in the row after converting it to the localized percentage format.
-     * @param key Which should be associated with the given value.
-     * @param value That should be placed in the row.
-     */
-    setLocalizedPercent(key: string, value: number) {
-        this.set(key, this.percentLocalizer(value));
     }
 
     /**

--- a/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
@@ -41,7 +41,11 @@ export class CourseScoresCsvRowBuilder {
      * @param value That should be placed in the row. Replaced by the empty string if undefined.
      */
     set<T>(key: string, value: T) {
-        this.csvRow[key] = value ?? '';
+        if (typeof value === 'number' && isNaN(value)) {
+            this.csvRow[key] = '-';
+        } else {
+            this.csvRow[key] = value ?? '';
+        }
     }
 
     /**
@@ -80,11 +84,7 @@ export class CourseScoresCsvRowBuilder {
      */
     setExerciseTypePoints(exerciseType: ExerciseType, points: number | string) {
         const key = CourseScoresCsvRowBuilder.getExerciseTypeKey(exerciseType, POINTS_KEY);
-        if (typeof points === 'number') {
-            this.setLocalized(key, points);
-        } else {
-            this.set(key, points);
-        }
+        this.set(key, points);
     }
 
     /**
@@ -94,11 +94,7 @@ export class CourseScoresCsvRowBuilder {
      */
     setExerciseTypeScore(exerciseType: ExerciseType, score: number | string) {
         const key = CourseScoresCsvRowBuilder.getExerciseTypeKey(exerciseType, SCORE_KEY);
-        if (typeof score === 'number') {
-            this.setLocalizedPercent(key, score);
-        } else {
-            this.set(key, score);
-        }
+        this.set(key, score);
     }
 
     /**

--- a/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
@@ -2,6 +2,7 @@ import { ExerciseType } from 'app/entities/exercise.model';
 import { EMAIL_KEY, NAME_KEY, POINTS_KEY, REGISTRATION_NUMBER_KEY, SCORE_KEY, USERNAME_KEY } from 'app/course/course-scores/course-scores.component';
 import { CourseScoresStudentStatistics } from 'app/course/course-scores/course-scores-student-statistics';
 import { CsvDecimalSeparator } from 'app/shared/export/csv-export-modal.component';
+import { round } from 'app/shared/util/utils';
 
 export type CourseScoresCsvRow = any;
 
@@ -46,13 +47,10 @@ export class CourseScoresCsvRowBuilder {
      * @param value That should be placed in the row.
      */
     setLocalized(key: string, value: number) {
-        const options: Intl.NumberFormatOptions = {
-            maximumFractionDigits: this.accuracyOfScores,
-        };
         if (isNaN(value)) {
             this.set(key, '-');
         } else {
-            this.set(key, value.toLocaleString(undefined, options).replace(/\./, this.decimalSeparator));
+            this.set(key, round(value, this.accuracyOfScores).toString().replace(/\./, this.decimalSeparator));
         }
     }
 
@@ -62,13 +60,10 @@ export class CourseScoresCsvRowBuilder {
      * @param value That should be placed in the row.
      */
     setLocalizedPercent(key: string, value: number) {
-        const options: Intl.NumberFormatOptions = {
-            maximumFractionDigits: this.accuracyOfScores,
-        };
         if (isNaN(value)) {
             this.set(key, '-');
         } else {
-            this.set(key, `${value.toLocaleString(undefined, options).replace(/\./, this.decimalSeparator)}%`);
+            this.set(key, `${round(value, this.accuracyOfScores).toString().replace(/\./, this.decimalSeparator)}%`);
         }
     }
 

--- a/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
@@ -10,15 +10,18 @@ export type CourseScoresCsvRow = any;
  */
 export class CourseScoresCsvRowBuilder {
     private readonly decimalSeparator: CsvDecimalSeparator;
+    private readonly accuracyOfScores: number;
 
     private csvRow = {};
 
     /**
      * Creates a new empty CSV row.
      * @param decimalSeparator The separator that should be used for numbers.
+     * @param accuracyOfScores The accuracy of fraction digits that should be used for numbers.
      */
-    constructor(decimalSeparator: CsvDecimalSeparator) {
+    constructor(decimalSeparator: CsvDecimalSeparator, accuracyOfScores = 1) {
         this.decimalSeparator = decimalSeparator;
+        this.accuracyOfScores = accuracyOfScores;
     }
 
     /**
@@ -43,10 +46,13 @@ export class CourseScoresCsvRowBuilder {
      * @param value That should be placed in the row.
      */
     setLocalized(key: string, value: number) {
+        const options: Intl.NumberFormatOptions = {
+            maximumFractionDigits: this.accuracyOfScores,
+        };
         if (isNaN(value)) {
             this.set(key, '-');
         } else {
-            this.set(key, value.toString().replace(/\./, this.decimalSeparator));
+            this.set(key, value.toLocaleString(undefined, options).replace(/\./, this.decimalSeparator));
         }
     }
 
@@ -56,10 +62,13 @@ export class CourseScoresCsvRowBuilder {
      * @param value That should be placed in the row.
      */
     setLocalizedPercent(key: string, value: number) {
+        const options: Intl.NumberFormatOptions = {
+            maximumFractionDigits: this.accuracyOfScores,
+        };
         if (isNaN(value)) {
             this.set(key, '-');
         } else {
-            this.set(key, `${value.toString().replace(/\./, this.decimalSeparator)}%`);
+            this.set(key, `${value.toLocaleString(undefined, options).replace(/\./, this.decimalSeparator)}%`);
         }
     }
 

--- a/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores-csv-row-builder.ts
@@ -38,7 +38,7 @@ export class CourseScoresCsvRowBuilder {
     }
 
     /**
-     * Stores the given value under the key in the row after converting it to the localized format.
+     * Stores the given value under the key in the row after converting it to the format using the specified decimal separator.
      * @param key Which should be associated with the given value.
      * @param value That should be placed in the row.
      */
@@ -51,7 +51,7 @@ export class CourseScoresCsvRowBuilder {
     }
 
     /**
-     * Stores the given value under the key in the row after converting it to the localized percentage format.
+     * Stores the given value under the key in the row after converting it to the percentage format using the specified decimal separator.
      * @param key Which should be associated with the given value.
      * @param value That should be placed in the row.
      */

--- a/src/main/webapp/app/course/course-scores/course-scores.component.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.ts
@@ -32,9 +32,9 @@ export const USERNAME_KEY = 'Username';
 export const EMAIL_KEY = 'Email';
 export const REGISTRATION_NUMBER_KEY = 'Registration Number';
 export const OVERALL_COURSE_POINTS_KEY = 'Overall Course Points';
-export const OVERALL_COURSE_SCORE_KEY = 'Overall Course Score';
+export const OVERALL_COURSE_SCORE_KEY = 'Overall Course Score (%)';
 export const POINTS_KEY = 'Points';
-export const SCORE_KEY = 'Score';
+export const SCORE_KEY = 'Score (%)';
 export const GRADE_KEY = 'Grades';
 export const BONUS_KEY = 'Bonus Points';
 
@@ -618,7 +618,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
             const exercisesForType = this.exercisesPerType.get(exerciseType)!;
             exercisesForType.forEach((exercise) => {
                 const points = roundValueSpecifiedByCourseSettings(student.pointsPerExerciseType.getValue(exerciseType, exercise), this.course);
-                rowData.setLocalized(exercise.title!, points);
+                rowData.set(exercise.title!, points);
             });
 
             rowData.setExerciseTypePoints(exerciseType, exercisePointsPerType);
@@ -626,11 +626,11 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
         }
 
         const overallScore = roundScorePercentSpecifiedByCourseSettings(student.overallPoints / this.maxNumberOfOverallPoints, this.course);
-        rowData.setLocalized(OVERALL_COURSE_POINTS_KEY, student.overallPoints);
-        rowData.setLocalizedPercent(OVERALL_COURSE_SCORE_KEY, overallScore);
+        rowData.set(OVERALL_COURSE_POINTS_KEY, student.overallPoints);
+        rowData.set(OVERALL_COURSE_SCORE_KEY, overallScore);
 
         if (this.course.presentationScore) {
-            rowData.setLocalized(PRESENTATION_SCORE_KEY, student.presentationScore);
+            rowData.set(PRESENTATION_SCORE_KEY, student.presentationScore);
         }
 
         this.setCsvRowGradeValue(rowData, student.gradeStep?.gradeName);
@@ -648,14 +648,14 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
         for (const exerciseType of this.exerciseTypesWithExercises) {
             const exercisesForType = this.exercisesPerType.get(exerciseType)!;
             exercisesForType.forEach((exercise) => {
-                rowData.setLocalized(exercise.title!, this.exerciseMaxPointsPerType.getValue(exerciseType, exercise) ?? 0);
+                rowData.set(exercise.title!, this.exerciseMaxPointsPerType.getValue(exerciseType, exercise) ?? 0);
             });
             rowData.setExerciseTypePoints(exerciseType, this.maxNumberOfPointsPerExerciseType.get(exerciseType)!);
             rowData.setExerciseTypeScore(exerciseType, 100);
         }
 
-        rowData.setLocalized(OVERALL_COURSE_POINTS_KEY, this.maxNumberOfOverallPoints);
-        rowData.setLocalizedPercent(OVERALL_COURSE_SCORE_KEY, 100);
+        rowData.set(OVERALL_COURSE_POINTS_KEY, this.maxNumberOfOverallPoints);
+        rowData.set(OVERALL_COURSE_SCORE_KEY, 100);
 
         if (this.course.presentationScore) {
             rowData.set(PRESENTATION_SCORE_KEY, '');
@@ -677,7 +677,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
             const exercisesForType = this.exercisesPerType.get(exerciseType)!;
             exercisesForType.forEach((exercise) => {
                 const points = roundValueSpecifiedByCourseSettings(this.exerciseAveragePointsPerType.getValue(exerciseType, exercise), this.course);
-                rowData.setLocalized(exercise.title!, points);
+                rowData.set(exercise.title!, points);
             });
 
             const averageScore = roundScorePercentSpecifiedByCourseSettings(
@@ -690,8 +690,8 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
         }
 
         const averageOverallScore = roundScorePercentSpecifiedByCourseSettings(this.averageNumberOfOverallPoints / this.maxNumberOfOverallPoints, this.course);
-        rowData.setLocalized(OVERALL_COURSE_POINTS_KEY, this.averageNumberOfOverallPoints);
-        rowData.setLocalizedPercent(OVERALL_COURSE_SCORE_KEY, averageOverallScore);
+        rowData.set(OVERALL_COURSE_POINTS_KEY, this.averageNumberOfOverallPoints);
+        rowData.set(OVERALL_COURSE_SCORE_KEY, averageOverallScore);
 
         if (this.course.presentationScore) {
             rowData.set(PRESENTATION_SCORE_KEY, '');
@@ -712,7 +712,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
         for (const exerciseType of this.exerciseTypesWithExercises) {
             const exercisesForType = this.exercisesPerType.get(exerciseType)!;
             exercisesForType.forEach((exercise) => {
-                rowData.setLocalized(exercise.title!, this.exerciseParticipationsPerType.getValue(exerciseType, exercise) ?? 0);
+                rowData.set(exercise.title!, this.exerciseParticipationsPerType.getValue(exerciseType, exercise) ?? 0);
             });
             rowData.setExerciseTypePoints(exerciseType, '');
             rowData.setExerciseTypeScore(exerciseType, '');
@@ -732,7 +732,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
         for (const exerciseType of this.exerciseTypesWithExercises) {
             const exercisesForType = this.exercisesPerType.get(exerciseType)!;
             exercisesForType.forEach((exercise) => {
-                rowData.setLocalized(exercise.title!, this.exerciseSuccessfulPerType.getValue(exerciseType, exercise) ?? 0);
+                rowData.set(exercise.title!, this.exerciseSuccessfulPerType.getValue(exerciseType, exercise) ?? 0);
             });
             rowData.setExerciseTypePoints(exerciseType, '');
             rowData.setExerciseTypeScore(exerciseType, '');

--- a/src/main/webapp/app/course/course-scores/course-scores.component.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.ts
@@ -558,7 +558,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
      * @private
      */
     private newCsvRowBuilder(decimalSeparator: CsvDecimalSeparator): CourseScoresCsvRowBuilder {
-        return new CourseScoresCsvRowBuilder(decimalSeparator);
+        return new CourseScoresCsvRowBuilder(decimalSeparator, this.course.accuracyOfScores);
     }
 
     /**

--- a/src/main/webapp/app/course/course-scores/course-scores.component.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.ts
@@ -565,9 +565,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
      * @private
      */
     private newCsvRowBuilder(): CourseScoresCsvRowBuilder {
-        const localizer = this.localize.bind(this);
-        const percentageLocalizer = this.localizePercent.bind(this);
-        return new CourseScoresCsvRowBuilder(localizer, percentageLocalizer);
+        return new CourseScoresCsvRowBuilder();
     }
 
     /**

--- a/src/main/webapp/app/course/course-scores/course-scores.component.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.ts
@@ -562,6 +562,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
 
     /**
      * Constructs a new builder for a new CSV row.
+     * @param decimalSeparator that is used for number values
      * @private
      */
     private newCsvRowBuilder(decimalSeparator: CsvDecimalSeparator): CourseScoresCsvRowBuilder {
@@ -597,6 +598,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
     /**
      * Generates a row for the exported csv with the statistics for the given student.
      * @param student The student for which a row in the CSV should be created.
+     * @param decimalSeparator that is used for number values
      * @private
      */
     private generateStudentStatisticsCsvRow(student: CourseScoresStudentStatistics, decimalSeparator: CsvDecimalSeparator): CourseScoresCsvRow {
@@ -638,6 +640,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
 
     /**
      * Generates a row for the exported csv with the maximum values of the various statistics.
+     * @param decimalSeparator that is used for number values
      * @private
      */
     private generateCsvRowMaxValues(decimalSeparator: CsvDecimalSeparator): CourseScoresCsvRow {
@@ -666,6 +669,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
 
     /**
      * Generates a row for the exported csv with the average values of the various statistics.
+     * @param decimalSeparator that is used for number values
      * @private
      */
     private generateCsvRowAverageValues(decimalSeparator: CsvDecimalSeparator): CourseScoresCsvRow {
@@ -702,6 +706,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
 
     /**
      * Generates a row for the exported Csv with information about the number of participants.
+     * @param decimalSeparator that is used for number values
      * @private
      */
     private generateCsvRowParticipation(decimalSeparator: CsvDecimalSeparator): CourseScoresCsvRow {
@@ -722,6 +727,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
 
     /**
      * Generates a row for the exported Csv with information about the number of successful participants.
+     * @param decimalSeparator that is used for number values
      * @private
      */
     private generateCsvRowSuccessfulParticipation(decimalSeparator: CsvDecimalSeparator): CourseScoresCsvRow {
@@ -743,6 +749,7 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
     /**
      * Prepares an empty row (except for the first column) with an empty column for each exercise type.
      * @param firstValue The value that should be placed in the first column of the row.
+     * @param decimalSeparator that is used for number values
      */
     private prepareEmptyCsvRow(firstValue: string, decimalSeparator: CsvDecimalSeparator): CourseScoresCsvRowBuilder {
         const emptyLine = this.newCsvRowBuilder(decimalSeparator);

--- a/src/main/webapp/app/course/course-scores/course-scores.component.ts
+++ b/src/main/webapp/app/course/course-scores/course-scores.component.ts
@@ -506,13 +506,6 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Localizes a percent number, e.g. switching the decimal separator
-     */
-    localizePercent(numberToLocalize: number): string {
-        return this.localeConversionService.toLocalePercentageString(numberToLocalize, this.course.accuracyOfScores);
-    }
-
-    /**
      * Method for exporting the csv with the needed data
      */
     exportResults(customOptions: CsvExportOptions) {
@@ -546,7 +539,6 @@ export class CourseScoresComponent implements OnInit, OnDestroy {
      */
     exportAsCsv(keys: string[], rows: CourseScoresCsvRow[], customOptions: CsvExportOptions) {
         const generalExportOptions = {
-            decimalSeparator: 'locale',
             showLabels: true,
             showTitle: false,
             filename: 'Artemis Course ' + this.course.title + ' Scores',

--- a/src/main/webapp/app/shared/export/csv-export-modal.component.html
+++ b/src/main/webapp/app/shared/export/csv-export-modal.component.html
@@ -57,7 +57,6 @@
             </div>
         </div>
     </div>
-
     <div class="modal-footer justify-content-between">
         <div class="flex-grow-1 d-flex justify-content-end">
             <button type="button" class="btn btn-default cancel me-1" data-dismiss="modal" (click)="cancel()">

--- a/src/main/webapp/app/shared/export/csv-export-modal.component.html
+++ b/src/main/webapp/app/shared/export/csv-export-modal.component.html
@@ -56,9 +56,6 @@
                 </div>
             </div>
         </div>
-        <div *ngIf="options.decimalSeparator.toString() === options.fieldSeparator.toString()" class="alert alert-warning">
-            {{ 'export.csvFile.options.noExportPossible' | artemisTranslate }}
-        </div>
     </div>
 
     <div class="modal-footer justify-content-between">
@@ -66,7 +63,7 @@
             <button type="button" class="btn btn-default cancel me-1" data-dismiss="modal" (click)="cancel()">
                 <fa-icon [icon]="faBan"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
             </button>
-            <button class="btn btn-success" [disabled]="options.decimalSeparator.toString() === options.fieldSeparator.toString()" id="finish-button" (click)="onFinish()">
+            <button class="btn btn-success" id="finish-button" (click)="onFinish()">
                 <fa-icon [icon]="faDownload" class="me-2"></fa-icon>
                 <span jhiTranslate="entity.action.export">Export</span>
             </button>

--- a/src/main/webapp/app/shared/export/csv-export-modal.component.html
+++ b/src/main/webapp/app/shared/export/csv-export-modal.component.html
@@ -41,13 +41,32 @@
                 </div>
             </div>
         </div>
+        <div class="form-group">
+            <label class="form-control-label" jhiTranslate="export.csvFile.decimalSeparator.label">Decimal Separator</label>
+            <div>
+                <div class="btn-group">
+                    <div
+                        *ngFor="let separator of CsvDecimalSeparator | keyvalue"
+                        class="btn"
+                        [ngClass]="{ 'btn-primary': options.decimalSeparator === separator.value, 'btn-default': options.decimalSeparator !== separator.value }"
+                        (click)="setCsvDecimalSeparator(separator.value)"
+                    >
+                        {{ 'export.csvFile.decimalSeparator.' + separator.key.toLowerCase() | artemisTranslate }}
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div *ngIf="options.decimalSeparator.toString() === options.fieldSeparator.toString()" class="alert alert-warning">
+            {{ 'export.csvFile.options.noExportPossible' | artemisTranslate }}
+        </div>
     </div>
+
     <div class="modal-footer justify-content-between">
         <div class="flex-grow-1 d-flex justify-content-end">
             <button type="button" class="btn btn-default cancel me-1" data-dismiss="modal" (click)="cancel()">
                 <fa-icon [icon]="faBan"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
             </button>
-            <button class="btn btn-success" id="finish-button" (click)="onFinish()">
+            <button class="btn btn-success" [disabled]="options.decimalSeparator.toString() === options.fieldSeparator.toString()" id="finish-button" (click)="onFinish()">
                 <fa-icon [icon]="faDownload" class="me-2"></fa-icon>
                 <span jhiTranslate="entity.action.export">Export</span>
             </button>

--- a/src/main/webapp/app/shared/export/csv-export-modal.component.ts
+++ b/src/main/webapp/app/shared/export/csv-export-modal.component.ts
@@ -17,9 +17,15 @@ export enum CsvQuoteStrings {
     NONE = '',
 }
 
+export enum CsvDecimalSeparator {
+    COMMA = ',',
+    PERIOD = '.',
+}
+
 export interface CsvExportOptions {
     fieldSeparator: CsvFieldSeparator;
     quoteStrings: CsvQuoteStrings;
+    decimalSeparator: CsvDecimalSeparator;
 }
 
 @Component({
@@ -30,6 +36,7 @@ export interface CsvExportOptions {
 export class CsvExportModalComponent implements OnInit {
     readonly CsvFieldSeparator = CsvFieldSeparator;
     readonly CsvQuoteStrings = CsvQuoteStrings;
+    readonly CsvDecimalSeparator = CsvDecimalSeparator;
 
     options: CsvExportOptions;
 
@@ -46,12 +53,14 @@ export class CsvExportModalComponent implements OnInit {
                 this.options = {
                     fieldSeparator: CsvFieldSeparator.SEMICOLON,
                     quoteStrings: CsvQuoteStrings.QUOTES_DOUBLE,
+                    decimalSeparator: CsvDecimalSeparator.COMMA,
                 };
                 break;
             default:
                 this.options = {
                     fieldSeparator: CsvFieldSeparator.COMMA,
                     quoteStrings: CsvQuoteStrings.QUOTES_DOUBLE,
+                    decimalSeparator: CsvDecimalSeparator.PERIOD,
                 };
         }
     }
@@ -70,6 +79,14 @@ export class CsvExportModalComponent implements OnInit {
      */
     setCsvQuoteString(quoteString: CsvQuoteStrings) {
         this.options.quoteStrings = quoteString;
+    }
+
+    /**
+     * Sets the decimal separator for the csv export options
+     * @param separator chosen decimal separator which is used in the generated csv file
+     */
+    setCsvDecimalSeparator(separator: CsvDecimalSeparator) {
+        this.options.decimalSeparator = separator;
     }
 
     /**

--- a/src/main/webapp/i18n/de/export.json
+++ b/src/main/webapp/i18n/de/export.json
@@ -3,8 +3,7 @@
         "csvFile": {
             "options": {
                 "dialogTitle": "CSV-Export Optionen",
-                "introText": "Wähle die Optionen, die beim Erstellen der .csv Datei angewendet werden sollen.",
-                "noExportPossible": "Kein Export möglich, da das gewählte Trennzeichen und Dezimaltrennzeichen gleich sind. Bitte wähle ein anderes Trennzeichen."
+                "introText": "Wähle die Optionen, die beim Erstellen der .csv Datei angewendet werden sollen."
             },
             "fieldSeparator": {
                 "label": "Trennzeichen",

--- a/src/main/webapp/i18n/de/export.json
+++ b/src/main/webapp/i18n/de/export.json
@@ -3,7 +3,8 @@
         "csvFile": {
             "options": {
                 "dialogTitle": "CSV-Export Optionen",
-                "introText": "Wähle die Optionen, die beim Erstellen der .csv Datei angewendet werden sollen."
+                "introText": "Wähle die Optionen, die beim Erstellen der .csv Datei angewendet werden sollen.",
+                "noExportPossible": "Kein Export möglich, da das gewählte Trennzeichen und Dezimaltrennzeichen gleich sind. Bitte wähle ein anderes Trennzeichen."
             },
             "fieldSeparator": {
                 "label": "Trennzeichen",
@@ -18,6 +19,11 @@
                 "quotes_single": "'",
                 "quotes_double": "\"",
                 "none": "Kein"
+            },
+            "decimalSeparator": {
+                "label": "Dezimaltrennzeichen",
+                "comma": "Komma (1,42)",
+                "period": "Punkt (1.42)"
             }
         }
     }

--- a/src/main/webapp/i18n/en/export.json
+++ b/src/main/webapp/i18n/en/export.json
@@ -3,7 +3,8 @@
         "csvFile": {
             "options": {
                 "dialogTitle": "CSV-Export Options",
-                "introText": "Select the options used for generating the .csv file."
+                "introText": "Select the options used for generating the .csv file.",
+                "noExportPossible": "No export possible as the chosen field separator and decimal separator are the same. Please select another field separator."
             },
             "fieldSeparator": {
                 "label": "Field Separator",
@@ -18,6 +19,11 @@
                 "quotes_single": "'",
                 "quotes_double": "\"",
                 "none": "None"
+            },
+            "decimalSeparator": {
+                "label": "Decimal Separator",
+                "comma": "Comma (1,42)",
+                "period": "Period (1.42)"
             }
         }
     }

--- a/src/main/webapp/i18n/en/export.json
+++ b/src/main/webapp/i18n/en/export.json
@@ -3,8 +3,7 @@
         "csvFile": {
             "options": {
                 "dialogTitle": "CSV-Export Options",
-                "introText": "Select the options used for generating the .csv file.",
-                "noExportPossible": "No export possible as the chosen field separator and decimal separator are the same. Please select another field separator."
+                "introText": "Select the options used for generating the .csv file."
             },
             "fieldSeparator": {
                 "label": "Field Separator",

--- a/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
@@ -3,12 +3,13 @@ import { CourseScoresStudentStatistics } from 'app/course/course-scores/course-s
 import { User } from 'app/core/user/user.model';
 import { EMAIL_KEY, NAME_KEY, POINTS_KEY, REGISTRATION_NUMBER_KEY, SCORE_KEY, USERNAME_KEY } from 'app/course/course-scores/course-scores.component';
 import { ExerciseType } from 'app/entities/exercise.model';
+import { CsvDecimalSeparator } from 'app/shared/export/csv-export-modal.component';
 
 describe('The CourseScoresCsvRowBuilder', () => {
     let csvRow: CourseScoresCsvRowBuilder;
 
     beforeEach(() => {
-        csvRow = new CourseScoresCsvRowBuilder();
+        csvRow = new CourseScoresCsvRowBuilder(CsvDecimalSeparator.PERIOD);
     });
 
     it('should set a string', () => {
@@ -20,6 +21,18 @@ describe('The CourseScoresCsvRowBuilder', () => {
     it('should set an empty string instead of undefined', () => {
         csvRow.set('a', undefined);
         expect(csvRow.build()['a']).toBe('');
+    });
+
+    it('should convert numbers to their localized format', () => {
+        csvRow.setLocalized('n', 100);
+        expect(csvRow.build()['n']).toBe('100');
+        csvRow.setLocalized('n', 25.5);
+        expect(csvRow.build()['n']).toBe('25.5');
+    });
+
+    it('should convert percentage numbers to their localized format', () => {
+        csvRow.setLocalizedPercent('n', 5);
+        expect(csvRow.build()['n']).toBe('5%');
     });
 
     it('should trim all user values when storing them', () => {
@@ -57,7 +70,7 @@ describe('The CourseScoresCsvRowBuilder', () => {
         const key = `Programming ${POINTS_KEY}`;
 
         csvRow.setExerciseTypePoints(exerciseType, 100);
-        expect(csvRow.build()[key]).toBe(100);
+        expect(csvRow.build()[key]).toBe('100');
 
         // should take the value as is if it is a string
         csvRow.setExerciseTypePoints(exerciseType, '');
@@ -69,7 +82,7 @@ describe('The CourseScoresCsvRowBuilder', () => {
         const key = `Programming ${SCORE_KEY}`;
 
         csvRow.setExerciseTypeScore(exerciseType, 100);
-        expect(csvRow.build()[key]).toBe(100);
+        expect(csvRow.build()[key]).toBe('100%');
 
         // should take the value as is if it is a string
         csvRow.setExerciseTypeScore(exerciseType, '');

--- a/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
@@ -5,13 +5,10 @@ import { EMAIL_KEY, NAME_KEY, POINTS_KEY, REGISTRATION_NUMBER_KEY, SCORE_KEY, US
 import { ExerciseType } from 'app/entities/exercise.model';
 
 describe('The CourseScoresCsvRowBuilder', () => {
-    const localizer = (value: number): string => `${value}l`;
-    const percentageLocalizer = (value: number): string => `${value}%`;
-
     let csvRow: CourseScoresCsvRowBuilder;
 
     beforeEach(() => {
-        csvRow = new CourseScoresCsvRowBuilder(localizer, percentageLocalizer);
+        csvRow = new CourseScoresCsvRowBuilder();
     });
 
     it('should set a string', () => {
@@ -23,16 +20,6 @@ describe('The CourseScoresCsvRowBuilder', () => {
     it('should set an empty string instead of undefined', () => {
         csvRow.set('a', undefined);
         expect(csvRow.build()['a']).toBe('');
-    });
-
-    it('should convert numbers to their localized format', () => {
-        csvRow.setLocalized('n', 100);
-        expect(csvRow.build()['n']).toBe('100l');
-    });
-
-    it('should convert percentage numbers to their localized format', () => {
-        csvRow.setLocalizedPercent('n', 5);
-        expect(csvRow.build()['n']).toBe('5%');
     });
 
     it('should trim all user values when storing them', () => {
@@ -70,7 +57,7 @@ describe('The CourseScoresCsvRowBuilder', () => {
         const key = `Programming ${POINTS_KEY}`;
 
         csvRow.setExerciseTypePoints(exerciseType, 100);
-        expect(csvRow.build()[key]).toBe('100l');
+        expect(csvRow.build()[key]).toBe(100);
 
         // should take the value as is if it is a string
         csvRow.setExerciseTypePoints(exerciseType, '');
@@ -82,7 +69,7 @@ describe('The CourseScoresCsvRowBuilder', () => {
         const key = `Programming ${SCORE_KEY}`;
 
         csvRow.setExerciseTypeScore(exerciseType, 100);
-        expect(csvRow.build()[key]).toBe('100%');
+        expect(csvRow.build()[key]).toBe(100);
 
         // should take the value as is if it is a string
         csvRow.setExerciseTypeScore(exerciseType, '');

--- a/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
@@ -33,6 +33,8 @@ describe('The CourseScoresCsvRowBuilder', () => {
     it('should convert percentage numbers to their localized format', () => {
         csvRow.setLocalizedPercent('n', 5);
         expect(csvRow.build()['n']).toBe('5%');
+        csvRow.setLocalizedPercent('n', 5.5);
+        expect(csvRow.build()['n']).toBe('5.5%');
     });
 
     it('should return a hyphen for NaN values', () => {
@@ -40,6 +42,50 @@ describe('The CourseScoresCsvRowBuilder', () => {
         expect(csvRow.build()['n']).toBe('-');
         csvRow.setLocalizedPercent('p', NaN);
         expect(csvRow.build()['p']).toBe('-');
+    });
+
+    describe('Test the CourseScoresCsvRowBuilder with a comma as a decimal separator', () => {
+        beforeEach(() => {
+            csvRow = new CourseScoresCsvRowBuilder(CsvDecimalSeparator.COMMA);
+        });
+
+        it('should convert numbers to their localized format', () => {
+            csvRow.setLocalized('n', 100);
+            expect(csvRow.build()['n']).toBe('100');
+            csvRow.setLocalized('n', 25.5);
+            expect(csvRow.build()['n']).toBe('25,5');
+        });
+
+        it('should convert percentage numbers to their localized format', () => {
+            csvRow.setLocalizedPercent('n', 5);
+            expect(csvRow.build()['n']).toBe('5%');
+            csvRow.setLocalizedPercent('n', 5.5);
+            expect(csvRow.build()['n']).toBe('5,5%');
+        });
+    });
+
+    describe('Test the CourseScoresCsvRowBuilder with a specific accuracyOfScores', () => {
+        beforeEach(() => {
+            csvRow = new CourseScoresCsvRowBuilder(CsvDecimalSeparator.PERIOD, 3);
+        });
+
+        it('should convert numbers to their localized format respecting the accuracyOfScores', () => {
+            csvRow.setLocalized('n', 100.12345);
+            expect(csvRow.build()['n']).toBe('100.123');
+            csvRow.setLocalized('n', 99.9999);
+            expect(csvRow.build()['n']).toBe('100');
+            csvRow.setLocalized('n', 25.5678);
+            expect(csvRow.build()['n']).toBe('25.568');
+        });
+
+        it('should convert percentage numbers to their localized format', () => {
+            csvRow.setLocalizedPercent('n', 5.12345);
+            expect(csvRow.build()['n']).toBe('5.123%');
+            csvRow.setLocalizedPercent('n', 99.9999);
+            expect(csvRow.build()['n']).toBe('100%');
+            csvRow.setLocalizedPercent('n', 25.5678);
+            expect(csvRow.build()['n']).toBe('25.568%');
+        });
     });
 
     it('should trim all user values when storing them', () => {

--- a/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
@@ -28,6 +28,8 @@ describe('The CourseScoresCsvRowBuilder', () => {
         expect(csvRow.build()['n']).toBe('100');
         csvRow.setLocalized('n', 25.5);
         expect(csvRow.build()['n']).toBe('25.5');
+        csvRow.setLocalized('n', 1000.23);
+        expect(csvRow.build()['n']).toBe('1000.2');
     });
 
     it('should convert percentage numbers to their localized format', () => {
@@ -54,6 +56,8 @@ describe('The CourseScoresCsvRowBuilder', () => {
             expect(csvRow.build()['n']).toBe('100');
             csvRow.setLocalized('n', 25.5);
             expect(csvRow.build()['n']).toBe('25,5');
+            csvRow.setLocalized('n', 1000.23);
+            expect(csvRow.build()['n']).toBe('1000,2');
         });
 
         it('should convert percentage numbers to their localized format', () => {
@@ -76,6 +80,8 @@ describe('The CourseScoresCsvRowBuilder', () => {
             expect(csvRow.build()['n']).toBe('100');
             csvRow.setLocalized('n', 25.5678);
             expect(csvRow.build()['n']).toBe('25.568');
+            csvRow.setLocalized('n', 1000.2345);
+            expect(csvRow.build()['n']).toBe('1000.235');
         });
 
         it('should convert percentage numbers to their localized format', () => {

--- a/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores-csv-row-builder.spec.ts
@@ -35,6 +35,13 @@ describe('The CourseScoresCsvRowBuilder', () => {
         expect(csvRow.build()['n']).toBe('5%');
     });
 
+    it('should return a hyphen for NaN values', () => {
+        csvRow.setLocalized('n', NaN);
+        expect(csvRow.build()['n']).toBe('-');
+        csvRow.setLocalizedPercent('p', NaN);
+        expect(csvRow.build()['p']).toBe('-');
+    });
+
     it('should trim all user values when storing them', () => {
         const user = new User();
         user.name = 'Testuser ';

--- a/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
@@ -38,7 +38,7 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ParticipantScoresDistributionComponent } from 'app/shared/participant-scores/participant-scores-distribution/participant-scores-distribution.component';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { ExerciseTypeStatisticsMap } from 'app/course/course-scores/exercise-type-statistics-map';
-import { CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings } from 'app/shared/export/csv-export-modal.component';
+import { CsvDecimalSeparator, CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings } from 'app/shared/export/csv-export-modal.component';
 import { CsvExportButtonComponent } from 'app/shared/export/csv-export-button.component';
 
 describe('CourseScoresComponent', () => {
@@ -407,31 +407,16 @@ describe('CourseScoresComponent', () => {
         const testOptions: CsvExportOptions = {
             fieldSeparator: CsvFieldSeparator.SEMICOLON,
             quoteStrings: CsvQuoteStrings.QUOTES_DOUBLE,
+            decimalSeparator: CsvDecimalSeparator.COMMA,
         };
         component.exportResults(testOptions);
         const generatedRows = exportAsCsvStub.mock.calls[0][1];
         const user1Row = generatedRows[0];
-        validateUserRow(
-            user1Row,
-            user1.name!,
-            user1.login!,
-            user1.email!,
-            '0',
-            '0%',
-            '10',
-            '10',
-            '100%',
-            '20',
-            '200%',
-            '10',
-            '0%',
-            '40',
-            roundScorePercentSpecifiedByCourseSettings(40 / 30, course).toLocaleString() + '%',
-        );
+        validateUserRow(user1Row, user1.name!, user1.login!, user1.email!, 0, 0, 10, 10, 100, 20, 200, 10, 0, 40, roundScorePercentSpecifiedByCourseSettings(40 / 30, course));
         const user2Row = generatedRows[1];
-        validateUserRow(user2Row, user2.name!, user2.login!, user2.email!, '0', '0%', '5', '5', '50%', '0', '0%', '10', '0%', '15', '50%');
+        validateUserRow(user2Row, user2.name!, user2.login!, user2.email!, 0, 0, 5, 5, 50, 0, 0, 10, 0, 15, 50);
         const maxRow = generatedRows[3];
-        expect(maxRow[OVERALL_COURSE_POINTS_KEY]).toEqual('30');
+        expect(maxRow[OVERALL_COURSE_POINTS_KEY]).toEqual(30);
     });
 
     it('should set grading scale properties correctly', () => {
@@ -486,28 +471,28 @@ describe('CourseScoresComponent', () => {
         expectedName: string,
         expectedUsername: string,
         expectedEmail: string,
-        expectedQuizPoints: string,
-        expectedQuizScore: string,
-        expectedScoreModelingExercise: string,
-        expectedModelingPoints: string,
-        expectedModelingScore: string,
-        expectedTextPoints: string,
-        expectedTextScore: string,
-        expectedFileUploadPoints: string,
-        expectedFileUploadScore: string,
-        expectedOverallCoursePoints: string,
-        expectedOverallCourseScore: string,
+        expectedQuizPoints: number,
+        expectedQuizScore: number,
+        expectedScoreModelingExercise: number,
+        expectedModelingPoints: number,
+        expectedModelingScore: number,
+        expectedTextPoints: number,
+        expectedTextScore: number,
+        expectedFileUploadPoints: number,
+        expectedFileUploadScore: number,
+        expectedOverallCoursePoints: number,
+        expectedOverallCourseScore: number,
     ) {
         expect(userRow[NAME_KEY]).toEqual(expectedName);
         expect(userRow[USERNAME_KEY]).toEqual(expectedUsername);
         expect(userRow[EMAIL_KEY]).toEqual(expectedEmail);
         expect(userRow['Quiz Points']).toEqual(expectedQuizPoints);
-        expect(userRow['Quiz Score']).toEqual(expectedQuizScore);
+        expect(userRow['Quiz Score (%)']).toEqual(expectedQuizScore);
         expect(userRow['exercise four']).toEqual(expectedScoreModelingExercise);
         expect(userRow['Modeling Points']).toEqual(expectedModelingPoints);
-        expect(userRow['Modeling Score']).toEqual(expectedModelingScore);
+        expect(userRow['Modeling Score (%)']).toEqual(expectedModelingScore);
         expect(userRow['File-upload Points']).toEqual(expectedFileUploadPoints);
-        expect(userRow['File-upload Score']).toEqual(expectedFileUploadScore);
+        expect(userRow['File-upload Score (%)']).toEqual(expectedFileUploadScore);
         expect(userRow[OVERALL_COURSE_POINTS_KEY]).toEqual(expectedOverallCoursePoints);
         expect(userRow[OVERALL_COURSE_SCORE_KEY]).toEqual(expectedOverallCourseScore);
     }

--- a/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
@@ -38,7 +38,7 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ParticipantScoresDistributionComponent } from 'app/shared/participant-scores/participant-scores-distribution/participant-scores-distribution.component';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { ExerciseTypeStatisticsMap } from 'app/course/course-scores/exercise-type-statistics-map';
-import { CsvDecimalSeparator, CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings } from 'app/shared/export/csv-export-modal.component';
+import { CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings } from 'app/shared/export/csv-export-modal.component';
 import { CsvExportButtonComponent } from 'app/shared/export/csv-export-button.component';
 
 describe('CourseScoresComponent', () => {
@@ -407,16 +407,31 @@ describe('CourseScoresComponent', () => {
         const testOptions: CsvExportOptions = {
             fieldSeparator: CsvFieldSeparator.SEMICOLON,
             quoteStrings: CsvQuoteStrings.QUOTES_DOUBLE,
-            decimalSeparator: CsvDecimalSeparator.COMMA,
         };
         component.exportResults(testOptions);
         const generatedRows = exportAsCsvStub.mock.calls[0][1];
         const user1Row = generatedRows[0];
-        validateUserRow(user1Row, user1.name!, user1.login!, user1.email!, 0, 0, 10, 10, 100, 20, 200, 10, 0, 40, roundScorePercentSpecifiedByCourseSettings(40 / 30, course));
+        validateUserRow(
+            user1Row,
+            user1.name!,
+            user1.login!,
+            user1.email!,
+            '0',
+            '0%',
+            '10',
+            '10',
+            '100%',
+            '20',
+            '200%',
+            '10',
+            '0%',
+            '40',
+            roundScorePercentSpecifiedByCourseSettings(40 / 30, course).toLocaleString() + '%',
+        );
         const user2Row = generatedRows[1];
-        validateUserRow(user2Row, user2.name!, user2.login!, user2.email!, 0, 0, 5, 5, 50, 0, 0, 10, 0, 15, 50);
+        validateUserRow(user2Row, user2.name!, user2.login!, user2.email!, '0', '0%', '5', '5', '50%', '0', '0%', '10', '0%', '15', '50%');
         const maxRow = generatedRows[3];
-        expect(maxRow[OVERALL_COURSE_POINTS_KEY]).toEqual(30);
+        expect(maxRow[OVERALL_COURSE_POINTS_KEY]).toEqual('30');
     });
 
     it('should set grading scale properties correctly', () => {
@@ -471,28 +486,28 @@ describe('CourseScoresComponent', () => {
         expectedName: string,
         expectedUsername: string,
         expectedEmail: string,
-        expectedQuizPoints: number,
-        expectedQuizScore: number,
-        expectedScoreModelingExercise: number,
-        expectedModelingPoints: number,
-        expectedModelingScore: number,
-        expectedTextPoints: number,
-        expectedTextScore: number,
-        expectedFileUploadPoints: number,
-        expectedFileUploadScore: number,
-        expectedOverallCoursePoints: number,
-        expectedOverallCourseScore: number,
+        expectedQuizPoints: string,
+        expectedQuizScore: string,
+        expectedScoreModelingExercise: string,
+        expectedModelingPoints: string,
+        expectedModelingScore: string,
+        expectedTextPoints: string,
+        expectedTextScore: string,
+        expectedFileUploadPoints: string,
+        expectedFileUploadScore: string,
+        expectedOverallCoursePoints: string,
+        expectedOverallCourseScore: string,
     ) {
         expect(userRow[NAME_KEY]).toEqual(expectedName);
         expect(userRow[USERNAME_KEY]).toEqual(expectedUsername);
         expect(userRow[EMAIL_KEY]).toEqual(expectedEmail);
         expect(userRow['Quiz Points']).toEqual(expectedQuizPoints);
-        expect(userRow['Quiz Score (%)']).toEqual(expectedQuizScore);
+        expect(userRow['Quiz Score']).toEqual(expectedQuizScore);
         expect(userRow['exercise four']).toEqual(expectedScoreModelingExercise);
         expect(userRow['Modeling Points']).toEqual(expectedModelingPoints);
-        expect(userRow['Modeling Score (%)']).toEqual(expectedModelingScore);
+        expect(userRow['Modeling Score']).toEqual(expectedModelingScore);
         expect(userRow['File-upload Points']).toEqual(expectedFileUploadPoints);
-        expect(userRow['File-upload Score (%)']).toEqual(expectedFileUploadScore);
+        expect(userRow['File-upload Score']).toEqual(expectedFileUploadScore);
         expect(userRow[OVERALL_COURSE_POINTS_KEY]).toEqual(expectedOverallCoursePoints);
         expect(userRow[OVERALL_COURSE_SCORE_KEY]).toEqual(expectedOverallCourseScore);
     }

--- a/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
@@ -38,7 +38,7 @@ import { TranslateDirective } from 'app/shared/language/translate.directive';
 import { ParticipantScoresDistributionComponent } from 'app/shared/participant-scores/participant-scores-distribution/participant-scores-distribution.component';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { ExerciseTypeStatisticsMap } from 'app/course/course-scores/exercise-type-statistics-map';
-import { CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings } from 'app/shared/export/csv-export-modal.component';
+import { CsvDecimalSeparator, CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings } from 'app/shared/export/csv-export-modal.component';
 import { CsvExportButtonComponent } from 'app/shared/export/csv-export-button.component';
 
 describe('CourseScoresComponent', () => {
@@ -407,6 +407,7 @@ describe('CourseScoresComponent', () => {
         const testOptions: CsvExportOptions = {
             fieldSeparator: CsvFieldSeparator.SEMICOLON,
             quoteStrings: CsvQuoteStrings.QUOTES_DOUBLE,
+            decimalSeparator: CsvDecimalSeparator.COMMA,
         };
         component.exportResults(testOptions);
         const generatedRows = exportAsCsvStub.mock.calls[0][1];

--- a/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/course-scores.component.spec.ts
@@ -407,7 +407,7 @@ describe('CourseScoresComponent', () => {
         const testOptions: CsvExportOptions = {
             fieldSeparator: CsvFieldSeparator.SEMICOLON,
             quoteStrings: CsvQuoteStrings.QUOTES_DOUBLE,
-            decimalSeparator: CsvDecimalSeparator.COMMA,
+            decimalSeparator: CsvDecimalSeparator.PERIOD,
         };
         component.exportResults(testOptions);
         const generatedRows = exportAsCsvStub.mock.calls[0][1];

--- a/src/test/javascript/spec/component/course/course-scores/csv-export-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-scores/csv-export-modal.component.spec.ts
@@ -4,7 +4,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
-import { CsvExportModalComponent, CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings } from 'app/shared/export/csv-export-modal.component';
+import { CsvDecimalSeparator, CsvExportModalComponent, CsvExportOptions, CsvFieldSeparator, CsvQuoteStrings } from 'app/shared/export/csv-export-modal.component';
 import { TranslateDirective } from 'app/shared/language/translate.directive';
 
 describe('CsvExportModalComponent', () => {
@@ -37,6 +37,7 @@ describe('CsvExportModalComponent', () => {
         component.ngOnInit();
         expect(component.options.fieldSeparator).toBe(CsvFieldSeparator.COMMA);
         expect(component.options.quoteStrings).toBe(CsvQuoteStrings.QUOTES_DOUBLE);
+        expect(component.options.decimalSeparator).toBe(CsvDecimalSeparator.PERIOD);
     });
 
     it('should init with german default options', () => {
@@ -44,19 +45,23 @@ describe('CsvExportModalComponent', () => {
         component.ngOnInit();
         expect(component.options.fieldSeparator).toBe(CsvFieldSeparator.SEMICOLON);
         expect(component.options.quoteStrings).toBe(CsvQuoteStrings.QUOTES_DOUBLE);
+        expect(component.options.decimalSeparator).toBe(CsvDecimalSeparator.COMMA);
     });
 
     it('should set csv options', () => {
         component.setCsvFieldSeparator(CsvFieldSeparator.SPACE);
         component.setCsvQuoteString(CsvQuoteStrings.NONE);
+        component.setCsvDecimalSeparator(CsvDecimalSeparator.PERIOD);
         expect(component.options.fieldSeparator).toBe(CsvFieldSeparator.SPACE);
         expect(component.options.quoteStrings).toBe(CsvQuoteStrings.NONE);
+        expect(component.options.decimalSeparator).toBe(CsvDecimalSeparator.PERIOD);
     });
 
     it('should return the export options on finish', () => {
         const testOptions: CsvExportOptions = {
             fieldSeparator: CsvFieldSeparator.SEMICOLON,
             quoteStrings: CsvQuoteStrings.QUOTES_SINGLE,
+            decimalSeparator: CsvDecimalSeparator.COMMA,
         };
         component.options = testOptions;
         const activeModalStub = jest.spyOn(ngbActiveModal, 'close');


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When course scores get downloaded, the decimal separator used for the export depends on the language set by the user in Artemis, which is not very transparent for the user. This can also result in problems when the user set a different language in Artemis than their system's setting and imports it into Excel, which than interprets values differently (e.g. Artemis: 'en', User system: 'de' -> Generated csv contains numbers in the format 1.4 -> Excel interprets this as a date (1. April)).

### Description
<!-- Describe your changes in detail -->
The user now can specify which decimal separator should be used before the export. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:

- 1 Course
- 1 Student
- 1 Exercise, on which the student participated

1. Log in to Artemis
2. Navigate to Course Administration, select the course, then Scores
3. Click the `Export as CSV` button
4. Select a decimal separator that should be used for generating the csv file
5. Click `Export`
6. View the downloaded csv file in a text editor and make sure the previously selected option was applied

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| course-scores-csv-row-builder.ts | 100% | 100% |
| course-scores.component.ts | 73.84% | 94.69% |
| csv-export-modal.component.ts | 87.5% | 96.96% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![Export-Chrome](https://user-images.githubusercontent.com/9954674/162969690-ba7aa49a-6aa8-4bdd-8b8e-70c25e2fc6dc.gif)


