### PR TITLE
`Development`: Replace Paths.get() with Path.of()

### DIFF
--- a/docs/dev/guidelines/server.rst
+++ b/docs/dev/guidelines/server.rst
@@ -157,7 +157,7 @@ Additional notes on the controller methods:
 =================
 
 * Never use operating system (OS) specific file paths such as "test/test". Always use OS independent paths.
-* Do not deal with File.separator manually. Instead use the Paths.get(firstPart, secondPart, ...) method which deals with separators automatically.
+* Do not deal with File.separator manually. Instead use the Path.of(firstPart, secondPart, ...) method which deals with separators automatically.
 * Existing paths can easily be appended with a new folder using ``existingPath.resolve(subfolder)``
 
 15. General best practices

--- a/src/main/java/de/tum/in/www1/artemis/config/PublicResourcesConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/PublicResourcesConfiguration.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.config;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -14,7 +14,7 @@ public class PublicResourcesConfiguration implements WebMvcConfigurer {
         // Static assets, accessible without authorization.
         // Allowed locations are under $artemisRunDir/public/** and resource/public/**
         final var userDir = System.getProperty("user.dir");
-        final var publicFiles = Paths.get(userDir, "public");
+        final var publicFiles = Path.of(userDir, "public");
         registry.addResourceHandler("/public/**").addResourceLocations("file:" + publicFiles + "/", "classpath:public/");
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/config/SecurityConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/SecurityConfiguration.java
@@ -23,7 +23,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;

--- a/src/main/java/de/tum/in/www1/artemis/config/WebConfigurer.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/WebConfigurer.java
@@ -4,7 +4,7 @@ import static java.net.URLDecoder.decode;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import javax.servlet.ServletContext;
 
@@ -87,7 +87,7 @@ public class WebConfigurer implements ServletContextInitializer, WebServerFactor
      */
     private String resolvePathPrefix() {
         String fullExecutablePath = decode(this.getClass().getResource("").getPath(), StandardCharsets.UTF_8);
-        String rootPath = Paths.get(".").toUri().normalize().getPath();
+        String rootPath = Path.of(".").toUri().normalize().getPath();
         String extractedPath = fullExecutablePath.replace(rootPath, "");
         int extractionEndIndex = extractedPath.indexOf("build/");
         if (extractionEndIndex <= 0) {

--- a/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Attachment.java
@@ -1,7 +1,7 @@
 package de.tum.in.www1.artemis.domain;
 
 import java.io.Serializable;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.time.ZonedDateTime;
 
 import javax.persistence.*;
@@ -127,12 +127,12 @@ public class Attachment extends DomainObject implements Serializable {
     private void handleFileChange() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // move file and delete old file if necessary
-            var targetFolder = Paths.get(FilePathService.getLectureAttachmentFilePath(), getLecture().getId().toString()).toString();
+            var targetFolder = Path.of(FilePathService.getLectureAttachmentFilePath(), getLecture().getId().toString()).toString();
             link = fileService.manageFilesForUpdatedFilePath(prevLink, link, targetFolder, getLecture().getId(), true);
         }
         else if (attachmentType == AttachmentType.FILE && getAttachmentUnit() != null) {
             // move file and delete old file if necessary
-            var targetFolder = Paths.get(FilePathService.getAttachmentUnitFilePath(), getAttachmentUnit().getId().toString()).toString();
+            var targetFolder = Path.of(FilePathService.getAttachmentUnitFilePath(), getAttachmentUnit().getId().toString()).toString();
             link = fileService.manageFilesForUpdatedFilePath(prevLink, link, targetFolder, getAttachmentUnit().getId(), true);
         }
     }
@@ -145,12 +145,12 @@ public class Attachment extends DomainObject implements Serializable {
     public void onDelete() {
         if (attachmentType == AttachmentType.FILE && getLecture() != null) {
             // delete old file if necessary
-            var targetFolder = Paths.get(FilePathService.getLectureAttachmentFilePath(), getLecture().getId().toString()).toString();
+            var targetFolder = Path.of(FilePathService.getLectureAttachmentFilePath(), getLecture().getId().toString()).toString();
             fileService.manageFilesForUpdatedFilePath(prevLink, null, targetFolder, getLecture().getId(), true);
         }
         else if (attachmentType == AttachmentType.FILE && getAttachmentUnit() != null) {
             // delete old file if necessary
-            var targetFolder = Paths.get(FilePathService.getAttachmentUnitFilePath(), getAttachmentUnit().getId().toString()).toString();
+            var targetFolder = Path.of(FilePathService.getAttachmentUnitFilePath(), getAttachmentUnit().getId().toString()).toString();
             fileService.manageFilesForUpdatedFilePath(prevLink, null, targetFolder, getAttachmentUnit().getId(), true);
         }
     }

--- a/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/FileUploadSubmission.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.domain;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import javax.persistence.*;
 
@@ -54,7 +54,7 @@ public class FileUploadSubmission extends Submission {
      * @return path where submission for file upload exercise is stored
      */
     public static String buildFilePath(Long exerciseId, Long submissionId) {
-        return Paths.get(FilePathService.getFileUploadExercisesFilePath(), String.valueOf(exerciseId), String.valueOf(submissionId)).toString();
+        return Path.of(FilePathService.getFileUploadExercisesFilePath(), String.valueOf(exerciseId), String.valueOf(submissionId)).toString();
     }
 
     public void setFilePath(String filePath) {

--- a/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FilePathService.java
@@ -1,6 +1,6 @@
 package de.tum.in.www1.artemis.service;
 
-import java.nio.file.Paths;
+import java.nio.file.Path;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -21,34 +21,34 @@ public class FilePathService {
     }
 
     public static String getTempFilePath() {
-        return Paths.get(fileUploadPath, "images", "temp").toString();
+        return Path.of(fileUploadPath, "images", "temp").toString();
     }
 
     public static String getDragAndDropBackgroundFilePath() {
-        return Paths.get(fileUploadPath, "images", "drag-and-drop", "backgrounds").toString();
+        return Path.of(fileUploadPath, "images", "drag-and-drop", "backgrounds").toString();
     }
 
     public static String getDragItemFilePath() {
-        return Paths.get(fileUploadPath, "images", "drag-and-drop", "drag-items").toString();
+        return Path.of(fileUploadPath, "images", "drag-and-drop", "drag-items").toString();
     }
 
     public static String getCourseIconFilePath() {
-        return Paths.get(fileUploadPath, "images", "course", "icons").toString();
+        return Path.of(fileUploadPath, "images", "course", "icons").toString();
     }
 
     public static String getLectureAttachmentFilePath() {
-        return Paths.get(fileUploadPath, "attachments", "lecture").toString();
+        return Path.of(fileUploadPath, "attachments", "lecture").toString();
     }
 
     public static String getAttachmentUnitFilePath() {
-        return Paths.get(fileUploadPath, "attachments", "attachment-unit").toString();
+        return Path.of(fileUploadPath, "attachments", "attachment-unit").toString();
     }
 
     public static String getFileUploadExercisesFilePath() {
-        return Paths.get(fileUploadPath, "file-upload-exercises").toString();
+        return Path.of(fileUploadPath, "file-upload-exercises").toString();
     }
 
     public static String getMarkdownFilePath() {
-        return Paths.get(fileUploadPath, "markdown").toString();
+        return Path.of(fileUploadPath, "markdown").toString();
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/FileService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileService.java
@@ -7,7 +7,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -154,7 +153,7 @@ public class FileService implements DisposableBean {
         if (newFilePath != null && newFilePath.contains("files/temp")) {
             // rename and move file
             try {
-                Path source = Paths.get(actualPathForPublicPath(newFilePath));
+                Path source = Path.of(actualPathForPublicPath(newFilePath));
                 File targetFile = generateTargetFile(newFilePath, targetFolder, keepFileName);
                 Path target = targetFile.toPath();
                 Files.move(source, target, REPLACE_EXISTING);
@@ -180,24 +179,24 @@ public class FileService implements DisposableBean {
 
         // check for known path to convert
         if (publicPath.contains("files/temp")) {
-            return Paths.get(FilePathService.getTempFilePath(), filename).toString();
+            return Path.of(FilePathService.getTempFilePath(), filename).toString();
         }
         if (publicPath.contains("files/drag-and-drop/backgrounds")) {
-            return Paths.get(FilePathService.getDragAndDropBackgroundFilePath(), filename).toString();
+            return Path.of(FilePathService.getDragAndDropBackgroundFilePath(), filename).toString();
         }
         if (publicPath.contains("files/drag-and-drop/drag-items")) {
-            return Paths.get(FilePathService.getDragItemFilePath(), filename).toString();
+            return Path.of(FilePathService.getDragItemFilePath(), filename).toString();
         }
         if (publicPath.contains("files/course/icons")) {
-            return Paths.get(FilePathService.getCourseIconFilePath(), filename).toString();
+            return Path.of(FilePathService.getCourseIconFilePath(), filename).toString();
         }
         if (publicPath.contains("files/attachments/lecture")) {
             String lectureId = publicPath.replace(filename, "").replace("/api/files/attachments/lecture/", "");
-            return Paths.get(FilePathService.getLectureAttachmentFilePath(), lectureId, filename).toString();
+            return Path.of(FilePathService.getLectureAttachmentFilePath(), lectureId, filename).toString();
         }
         if (publicPath.contains("files/attachments/attachment-unit")) {
             String attachmentUnitId = publicPath.replace(filename, "").replace("/api/files/attachments/attachment-unit/", "");
-            return Paths.get(FilePathService.getAttachmentUnitFilePath(), attachmentUnitId, filename).toString();
+            return Path.of(FilePathService.getAttachmentUnitFilePath(), attachmentUnitId, filename).toString();
         }
         if (publicPath.contains("files/file-upload-exercises")) {
             final var uploadSubPath = publicPath.replace(filename, "").replace("/api/files/file-upload-exercises/", "").split("/");
@@ -208,7 +207,7 @@ public class FileService implements DisposableBean {
             }
             final var exerciseId = Long.parseLong(shouldBeExerciseId);
             final var submissionId = Long.parseLong(shouldBeSubmissionId);
-            return Paths.get(FileUploadSubmission.buildFilePath(exerciseId, submissionId), filename).toString();
+            return Path.of(FileUploadSubmission.buildFilePath(exerciseId, submissionId), filename).toString();
         }
 
         // path is unknown => cannot convert
@@ -224,7 +223,7 @@ public class FileService implements DisposableBean {
      */
     public String publicPathForActualPath(String actualPath, @Nullable Long entityId) {
         // first extract filename
-        String filename = Paths.get(actualPath).getFileName().toString();
+        String filename = Path.of(actualPath).getFileName().toString();
 
         // generate part for id
         String id = entityId == null ? Constants.FILEPATH_ID_PLACEHOLDER : entityId.toString();
@@ -249,7 +248,7 @@ public class FileService implements DisposableBean {
             return "/api/files/attachments/attachment-unit/" + id + "/" + filename;
         }
         if (actualPath.contains(FilePathService.getFileUploadExercisesFilePath())) {
-            final var path = Paths.get(actualPath);
+            final var path = Path.of(actualPath);
             final long exerciseId;
             try {
                 // The last name is the file name, the one before that is the submissionId and the one before that is the exerciseId, in which we are interested
@@ -320,7 +319,7 @@ public class FileService implements DisposableBean {
                 filename = filenameBase + ZonedDateTime.now().toString().substring(0, 23).replaceAll("[:.]", "-") + "_" + UUID.randomUUID().toString().substring(0, 8) + "."
                         + fileExtension;
             }
-            var path = Paths.get(targetFolder, filename).toString();
+            var path = Path.of(targetFolder, filename).toString();
 
             newFile = new File(path);
             if (keepFileName && newFile.exists()) {
@@ -356,7 +355,7 @@ public class FileService implements DisposableBean {
                 continue;
             }
 
-            Path copyPath = Paths.get(targetDirectoryPath + targetFilePath);
+            Path copyPath = Path.of(targetDirectoryPath + targetFilePath);
             File parentFolder = copyPath.toFile().getParentFile();
             if (!parentFolder.exists()) {
                 Files.createDirectories(parentFolder.toPath());
@@ -536,7 +535,7 @@ public class FileService implements DisposableBean {
 
         if (subDirectories != null) {
             for (String subDirectory : subDirectories) {
-                replaceVariablesInDirectoryName(Paths.get(directory.getAbsolutePath(), subDirectory).toString(), targetString, replacementString);
+                replaceVariablesInDirectoryName(Path.of(directory.getAbsolutePath(), subDirectory).toString(), targetString, replacementString);
             }
         }
     }
@@ -605,7 +604,7 @@ public class FileService implements DisposableBean {
             // filter out files that should be ignored
             files = Arrays.stream(files).filter(Predicate.not(filesToIgnore::contains)).toArray(String[]::new);
             for (String file : files) {
-                replaceVariablesInFile(Paths.get(directory.getAbsolutePath(), file).toString(), replacements);
+                replaceVariablesInFile(Path.of(directory.getAbsolutePath(), file).toString(), replacements);
             }
         }
 
@@ -617,7 +616,7 @@ public class FileService implements DisposableBean {
                     // ignore files in the '.git' folder
                     continue;
                 }
-                replaceVariablesInFileRecursive(Paths.get(directory.getAbsolutePath(), subDirectory).toString(), replacements, filesToIgnore);
+                replaceVariablesInFileRecursive(Path.of(directory.getAbsolutePath(), subDirectory).toString(), replacements, filesToIgnore);
             }
         }
     }
@@ -633,7 +632,7 @@ public class FileService implements DisposableBean {
     public void replaceVariablesInFile(String filePath, Map<String, String> replacements) throws IOException {
         log.debug("Replacing {} in file {}", replacements, filePath);
         // https://stackoverflow.com/questions/3935791/find-and-replace-words-lines-in-a-file
-        Path replaceFilePath = Paths.get(filePath);
+        Path replaceFilePath = Path.of(filePath);
         Charset charset = StandardCharsets.UTF_8;
 
         String fileContent = Files.readString(replaceFilePath, charset);
@@ -679,7 +678,7 @@ public class FileService implements DisposableBean {
     public void normalizeLineEndings(String filePath) throws IOException {
         log.debug("Normalizing line endings in file {}", filePath);
         // https://stackoverflow.com/questions/3776923/how-can-i-normalize-the-eol-character-in-java
-        Path replaceFilePath = Paths.get(filePath);
+        Path replaceFilePath = Path.of(filePath);
         Charset charset = StandardCharsets.UTF_8;
 
         String fileContent = Files.readString(replaceFilePath, charset);
@@ -721,7 +720,7 @@ public class FileService implements DisposableBean {
      */
     public void convertToUTF8(String filePath) throws IOException {
         log.debug("Converting file {} to UTF-8", filePath);
-        Path replaceFilePath = Paths.get(filePath);
+        Path replaceFilePath = Path.of(filePath);
         byte[] contentArray = Files.readAllBytes(replaceFilePath);
 
         Charset charset = detectCharset(contentArray);
@@ -810,7 +809,7 @@ public class FileService implements DisposableBean {
      * @return the unique path, e.g. /opt/artemis/repos-download/1609579674868
      */
     public Path getUniquePath(String path) {
-        var uniquePath = Paths.get(path, String.valueOf(System.currentTimeMillis()));
+        var uniquePath = Path.of(path, String.valueOf(System.currentTimeMillis()));
         if (!Files.exists(uniquePath) && Files.isDirectory(uniquePath)) {
             try {
                 Files.createDirectories(uniquePath);

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -3,7 +3,7 @@ package de.tum.in.www1.artemis.service;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.security.Principal;
 import java.time.ZonedDateTime;
@@ -120,7 +120,7 @@ public class FileUploadSubmissionService extends SubmissionService {
         final var newFilePath = fileService.publicPathForActualPath(newLocalFilePath, fileUploadSubmission.getId());
 
         // We need to ensure that we can access the store file and the stored file is the same as was passed to us in the request
-        final var storedFileHash = DigestUtils.md5Hex(Files.newInputStream(Paths.get(newLocalFilePath)));
+        final var storedFileHash = DigestUtils.md5Hex(Files.newInputStream(Path.of(newLocalFilePath)));
         if (!multipartFileHash.equals(storedFileHash)) {
             throw new IOException("The file " + file.getName() + "could not be stored");
         }
@@ -185,7 +185,7 @@ public class FileUploadSubmissionService extends SubmissionService {
             filename = "file" + filename;
         }
         final var dirPath = FileUploadSubmission.buildFilePath(exerciseId, submissionId);
-        final var filePath = Paths.get(dirPath, filename).toString();
+        final var filePath = Path.of(dirPath, filename).toString();
         final var savedFile = new File(filePath);
         final var dir = new File(dirPath);
 

--- a/src/main/java/de/tum/in/www1/artemis/service/RepositoryService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/RepositoryService.java
@@ -181,7 +181,7 @@ public class RepositoryService {
             throw new FileAlreadyExistsException("file already exists");
         }
 
-        File file = new File(Paths.get(repository.getLocalPath().toString(), filename).toFile(), repository);
+        File file = new File(Path.of(repository.getLocalPath().toString(), filename).toFile(), repository);
         if (!repository.isValidFile(file)) {
             throw new IllegalArgumentException();
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
@@ -3,7 +3,6 @@ package de.tum.in.www1.artemis.service;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -171,8 +170,8 @@ public abstract class SubmissionExportService {
         String zipFileName = cleanZipGroupName + "-" + ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-Hmss")) + ".zip";
 
         // Create directory
-        Path submissionsFolderPath = Paths.get(outputDir.toString(), "zippedSubmissions", zipGroupName);
-        Path zipFilePath = Paths.get(outputDir.toString(), "zippedSubmissions", zipFileName);
+        Path submissionsFolderPath = Path.of(outputDir.toString(), "zippedSubmissions", zipGroupName);
+        Path zipFilePath = Path.of(outputDir.toString(), "zippedSubmissions", zipFileName);
 
         File submissionFolder = submissionsFolderPath.toFile();
         if (!submissionFolder.exists() && !submissionFolder.mkdirs()) {
@@ -195,7 +194,7 @@ public abstract class SubmissionExportService {
             // create file path
             String submissionFileName = exercise.getTitle() + "-" + participation.getParticipantIdentifier() + "-" + latestSubmission.getId()
                     + this.getFileEndingForSubmission(latestSubmission);
-            Path submissionFilePath = Paths.get(submissionsFolderPath.toString(), submissionFileName);
+            Path submissionFilePath = Path.of(submissionsFolderPath.toString(), submissionFileName);
 
             // store file
             try {

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/GitService.java
@@ -11,7 +11,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -1255,8 +1254,8 @@ public class GitService {
             zipFilenameWithoutSlash += ".zip";
         }
 
-        Path zipFilePath = Paths.get(repositoryDir, zipFilenameWithoutSlash);
-        Files.createDirectories(Paths.get(repositoryDir));
+        Path zipFilePath = Path.of(repositoryDir, zipFilenameWithoutSlash);
+        Files.createDirectories(Path.of(repositoryDir));
         return zipFileService.createZipFileWithFolderContent(zipFilePath, repository.getLocalPath(), contentFilter);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
@@ -2,7 +2,7 @@ package de.tum.in.www1.artemis.service.connectors.jenkins;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -151,7 +151,7 @@ public class JenkinsBuildPlanCreator implements JenkinsXmlConfigBuilder {
     @Override
     public Document buildBasicConfig(ProgrammingLanguage programmingLanguage, Optional<ProjectType> projectType, VcsRepositoryUrl testRepositoryURL,
             VcsRepositoryUrl assignmentRepositoryURL, boolean isStaticCodeAnalysisEnabled, boolean isSequentialRuns) {
-        final var resourcePath = Paths.get("templates", "jenkins", "config.xml");
+        final var resourcePath = Path.of("templates", "jenkins", "config.xml");
 
         String pipeLineScript = getPipelineScript(programmingLanguage, projectType, testRepositoryURL, assignmentRepositoryURL, isStaticCodeAnalysisEnabled, isSequentialRuns);
         pipeLineScript = pipeLineScript.replace("'", "&apos;");

--- a/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/plagiarism/ProgrammingPlagiarismDetectionService.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -174,7 +173,7 @@ public class ProgrammingPlagiarismDetectionService {
         log.info("Downloading repositories done for programming exercise {}", programmingExerciseId);
 
         final var projectKey = programmingExercise.getProjectKey();
-        final var repoFolder = Paths.get(targetPath, projectKey).toString();
+        final var repoFolder = Path.of(targetPath, projectKey).toString();
         final LanguageOption programmingLanguage = getJPlagProgrammingLanguage(programmingExercise);
 
         final var templateRepoName = urlService.getRepositorySlugFromRepositoryUrl(programmingExercise.getTemplateParticipation().getVcsRepositoryUrl());
@@ -231,7 +230,7 @@ public class ProgrammingPlagiarismDetectionService {
      */
     public File generateJPlagReportZip(JPlagResult jPlagResult, ProgrammingExercise programmingExercise) throws ExitException, IOException {
         final var targetPath = fileService.getUniquePathString(repoDownloadClonePath);
-        final var outputFolder = Paths.get(targetPath, programmingExercise.getProjectKey() + "-output").toString();
+        final var outputFolder = Path.of(targetPath, programmingExercise.getProjectKey() + "-output").toString();
         final var outputFolderFile = new File(outputFolder);
 
         // Create directories.
@@ -265,7 +264,7 @@ public class ProgrammingPlagiarismDetectionService {
         log.info("JPlag report zipping to {}", targetPath);
         final var courseShortName = programmingExercise.getCourseViaExerciseGroupOrCourseMember().getShortName();
         final var filename = courseShortName + "-" + programmingExercise.getShortName() + "-" + System.currentTimeMillis() + "-Jplag-Analysis-Output.zip";
-        final var zipFilePath = Paths.get(targetPath, filename);
+        final var zipFilePath = Path.of(targetPath, filename);
         zipFileService.createZipFileWithFolderContent(zipFilePath, outputFolderPath, null);
         log.info("JPlag report zipped. Schedule deletion of zip file in 1 minute");
         fileService.scheduleForDeletion(zipFilePath, 1);

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -582,7 +581,7 @@ public class ProgrammingExerciseExportService {
      */
     public void deleteReposDownloadProjectRootDirectory(ProgrammingExercise programmingExercise, String targetPath) {
         final String projectDirName = programmingExercise.getProjectKey();
-        Path projectPath = Paths.get(targetPath, projectDirName);
+        Path projectPath = Path.of(targetPath, projectDirName);
         try {
             log.info("Delete project root directory {}", projectPath.toFile());
             FileUtils.deleteDirectory(projectPath.toFile());

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -8,7 +8,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -543,7 +542,7 @@ public class ProgrammingExerciseService {
             if (!programmingExercise.hasSequentialTestRuns()) {
                 String testFilePath = templatePath + "/testFiles/**/*.*";
                 Resource[] testFileResources = resourceLoaderService.getResources(testFilePath);
-                String packagePath = Paths.get(repository.getLocalPath().toAbsolutePath().toString(), "test", "${packageNameFolder}").toAbsolutePath().toString();
+                String packagePath = Path.of(repository.getLocalPath().toAbsolutePath().toString(), "test", "${packageNameFolder}").toAbsolutePath().toString();
 
                 sectionsMap.put("non-sequential", true);
                 sectionsMap.put("sequential", false);
@@ -556,7 +555,7 @@ public class ProgrammingExerciseService {
                 else {
                     projectFileFileName = "pom.xml";
                 }
-                fileService.replacePlaceholderSections(Paths.get(repository.getLocalPath().toAbsolutePath().toString(), projectFileFileName).toAbsolutePath().toString(),
+                fileService.replacePlaceholderSections(Path.of(repository.getLocalPath().toAbsolutePath().toString(), projectFileFileName).toAbsolutePath().toString(),
                         sectionsMap);
 
                 fileService.copyResources(testFileResources, prefix, packagePath, false);
@@ -602,7 +601,7 @@ public class ProgrammingExerciseService {
                 else {
                     projectFileName = "build.gradle";
                 }
-                fileService.replacePlaceholderSections(Paths.get(repository.getLocalPath().toAbsolutePath().toString(), projectFileName).toAbsolutePath().toString(), sectionsMap);
+                fileService.replacePlaceholderSections(Path.of(repository.getLocalPath().toAbsolutePath().toString(), projectFileName).toAbsolutePath().toString(), sectionsMap);
 
                 // staging project files are only required for maven
                 Resource stagePomXml = null;
@@ -621,16 +620,16 @@ public class ProgrammingExerciseService {
 
                 for (String buildStage : sequentialTestTasks) {
 
-                    Path buildStagePath = Paths.get(repository.getLocalPath().toAbsolutePath().toString(), buildStage);
+                    Path buildStagePath = Path.of(repository.getLocalPath().toAbsolutePath().toString(), buildStage);
                     Files.createDirectory(buildStagePath);
 
                     String buildStageResourcesPath = templatePath + "/testFiles/" + buildStage + "/**/*.*";
                     Resource[] buildStageResources = resourceLoaderService.getResources(buildStageResourcesPath);
 
-                    Files.createDirectory(Paths.get(buildStagePath.toAbsolutePath().toString(), "test"));
-                    Files.createDirectory(Paths.get(buildStagePath.toAbsolutePath().toString(), "test", "${packageNameFolder}"));
+                    Files.createDirectory(Path.of(buildStagePath.toAbsolutePath().toString(), "test"));
+                    Files.createDirectory(Path.of(buildStagePath.toAbsolutePath().toString(), "test", "${packageNameFolder}"));
 
-                    String packagePath = Paths.get(buildStagePath.toAbsolutePath().toString(), "test", "${packageNameFolder}").toAbsolutePath().toString();
+                    String packagePath = Path.of(buildStagePath.toAbsolutePath().toString(), "test", "${packageNameFolder}").toAbsolutePath().toString();
 
                     // staging project files are only required for maven
                     if (isMaven && stagePomXml != null) {
@@ -797,7 +796,7 @@ public class ProgrammingExerciseService {
 
         Path solutionRepositoryPath = solutionRepository.getLocalPath().toRealPath();
         Path exerciseRepositoryPath = exerciseRepository.getLocalPath().toRealPath();
-        Path structureOraclePath = Paths.get(testRepository.getLocalPath().toRealPath().toString(), testsPath, "test.json");
+        Path structureOraclePath = Path.of(testRepository.getLocalPath().toRealPath().toString(), testsPath, "test.json");
 
         String structureOracleJSON = OracleGenerator.generateStructureOracleJSON(solutionRepositoryPath, exerciseRepositoryPath);
         return saveAndPushStructuralOracle(user, testRepository, structureOraclePath, structureOracleJSON);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -8,7 +8,6 @@ import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -355,8 +354,7 @@ public class FileResource {
 
         List<String> attachmentLinks = lectureAttachments.stream()
                 .filter(unit -> unit.isVisibleToStudents() && "pdf".equals(StringUtils.substringAfterLast(unit.getAttachment().getLink(), ".")))
-                .map(unit -> Paths
-                        .get(FilePathService.getAttachmentUnitFilePath(), String.valueOf(unit.getId()), StringUtils.substringAfterLast(unit.getAttachment().getLink(), "/"))
+                .map(unit -> Path.of(FilePathService.getAttachmentUnitFilePath(), String.valueOf(unit.getId()), StringUtils.substringAfterLast(unit.getAttachment().getLink(), "/"))
                         .toString())
                 .collect(Collectors.toList());
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileResource.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.ZonedDateTime;
@@ -326,7 +327,7 @@ public class FileResource {
             String errorMessage = "You don't have the access rights for this file! Please login to Artemis and download the attachment in the corresponding lecture";
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorMessage.getBytes());
         }
-        return buildFileResponse(Paths.get(FilePathService.getLectureAttachmentFilePath(), String.valueOf(optionalLecture.get().getId())).toString(), filename);
+        return buildFileResponse(Path.of(FilePathService.getLectureAttachmentFilePath(), String.valueOf(optionalLecture.get().getId())).toString(), filename);
     }
 
     /**
@@ -390,7 +391,7 @@ public class FileResource {
             String errorMessage = "You don't have the access rights for this file! Please login to Artemis and download the attachment in the corresponding attachmentUnit";
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorMessage.getBytes());
         }
-        return buildFileResponse(Paths.get(FilePathService.getAttachmentUnitFilePath(), String.valueOf(optionalAttachmentUnit.get().getId())).toString(), filename);
+        return buildFileResponse(Path.of(FilePathService.getAttachmentUnitFilePath(), String.valueOf(optionalAttachmentUnit.get().getId())).toString(), filename);
     }
 
     /**
@@ -484,7 +485,7 @@ public class FileResource {
                     filename = fileNameAddition + ZonedDateTime.now().toString().substring(0, 23).replaceAll(":|\\.", "-") + "_" + UUID.randomUUID().toString().substring(0, 8)
                             + "." + fileExtension;
                 }
-                String path = Paths.get(filePath, filename).toString();
+                String path = Path.of(filePath, filename).toString();
 
                 newFile = new File(path);
                 if (keepFileName && newFile.exists()) {
@@ -517,7 +518,7 @@ public class FileResource {
      */
     private ResponseEntity<byte[]> buildFileResponse(String path, String filename) {
         try {
-            var actualPath = Paths.get(path, filename).toString();
+            var actualPath = Path.of(path, filename).toString();
             var file = fileService.getFileForPath(actualPath);
             if (file == null) {
                 return ResponseEntity.notFound().build();
@@ -554,7 +555,7 @@ public class FileResource {
      */
     private ResponseEntity<byte[]> responseEntityForFilePath(String path, String filename) {
         try {
-            var actualPath = Paths.get(path, filename).toString();
+            var actualPath = Path.of(path, filename).toString();
             var file = fileService.getFileForPath(actualPath);
             if (file == null) {
                 return ResponseEntity.notFound().build();

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -5,7 +5,7 @@ import static de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResourceEndpoin
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -557,9 +557,9 @@ public class ProgrammingExerciseResource {
         var testRepoURL = programmingExercise.getVcsTestRepositoryUrl();
 
         try {
-            String testsPath = Paths.get("test", programmingExercise.getPackageFolderName()).toString();
+            String testsPath = Path.of("test", programmingExercise.getPackageFolderName()).toString();
             // Atm we only have one folder that can have structural tests, but this could change.
-            testsPath = programmingExercise.hasSequentialTestRuns() ? Paths.get("structural", testsPath).toString() : testsPath;
+            testsPath = programmingExercise.hasSequentialTestRuns() ? Path.of("structural", testsPath).toString() : testsPath;
             boolean didGenerateOracle = programmingExerciseService.generateStructureOracleFile(solutionRepoURL, exerciseRepoURL, testRepoURL, testsPath, user);
 
             if (didGenerateOracle) {

--- a/src/test/java/de/tum/in/www1/artemis/ContinuousIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/ContinuousIntegrationTestService.java
@@ -8,7 +8,6 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,12 +70,12 @@ public class ContinuousIntegrationTestService {
         String currentLocalFolderName = "currentFolderName";
         localRepo.configureRepos("testLocalRepo", "testOriginRepo");
         // add file to the repository folder
-        Path filePath = Paths.get(localRepo.localRepoFile + "/" + currentLocalFileName);
+        Path filePath = Path.of(localRepo.localRepoFile + "/" + currentLocalFileName);
         var file = Files.createFile(filePath).toFile();
         // write content to the created file
         FileUtils.write(file, currentLocalFileContent, Charset.defaultCharset());
         // add folder to the repository folder
-        filePath = Paths.get(localRepo.localRepoFile + "/" + currentLocalFolderName);
+        filePath = Path.of(localRepo.localRepoFile + "/" + currentLocalFolderName);
         Files.createDirectory(filePath).toFile();
 
         GitUtilService.MockFileRepositoryUrl localRepoUrl = new GitUtilService.MockFileRepositoryUrl(localRepo.localRepoFile);

--- a/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileIntegrationTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
@@ -221,7 +221,7 @@ public class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         }
         String responsePath = response.get("path").asText();
         // move file from temp folder to correct folder
-        var targetFolder = Paths.get(FilePathService.getLectureAttachmentFilePath(), String.valueOf(lecture.getId())).toString();
+        var targetFolder = Path.of(FilePathService.getLectureAttachmentFilePath(), String.valueOf(lecture.getId())).toString();
         String attachmentPath = fileService.manageFilesForUpdatedFilePath(null, responsePath, targetFolder, lecture.getId(), true);
 
         attachment.setLink(attachmentPath);
@@ -389,7 +389,7 @@ public class FileIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
 
         String responsePath = response.get("path").asText();
         // move file from temp folder to correct folder
-        var targetFolder = Paths.get(FilePathService.getAttachmentUnitFilePath(), String.valueOf(attachmentUnit.getId())).toString();
+        var targetFolder = Path.of(FilePathService.getAttachmentUnitFilePath(), String.valueOf(attachmentUnit.getId())).toString();
 
         fileService.manageFilesForUpdatedFilePath(null, responsePath, targetFolder, lecture.getId(), true);
         var attachmentPath = targetFolder + "/" + file.getOriginalFilename();

--- a/src/test/java/de/tum/in/www1/artemis/FileUploadSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/FileUploadSubmissionIntegrationTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -128,24 +128,24 @@ public class FileUploadSubmissionIntegrationTest extends AbstractSpringIntegrati
         String actualFilePath;
 
         if (differentFilePath) {
-            actualFilePath = Paths.get(FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()), filename).toString();
+            actualFilePath = Path.of(FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()), filename).toString();
         }
         else {
             if (filename.length() < 5) {
-                actualFilePath = Paths.get(FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()), "file" + filename).toString();
+                actualFilePath = Path.of(FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()), "file" + filename).toString();
             }
             else if (filename.contains("\\")) {
-                actualFilePath = Paths.get(FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()), "file.png").toString();
+                actualFilePath = Path.of(FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()), "file.png").toString();
             }
             else {
-                actualFilePath = Paths.get(FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()), filename).toString();
+                actualFilePath = Path.of(FileUploadSubmission.buildFilePath(releasedFileUploadExercise.getId(), returnedSubmission.getId()), filename).toString();
             }
         }
 
         String publicFilePath = fileService.publicPathForActualPath(actualFilePath, returnedSubmission.getId());
         assertThat(returnedSubmission).as("submission correctly posted").isNotNull();
         assertThat(returnedSubmission.getFilePath()).isEqualTo(publicFilePath);
-        var fileBytes = Files.readAllBytes(Paths.get(actualFilePath));
+        var fileBytes = Files.readAllBytes(Path.of(actualFilePath));
         assertThat(fileBytes.length > 0).as("Stored file has content").isTrue();
         checkDetailsHidden(returnedSubmission, true);
     }

--- a/src/test/java/de/tum/in/www1/artemis/TestRepositoryResourceIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TestRepositoryResourceIntegrationTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.Principal;
 import java.time.ZonedDateTime;
 import java.util.*;
@@ -64,13 +63,13 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
         testRepo.configureRepos("testLocalRepo", "testOriginRepo");
 
         // add file to the repository folder
-        Path filePath = Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName);
+        Path filePath = Path.of(testRepo.localRepoFile + "/" + currentLocalFileName);
         var file = Files.createFile(filePath).toFile();
         // write content to the created file
         FileUtils.write(file, currentLocalFileContent, Charset.defaultCharset());
 
         // add folder to the repository folder
-        filePath = Paths.get(testRepo.localRepoFile + "/" + currentLocalFolderName);
+        filePath = Path.of(testRepo.localRepoFile + "/" + currentLocalFolderName);
         Files.createDirectory(filePath).toFile();
 
         var testRepoUrl = new GitUtilService.MockFileRepositoryUrl(testRepo.localRepoFile);
@@ -103,7 +102,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
 
         // Check if all files exist
         for (String key : files.keySet()) {
-            assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + key))).isTrue();
+            assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + key))).isTrue();
         }
     }
 
@@ -117,7 +116,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
 
         // Check if all files exist
         for (String key : files.keySet()) {
-            assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + key))).isTrue();
+            assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + key))).isTrue();
         }
     }
 
@@ -129,7 +128,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
         params.add("file", currentLocalFileName);
         var file = request.get(testRepoBaseUrl + programmingExercise.getId() + "/file", HttpStatus.OK, byte[].class, params);
         assertThat(file).isNotEmpty();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
         assertThat(new String(file)).isEqualTo(currentLocalFileContent);
     }
 
@@ -138,10 +137,10 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     public void testCreateFile() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/newFile"))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/newFile"))).isFalse();
         params.add("file", "newFile");
         request.postWithoutResponseBody(testRepoBaseUrl + programmingExercise.getId() + "/file", HttpStatus.OK, params);
-        assertThat(Files.isRegularFile(Paths.get(testRepo.localRepoFile + "/newFile"))).isTrue();
+        assertThat(Files.isRegularFile(Path.of(testRepo.localRepoFile + "/newFile"))).isTrue();
     }
 
     @Test
@@ -149,7 +148,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     public void testCreateFile_alreadyExists() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/newFile"))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/newFile"))).isFalse();
         params.add("file", "newFile");
 
         doReturn(Optional.of(true)).when(gitService).getFileByName(any(), any());
@@ -161,7 +160,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     public void testCreateFile_invalidRepository() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/newFile"))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/newFile"))).isFalse();
         params.add("file", "newFile");
 
         Repository mockRepository = mock(Repository.class);
@@ -176,25 +175,25 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     public void testCreateFolder() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/newFolder"))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/newFolder"))).isFalse();
         params.add("folder", "newFolder");
         request.postWithoutResponseBody(testRepoBaseUrl + programmingExercise.getId() + "/folder", HttpStatus.OK, params);
-        assertThat(Files.isDirectory(Paths.get(testRepo.localRepoFile + "/newFolder"))).isTrue();
+        assertThat(Files.isDirectory(Path.of(testRepo.localRepoFile + "/newFolder"))).isTrue();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testRenameFile() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
         String newLocalFileName = "newFileName";
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + newLocalFileName))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + newLocalFileName))).isFalse();
         FileMove fileMove = new FileMove();
         fileMove.setCurrentFilePath(currentLocalFileName);
         fileMove.setNewFilename(newLocalFileName);
         request.postWithoutLocation(testRepoBaseUrl + programmingExercise.getId() + "/rename-file", fileMove, HttpStatus.OK, null);
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isFalse();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + newLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + newLocalFileName))).isTrue();
     }
 
     @Test
@@ -225,8 +224,8 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     private FileMove createRenameFileMove() {
         String newLocalFileName = "newFileName";
 
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + newLocalFileName))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + newLocalFileName))).isFalse();
 
         FileMove fileMove = new FileMove();
         fileMove.setCurrentFilePath(currentLocalFileName);
@@ -238,15 +237,15 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testRenameFolder() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFolderName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFolderName))).isTrue();
         String newLocalFolderName = "newFolderName";
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + newLocalFolderName))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + newLocalFolderName))).isFalse();
         FileMove fileMove = new FileMove();
         fileMove.setCurrentFilePath(currentLocalFolderName);
         fileMove.setNewFilename(newLocalFolderName);
         request.postWithoutLocation(testRepoBaseUrl + programmingExercise.getId() + "/rename-file", fileMove, HttpStatus.OK, null);
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFolderName))).isFalse();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + newLocalFolderName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFolderName))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + newLocalFolderName))).isTrue();
     }
 
     @Test
