### PR TITLE
`Quiz Exercises`: Remove release date for quiz exam exercises

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -207,7 +207,9 @@ export class QuizExerciseDetailComponent extends QuizExerciseValidationDirective
             this.entity.title = '';
             this.entity.duration = 600;
             this.entity.isOpenForPractice = false;
-            this.entity.releaseDate = dayjs();
+            if (!this.isExamMode) {
+                this.entity.releaseDate = dayjs();
+            }
             this.entity.randomizeQuestionOrder = true;
             this.entity.quizQuestions = [];
             this.entity.quizMode = QuizMode.SYNCHRONIZED;
@@ -870,7 +872,8 @@ export class QuizExerciseDetailComponent extends QuizExerciseValidationDirective
      */
     prepareEntity(quizExercise: QuizExercise): void {
         if (this.isExamMode) {
-            quizExercise.releaseDate = dayjs(quizExercise.releaseDate);
+            // quizExercise.releaseDate = dayjs(quizExercise.releaseDate);
+            quizExercise.releaseDate = undefined;
         } else {
             quizExercise.releaseDate = quizExercise.releaseDate ? dayjs(quizExercise.releaseDate) : dayjs();
             quizExercise.duration = Number(quizExercise.duration);

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.ts
@@ -207,6 +207,7 @@ export class QuizExerciseDetailComponent extends QuizExerciseValidationDirective
             this.entity.title = '';
             this.entity.duration = 600;
             this.entity.isOpenForPractice = false;
+            // For the examMode, no release Date should be set
             if (!this.isExamMode) {
                 this.entity.releaseDate = dayjs();
             }
@@ -872,7 +873,6 @@ export class QuizExerciseDetailComponent extends QuizExerciseValidationDirective
      */
     prepareEntity(quizExercise: QuizExercise): void {
         if (this.isExamMode) {
-            // quizExercise.releaseDate = dayjs(quizExercise.releaseDate);
             quizExercise.releaseDate = undefined;
         } else {
             quizExercise.releaseDate = quizExercise.releaseDate ? dayjs(quizExercise.releaseDate) : dayjs();

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
@@ -1307,12 +1307,11 @@ describe('QuizExercise Management Detail Component', () => {
                 expect(comp.quizExercise.duration).toBe(10);
             });
 
-            it('should set release date to dayjs release date if exam mode', () => {
+            it('should set release date to undefined if exam mode', () => {
                 comp.isExamMode = true;
-                const now = dayjs();
-                comp.quizExercise.releaseDate = now;
+                comp.quizExercise.releaseDate = undefined;
                 comp.prepareEntity(comp.quizExercise);
-                expect(comp.quizExercise.releaseDate).toEqual(dayjs(now));
+                expect(comp.quizExercise.releaseDate).toEqual(undefined);
             });
         });
 


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).

### Motivation and Context
When adding a new quiz exercise to an exam, a (server) error is thrown. This is because the client sets the release Date of the quiz exercise, however, no dates should be set for an exam exercise and that's why the server rejects the request.
```
errorKey: "invalidDatesForExamExercise"
message: "error.invalidDatesForExamExercise"
status: 400
title: "An exam exercise may not have any dates set!" 
```

### Description
In the `quiz-exercise-detail.component.ts` the assignment of a release date for exam quiz exercises was removed, the release date remains undefined. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Editor / Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to the Exam Menu
4. Create a new Exam
5. Try to add a Quiz to an Exercise Group and verify, that no error is shown

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
![image](https://user-images.githubusercontent.com/94070506/171288521-7b9ae726-1935-4c72-8b3e-49ceb779bb76.png)