### PR TITLE
`Programming exercises`: Move ace editor theme handling into ace editor component

### DIFF
--- a/src/main/webapp/app/entities/course.model.ts
+++ b/src/main/webapp/app/entities/course.model.ts
@@ -9,7 +9,6 @@ import { Language } from 'app/entities/tutor-group.model';
 import { LearningGoal } from 'app/entities/learningGoal.model';
 import { Organization } from 'app/entities/organization.model';
 import { Post } from 'app/entities/metis/post.model';
-import { PlagiarismCase } from 'app/exercises/shared/plagiarism/types/PlagiarismCase';
 import { ProgrammingLanguage } from 'app/entities/programming-exercise.model';
 
 export class Course implements BaseEntity {

--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/full-git-diff-entry.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/full-git-diff-entry.component.ts
@@ -36,7 +36,6 @@ export class FullGitDiffEntryComponent implements OnInit {
      * @param color The background color of the editor
      */
     private setupEditor(editor: AceEditorComponent, line: number | undefined, code: string, color: string) {
-        editor.setTheme(this.themeService.getCurrentTheme().codeAceTheme);
         editor.getEditor().setOptions({
             animatedScroll: true,
             maxLines: Infinity,

--- a/src/main/webapp/app/exercises/programming/hestia/testwise-coverage-report/testwise-coverage-file.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/testwise-coverage-report/testwise-coverage-file.component.ts
@@ -1,16 +1,14 @@
-import { Component, Input, ViewChild, OnInit, OnChanges, SimpleChanges, OnDestroy } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@angular/core';
 import { AceEditorComponent } from 'app/shared/markdown-editor/ace-editor/ace-editor.component';
 import ace from 'brace';
 import { CoverageFileReport } from 'app/entities/hestia/coverage-file-report.model';
-import { ThemeService } from 'app/core/theme/theme.service';
-import { Subscription } from 'rxjs';
 
 @Component({
     selector: 'jhi-testwise-coverage-file',
     templateUrl: './testwise-coverage-file.component.html',
     styleUrls: ['./testwise-coverage-file.component.scss'],
 })
-export class TestwiseCoverageFileComponent implements OnInit, OnChanges, OnDestroy {
+export class TestwiseCoverageFileComponent implements OnInit, OnChanges {
     @Input()
     fileContent: string;
 
@@ -25,26 +23,15 @@ export class TestwiseCoverageFileComponent implements OnInit, OnChanges, OnDestr
 
     proportionCoveredLines: number;
 
-    themeSubscription: Subscription;
-
-    constructor(private themeService: ThemeService) {}
-
     ngOnInit(): void {
         this.setupEditor();
         this.renderFile();
-        this.themeSubscription = this.themeService.getCurrentThemeObservable().subscribe((theme) => {
-            this.editor.setTheme(theme.codeAceTheme);
-        });
     }
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.fileReport || changes.fileContent) {
             this.renderFile();
         }
-    }
-
-    ngOnDestroy(): void {
-        this.themeSubscription?.unsubscribe();
     }
 
     private aggregateCoveredLinesBlocks(fileReport: CoverageFileReport): Map<number, number> {

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.ts
@@ -30,7 +30,6 @@ import { Feedback } from 'app/entities/feedback.model';
 import { Course } from 'app/entities/course.model';
 import { faFileAlt } from '@fortawesome/free-regular-svg-icons';
 import { faCircleNotch, faGear, faPlusSquare } from '@fortawesome/free-solid-svg-icons';
-import { ThemeService } from 'app/core/theme/theme.service';
 
 export type Annotation = { fileName: string; row: number; column: number; text: string; type: string; timestamp: number; hash?: string | null };
 
@@ -103,29 +102,19 @@ export class CodeEditorAceComponent implements AfterViewInit, OnChanges, OnDestr
     gutterHighlights: Map<number, string[]> = new Map<number, string[]>();
     tabSize = 4;
 
-    themeSubscription: Subscription;
-
     // Icons
     farFileAlt = faFileAlt;
     faPlusSquare = faPlusSquare;
     faCircleNotch = faCircleNotch;
     faGear = faGear;
 
-    constructor(
-        private repositoryFileService: CodeEditorRepositoryFileService,
-        private fileService: CodeEditorFileService,
-        protected localStorageService: LocalStorageService,
-        private themeService: ThemeService,
-    ) {}
+    constructor(private repositoryFileService: CodeEditorRepositoryFileService, private fileService: CodeEditorFileService, protected localStorageService: LocalStorageService) {}
 
     /**
      * @function ngAfterViewInit
      * @desc Sets the theme and other editor options
      */
     ngAfterViewInit(): void {
-        this.themeSubscription = this.themeService.getCurrentThemeObservable().subscribe((theme) => {
-            this.editor.setTheme(theme.codeAceTheme);
-        });
         this.editor.getEditor().setOptions({
             animatedScroll: true,
             enableBasicAutocompletion: true,
@@ -295,7 +284,6 @@ export class CodeEditorAceComponent implements AfterViewInit, OnChanges, OnDestr
         if (this.annotationChange) {
             this.annotationChange.unsubscribe();
         }
-        this.themeSubscription?.unsubscribe();
     }
 
     /**

--- a/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.ts
@@ -6,7 +6,6 @@ import {
     EventEmitter,
     Input,
     OnChanges,
-    OnDestroy,
     OnInit,
     Output,
     SimpleChanges,
@@ -29,8 +28,6 @@ import { QuizQuestion } from 'app/entities/quiz/quiz-question.model';
 import { markdownForHtml } from 'app/shared/util/markdown.conversion.util';
 import { generateExerciseHintExplanation, parseExerciseHintExplanation } from 'app/shared/util/markdown.util';
 import { faAngleDown, faAngleRight, faBan, faBars, faChevronDown, faChevronUp, faTrash, faUndo, faUnlink } from '@fortawesome/free-solid-svg-icons';
-import { Theme, ThemeService } from 'app/core/theme/theme.service';
-import { Subscription } from 'rxjs';
 
 @Component({
     selector: 'jhi-short-answer-question-edit',
@@ -38,7 +35,7 @@ import { Subscription } from 'rxjs';
     styleUrls: ['./short-answer-question-edit.component.scss', '../quiz-exercise.scss', '../../shared/quiz.scss'],
     encapsulation: ViewEncapsulation.None,
 })
-export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, AfterViewInit, OnDestroy, QuizQuestionEdit {
+export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, AfterViewInit, QuizQuestionEdit {
     @ViewChild('questionEditor', { static: false })
     private questionEditor: AceEditorComponent;
     @ViewChild('clickLayer', { static: false })
@@ -88,8 +85,6 @@ export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, Afte
 
     backupQuestion: ShortAnswerQuestion;
 
-    themeSubscription: Subscription;
-
     // Icons
     faBan = faBan;
     faTrash = faTrash;
@@ -106,7 +101,6 @@ export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, Afte
         public shortAnswerQuestionUtil: ShortAnswerQuestionUtil,
         private modalService: NgbModal,
         private changeDetector: ChangeDetectorRef,
-        private themeService: ThemeService,
     ) {}
 
     ngOnInit(): void {
@@ -144,10 +138,6 @@ export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, Afte
         if (!this.reEvaluationInProgress) {
             requestAnimationFrame(this.setupQuestionEditor.bind(this));
         }
-    }
-
-    ngOnDestroy(): void {
-        this.themeSubscription?.unsubscribe();
     }
 
     /**
@@ -190,12 +180,6 @@ export class ShortAnswerQuestionEditComponent implements OnInit, OnChanges, Afte
         this.numberOfSpot = this.shortAnswerQuestion.spots!.length + 1;
 
         // Default editor settings for inline markup editor
-        this.themeSubscription = this.themeService.getCurrentThemeObservable().subscribe((theme: Theme) => {
-            if (!this.questionEditor) {
-                return;
-            }
-            this.questionEditor.setTheme(theme.markdownAceTheme);
-        });
         this.questionEditor.getEditor().renderer.setShowGutter(false);
         this.questionEditor.getEditor().renderer.setPadding(10);
         this.questionEditor.getEditor().renderer.setScrollMargin(8, 8);

--- a/src/main/webapp/app/shared/markdown-editor/ace-editor/ace-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/ace-editor/ace-editor.component.ts
@@ -5,6 +5,8 @@ import 'brace/theme/monokai';
 import 'brace/theme/chrome';
 import 'brace/theme/dreamweaver';
 import 'brace/theme/dracula';
+import { ThemeService } from 'app/core/theme/theme.service';
+import { Subscription } from 'rxjs';
 
 declare var ace: any;
 
@@ -44,14 +46,16 @@ export class AceEditorComponent implements ControlValueAccessor, OnInit, OnDestr
 
     private _options: any = {};
     private _readOnly = false;
-    private _theme = 'monokai';
-    private _mode = 'html';
+    private _theme = 'dreamweaver';
+    private _mode = 'java';
     private _autoUpdateContent = true;
     private _editor: any; // TODO: use Editor (defined in brace) or Editor (defined in ace-builds) and make sure to use typings consistently
     private _durationBeforeCallback = 0;
     private _text = '';
 
-    constructor(elementRef: ElementRef, private zone: NgZone) {
+    private themeSubscription: Subscription;
+
+    constructor(elementRef: ElementRef, private zone: NgZone, private themeService: ThemeService) {
         const el = elementRef.nativeElement;
         this.zone.runOutsideAngular(() => {
             this._editor = ace['edit'](el);
@@ -66,11 +70,11 @@ export class AceEditorComponent implements ControlValueAccessor, OnInit, OnDestr
 
     ngOnDestroy() {
         this._editor.destroy();
+        this.themeSubscription?.unsubscribe();
     }
 
     init() {
         this.setOptions(this._options || {});
-        this.setTheme(this._theme);
         this.setMode(this._mode);
         this.setReadOnly(this._readOnly);
     }
@@ -78,6 +82,8 @@ export class AceEditorComponent implements ControlValueAccessor, OnInit, OnDestr
     initEvents() {
         this._editor.on('change', () => this.updateText());
         this._editor.on('paste', () => this.updateText());
+
+        this.themeSubscription = this.themeService.getCurrentThemeObservable().subscribe(() => this.setThemeFromMode());
     }
 
     updateText() {
@@ -130,16 +136,6 @@ export class AceEditorComponent implements ControlValueAccessor, OnInit, OnDestr
     }
 
     @Input()
-    set theme(theme: string) {
-        this.setTheme(theme);
-    }
-
-    setTheme(theme: string) {
-        this._theme = theme;
-        this._editor.setTheme(`ace/theme/${theme}`);
-    }
-
-    @Input()
     set mode(mode: string) {
         this.setMode(mode);
     }
@@ -151,6 +147,14 @@ export class AceEditorComponent implements ControlValueAccessor, OnInit, OnDestr
         } else {
             this._editor.getSession().setMode(`ace/mode/${this._mode}`);
         }
+
+        this.setThemeFromMode();
+    }
+
+    private setThemeFromMode() {
+        const currentApplicationTheme = this.themeService.getCurrentTheme();
+        this._theme = this._mode.toLowerCase() === 'markdown' ? currentApplicationTheme.markdownAceTheme : currentApplicationTheme.codeAceTheme;
+        this._editor.setTheme(`ace/theme/${this._theme}`);
     }
 
     get value() {

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ContentChild, ElementRef, EventEmitter, Input, OnDestroy, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, Component, ContentChild, ElementRef, EventEmitter, Input, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
 // Note: this import has to be before the 'brace' imports
 import { AceEditorComponent } from 'app/shared/markdown-editor/ace-editor/ace-editor.component';
@@ -62,7 +62,7 @@ const getAceMode = (mode: EditorMode) => {
     styleUrls: ['./markdown-editor.component.scss'],
     encapsulation: ViewEncapsulation.None,
 })
-export class MarkdownEditorComponent implements AfterViewInit, OnDestroy {
+export class MarkdownEditorComponent implements AfterViewInit {
     public DomainMultiOptionCommand = DomainMultiOptionCommand;
     public DomainTagCommand = DomainTagCommand;
     // This ref is used for entering the fullscreen mode.

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -34,7 +34,6 @@ import { HeadingThreeCommand } from 'app/shared/markdown-editor/commands/heading
 import { CodeBlockCommand } from 'app/shared/markdown-editor/commands/codeblock.command';
 import { faGripLines, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import { Subscription } from 'rxjs';
-import { Theme, ThemeService } from 'app/core/theme/theme.service';
 
 export enum MarkdownEditorHeight {
     SMALL = 200,
@@ -163,12 +162,7 @@ export class MarkdownEditorComponent implements AfterViewInit, OnDestroy {
     faQuestionCircle = faQuestionCircle;
     faGripLines = faGripLines;
 
-    constructor(
-        private artemisMarkdown: ArtemisMarkdownService,
-        private fileUploaderService: FileUploaderService,
-        private alertService: AlertService,
-        private themeService: ThemeService,
-    ) {}
+    constructor(private artemisMarkdown: ArtemisMarkdownService, private fileUploaderService: FileUploaderService, private alertService: AlertService) {}
 
     /** {boolean} true when the plane html view is needed, false when the preview content is needed from the parent */
     get showDefaultPreview(): boolean {
@@ -226,13 +220,6 @@ export class MarkdownEditorComponent implements AfterViewInit, OnDestroy {
             });
         }
         this.setupMarkdownEditor();
-        this.themeSubscription = this.themeService.getCurrentThemeObservable().subscribe((theme: Theme) => {
-            if (!this.aceEditorContainer) {
-                return;
-            }
-            this.aceEditorContainer.setTheme(theme.markdownAceTheme);
-        });
-
         const selectedAceMode = getAceMode(this.editorMode);
         if (selectedAceMode) {
             this.aceEditorContainer.getEditor().getSession().setMode(selectedAceMode);

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -33,7 +33,6 @@ import { UnorderedListCommand } from 'app/shared/markdown-editor/commands/unorde
 import { HeadingThreeCommand } from 'app/shared/markdown-editor/commands/headingThree.command';
 import { CodeBlockCommand } from 'app/shared/markdown-editor/commands/codeblock.command';
 import { faGripLines, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
-import { Subscription } from 'rxjs';
 
 export enum MarkdownEditorHeight {
     SMALL = 200,
@@ -156,8 +155,6 @@ export class MarkdownEditorComponent implements AfterViewInit, OnDestroy {
     enableFileUpload = true;
     acceptedFileExtensions = 'png,jpg,jpeg,svg,pdf';
 
-    themeSubscription: Subscription;
-
     // Icons
     faQuestionCircle = faQuestionCircle;
     faGripLines = faGripLines;
@@ -228,10 +225,6 @@ export class MarkdownEditorComponent implements AfterViewInit, OnDestroy {
         if (this.enableResize) {
             this.setupResizable();
         }
-    }
-
-    ngOnDestroy() {
-        this.themeSubscription?.unsubscribe();
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Currently, all components that used the ace editor component had to subscribe to the theme service and apply the correct editor theme based on the application theme. This is cumbersome to write andone has to remember it every time. Additionally, it could cause the theme to be applied too late, causing glitches when loading the editor.

Fixes #5100. Hopefully at least; I was not able to reproduce the shown behavior. It might be related to the speed of the machine the client runs on.

### Description
<!-- Describe your changes in detail -->

Moved the editor theme handling directly into the ace editor component. External components can no longer set the theme from outside; instead, it will be directly inferred from the editor mode and the current application theme.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

Please check both a code editor (for example when working on a programming exercise) and a markdown editor (for example when creating a discussion post or editing an exercise problem statement as an instructor).

1. Check that there are no unexpected theme glitches when loading the editor as shown in #5100.
2. Check that a correct, good looking theme is chosen for light and dark mode
3. Check that the editor theme changes if you switch the application theme from light to dark or vice versa

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
