### PR TITLE
`General`: Move notifications icon, theme switcher and account menu to horizontal row in collapsed mobile menu

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -156,76 +156,88 @@
                 </ul>
             </li>
 
-            <jhi-notification-sidebar [ngClass]="'nav-item'" *ngIf="currAccount && !examModeActive()"></jhi-notification-sidebar>
-
-            <jhi-theme-switch [ngClass]="'nav-item'" [popoverPlacement]="isCollapsed ? 'bottom-left' : 'bottom-right'"></jhi-theme-switch>
-
-            <li
-                *ngSwitchCase="true"
-                ngbDropdown
-                class="nav-item dropdown pointer"
-                display="dynamic"
-                [placement]="isCollapsed ? 'bottom-left' : 'bottom-right'"
-                routerLinkActive="active"
-                [routerLinkActiveOptions]="{ exact: true }"
-                [autoClose]="true"
-            >
-                <a class="guided-tour-account nav-link dropdown-toggle" ngbDropdownToggle id="account-menu">
-                    <span *ngIf="!getImageUrl()">
-                        <fa-icon [icon]="faUser"></fa-icon>
-                        <span jhiTranslate="global.menu.account.main" *ngIf="!currAccount">Account</span>
-                        <span *ngIf="currAccount">{{ currAccount.login }}</span>
-                    </span>
-                    <span *ngIf="getImageUrl()">
-                        <img [src]="getImageUrl()" class="profile-image img-circle" alt="Avatar" />
-                    </span>
-                </a>
-                <ul class="dropdown-menu dropdown-menu-index" ngbDropdownMenu>
-                    <li>
-                        <a class="dropdown-item" [routerLink]="['/user-settings']" (click)="collapseNavbar()">
-                            <fa-icon [icon]="faCog" [fixedWidth]="true"></fa-icon>
-                            <span>{{ 'global.menu.settings' | artemisTranslate }}</span>
-                        </a>
-                    </li>
-                    <div class="dropdown-divider"></div>
-                    <li>
-                        <h6 class="dropdown-header fw-medium" jhiTranslate="global.menu.language">Language</h6>
-                    </li>
-                    <div *ngIf="languages && languages.length > 1">
-                        <li *ngFor="let language of languages">
-                            <a class="dropdown-item" [jhiActiveMenu]="language" (click)="changeLanguage(language); collapseNavbar()">{{ language | findLanguageFromKey }}</a>
+            <ng-template #userMenu>
+                <li
+                    *ngSwitchCase="true"
+                    ngbDropdown
+                    class="nav-item dropdown pointer"
+                    display="dynamic"
+                    [placement]="'bottom-right'"
+                    routerLinkActive="active"
+                    [routerLinkActiveOptions]="{ exact: true }"
+                    [autoClose]="true"
+                >
+                    <a class="guided-tour-account nav-link dropdown-toggle" ngbDropdownToggle id="account-menu">
+                        <span *ngIf="!getImageUrl()">
+                            <fa-icon [icon]="faUser"></fa-icon>
+                            <span jhiTranslate="global.menu.account.main" *ngIf="!currAccount">Account</span>
+                            <span *ngIf="currAccount">{{ currAccount.login }}</span>
+                        </span>
+                        <span *ngIf="getImageUrl()">
+                            <img [src]="getImageUrl()" class="profile-image img-circle" alt="Avatar" />
+                        </span>
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-index" ngbDropdownMenu>
+                        <li>
+                            <a class="dropdown-item" [routerLink]="['/user-settings']" (click)="collapseNavbar()">
+                                <fa-icon [icon]="faCog" [fixedWidth]="true"></fa-icon>
+                                <span>{{ 'global.menu.settings' | artemisTranslate }}</span>
+                            </a>
                         </li>
-                    </div>
-                    <ng-template [ngIf]="isTourAvailable">
                         <div class="dropdown-divider"></div>
                         <li>
-                            <h6 class="dropdown-header fw-medium" jhiTranslate="global.menu.guidedTutorial">Guided Tutorial</h6>
+                            <h6 class="dropdown-header fw-medium" jhiTranslate="global.menu.language">Language</h6>
+                        </li>
+                        <div *ngIf="languages && languages.length > 1">
+                            <li *ngFor="let language of languages">
+                                <a class="dropdown-item" [jhiActiveMenu]="language" (click)="changeLanguage(language); collapseNavbar()">{{ language | findLanguageFromKey }}</a>
+                            </li>
+                        </div>
+                        <ng-template [ngIf]="isTourAvailable">
+                            <div class="dropdown-divider"></div>
+                            <li>
+                                <h6 class="dropdown-header fw-medium" jhiTranslate="global.menu.guidedTutorial">Guided Tutorial</h6>
+                            </li>
+                            <li>
+                                <a class="dropdown-item guided-tour" [jhiTranslate]="this.guidedTourInitLabel()" (click)="this.guidedTourService.initGuidedTour()"
+                                    >Start tutorial</a
+                                >
+                            </li>
+                        </ng-template>
+                        <div class="dropdown-divider"></div>
+                        <li *ngIf="isRegistrationEnabled">
+                            <a class="dropdown-item" routerLink="account/settings" routerLinkActive="active" (click)="collapseNavbar()">
+                                <fa-icon [icon]="faWrench" [fixedWidth]="true"></fa-icon>
+                                <span jhiTranslate="global.menu.account.settings">Settings</span>
+                            </a>
+                        </li>
+                        <li *ngIf="passwordResetEnabled">
+                            <a class="dropdown-item" routerLink="account/password" routerLinkActive="active" (click)="collapseNavbar()">
+                                <fa-icon [icon]="faLock" [fixedWidth]="true"></fa-icon>
+                                <span jhiTranslate="global.menu.account.password">Password</span>
+                            </a>
                         </li>
                         <li>
