### PR TITLE
`Quiz exercises`: Fix rounding of live quiz results

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/Course.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/Course.java
@@ -158,6 +158,7 @@ public class Course extends DomainObject {
     private Integer maxPoints;
 
     @Column(name = "accuracy_of_scores")
+    @JsonView(QuizView.Before.class)
     private Integer accuracyOfScores;
 
     @OneToMany(mappedBy = "course", fetch = FetchType.LAZY)


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context

Fixes #5005 . The issue was not related to the browser, but instead to viewing the result before refreshing the page.

### Description
Course.accuracyOfScores is now annotated with QuizView.Before so that the finalScore can be calculated with the correct rounding.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student

(Following similar steps as described in #5005 )

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a course
4. Create a short answer quiz as an instructor
5. The quiz should have 2 answer options
6. Make the duration of the quiz 1 minute for ease of testing
7. Start the quiz
8. Participate as a student and answer one question right, the other wrong
9. Submit the quiz, and wait for the quiz to end and the result to be shown **without refreshing**
10. Check that the result is "1.5/2 (75%)".

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
