### PR TITLE
`Development`: Create /opt/artemis/repos folder within Dockerfile to fix file permission issues

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -44,11 +44,12 @@ RUN chmod +x /bootstrap.sh \
   && useradd -ms /bin/bash artemis
 
 # Create directories for volumes
-RUN mkdir -p /opt/artemis/config /opt/artemis/data /opt/artemis/public/content
+RUN mkdir -p /opt/artemis/config /opt/artemis/data /opt/artemis/public/content /opt/artemis/repos
 
 VOLUME ["/opt/artemis/config"]
 VOLUME ["/opt/artemis/data"]
 VOLUME ["/opt/artemis/public/content"]
+VOLUME ["/opt/artemis/repos"]
 
 EXPOSE 8080
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When I used this [docker compose file](https://github.com/ls1intum/Artemis/blob/develop/src/main/docker/docker-compose.yml) to run Artemis within docker, and tried to create a programming exercise within a course, I got this error:
```
Exception in de.tum.in.www1.artemis.web.rest.ProgrammingExerciseResource.createProgrammingExercise() with cause = 'java.io.IOException: Creating directories for /opt/artemis/repos/TEMPTEST2/temptest2-exercise/.git failed' and exception = 'Creating directories for /opt/artemis/repos/TEMPTEST2/temptest2-exercise/.git failed'

org.eclipse.jgit.api.errors.JGitInternalException: Creating directories for /opt/artemis/repos/TEMPTEST2/temptest2-exercise/.git failed
	at org.eclipse.jgit.api.InitCommand.call(InitCommand.java:106)
	at org.eclipse.jgit.api.CloneCommand.init(CloneCommand.java:275)
	at org.eclipse.jgit.api.CloneCommand.call(CloneCommand.java:173)
	at de.tum.in.www1.artemis.service.connectors.GitService.getOrCheckoutRepository(GitService.java:438)
```

After I created the folder inside the container manually and gave it the correct ownership, the issue disappeared. 

### Description
<!-- Describe your changes in detail -->
To solve this issue, I added a new line to the Dockerfile, that creates this folder, when the docker image is build. This should fix this issue, since the folder exists and artemis can access it with the correct permissions. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
1. Use the [docker-compose.yml](https://github.com/ls1intum/Artemis/blob/develop/src/main/docker/docker-compose.yml) file to setup artemis on docker
2. Start the container
3. Create a new course
4. Create a new programming exercise within this course

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
