### PR TITLE
`Lectures`: Preserve ordering when editing lecture units

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/lecture/LectureUnit.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/lecture/LectureUnit.java
@@ -10,10 +10,7 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.DiscriminatorOptions;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.*;
 
 import de.tum.in.www1.artemis.domain.DomainObject;
 import de.tum.in.www1.artemis.domain.LearningGoal;
@@ -42,10 +39,10 @@ public abstract class LectureUnit extends DomainObject {
     @Column(name = "release_date")
     private ZonedDateTime releaseDate;
 
-    // This is explicitly required by Hibernate for the indexed collection
+    // This is explicitly required by Hibernate for the indexed collection (OrderColumn)
     // https://docs.jboss.org/hibernate/stable/annotations/reference/en/html_single/#entity-hibspec-collection-extratype-indexbidir
-    @SuppressWarnings("unused")
     @Column(name = "lecture_unit_order")
+    @JsonIgnore
     private int order;
 
     @ManyToOne
@@ -64,6 +61,14 @@ public abstract class LectureUnit extends DomainObject {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
     }
 
     public Lecture getLecture() {

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
@@ -65,6 +65,7 @@ public class LectureImportService {
             LectureUnit clonedLectureUnit = cloneLectureUnit(lectureUnit, lecture);
             if (clonedLectureUnit != null) {
                 clonedLectureUnit.setLecture(lecture);
+                clonedLectureUnit.setOrder(lectureUnit.getOrder());
                 lectureUnits.add(clonedLectureUnit);
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/AttachmentUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/AttachmentUnitResource.java
@@ -85,6 +85,7 @@ public class AttachmentUnitResource {
         // Make sure that the original references are preserved.
         AttachmentUnit originalAttachmentUnit = attachmentUnitRepository.findById(attachmentUnit.getId()).get();
         attachmentUnit.setAttachment(originalAttachmentUnit.getAttachment());
+        attachmentUnit.setOrder(originalAttachmentUnit.getOrder());
 
         AttachmentUnit result = attachmentUnitRepository.save(attachmentUnit);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, attachmentUnit.getId().toString())).body(result);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/TextUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/TextUnitResource.java
@@ -87,6 +87,9 @@ public class TextUnitResource {
         }
         authorizationCheckService.checkHasAtLeastRoleForLectureElseThrow(Role.EDITOR, textUnit.getLecture(), null);
 
+        TextUnit existingUnit = textUnitRepository.findById(textUnit.getId()).orElseThrow();
+        textUnit.setOrder(existingUnit.getOrder());
+
         TextUnit result = textUnitRepository.save(textUnit);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, textUnit.getId().toString())).body(result);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
@@ -101,6 +101,9 @@ public class VideoUnitResource {
             return conflict();
         }
 
+        VideoUnit existingUnit = videoUnitRepository.findById(videoUnit.getId()).orElseThrow();
+        videoUnit.setOrder(existingUnit.getOrder());
+
         VideoUnit result = videoUnitRepository.save(videoUnit);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, videoUnit.getId().toString())).body(result);
     }

