### PR TITLE
`Exam Mode`: Adapt upcoming exams to TestExams

### DIFF
--- a/src/main/webapp/app/overview/courses.component.html
+++ b/src/main/webapp/app/overview/courses.component.html
@@ -3,13 +3,13 @@
     <h3 class="col mb-3 fw-medium">
         {{ 'artemisApp.studentDashboard.' + (nextRelevantExam.testExam ? 'testExam.' : '') + 'examTitle' | artemisTranslate: { course: nextRelevantCourseForExam.title } }}
     </h3>
-    <div class="col-12 ps-4 pe-4 mb-5">
+    <div class="col-12 px-4 mb-5">
         <div class="row justify-content-between align-items-center exam-container ps-3 pe-3" (click)="openExam()">
-            <div class="mb-4 mt-4 d-flex" style="width: unset">
+            <div class="mb-4 mt-4 d-flex w-auto">
                 <fa-icon [icon]="faPenAlt" size="2x"></fa-icon>
                 <h4 class="ms-2 fw-medium">{{ nextRelevantExam.title }}</h4>
             </div>
-            <div class="text-end mb-4 mt-4" style="width: unset">
+            <div class="text-end my-4 w-auto">
                 <div *ngIf="nextRelevantExam.startDate">{{ 'artemisApp.exam.overview.start' | artemisTranslate: { start: nextRelevantExam.startDate | artemisDate } }}</div>
                 <div *ngIf="nextRelevantExam.maxPoints">{{ 'artemisApp.exam.overview.maxPoints' | artemisTranslate: { points: nextRelevantExam.maxPoints } }}</div>
                 <ng-container>

--- a/src/main/webapp/app/overview/courses.component.html
+++ b/src/main/webapp/app/overview/courses.component.html
@@ -1,3 +1,4 @@
+<!-- Display next relevant exam -->
 <div *ngIf="nextRelevantExam && nextRelevantCourseForExam" class="row">
     <h3 class="col mb-3 fw-medium">
         {{ 'artemisApp.studentDashboard.' + (nextRelevantExam.testExam ? 'testExam.' : '') + 'examTitle' | artemisTranslate: { course: nextRelevantCourseForExam.title } }}
@@ -21,6 +22,7 @@
         </div>
     </div>
 </div>
+<!-- Display next relevant exercise -->
 <div class="row mb-1" *ngIf="nextRelevantExercise && nextRelevantCourse">
     <div class="col">
         <h3 class="fw-medium">

--- a/src/main/webapp/app/overview/courses.component.html
+++ b/src/main/webapp/app/overview/courses.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="nextRelevantExam && nextRelevantCourseForExam" class="row">
     <h3 class="col mb-3 fw-medium">
-        {{ 'artemisApp.studentDashboard.examTitle' | artemisTranslate: { course: nextRelevantCourseForExam.title } }}
+        {{ 'artemisApp.studentDashboard.' + (nextRelevantExam.testExam ? 'testExam.' : '') + 'examTitle' | artemisTranslate: { course: nextRelevantCourseForExam.title } }}
     </h3>
     <div class="col-12 ps-4 pe-4 mb-5">
         <div class="row justify-content-between align-items-center exam-container ps-3 pe-3" (click)="openExam()">
@@ -11,11 +11,16 @@
             <div class="text-end mb-4 mt-4" style="width: unset">
                 <div *ngIf="nextRelevantExam.startDate">{{ 'artemisApp.exam.overview.start' | artemisTranslate: { start: nextRelevantExam.startDate | artemisDate } }}</div>
                 <div *ngIf="nextRelevantExam.maxPoints">{{ 'artemisApp.exam.overview.maxPoints' | artemisTranslate: { points: nextRelevantExam.maxPoints } }}</div>
+                <ng-container>
+                    <span>{{ 'artemisApp.examManagement.testExam.examMode' | artemisTranslate }}</span
+                    >:
+                    <span class="badge bg-success" *ngIf="!nextRelevantExam.testExam">{{ 'artemisApp.examManagement.testExam.realExam' | artemisTranslate }}</span>
+                    <span class="badge bg-primary" *ngIf="nextRelevantExam.testExam">{{ 'artemisApp.examManagement.testExam.testExam' | artemisTranslate }}</span>
+                </ng-container>
             </div>
         </div>
     </div>
 </div>
-
 <div class="row mb-1" *ngIf="nextRelevantExercise && nextRelevantCourse">
     <div class="col">
         <h3 class="fw-medium">

