### PR TITLE
`Programming exercises`: Improve code assessment editor colors

### DIFF
--- a/src/main/webapp/app/app.main.ts
+++ b/src/main/webapp/app/app.main.ts
@@ -1,5 +1,6 @@
 import './polyfills';
 import 'app/shared/util/array.extension';
+import 'app/shared/util/map.extension';
 import 'app/shared/util/string.extension';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { ProdConfig } from './core/config/prod.config';

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-container.component.ts
@@ -254,9 +254,7 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
             // When the selectedFile is not part of the template, then this is a new file and all lines in code editor are highlighted
             if (!this.templateFileSession[selectedFile]) {
                 const lastLine = this.codeEditorContainer.aceEditor.editorSession.getLength() - 1;
-                this.codeEditorContainer.aceEditor.markerIds.push(
-                    this.codeEditorContainer.aceEditor.editorSession.addMarker(new this.codeEditorContainer.aceEditor.Range(0, 0, lastLine, 1), 'diff-newLine', 'fullLine'),
-                );
+                this.highlightLines(0, lastLine);
             } else {
                 // Calculation of the diff, see: https://github.com/google/diff-match-patch/wiki/Line-or-Word-Diffs
                 const diffArray = this.diffMatchPatch.diff_linesToChars(this.templateFileSession[selectedFile], this.codeEditorContainer.aceEditor.editorSession.getValue());
@@ -279,18 +277,16 @@ export class CodeEditorTutorAssessmentContainerComponent implements OnInit, OnDe
                         const lines = diffElement[1].split(/\r?\n/).filter(Boolean);
                         const firstLineToHighlight = counter;
                         const lastLineToHighlight = counter + lines.length - 1;
-                        this.codeEditorContainer.aceEditor.markerIds.push(
-                            this.codeEditorContainer.aceEditor.editorSession.addMarker(
-                                new this.codeEditorContainer.aceEditor.Range(firstLineToHighlight, 0, lastLineToHighlight, 1),
-                                'diff-newLine',
-                                'fullLine',
-                            ),
-                        );
+                        this.highlightLines(firstLineToHighlight, lastLineToHighlight);
                         counter += lines.length;
                     }
                 });
             }
         }