--- a/src/test/java/de/tum/in/www1/artemis/AttachmentUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AttachmentUnitIntegrationTest.java
@@ -109,6 +109,23 @@ public class AttachmentUnitIntegrationTest extends AbstractSpringIntegrationBamb
         assertThat(this.attachment.getAttachmentUnit()).isEqualTo(this.attachmentUnit);
     }
 
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void updateAttachmentUnit_asInstructor_shouldKeepOrdering() throws Exception {
+        persistAttachmentUnitWithLecture();
+
+        // Add a second lecture unit
+        AttachmentUnit attachmentUnit = database.createAttachmentUnit(false);
+        lecture1.addLectureUnit(attachmentUnit);
+        lectureRepository.save(lecture1);
+
+        // Updating the lecture unit should not change order attribute
+        request.putWithResponseBody("/api/lectures/" + lecture1.getId() + "/attachment-units", attachmentUnit, AttachmentUnit.class, HttpStatus.OK);
+
+        AttachmentUnit updatedAttachmentUnit = attachmentUnitRepository.findById(attachmentUnit.getId()).orElseThrow();
+        assertThat(updatedAttachmentUnit.getOrder()).isEqualTo(1);
+    }
+
     private void persistAttachmentUnitWithLecture() {
         this.attachmentUnit = attachmentUnitRepository.save(this.attachmentUnit);
         lecture1 = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get();

--- a/src/test/java/de/tum/in/www1/artemis/TextUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextUnitIntegrationTest.java
@@ -101,6 +101,23 @@ public class TextUnitIntegrationTest extends AbstractSpringIntegrationBambooBitb
 
     @Test
     @WithMockUser(username = "editor1", roles = "EDITOR")
+    public void updateTextUnit_asEditor_shouldKeepOrdering() throws Exception {
+        persistTextUnitWithLecture();
+
+        // Add a second lecture unit
+        TextUnit textUnit = database.createTextUnit();
+        lecture.addLectureUnit(textUnit);
+        lectureRepository.save(lecture);
+
+        // Updating the lecture unit should not change order attribute
+        request.putWithResponseBody("/api/lectures/" + lecture.getId() + "/text-units", textUnit, TextUnit.class, HttpStatus.OK);
+
+        TextUnit updatedTextUnit = textUnitRepository.findById(textUnit.getId()).orElseThrow();
+        assertThat(updatedTextUnit.getOrder()).isEqualTo(1);
+    }
+
+    @Test
+    @WithMockUser(username = "editor1", roles = "EDITOR")
     public void updateTextUnit_noId_shouldReturnBadRequest() throws Exception {
         persistTextUnitWithLecture();
         TextUnit textUnitFromRequest = request.get("/api/lectures/" + lecture.getId() + "/text-units/" + this.textUnit.getId(), HttpStatus.OK, TextUnit.class);

--- a/src/test/java/de/tum/in/www1/artemis/VideoUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/VideoUnitIntegrationTest.java
@@ -87,10 +87,7 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateVideoUnit_asInstructor_shouldUpdateVideoUnit() throws Exception {
-        this.videoUnit = videoUnitRepository.save(this.videoUnit);
-        lecture1 = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get();
-        lecture1.addLectureUnit(this.videoUnit);
-        lecture1 = lectureRepository.save(lecture1);
+        persistVideoUnitWithLecture();
 
         this.videoUnit = (VideoUnit) lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get().getLectureUnits().stream().findFirst().get();
         this.videoUnit.setSource("https://www.youtube.com/embed/8iU8LPEa4o0");
@@ -100,12 +97,33 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
     }
 
     @Test
-    @WithMockUser(username = "instructor42", roles = "INSTRUCTOR")
-    public void updateVideoUnit_InstructorNotInCourse_shouldReturnForbidden() throws Exception {
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void updateVideoUnit_asInstructor_shouldKeepOrdering() throws Exception {
+        persistVideoUnitWithLecture();
+
+        // Add a second lecture unit
+        VideoUnit videoUnit = database.createVideoUnit();
+        lecture1.addLectureUnit(videoUnit);
+        lectureRepository.save(lecture1);
+
+        // Updating the lecture unit should not change order attribute
+        request.putWithResponseBody("/api/lectures/" + lecture1.getId() + "/video-units", videoUnit, VideoUnit.class, HttpStatus.OK);
+
+        VideoUnit updatedVideoUnit = videoUnitRepository.findById(videoUnit.getId()).orElseThrow();
+        assertThat(updatedVideoUnit.getOrder()).isEqualTo(1);
+    }
+
+    private void persistVideoUnitWithLecture() {
         this.videoUnit = videoUnitRepository.save(this.videoUnit);
-        lecture1 = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get();
         lecture1.addLectureUnit(this.videoUnit);
         lecture1 = lectureRepository.save(lecture1);
+        this.videoUnit = (VideoUnit) lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get().getLectureUnits().stream().findFirst().get();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor42", roles = "INSTRUCTOR")
+    public void updateVideoUnit_InstructorNotInCourse_shouldReturnForbidden() throws Exception {
+        persistVideoUnitWithLecture();
 
         this.videoUnit = (VideoUnit) lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get().getLectureUnits().stream().findFirst().get();
         this.videoUnit.setDescription("Changed");
@@ -116,10 +134,8 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateVideoUnit_noId_shouldReturnBadRequest() throws Exception {
-        this.videoUnit = videoUnitRepository.save(this.videoUnit);
-        lecture1 = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get();
-        lecture1.addLectureUnit(this.videoUnit);
-        lecture1 = lectureRepository.save(lecture1);
+        persistVideoUnitWithLecture();
+
         this.videoUnit = (VideoUnit) lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get().getLectureUnits().stream().findFirst().get();
         this.videoUnit.setId(null);
         this.videoUnit = request.putWithResponseBody("/api/lectures/" + lecture1.getId() + "/video-units", this.videoUnit, VideoUnit.class, HttpStatus.BAD_REQUEST);
@@ -128,10 +144,8 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void getVideoUnit_correctId_shouldReturnVideoUnit() throws Exception {
-        this.videoUnit = videoUnitRepository.save(this.videoUnit);
-        lecture1 = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get();
-        lecture1.addLectureUnit(this.videoUnit);
-        lecture1 = lectureRepository.save(lecture1);
+        persistVideoUnitWithLecture();
+
         this.videoUnit = (VideoUnit) lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get().getLectureUnits().stream().findFirst().get();
         VideoUnit videoUnitFromRequest = request.get("/api/lectures/" + lecture1.getId() + "/video-units/" + this.videoUnit.getId(), HttpStatus.OK, VideoUnit.class);
         assertThat(this.videoUnit.getId()).isEqualTo(videoUnitFromRequest.getId());
@@ -140,10 +154,8 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void deleteVideoUnit_correctId_shouldDeleteVideoUnit() throws Exception {
-        this.videoUnit = videoUnitRepository.save(this.videoUnit);
-        lecture1 = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get();
-        lecture1.addLectureUnit(this.videoUnit);
-        lecture1 = lectureRepository.save(lecture1);
+        persistVideoUnitWithLecture();
+
         this.videoUnit = (VideoUnit) lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lecture1.getId()).get().getLectureUnits().stream().findFirst().get();
         assertThat(this.videoUnit.getId()).isNotNull();
         request.delete("/api/lectures/" + lecture1.getId() + "/lecture-units/" + this.videoUnit.getId(), HttpStatus.OK);

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -590,7 +590,7 @@ public class DatabaseUtilService {
     public VideoUnit createVideoUnit() {
         VideoUnit videoUnit = new VideoUnit();
         videoUnit.setDescription("Lorem Ipsum");
-        videoUnit.setSource("Some URL");
+        videoUnit.setSource("http://video.fake");
         return videoUnitRepository.save(videoUnit);
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There was an issue related to the introduction of the `order` attribute on `LectureUnit` in #4931, which was done to [fix](https://docs.jboss.org/hibernate/stable/annotations/reference/en/html_single/#entity-hibspec-collection-extratype-indexbidir) some Hibernate quirks regarding the `OrderColumn`.
When a lecture unit was updated, the `order` would be set to `0` (which made it disappear as multiple lecture units can not have the same order number).

### Description

This PR fixes the issue by fetching the previous lecture unit from the database and overriding the `order` attribute of the posted object with the previous value in the put requests of all different lecture units.
I also added some tests to make sure this bug does not re-appear.
In the future, we should discuss whether we want to put a unique index on the tuple `(lecture_id, lecture_unit_order)` of the `lecture_unit` table.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a lecture with multiple lecture units
4. Edit the last lecture unit
5. Lecture unit should have updated and the ordering preserved

Please also make sure that importing a lecture with its lecture units and attachments still works.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
