### PR TITLE
`General`: Fix several issues in the new dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "@fortawesome/fontawesome-svg-core": "6.1.1",
                 "@fortawesome/free-regular-svg-icons": "6.1.1",
                 "@fortawesome/free-solid-svg-icons": "6.1.1",
-                "@ls1intum/apollon": "2.10.0",
+                "@ls1intum/apollon": "2.10.2",
                 "@ng-bootstrap/ng-bootstrap": "12.1.1",
                 "@ngx-translate/core": "14.0.0",
                 "@ngx-translate/http-loader": "7.0.0",
@@ -4071,9 +4071,9 @@
             "dev": true
         },
         "node_modules/@ls1intum/apollon": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/@ls1intum/apollon/-/apollon-2.10.0.tgz",
-            "integrity": "sha512-hI9b2c7SjxBtSEqmcB0UobjFRmQoY4tQpPuDDdA4UZE93vgy4MPWjFNAc6pGi8NBXcu/yQO9oH/mufWoxg+kIA==",
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/@ls1intum/apollon/-/apollon-2.10.2.tgz",
+            "integrity": "sha512-i4Y9+es3nclEws+Sb3jzCGynHhKkHhUjp56tIGeUwL3IzguZ/GFUqZM/rPIUO5WJ8vDz7k5R33JAFuTJrxIxIQ==",
             "dependencies": {
                 "is-mobile": "3.0.0",
                 "pepjs": "0.5.3",
@@ -22298,9 +22298,9 @@
             "dev": true
         },
         "@ls1intum/apollon": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/@ls1intum/apollon/-/apollon-2.10.0.tgz",
-            "integrity": "sha512-hI9b2c7SjxBtSEqmcB0UobjFRmQoY4tQpPuDDdA4UZE93vgy4MPWjFNAc6pGi8NBXcu/yQO9oH/mufWoxg+kIA==",
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/@ls1intum/apollon/-/apollon-2.10.2.tgz",
+            "integrity": "sha512-i4Y9+es3nclEws+Sb3jzCGynHhKkHhUjp56tIGeUwL3IzguZ/GFUqZM/rPIUO5WJ8vDz7k5R33JAFuTJrxIxIQ==",
             "requires": {
                 "is-mobile": "3.0.0",
                 "pepjs": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@fortawesome/fontawesome-svg-core": "6.1.1",
         "@fortawesome/free-regular-svg-icons": "6.1.1",
         "@fortawesome/free-solid-svg-icons": "6.1.1",
-        "@ls1intum/apollon": "2.10.0",
+        "@ls1intum/apollon": "2.10.2",
         "@ng-bootstrap/ng-bootstrap": "12.1.1",
         "@ngx-translate/core": "14.0.0",
         "@ngx-translate/http-loader": "7.0.0",

--- a/src/main/webapp/app/core/theme/theme-switch.component.html
+++ b/src/main/webapp/app/core/theme/theme-switch.component.html
@@ -32,7 +32,7 @@
         #popover="ngbPopover"
         [autoClose]="false"
         [animation]="animate"
-        placement="bottom-right"
+        [placement]="popoverPlacement"
     >
         <div class="theme-toggle" [ngClass]="{ dark: isDark }" id="theme-toggle">
             <svg class="sun-and-moon" aria-hidden="true" width="24" height="24" viewBox="0 0 24 24">

--- a/src/main/webapp/app/core/theme/theme-switch.component.ts
+++ b/src/main/webapp/app/core/theme/theme-switch.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, OnInit, ViewChild } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap';
 import { Theme, ThemeService } from 'app/core/theme/theme.service';
 import { fromEvent } from 'rxjs';
