### PR TITLE
`Assessment`: Prevent usage of wrong REST-call when posting a complaint

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ComplaintResource.java
@@ -60,8 +60,7 @@ public class ComplaintResource {
     private final CourseRepository courseRepository;
 
     public ComplaintResource(AuthorizationCheckService authCheckService, ExerciseRepository exerciseRepository, UserRepository userRepository, TeamRepository teamRepository,
-            ResultRepository resultRepository, ComplaintService complaintService, ComplaintRepository complaintRepository, CourseRepository courseRepository,
-            ExamRepository examRepository) {
+            ResultRepository resultRepository, ComplaintService complaintService, ComplaintRepository complaintRepository, CourseRepository courseRepository) {
         this.authCheckService = authCheckService;
         this.exerciseRepository = exerciseRepository;
         this.userRepository = userRepository;

--- a/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
@@ -22,6 +22,7 @@ import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.ComplaintType;
 import de.tum.in.www1.artemis.domain.enumeration.FeedbackType;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
+import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.modeling.ModelingSubmission;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
@@ -735,7 +736,28 @@ public class AssessmentComplaintIntegrationTest extends AbstractSpringIntegratio
         final var examExerciseComplaint = new Complaint().result(null).complaintText("This is not fair").complaintType(ComplaintType.COMPLAINT);
         final String url = "/api/complaints/exam/{examId}".replace("{examId}", String.valueOf(examId));
         request.post(url, examExerciseComplaint, HttpStatus.BAD_REQUEST);
+    }
 
+    @Test
+    @WithMockUser(username = "student1", roles = "USER")
+    public void submitComplaintForCourseExerciseUsingTheExamExerciseCall_badRequest() throws Exception {
+        // "Mock Exam" which id is used to call the wrong REST-Call
+        final Exam exam = ModelFactory.generateExam(course);
+        // The complaint is about a course exercise, not an exam exercise
+        request.post("/api/complaints/exam/" + exam.getId(), complaint, HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @WithMockUser(username = "student1", roles = "USER")
+    public void submitComplaintForExamExerciseUsingTheCourseExerciseCall_badRequest() throws Exception {
+        // Set up Exam, Exercise, Participation and Complaint
+        final TextExercise examExercise = database.addCourseExamExerciseGroupWithOneTextExercise();
+        final long examId = examExercise.getExerciseGroup().getExam().getId();
+        final TextSubmission textSubmission = ModelFactory.generateTextSubmission("This is my submission", Language.ENGLISH, true);
+        database.saveTextSubmissionWithResultAndAssessor(examExercise, textSubmission, "student1", "tutor1");
+        final var examExerciseComplaint = new Complaint().result(null).complaintText("This is not fair").complaintType(ComplaintType.COMPLAINT);
+        // The complaint is about an exam exercise, but the REST-Call for course exercises is used
+        request.post("api/complaints", examExerciseComplaint, HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
@@ -754,9 +754,9 @@ public class AssessmentComplaintIntegrationTest extends AbstractSpringIntegratio
         final TextExercise examExercise = database.addCourseExamExerciseGroupWithOneTextExercise();
         final TextSubmission textSubmission = ModelFactory.generateTextSubmission("This is my submission", Language.ENGLISH, true);
         database.saveTextSubmissionWithResultAndAssessor(examExercise, textSubmission, "student1", "tutor1");
-        final var examExerciseComplaint = new Complaint().complaintText("This is not fair").complaintType(ComplaintType.COMPLAINT);
+        final var examExerciseComplaint = new Complaint().result(textSubmission.getLatestResult()).complaintText("This is not fair").complaintType(ComplaintType.COMPLAINT);
         // The complaint is about an exam exercise, but the REST-Call for course exercises is used
-        request.post("api/complaints", examExerciseComplaint, HttpStatus.BAD_REQUEST);
+        request.post("/api/complaints", examExerciseComplaint, HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AssessmentComplaintIntegrationTest.java
@@ -752,10 +752,9 @@ public class AssessmentComplaintIntegrationTest extends AbstractSpringIntegratio
     public void submitComplaintForExamExerciseUsingTheCourseExerciseCall_badRequest() throws Exception {
         // Set up Exam, Exercise, Participation and Complaint
         final TextExercise examExercise = database.addCourseExamExerciseGroupWithOneTextExercise();
-        final long examId = examExercise.getExerciseGroup().getExam().getId();
         final TextSubmission textSubmission = ModelFactory.generateTextSubmission("This is my submission", Language.ENGLISH, true);
         database.saveTextSubmissionWithResultAndAssessor(examExercise, textSubmission, "student1", "tutor1");
-        final var examExerciseComplaint = new Complaint().result(null).complaintText("This is not fair").complaintType(ComplaintType.COMPLAINT);
+        final var examExerciseComplaint = new Complaint().complaintText("This is not fair").complaintType(ComplaintType.COMPLAINT);
         // The complaint is about an exam exercise, but the REST-Call for course exercises is used
         request.post("api/complaints", examExerciseComplaint, HttpStatus.BAD_REQUEST);
     }


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Follow up to #4988 
To post a complaint, two REST-Calls can be used. One for course exercises `api/complaints` and one for exam exercises `api/complaints/exam/{examId}`. Currently there is no cross-check implemented which prevents the use of the wrong REST call in either case. This lead in #4988 and #4984 to the issue, that students could post complaints outside of the student review window.

### Description
This PR implements the cross-check to prevent the usage of `api/complaints` for exam exercises and `api/complaints/exam/{examId}` for course exercises.

### Steps for Testing
- 1 Instructor
- 1 Student
- 1 Exercise with a graded participation
- 1 Exam within the student review window and an assessed exercise

1. Log in to Artemis
2. Try to complain about the course exercise. Make sure that the complaint is handled correctly.
3. Try to complain about the exam exercise. Make sure that the complaint is handled correctly.
4. *Optional* Try to send a complaint about an exam exercise to the course exercise url `api/complaints`


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
