### PR TITLE
`Development`: Add comments regarding the task regex for programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
@@ -27,6 +27,7 @@ public class ProgrammingExerciseTaskService {
      * - tests: "testBubbleSort,testBubbleSortHidden"
      *
      * This is coupled to the value used in `ProgrammingExerciseTaskExtensionWrapper` and `TaskCommand` in the client
+     * If you change the regex, make sure to change it in all places!
      */
     private final Pattern taskPatternForProblemStatementMarkdown = Pattern.compile("\\[task]\\[(?<name>[^\\[\\]]+)]\\((?<tests>.*)\\)");
 

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
@@ -25,6 +25,8 @@ public class ProgrammingExerciseTaskService {
      * Example: "[task][Implement BubbleSort](testBubbleSort,testBubbleSortHidden)". Following values are extracted by the named capturing groups:
      * - name: "Implement BubbleSort"
      * - tests: "testBubbleSort,testBubbleSortHidden"
+     *
+     * This is coupled to the value used in `ProgrammingExerciseTaskExtensionWrapper` and `TaskCommand` in the client
      */
     private final Pattern taskPatternForProblemStatementMarkdown = Pattern.compile("\\[task]\\[(?<name>[^\\[\\]]+)]\\((?<tests>.*)\\)");
 
@@ -122,6 +124,10 @@ public class ProgrammingExerciseTaskService {
      */
     private List<ProgrammingExerciseTask> extractTasks(ProgrammingExercise exercise) {
         var problemStatement = exercise.getProblemStatement();
+        // Rare edge case, as some old programming exercises have no problem statement
+        if (problemStatement == null) {
+            return new ArrayList<>();
+        }
         var matcher = taskPatternForProblemStatementMarkdown.matcher(problemStatement);
         var testCases = programmingExerciseTestCaseRepository.findByExerciseIdAndActive(exercise.getId(), true);
         var tasks = new ArrayList<ProgrammingExerciseTask>();

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
@@ -125,10 +125,6 @@ public class ProgrammingExerciseTaskService {
      */
     private List<ProgrammingExerciseTask> extractTasks(ProgrammingExercise exercise) {
         var problemStatement = exercise.getProblemStatement();
-        // Rare edge case, as some old programming exercises have no problem statement
-        if (problemStatement == null) {
-            return new ArrayList<>();
-        }
         var matcher = taskPatternForProblemStatementMarkdown.matcher(problemStatement);
         var testCases = programmingExerciseTestCaseRepository.findByExerciseIdAndActive(exercise.getId(), true);
         var tasks = new ArrayList<ProgrammingExerciseTask>();

--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/extensions/programming-exercise-task.extension.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/extensions/programming-exercise-task.extension.ts
@@ -88,6 +88,8 @@ export class ProgrammingExerciseTaskExtensionWrapper implements ArtemisShowdownE
 
     /**
      * Creates and returns an extension to current exercise.
+     * The task regex is coupled to the value used in ProgrammingExerciseTaskService in the server and
+     * `TaskCommand` in the client
      */
     getExtension() {
         const extension: ShowdownExtension = {

--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/extensions/programming-exercise-task.extension.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/extensions/programming-exercise-task.extension.ts
@@ -90,6 +90,7 @@ export class ProgrammingExerciseTaskExtensionWrapper implements ArtemisShowdownE
      * Creates and returns an extension to current exercise.
      * The task regex is coupled to the value used in ProgrammingExerciseTaskService in the server and
      * `TaskCommand` in the client
+     * If you change the regex, make sure to change it in all places!
      */
     getExtension() {
         const extension: ShowdownExtension = {

--- a/src/main/webapp/app/shared/markdown-editor/domainCommands/programming-exercise/task.command.ts
+++ b/src/main/webapp/app/shared/markdown-editor/domainCommands/programming-exercise/task.command.ts
@@ -19,6 +19,10 @@ export class TaskCommand extends DomainTagCommand {
         this.addCompleter(taskCommandCompleter);
     }
 
+    /**
+     * The task structure is coupled to the value used in `ProgrammingExerciseTaskService` in the server and
+     * `ProgrammingExerciseTaskExtensionWrapper` in the client
+     */
     private getTask() {
         return `${this.getOpeningIdentifier()}[${TaskCommand.taskPlaceholder}](${TaskCommand.testCasePlaceholder})`;
     }

--- a/src/main/webapp/app/shared/markdown-editor/domainCommands/programming-exercise/task.command.ts
+++ b/src/main/webapp/app/shared/markdown-editor/domainCommands/programming-exercise/task.command.ts
@@ -22,6 +22,7 @@ export class TaskCommand extends DomainTagCommand {
     /**
      * The task structure is coupled to the value used in `ProgrammingExerciseTaskService` in the server and
      * `ProgrammingExerciseTaskExtensionWrapper` in the client
+     * If you change the template, make sure to change it in all places!
      */
     private getTask() {
         return `${this.getOpeningIdentifier()}[${TaskCommand.taskPlaceholder}](${TaskCommand.testCasePlaceholder})`;


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
~~Stephan approached Ole and me with an issue when applying our Java migration to the production server.~~

### Description
<!-- Describe your changes in detail -->
~~This is due to the fact that some old programming exercises do not have a problem statement which lead to a NullPointerException. This PR adds a check for that.~~
This fix was already pushed to develop and therefore this PR only contains some JavaDoc comments

### Steps for Testing
Nothing

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
