### PR TITLE
`Lectures`: Fix unreadable text when creating attachment units in darkmode

### DIFF
--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.html
@@ -2,7 +2,7 @@
     <div class="col-12">
         <form [formGroup]="form" (ngSubmit)="submitForm()">
             <div class="form-group">
-                <label class="required" for="name">{{ 'artemisApp.attachmentUnit.createAttachmentUnit.name' | artemisTranslate }}*</label>
+                <label for="name">{{ 'artemisApp.attachmentUnit.createAttachmentUnit.name' | artemisTranslate }}*</label>
                 <input
                     type="text"
                     class="form-control"
@@ -35,7 +35,7 @@
                 </div>
             </div>
             <div class="form-group">
-                <label class="required">{{ 'artemisApp.attachmentUnit.createAttachmentUnit.file' | artemisTranslate }}*</label>
+                <label>{{ 'artemisApp.attachmentUnit.createAttachmentUnit.file' | artemisTranslate }}*</label>
                 <small id="fileHelp" class="form-text text-muted">{{ 'artemisApp.attachmentUnit.createAttachmentUnit.fileLimitations' | artemisTranslate }}</small>
                 <div class="input-group background-file">
                     <div class="custom-file overflow-ellipsis">

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.scss
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.scss
@@ -1,3 +1,0 @@
-.required {
-    color: blue;
-}

--- a/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
+++ b/src/main/webapp/app/lecture/lecture-unit/lecture-unit-management/attachment-unit-form/attachment-unit-form.component.ts
@@ -26,7 +26,6 @@ export interface FileProperties {
 @Component({
     selector: 'jhi-attachment-unit-form',
     templateUrl: './attachment-unit-form.component.html',
-    styleUrls: ['./attachment-unit-form.component.scss'],
 })
 export class AttachmentUnitFormComponent implements OnInit, OnChanges {
     @Input()


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
When creating new attachment lecture units, text in dark blue is displayed which is unreadable in dark mode (see screenshot below).

### Description
The color was used to indicate these fileds to be required. But this was already done with the asteriks behind the text, and using a blue color for required fields is not done in any other component. Therefore I just removed this class and with it the whole .scss-file.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Navigate to Course Management -> Lectures -> Lecture Units -> Create File Lecture Unit
2. Check that every text is readable in white and dark mode.

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
old:
![grafik](https://user-images.githubusercontent.com/26540346/171942246-d3a02483-db5a-44b7-9774-bddb2f436f62.png)

new:
![grafik](https://user-images.githubusercontent.com/26540346/171942888-3c5e1b60-86f8-4402-8c6a-dd5c5d5c2a1a.png)