--- a/src/main/webapp/app/overview/courses.component.ts
+++ b/src/main/webapp/app/overview/courses.component.ts
@@ -62,9 +62,7 @@ export class CoursesComponent implements OnInit, OnChanges, OnDestroy {
     ngOnChanges() {
         this.nextRelevantExam = this.findNextRelevantExam;
         // We only need to look for relevant Exercises, if no Exam is upcoming
-        if (!this.nextRelevantExam) {
-            this.nextRelevantExercise = this.findNextRelevantExercise();
-        }
+        this.nextRelevantExercise = this.findNextRelevantExercise();
     }
 
     /**

--- a/src/main/webapp/app/overview/courses.component.ts
+++ b/src/main/webapp/app/overview/courses.component.ts
@@ -91,15 +91,14 @@ export class CoursesComponent implements OnInit, OnChanges, OnDestroy {
                         });
                     }
                 });
+                // Used as constant to limit the number of calls
+                const timeNow = this.serverDateService.now();
                 this.nextRelevantExams = this.exams.filter((exam) => {
                     if (exam.testExam!) {
                         // As TestExams can have a working window of multiple months, they should only be a relevant exam for [visibleDate, startDate + workingTime]
-                        return (
-                            this.serverDateService.now().isAfter(exam.visibleDate!) &&
-                            this.serverDateService.now().isBefore(dayjs(exam.startDate!).add(exam.workingTime!, 'seconds'))
-                        );
+                        return timeNow.isAfter(exam.visibleDate!) && timeNow.isBefore(dayjs(exam.startDate!).add(exam.workingTime!, 'seconds'));
                     } else {
-                        return this.serverDateService.now().isBefore(exam.endDate!) && this.serverDateService.now().isAfter(exam.visibleDate!);
+                        return timeNow.isBefore(exam.endDate!) && timeNow.isAfter(exam.visibleDate!);
                     }
                 });
                 this.ngOnChanges();

--- a/src/main/webapp/i18n/de/student-dashboard.json
+++ b/src/main/webapp/i18n/de/student-dashboard.json
@@ -19,6 +19,9 @@
                 "courseLoading": "Kurse werden geladen...",
                 "courseSignupConfirmationTitle": "Bestätigung der Kursteilnahme"
             },
+            "testExam": {
+                "examTitle": "Aktuelle Testklausur von \"{{ course }}\":"
+            },
             "course": "Kurs"
         },
         "courseOverview": {

--- a/src/main/webapp/i18n/en/student-dashboard.json
+++ b/src/main/webapp/i18n/en/student-dashboard.json
@@ -19,6 +19,9 @@
                 "courseLoading": "Courses are loading...",
                 "courseSignupConfirmationTitle": "Confirm Course Registration"
             },
+            "testExam": {
+                "examTitle": "Current test exam in \"{{ course }}\":"
+            },
             "course": "Course"
         },
         "courseOverview": {

--- a/src/test/javascript/spec/component/course/course.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course.component.spec.ts
@@ -31,7 +31,6 @@ import { AlertService } from 'app/core/util/alert.service';
 import { Component } from '@angular/core';
 import { of } from 'rxjs';
 import dayjs from 'dayjs/esm';
-import { Exam } from 'app/entities/exam.model';
 
 const endDate1 = dayjs().add(1, 'days');
 const visibleDate1 = dayjs().subtract(1, 'days');
@@ -64,7 +63,7 @@ const exam1 = {
     testExam: false,
 };
 const exam2 = { id: 4, endDate: endDate2, visibleDate: visibleDate2, course: courseEmpty, testExam: false };
-let exams = [exam1, exam2];
+const exams = [exam1, exam2];
 const course1 = { id: 1, exams, exercises: [exercise1] };
 const course2 = { id: 2, exercises: [exercise2] };
 const courses: Course[] = [course1, course2];


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
For the upcoming exercise, displayed on the course-page, exams currently have priority over exercises. 
PR #5194  will introduce TestExams. As TestExams can have a working window of multiple months, the upcoming exercise would be blocked by this one TestExam and thus become meaningless.

### Description
TestExams are only displayed as an upcoming exam between their visibleDate and their startDate + workingTime `[visibleDate; startDate + workingTime]`
Thus, the TestExam will be displayed as an upcoming exam when released and if it is within the simple working time. This corresponds to a RealExam, which is also displayed until the end of the working time.
However, if the TestExam is open for a longer period of time, the upcoming exam note will be removed after the simple working time and normal (course)-exercises can be displayed again.

### Steps for Testing
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a RealExam with Dates set. 
4. Verify, that the RealExam is shown as an upcoming exam between [visibleDate, endDate]
5. Create a TestExam with Dates set.
6. Verify, that the TestExam is shown as an upcoming exam between [visibleDate, startDate + workingTime] and will not be shown afterwards

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2


### Screenshots
![Next-RealExam](https://user-images.githubusercontent.com/94070506/172212103-e3cbf228-0dc0-4394-ad77-4332c217cb45.png)
![Next-RelevantExam](https://user-images.githubusercontent.com/94070506/172212106-133882f1-8f98-4379-9575-ebb4dcba29b4.png)

