### PR TITLE
`Lectures`: Fix race condition when re-ordering lecture units

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/lecture/LectureUnit.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/lecture/LectureUnit.java
@@ -42,7 +42,7 @@ public abstract class LectureUnit extends DomainObject {
     // This is explicitly required by Hibernate for the indexed collection (OrderColumn)
     // https://docs.jboss.org/hibernate/stable/annotations/reference/en/html_single/#entity-hibspec-collection-extratype-indexbidir
     @Column(name = "lecture_unit_order")
-    @JsonIgnore
+    @Transient
     private int order;
 
     @ManyToOne
@@ -65,10 +65,6 @@ public abstract class LectureUnit extends DomainObject {
 
     public int getOrder() {
         return order;
-    }
-
-    public void setOrder(int order) {
-        this.order = order;
     }
 
     public Lecture getLecture() {

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
@@ -65,7 +65,6 @@ public class LectureImportService {
             LectureUnit clonedLectureUnit = cloneLectureUnit(lectureUnit, lecture);
             if (clonedLectureUnit != null) {
                 clonedLectureUnit.setLecture(lecture);
-                clonedLectureUnit.setOrder(lectureUnit.getOrder());
                 lectureUnits.add(clonedLectureUnit);
             }
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/LectureImportService.java
@@ -9,6 +9,7 @@ import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.tum.in.www1.artemis.domain.Attachment;
 import de.tum.in.www1.artemis.domain.Course;
@@ -46,6 +47,7 @@ public class LectureImportService {
      * @param course          The course to import to
      * @return The lecture in the new course
      */
+    @Transactional // Required to circumvent errors with ordered collection of lecture units
     public Lecture importLecture(final Lecture importedLecture, final Course course) {
         log.debug("Creating a new Lecture based on lecture {}", importedLecture);
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/AttachmentUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/AttachmentUnitResource.java
@@ -93,7 +93,6 @@ public class AttachmentUnitResource {
         // Make sure that the original references are preserved.
         AttachmentUnit originalAttachmentUnit = attachmentUnitRepository.findById(attachmentUnit.getId()).get();
         attachmentUnit.setAttachment(originalAttachmentUnit.getAttachment());
-        attachmentUnit.setOrder(originalAttachmentUnit.getOrder());
 
         AttachmentUnit result = attachmentUnitRepository.save(attachmentUnit);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, attachmentUnit.getId().toString())).body(result);

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/TextUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/TextUnitResource.java
@@ -87,9 +87,6 @@ public class TextUnitResource {
         }
         authorizationCheckService.checkHasAtLeastRoleForLectureElseThrow(Role.EDITOR, textUnit.getLecture(), null);
 
-        TextUnit existingUnit = textUnitRepository.findById(textUnit.getId()).orElseThrow();
-        textUnit.setOrder(existingUnit.getOrder());
-
         TextUnit result = textUnitRepository.save(textUnit);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, textUnit.getId().toString())).body(result);
     }

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
@@ -102,9 +102,6 @@ public class VideoUnitResource {
             throw new ConflictException("Requested lecture unit is not part of the specified lecture", "VideoUnit", "lectureIdMismatch");
         }
 
-        VideoUnit existingUnit = videoUnitRepository.findById(videoUnit.getId()).orElseThrow();
-        videoUnit.setOrder(existingUnit.getOrder());
-
         VideoUnit result = videoUnitRepository.save(videoUnit);
         return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, videoUnit.getId().toString())).body(result);
     }

--- a/src/test/java/de/tum/in/www1/artemis/AttachmentUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AttachmentUnitIntegrationTest.java
@@ -2,6 +2,8 @@ package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +14,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import de.tum.in.www1.artemis.domain.Attachment;
 import de.tum.in.www1.artemis.domain.Lecture;
 import de.tum.in.www1.artemis.domain.lecture.AttachmentUnit;
+import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.util.ModelFactory;
 
@@ -117,13 +120,15 @@ public class AttachmentUnitIntegrationTest extends AbstractSpringIntegrationBamb
         // Add a second lecture unit
         AttachmentUnit attachmentUnit = database.createAttachmentUnit(false);
         lecture1.addLectureUnit(attachmentUnit);
-        lectureRepository.save(lecture1);
+        lecture1 = lectureRepository.save(lecture1);
 
-        // Updating the lecture unit should not change order attribute
+        List<LectureUnit> orderedUnits = lecture1.getLectureUnits();
+
+        // Updating the lecture unit should not influence order
         request.putWithResponseBody("/api/lectures/" + lecture1.getId() + "/attachment-units", attachmentUnit, AttachmentUnit.class, HttpStatus.OK);
 
