### PR TITLE
``Development``: Fix ESLint deprecation warnings

### DIFF
--- a/src/main/webapp/app/shared/participant-scores/participant-scores-tables-container/participant-scores-tables-container.component.html
+++ b/src/main/webapp/app/shared/participant-scores/participant-scores-tables-container/participant-scores-tables-container.component.html
@@ -1,7 +1,10 @@
 <button class="btn btn-info mb-2" (click)="reload.emit()">{{ 'global.form.refresh' | artemisTranslate }}</button>
-<div class="btn-group btn-group-toggle mb-2" ngbRadioGroup name="radioBasic" [(ngModel)]="mode">
-    <label ngbButtonLabel class="btn-primary"> <input ngbButton type="radio" [value]="'individual'" /> {{ 'artemisApp.participantScores.individual' | artemisTranslate }} </label>
-    <label ngbButtonLabel class="btn-primary"> <input ngbButton type="radio" [value]="'average'" /> {{ 'artemisApp.participantScores.average' | artemisTranslate }} </label>
+<div class="btn-group mb-2" role="group">
+    <input class="btn-check" type="radio" [value]="'individual'" id="individual-radio" [formControl]="mode" />
+    <label class="btn btn-primary" for="individual-radio"> {{ 'artemisApp.participantScores.individual' | artemisTranslate }} </label>
+
+    <input class="btn-check" type="radio" [value]="'average'" id="average-radio" [formControl]="mode" />
+    <label class="btn btn-primary" for="average-radio"> {{ 'artemisApp.participantScores.average' | artemisTranslate }} </label>
 </div>
 
 <ng-template #tipContent>{{ 'artemisApp.participantScores.notIncluded' | artemisTranslate }}</ng-template>
@@ -22,7 +25,7 @@
     {{ avgRatedGrade }}
 </span>
 
-<div [ngSwitch]="mode">
+<div [ngSwitch]="mode.value">
     <jhi-participant-scores-table *ngSwitchCase="'individual'" [isLoading]="isLoading" [participantScores]="participantScores" [course]="course"></jhi-participant-scores-table>
     <jhi-participant-scores-average-table
         *ngSwitchCase="'average'"

--- a/src/main/webapp/app/shared/participant-scores/participant-scores-tables-container/participant-scores-tables-container.component.ts
+++ b/src/main/webapp/app/shared/participant-scores/participant-scores-tables-container/participant-scores-tables-container.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ParticipantScoreAverageDTO, ParticipantScoreDTO } from 'app/shared/participant-scores/participant-scores.service';
 import { roundValueSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { Course } from 'app/entities/course.model';
+import { FormControl } from '@angular/forms';
 
 @Component({
     selector: 'jhi-participant-scores-tables-container',
@@ -31,5 +32,5 @@ export class ParticipantScoresTablesContainerComponent {
     @Output()
     reload = new EventEmitter<void>();
 
-    mode: 'individual' | 'average' = 'individual';
+    mode = new FormControl('individual');
 }

--- a/src/test/javascript/spec/component/shared/participant-scores-tables-container.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/participant-scores-tables-container.component.spec.ts
@@ -3,8 +3,8 @@ import { MockPipe } from 'ng-mocks';
 import { Component, Input } from '@angular/core';
 import { ParticipantScoreAverageDTO, ParticipantScoreDTO } from 'app/shared/participant-scores/participant-scores.service';
 import { ParticipantScoresTablesContainerComponent } from 'app/shared/participant-scores/participant-scores-tables-container/participant-scores-tables-container.component';
-import { NgbButtonsModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-import { FormsModule } from '@angular/forms';
+import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { Course } from 'app/entities/course.model';
 
@@ -36,7 +36,7 @@ describe('ParticipantScoresTablesContainer', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [FormsModule, NgbTooltipModule, NgbButtonsModule],
+            imports: [ReactiveFormsModule, FormsModule, NgbTooltipModule],
             declarations: [
                 ParticipantScoresTablesContainerComponent,
                 ParticipantScoresTableStubComponent,

--- a/src/test/javascript/spec/component/team/team-owner-search.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team-owner-search.component.spec.ts
@@ -102,7 +102,7 @@ describe('Team Owner Search Component', () => {
         const searchFailedSpy = jest.spyOn(comp.searchFailed, 'emit');
 
         const courseServiceSpy = jest.spyOn(courseService, 'getAllUsersInCourseGroup');
-        courseServiceSpy.mockReturnValue(throwError(new Error('getAllUsersInCourseGroup failed')));
+        courseServiceSpy.mockReturnValue(throwError(() => new Error('getAllUsersInCourseGroup failed')));
 
         comp.course = { id: 1 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

``npm run lint`` shows three deprecation warnings on current ``develop``.

```
.../Artemis/src/main/webapp/app/exercises/programming/shared/instructions-render/extensions/programming-exercise-task.extension.ts
  29:43  warning  'ComponentFactoryResolver' is deprecated. Angular no longer requires Component factories. Please use other APIs where
Component class can be used directly  deprecation/deprecation

.../Artemis/src/test/javascript/spec/component/shared/participant-scores-tables-container.component.spec.ts
  39:54  warning  'NgbButtonsModule' is deprecated. 12.0.0 Please use native Angular code instead  deprecation/deprecation

.../Artemis/src/test/javascript/spec/component/team/team-owner-search.component.spec.ts
  105:42  warning  'throwError' is deprecated. Support for passing an error value will be removed in v8. Instead, pass a factory function to `throwError(() => new Error('test'))`. This is
because it will create the error at the moment it should be created and capture a more appropriate stack trace. If
for some reason you need to create the error ahead of time, you can still do that: `const err = new Error('test'); throwError(() => err);`  deprecation/deprecation
```

### Description
<!-- Describe your changes in detail -->

This PR fixes the last two warnings:
1. Do not use ``NgbButtonsModule`` / button directives anymore and use native angular code as described at https://ng-bootstrap.github.io/#/components/buttons/overview
2. Update the ``throwError`` call correctly

The first warning can currently not be fixed as there is no adequate replacement API for Angular component factories for our use case.
The Angular Devs promised to not remove this deprecated API we use until a replacement is available, see
https://github.com/angular/angular/issues/45263#issuecomment-1082530357

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

The only thing that should be manually tested is ``CourseParticipantScoresComponent`` where I've updated the radio button group:

- As instructor, navigate to ``/course-management/<YOUR_COURSE_ID>/participant-scores``
- Verify that the two buttons on the top work and toggle the table appearance below correctly

<img width="657" alt="grafik" src="https://user-images.githubusercontent.com/23171488/163045768-db34272b-1855-405e-acd2-de1c8f47530c.png">


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
