### PR TITLE
`Programming exercises`: Add fix for duplicate git-diff reports

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/hestia/ProgrammingExerciseGitDiffReportRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/hestia/ProgrammingExerciseGitDiffReportRepository.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.repository.hestia;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,7 +13,13 @@ import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffReport;
 @Repository
 public interface ProgrammingExerciseGitDiffReportRepository extends JpaRepository<ProgrammingExerciseGitDiffReport, Long> {
 
-    ProgrammingExerciseGitDiffReport findByProgrammingExerciseId(Long exerciseId);
+    /**
+     * Avoid using this method. Use ProgrammingExerciseGitDiffReportService::getReportOfExercise instead
+     *
+     * @param exerciseId The id of the programming exercise
+     * @return A list of all git-diff reports that belong to the exercise
+     */
+    List<ProgrammingExerciseGitDiffReport> findByProgrammingExerciseId(Long exerciseId);
 
     void deleteByProgrammingExerciseId(Long exerciseId);
 }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/hestia/ProgrammingExerciseGitDiffReportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/hestia/ProgrammingExerciseGitDiffReportResource.java
@@ -54,7 +54,7 @@ public class ProgrammingExerciseGitDiffReportResource {
         var exercise = programmingExerciseRepository.findByIdElseThrow(exerciseId);
         authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.EDITOR, exercise, null);
 
-        var report = programmingExerciseGitDiffReportRepository.findByProgrammingExerciseId(exercise.getId());
+        var report = gitDiffReportService.getReportOfExercise(exercise);
 
         return ResponseEntity.ok(report);
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
@krusche approached me with an internal server error after importing a programming exercise.
The underlying error message was `query did not return a unique result: 3; nested exception is javax.persistence.NonUniqueResultException: query did not return a unique result: 3`. This means that for some reason 3 git-diff reports exist for a single programming exercise. This should obviously not be the case and therefore results in an error.

### Description
<!-- Describe your changes in detail -->
Since there is no simple fix to prevent duplicate git-diff reports I added a check when retrieving the git-diff report for a programming exercise. If there is more than one report all reports except for the latest one will be deleted and the latest one will be returned.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
There is no reliable way to create a situation where two reports exist at the same time for one exercise. I added a test case where I manually insert two reports into the database to test my change.
Apart from that you should check if git-diff reports still work as expected:

Prerequisites:
- 1 Instructor
- 1 Programming exercise

1. Log in to Artemis
2. Navigate to the programming exercise detail page
3. Check that you can view the git-diff as usual

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ProgrammingExerciseGitDiffReportService.getReportOfExercise | 100% | 100% |