### PR TITLE
`Programming exercises`: Update to the latest artemis-maven-docker version java17-6

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -34,9 +34,9 @@ artemis:
         # Defines the used docker images for certain programming languages
         build:
             images:
-                JAVA: "ls1tum/artemis-maven-template:java17-5"
-                KOTLIN: "ls1tum/artemis-maven-template:java17-5"
-                EMPTY: "ls1tum/artemis-maven-template:java17-5"
+                JAVA: "ls1tum/artemis-maven-template:java17-6"
+                KOTLIN: "ls1tum/artemis-maven-template:java17-6"
+                EMPTY: "ls1tum/artemis-maven-template:java17-6"
                 PYTHON: "ls1tum/artemis-python-docker:latest"
                 C: "ls1tum/artemis-c-docker:latest"
                 C_FACT: "sharingcodeability/fact:latest"


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] ~~This is a small issue that I tested locally and was confirmed by another developer on a test server.~~
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
The current version java17-5 does not contain some updated dependency, in particular the Gradle wrapper version 7.4.2 (but the older and in Artemis unused version 7.4.1). This results in a download of the whole Gradle version within every build plan for Gradle exercises which breaks the purpose of the caching).
Especially for courses with a high number of participants like EIST, this increases the build time and workload of the build agents noticeably.

### Description
Upgrade to [java17-6](https://github.com/ls1intum/artemis-maven-docker/releases/tag/java17-6) which includes these updated cached dependencies.