@@ -19,6 +19,8 @@ export const THEME_SWITCH_HAS_SHOWN_INITIAL_KEY = 'artemisApp.theme.hasShownInit
 })
 export class ThemeSwitchComponent implements OnInit {
     @ViewChild('popover') popover: NgbPopover;
+
+    @Input() popoverPlacement: string;
 
     isDark = false;
     isSynced = false;

--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.component.html
@@ -7,7 +7,7 @@
                     data-toggle="tooltip"
                     data-placement="bottom"
                     title="{{ step.title }}"
-                    class="btn btn-light btn-circle stepwizard-circle"
+                    class="btn btn-circle"
                     [class.stepwizard-step--success]="step.done === TestCaseState.SUCCESS"
                     [class.stepwizard-step--failed]="step.done === TestCaseState.FAIL"
                     [class.stepwizard-step--not-executed]="step.done === TestCaseState.NOT_EXECUTED"

--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.scss
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.scss
@@ -4,14 +4,6 @@
     border-bottom: 1px solid var(--programming-exercise-instruction-step-wizard-card-header-border);
 }
 
-.stepwizard-step p {
-    margin-top: 10px;
-}
-
-.stepwizard-step .fa {
-    vertical-align: initial;
-}
-
 .stepwizard-row {
     display: table-row;
 }
@@ -20,16 +12,6 @@
     display: table;
     width: 100%;
     position: relative;
-}
-
-.stepwizard-step button[disabled] {
-    opacity: 1 !important;
-    filter: alpha(opacity=100) !important;
-    cursor: default;
-}
-
-.stepwizard-step .btn {
-    cursor: default;
 }
 
 .stepwizard-row:before {
@@ -48,6 +30,20 @@
     text-align: center;
     position: relative;
 
+    .fa {
+        vertical-align: initial;
+    }
+
+    p {
+        margin-top: 10px;
+    }
+
+    button[disabled] {
+        opacity: 1 !important;
+        filter: alpha(opacity=100) !important;
+        cursor: default;
+    }
+
     &--no-result.btn {
         cursor: default;
     }
@@ -55,22 +51,23 @@
     &--failed.btn {
         cursor: pointer;
     }
-}
 