-                            <a class="dropdown-item guided-tour" [jhiTranslate]="this.guidedTourInitLabel()" (click)="this.guidedTourService.initGuidedTour()">Start tutorial</a>
+                            <a class="dropdown-item" *ngIf="currAccount" (click)="logout()" id="logout">
+                                <fa-icon [icon]="faSignOutAlt" [fixedWidth]="true"></fa-icon>
+                                <span jhiTranslate="global.menu.account.logout">Sign out</span>
+                            </a>
                         </li>
-                    </ng-template>
-                    <div class="dropdown-divider"></div>
-                    <li *ngIf="isRegistrationEnabled">
-                        <a class="dropdown-item" routerLink="account/settings" routerLinkActive="active" (click)="collapseNavbar()">
-                            <fa-icon [icon]="faWrench" [fixedWidth]="true"></fa-icon>
-                            <span jhiTranslate="global.menu.account.settings">Settings</span>
-                        </a>
-                    </li>
-                    <li *ngIf="passwordResetEnabled">
-                        <a class="dropdown-item" routerLink="account/password" routerLinkActive="active" (click)="collapseNavbar()">
-                            <fa-icon [icon]="faLock" [fixedWidth]="true"></fa-icon>
-                            <span jhiTranslate="global.menu.account.password">Password</span>
-                        </a>
-                    </li>
-                    <li>
-                        <a class="dropdown-item" *ngIf="currAccount" (click)="logout()" id="logout">
-                            <fa-icon [icon]="faSignOutAlt" [fixedWidth]="true"></fa-icon>
-                            <span jhiTranslate="global.menu.account.logout">Sign out</span>
-                        </a>
-                    </li>
-                </ul>
-            </li>
+                    </ul>
+                </li>
+            </ng-template>
+
+            <ng-container *ngIf="!isCollapsed">
+                <jhi-notification-sidebar [ngClass]="'nav-item'" *ngIf="currAccount && !examModeActive()"></jhi-notification-sidebar>
+                <jhi-theme-switch [ngClass]="'nav-item'" [popoverPlacement]="isCollapsed ? 'bottom-left' : 'bottom-right'"></jhi-theme-switch>
+                <ng-container *ngTemplateOutlet="userMenu"></ng-container>
+            </ng-container>
+
+            <div *ngIf="isCollapsed" class="navbar-bottom-bar">
+                <jhi-notification-sidebar [ngClass]="'nav-item'" *ngIf="currAccount && !examModeActive()"></jhi-notification-sidebar>
+                <jhi-theme-switch [ngClass]="'nav-item'" [popoverPlacement]="'bottom'"></jhi-theme-switch>
+                <ng-container *ngTemplateOutlet="userMenu"></ng-container>
+            </div>
         </ul>
     </div>
 </nav>

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -229,7 +229,7 @@
 
             <ng-container *ngIf="!isCollapsed">
                 <jhi-notification-sidebar [ngClass]="'nav-item'" *ngIf="currAccount && !examModeActive()"></jhi-notification-sidebar>
-                <jhi-theme-switch [ngClass]="'nav-item'" [popoverPlacement]="isCollapsed ? 'bottom-left' : 'bottom-right'"></jhi-theme-switch>
+                <jhi-theme-switch [ngClass]="'nav-item'" [popoverPlacement]="'bottom-right'"></jhi-theme-switch>
                 <ng-container *ngTemplateOutlet="userMenu"></ng-container>
             </ng-container>
 

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -36,6 +36,19 @@ a:not(.btn):hover {
         .nav-item {
             margin-left: 1.5rem;
         }
+
+        .navbar-bottom-bar {
+            display: flex;
+            gap: 5px;
+            justify-content: space-evenly;
+            align-items: center;
+            flex-wrap: wrap;
+
+            > .nav-item {
+                flex: 0 1 auto;
+                margin-left: 0;
+            }
+        }
     }
     a.nav-link {
         font-weight: 400;

--- a/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.scss
+++ b/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.scss
@@ -1,5 +1,5 @@
 :host {
-    white-space: initial;
+    white-space: nowrap;
 }
 
 .light-button {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

On mobile, the navbar collapses to an openable menu. The icons for notifications and the theme switcher look odd in that view as they don't have a text attached like the other menu items. Furthermore, it was reported in #5211 that if the collapsed view is used with a mouse, the theme switcher popup opens if you hover the line of the theme switcher at any place in the row, making it hard to reach the user menu. Please see the following video to learn about both problems.

https://user-images.githubusercontent.com/23171488/172449726-e7f7557c-ba80-43e0-9de0-f398b0e603ed.mov

### Description
<!-- Describe your changes in detail -->

To make these icons look less weird, and to solve the problem in #5211, I suggest to arrange the two unlabeled icons and the user menu in a horizontal row at the bottom of the menu. There's more than enough horizontal space to do that; it also makes the icons look less weird without a label, and allows to easily reach the user menu without triggering the theme switcher popup.
The icons and the user menu are evenly spread through the entire row using flexbox.
See the screencast below for the new version.

https://user-images.githubusercontent.com/23171488/172450088-ee81a10b-5b46-4045-83ed-dd8f1e30ee9c.mov

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 User

1. Log in to Artemis
2. Use your browser dev tools to simulate the width of a phone (use 360px width for the most common width to support; an iPhone Pro would be 390px)
3. Open the navbar menu
4. Check that you can still open the notifications sidebar
5. Check that you can still open the dark mode popup
6. Check that you can open the user menu without triggering the dark mode popup
7. Check that everything still works on normal PC screen sizes

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