@@ -254,10 +253,10 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     public void testDeleteFile() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
         params.add("file", currentLocalFileName);
         request.delete(testRepoBaseUrl + programmingExercise.getId() + "/file", HttpStatus.OK, params);
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isFalse();
     }
 
     @Test
@@ -265,7 +264,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     public void testDeleteFile_notFound() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
         params.add("file", currentLocalFileName);
 
         doReturn(Optional.empty()).when(gitService).getFileByName(any(), any());
@@ -278,7 +277,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     public void testDeleteFile_invalidFile() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
         params.add("file", currentLocalFileName);
 
         doReturn(Optional.of(testRepo.localRepoFile)).when(gitService).getFileByName(any(), eq(currentLocalFileName));
@@ -295,7 +294,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     public void testDeleteFile_validFile() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
         params.add("file", currentLocalFileName);
 
         File mockFile = mock(File.class);
@@ -337,10 +336,10 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testSaveFiles() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
         request.put(testRepoBaseUrl + programmingExercise.getId() + "/files?commit=false", getFileSubmissions(), HttpStatus.OK);
 
-        Path filePath = Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName);
+        Path filePath = Path.of(testRepo.localRepoFile + "/" + currentLocalFileName);
         assertThat(FileUtils.readFileToString(filePath.toFile(), Charset.defaultCharset())).isEqualTo("updatedFileContent");
     }
 
