### PR TITLE
`Quiz exercises`: Fix re-evaluate for batched and individual mode quizzes

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/quiz/QuizExercise.java
@@ -412,6 +412,9 @@ public class QuizExercise extends Exercise {
         this.setDueDate(originalQuizExercise.getDueDate());
         this.setReleaseDate(originalQuizExercise.getReleaseDate());
 
+        // cannot update batches
+        this.setQuizBatches(originalQuizExercise.getQuizBatches());
+
         // remove added Questions, which are not allowed to be added
         Set<QuizQuestion> addedQuizQuestions = new HashSet<>();
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -184,6 +184,11 @@ public class QuizExerciseResource {
 
         quizExercise.reconnectJSONIgnoreAttributes();
 
+        // don't allow changing batches except in synchronized mode as the client doesn't have the full list and saving the exercise could otherwise end up deleting a bunch
+        if (quizExercise.getQuizMode() != QuizMode.SYNCHRONIZED || quizExercise.getQuizBatches() == null || quizExercise.getQuizBatches().size() > 1) {
+            quizExercise.setQuizBatches(batches);
+        }
+
         quizExercise = quizExerciseService.save(quizExercise);
         exerciseService.logUpdate(quizExercise, quizExercise.getCourseViaExerciseGroupOrCourseMember(), user);
 


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
Followup to #4936 
Re-evaluating or saving a quiz exercise in batched or individual mode would delete all batches you did not create. While for saving this doesn't matter when reevaluating when those batches have submissions, deleting the batch would fail causing the quiz to not be updated after the scores have already been re-computed and saved.

### Description
Disregard changes to batches unless saving a synchronized quiz with a scheduled start. Dedicated endpoints are used to modify batches when actually intended.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 2 Instructors (one of them may also be a tutor

1. Create a quiz exercise in batched mode
2. Create (but not start) batches as both users
3. Edit the quiz, ie change the duration and save
4. Check that all batches of both users still exist
5. Participate in batches of both users
6. End the quiz
7. Re-evaluate the quiz and set one question as invalid
    NOTE: the re-evaluate in general is fairly broken but that is beyond the scope of this PR
8. Check that the re-evaluate completes successfully
9. Check that the question is indeed invalid (or whatever change you made got saved)
10. ~~Check that all batches still exist~~
    There is currently no UI check this, but the next check is the actually important property anyways.
11. Check that all submission still exist

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


