### PR TITLE
`General`: Improve the selection of exercise details buttons for tutors

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -38,9 +38,12 @@
             [triggerLastGraded]="false"
         >
         </jhi-submission-result-status>
-        <div class="col-auto d-md-flex align-items-center" *ngIf="exercise.isAtLeastEditor">
-            <span class="ms-1 me-1">{{ 'artemisApp.courseOverview.exerciseDetails.instructorActions.title' | artemisTranslate }}</span>
+        <div class="col-auto d-md-flex align-items-center" *ngIf="exercise.isAtLeastTutor">
+            <span class="ms-1 me-1">{{
+                'artemisApp.courseOverview.exerciseDetails.instructorActions.title' + (exercise.isAtLeastInstructor ? '' : 'Tutor') | artemisTranslate
+            }}</span>
             <div class="btn-group flex-btn-group-container">
+                <!-- Actions for Tutors, Editors and Instructors -->
                 <a *ngIf="exercise.type !== QUIZ" [routerLink]="baseResource" class="btn btn-info btn-sm me-1">
                     <fa-icon [icon]="faEye"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
@@ -49,43 +52,66 @@
                     <fa-icon [icon]="faTable"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="entity.action.scores">Scores</span>
                 </a>
-                <a *ngIf="exercise.type !== QUIZ" [routerLink]="baseResource + 'submissions'" class="btn btn-success btn-sm me-1">
-                    <fa-icon [icon]="faBook"></fa-icon>
-                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.submissions">Submissions</span>
-                </a>
-                <a *ngIf="exercise.type === QUIZ" [routerLink]="baseResource + 'quiz-point-statistic'" class="btn btn-info btn-sm me-1">
-                    <fa-icon [icon]="faSignal"></fa-icon>
-                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.statistics">Statistics</span>
-                </a>
-                <a *ngIf="exercise.type === MODELING" [routerLink]="baseResource + 'exercise-statistics'" class="btn btn-info btn-sm me-1">
-                    <fa-icon [icon]="faSignal"></fa-icon>
-                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.statistics">Statistics</span>
-                </a>
-                <a *ngIf="exercise.type === PROGRAMMING" [routerLink]="baseResource + 'participations'" class="btn btn-primary btn-sm me-1">
+                <a *ngIf="exercise.type !== QUIZ" [routerLink]="baseResource + 'participations'" class="btn btn-primary btn-sm me-1">
                     <fa-icon [icon]="faListAlt"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="artemisApp.exercise.participations">Participations</span>
                 </a>
-                <a *ngIf="exercise.type === PROGRAMMING" [routerLink]="baseResource + 'grading/test-cases'" class="btn btn-info btn-sm me-1">
-                    <fa-icon [icon]="faFileSignature"></fa-icon>
-                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.programmingExercise.configureGrading.shortTitle">Grading</span>
+                <a
+                    *ngIf="exercise.type === QUIZ"
+                    [routerLink]="['/course-management', exercise.course?.id, 'quiz-exercises', exercise.id, 'preview']"
+                    class="btn btn-success btn-sm me-1"
+                >
+                    <fa-icon [icon]="faEye"></fa-icon>
+                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.quizExercise.preview">Preview</span>
                 </a>
                 <a
-                    *ngIf="!QUIZ_ENDED_STATUS.includes(quizExerciseStatus)"
-                    [class.disabled]="quizExerciseStatus === QuizStatus.ACTIVE"
-                    [routerLink]="baseResource + 'edit'"
-                    class="btn btn-warning btn-sm me-1"
+                    *ngIf="exercise.type === QUIZ"
+                    [routerLink]="['/course-management', exercise.course?.id, 'quiz-exercises', exercise.id, 'solution']"
+                    class="btn btn-success btn-sm me-1"
                 >
-                    <fa-icon [icon]="faWrench"></fa-icon>
-                    <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
+                    <fa-icon [icon]="faEye"></fa-icon>
+                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.quizExercise.solution">Solution</span>
                 </a>
