### PR TITLE
`General`: Fix a dark mode issue with complaint results and focus-visible dropdowns

### DIFF
--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
@@ -37,14 +37,14 @@
                     }}
                 </span>
                 <small *ngIf="handled">
-                    <span *ngIf="complaint?.accepted" class="text-light bg-success small">
+                    <span *ngIf="complaint?.accepted" class="badge bg-success">
                         &nbsp;{{
                             complaint.complaintType === ComplaintType.MORE_FEEDBACK
                                 ? ('artemisApp.moreFeedback.accepted' | artemisTranslate)
                                 : ('artemisApp.complaint.accepted' | artemisTranslate)
                         }}&nbsp;
                     </span>
-                    <span *ngIf="!complaint?.accepted" class="text-light bg-danger small"> &nbsp;{{ 'artemisApp.complaint.rejected' | artemisTranslate }}&nbsp; </span>
+                    <span *ngIf="!complaint?.accepted" class="badge bg-danger"> &nbsp;{{ 'artemisApp.complaint.rejected' | artemisTranslate }}&nbsp; </span>
                 </small>
             </h4>
             <textarea id="complaintTextArea" class="col-12 px-1" rows="4" [(ngModel)]="complaintText" [readonly]="true" [disabled]="true"></textarea>

--- a/src/main/webapp/app/complaints/request/complaint-request.component.html
+++ b/src/main/webapp/app/complaints/request/complaint-request.component.html
@@ -6,14 +6,14 @@
                 : ('artemisApp.moreFeedback.alreadySubmittedSubmissionAuthor' | artemisTranslate)
         }}
         <span [ngbTooltip]="complaint.submittedTime | artemisDate">{{ complaint.submittedTime | artemisTimeAgo }}</span>
-        <span *ngIf="complaint.accepted === true" class="text-light bg-success">
+        <span *ngIf="complaint.accepted === true" class="badge bg-success">
             {{
                 complaint.complaintType === ComplaintType.COMPLAINT
                     ? ('artemisApp.complaint.acceptedLong' | artemisTranslate)
                     : ('artemisApp.moreFeedback.acceptedLong' | artemisTranslate)
             }}
         </span>
-        <span *ngIf="complaint.accepted === false" class="text-light bg-danger">
+        <span *ngIf="complaint.accepted === false" class="badge bg-danger">
             {{ 'artemisApp.complaint.rejectedLong' | artemisTranslate }}
         </span>
     </p>

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -163,7 +163,7 @@ a.btn {
 .form-control:focus-visible,
 textarea {
     background-color: $form-control-focus-background;
-    color: $form-control-color;
+    color: $form-control-color !important;
 }
 
 .form-inline .form-control {

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -160,6 +160,7 @@ a.btn {
 .form-check-input,
 .form-control:not(.ace_editor):hover,
 .form-control:focus,
+.form-control:focus-visible,
 textarea {
     background-color: $form-control-focus-background;
     color: $form-control-color;

--- a/src/main/webapp/content/scss/themes/theme-dark.scss
+++ b/src/main/webapp/content/scss/themes/theme-dark.scss
@@ -114,8 +114,8 @@ html {
 .form-select[readonly],
 .form-check-input:disabled:not(:checked),
 .form-check-input[readonly]:not(:checked) {
-    background: $gray-700 !important;
-    color: $gray-400;
+    background-color: $gray-800 !important;
+    color: $gray-500 !important;
 }
 
 .form-control,


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #5120.

Fixes an issue @Strohgelaender sent me in DMs where a focus-visible dropdown gets a transparent text color for some reason, which doesn't work in dark mode:

https://user-images.githubusercontent.com/23171488/169027378-edb16010-9bad-409b-8bff-802adba07dfe.mp4


### Description
<!-- Describe your changes in detail -->

- Replaces the simple text with colored background used as complaint result indicator with better-looking badges that are themed correctly:
![Screenshot 2022-05-18 at 13 14 02](https://user-images.githubusercontent.com/23171488/169027516-f61c1421-2d6f-4a55-92aa-c2f8c013c2eb.png)
![Screenshot 2022-05-18 at 13 15 30](https://user-images.githubusercontent.com/23171488/169027520-f26c9237-9fc5-4d9f-928a-5f7ebcb7229d.png)

- Forced the default form color on form select elements in focus-visible state to the default color
- Adjusted the inactive color of form selects a bit


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students
- 1 Exercise with complaints enabled
- 1 Programming Exercise with static code analysis enabled

1. Submit a submission for the exercise as the student
2. Assess the submission as the instructor
3. Submit a complaint as the student
4. Accept the complaint as the instructor. Check that the "Accepted" badge appears and looks good in both themes
5. Check that the "Complaint was accepted" badge appears for the student as well when looking at the submission and that it looks good in both themes
6. As the instructor, go to the grading configuration page of the programming exercise and visit the tab "Code analysis"
7. Try to select the dropdown using the "Tab" key on your keyboard like in the video above. The text should be visible in both themes

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
