### PR TITLE
`General`: Fix tooltips in course exercise row

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-headers/included-in-score-badge.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/included-in-score-badge.component.html
@@ -1,1 +1,1 @@
-<span class="badge" [ngClass]="badgeClass" [ngbTooltip]="translatedTooltip" container="body">{{ translatedEnum }}</span>
+<span class="badge included-score-badge" [ngClass]="badgeClass" [ngbTooltip]="translatedTooltip" container="body">{{ translatedEnum }}</span>

--- a/src/main/webapp/app/exercises/shared/exercise-headers/included-in-score-badge.component.scss
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/included-in-score-badge.component.scss
@@ -1,0 +1,4 @@
+.included-score-badge {
+    position: relative;
+    z-index: 1;
+}

--- a/src/main/webapp/app/exercises/shared/exercise-headers/included-in-score-badge.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/included-in-score-badge.component.ts
@@ -6,7 +6,7 @@ import { Subscription } from 'rxjs';
 @Component({
     selector: 'jhi-included-in-score-badge',
     templateUrl: './included-in-score-badge.component.html',
-    styles: [],
+    styleUrls: ['./included-in-score-badge.component.scss'],
 })
 export class IncludedInScoreBadgeComponent implements OnInit, OnDestroy, OnChanges {
     @Input() includedInOverallScore: IncludedInOverallScore | undefined;

--- a/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
+++ b/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
@@ -1,9 +1,9 @@
 <div [id]="'exercise-card-' + exercise.id" class="course-exercise-row row align-items-center mb-2 mt-2 position-relative" [class.guided-tour]="hasGuidedTour">
     <a class="stretched-link" [routerLink]="['/courses', course.id!, 'exercises', exercise.id!]"></a>
     <div class="col-auto d-none d-sm-block">
-        <div class="exercise-row-icon">
+        <a class="exercise-row-icon" [routerLink]="['/courses', course.id!, 'exercises', exercise.id!]">
             <fa-icon *ngIf="exercise.type" [icon]="getIcon(exercise.type)" size="2x" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate" container="body"></fa-icon>
-        </div>
+        </a>
     </div>
     <div class="col">
         <div class="row">
@@ -38,7 +38,7 @@
             ></jhi-exercise-details-student-actions>
             <div class="exercise-tags col-auto col-sm d-flex justify-content-center mt-2">
                 <h4 class="fw-medium">
-                    <jhi-not-released-tag class="me-1" [exercise]="exercise"></jhi-not-released-tag>
+                    <a [routerLink]="['/courses', course.id!, 'exercises', exercise.id!]"><jhi-not-released-tag class="me-1" [exercise]="exercise"></jhi-not-released-tag></a>
                 </h4>
                 <h4 class="fw-medium" *ngIf="!isPresentationMode">
                     <span class="badge bg-success me-1" [hidden]="!asQuizExercise(exercise).isActiveQuiz">{{
@@ -52,7 +52,9 @@
                     <jhi-difficulty-badge class="me-1" [exercise]="exercise" [showNoLevel]="false"></jhi-difficulty-badge>
                 </h4>
                 <h4 class="fw-medium" *ngIf="exercise.includedInOverallScore !== IncludedInOverallScore.INCLUDED_COMPLETELY">
-                    <jhi-included-in-score-badge [includedInOverallScore]="exercise.includedInOverallScore"></jhi-included-in-score-badge>
+                    <a [routerLink]="['/courses', course.id!, 'exercises', exercise.id!]">
+                        <jhi-included-in-score-badge [includedInOverallScore]="exercise.includedInOverallScore"></jhi-included-in-score-badge>
+                    </a>
                 </h4>
             </div>
             <div class="col-sm-auto mb-2" *ngIf="dueDate; else noDate" [ngClass]="getUrgentClass(dueDate) || ''">

--- a/src/main/webapp/app/overview/course-exercises/course-exercise-row.scss
+++ b/src/main/webapp/app/overview/course-exercises/course-exercise-row.scss
@@ -25,10 +25,15 @@
         }
     }
     .exercise-row-icon {
+        color: var(--bs-body-color);
         display: flex;
         justify-content: center;
         align-items: center;
         min-width: 40px;
+
+        > fa-icon {
+            z-index: 1;
+        }
     }
 
     .result {

--- a/src/main/webapp/app/shared/components/not-released-tag.component.html
+++ b/src/main/webapp/app/shared/components/not-released-tag.component.html
@@ -1,5 +1,5 @@
 <span
-    class="ms-1 badge bg-warning"
+    class="not-released-tag ms-1 badge bg-warning"
     *ngIf="exercise.isAtLeastTutor && exercise.releaseDate != undefined && !dayjs(exercise.releaseDate).isBefore(dayjs())"
     ngbTooltip="{{ 'artemisApp.courseOverview.exerciseList.notReleasedTooltip' | artemisTranslate }}{{ exercise.releaseDate | artemisDate }}"
 >

--- a/src/main/webapp/app/shared/components/not-released-tag.component.scss
+++ b/src/main/webapp/app/shared/components/not-released-tag.component.scss
@@ -1,0 +1,4 @@
+.not-released-tag {
+    position: relative;
+    z-index: 1;
+}

--- a/src/main/webapp/app/shared/components/not-released-tag.component.ts
+++ b/src/main/webapp/app/shared/components/not-released-tag.component.ts
@@ -5,6 +5,7 @@ import { Exercise } from 'app/entities/exercise.model';
 @Component({
     selector: 'jhi-not-released-tag',
     templateUrl: './not-released-tag.component.html',
+    styleUrls: ['./not-released-tag.component.scss'],
 })
 export class NotReleasedTagComponent {
     @Input() public exercise: Exercise;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The exercise type icon and some of the badges in a course exercise row usually had some explanatory popovers.
After we added stretched links to let these rows behave as links in #4409, these popovers were disabled as the stretched link captured all cursor events.

### Description
<!-- Describe your changes in detail -->

Popovers are re-enabled by moving the elements having popovers on top of the stretched link using ``z-index``. Additionally, these elements are converted to or covered in HTML links ( ``<a>`` ) to preserve the previous native link functionality in the area they cover.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- A programming exercise set to: Bonus, Release Date in the future

1. Log in to Artemis
2. Navigate to the course page
3. Verify that the "Bonus" and "Not released" badges are visible
4. Verify that you can hover on the exercise type icon, the bonus badge, and the not released badge, and that the popover for each appears
5. Verify that you can still right click these elements to open the link in a new tab, for example

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


https://user-images.githubusercontent.com/23171488/166109677-4c03709b-c321-4f79-9454-3da837a622ff.mov