-.stepwizard-circle .not-done {
-    color: var(--programming-exercise-instruction-step-wizard-circle-not-done-color);
-}
+    .btn {
+        cursor: default;
+        background-color: var(--programming-exercise-instruction-step-wizard-card-header-background);
 
-.btn-circle.btn-circle {
-    width: 30px;
-    height: 30px;
-    text-align: center;
-    padding: 6px 0;
-    font-size: 12px;
-    line-height: 1.428571429;
-    border-radius: 15px;
-    &.btn-light {
-        border-color: var(--programming-exercise-instruction-step-wizard-btn-circle-light-border-color);
+        width: 30px;
+        height: 30px;
+        text-align: center;
+        padding: 6px 0;
+        font-size: 12px;
+        line-height: 1.428571429;
+        border-radius: 15px;
+        border-color: var(--programming-exercise-instruction-step-wizard-btn-border-color);
+    }
+
+    .btn.not-done {
+        color: var(--programming-exercise-instruction-step-wizard-circle-not-done-color);
     }
 }
 

--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.scss
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/step-wizard/programming-exercise-instruction-step-wizard.scss
@@ -55,7 +55,6 @@
     .btn {
         cursor: default;
         background-color: var(--programming-exercise-instruction-step-wizard-card-header-background);
-
         width: 30px;
         height: 30px;
         text-align: center;

--- a/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-details.component.html
@@ -81,7 +81,7 @@
                                 {{ 'artemisApp.courseOverview.lectureDetails.notReleased' | artemisTranslate }}
                             </span>
                         </h5>
-                        <h6 class="text-black-50 mb-0 lecture-attachment-details">
+                        <h6 class="text-secondary mb-0 lecture-attachment-details">
                             ({{ 'artemisApp.courseOverview.lectureDetails.version' | artemisTranslate }}: {{ attachment.version }} -
                             {{ 'artemisApp.courseOverview.lectureDetails.date' | artemisTranslate }}: {{ attachment.uploadDate | artemisDate }})
                         </h6>

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -158,7 +158,7 @@
 
             <jhi-notification-sidebar [ngClass]="'nav-item'" *ngIf="currAccount && !examModeActive()"></jhi-notification-sidebar>
 
-            <jhi-theme-switch [ngClass]="'nav-item'"></jhi-theme-switch>
+            <jhi-theme-switch [ngClass]="'nav-item'" [popoverPlacement]="isCollapsed ? 'bottom-left' : 'bottom-right'"></jhi-theme-switch>
 
             <li
                 *ngSwitchCase="true"

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -52,7 +52,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { ExerciseHintService } from 'app/exercises/shared/exercise-hint/manage/exercise-hint.service';
 import { Exercise } from 'app/entities/exercise.model';
-import { Theme, ThemeService } from 'app/core/theme/theme.service';
+import { ThemeService } from 'app/core/theme/theme.service';
 
 @Component({
     selector: 'jhi-navbar',

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -62,8 +62,6 @@ import { Theme, ThemeService } from 'app/core/theme/theme.service';
 export class NavbarComponent implements OnInit, OnDestroy {
     readonly SERVER_API_URL = SERVER_API_URL;
 
-    readonly Themes = Theme;
-
     inProduction: boolean;
     isNavbarCollapsed: boolean;
     isTourAvailable: boolean;

--- a/src/main/webapp/content/scss/themes/_dark-variables.scss
+++ b/src/main/webapp/content/scss/themes/_dark-variables.scss
@@ -350,7 +350,7 @@ $mc-question-answer-option-hover-background: transparentize(#fff, 0.97);
 $programming-exercise-instruction-step-wizard-card-header-background: lighten($neutral-dark, 5%);
 $programming-exercise-instruction-step-wizard-card-header-border: lighten($neutral-dark, 10%);
 $programming-exercise-instruction-step-wizard-row-before-background: #ccc;
-$programming-exercise-instruction-step-wizard-btn-circle-light-border-color: #ccc;
+$programming-exercise-instruction-step-wizard-btn-border-color: #ccc;
 $programming-exercise-instruction-step-wizard-circle-not-done-color: $gray-700;
 $programming-exercise-instruction-step-wizard-test-passing-hover-color: #f8f9fa;
 

--- a/src/main/webapp/content/scss/themes/_dark-variables.scss
+++ b/src/main/webapp/content/scss/themes/_dark-variables.scss
@@ -211,7 +211,7 @@ $markdown-preview-blockquote-border: #dfe2e5;
 $connection-status: $success;
 $connection-status-disconnected: $danger;
 
-$mat-autocomplete-visible-box-shadow: rgb(100 100 100);
+$mat-autocomplete-visible-box-shadow: black;
 $mat-form-field-outline: #ccc;
 
 // Feature Overview

--- a/src/main/webapp/content/scss/themes/_default-variables.scss
+++ b/src/main/webapp/content/scss/themes/_default-variables.scss
@@ -268,7 +268,7 @@ $mc-question-answer-option-hover-background: #fafafa;
 $programming-exercise-instruction-step-wizard-card-header-background: #f5f5f5;
 $programming-exercise-instruction-step-wizard-card-header-border: #ddd;
 $programming-exercise-instruction-step-wizard-row-before-background: #ccc;
-$programming-exercise-instruction-step-wizard-btn-circle-light-border-color: #ccc;
+$programming-exercise-instruction-step-wizard-btn-border-color: #ccc;
 $programming-exercise-instruction-step-wizard-circle-not-done-color: $secondary;
 $programming-exercise-instruction-step-wizard-test-passing-hover-color: #f8f9fa;
 

--- a/src/main/webapp/content/scss/themes/theme-dark.scss
+++ b/src/main/webapp/content/scss/themes/theme-dark.scss
@@ -104,8 +104,8 @@ html {
 .form-control[readonly],
 .form-select:disabled,
 .form-select[readonly],
-.form-check-input:disabled,
-.form-check-input[readonly] {
+.form-check-input:disabled:not(:checked),
+.form-check-input[readonly]:not(:checked) {
     background: $gray-700 !important;
     color: $gray-400;
 }

--- a/src/main/webapp/content/scss/themes/theme-dark.scss
+++ b/src/main/webapp/content/scss/themes/theme-dark.scss
@@ -168,6 +168,14 @@ html {
     background-color: $neutral-dark !important;
 }
 
+.cdk-overlay-container .tag-option {
+    background: mix($neutral-dark, $white, 90%);
+
+    &:hover {
+        background: mix($neutral-dark, $white, 80%);
+    }
+}
+
 // ==================
 // NGX CHARTS STYLING
 // ==================

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
@@ -323,7 +323,7 @@ describe('ProgrammingExerciseInstructionComponent', () => {
         fixture.detectChanges();
 
         expect(debugElement.query(By.css('.stepwizard'))).not.toBe(null);
-        expect(debugElement.queryAll(By.css('.stepwizard-circle'))).toHaveLength(2);
+        expect(debugElement.queryAll(By.css('.btn-circle'))).toHaveLength(2);
         tick();
         fixture.detectChanges();
         expect(debugElement.query(By.css('.instructions__content__markdown')).nativeElement.innerHTML).toEqual(problemStatementBubbleSortNotExecutedHtml);
@@ -380,7 +380,7 @@ describe('ProgrammingExerciseInstructionComponent', () => {
         fixture.detectChanges();
 
         expect(debugElement.query(By.css('.stepwizard'))).not.toBe(null);
-        expect(debugElement.queryAll(By.css('.stepwizard-circle'))).toHaveLength(2);
+        expect(debugElement.queryAll(By.css('.btn-circle'))).toHaveLength(2);
         tick();
         fixture.detectChanges();
         expect(debugElement.query(By.css('.instructions__content__markdown')).nativeElement.innerHTML).toEqual(problemStatementBubbleSortFailsHtml);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Description
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR fixes four follow up issues regarding the dark mode

#### 1. Dark Mode settings popover is wrongly positioned if the navbar collapses on smaller screens:
Reported by @jpbernius, @krusche, @JohannesStoehr and @Funky-Punky.
Closes #5036.

<img src="https://user-images.githubusercontent.com/23171488/167262189-353f657c-2a7c-46ec-b0f3-af30bc3a50b8.png" width=200 />

#### 2. Lecture attachment details appear black in dark mode
Reported by @ge65cer 

Happens if you select a lecture with at least one attachment as student:
![grafik](https://user-images.githubusercontent.com/23171488/167262552-9e9b70ea-a007-409a-9134-713b7250feff.png)

#### 3. Exercise feedback is less noticeable in dark mode
Reported by @LadnerJonas
Closes #5037.

Before:
![grafik](https://user-images.githubusercontent.com/23171488/167263376-fcd52b98-8029-4b9c-8399-f257c20cbb3b.png)

After:
![grafik](https://user-images.githubusercontent.com/23171488/167263385-bb212d1c-e602-44ef-9efb-00c61247ba16.png)

#### 4. Category dropdown background is white
Reported by @bottbenj
Closes #5039.

Before:
![grafik](https://user-images.githubusercontent.com/23171488/167263857-da016273-c9b8-4365-9b2d-cf107fe53039.png)

After:
![Screenshot 2022-05-07 at 18 43 07](https://user-images.githubusercontent.com/23171488/167263860-602d8985-1678-48f1-9ecf-23c6d1dc049d.png)

#### 5. Checked, but disabled checkbox looks like unchecked checkbox in dark mode
Closes #5048.

**Before:**
Light mode
![grafik](https://user-images.githubusercontent.com/23171488/167303976-f9e08212-8cd5-4632-95f3-86c86d78f77b.png)

Dark mode:
![grafik](https://user-images.githubusercontent.com/23171488/167303977-6b235bc8-aa14-4c27-840a-3443c6ea3c83.png)

**After:**
![grafik](https://user-images.githubusercontent.com/23171488/167304003-f0f2efab-271b-4ed2-b982-3d1d83fc0ba1.png)

#### 6. Include Apollon release with dark mode issues fixed

Related Apollon Issues: https://github.com/ls1intum/Apollon/issues/225 (resolved by https://github.com/ls1intum/Apollon/pull/226), https://github.com/ls1intum/Apollon/pull/227

Closes #5040.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Please check that each of the described bugs do not appear anymore.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2