### PR TITLE
`Programming exercises`: Prevent test execution for SCA task for Gradle exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooBuildPlanService.java
@@ -310,7 +310,7 @@ public class BambooBuildPlanService {
             finalTasks.add(new MavenTask().goal(command).jdk("JDK").executableLabel("Maven 3").description("Static Code Analysis").hasTests(false));
         }
         else {
-            finalTasks.add(new ScriptTask().inlineBody("./gradlew check").description("Static Code Analysis"));
+            finalTasks.add(new ScriptTask().inlineBody("./gradlew check -x test").description("Static Code Analysis"));
         }
         artifacts.addAll(scaArtifacts);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jenkins/JenkinsBuildPlanCreator.java
@@ -199,7 +199,7 @@ public class JenkinsBuildPlanCreator implements JenkinsXmlConfigBuilder {
                 script.append(StaticCodeAnalysisTool.createBuildPlanCommandForProgrammingLanguage(programmingLanguage)).append(lineEnding);
             }
             else {
-                script.append("./gradlew check").append(lineEnding);
+                script.append("./gradlew check -x test").append(lineEnding);
             }
 
             // Copy all static code analysis reports to new directory


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
As @Strohgelaender advised me, the command `./gradlew check` used for the static code analysis within Gradle programing exercises also executes all test cases. This is not required and increases the build time for no reason.

### Description
Changing the command to `./gradlew check -x test` excludes the test task from the SCA check.

### Steps for Testing
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a new Java programming exercise with project type Gradle and enabled static code analysis
4. Wait for the builds to finish and verify that the static code analysis findings are displayed.
5. Have a look into the build plan of the template and solution submission. Verify that inside of the `check`-task the tests are not executed again.

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
Build log before changes:
![Bildschirmfoto 2022-05-03 um 15 30 55](https://user-images.githubusercontent.com/73833780/166462107-06ffd4d6-5041-4434-a854-7ed62d7c94ee.png)

Build log after the changes:
-> The test task should not appear anymore within the `check`-task execution.