### PR TITLE
`Development`: Improve PostRepository queries

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/metis/PostRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/metis/PostRepository.java
@@ -29,18 +29,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
                 OR post.course.id = :#{#courseId})
             AND (:#{#courseWideContext} IS NULL
                 OR post.courseWideContext = :#{#courseWideContext})
-            AND (:#{#own} IS NULL
+            AND (:#{#own} = false
                 OR post.author.id = :#{#userId})
-            AND (:#{#reactedOrReplied} IS NULL
+            AND (:#{#reactedOrReplied} = false
                 OR answer.author.id = :#{#userId}
                 OR reaction.user.id = :#{#userId})
-            AND (:#{#unresolved} IS NULL
-                OR NOT EXISTS (SELECT answerPost FROM AnswerPost answerPost
+            AND (:#{#unresolved} = false
+                OR NOT EXISTS (SELECT answerPost FROM post.answers answerPost
                     WHERE answerPost.resolvesPost = true
                     AND answerPost.post.id = post.id))
             """)
-    List<Post> findPostsForCourse(@Param("courseId") Long courseId, @Param("courseWideContext") CourseWideContext courseWideContext, @Param("unresolved") Boolean unresolved,
-            @Param("own") Boolean own, @Param("reactedOrReplied") Boolean reactedOrReplied, @Param("userId") Long userId);
+    List<Post> findPostsForCourse(@Param("courseId") Long courseId, @Param("courseWideContext") CourseWideContext courseWideContext, @Param("unresolved") boolean unresolved,
+            @Param("own") boolean own, @Param("reactedOrReplied") boolean reactedOrReplied, @Param("userId") Long userId);
 
     @Query("""
             SELECT DISTINCT tag FROM Post post
@@ -55,35 +55,35 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             SELECT DISTINCT post FROM Post post
             LEFT JOIN post.answers answer LEFT JOIN post.reactions reaction
             WHERE post.lecture.id = :#{#lectureId}
-            AND (:#{#own} IS NULL
+            AND (:#{#own} = false
                 OR post.author.id = :#{#userId})
-            AND (:#{#reactedOrReplied} IS NULL
+            AND (:#{#reactedOrReplied} = false
                 OR answer.author.id = :#{#userId}
                 OR reaction.user.id = :#{#userId})
-            AND (:#{#unresolved} IS NULL
-                OR NOT EXISTS (SELECT answerPost FROM AnswerPost answerPost
+            AND (:#{#unresolved} = false
+                OR NOT EXISTS (SELECT answerPost FROM post.answers answerPost
                     WHERE answerPost.resolvesPost = true
                     AND answerPost.post.id = post.id))
                 """)
-    List<Post> findPostsByLectureId(@Param("lectureId") Long lectureId, @Param("unresolved") Boolean unresolved, @Param("own") Boolean own,
-            @Param("reactedOrReplied") Boolean reactedOrReplied, @Param("userId") Long userId);
+    List<Post> findPostsByLectureId(@Param("lectureId") Long lectureId, @Param("unresolved") boolean unresolved, @Param("own") boolean own,
+            @Param("reactedOrReplied") boolean reactedOrReplied, @Param("userId") Long userId);
 
     @Query("""
             SELECT DISTINCT post FROM Post post
             LEFT JOIN post.answers answer LEFT JOIN post.reactions reaction
             WHERE post.exercise.id = :#{#exerciseId}
-            AND (:#{#own} IS NULL
+            AND (:#{#own} = false
                 OR post.author.id = :#{#userId})
-            AND (:#{#reactedOrReplied} IS NULL
+            AND (:#{#reactedOrReplied} = false
                 OR answer.author.id = :#{#userId}
                 OR reaction.user.id = :#{#userId})
-            AND (:#{#unresolved} IS NULL
-                OR NOT EXISTS (SELECT answerPost FROM AnswerPost answerPost
+            AND (:#{#unresolved} = false
+                OR NOT EXISTS (SELECT answerPost FROM post.answers answerPost
                     WHERE answerPost.resolvesPost = true
                     AND answerPost.post.id = post.id))
             """)
-    List<Post> findPostsByExerciseId(@Param("exerciseId") Long exerciseId, @Param("unresolved") Boolean unresolved, @Param("own") Boolean own,
-            @Param("reactedOrReplied") Boolean reactedOrReplied, @Param("userId") Long userId);
+    List<Post> findPostsByExerciseId(@Param("exerciseId") Long exerciseId, @Param("unresolved") boolean unresolved, @Param("own") boolean own,
+            @Param("reactedOrReplied") boolean reactedOrReplied, @Param("userId") Long userId);
 
     default Post findByIdElseThrow(Long postId) throws EntityNotFoundException {
         return findById(postId).orElseThrow(() -> new EntityNotFoundException("Post", postId));

--- a/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/metis/PostService.java
@@ -277,7 +277,7 @@ public class PostService extends PostingService {
         authorizationCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.STUDENT, course, null);
 
         // retrieve posts
-        List<Post> coursePosts = postRepository.findPostsForCourse(courseId, null, null, null, null, null);
+        List<Post> coursePosts = postRepository.findPostsForCourse(courseId, null, false, false, false, null);
         // protect sample solution, grading instructions, etc.
         coursePosts.stream().map(Post::getExercise).filter(Objects::nonNull).forEach(Exercise::filterSensitiveInformation);
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/dto/PostContextFilter.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/dto/PostContextFilter.java
@@ -22,11 +22,11 @@ public class PostContextFilter {
 
     private String searchText;
 
-    private Boolean filterToUnresolved;
+    private boolean filterToUnresolved = false;
 
-    private Boolean filterToOwn;
+    private boolean filterToOwn = false;
 
-    private Boolean filterToAnsweredOrReacted;
+    private boolean filterToAnsweredOrReacted = false;
 
     private PostSortCriterion postSortCriterion;
 
@@ -72,27 +72,27 @@ public class PostContextFilter {
         this.searchText = searchText;
     }
 
-    public Boolean getFilterToUnresolved() {
+    public boolean getFilterToUnresolved() {
         return filterToUnresolved;
     }
 
-    public void setFilterToUnresolved(Boolean filterToUnresolved) {
+    public void setFilterToUnresolved(boolean filterToUnresolved) {
         this.filterToUnresolved = filterToUnresolved;
     }
 
-    public Boolean getFilterToOwn() {
+    public boolean getFilterToOwn() {
         return filterToOwn;
     }
 
-    public void setFilterToOwn(Boolean filterToOwn) {
+    public void setFilterToOwn(boolean filterToOwn) {
         this.filterToOwn = filterToOwn;
     }
 
-    public Boolean getFilterToAnsweredOrReacted() {
+    public boolean getFilterToAnsweredOrReacted() {
         return filterToAnsweredOrReacted;
     }
 
-    public void setFilterToAnsweredOrReacted(Boolean filterToAnsweredOrReacted) {
+    public void setFilterToAnsweredOrReacted(boolean filterToAnsweredOrReacted) {
         this.filterToAnsweredOrReacted = filterToAnsweredOrReacted;
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/PostIntegrationTest.java
@@ -118,7 +118,7 @@ public class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         Post createdPost = request.postWithResponseBody("/api/courses/" + courseId + "/posts", postToSave, Post.class, HttpStatus.CREATED);
         database.assertSensitiveInformationHidden(createdPost);
         checkCreatedPost(postToSave, createdPost);
-        assertThat(existingExercisePosts).hasSize(postRepository.findPostsByExerciseId(exerciseId, null, null, null, null).size() - 1);
+        assertThat(existingExercisePosts).hasSize(postRepository.findPostsByExerciseId(exerciseId, false, false, false, null).size() - 1);
         verify(groupNotificationService, times(1)).notifyAllGroupsAboutNewPostForExercise(createdPost, course);
     }
 
@@ -131,7 +131,7 @@ public class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         postToSave.setExercise(examExercise);
 
         request.postWithResponseBody("/api/courses/" + courseId + "/posts", postToSave, Post.class, HttpStatus.BAD_REQUEST);
-        assertThat(existingExercisePosts).hasSameSizeAs(postRepository.findPostsByExerciseId(exerciseId, null, null, null, null));
+        assertThat(existingExercisePosts).hasSameSizeAs(postRepository.findPostsByExerciseId(exerciseId, false, false, false, null));
         verify(groupNotificationService, times(0)).notifyAllGroupsAboutNewPostForExercise(any(), any());
 
     }
@@ -146,7 +146,7 @@ public class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         Post createdPost = request.postWithResponseBody("/api/courses/" + courseId + "/posts", postToSave, Post.class, HttpStatus.CREATED);
         database.assertSensitiveInformationHidden(createdPost);
         checkCreatedPost(postToSave, createdPost);
-        assertThat(existingLecturePosts).hasSize(postRepository.findPostsByLectureId(lectureId, null, null, null, null).size() - 1);
+        assertThat(existingLecturePosts).hasSize(postRepository.findPostsByLectureId(lectureId, false, false, false, null).size() - 1);
         verify(groupNotificationService, times(1)).notifyAllGroupsAboutNewPostForLecture(createdPost, course);
     }
 
@@ -161,8 +161,8 @@ public class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         database.assertSensitiveInformationHidden(createdPost);
         checkCreatedPost(postToSave, createdPost);
 
-        List<Post> updatedCourseWidePosts = postRepository.findPostsForCourse(courseId, null, null, null, null, null).stream().filter(post -> post.getCourseWideContext() != null)
-                .toList();
+        List<Post> updatedCourseWidePosts = postRepository.findPostsForCourse(courseId, null, false, false, false, null).stream()
+                .filter(post -> post.getCourseWideContext() != null).toList();
         assertThat(existingCourseWidePosts).hasSize(updatedCourseWidePosts.size() - 1);
         verify(groupNotificationService, times(1)).notifyAllGroupsAboutNewCoursePost(createdPost, course);
     }
@@ -179,8 +179,8 @@ public class PostIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         postToSave.setDisplayPriority(DisplayPriority.PINNED);
         checkCreatedPost(postToSave, createdPost);
 
-        List<Post> updatedCourseWidePosts = postRepository.findPostsForCourse(courseId, null, null, null, null, null).stream().filter(post -> post.getCourseWideContext() != null)
-                .toList();
+        List<Post> updatedCourseWidePosts = postRepository.findPostsForCourse(courseId, null, false, false, false, null).stream()
+                .filter(post -> post.getCourseWideContext() != null).toList();
         assertThat(existingCourseWidePosts).hasSize(updatedCourseWidePosts.size() - 1);
         verify(groupNotificationService, times(1)).notifyAllGroupsAboutNewAnnouncement(createdPost, course);
     }

--- a/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ReactionIntegrationTest.java
@@ -221,7 +221,7 @@ public class ReactionIntegrationTest extends AbstractSpringIntegrationBambooBitb
         createVoteReactionOnPost(postReactedOn2, student2);
 
         // refresh posts after reactions are added
-        existingPostsWithAnswers = postRepository.findPostsForCourse(courseId, null, null, null, null, null);
+        existingPostsWithAnswers = postRepository.findPostsForCourse(courseId, null, false, false, false, null);
 
         var params = new LinkedMultiValueMap<String, String>();
 
@@ -258,7 +258,7 @@ public class ReactionIntegrationTest extends AbstractSpringIntegrationBambooBitb
         createVoteReactionOnPost(post2ReactedOn, student2);
 
         // refresh posts after reactions are added
-        existingPostsWithAnswers = postRepository.findPostsForCourse(courseId, null, null, null, null, null);
+        existingPostsWithAnswers = postRepository.findPostsForCourse(courseId, null, false, false, false, null);
 
         var params = new LinkedMultiValueMap<String, String>();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
While reviewing #4933 I noticed that the queries in the `PostRepository` had some minor issues.
These issues were:
- If any of the booleans were set to false they would be interpreted the same way as if they were true
- The nested subquery was more resource-intensive than necessary

Just for reference, these queries were introduced in #4685

### Description
<!-- Describe your changes in detail -->
To fix this I did the following:
- Converted the `Boolean`s in `PostContextFilter` to `boolean`s and assigned them false as a default value
- Adapted the queries to no longer check for `<some-Boolean> IS NULL` but instead for `<some-boolean> = false`
- Adapted the subqueries to only check the answers of the current post instead of all answers.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 2 Users
- 1 Course

1. Log in to Artemis
2. Navigate to the Course Discussion Page
3. Create some posts, answers, and reactions with both users
4. Check that the filtering still works as it should

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
Unchanged
