### PR TITLE
`Programming exercises`: Update to the latest artemis-maven-docker version java17-7

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -34,9 +34,9 @@ artemis:
         # Defines the used docker images for certain programming languages
         build:
             images:
-                JAVA: "ls1tum/artemis-maven-template:java17-6"
-                KOTLIN: "ls1tum/artemis-maven-template:java17-6"
-                EMPTY: "ls1tum/artemis-maven-template:java17-6"
+                JAVA: "ls1tum/artemis-maven-template:java17-7"
+                KOTLIN: "ls1tum/artemis-maven-template:java17-7"
+                EMPTY: "ls1tum/artemis-maven-template:java17-7"
                 PYTHON: "ls1tum/artemis-python-docker:latest"
                 C: "ls1tum/artemis-c-docker:latest"
                 C_FACT: "sharingcodeability/fact:latest"


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
The current version `java17-6` of the `artemis-maven-template` docker image does not cache the newest Ares version `1.10.1` that will be used for newly created Java/Kotlin exercises once #5173 has been merged.

### Description
Upgrade the version of the artemis-maven-template to [java17-7](https://github.com/ls1intum/artemis-maven-docker/releases/tag/java17-7) that is used for creating new exercises. This version caches the newest Ares version 1.10.1.