### PR TITLE
`Development`: Fix an issue in the statistics service when a course has no exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/StatisticsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StatisticsService.java
@@ -56,11 +56,11 @@ public class StatisticsService {
      * which then contains the date in the ZonedDateFormat as Integer and the amount as Long
      * It then collects the amounts in an array, depending on the span value, and returns it
      *
-     * @param span DAY,WEEK,MONTH or YEAR depending on the active tab in the view
+     * @param span        DAY,WEEK,MONTH or YEAR depending on the active tab in the view
      * @param periodIndex an index indicating which time period, 0 is current week, -1 is one week in the past, -2 is two weeks in the past ...
-     * @param graphType the type of graph the data should be fetched
-     * @param view the view in which the data will be displayed (Artemis, Course, Exercise)
-     * @param entityId the entityId. Only set if we fetch value for the course statistics
+     * @param graphType   the type of graph the data should be fetched
+     * @param view        the view in which the data will be displayed (Artemis, Course, Exercise)
+     * @param entityId    the entityId. Only set if we fetch value for the course statistics
      * @return an array, containing the values for each bar in the graph
      */
     public List<Integer> getChartData(SpanType span, Integer periodIndex, GraphType graphType, StatisticsView view, @Nullable Long entityId) {
@@ -87,7 +87,7 @@ public class StatisticsService {
                 this.statisticsRepository.sortDataIntoDays(outcome, result, startDate);
             }
             case MONTH -> {
-                startDate = now.minusMonths(1 - periodIndex).withHour(0).withMinute(0).withSecond(0).withNano(0);
+                startDate = now.minusMonths(1L - periodIndex).withHour(0).withMinute(0).withSecond(0).withNano(0);
                 endDate = now.minusMonths(-periodIndex).withHour(23).withMinute(59).withSecond(59);
                 result = new ArrayList<>(Collections.nCopies((int) ChronoUnit.DAYS.between(startDate, endDate), 0));
                 outcome = this.statisticsRepository.getNumberOfEntriesPerTimeSlot(graphType, span, startDate.plusDays(1), endDate, view, entityId);
@@ -104,7 +104,7 @@ public class StatisticsService {
                 this.statisticsRepository.sortDataIntoWeeks(outcome, result, startDate);
             }
             case YEAR -> {
-                startDate = now.minusYears(1 - periodIndex).plusMonths(1).withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+                startDate = now.minusYears(1L - periodIndex).plusMonths(1).withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
                 lengthOfMonth = YearMonth.of(now.minusYears(-periodIndex).getYear(), now.minusYears(-periodIndex).getMonth()).lengthOfMonth();
                 endDate = now.minusYears(-periodIndex).withDayOfMonth(lengthOfMonth).withHour(23).withMinute(59).withSecond(59);
                 outcome = this.statisticsRepository.getNumberOfEntriesPerTimeSlot(graphType, span, startDate, endDate, view, entityId);
@@ -122,14 +122,22 @@ public class StatisticsService {
     /**
      * Get the average score of the course and all exercises for the course statistics
      *
-     * @param courseId    the id of the course for which the data should be fetched
+     * @param courseId the id of the course for which the data should be fetched
      * @return a custom CourseManagementStatisticsDTO, which contains the relevant data
      */
     public CourseManagementStatisticsDTO getCourseStatistics(Long courseId) {
 
         var courseManagementStatisticsDTO = new CourseManagementStatisticsDTO();
         Set<Exercise> exercises = statisticsRepository.findExercisesByCourseId(courseId);
-        Course course = exercises.stream().findAny().get().getCourseViaExerciseGroupOrCourseMember();
+
+        if (exercises.isEmpty()) {
+            // Handle newly created courses that have no exercises
+            courseManagementStatisticsDTO.setAverageScoreOfCourse(0.0);
+            courseManagementStatisticsDTO.setAverageScoresOfExercises(new ArrayList<>());
+            return courseManagementStatisticsDTO;
+        }
+
+        Course course = exercises.stream().findFirst().orElseThrow().getCourseViaExerciseGroupOrCourseMember();
         var includedExercises = exercises.stream().filter(Exercise::isCourseExercise)
                 .filter(exercise -> !exercise.getIncludedInOverallScore().equals(IncludedInOverallScore.NOT_INCLUDED)).collect(Collectors.toSet());
         Double averageScoreForCourse = participantScoreRepository.findAvgScore(includedExercises);
@@ -138,7 +146,7 @@ public class StatisticsService {
         averageScoreForExercises.forEach(exercise -> {
             var roundedAverageScore = roundScoreSpecifiedByCourseSettings(exercise.getAverageScore(), course);
             exercise.setAverageScore(roundedAverageScore);
-            var fittingExercise = includedExercises.stream().filter(includedExercise -> includedExercise.getId() == exercise.getExerciseId()).findAny().get();
+            var fittingExercise = includedExercises.stream().filter(includedExercise -> includedExercise.getId() == exercise.getExerciseId()).findAny().orElseThrow();
             exercise.setExerciseType(fittingExercise.getExerciseType());
         });
 
@@ -149,7 +157,7 @@ public class StatisticsService {
             courseManagementStatisticsDTO.setAverageScoreOfCourse(0.0);
         }
 
-        if (averageScoreForExercises.size() > 0) {
+        if (!averageScoreForExercises.isEmpty()) {
             courseManagementStatisticsDTO.setAverageScoresOfExercises(averageScoreForExercises);
         }
         else {
@@ -162,7 +170,7 @@ public class StatisticsService {
     /**
      * Get statistics regarding a specific exercise
      *
-     * @param exercise    the exercise for which the data should be fetched
+     * @param exercise the exercise for which the data should be fetched
      * @return a custom ExerciseManagementStatisticsDTO, which contains the relevant data
      */
     public ExerciseManagementStatisticsDTO getExerciseStatistics(Exercise exercise) throws EntityNotFoundException {
@@ -221,6 +229,7 @@ public class StatisticsService {
 
     /**
      * Sorting averageScores for release dates
+     *
      * @param exercises the exercises which we want to sort
      */
     private void sortAfterReleaseDate(List<CourseStatisticsAverageScore> exercises) {

--- a/src/main/java/de/tum/in/www1/artemis/service/StatisticsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/StatisticsService.java
@@ -133,7 +133,7 @@ public class StatisticsService {
         if (exercises.isEmpty()) {
             // Handle newly created courses that have no exercises
             courseManagementStatisticsDTO.setAverageScoreOfCourse(0.0);
-            courseManagementStatisticsDTO.setAverageScoresOfExercises(new ArrayList<>());
+            courseManagementStatisticsDTO.setAverageScoresOfExercises(Collections.emptyList());
             return courseManagementStatisticsDTO;
         }
 
@@ -161,7 +161,7 @@ public class StatisticsService {
             courseManagementStatisticsDTO.setAverageScoresOfExercises(averageScoreForExercises);
         }
         else {
-            courseManagementStatisticsDTO.setAverageScoresOfExercises(new ArrayList<>());
+            courseManagementStatisticsDTO.setAverageScoresOfExercises(Collections.emptyList());
         }
 
         return courseManagementStatisticsDTO;


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
~-  I tested **all** changes and their related features with **all** corresponding user types on a test server.~
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Optional.get() with courses that have no exercises leads to an internal server error & minor code improvements

See https://github.com/ls1intum/Artemis/pull/4926/files#diff-759a2ec63cde05b2a2476a1aae1df8b7d49fc4c07da1624887e8643dae556d68L132

### Description
see motivation

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Admin

1. Create a new course with no exercises
2. Open the course statistics
3. No internal server error should be shown

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2


