### PR TITLE
`Lectures`: Fix display of exercise lecture units

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/lecture/ExerciseUnit.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/lecture/ExerciseUnit.java
@@ -11,7 +11,6 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonIncludeProperties;
 
 import de.tum.in.www1.artemis.domain.Exercise;
 
@@ -24,7 +23,6 @@ public class ExerciseUnit extends LectureUnit {
     @ManyToOne
     @JoinColumn(name = "exercise_id")
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
-    @JsonIncludeProperties({ "id", "title", "type", "maxPoints", "assessmentDueDate", "teamMode", "visibleToStudents", "releaseDate", "released" })
     private Exercise exercise;
 
     public Exercise getExercise() {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/LectureUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/LectureUnitResource.java
@@ -60,7 +60,7 @@ public class LectureUnitResource {
     @PreAuthorize("hasRole('EDITOR')")
     public ResponseEntity<List<LectureUnit>> updateLectureUnitsOrder(@PathVariable Long lectureId, @RequestBody List<Long> orderedLectureUnitIds) {
         log.debug("REST request to update the order of lecture units of lecture: {}", lectureId);
-        final Lecture lecture = lectureRepository.findByIdWithPostsAndLectureUnitsAndLearningGoals(lectureId).orElseThrow();
+        final Lecture lecture = lectureRepository.findByIdWithLectureUnitsElseThrow(lectureId);
 
         if (lecture.getCourse() == null) {
             throw new ConflictException("Specified lecture is not part of a course", "LectureUnit", "courseMissing");

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service.ts
@@ -20,16 +20,11 @@ export class LectureUnitService {
     constructor(private httpClient: HttpClient, private attachmentService: AttachmentService) {}
 
     updateOrder(lectureId: number, lectureUnits: LectureUnit[]): Observable<HttpResponse<LectureUnit[]>> {
-        // need to remove participations from exercise units to prevent circular structure failure
-        lectureUnits = lectureUnits.map((lectureUnit) => {
-            if (lectureUnit.type === LectureUnitType.EXERCISE && (lectureUnit as ExerciseUnit).exercise) {
-                (lectureUnit as ExerciseUnit).exercise!.studentParticipations = undefined;
-                (lectureUnit as ExerciseUnit).exercise!.tutorParticipations = undefined;
-            }
-            return lectureUnit;
-        });
+        // Send an ordered list of ids of the lecture units
+        // This also overcomes circular structure issues with participations and categories in exercise units
+        const lectureUnitIds = lectureUnits.map((lectureUnit) => lectureUnit.id);
         return this.httpClient
-            .put<LectureUnit[]>(`${this.resourceURL}/lectures/${lectureId}/lecture-units-order`, lectureUnits, { observe: 'response' })
+            .put<LectureUnit[]>(`${this.resourceURL}/lectures/${lectureId}/lecture-units-order`, lectureUnitIds, { observe: 'response' })
             .pipe(map((res: EntityArrayResponseType) => this.convertDateArrayFromServerResponse(res)));
     }
 

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/lectureUnit.service.ts
@@ -46,6 +46,7 @@ export class LectureUnitService {
         } else if (lectureUnit.type === LectureUnitType.EXERCISE) {
             if ((<ExerciseUnit>lectureUnit).exercise) {
                 (<ExerciseUnit>lectureUnit).exercise = ExerciseService.convertDateFromClient((<ExerciseUnit>lectureUnit).exercise!);
+                (<ExerciseUnit>lectureUnit).exercise!.categories = ExerciseService.stringifyExerciseCategories((<ExerciseUnit>lectureUnit).exercise!);
                 return lectureUnit;
             }
         }
@@ -72,6 +73,7 @@ export class LectureUnitService {
             } else if (res.body.type === LectureUnitType.EXERCISE) {
                 if ((<ExerciseUnit>res.body).exercise) {
                     (<ExerciseUnit>res.body).exercise = ExerciseService.convertExerciseDateFromServer((<ExerciseUnit>res.body).exercise);
+                    ExerciseService.parseExerciseCategories((<ExerciseUnit>res.body).exercise);
                 }
             } else {
                 res.body.releaseDate = res.body.releaseDate ? dayjs(res.body.releaseDate) : undefined;
@@ -88,6 +90,7 @@ export class LectureUnitService {
         } else if (lectureUnit.type === LectureUnitType.EXERCISE) {
             if ((<ExerciseUnit>lectureUnit).exercise) {
                 (<ExerciseUnit>lectureUnit).exercise = ExerciseService.convertExerciseDateFromServer((<ExerciseUnit>lectureUnit).exercise);
+                ExerciseService.parseExerciseCategories((<ExerciseUnit>lectureUnit).exercise);
             }
         } else {
             lectureUnit.releaseDate = lectureUnit.releaseDate ? dayjs(lectureUnit.releaseDate) : undefined;

--- a/src/test/java/de/tum/in/www1/artemis/LectureUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LectureUnitIntegrationTest.java
@@ -42,11 +42,6 @@ public class LectureUnitIntegrationTest extends AbstractSpringIntegrationBambooB
 
     private TextUnit textUnit3;
 
-    // needed for correct jackson subtype serialization: see https://github.com/FasterXML/jackson-databind/issues/336#issuecomment-27228643
-    static class TextUnitList extends ArrayList<TextUnit> {
-
-    }
-
     @AfterEach
     public void resetDatabase() {
         database.resetDatabase();
@@ -103,12 +98,9 @@ public class LectureUnitIntegrationTest extends AbstractSpringIntegrationBambooB
     public void updateLectureUnitOrder_asInstructor_shouldUpdateLectureUnitOrder() throws Exception {
         long idOfOriginalFirstPosition = lecture1.getLectureUnits().get(0).getId();
         long idOfOriginalSecondPosition = lecture1.getLectureUnits().get(1).getId();
-        TextUnitList newlyOrderedList = new TextUnitList();
-        newlyOrderedList.add(textUnit);
-        newlyOrderedList.add(textUnit2);
-        for (TextUnit textUnit : newlyOrderedList) {
-            textUnit.setLecture(null);
-        }
+        List<Long> newlyOrderedList = new ArrayList<>();
+        newlyOrderedList.add(idOfOriginalFirstPosition);
+        newlyOrderedList.add(idOfOriginalSecondPosition);
         Collections.swap(newlyOrderedList, 0, 1);
         List<TextUnit> returnedList = request.putWithResponseBodyList("/api/lectures/" + lecture1.getId() + "/lecture-units-order", newlyOrderedList, TextUnit.class,
                 HttpStatus.OK);
@@ -119,14 +111,11 @@ public class LectureUnitIntegrationTest extends AbstractSpringIntegrationBambooB
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateLectureUnitOrder_asInstructorNewTextUnitInOrderedList_shouldReturnConflict() throws Exception {
-        TextUnitList newlyOrderedList = new TextUnitList();
-        newlyOrderedList.add(textUnit);
-        newlyOrderedList.add(textUnit2);
-        newlyOrderedList.add(textUnit3);
-        for (TextUnit textUnit : newlyOrderedList) {
-            textUnit.setLecture(null);
-        }
-        request.put("/api/lectures/" + lecture1.getId() + "/lecture-units-order", List.of(), HttpStatus.CONFLICT);
+        List<Long> newlyOrderedList = new ArrayList<>();
+        newlyOrderedList.add(textUnit.getId());
+        newlyOrderedList.add(textUnit2.getId());
+        newlyOrderedList.add(textUnit3.getId());
+        request.put("/api/lectures/" + lecture1.getId() + "/lecture-units-order", newlyOrderedList, HttpStatus.CONFLICT);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When an instructor would add exercises to lectures as units, they would display incorrectly.
PR #4052, which fixed another bug by excluding certain attributes from exercises, introduced this issue where now the client component misses some data to display the exercise row correctly (such as `categories` and `participations`).

### Description
<!-- Describe your changes in detail -->

By reverting the change in #4052, the exercise component now again has all data to display correctly.
However, that meant that I had to fix the former bug differently.
I accomplished that by reworking the client-server interface in the lecture unit management page (for ordering the units). 
Now, only the IDs of the units and transmitted, which drastically improves the request size.
Additionally, the lecture units now also parse the exercise categories.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Lecture
- 1 Exercise of each kind

1. Log in to Artemis as instructor
2. Navigate to Course Administration, then to Lectures
3. Add the exercises as units to the lecture
4. Test that you can re-order all lecture units without issues and the order is persisted correctly
5. Test that you can edit lecture units and the lecture itself without any problems (e.g., make sure the bug described in #3958 did not re-appear)
7. Login as student
8. Make sure the exercises in the course overview are displayed equally on the lecture unit page
9. Make sure the exercise lecture units update accordingly when you submit a solution or the due date passes

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Method | Line |
|------------|-------:|-----:|
| LectureUnitResource.java | 66% | 50% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

New and correct:
<img width="500" alt="Screenshot 2022-05-03 at 14 55 33" src="https://user-images.githubusercontent.com/102237363/166457164-dc39238c-f3fc-48bc-8b4e-44d574e8b82f.png">

Old and incorrect:
<img width="500" alt="Screenshot 2022-05-03 at 14 58 20" src="https://user-images.githubusercontent.com/102237363/166457132-f3588dba-695d-4272-9a0f-308620c8ee57.png">