-        AttachmentUnit updatedAttachmentUnit = attachmentUnitRepository.findById(attachmentUnit.getId()).orElseThrow();
-        assertThat(updatedAttachmentUnit.getOrder()).isEqualTo(1);
+        List<LectureUnit> updatedOrderedUnits = lectureRepository.findByIdWithLectureUnits(lecture1.getId()).get().getLectureUnits();
+        assertThat(updatedOrderedUnits).containsExactlyElementsOf(orderedUnits);
     }
 
     private void persistAttachmentUnitWithLecture() {

--- a/src/test/java/de/tum/in/www1/artemis/TextUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/TextUnitIntegrationTest.java
@@ -2,6 +2,8 @@ package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.domain.Lecture;
+import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.domain.lecture.TextUnit;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.TextUnitRepository;
@@ -107,13 +110,15 @@ public class TextUnitIntegrationTest extends AbstractSpringIntegrationBambooBitb
         // Add a second lecture unit
         TextUnit textUnit = database.createTextUnit();
         lecture.addLectureUnit(textUnit);
-        lectureRepository.save(lecture);
+        lecture = lectureRepository.save(lecture);
+
+        List<LectureUnit> orderedUnits = lecture.getLectureUnits();
 
         // Updating the lecture unit should not change order attribute
         request.putWithResponseBody("/api/lectures/" + lecture.getId() + "/text-units", textUnit, TextUnit.class, HttpStatus.OK);
 
-        TextUnit updatedTextUnit = textUnitRepository.findById(textUnit.getId()).orElseThrow();
-        assertThat(updatedTextUnit.getOrder()).isEqualTo(1);
+        List<LectureUnit> updatedOrderedUnits = lectureRepository.findByIdWithLectureUnits(lecture.getId()).get().getLectureUnits();
+        assertThat(updatedOrderedUnits).containsExactlyElementsOf(orderedUnits);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/VideoUnitIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/VideoUnitIntegrationTest.java
@@ -2,6 +2,8 @@ package de.tum.in.www1.artemis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.domain.Lecture;
+import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.domain.lecture.VideoUnit;
 import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
@@ -106,11 +109,13 @@ public class VideoUnitIntegrationTest extends AbstractSpringIntegrationBambooBit
         lecture1.addLectureUnit(videoUnit);
         lectureRepository.save(lecture1);
 
+        List<LectureUnit> orderedUnits = lecture1.getLectureUnits();
+
         // Updating the lecture unit should not change order attribute
         request.putWithResponseBody("/api/lectures/" + lecture1.getId() + "/video-units", videoUnit, VideoUnit.class, HttpStatus.OK);
 
-        VideoUnit updatedVideoUnit = videoUnitRepository.findById(videoUnit.getId()).orElseThrow();
-        assertThat(updatedVideoUnit.getOrder()).isEqualTo(1);
+        List<LectureUnit> updatedOrderedUnits = lectureRepository.findByIdWithLectureUnits(lecture1.getId()).get().getLectureUnits();
+        assertThat(updatedOrderedUnits).containsExactlyElementsOf(orderedUnits);
     }
 
     private void persistVideoUnitWithLecture() {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I implemented the changes with a good performance and prevented too many database calls.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

@nairaarnez found an issue that seems to be a race condition when re-ordering lecture units and editing them in quick succession. Then, when two units have the same `order` value, one of them disappears. This can only be reverted in the database itself.
_This issue is again related to Hibernate's `@OrderColumn` annotation._

In the current approach (introduced in #4968 and tested without issues), the order should theoretically be taken from the existing entity and then re-applied to the updated unit. However, this does not work reliably (race condition?).
I could not make out the root cause of the bug. Even flushing the database after re-ordering the items did not solve it.

On a side note, adding a unique index to the tuple `(lecture_id, lecture_unit_order)` could prevent further issues but sadly does not work with the way Hibernate updates the ordering.

### Description
<!-- Describe your changes in detail -->

The `order` attribute is now transient, so that from our perspective we never update it manually, but it should be entirely taken care of by Hibernate.
This fixes the race condition in my tests, but nevertheless this PR should be tested extensively.

The proposed solution had re-introduced a known issue with the lecture importing, which from my current understanding can only be fixed with the `@Transactional` annotation on the function (which we tried to avoid back then, see [discussion](https://github.com/ls1intum/Artemis/pull/4931#discussion_r852995125)).

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Lecture with Lecture Units

1. Log in to Artemis
2. Navigate to Course Administration
3. Edit the lecture
4. Re-order lecture units and/or edit the units
5. Perform actions in quick-succession and different sequences
6. Make sure the ordering stays consistent and no lecture unit disappears
7. Ensure that you can also still import a lecture (with associated lecture units) without issues

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
