### PR TITLE
`Assessment`: Fix an issue during the assessment in the tutor training

### DIFF
--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
@@ -149,10 +149,12 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
         return new Promise((resolve) => {
             this.assessmentsService
                 .getExampleResult(this.exerciseId, this.submission?.id!)
-                .pipe(filter((value) => value != undefined))
+                .pipe(filter(notUndefined))
                 .subscribe((result) => {
-                    this.result = result;
-                    this.exampleSubmission.submission = this.submission = result.submission;
+                    if (result) {
+                        this.result = result;
+                        this.exampleSubmission.submission = this.submission = result.submission;
+                    }
                     this.prepareTextBlocksAndFeedbacks();
                     this.areNewAssessments = this.assessments.length <= 0;
                     this.validateFeedback();

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
@@ -154,6 +154,10 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
                     if (result) {
                         this.result = result;
                         this.exampleSubmission.submission = this.submission = result.submission;
+                    } else {
+                        this.result = new Result();
+                        this.result.submission = this.submission;
+                        this.submission!.results = [this.result];
                     }
                     this.prepareTextBlocksAndFeedbacks();
                     this.areNewAssessments = this.assessments.length <= 0;

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Location } from '@angular/common';
 import { AlertService } from 'app/core/util/alert.service';
 import { HttpResponse } from '@angular/common/http';
-import { ExampleSubmissionService, EntityResponseType } from 'app/exercises/shared/example-submission/example-submission.service';
+import { EntityResponseType, ExampleSubmissionService } from 'app/exercises/shared/example-submission/example-submission.service';
 import { TextAssessmentService } from 'app/exercises/text/assess/text-assessment.service';
 import { TutorParticipationService } from 'app/exercises/shared/dashboards/tutor/tutor-participation.service';
 import { ArtemisMarkdownService } from 'app/shared/markdown.service';
@@ -24,7 +24,7 @@ import { StructuredGradingCriterionService } from 'app/exercises/shared/structur
 import { notUndefined } from 'app/shared/util/global.utils';
 import { AssessButtonStates, Context, State, SubmissionButtonStates, UIStates } from 'app/exercises/text/manage/example-text-submission/example-text-submission-state.model';
 import { filter, switchMap, tap } from 'rxjs/operators';
-import { FeedbackMarker, ExampleSubmissionAssessCommand } from 'app/exercises/shared/example-submission/example-submission-assess-command';
+import { ExampleSubmissionAssessCommand, FeedbackMarker } from 'app/exercises/shared/example-submission/example-submission-assess-command';
 import { getCourseFromExercise } from 'app/entities/exercise.model';
 import { faEdit, faSave } from '@fortawesome/free-solid-svg-icons';
 import { faListAlt } from '@fortawesome/free-regular-svg-icons';
@@ -149,7 +149,7 @@ export class ExampleTextSubmissionComponent extends TextAssessmentBaseComponent 
         return new Promise((resolve) => {
             this.assessmentsService
                 .getExampleResult(this.exerciseId, this.submission?.id!)
-                .pipe(filter(notUndefined))
+                .pipe(filter((value) => value != undefined))
                 .subscribe((result) => {
                     this.result = result;
                     this.exampleSubmission.submission = this.submission = result.submission;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During the assessment of an example solution as a tutor, the screen shows an editable textarea instead of the expected text assessment area. This prevents the tutors from grading the example submission and continuing to the actual submission grading.

![image](https://user-images.githubusercontent.com/18427209/164280710-83fc869c-23be-471a-bca2-384f0354a195.png)

### Description
<!-- Describe your changes in detail -->
We solved a bug where a TypeError occurs due to accessing a field of a null response from server. The response is expected to be null to tutors by design but if that tutor is also an instructor or admin, then the response is not null so client should be able to handle both cases. We handled the first case which was missing and unblocked the non-instructor tutors to continue grading example submissions as expected.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Tutor (not an Admin nor Instructor)
- 1 Text Exercise with Example Submission (Create with an Instructor if it does not exist)

1. Log in to Artemis with the Tutor account
2. Navigate to Course Administration
3. Go to the course of the prerequisite Text Exercise > Assessment Dashboard > Text Exercise's Exercise Dashboard
4. Click `Start assessing example submissions`.
5. Check that the example solution, assessment instructions and `Submit assessment` button is visible.
6. Check that text of the example solution is not editable but grading is possible (both with `Add new Feedback` functionality and with assessment instructions.
7. Make an assessment and then submit to see the result.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| example-text-submission.component.ts | 65.8% | 85.05% |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/18427209/164284284-2b5bb32b-786b-4bfc-b5bb-fdc7e2357e9f.png)

![image](https://user-images.githubusercontent.com/18427209/164284369-44040886-1e8d-4ab0-9b18-096e34d376f7.png)

