### PR TITLE
`Modeling exercises`: Prevent UI jumps when using Apollon in Safari

### DIFF
--- a/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
@@ -32,8 +32,7 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
     farQuestionCircle = faQuestionCircle;
 
     htmlScroll = 0;
-    clickNoScroll = false;
-    mouseDownListener: ((this: Document, ev: MouseEvent) => any) | undefined;
+    mouseDownListener: any;
     scrollListener: ((this: Document, ev: Event) => any) | undefined;
 
     constructor(private alertService: AlertService, private renderer: Renderer2, private modalService: NgbModal, private guidedTourService: GuidedTourService) {
@@ -66,18 +65,13 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
             console.log('Warning: If you experience problems regarding the scrolling behavior, please report them at https://github.com/ls1intum/Artemis');
 
             this.mouseDownListener = () => {
-                if (this.clickNoScroll) {
-                    const copy = this.htmlScroll;
-                    // @ts-ignore behavior 'instant' works with safari
-                    requestAnimationFrame(() => window.scrollTo({ top: copy, left: 0, behavior: 'instant' }));
-                }
-
-                this.clickNoScroll = true;
+                const copy = this.htmlScroll;
+                // @ts-ignore behavior 'instant' works with safari
+                requestAnimationFrame(() => window.scrollTo({ top: copy, left: 0, behavior: 'instant' }));
             };
 
             this.scrollListener = () => {
                 this.htmlScroll = document.getElementsByTagName('html')[0].scrollTop;
-                this.clickNoScroll = false;
             };
 
             document.addEventListener('mousedown', this.mouseDownListener);

--- a/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
@@ -52,34 +52,7 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
             }
         });
         this.setupInteract();
-
-        // Detect Safari desktop: https://stackoverflow.com/a/52205049/7441850
-        const isSafariDesktop = /Safari/i.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor) && !/Mobi|Android/i.test(navigator.userAgent);
-
-        /*
-        This is a hack to prevent the UI jumping to bottom when using popovers in Apollon while using Safari.
-        Other browsers do not show this behavior.
-         */
-        if (!this.readOnly && isSafariDesktop) {
-            console.log('Warning: Installing hack to prevent UI scroll jumps in Safari while using Apollon!');
-            console.log('Warning: If you experience problems regarding the scrolling behavior, please report them at https://github.com/ls1intum/Artemis');
-
-            this.mouseDownListener = () => {
-                const newScroll = document.getElementsByTagName('html')[0].scrollTop;
-                if (newScroll !== this.htmlScroll) {
-                    const copy = this.htmlScroll;
-                    // @ts-ignore behavior 'instant' works with safari
-                    requestAnimationFrame(() => window.scrollTo({ top: copy, left: 0, behavior: 'instant' }));
-                }
-            };
-
-            this.scrollListener = () => {
-                this.htmlScroll = document.getElementsByTagName('html')[0].scrollTop;
-            };
-
-            document.addEventListener('mousedown', this.mouseDownListener);
-            document.addEventListener('scroll', this.scrollListener);
-        }
+        this.setupSafariScrollFix();
     }
 
     /**
@@ -107,6 +80,39 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
                 this.onModelChanged.emit(model);
             });
         }
+    }
+
+    /**
+     * This is a hack to prevent the UI jumping to bottom when using popovers in Apollon while using Safari.
+     * Other browsers do not show this behavior.
+     * @private
+     */
+    private setupSafariScrollFix() {
+        // Detect Safari desktop: https://stackoverflow.com/a/52205049/7441850
+        const isSafariDesktop = /Safari/i.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor) && !/Mobi|Android/i.test(navigator.userAgent);
+
+        if (this.readOnly || !isSafariDesktop) {
+            return;
+        }
+
+        console.log('Warning: Installing hack to prevent UI scroll jumps in Safari while using Apollon!');
+        console.log('Warning: If you experience problems regarding the scrolling behavior, please report them at https://github.com/ls1intum/Artemis');
+
+        this.mouseDownListener = () => {
+            const newScroll = document.getElementsByTagName('html')[0].scrollTop;
+            if (newScroll !== this.htmlScroll) {
+                const copy = this.htmlScroll;
+                // @ts-ignore behavior 'instant' works with safari
+                requestAnimationFrame(() => window.scrollTo({ top: copy, left: 0, behavior: 'instant' }));
+            }
+        };
+
+        this.scrollListener = () => {
+            this.htmlScroll = document.getElementsByTagName('html')[0].scrollTop;
+        };
+
+        document.addEventListener('mousedown', this.mouseDownListener);
+        document.addEventListener('scroll', this.scrollListener);
     }
 
     get isApollonEditorMounted(): boolean {

--- a/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
@@ -32,7 +32,7 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
     farQuestionCircle = faQuestionCircle;
 
     htmlScroll = 0;
-    mouseDownListener: any;
+    mouseDownListener: ((this: Document, ev: MouseEvent) => any) | undefined;
     scrollListener: ((this: Document, ev: Event) => any) | undefined;
 
     constructor(private alertService: AlertService, private renderer: Renderer2, private modalService: NgbModal, private guidedTourService: GuidedTourService) {

--- a/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/shared/modeling-editor.component.ts
@@ -65,9 +65,12 @@ export class ModelingEditorComponent extends ModelingComponent implements AfterV
             console.log('Warning: If you experience problems regarding the scrolling behavior, please report them at https://github.com/ls1intum/Artemis');
 
             this.mouseDownListener = () => {
-                const copy = this.htmlScroll;
-                // @ts-ignore behavior 'instant' works with safari
-                requestAnimationFrame(() => window.scrollTo({ top: copy, left: 0, behavior: 'instant' }));
+                const newScroll = document.getElementsByTagName('html')[0].scrollTop;
+                if (newScroll !== this.htmlScroll) {
+                    const copy = this.htmlScroll;
+                    // @ts-ignore behavior 'instant' works with safari
+                    requestAnimationFrame(() => window.scrollTo({ top: copy, left: 0, behavior: 'instant' }));
+                }
             };
 
             this.scrollListener = () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

@krusche reported a bug where the browser jumps to the bottom of the screen when using the modeling editor and closing popovers in it by clicking somewhere else.

This happens only in Safari. Chrome and Firefox are not affected.
See this screencast:

https://user-images.githubusercontent.com/23171488/167619927-3602d6a3-fac7-405e-a973-01773f487412.mov

The internet is full of problems with nasty scrolling behavior of Safari, but I haven't found any other suggestions than resetting the scroll to the desired position manually.

### Description
<!-- Describe your changes in detail -->
To solve this, I've added a pretty dark hack where we store the current scroll position by listening to scroll events and reset scroll to the original position later.
If we receive a mousedown event, we will reset the scroll position to the last one stored in an animation frame.
By that, there's no visual scrolling behavior and it works like in the other browsers.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Modeling Exercise
- macOS and Safari

The steps below show how to verify that the bug is not present anymore. To compare, I suggest that you test that the bug appears at all for you on current ``develop`` or on the production instance.

1. Participate in the modeling exercise in Safari
2. Zoom the page much in (like in the video) so that the bottom border of the editor is not in the viewport anymore
3. Double click a UML item to bring up the edit popover
4. Click somewhere else to close it
5. Make sure that Safari didn't jump to the bottom of the page
6. Open the console. Check that the warning is printed
7. Repeat 1 to 5 in Chrome and/or Firefox. Make sure that the editor works there correctly as well and that the warning is NOT printed to the console

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
