### PR TITLE
`Assessment`: Improve the manual text selection for tutors 

### DIFF
--- a/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.html
+++ b/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.html
@@ -10,8 +10,6 @@
     ></jhi-textblock-assessment-card>
     <ng-template #selectionInterface>
         <!-- DO NOT ADD LINEBREAKS INSIDE <jhi-manual-text-selection> -->
-        <jhi-manual-text-selection [positionRelative]="true" (assess)="handleTextSelection($event, group)"
-            ><span [textContent]="group.getText(submission)"></span
-        ></jhi-manual-text-selection>
+        <jhi-manual-text-selection [submission]="submission" [words]="group" [textBlockRefGroup]="group" (didSelectWord)="handleTextSelection($event)"></jhi-manual-text-selection>
     </ng-template>
 </ng-container>

--- a/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.ts
+++ b/src/main/webapp/app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component.ts
@@ -3,6 +3,7 @@ import { TextBlockRef } from 'app/entities/text-block-ref.model';
 import { TextSubmission } from 'app/entities/text-submission.model';
 import { TextBlock } from 'app/entities/text-block.model';
 import { GradingCriterion } from 'app/exercises/shared/structured-grading-criterion/grading-criterion.model';
+import { wordSelection } from 'app/exercises/text/shared/manual-text-selection/manual-text-selection.component';
 
 @Component({
     selector: 'jhi-manual-textblock-selection',
@@ -29,32 +30,19 @@ export class ManualTextblockSelectionComponent {
     }
 
     /**
-     * Called by <jhi-manual-text-selection> component (form [jhiTextSelect] directive).
+     * Called by <jhi-manual-text-selection> component.
      * Select Text within text block ref group and emit to parent component if it is indeed a new text block.
      *
-     * @param text response from directive.
-     * @param group TextBlockRefGroup of text blocks allowed to select text in.
+     * @param selectedWords first and last word selected received from <jhi-manual-text-selection>.
      */
-    handleTextSelection(text: string, group: TextBlockRefGroup): void {
-        // Text Selection returns <br> for linebreaks, model uses \n so we need to convert.
-        text = text.replace(/<br>/g, '\n');
-
+    handleTextSelection(selectedWords: wordSelection[]): void {
         // create new Text Block for text
         const textBlockRef = TextBlockRef.new();
         const textBlock = textBlockRef.block;
 
-        const baseIndex = group.startIndex;
-        const groupText = group.getText(this.submission);
-
-        const startIndexInGroup = groupText.indexOf(text);
-
-        if (text.length > groupText.length || startIndexInGroup === -1) {
-            return;
-        }
-
         if (textBlock) {
-            textBlock.startIndex = baseIndex! + startIndexInGroup;
-            textBlock.endIndex = textBlock.startIndex + text.length;
+            textBlock.startIndex = selectedWords[0].index;
+            textBlock.endIndex = selectedWords[1].index + selectedWords[1].word.length;
             textBlock.setTextFromSubmission(this.submission);
             textBlock.computeId();
             const existingRef = this.textBlockRefs.find((ref) => ref.block?.id === textBlock.id);
@@ -70,7 +58,7 @@ export class ManualTextblockSelectionComponent {
     }
 }
 
-class TextBlockRefGroup {
+export class TextBlockRefGroup {
     public refs: TextBlockRef[];
 
     constructor(textBlockRef: TextBlockRef) {

--- a/src/main/webapp/app/exercises/text/shared/manual-text-selection/manual-text-selection.component.html
+++ b/src/main/webapp/app/exercises/text/shared/manual-text-selection/manual-text-selection.component.html
@@ -1,26 +1,4 @@
-<div (jhiTextSelect)="didSelectSolutionText($event)">
+<div>
     <!-- DO NOT ADD LINEBREAKS INSIDE div.manual-text-selection-area -->
-    <div class="manual-text-selection-area"><ng-content></ng-content></div>
-
-    <div
-        *ngIf="hostRectangle"
-        class="indicator"
-        [style.left.px]="hostRectangle.left"
-        [style.top.px]="positionRelative ? hostRectangle.top - 50 : hostRectangle.top + 20"
-        [style.width.px]="hostRectangle.width"
-        [style.height.px]="0"
-        [style.position]="positionRelative ? 'relative' : 'absolute'"
-    >
-        <div class="indicator__cta">
-            <!--
-                NOTE: Because we DON'T WANT the selected text to get deselected
-                when we click on the call-to-action, we have to PREVENT THE
-                DEFAULT BEHAVIOR and STOP PROPAGATION on some of the events. The
-                byproduct of this is that the (click) event won't fire. As such,
-                we then have to consume the click-intent by way of the (mouseup)
-                event.
-            -->
-            <a (mousedown)="$event.preventDefault()" (mouseup)="$event.stopPropagation(); assessAction()" class="indicator__cta-link">{{ assessText }}</a>
-        </div>
-    </div>
+    <span class="manual-text-selection-area" tabindex="-1" *ngFor="let word of submissionWords; let i = index" (click)="calculateIndex(i); selectWord(word)">{{ ' ' + word }}</span>
 </div>

--- a/src/main/webapp/app/exercises/text/shared/manual-text-selection/manual-text-selection.component.scss
+++ b/src/main/webapp/app/exercises/text/shared/manual-text-selection/manual-text-selection.component.scss
@@ -1,5 +1,18 @@
+@import 'node_modules/bootstrap/scss/functions';
+@import 'node_modules/bootstrap/scss/variables';
+
 .manual-text-selection-area {
     white-space: pre-wrap;
+}
+
+span {
+    &:hover,
+    &:focus {
+        background: $gray-300;
+        padding: 2px 4px;
+        border-radius: 4px;
+        cursor: default;
+    }
 }
 
 .indicator {

--- a/src/main/webapp/app/exercises/text/shared/manual-text-selection/manual-text-selection.component.scss
+++ b/src/main/webapp/app/exercises/text/shared/manual-text-selection/manual-text-selection.component.scss
@@ -1,6 +1,3 @@
-@import 'node_modules/bootstrap/scss/functions';
-@import 'node_modules/bootstrap/scss/variables';
-
 .manual-text-selection-area {
     white-space: pre-wrap;
 }
@@ -8,7 +5,7 @@
 span {
     &:hover,
     &:focus {
-        background: $gray-300;
+        background: var(--manual-text-selection-span-hover-background-color);
         padding: 2px 4px;
         border-radius: 4px;
         cursor: default;

--- a/src/main/webapp/content/scss/themes/_dark-variables.scss
+++ b/src/main/webapp/content/scss/themes/_dark-variables.scss
@@ -456,13 +456,13 @@ $textblock-assessment-text-feedback-conflicting-color: $gray-100;
 $textblock-assessment-text-feedback-conflicting-background: $warning;
 $textblock-assessment-text-feedback-conflicting-active-decoration: $gray-100;
 $textblock-assessment-textblock-feedback-editor-active-border: $gray-600;
-$manual-text-selection-span-hover-background-color: $gray-700;
 $textblock-feedback-editor-feedback-positive-color: #3579b2;
 $textblock-feedback-editor-feedback-positive-background-color: $gray-800;
 $textblock-feedback-editor-feedback-neutral-color: $gray-100;
 $textblock-feedback-editor-feedback-neutral-background-color: $gray-900;
 $textblock-feedback-editor-reused-feedback-preview-border: rgba(228, 228, 228, 0.87);
 $textblock-feedback-editor-dropdown-hover: $gray-700;
+$manual-text-selection-span-hover-background-color: $gray-700;
 
 // Guided tour
 $gt-tour-step-bg-color: $gray-700;

--- a/src/main/webapp/content/scss/themes/_dark-variables.scss
+++ b/src/main/webapp/content/scss/themes/_dark-variables.scss
@@ -456,6 +456,7 @@ $textblock-assessment-text-feedback-conflicting-color: $gray-100;
 $textblock-assessment-text-feedback-conflicting-background: $warning;
 $textblock-assessment-text-feedback-conflicting-active-decoration: $gray-100;
 $textblock-assessment-textblock-feedback-editor-active-border: $gray-600;
+$manual-text-selection-span-hover-background-color: $gray-700;
 $textblock-feedback-editor-feedback-positive-color: #3579b2;
 $textblock-feedback-editor-feedback-positive-background-color: $gray-800;
 $textblock-feedback-editor-feedback-neutral-color: $gray-100;

--- a/src/main/webapp/content/scss/themes/_default-variables.scss
+++ b/src/main/webapp/content/scss/themes/_default-variables.scss
@@ -374,6 +374,7 @@ $textblock-assessment-text-feedback-conflicting-color: $gray-900;
 $textblock-assessment-text-feedback-conflicting-background: $warning;
 $textblock-assessment-text-feedback-conflicting-active-decoration: $gray-900;
 $textblock-assessment-textblock-feedback-editor-active-border: $gray-500;
+$manual-text-selection-span-hover-background-color: $gray-300;
 $textblock-feedback-editor-feedback-positive-color: #25537a;
 $textblock-feedback-editor-feedback-positive-background-color: #d8e8f5;
 $textblock-feedback-editor-feedback-neutral-color: $gray-900;

--- a/src/main/webapp/content/scss/themes/_default-variables.scss
+++ b/src/main/webapp/content/scss/themes/_default-variables.scss
@@ -374,13 +374,13 @@ $textblock-assessment-text-feedback-conflicting-color: $gray-900;
 $textblock-assessment-text-feedback-conflicting-background: $warning;
 $textblock-assessment-text-feedback-conflicting-active-decoration: $gray-900;
 $textblock-assessment-textblock-feedback-editor-active-border: $gray-500;
-$manual-text-selection-span-hover-background-color: $gray-300;
 $textblock-feedback-editor-feedback-positive-color: #25537a;
 $textblock-feedback-editor-feedback-positive-background-color: #d8e8f5;
 $textblock-feedback-editor-feedback-neutral-color: $gray-900;
 $textblock-feedback-editor-feedback-neutral-background-color: $gray-100;
 $textblock-feedback-editor-reused-feedback-preview-border: rgba(228, 228, 228, 0.87);
 $textblock-feedback-editor-dropdown-hover: #e9ecef;
+$manual-text-selection-span-hover-background-color: $gray-300;
 
 // Guided tour
 $gt-tour-step-bg-color: #ffffff;

--- a/src/main/webapp/i18n/de/textAssessment.json
+++ b/src/main/webapp/i18n/de/textAssessment.json
@@ -59,7 +59,7 @@
                     "reused": "{{reusedCount}} mal wiederverwendet"
                 }
             },
-            "assessmentInstruction": "Bitte bewege die Maus über den zu bewertenden Textblock und klicke diesen an, um ihn zu bewerten.<br>Um eigene Textblöcke zu bewerten, drücke <code>alt</code>/<code>option</code> und klicke in beliebiger Reihenfolge auf das erste und letzte Wort eines Textabchnitts.",
+            "assessmentInstruction": "Bitte bewege die Maus über den zu bewertenden Textblock und klicke diesen an, um ihn zu bewerten.<br>Um eigene Textblöcke zu bewerten, drücke <code>alt</code>/<code>option</code> und klicke in beliebiger Reihenfolge auf das erste und letzte Wort eines Textabschnitts.",
             "conflict": {
                 "assessor": "Bewertet von: Dir",
                 "otherAssessor": "Bewertet von: {{otherUser}}",

--- a/src/main/webapp/i18n/de/textAssessment.json
+++ b/src/main/webapp/i18n/de/textAssessment.json
@@ -59,7 +59,7 @@
                     "reused": "{{reusedCount}} mal wiederverwendet"
                 }
             },
-            "assessmentInstruction": "Bitte bewege die Maus über den zu bewertenden Textblock und klicke diesen an, um ihn zu bewerten.<br>Drücke <code>alt</code>/<code>option</code> und wähle gleichzeitig Text aus, um eigene Textblöcke zu bewerten.",
+            "assessmentInstruction": "Bitte bewege die Maus über den zu bewertenden Textblock und klicke diesen an, um ihn zu bewerten.<br>Um eigene Textblöcke zu bewerten, drücke <code>alt</code>/<code>option</code> und klicke in beliebiger Reihenfolge auf das erste und letzte Wort eines Textabchnitts.",
             "conflict": {
                 "assessor": "Bewertet von: Dir",
                 "otherAssessor": "Bewertet von: {{otherUser}}",

--- a/src/main/webapp/i18n/en/textAssessment.json
+++ b/src/main/webapp/i18n/en/textAssessment.json
@@ -59,7 +59,7 @@
                     "reused": "Reused {{reusedCount}} times"
                 }
             },
-            "assessmentInstruction": "Please hover over and click on the text block you want to assess.<br>Hold <code>alt</code>/<code>option</code> while selecting a piece of text to assess custom blocks.",
+            "assessmentInstruction": "Please hover over and click on the text block you want to assess.<br>To assess custom text blocks, hold <code>alt</code>/<code>option</code> while clicking in any order on the first and last word of a text segment.",
             "conflict": {
                 "assessor": "Assessor: You",
                 "otherAssessor": "Assessor: {{otherUser}}",

--- a/src/test/javascript/spec/component/text-submission-assessment/manual-textblock-selection.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/manual-textblock-selection.component.spec.ts
@@ -5,7 +5,7 @@ import { TextblockAssessmentCardComponent } from 'app/exercises/text/assess/text
 import { MockComponent, MockProvider } from 'ng-mocks';
 import { By } from '@angular/platform-browser';
 import { TextBlockRef } from 'app/entities/text-block-ref.model';
-import { ManualTextSelectionComponent } from 'app/exercises/text/shared/manual-text-selection/manual-text-selection.component';
+import { ManualTextSelectionComponent, wordSelection } from 'app/exercises/text/shared/manual-text-selection/manual-text-selection.component';
 import { SubmissionExerciseType, SubmissionType } from 'app/entities/submission.model';
 import { TextSubmission } from 'app/entities/text-submission.model';
 import { TextBlock } from 'app/entities/text-block.model';
@@ -20,7 +20,7 @@ describe('ManualTextblockSelectionComponent', () => {
         id: 2278,
         submitted: true,
         type: SubmissionType.MANUAL,
-        text: 'First text. Second text. Third text. Fourth text. Fifth text.',
+        text: 'First text. Second text. Third text. Fourth text. Fifth sixth text.',
     } as unknown as TextSubmission;
     const blocks = [
         {
@@ -48,9 +48,9 @@ describe('ManualTextblockSelectionComponent', () => {
             submission,
         } as TextBlock,
         {
-            text: 'Fifth text.',
+            text: 'Fifth sixth text.',
             startIndex: 50,
-            endIndex: 61,
+            endIndex: 67,
             submission,
         } as TextBlock,
     ];
@@ -89,12 +89,15 @@ describe('ManualTextblockSelectionComponent', () => {
 
     it('should handle manual text selection correctly', () => {
         jest.spyOn(component.textBlockRefAdded, 'emit');
-        component.handleTextSelection('Third text. Fourth text.', component.textBlockRefGroups[2]);
+        const firstWord: wordSelection = { word: 'Fifth', index: 50 };
+        const lastWord: wordSelection = { word: 'sixth', index: 56 };
+        const selectedWords = [firstWord, lastWord];
+        component.handleTextSelection(selectedWords);
         fixture.detectChanges();
 
         const textBlockRef = TextBlockRef.new();
-        textBlockRef.block!.startIndex = 25;
-        textBlockRef.block!.endIndex = 49;
+        textBlockRef.block!.startIndex = 50;
+        textBlockRef.block!.endIndex = 61;
         textBlockRef.block!.setTextFromSubmission(submission);
         textBlockRef.block!.computeId();
         textBlockRef.initFeedback();

--- a/src/test/javascript/spec/component/text/manual-text-selection.component.spec.ts
+++ b/src/test/javascript/spec/component/text/manual-text-selection.component.spec.ts
@@ -1,17 +1,38 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ArtemisTestModule } from '../../test.module';
 import { ManualTextSelectionComponent } from 'app/exercises/text/shared/manual-text-selection/manual-text-selection.component';
-import { SelectionRectangle, TextSelectEvent } from 'app/exercises/text/shared/text-select.directive';
 import { TextAssessmentEventType } from 'app/entities/text-assesment-event.model';
 import { FeedbackType } from 'app/entities/feedback.model';
-import { TextBlockType } from 'app/entities/text-block.model';
+import { TextBlock, TextBlockType } from 'app/entities/text-block.model';
 import { MockProvider } from 'ng-mocks';
 import { TextAssessmentAnalytics } from 'app/exercises/text/assess/analytics/text-assesment-analytics.service';
 import { ActivatedRoute } from '@angular/router';
+import { SubmissionExerciseType, SubmissionType } from 'app/entities/submission.model';
+import { TextSubmission } from 'app/entities/text-submission.model';
+import { TextBlockRef } from 'app/entities/text-block-ref.model';
+import { TextBlockRefGroup } from 'app/exercises/text/assess/manual-textblock-selection/manual-textblock-selection.component';
 
 describe('ManualTextSelectionComponent', () => {
     let component: ManualTextSelectionComponent;
     let fixture: ComponentFixture<ManualTextSelectionComponent>;
+
+    const submission = {
+        submissionExerciseType: SubmissionExerciseType.TEXT,
+        id: 2278,
+        submitted: true,
+        type: SubmissionType.MANUAL,
+        text: 'First last text. Second text.',
+    } as unknown as TextSubmission;
+
+    const blocks = [
+        {
+            text: 'First last text. Second text.',
+            startIndex: 0,
+            endIndex: 16,
+            submission,
+        } as TextBlock,
+    ];
+    const textBlockRefs = new TextBlockRef(blocks[0]);
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -23,45 +44,39 @@ describe('ManualTextSelectionComponent', () => {
             .then(() => {
                 fixture = TestBed.createComponent(ManualTextSelectionComponent);
                 component = fixture.componentInstance;
+                component.textBlockRefGroup = new TextBlockRefGroup(textBlockRefs);
                 fixture.detectChanges();
             });
     });
 
-    it('should select text and assess the text', () => {
-        const rectangle = { left: 0, top: 0, width: 0, height: 0 } as SelectionRectangle;
-        const event = { text: 'This is a text\n another line', viewportRectangle: null, hostRectangle: null } as TextSelectEvent;
+    it('should set words correctly', () => {
+        component.submission = submission;
+        component.words = new TextBlockRefGroup(textBlockRefs);
 
-        component.disabled = true;
+        expect(component.submissionWords).toEqual(['First', 'last', 'text.']);
+    });
 
-        // catch edge case
-        component.didSelectSolutionText(event);
+    it('should calculate word indices correctly', () => {
+        component.submission = submission;
+        component.words = new TextBlockRefGroup(textBlockRefs);
+        component.calculateIndex(1);
 
-        component.disabled = false;
+        expect(component.currentWordIndex).toBe(6);
+    });
 
-        component.didSelectSolutionText(event);
+    it('should reverse word entries if the tutor clicks on the last word first', () => {
+        component.selectedWords = [{ word: 'last', index: 6 }];
+        component.currentWordIndex = 0;
+        component.selectWord('first');
 
-        expect(component.hostRectangle).toBe(undefined);
-        expect(component.selectedText).toBe(undefined);
-
-        event.hostRectangle = rectangle;
-
-        component.didSelectSolutionText(event);
-
-        expect(component.hostRectangle).toEqual(rectangle);
-        expect(component.selectedText).toBe('This is a text<br> another line');
-
-        const emitSpy = jest.spyOn(component.assess, 'emit');
-        component.assessAction();
-
-        expect(emitSpy).toHaveBeenCalledTimes(1);
-        expect(component.selectedText).toBe(undefined);
-        expect(component.hostRectangle).toBe(undefined);
+        expect(component.selectedWords[0]).toEqual({ word: 'first', index: 0 });
+        expect(component.selectedWords[1]).toEqual({ word: 'last', index: 6 });
     });
 
     it('should send assessment event when selecting text block manually', () => {
-        component.selectedText = 'sample text';
+        component.ready = true;
         const sendAssessmentEventSpy = jest.spyOn(component.textAssessmentAnalytics, 'sendAssessmentEvent');
-        component.assessAction();
+        component.selectWord('lastWord');
         fixture.detectChanges();
         expect(sendAssessmentEventSpy).toHaveBeenCalledTimes(1);
         expect(sendAssessmentEventSpy).toHaveBeenCalledWith(TextAssessmentEventType.ADD_FEEDBACK_MANUALLY_SELECTED_BLOCK, FeedbackType.MANUAL, TextBlockType.MANUAL);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
During the assessment of text exercises, tutors can create custom text blocks by pressing `alt/option`, selecting a piece of text, and then clicking the `Assess` button. This functionality often leads to problems because the `Assess` button appears at a random position or not at all. (see screencast below)
The changes within this PR allow tutors to manually select text easier by clicking on the first and last word of the text they want to assess. 

### Description
<!-- Describe your changes in detail -->
There are multiple text block groups within a text submission; by iterating over these groups and splitting the text by spaces, we get the submission words that can be clicked on.
First, the word index within the whole submission needs to be calculated for each selected word. The selected word and its index are saved in an array. Once two words are selected, the array is emitted to the `manual-textblock-selection.component` where the corresponding text block is created.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Tutor
- 1 Text Exercise with a submission

1. Go to the `Exercise Dashboard` of the text exercise.
2. Start the assessment on a text submission.
3. Press `alt/option` to select a custom text block.
4. Click on the first and last word of the text block you want to assess. The corresponding textblock should be created.
5. Change the order: Click the ending word first and then the starting word. The corresponding textblock should be created.
6. Check that it works if the submission contains whitespaces (linebreaks, tabs, spaces).
7. Check that nothing should happen if the tutor clicks on two words but an already created text block is inbetween (see screenshot example).

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

**Old version:**

https://user-images.githubusercontent.com/73841445/167175066-62983f94-cae5-4247-86dd-fe3029b29f92.mov


**New version:**

https://user-images.githubusercontent.com/73841445/167175100-a3042868-d62d-4def-acf0-853f2b58db0c.mov


**Example for testing step 6:**

<img width="379" alt="Bildschirmfoto 2022-05-06 um 17 29 50" src="https://user-images.githubusercontent.com/73841445/167175192-23a2465c-61ab-498e-9c60-3dd40fe65767.png">


