### PR TITLE
`Assessment`: Hide complaint component on result subpage for exam exercises

### DIFF
--- a/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.html
+++ b/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.html
@@ -64,7 +64,7 @@
             </div>
         </div>
         <jhi-complaint-student-view
-            *ngIf="fileUploadExercise && result && participation && isAfterAssessmentDueDate"
+            *ngIf="fileUploadExercise && result && participation && isAfterAssessmentDueDate && !examMode"
             [result]="resultWithComplaint ? resultWithComplaint : result"
             [participation]="participation"
             [exercise]="fileUploadExercise"

--- a/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.ts
+++ b/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.ts
@@ -48,6 +48,7 @@ export class FileUploadSubmissionComponent implements OnInit, ComponentCanDeacti
     isAfterAssessmentDueDate: boolean;
     isSaving: boolean;
     isOwnerOfParticipation: boolean;
+    examMode = false;
 
     acceptedFileExtensions: string;
 
@@ -56,7 +57,6 @@ export class FileUploadSubmissionComponent implements OnInit, ComponentCanDeacti
     readonly ButtonType = ButtonType;
 
     private submissionConfirmationText: string;
-    private examMode = false;
 
     // Icons
     farListAlt = faListAlt;

--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.html
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.html
@@ -130,7 +130,7 @@
             <jhi-rating class="mt-2 alert alert-info" [result]="addParticipationToResult(result, participation)"></jhi-rating>
         </div>
         <jhi-complaint-student-view
-            *ngIf="modelingExercise && result"
+            *ngIf="modelingExercise && result && !examMode"
             [exercise]="modelingExercise"
             [participation]="participation"
             [result]="resultWithComplaint ? resultWithComplaint : result"

--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
@@ -85,7 +85,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
     isLoading: boolean;
     isLate: boolean; // indicates if the submission is late
     ComplaintType = ComplaintType;
-    private examMode = false;
+    examMode = false;
 
     // submission sync with team members
     teamSyncInterval: number;

--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.html
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.html
@@ -86,7 +86,7 @@
             </ng-template>
 
             <jhi-complaint-student-view
-                *ngIf="textExercise && result && participation"
+                *ngIf="textExercise && result && participation && !examMode"
                 [exercise]="textExercise"
                 [result]="resultWithComplaint ? resultWithComplaint : result"
                 [participation]="participation"

--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.ts
@@ -56,7 +56,7 @@ export class TextEditorComponent implements OnInit, OnDestroy, ComponentCanDeact
     answer: string;
     // indicates if the assessment due date is in the past. the assessment will not be loaded and displayed to the student if it is not.
     isAfterAssessmentDueDate: boolean;
-    private examMode = false;
+    examMode = false;
 
     // indicates, that it is an exam exercise and the publishResults date is in the past
     isAfterPublishDate: boolean;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.


### Motivation and Context
**High priority** because students can submit complaints for text- / modelling- and file-upload exercises of an exam up to one week after the assessment due date. This is completely decoupled from the student review window and with that complaints can be filed potentially after the student Review window of an exam.

Closes #4984 

Currently students have two ways to complain about a text-, modelling- or file-upload exercise: 
- The complaint can be filed on the exam summary page. Here, the complaint can only be filed during the specified student review dates. This is the intended way how students should submit their complaints.
- The complaint can also be filed on the results - subpage of the exercise. Here, the complaint can be filed at any time because the complaint-component doesn't receive the exam information and thus cannot determine the student review period. The corresponding text-/modelling-/file-upload component also has no exam information, only a Boolean `examMode` is determined. Thus, the complaint component is displayed, as for normal course exercises, after the assessment due date, which is independent of the exam review period. That's also the reason the wrong hint with the limited number of complaints is shown to the student, because the complaint component identifies the exercises as a course and not as an exam exercise. (see screenshot) 

(Only these three exercise types use result subpages to display the assessment. Programming Exercises and Quiz exercises are displayed only in the summary and for quiz exercises no complaints are possible in general)

### Description
The complaint-component on the results- subpage for text-, modelling- and file-upload exercises only display the component if it is not an exam question. For this, the boolean `examMode` is reused.
In case of an exam question, the students can file their complaints on the exam summary page and the complaint-component on the results - subpage is not needed. 

### Steps for Testing
- 1 Instructor
- 1 Student
- 1 Exam with Text-, Modelling- and File-upload exercise 

1. Create the exam, participate as a student and assess the exercises
2. Open the exam summary page as a student between the `Publish Date of Results` and the `Student Review Start`. Make sure, that the complaint-button isn't shown on both the summary page and the results - subpage
3. Wait until the `Student Review Start`
4. Make sure, that the complaint-button is shown only on the summary page and not on the results - subpage

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
The first and intended way students can submit complaints - via the exam summary page.
![image](https://user-images.githubusercontent.com/94070506/165825879-e9efa1f8-b7ad-4ae4-9639-c77e011356de.png)

This complaint - component is currently displayed on the results - subpage for Text-, Modelling- and File-upload exercises. It should no longer be displayed. 
![image](https://user-images.githubusercontent.com/94070506/165825396-ed4c0d2d-c4ad-4989-954f-d6e6368e0deb.png)

![image](https://user-images.githubusercontent.com/94070506/165825763-4e57e85c-c19f-483a-a2b2-7ed1c75d0ecd.png)