@@ -348,7 +347,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void testSaveFilesAndCommit() throws Exception {
         programmingExerciseRepository.save(programmingExercise);
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + currentLocalFileName))).isTrue();
 
         var receivedStatusBeforeCommit = request.get(testRepoBaseUrl + programmingExercise.getId(), HttpStatus.OK, RepositoryStatusDTO.class);
         assertThat(receivedStatusBeforeCommit.repositoryStatus).hasToString("UNCOMMITTED_CHANGES");
@@ -358,7 +357,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
         var receivedStatusAfterCommit = request.get(testRepoBaseUrl + programmingExercise.getId(), HttpStatus.OK, RepositoryStatusDTO.class);
         assertThat(receivedStatusAfterCommit.repositoryStatus).hasToString("CLEAN");
 
-        Path filePath = Paths.get(testRepo.localRepoFile + "/" + currentLocalFileName);
+        Path filePath = Path.of(testRepo.localRepoFile + "/" + currentLocalFileName);
         assertThat(FileUtils.readFileToString(filePath.toFile(), Charset.defaultCharset())).isEqualTo("updatedFileContent");
 
         var testRepoCommits = testRepo.getAllLocalCommits();
@@ -377,12 +376,12 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
         var remoteRepository = gitService.getExistingCheckedOutRepositoryByLocalPath(testRepo.originRepoFile.toPath(), null);
 
         // Create file in the remote repository
