### PR TITLE
`Exam mode`: Fix the checkbox in the start and end confirmation screen

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -40,7 +40,7 @@
                 id="confirmBox"
                 (click)="updateConfirmation()"
                 class="form-check-input"
-                [class.ms-0]="(this.exam.confirmationStartText?.length ?? '') == 0"
+                [class.ms-0]="((startView ? this.exam.confirmationStartText?.length : this.exam.confirmationEndText?.length) ?? 0) == 0"
                 [required]="inserted"
                 [disabled]="startView ? waitingForExamStart : false"
             />

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -39,7 +39,8 @@
                 type="checkbox"
                 id="confirmBox"
                 (click)="updateConfirmation()"
-                class="form-check-input ms-0"
+                class="form-check-input"
+                [class.ms-0]="(this.exam.confirmationStartText?.length ?? '') == 0"
                 [required]="inserted"
                 [disabled]="startView ? waitingForExamStart : false"
             />

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -33,13 +33,13 @@
         {{ 'artemisApp.studentExam.submissionNotInTime' | artemisTranslate }}
     </div>
     <ng-container *ngIf="!studentFailedToSubmit">
-        <div class="form-check mt-1">
+        <div class="form-check mt-1 ps-0">
             <input
                 [(ngModel)]="confirmed"
                 type="checkbox"
                 id="confirmBox"
                 (click)="updateConfirmation()"
-                class="form-check-input"
+                class="form-check-input ms-0"
                 [required]="inserted"
                 [disabled]="startView ? waitingForExamStart : false"
             />

--- a/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
+++ b/src/main/webapp/app/exam/participate/exam-cover/exam-participation-cover.component.html
@@ -40,7 +40,7 @@
                 id="confirmBox"
                 (click)="updateConfirmation()"
                 class="form-check-input"
-                [class.ms-0]="((startView ? this.exam.confirmationStartText?.length : this.exam.confirmationEndText?.length) ?? 0) == 0"
+                [class.ms-0]="!(startView ? this.exam.confirmationStartText : this.exam.confirmationEndText)"
                 [required]="inserted"
                 [disabled]="startView ? waitingForExamStart : false"
             />


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When testing other PR's I saw that the checkbox no longer works as intended. 

### Description
<!-- Describe your changes in detail -->
I removed the `padding-left (ps-0)` of the `form-check` div and the `margin-left (ms-0)` of the `form-check-input` input. For reference: https://getbootstrap.com/docs/5.0/utilities/spacing/

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam

1. Create an Exam
2. Participate as a Student
3. Verify that the checkbox works as intended
4. Hand in early
5. Verify the check boxes works for the exam end

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![first](https://user-images.githubusercontent.com/60005702/167108322-2a9e7d7f-219c-42e4-8b59-317d4c0e7ef0.png)
![second](https://user-images.githubusercontent.com/60005702/167108335-f10c785f-8aa9-45bb-80cf-0aa4dc5d1c1b.png)