+    }
+
+    private highlightLines(firstLine: number, lastLine: number) {
+        this.codeEditorContainer.aceEditor.highlightLines(firstLine, lastLine, 'diff-newLine', 'gutter-diff-newLine');
     }
 
     /**

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
@@ -234,6 +234,7 @@ export class CodeEditorAceComponent implements AfterViewInit, OnChanges, OnDestr
             }
             if (this.gutterHighlights.size > 0) {
                 this.gutterHighlights.forEach((classes, row) => classes.forEach((className) => this.editorSession.removeGutterDecoration(row, className)));
+                this.gutterHighlights.clear();
             }
             this.onFileLoad.emit(this.selectedFile);
         }

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.scss
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.scss
@@ -23,7 +23,7 @@ Ace Editor
 
         .btn-inline-comment {
             display: none;
-            color: #3e8acc; // btn-primary color
+            color: var(--primary);
             height: 16px;
         }
 
@@ -37,10 +37,21 @@ Ace Editor
             top: 8px; // standard gutter height is 16px
             left: 25%;
             transform: translate(-50%, -50%);
+            cursor: pointer;
 
-            fa-icon:hover {
-                font-size: 15px;
-                transition: font-size 0.35s ease;
+            fa-icon {
+                position: relative;
+
+                &::after {
+                    content: '';
+                    position: absolute;
+                    width: calc(100% - 6px);
+                    height: calc(100% - 6px);
+                    top: 3px;
+                    left: 3px;
+                    background: white;
+                    z-index: -1;
+                }
             }
         }
 

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.scss
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.scss
@@ -60,4 +60,13 @@ Ace Editor
         background: var(--code-editor-diff-newline-background);
         z-index: 20;
     }
+
+    .ace_gutter-cell {
+        transition: background 0s;
+
+        &.gutter-diff-newLine {
+            transition: background 0s;
+            background: var(--code-editor-gutter-newline-background);
+        }
+    }
 }

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.scss
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.scss
@@ -61,12 +61,8 @@ Ace Editor
         z-index: 20;
     }
 
-    .ace_gutter-cell {
+    .ace_gutter-cell.gutter-diff-newLine {
         transition: background 0s;
-
-        &.gutter-diff-newLine {
-            transition: background 0s;
-            background: var(--code-editor-gutter-newline-background);
-        }
+        background: var(--code-editor-gutter-newline-background);
     }
 }

--- a/src/main/webapp/app/shared/util/map.extension.ts
+++ b/src/main/webapp/app/shared/util/map.extension.ts
@@ -1,0 +1,19 @@
+export {};
+
+declare global {
+    export interface Map<K, V> {
+        computeIfAbsent(key: K, mappingFunction: (key: K) => V): V;
+    }
+}
+
+if (!Map.prototype.computeIfAbsent) {
+    Map.prototype.computeIfAbsent = function (key, mappingFunction) {
+        const value = this.get(key);
+        if (value !== undefined) {
+            return value;
+        }
+        const valueToAdd = mappingFunction(key);
+        this.set(key, valueToAdd);
+        return valueToAdd;
+    };
+}

--- a/src/main/webapp/content/scss/themes/_dark-variables.scss
+++ b/src/main/webapp/content/scss/themes/_dark-variables.scss
@@ -368,7 +368,8 @@ $code-editor-file-browser-header-border: lighten($neutral-dark, 10%);
 $code-editor-file-browser-tree-hover: lighten($neutral-dark, 5%);
 $code-editor-file-browser-input-background: darken($neutral-dark, 10%);
 $code-editor-file-browser-input-color: white;
-$code-editor-diff-newline-background: rgba(46, 160, 67, 0.15);
+$code-editor-diff-newline-background: rgba(46, 160, 67, 0.22);
+$code-editor-gutter-newline-background: rgba(46, 160, 67, 0.6);
 
 // Overview variables
 $overview-border-color: $border-color;

--- a/src/main/webapp/content/scss/themes/_default-variables.scss
+++ b/src/main/webapp/content/scss/themes/_default-variables.scss
@@ -287,6 +287,7 @@ $code-editor-file-browser-tree-hover: #f5f5f5;
 $code-editor-file-browser-input-background: white;
 $code-editor-file-browser-input-color: black;
 $code-editor-diff-newline-background: rgba(63, 185, 80, 0.4);
+$code-editor-gutter-newline-background: rgba(63, 185, 80, 0.8);
 
 // Overview variables
 $overview-border-color: $border-color;

--- a/src/main/webapp/content/scss/themes/theme-dark.scss
+++ b/src/main/webapp/content/scss/themes/theme-dark.scss
@@ -176,12 +176,16 @@ html {
     }
 }
 
-.ace-dracula {
+.ace_editor.ace_dark.ace-dracula {
     background-color: $neutral-dark !important;
-}
 
-.ace_gutter {
-    background-color: #242724;
+    .ace_gutter {
+        background-color: #242724;
+    }
+
+    .ace_comment {
+        color: #8497ce;
+    }
 }
 
 // ==================

--- a/src/test/javascript/spec/jest-test-setup.ts
+++ b/src/test/javascript/spec/jest-test-setup.ts
@@ -1,5 +1,6 @@
 import 'jest-canvas-mock';
 import 'app/shared/util/array.extension';
+import 'app/shared/util/map.extension';
 import 'app/shared/util/string.extension';
 import 'app/core/config/dayjs';
 import 'jest-extended';


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

A follow-up to #5077, which worked well as a quick fix, but needed some further color adoptions.
In Dark Mode, the green diff highlight was not visible enough; additionally, comments do have a badly readable color when using highlighted lines.

### Description
<!-- Describe your changes in detail -->

In the assessment code editor:

- Amplified color of green diff highlight in text area
- Amplified color of comments to be better readable in highlighted areas
- Add highlighting to line number backgrounds as well to make highlighted lines better visible
- Removed the weird scaling animation from the button to add inline comments, and gave it a not-overflowing white background (for the small plus).

Additionally, I extracted the code for highlighting lines into a method in the code editor component itself to combine line- and line number gutter highlighting.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with manual assessment with participations

1. Go the assessment view of an exercise submission
2. Check that the green overlay and editor colors look good and readable in both dark and light mode
3. Check that you can still add inline feedback

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
![image](https://user-images.githubusercontent.com/23171488/168276047-08689b54-259a-460c-a13c-a02e66878fda.png)


After:
![image](https://user-images.githubusercontent.com/23171488/168275918-449b630d-406e-4040-820e-acb933f59507.png)

Highlighted line numbers in light mode:
![image](https://user-images.githubusercontent.com/23171488/168276303-058cc5d9-7e43-4d98-a85c-35138d235e9a.png)