-        Path filePath = Paths.get(testRepo.originRepoFile + "/" + fileName);
+        Path filePath = Path.of(testRepo.originRepoFile + "/" + fileName);
         Files.createFile(filePath).toFile();
 
         // Check if the file exists in the remote repository and that it doesn't yet exists in the local repository
-        assertThat(Files.exists(Paths.get(testRepo.originRepoFile + "/" + fileName))).isTrue();
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + fileName))).isFalse();
+        assertThat(Files.exists(Path.of(testRepo.originRepoFile + "/" + fileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + fileName))).isFalse();
 
         // Stage all changes and make a second commit in the remote repository
         gitService.stageAllChanges(remoteRepository);
@@ -396,7 +395,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
 
         // Check if the current commit is the same on the local and the remote repository and if the file exists on the local repository
         assertThat(testRepo.getAllLocalCommits().get(0)).isEqualTo(testRepo.getAllOriginCommits().get(0));
-        assertThat(Files.exists(Paths.get(testRepo.localRepoFile + "/" + fileName))).isTrue();
+        assertThat(Files.exists(Path.of(testRepo.localRepoFile + "/" + fileName))).isTrue();
     }
 
     @Test
@@ -419,7 +418,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
         assertThat(receivedStatusAfterCommit.repositoryStatus).hasToString("CLEAN");
 
         // Create file in the local repository and commit it