-                <a
-                    *ngIf="QUIZ_ENDED_STATUS.includes(quizExerciseStatus) && exercise.isAtLeastInstructor"
-                    [routerLink]="baseResource + 're-evaluate'"
-                    class="btn btn-warning btn-sm me-1"
-                >
-                    <fa-icon [icon]="faWrench"></fa-icon>
-                    <span class="d-none d-md-inline" jhiTranslate="entity.action.re-evaluate">Re-evaluate</span>
-                </a>
+                <ng-container *ngIf="exercise.isAtLeastEditor">
+                    <!-- Actions for Editors and Instructors -->
+                    <a
+                        *ngIf="exercise.type !== QUIZ && (exercise.isAtLeastInstructor || exercise.type === PROGRAMMING)"
+                        [routerLink]="baseResource + 'submissions'"
+                        class="btn btn-success btn-sm me-1"
+                    >
+                        <fa-icon [icon]="faBook"></fa-icon>
+                        <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.submissions">Submissions</span>
+                    </a>
+                    <a *ngIf="exercise.type === QUIZ" [routerLink]="baseResource + 'quiz-point-statistic'" class="btn btn-info btn-sm me-1">
+                        <fa-icon [icon]="faSignal"></fa-icon>
+                        <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.statistics">Statistics</span>
+                    </a>
+                    <a *ngIf="exercise.type === MODELING" [routerLink]="baseResource + 'exercise-statistics'" class="btn btn-info btn-sm me-1">
+                        <fa-icon [icon]="faSignal"></fa-icon>
+                        <span class="d-none d-md-inline" jhiTranslate="artemisApp.courseOverview.exerciseDetails.instructorActions.statistics">Statistics</span>
+                    </a>
+                    <a *ngIf="exercise.type === PROGRAMMING" [routerLink]="baseResource + 'grading/test-cases'" class="btn btn-info btn-sm me-1">
+                        <fa-icon [icon]="faFileSignature"></fa-icon>
+                        <span class="d-none d-md-inline" jhiTranslate="artemisApp.programmingExercise.configureGrading.shortTitle">Grading</span>
+                    </a>
+                    <a
+                        *ngIf="!QUIZ_ENDED_STATUS.includes(quizExerciseStatus)"
+                        [class.disabled]="quizExerciseStatus === QuizStatus.ACTIVE"
+                        [routerLink]="baseResource + 'edit'"
+                        class="btn btn-warning btn-sm me-1"
+                    >
+                        <fa-icon [icon]="faWrench"></fa-icon>
+                        <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
+                    </a>
+                    <a
+                        *ngIf="QUIZ_ENDED_STATUS.includes(quizExerciseStatus) && exercise.isAtLeastInstructor"
+                        [routerLink]="baseResource + 're-evaluate'"
+                        class="btn btn-warning btn-sm me-1"
+                    >
+                        <fa-icon [icon]="faWrench"></fa-icon>
+                        <span class="d-none d-md-inline" jhiTranslate="entity.action.re-evaluate">Re-evaluate</span>
+                    </a>
+                </ng-container>
             </div>
         </div>
     </div>

--- a/src/main/webapp/i18n/de/student-dashboard.json
+++ b/src/main/webapp/i18n/de/student-dashboard.json
@@ -161,6 +161,7 @@
                 "noResults": "Du hast noch keine Ergebnisse",
                 "instructorActions": {
                     "title": "Aktionen für Lehrende:",
+                    "titleTutor": "Aktionen für Tutor:innen",
                     "scores": "Bewertungen",
                     "submissions": "Einreichungen",
                     "statistics": "Statistiken"

--- a/src/main/webapp/i18n/en/student-dashboard.json
+++ b/src/main/webapp/i18n/en/student-dashboard.json
@@ -163,6 +163,7 @@
                 "noResults": "You have no results yet",
                 "instructorActions": {
                     "title": "Instructor actions:",
+                    "titleTutor": "Tutor actions:",
                     "scores": "Scores",
                     "submissions": "Submissions",
                     "statistics": "Statistics"


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
The current selection of the exercise details shortcut buttons has a few drawbacks:
- Tutors have no selection of exercise details button shown. If they want to open the detail view, the scores or the participation page, they must navigate into the Course Management -> Exercise and select the exercise from the list.
- Editors are displayed with the button `Submissions`, but they are not allowed to open the submission page for Text- and Modelling-Exercises
- Participations are only shown for Programming Exercises, however, the Participation Page is used to set the presentation score
- Quiz-Exercises lack the feature to open the preview or the example solution for the exercise

### Description
The corresponding `course-exercise-details.component.html` was modified to present a selection of shortcut buttons to Tutors, Editors, and Instructors. 
- The Shortcut-Buttons are either labeled `Tutor actions` or `Instructor actions`
- Tutors have shortcuts to view the details page, open the scores or the participations
- Editors can only open the Submissions for Programming Exercises. For Text-, Modelling- and Quiz-Exercises, they can open the Participations instead
- For Quiz-Exercises, shortcuts to the preview and the example solutions are added

A detailed overview can be found below.

### Steps for Testing
- 1 Instructor
- 1 Editor
- 1 Tutor
- 1 Exercise of each type (Programming-, Modelling-, Text-, Quiz-, File-Upload)

1. Log in to Artemis
2. Open a course 
3. Open the 5 Exercises with all 3 roles and make sure, that the buttons are displayed as shown in the screenshot below. Also make sure, that all buttons are functional. 
_(Note: For Quiz-Exercises, editors should only be able to edit the Quiz before the start of the quiz. During the quiz, both editors and instructors should not be able to edit the quiz. After the quiz, only instructors should be able to re-evaluate the quiz. But this is independent of this PR)_

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
![PR-Buttons_new](https://user-images.githubusercontent.com/94070506/165606951-d274d6b1-bf65-4e63-b7ee-dfcd5cd608f4.jpg)

