### PR TITLE
`General`: Fix missing images in exam grading documentation

### DIFF
--- a/docs/user/exams/students_guide.rst
+++ b/docs/user/exams/students_guide.rst
@@ -335,9 +335,10 @@ Grades
 - You will see your obtained points along with the maximum achievable points for each individual exercise.
 - If the instructor defined a grading key for your exam, you will also see your grade.
 
-.. figure:: student/exam_grade.png
+.. figure:: student/student_grade.png
    :alt: Exam Grade
    :align: center
+
    Exam Grade
 
     .. note::
@@ -347,9 +348,10 @@ Grades
 - A square bracket ``[`` or ``]`` in the interval of a grade step means the bound is included in the current grade step, and a parenthesis ``(`` or ``)`` means it is excluded.
 - For example, if the grade step for ``2.0`` shows the percentage interval as ``[80 - 85)`` this means that a student achieving ``80%`` has the grade ``2.0``, whereas a student achieving ``85%`` receives the grade right above ``2.0`` (i.e. ``1.7`` if the default grading key is used).
 
-.. figure:: student/exam_grade_key.png
+.. figure:: student/student_grade_key.png
    :alt: Exam Grading Key
    :align: center
+
    Exam Grading Key for a student receiving 135 points out of 150
 
 |


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
The images in the section added in #4967 are not actually shown.

### Description
Fix two issues:
- Missing empty line between image and caption.
- Wrong image name.

### Steps for Testing
Compare the documentation 
- https://docs.artemis.ase.in.tum.de/user/exams/students_guide/#grades
- https://artemis-platform--5080.org.readthedocs.build/en/5080/user/exams/students_guide/#grades

### Review Progress
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
![Screenshot 2022-05-12 at 19-59-05 Students’ Guide — Artemis documentation](https://user-images.githubusercontent.com/64250573/168158188-22e928ff-5e52-4d23-8fd4-b516e6e64354.png)