-        Path localFilePath = Paths.get(testRepo.localRepoFile + "/" + fileName);
+        Path localFilePath = Path.of(testRepo.localRepoFile + "/" + fileName);
         var localFile = Files.createFile(localFilePath).toFile();
         // write content to the created file
         FileUtils.write(localFile, "local", Charset.defaultCharset());
@@ -427,7 +426,7 @@ public class TestRepositoryResourceIntegrationTest extends AbstractSpringIntegra
         testRepo.localGit.commit().setMessage("local").call();
 
         // Create file in the remote repository and commit it
-        Path remoteFilePath = Paths.get(testRepo.originRepoFile + "/" + fileName);
+        Path remoteFilePath = Path.of(testRepo.originRepoFile + "/" + fileName);
         var remoteFile = Files.createFile(remoteFilePath).toFile();
         // write content to the created file
         FileUtils.write(remoteFile, "remote", Charset.defaultCharset());

--- a/src/test/java/de/tum/in/www1/artemis/connector/BambooRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/BambooRequestMockProvider.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.connector;
 
 import static de.tum.in.www1.artemis.util.FileUtils.loadFileFromResources;
-import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGitIntegrationTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.*;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -59,13 +59,13 @@ public class ProgrammingExerciseGitIntegrationTest extends AbstractSpringIntegra
 
         // create commits
         // the following 2 lines prepare the generation of the structural test oracle
