### PR TITLE
`Programming exercises`: Improve performance by avoiding unnecessary database calls for diff reports and test coverage analysis

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingExercise.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import de.tum.in.www1.artemis.domain.enumeration.*;
-import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffReport;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseTask;
 import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.participation.SolutionProgrammingExerciseParticipation;
@@ -120,12 +119,6 @@ public class ProgrammingExercise extends Exercise {
     @Nullable
     @Column(name = "project_type", table = "programming_exercise_details")
     private ProjectType projectType;
-
-    // Should be lazily loaded, but Hibernate does not support lazy loading for OneToOne relations
-    // Therefore we need JsonIgnore here
-    @OneToOne(mappedBy = "programmingExercise", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
-    @JsonIgnore
-    private ProgrammingExerciseGitDiffReport gitDiffReport;
 
     @Column(name = "testwise_coverage_enabled", table = "programming_exercise_details")
     private boolean testwiseCoverageEnabled;
@@ -763,13 +756,5 @@ public class ProgrammingExercise extends Exercise {
         if (getMaxStaticCodeAnalysisPenalty() != null && getMaxStaticCodeAnalysisPenalty() < 0) {
             throw new BadRequestAlertException("The static code analysis penalty must not be negative", "Exercise", "staticCodeAnalysisPenaltyNotNegative");
         }
-    }
-
-    public ProgrammingExerciseGitDiffReport getGitDiffReport() {
-        return gitDiffReport;
-    }
-
-    public void setGitDiffReport(ProgrammingExerciseGitDiffReport programmingExerciseGitDiffReport) {
-        this.gitDiffReport = programmingExerciseGitDiffReport;
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/ProgrammingSubmission.java
@@ -10,12 +10,10 @@ import javax.validation.constraints.NotNull;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tum.in.www1.artemis.domain.enumeration.SubmissionType;
-import de.tum.in.www1.artemis.domain.hestia.CoverageReport;
 import de.tum.in.www1.artemis.domain.participation.Participation;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
 
@@ -42,12 +40,6 @@ public class ProgrammingSubmission extends Submission {
     @JsonIgnoreProperties(value = "programmingSubmission", allowSetters = true)
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     private List<BuildLogEntry> buildLogEntries = new ArrayList<>();
-
-    // This attribute is only valid for ProgrammingSubmissions related to a SolutionProgrammingExerciseParticipation.
-    // If the submission is deleted, the coverage report with all child entities are deleted.
-    @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    @JsonIgnore
-    private CoverageReport coverageReport;
 
     /**
      * There can be two reasons for the case that there is no programmingSubmission:
@@ -109,14 +101,6 @@ public class ProgrammingSubmission extends Submission {
 
     public void setBuildLogEntries(List<BuildLogEntry> buildLogEntries) {
         this.buildLogEntries = buildLogEntries;
-    }
-
-    public CoverageReport getCoverageReport() {
-        return coverageReport;
-    }
-
-    public void setCoverageReport(CoverageReport testwiseCoverageReport) {
-        this.coverageReport = testwiseCoverageReport;
     }
 
     public boolean belongsToTestRepository() {

--- a/src/main/java/de/tum/in/www1/artemis/repository/hestia/CoverageReportRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/hestia/CoverageReportRepository.java
@@ -24,6 +24,8 @@ public interface CoverageReportRepository extends JpaRepository<CoverageReport, 
 
     Boolean existsBySubmissionId(@Param("submissionId") Long submissionId);
 
+    void deleteBySubmissionId(Long submissionId);
+
     @Query("""
             SELECT DISTINCT r FROM CoverageReport r
             LEFT JOIN FETCH r.submission s

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -18,6 +18,7 @@ import de.tum.in.www1.artemis.domain.quiz.QuizSubmission;
 import de.tum.in.www1.artemis.exception.ContinuousIntegrationException;
 import de.tum.in.www1.artemis.exception.VersionControlException;
 import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.repository.hestia.CoverageReportRepository;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
@@ -66,13 +67,15 @@ public class ParticipationService {
 
     private final UrlService urlService;
 
+    private final CoverageReportRepository coverageReportRepository;
+
     public ParticipationService(ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository,
             StudentParticipationRepository studentParticipationRepository, ExerciseRepository exerciseRepository, ProgrammingExerciseRepository programmingExerciseRepository,
             ResultRepository resultRepository, SubmissionRepository submissionRepository, ComplaintResponseRepository complaintResponseRepository,
             ComplaintRepository complaintRepository, TeamRepository teamRepository, GitService gitService, QuizScheduleService quizScheduleService,
             ParticipationRepository participationRepository, Optional<ContinuousIntegrationService> continuousIntegrationService,
-            Optional<VersionControlService> versionControlService, RatingRepository ratingRepository, ParticipantScoreRepository participantScoreRepository,
-            UrlService urlService) {
+            Optional<VersionControlService> versionControlService, RatingRepository ratingRepository, ParticipantScoreRepository participantScoreRepository, UrlService urlService,
+            CoverageReportRepository coverageReportRepository) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.participationRepository = participationRepository;
         this.programmingExerciseStudentParticipationRepository = programmingExerciseStudentParticipationRepository;
@@ -90,6 +93,7 @@ public class ParticipationService {
         this.ratingRepository = ratingRepository;
         this.participantScoreRepository = participantScoreRepository;
         this.urlService = urlService;
+        this.coverageReportRepository = coverageReportRepository;
     }
 
     /**
@@ -668,6 +672,7 @@ public class ParticipationService {
         // The result of the submissions will be deleted via cascade
         submissions.forEach(submission -> {
             resultsToBeDeleted.addAll(submission.getResults());
+            coverageReportRepository.deleteBySubmissionId(submission.getId());
             submissionRepository.deleteById(submission.getId());
         });
         resultsToBeDeleted.forEach(result -> participantScoreRepository.deleteAllByResultIdTransactional(result.getId()));

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseGitDiffReportService.java
@@ -196,7 +196,6 @@ public class ProgrammingExerciseGitDiffReportService {
                 programmingExerciseGitDiffReportRepository.delete(existingReport);
             }
             newReport = programmingExerciseGitDiffReportRepository.save(newReport);
-            programmingExercise.setGitDiffReport(newReport);
             programmingExerciseRepository.save(programmingExercise);
             return newReport;
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/BehavioralTestCaseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/BehavioralTestCaseService.java
@@ -14,6 +14,7 @@ import de.tum.in.www1.artemis.repository.SolutionProgrammingExerciseParticipatio
 import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseSolutionEntryRepository;
 import de.tum.in.www1.artemis.service.RepositoryService;
 import de.tum.in.www1.artemis.service.connectors.GitService;
+import de.tum.in.www1.artemis.service.hestia.ProgrammingExerciseGitDiffReportService;
 import de.tum.in.www1.artemis.service.hestia.TestwiseCoverageService;
 import de.tum.in.www1.artemis.service.hestia.behavioral.knowledgesource.*;
 
@@ -35,16 +36,20 @@ public class BehavioralTestCaseService {
 
     private final ProgrammingExerciseSolutionEntryRepository solutionEntryRepository;
 
+    private final ProgrammingExerciseGitDiffReportService programmingExerciseGitDiffReportService;
+
     private final SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository;
 
     public BehavioralTestCaseService(GitService gitService, RepositoryService repositoryService, TestwiseCoverageService testwiseCoverageService,
             ProgrammingExerciseTestCaseRepository testCaseRepository, ProgrammingExerciseSolutionEntryRepository solutionEntryRepository,
+            ProgrammingExerciseGitDiffReportService programmingExerciseGitDiffReportService,
             SolutionProgrammingExerciseParticipationRepository solutionProgrammingExerciseParticipationRepository) {
         this.gitService = gitService;
         this.repositoryService = repositoryService;
         this.testCaseRepository = testCaseRepository;
         this.testwiseCoverageService = testwiseCoverageService;
         this.solutionEntryRepository = solutionEntryRepository;
+        this.programmingExerciseGitDiffReportService = programmingExerciseGitDiffReportService;
         this.solutionProgrammingExerciseParticipationRepository = solutionProgrammingExerciseParticipationRepository;
     }
 
@@ -66,7 +71,7 @@ public class BehavioralTestCaseService {
         if (testCases.isEmpty()) {
             throw new BehavioralSolutionEntryGenerationException("Test cases have not been received yet");
         }
-        var gitDiffReport = programmingExercise.getGitDiffReport();
+        var gitDiffReport = programmingExerciseGitDiffReportService.getReportOfExercise(programmingExercise);
         if (gitDiffReport == null) {
             throw new BehavioralSolutionEntryGenerationException("Git-Diff Report has not been generated");
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -910,7 +910,6 @@ public class ProgrammingExerciseService {
         }
 
         programmingExerciseGitDiffReportRepository.deleteByProgrammingExerciseId(programmingExerciseId);
-        programmingExercise.setGitDiffReport(null);
 
         SolutionProgrammingExerciseParticipation solutionProgrammingExerciseParticipation = programmingExercise.getSolutionParticipation();
         TemplateProgrammingExerciseParticipation templateProgrammingExerciseParticipation = programmingExercise.getTemplateParticipation();

--- a/src/test/java/de/tum/in/www1/artemis/hestia/behavioral/BehavioralTestCaseServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/behavioral/BehavioralTestCaseServiceTest.java
@@ -89,7 +89,6 @@ public class BehavioralTestCaseServiceTest extends AbstractSpringIntegrationBamb
         gitDiffReport.setSolutionRepositoryCommitHash("123a");
         gitDiffReport.setTemplateRepositoryCommitHash("123b");
         gitDiffReport = programmingExerciseGitDiffReportRepository.save(gitDiffReport);
-        exercise.setGitDiffReport(gitDiffReport);
         return gitDiffReport;
     }
 
@@ -101,7 +100,6 @@ public class BehavioralTestCaseServiceTest extends AbstractSpringIntegrationBamb
         gitDiffEntry.setGitDiffReport(gitDiffReport);
         gitDiffReport.getEntries().add(gitDiffEntry);
         var savedGitDiffReport = programmingExerciseGitDiffReportRepository.save(gitDiffReport);
-        exercise.setGitDiffReport(savedGitDiffReport);
         return savedGitDiffReport;
     }
 
@@ -113,7 +111,6 @@ public class BehavioralTestCaseServiceTest extends AbstractSpringIntegrationBamb
         coverageReport.setFileReports(new HashSet<>());
         coverageReport.setSubmission(solutionSubmission);
         coverageReport = coverageReportRepository.save(coverageReport);
-        solutionSubmission.setCoverageReport(coverageReport);
         return coverageReport;
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Stephan approached @ole-ve and me about an issue when loading programming exercises from the database.
The GitDiffReport and CoverageReports were loaded for every programming exercise in the `courses/for-dashboard` endpoint. This has a measurable negative effect on the database performance and should therefore be removed, as the reports are both marked as JsonIgnore.

### Description
<!-- Describe your changes in detail -->
This issue occurs because Hibernate (at least with our configuration) is unable to lazily load OneToOne relationships. It will always eagerly load them. 
Therefore the only feasible solution at the moment is to remove the references to the reports in `ProgrammingExercise` and `ProgrammingSubmission`.
An alternative solution would be to change the global Hibernate configuration, but this could have unforeseen consequences and would therefore take a lot longer to test.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise with Testwise Coverage enabled

1. Log in to Artemis
2. Navigate to the course management detail page
3. Check that the git diff report and coverage report are still available
4. Delete the exercise -> Should work without issues

When testing locally additionally check:
- SQL queries for loading programming exercises no longer load the reports from the database (you can change the property `show-sql` to true in `application-dev.yml`.
- The reports are deleted properly (check in the database) 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
Unchanged
