### PR TITLE
`General`: Show registration number in course group table and in the corresponding CSV export

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -558,6 +558,8 @@ public class CourseService {
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.INSTRUCTOR, course, null);
         var usersInGroup = userRepository.findAllInGroup(groupName);
         usersInGroup.forEach(user -> {
+            // explicitly set the registration number
+            user.setVisibleRegistrationNumber(user.getRegistrationNumber());
             // remove some values which are not needed in the client
             user.setLastNotificationRead(null);
             user.setActivationKey(null);

--- a/src/main/webapp/app/course/manage/course-group.component.html
+++ b/src/main/webapp/app/course/manage/course-group.component.html
@@ -70,6 +70,18 @@
                     </ng-template>
                 </ngx-datatable-column>
 
+                <ngx-datatable-column prop="visibleRegistrationNumber" [minWidth]="150" [width]="200" [maxWidth]="200">
+                    <ng-template ngx-datatable-header-template>
+                        <span class="datatable-header-cell-wrapper" (click)="controls.onSort('visibleRegistrationNumber')">
+                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="userManagement.registrationNumber"> Registration Number </span>
+                            <fa-icon [icon]="controls.iconForSortPropField('visibleRegistrationNumber')"></fa-icon>
+                        </span>
+                    </ng-template>
+                    <ng-template ngx-datatable-cell-template let-value="value">
+                        <span>{{ value }}</span>
+                    </ng-template>
+                </ngx-datatable-column>
+
                 <ngx-datatable-column prop="name" [minWidth]="150" [width]="250" [maxWidth]="250">
                     <ng-template ngx-datatable-header-template>
                         <span class="datatable-header-cell-wrapper" (click)="controls.onSort('name')">

--- a/src/main/webapp/app/course/manage/course-group.component.html
+++ b/src/main/webapp/app/course/manage/course-group.component.html
@@ -73,7 +73,7 @@
                 <ngx-datatable-column prop="visibleRegistrationNumber" [minWidth]="150" [width]="200" [maxWidth]="200">
                     <ng-template ngx-datatable-header-template>
                         <span class="datatable-header-cell-wrapper" (click)="controls.onSort('visibleRegistrationNumber')">
-                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="userManagement.registrationNumber"> Registration Number </span>
+                            <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.course.courseGroup.registrationNumber"> Registration Number </span>
                             <fa-icon [icon]="controls.iconForSortPropField('visibleRegistrationNumber')"></fa-icon>
                         </span>
                     </ng-template>

--- a/src/main/webapp/i18n/de/course.json
+++ b/src/main/webapp/i18n/de/course.json
@@ -159,6 +159,7 @@
                 "searchForUsers": "Nutzer:in zu dieser Kursgruppe hinzufügen durch Suchen nach Login oder Namen",
                 "searchNoResults": "Kein:e Nutzer:innen gefunden",
                 "login": "Login",
+                "registrationNumber": "Matrikelnummer",
                 "name": "Name",
                 "email": "E-Mail",
                 "removeFromGroup": {

--- a/src/main/webapp/i18n/en/course.json
+++ b/src/main/webapp/i18n/en/course.json
@@ -159,6 +159,7 @@
                 "searchForUsers": "Add a user to this course group by searching for login or name",
                 "searchNoResults": "No users found",
                 "login": "Login",
+                "registrationNumber": "Registration Number",
                 "name": "Name",
                 "email": "Email",
                 "removeFromGroup": {


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In case an instructor exports user groups (tutors, students, etc.) to CSV, the registration number field in the resulting CSV file is currently empty. 
This makes it difficult to import the users into other systems, such as TUMonline, as a registration number is required.

### Description
<!-- Describe your changes in detail -->
Through this change the server now includes the registration number in the corresponding response and it is successfully exported in the CSV.
In addition, the registration number is displayed in a new column in the group table.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students **with a registration number**
- 2 Tutors **with a registration number**
- 2 Editors **with a registration number**

_You should be able to set a registration number for different users in the user management section when logged in as an admin_

Assign all of these users to the same course.


1. Log in to Artemis as Instructor
2. Navigate to Course Administration and then to your Test Course
3. For every group (students, tutors, editors, etc.):
4. Confirm that the registration number is shown in the table 
5. Use the Export to CSV button in the top right
6. Confirm that the registration number is also set in the exported CSV


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1920" alt="Bildschirmfoto 2022-06-07 um 16 03 52" src="https://user-images.githubusercontent.com/9954674/172405303-84529f3b-4c91-4fe3-9f01-d6469e462c61.png">
<img width="1915" alt="Bildschirmfoto 2022-06-07 um 16 03 07" src="https://user-images.githubusercontent.com/9954674/172405352-5e32b463-c5c1-4af2-a5ea-4cef4cee49f7.png">