-        var testJsonFilePath = Paths.get(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test.json");
+        var testJsonFilePath = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test.json");
         gitUtilService.writeEmptyJsonFileToPath(testJsonFilePath);
         localGit.commit().setMessage("add test.json").setAuthor("test", "test@test.com").call();
-        var testJsonFilePath2 = Paths.get(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test2.json");
+        var testJsonFilePath2 = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test2.json");
         gitUtilService.writeEmptyJsonFileToPath(testJsonFilePath2);
         localGit.commit().setMessage("add test2.json").setAuthor("test", "test@test.com").call();
-        var testJsonFilePath3 = Paths.get(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test3.json");
+        var testJsonFilePath3 = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test3.json");
         gitUtilService.writeEmptyJsonFileToPath(testJsonFilePath3);
         localGit.commit().setMessage("add test3.json").setAuthor("test", "test@test.com").call();
 

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -15,7 +15,6 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
@@ -186,7 +185,7 @@ public class ProgrammingExerciseIntegrationTestService {
         // so that e.g. addStudentIdToProjectName in ProgrammingExerciseExportService is tested properly as well
 
         // the following 2 lines prepare the generation of the structural test oracle
-        var testjsonFilePath = Paths.get(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test.json");
+        var testjsonFilePath = Path.of(localRepoFile.getPath(), "test", programmingExercise.getPackageFolderName(), "test.json");
         gitUtilService.writeEmptyJsonFileToPath(testjsonFilePath);
         // create two empty commits
         localGit.commit().setMessage("empty").setAllowEmpty(true).setSign(false).setAuthor("test", "test@test.com").call();
@@ -370,8 +369,8 @@ public class ProgrammingExerciseIntegrationTestService {
         List<Path> entries = unzipExportedFile();
 
         // Make sure both repositories are present
-        assertThat(entries).anyMatch(entry -> entry.toString().endsWith(Paths.get("student1", ".git").toString()))
-                .anyMatch(entry -> entry.toString().endsWith(Paths.get("student2", ".git").toString()));
+        assertThat(entries).anyMatch(entry -> entry.toString().endsWith(Path.of("student1", ".git").toString()))
+                .anyMatch(entry -> entry.toString().endsWith(Path.of("student2", ".git").toString()));
     }
 
     public void testExportSubmissionAnonymizationCombining() throws Exception {
@@ -401,7 +400,7 @@ public class ProgrammingExerciseIntegrationTestService {
 
         // Checks
         assertThat(entries).anyMatch(entry -> entry.endsWith("Test.java"));
-        Optional<Path> extractedRepo1 = entries.stream().filter(entry -> entry.toString().endsWith(Paths.get("student1", ".git").toString())).findFirst();
+        Optional<Path> extractedRepo1 = entries.stream().filter(entry -> entry.toString().endsWith(Path.of("student1", ".git").toString())).findFirst();
         assertThat(extractedRepo1).isPresent();
         try (Git downloadedGit = Git.open(extractedRepo1.get().toFile())) {
             RevCommit commit = downloadedGit.log().setMaxCount(1).call().iterator().next();
@@ -417,7 +416,7 @@ public class ProgrammingExerciseIntegrationTestService {
      */
     private List<Path> unzipExportedFile() throws Exception {
         (new ZipFileTestUtilService()).extractZipFileRecursively(downloadedFile.getAbsolutePath());
-        Path extractedZipDir = Paths.get(downloadedFile.getPath().substring(0, downloadedFile.getPath().length() - 4));
+        Path extractedZipDir = Path.of(downloadedFile.getPath().substring(0, downloadedFile.getPath().length() - 4));
         try (var files = Files.walk(extractedZipDir)) {
             return files.toList();
         }

--- a/src/test/java/de/tum/in/www1/artemis/service/ResourceLoaderServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ResourceLoaderServiceTest.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -21,9 +20,9 @@ public class ResourceLoaderServiceTest extends AbstractSpringIntegrationBambooBi
     @Autowired
     private ResourceLoaderService resourceLoaderService;
 
-    private final Path javaPath = Paths.get("templates", "java", "java.txt");
+    private final Path javaPath = Path.of("templates", "java", "java.txt");
 
-    private final Path jenkinsPath = Paths.get("templates", "jenkins", "jenkins.txt");
+    private final Path jenkinsPath = Path.of("templates", "jenkins", "jenkins.txt");
 
     @AfterEach
     public void cleanup() throws IOException {

--- a/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/GitUtilService.java
@@ -5,7 +5,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 
 import org.apache.commons.io.FileUtils;
@@ -27,7 +26,7 @@ public class GitUtilService {
     private String defaultBranch;
 
     // Note: the first string has to be same as artemis.repo-clone-path (see src/test/resources/config/application-artemis.yml) because here local git repos will be cloned
-    private final Path localPath = Paths.get(".", "repos", "server-integration-test").resolve("test-repository").normalize();
+    private final Path localPath = Path.of(".", "repos", "server-integration-test").resolve("test-repository").normalize();
 
     private final Path remotePath = Files.createTempDirectory("remotegittest").resolve("scm/test-repository");
 
@@ -153,7 +152,7 @@ public class GitUtilService {
 
     public void updateFile(REPOS repo, FILES fileToUpdate, String content) {
         try {
-            var fileName = Paths.get(getCompleteRepoPathStringByType(repo), fileToUpdate.toString()).toString();
+            var fileName = Path.of(getCompleteRepoPathStringByType(repo), fileToUpdate.toString()).toString();
             PrintWriter writer = new PrintWriter(fileName, StandardCharsets.UTF_8);
             writer.print(content);
             writer.close();
@@ -163,13 +162,13 @@ public class GitUtilService {
     }
 
     public File getFile(REPOS repo, FILES fileToRead) {
-        Path path = Paths.get(getCompleteRepoPathStringByType(repo), fileToRead.toString());
+        Path path = Path.of(getCompleteRepoPathStringByType(repo), fileToRead.toString());
         return path.toFile();
     }
 
     public String getFileContent(REPOS repo, FILES fileToRead) {
         try {
-            Path path = Paths.get(getCompleteRepoPathStringByType(repo), fileToRead.toString());
+            Path path = Path.of(getCompleteRepoPathStringByType(repo), fileToRead.toString());
             byte[] encoded = Files.readAllBytes(path);
             return new String(encoded, Charset.defaultCharset());
         }

--- a/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/HestiaUtilTestService.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
 
@@ -95,7 +94,7 @@ public class HestiaUtilTestService {
             String fileName = entry.getKey();
             String content = entry.getValue();
             // add file to the repository folder
-            Path filePath = Paths.get(templateRepo.localRepoFile + "/" + fileName);
+            Path filePath = Path.of(templateRepo.localRepoFile + "/" + fileName);
             Files.createDirectories(filePath.getParent());
             File solutionFile = Files.createFile(filePath).toFile();
             // write content to the created file
@@ -156,7 +155,7 @@ public class HestiaUtilTestService {
             String fileName = entry.getKey();
             String content = entry.getValue();
             // add file to the repository folder
-            Path filePath = Paths.get(solutionRepo.localRepoFile + "/" + fileName);
+            Path filePath = Path.of(solutionRepo.localRepoFile + "/" + fileName);
             Files.createDirectories(filePath.getParent());
             File solutionFile = Files.createFile(filePath).toFile();
             // write content to the created file
@@ -217,7 +216,7 @@ public class HestiaUtilTestService {
             String fileName = entry.getKey();
             String content = entry.getValue();
             // add file to the repository folder
-            Path filePath = Paths.get(testRepo.localRepoFile + "/" + fileName);
+            Path filePath = Path.of(testRepo.localRepoFile + "/" + fileName);
             Files.createDirectories(filePath.getParent());
             File solutionFile = Files.createFile(filePath).toFile();
             // write content to the created file

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.fail;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -84,7 +84,7 @@ public class ModelFactory {
         catch (IOException ex) {
             fail("Failed while copying test attachment files", ex);
         }
-        attachment.setLink(Paths.get("/api/files/temp/", testFileName).toString());
+        attachment.setLink(Path.of("/api/files/temp/", testFileName).toString());
         return attachment;
     }
 


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
Both methods `Paths.get()` and `Path.of()` do the same, with `Paths.get()` just calling `Path.of()`. Therfore `Path.of()` is the prefered option here.

### Description
I just applied Ctrl + R. Additionally I removed two unused imports.

### Steps for Testing
Code Review

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
