### PR TITLE
`Assessment`: Display both percentage and point intervals when editing grade keys

### DIFF
--- a/src/main/webapp/app/grading-system/interval-grading-system/interval-grading-system.component.html
+++ b/src/main/webapp/app/grading-system/interval-grading-system/interval-grading-system.component.html
@@ -61,13 +61,13 @@
                             {{ 'artemisApp.gradingSystem.intervalTab.title' | artemisTranslate }}
                         </span>
                     </th>
-                    <th *ngIf="gradeEditMode === GradeEditMode.PERCENTAGE">
+                    <th>
                         <span>
                             {{ 'artemisApp.gradingSystem.min' | artemisTranslate }}
                             - {{ 'artemisApp.gradingSystem.max' | artemisTranslate }}
                         </span>
                     </th>
-                    <th *ngIf="gradeEditMode === GradeEditMode.POINTS">
+                    <th>
                         <span>
                             {{ 'artemisApp.gradingSystem.minPoints' | artemisTranslate }}
                             - {{ 'artemisApp.gradingSystem.maxPoints' | artemisTranslate }}
@@ -106,7 +106,10 @@
                         </td>
                     </ng-template>
                     <td>
-                        <span [innerHTML]="gradeStep | gradeStepBounds: gradeEditMode:last | safeHtml"></span>
+                        <span [innerHTML]="gradeStep | gradeStepBounds: GradeEditMode.PERCENTAGE:last | safeHtml"></span>
+                    </td>
+                    <td>
+                        <span [innerHTML]="gradeStep | gradeStepBounds: GradeEditMode.POINTS:last | safeHtml"></span>
                     </td>
                     <td *ngIf="gradingScale.gradeType !== GradeType.BONUS">
                         <input [(ngModel)]="gradeStep.gradeName" type="text" required />


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The instructor should be able to view both Percentage and Point intervals of the grade steps even when they are editing the other one so that they don't need to switch editing modes just to view Percentages and Points.

### Description
<!-- Describe your changes in detail -->
When either Percentage or Points are chosen, the table should still show the column and values for the other interval type, however they should not be editable.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course or Exam

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to Grading Key editor of a Course or an Exam.
4. Ensure that both `Min % - Max %` and `Min Points - Max Points` columns are always visible and the values are consistent.
5. Ensure that the editable input field changes according to the selected Grade Editing Mode (Percentage or Points).
6. Grading Key can be edited and saved as expected.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/18427209/165693172-b4ca48a0-5622-4553-901b-2983eb3c1664.png)

![image](https://user-images.githubusercontent.com/18427209/165693184-5dd6aa92-e049-4528-8cc5-d446edc562de.png)

