### PR TITLE
`Quiz exercises`: Disable navigation to quiz exercise detail page when the quiz is active

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
@@ -50,7 +50,12 @@
             <tbody>
                 <tr *ngFor="let quizExercise of filteredQuizExercises; trackBy: trackId" id="exercise-card-{{ quizExercise.id }}">
                     <td *ngIf="!quizIsOver(quizExercise) || !quizExercise.isAtLeastEditor">
-                        <a [routerLink]="['/course-management', quizExercise.course?.id, 'quiz-exercises', quizExercise.id, 'edit']">{{ quizExercise.id }}</a>
+                        <a
+                            *ngIf="quizExercise.status !== QuizStatus.ACTIVE; else readOnlyId"
+                            [routerLink]="['/course-management', quizExercise.course?.id, 'quiz-exercises', quizExercise.id, 'edit']"
+                            >{{ quizExercise.id }}</a
+                        >
+                        <ng-template #readOnlyId>{{ quizExercise.id }}</ng-template>
                     </td>
                     <td *ngIf="quizIsOver(quizExercise) && quizExercise.isAtLeastEditor">
                         <a [routerLink]="['/course-management', quizExercise.course?.id, 'quiz-exercises', quizExercise.id, 're-evaluate']">{{ quizExercise.id }}</a>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Users should not be able to open the details page after the quiz has started. Instructors should be able to navigate to Re-evaluate page after the quiz ends. Closes #5022. 
### Description
<!-- Describe your changes in detail -->
There are already server-side checks disallowing quiz editing requests after the quiz has started. Also, the Edit button at the Course Management > Exercises page and the one at the Instructor actions bar at the Exercise details behaves correctly and get disabled when the quiz is active. Only the link on the id of the quiz exercise (see screenshot below) seems to be misbehaving so it is fixed in this PR to behave like other navigation buttons.
### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Active Quiz
- 1 Visible Quiz
- 1 Closed Quiz
- 1 Open for Practice Quiz
- 1 Hidden Quiz

1. Log in to Artemis
2. Navigate to Course Administration
3. Go to Exercises page
4. Check for quizzes in each status:
    - Hidden, Visible: Editing link/buttons should be enabled.
    - Closed, Open for Practice: Re-evaluate link/buttons should be enabled.
    - Active: Editing and Re-evaluate link/buttons should be disabled.
5. Ensure there are no other buttons or links in the application (apart from typing the url directly) should navigate the user to the re-evaluate and edit pages of Quiz Exercises which does not obey the status rules above.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![image](https://user-images.githubusercontent.com/18427209/167166285-867a84e7-6256-4927-b0b9-2eabc5f241ac.png)

The `Visible` quiz's id has the navigation link to the edit page while the `Active` quiz's id does not have it.
