### PR TITLE
`Development`: Reduce number of server log messages for modeling submission updates

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -113,12 +113,8 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
     @PutMapping("/exercises/{exerciseId}/modeling-submissions")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ModelingSubmission> updateModelingSubmission(@PathVariable long exerciseId, Principal principal, @RequestBody ModelingSubmission modelingSubmission) {
-        long start = System.currentTimeMillis();
         log.debug("REST request to update ModelingSubmission : {}", modelingSubmission.getModel());
-        ResponseEntity<ModelingSubmission> response = handleModelingSubmission(exerciseId, principal, modelingSubmission);
-        long end = System.currentTimeMillis();
-        log.info("updateModelingSubmission took {}ms for exercise {} and user {}", end - start, exerciseId, principal.getName());
-        return response;
+        return handleModelingSubmission(exerciseId, principal, modelingSubmission);
     }
 
     @NotNull

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -113,8 +113,12 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
     @PutMapping("/exercises/{exerciseId}/modeling-submissions")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ModelingSubmission> updateModelingSubmission(@PathVariable long exerciseId, Principal principal, @RequestBody ModelingSubmission modelingSubmission) {
+        long start = System.currentTimeMillis();
         log.debug("REST request to update ModelingSubmission : {}", modelingSubmission.getModel());
-        return handleModelingSubmission(exerciseId, principal, modelingSubmission);
+        ResponseEntity<ModelingSubmission> response = handleModelingSubmission(exerciseId, principal, modelingSubmission);
+        long end = System.currentTimeMillis();
+        log.info("updateModelingSubmission took {}ms for exercise {} and user {}", end - start, exerciseId, principal.getName());
+        return response;
     }
 
     @NotNull

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingSubmissionResource.java
@@ -117,7 +117,7 @@ public class ModelingSubmissionResource extends AbstractSubmissionResource {
         log.debug("REST request to update ModelingSubmission : {}", modelingSubmission.getModel());
         ResponseEntity<ModelingSubmission> response = handleModelingSubmission(exerciseId, principal, modelingSubmission);
         long end = System.currentTimeMillis();
-        log.info("updateModelingSubmission took {}ms for exercise {} and user {}", end - start, exerciseId, principal.getName());
+        log.debug("updateModelingSubmission took {}ms for exercise {} and user {}", end - start, exerciseId, principal.getName());
         return response;
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
~- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).~
~- [ ] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).~
- [x] I implemented the changes with a good performance and prevented too many database calls.
~- [ ] I documented the Java code using JavaDoc style.~

### Motivation and Context
The endpoint to update modelling submissions is called on a timer (30sec) in the client. Every call produced a message in the server log with a time measurement. This leads to a lot of messages in the server log when many students work on modelling exercises.

### Description
The log call has been removed to avoid spamming the log with unnecessary messages. The time measurement can be obtained from the `/admin/metrics` page in the client as well.

### Steps for Testing
n/a

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
unchanged
