### PR TITLE
`Development`: Use assertions consistently

### DIFF
--- a/docs/dev/guidelines/client-tests.rst
+++ b/docs/dev/guidelines/client-tests.rst
@@ -209,7 +209,7 @@ Some guidelines:
 
             fixture.detectChanges();
 
-            expect(saveExerciseWithoutReevaluationSpy).toHaveBeenCalledTimes(1);
+            expect(saveExerciseWithoutReevaluationSpy).toHaveBeenCalledOnce();
             expect(emitSpy).toHaveBeenCalled();
         });
 
@@ -309,13 +309,13 @@ Some guidelines:
   +--------------------------------------------------------+-----------------------------------------------------------------+
   | A spy should not have been called                      | :code:`expect(spy).not.toHaveBeenCalled();`                     |
   +--------------------------------------------------------+-----------------------------------------------------------------+
-  | A spy should have been called once                     | :code:`expect(spy).toHaveBeenCalledTimes(1);`                   |
+  | A spy should have been called once                     | :code:`expect(spy).toHaveBeenCalledOnce();`                   |
   +--------------------------------------------------------+-----------------------------------------------------------------+
   | A spy should have been called with a value             | Always test the number of calls as well:                        |
   |                                                        |                                                                 |
   |                                                        | .. code:: ts                                                    |
   |                                                        |                                                                 |
-  |                                                        |     expect(spy).toHaveBeenCalledTimes(1);                       |
+  |                                                        |     expect(spy).toHaveBeenCalledOnce();                       |
   |                                                        |     expect(spy).toHaveBeenCalledWith(value);                    |
   |                                                        |                                                                 |
   |                                                        | If you have multiple calls, you can verify the parameters       |

--- a/src/test/javascript/spec/component/about-us/about-us.component.spec.ts
+++ b/src/test/javascript/spec/component/about-us/about-us.component.spec.ts
@@ -45,7 +45,7 @@ describe('AboutUsComponent', () => {
         fixture.detectChanges();
         tick();
         fixture.whenStable().then(() => {
-            expect(getStaticJsonFromArtemisServerStub).toHaveBeenCalledTimes(1);
+            expect(getStaticJsonFromArtemisServerStub).toHaveBeenCalledOnce();
         });
     }));
 
@@ -68,8 +68,8 @@ describe('AboutUsComponent', () => {
         fixture.detectChanges();
         tick();
         fixture.whenStable().then(() => {
-            expect(getStaticJsonFromArtemisServerStub).toHaveBeenCalledTimes(1);
-            expect(getProfileInfoStub).toHaveBeenCalledTimes(1);
+            expect(getStaticJsonFromArtemisServerStub).toHaveBeenCalledOnce();
+            expect(getProfileInfoStub).toHaveBeenCalledOnce();
             expect(fixture.debugElement.nativeElement.querySelector('#contributorsName').innerHTML).toBe(fullName);
         });
     }));

--- a/src/test/javascript/spec/component/account/activate.component.spec.ts
+++ b/src/test/javascript/spec/component/account/activate.component.spec.ts
@@ -55,7 +55,7 @@ describe('ActivateComponent', () => {
             tick();
 
             expect(comp.error).toBe(false);
-            expect(comp.success).toBe(true);
+            expect(comp.success).toBeTrue();
         }),
     ));
 
@@ -67,7 +67,7 @@ describe('ActivateComponent', () => {
             comp.activateAccount();
             tick();
 
-            expect(comp.error).toBe(true);
+            expect(comp.error).toBeTrue();
             expect(comp.success).toBe(false);
         }),
     ));

--- a/src/test/javascript/spec/component/account/activate.component.spec.ts
+++ b/src/test/javascript/spec/component/account/activate.component.spec.ts
@@ -54,7 +54,7 @@ describe('ActivateComponent', () => {
             comp.activateAccount();
             tick();
 
-            expect(comp.error).toBe(false);
+            expect(comp.error).toBeFalse();
             expect(comp.success).toBeTrue();
         }),
     ));
@@ -68,7 +68,7 @@ describe('ActivateComponent', () => {
             tick();
 
             expect(comp.error).toBeTrue();
-            expect(comp.success).toBe(false);
+            expect(comp.success).toBeFalse();
         }),
     ));
 });

--- a/src/test/javascript/spec/component/account/password-reset-finish.component.spec.ts
+++ b/src/test/javascript/spec/component/account/password-reset-finish.component.spec.ts
@@ -101,7 +101,7 @@ describe('Component Tests', () => {
                 tick();
 
                 expect(service.save).toHaveBeenCalledWith('XYZPDQ', 'password');
-                expect(comp.success).toBe(false);
+                expect(comp.success).toBeFalse();
                 expect(comp.error).toBeTrue();
             }),
         ));

--- a/src/test/javascript/spec/component/account/password-reset-finish.component.spec.ts
+++ b/src/test/javascript/spec/component/account/password-reset-finish.component.spec.ts
@@ -44,7 +44,7 @@ describe('Component Tests', () => {
         });
 
         it('should define its initial state', () => {
-            expect(comp.initialized).toBe(true);
+            expect(comp.initialized).toBeTrue();
             expect(comp.key).toEqual('XYZPDQ');
         });
 
@@ -68,7 +68,7 @@ describe('Component Tests', () => {
 
             comp.finishReset();
 
-            expect(comp.doNotMatch).toBe(true);
+            expect(comp.doNotMatch).toBeTrue();
         });
 
         it('should update success to true after resetting password', inject(
@@ -84,7 +84,7 @@ describe('Component Tests', () => {
                 tick();
 
                 expect(service.save).toHaveBeenCalledWith('XYZPDQ', 'password');
-                expect(comp.success).toBe(true);
+                expect(comp.success).toBeTrue();
             }),
         ));
 
@@ -102,7 +102,7 @@ describe('Component Tests', () => {
 
                 expect(service.save).toHaveBeenCalledWith('XYZPDQ', 'password');
                 expect(comp.success).toBe(false);
-                expect(comp.error).toBe(true);
+                expect(comp.error).toBeTrue();
             }),
         ));
     });

--- a/src/test/javascript/spec/component/account/password.component.spec.ts
+++ b/src/test/javascript/spec/component/account/password.component.spec.ts
@@ -50,7 +50,7 @@ describe('Component Tests', () => {
             // WHEN
             comp.changePassword();
             // THEN
-            expect(comp.doNotMatch).toBe(true);
+            expect(comp.doNotMatch).toBeTrue();
             expect(comp.error).toBe(false);
             expect(comp.success).toBe(false);
         });
@@ -91,7 +91,7 @@ describe('Component Tests', () => {
             // THEN
             expect(comp.doNotMatch).toBe(false);
             expect(comp.error).toBe(false);
-            expect(comp.success).toBe(true);
+            expect(comp.success).toBeTrue();
         });
 
         it('should notify of error if change password fails', () => {
@@ -108,7 +108,7 @@ describe('Component Tests', () => {
             // THEN
             expect(comp.doNotMatch).toBe(false);
             expect(comp.success).toBe(false);
-            expect(comp.error).toBe(true);
+            expect(comp.error).toBeTrue();
         });
 
         it('sets user on init', fakeAsync(() => {

--- a/src/test/javascript/spec/component/account/password.component.spec.ts
+++ b/src/test/javascript/spec/component/account/password.component.spec.ts
@@ -51,8 +51,8 @@ describe('Component Tests', () => {
             comp.changePassword();
             // THEN
             expect(comp.doNotMatch).toBeTrue();
-            expect(comp.error).toBe(false);
-            expect(comp.success).toBe(false);
+            expect(comp.error).toBeFalse();
+            expect(comp.success).toBeFalse();
         });
 
         it('should call Auth.changePassword when passwords match', () => {
@@ -89,8 +89,8 @@ describe('Component Tests', () => {
             comp.changePassword();
 
             // THEN
-            expect(comp.doNotMatch).toBe(false);
-            expect(comp.error).toBe(false);
+            expect(comp.doNotMatch).toBeFalse();
+            expect(comp.error).toBeFalse();
             expect(comp.success).toBeTrue();
         });
 
@@ -106,8 +106,8 @@ describe('Component Tests', () => {
             comp.changePassword();
 
             // THEN
-            expect(comp.doNotMatch).toBe(false);
-            expect(comp.success).toBe(false);
+            expect(comp.doNotMatch).toBeFalse();
+            expect(comp.success).toBeFalse();
             expect(comp.error).toBeTrue();
         });
 

--- a/src/test/javascript/spec/component/account/register.component.spec.ts
+++ b/src/test/javascript/spec/component/account/register.component.spec.ts
@@ -52,7 +52,7 @@ describe('Component Tests', () => {
 
             comp.register();
 
-            expect(comp.doNotMatch).toBe(true);
+            expect(comp.doNotMatch).toBeTrue();
         });
 
         it('should update success to true after creating an account', inject(
@@ -74,7 +74,7 @@ describe('Component Tests', () => {
                 user.login = '';
                 user.langKey = 'en';
                 expect(service.save).toHaveBeenCalledWith(user);
-                expect(comp.success).toBe(true);
+                expect(comp.success).toBeTrue();
                 expect(comp.errorUserExists).toBe(false);
                 expect(comp.errorEmailExists).toBe(false);
                 expect(comp.error).toBe(false);
@@ -98,7 +98,7 @@ describe('Component Tests', () => {
                 comp.register();
                 tick();
 
-                expect(comp.errorUserExists).toBe(true);
+                expect(comp.errorUserExists).toBeTrue();
                 expect(comp.errorEmailExists).toBe(false);
                 expect(comp.error).toBe(false);
             }),
@@ -121,7 +121,7 @@ describe('Component Tests', () => {
                 comp.register();
                 tick();
 
-                expect(comp.errorEmailExists).toBe(true);
+                expect(comp.errorEmailExists).toBeTrue();
                 expect(comp.errorUserExists).toBe(false);
                 expect(comp.error).toBe(false);
             }),
@@ -145,7 +145,7 @@ describe('Component Tests', () => {
 
                 expect(comp.errorUserExists).toBe(false);
                 expect(comp.errorEmailExists).toBe(false);
-                expect(comp.error).toBe(true);
+                expect(comp.error).toBeTrue();
             }),
         ));
     });

--- a/src/test/javascript/spec/component/account/register.component.spec.ts
+++ b/src/test/javascript/spec/component/account/register.component.spec.ts
@@ -75,9 +75,9 @@ describe('Component Tests', () => {
                 user.langKey = 'en';
                 expect(service.save).toHaveBeenCalledWith(user);
                 expect(comp.success).toBeTrue();
-                expect(comp.errorUserExists).toBe(false);
-                expect(comp.errorEmailExists).toBe(false);
-                expect(comp.error).toBe(false);
+                expect(comp.errorUserExists).toBeFalse();
+                expect(comp.errorEmailExists).toBeFalse();
+                expect(comp.error).toBeFalse();
             }),
         ));
 
@@ -99,8 +99,8 @@ describe('Component Tests', () => {
                 tick();
 
                 expect(comp.errorUserExists).toBeTrue();
-                expect(comp.errorEmailExists).toBe(false);
-                expect(comp.error).toBe(false);
+                expect(comp.errorEmailExists).toBeFalse();
+                expect(comp.error).toBeFalse();
             }),
         ));
 
@@ -122,8 +122,8 @@ describe('Component Tests', () => {
                 tick();
 
                 expect(comp.errorEmailExists).toBeTrue();
-                expect(comp.errorUserExists).toBe(false);
-                expect(comp.error).toBe(false);
+                expect(comp.errorUserExists).toBeFalse();
+                expect(comp.error).toBeFalse();
             }),
         ));
 
@@ -143,8 +143,8 @@ describe('Component Tests', () => {
                 comp.register();
                 tick();
 
-                expect(comp.errorUserExists).toBe(false);
-                expect(comp.errorEmailExists).toBe(false);
+                expect(comp.errorUserExists).toBeFalse();
+                expect(comp.errorEmailExists).toBeFalse();
                 expect(comp.error).toBeTrue();
             }),
         ));

--- a/src/test/javascript/spec/component/account/settings.component.spec.ts
+++ b/src/test/javascript/spec/component/account/settings.component.spec.ts
@@ -114,7 +114,7 @@ describe('SettingsComponent', () => {
             tick();
 
             // THEN
-            expect(comp.success).toBe(false);
+            expect(comp.success).toBeFalse();
         }),
     ));
 });

--- a/src/test/javascript/spec/component/account/settings.component.spec.ts
+++ b/src/test/javascript/spec/component/account/settings.component.spec.ts
@@ -95,7 +95,7 @@ describe('SettingsComponent', () => {
             tick();
 
             // THEN
-            expect(comp.success).toBe(true);
+            expect(comp.success).toBeTrue();
         }),
     ));
 

--- a/src/test/javascript/spec/component/admin/admin-feature-toggle.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/admin-feature-toggle.component.spec.ts
@@ -42,6 +42,6 @@ describe('AdminFeatureToggleComponentTest', () => {
         comp.ngOnInit();
         comp.onFeatureToggle(event, comp.availableToggles[0]);
 
-        expect(comp.availableToggles[0].isActive).toBe(false);
+        expect(comp.availableToggles[0].isActive).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/admin/audits.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/audits.component.spec.ts
@@ -113,7 +113,7 @@ describe('AuditsComponent', () => {
             expect(comp.fromDate).toBe(getDate(false));
             expect(comp.itemsPerPage).toBe(ITEMS_PER_PAGE);
             expect(comp.page).toBe(1);
-            expect(comp.ascending).toBe(false);
+            expect(comp.ascending).toBeFalse();
             expect(comp.predicate).toBe('id');
         });
     });

--- a/src/test/javascript/spec/component/admin/health-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/health-modal.component.spec.ts
@@ -58,6 +58,6 @@ describe('HealthModalComponentTest', () => {
         expect(button).not.toBe(null);
 
         button.nativeElement.click();
-        expect(dismissSpy).toHaveBeenCalledTimes(1);
+        expect(dismissSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/admin/health.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/health.component.spec.ts
@@ -52,7 +52,7 @@ describe('HealthComponent', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(healthService.checkHealth).toHaveBeenCalledTimes(1);
+        expect(healthService.checkHealth).toHaveBeenCalledOnce();
         expect(comp.health).toEqual(health);
     });
 
@@ -65,7 +65,7 @@ describe('HealthComponent', () => {
         comp.refresh();
 
         // THEN
-        expect(healthService.checkHealth).toHaveBeenCalledTimes(1);
+        expect(healthService.checkHealth).toHaveBeenCalledOnce();
         expect(comp.health).toEqual(health);
     });
 
@@ -84,7 +84,7 @@ describe('HealthComponent', () => {
         linkToClick.nativeElement.click();
         fixture.detectChanges();
 
-        expect(modalServiceSpy).toHaveBeenCalledTimes(1);
+        expect(modalServiceSpy).toHaveBeenCalledOnce();
         expect(modalServiceSpy).toHaveBeenCalledWith(HealthModalComponent);
         expect(mockModalRef.componentInstance.health).toEqual({ key: 'mail', value: health.components.mail });
     });

--- a/src/test/javascript/spec/component/admin/logs.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/logs.component.spec.ts
@@ -29,7 +29,7 @@ describe('Component Tests', () => {
         it('should set all default values correctly', () => {
             expect(comp.filter).toBe('');
             expect(comp.orderProp).toBe('name');
-            expect(comp.ascending).toBe(true);
+            expect(comp.ascending).toBeTrue();
         });
 
         it('should call load all on init', () => {
@@ -49,7 +49,7 @@ describe('Component Tests', () => {
             comp.ngOnInit();
 
             // THEN
-            expect(service.findAll).toHaveBeenCalledTimes(1);
+            expect(service.findAll).toHaveBeenCalledOnce();
             expect(comp.loggers?.[0]).toEqual(expect.objectContaining(log));
         });
 
@@ -71,8 +71,8 @@ describe('Component Tests', () => {
             comp.changeLevel('main', 'ERROR');
 
             // THEN
-            expect(service.changeLevel).toHaveBeenCalledTimes(1);
-            expect(service.findAll).toHaveBeenCalledTimes(1);
+            expect(service.changeLevel).toHaveBeenCalledOnce();
+            expect(service.findAll).toHaveBeenCalledOnce();
             expect(comp.loggers?.[0]).toEqual(expect.objectContaining(log));
         });
 

--- a/src/test/javascript/spec/component/admin/metrics/jvm-threads.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/metrics/jvm-threads.component.spec.ts
@@ -64,7 +64,7 @@ describe('JvmThreadsComponent', () => {
 
         button.nativeElement.click();
 
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
         expect(spy).toHaveBeenCalledWith(MetricsModalThreadsComponent, { size: 'xl' });
         expect(mockModalRef.componentInstance.threads).toEqual(threads);
     });

--- a/src/test/javascript/spec/component/admin/metrics/metrics.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/metrics/metrics.component.spec.ts
@@ -29,10 +29,10 @@ describe('MetricsComponent', () => {
         const mockThreadDump = { threads: [] };
         jest.spyOn(service, 'getMetrics').mockReturnValue(of(mockMetrics as Metrics));
         jest.spyOn(service, 'threadDump').mockReturnValue(of(mockThreadDump as ThreadDump));
-        expect(comp.updatingMetrics).toBe(true);
+        expect(comp.updatingMetrics).toBeTrue();
         comp.ngOnInit();
-        expect(service.getMetrics).toHaveBeenCalledTimes(1);
-        expect(service.threadDump).toHaveBeenCalledTimes(1);
+        expect(service.getMetrics).toHaveBeenCalledOnce();
+        expect(service.threadDump).toHaveBeenCalledOnce();
         expect(comp.updatingMetrics).toBe(false);
         expect(comp.metrics).toEqual(mockMetrics);
         expect(comp.threads).toEqual(mockThreadDump.threads);
@@ -50,7 +50,7 @@ describe('MetricsComponent', () => {
         comp.metrics = {
             cache: {},
         } as any as Metrics;
-        expect(comp.metricsKeyExists('cache')).toBe(true);
+        expect(comp.metricsKeyExists('cache')).toBeTrue();
     });
 
     it('metricsKeyExistsAndObjectNotEmpty method should work correctly', () => {
@@ -67,6 +67,6 @@ describe('MetricsComponent', () => {
         comp.metrics = {
             cache: { randomKey: {} },
         } as any as Metrics;
-        expect(comp.metricsKeyExistsAndObjectNotEmpty('cache')).toBe(true);
+        expect(comp.metricsKeyExistsAndObjectNotEmpty('cache')).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/admin/metrics/metrics.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/metrics/metrics.component.spec.ts
@@ -33,19 +33,19 @@ describe('MetricsComponent', () => {
         comp.ngOnInit();
         expect(service.getMetrics).toHaveBeenCalledOnce();
         expect(service.threadDump).toHaveBeenCalledOnce();
-        expect(comp.updatingMetrics).toBe(false);
+        expect(comp.updatingMetrics).toBeFalse();
         expect(comp.metrics).toEqual(mockMetrics);
         expect(comp.threads).toEqual(mockThreadDump.threads);
     });
 
     it('metricsKeyExists method should work correctly', () => {
         comp.metrics = {} as any as Metrics;
-        expect(comp.metricsKeyExists('cache')).toBe(false);
+        expect(comp.metricsKeyExists('cache')).toBeFalse();
 
         comp.metrics = {
             cache: undefined,
         } as any as Metrics;
-        expect(comp.metricsKeyExists('cache')).toBe(false);
+        expect(comp.metricsKeyExists('cache')).toBeFalse();
 
         comp.metrics = {
             cache: {},
@@ -57,12 +57,12 @@ describe('MetricsComponent', () => {
         comp.metrics = {
             cache: undefined,
         } as any as Metrics;
-        expect(comp.metricsKeyExistsAndObjectNotEmpty('cache')).toBe(false);
+        expect(comp.metricsKeyExistsAndObjectNotEmpty('cache')).toBeFalse();
 
         comp.metrics = {
             cache: {},
         } as any as Metrics;
-        expect(comp.metricsKeyExistsAndObjectNotEmpty('cache')).toBe(false);
+        expect(comp.metricsKeyExistsAndObjectNotEmpty('cache')).toBeFalse();
 
         comp.metrics = {
             cache: { randomKey: {} },

--- a/src/test/javascript/spec/component/admin/system-notification-management/system-notification-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/system-notification-management/system-notification-detail.component.spec.ts
@@ -53,7 +53,7 @@ describe('SystemNotificationManagementDetailComponent', () => {
     it('should initialize', () => {
         const dataSpy = jest.spyOn(route.data, 'subscribe');
         detailComponentFixture.detectChanges();
-        expect(dataSpy).toHaveBeenCalledTimes(1);
+        expect(dataSpy).toHaveBeenCalledOnce();
     });
 
     it('should navigate to edit if edit is clicked', fakeAsync(() => {
@@ -63,7 +63,7 @@ describe('SystemNotificationManagementDetailComponent', () => {
         button.click();
 
         tick();
-        expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
+        expect(router.navigateByUrl).toHaveBeenCalledOnce();
         const navigationArray = router.navigateByUrl.mock.calls[0][0];
         expect(navigationArray).toEqual(['edit']);
     }));

--- a/src/test/javascript/spec/component/admin/system-notification-management/system-notification-management-resolve.service.spec.ts
+++ b/src/test/javascript/spec/component/admin/system-notification-management/system-notification-management-resolve.service.spec.ts
@@ -22,7 +22,7 @@ describe('SystemNotificationManagementResolveService', () => {
         // @ts-ignore
         systemNotificationManagementResolve.resolve({ params: { id: '1' } } as any as ActivatedRouteSnapshot).subscribe((noti) => (result = noti));
         expect(result).toBe(toReturn.body);
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
         expect(spy).toHaveBeenCalledWith(1);
     });
 

--- a/src/test/javascript/spec/component/admin/system-notification-management/system-notification-management.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/system-notification-management/system-notification-management.component.spec.ts
@@ -71,7 +71,7 @@ describe('SystemNotificationManagementComponent', () => {
         button.click();
 
         tick();
-        expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
+        expect(router.navigateByUrl).toHaveBeenCalledOnce();
         expect(router.navigateByUrl.mock.calls[0][0]).toEqual(['./', notification.id]);
     }));
 
@@ -87,14 +87,14 @@ describe('SystemNotificationManagementComponent', () => {
         button.click();
 
         tick();
-        expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
+        expect(router.navigateByUrl).toHaveBeenCalledOnce();
         expect(router.navigateByUrl.mock.calls[0][0]).toEqual(['./', notification.id, 'edit']);
     }));
 
     it('should unsubscribe on destroy', () => {
         const routeDataSpy = jest.spyOn(managementComponent.routeData, 'unsubscribe');
         managementComponentFixture.destroy();
-        expect(routeDataSpy).toHaveBeenCalledTimes(1);
+        expect(routeDataSpy).toHaveBeenCalledOnce();
     });
 
     it('should transition on page change', fakeAsync(() => {

--- a/src/test/javascript/spec/component/admin/system-notification-management/system-notification-update.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/system-notification-management/system-notification-update.component.spec.ts
@@ -54,7 +54,7 @@ describe('SystemNotificationManagementUpdateComponent', () => {
         button.click();
 
         tick();
-        expect(previousStateSpy).toHaveBeenCalledTimes(1);
+        expect(previousStateSpy).toHaveBeenCalledOnce();
     }));
 
     it('should update if save is clicked', fakeAsync(() => {
@@ -66,7 +66,7 @@ describe('SystemNotificationManagementUpdateComponent', () => {
         button.click();
 
         tick();
-        expect(saveSpy).toHaveBeenCalledTimes(1);
+        expect(saveSpy).toHaveBeenCalledOnce();
     }));
 
     it('should create if save is clicked', fakeAsync(() => {
@@ -82,6 +82,6 @@ describe('SystemNotificationManagementUpdateComponent', () => {
         button.click();
 
         tick();
-        expect(saveSpy).toHaveBeenCalledTimes(1);
+        expect(saveSpy).toHaveBeenCalledOnce();
     }));
 });

--- a/src/test/javascript/spec/component/admin/user-management-resolve.service.spec.ts
+++ b/src/test/javascript/spec/component/admin/user-management-resolve.service.spec.ts
@@ -22,7 +22,7 @@ describe('UserManagementResolve', () => {
         returned.subscribe((user) => (returnedUser = user));
 
         expect(returnedUser).toBe(mockReturnUser);
-        expect(userService.find).toHaveBeenCalledTimes(1);
+        expect(userService.find).toHaveBeenCalledOnce();
         expect(userService.find).toHaveBeenCalledWith('test123');
     });
 

--- a/src/test/javascript/spec/component/admin/user-management-update.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/user-management-update.component.spec.ts
@@ -108,7 +108,7 @@ describe('User Management Update Component', () => {
                 comp.ngOnInit();
 
                 // THEN
-                expect(getAllSpy).toHaveBeenCalledTimes(1);
+                expect(getAllSpy).toHaveBeenCalledOnce();
                 expect(comp.languages).toEqual(LANGUAGES);
             }),
         ));
@@ -142,8 +142,8 @@ describe('User Management Update Component', () => {
                 translateService.use('en');
 
                 // THEN
-                expect(updateTitleSpy).toHaveBeenCalledTimes(1);
-                expect(setTitleOnTitleServiceSpy).toHaveBeenCalledTimes(1);
+                expect(updateTitleSpy).toHaveBeenCalledOnce();
+                expect(setTitleOnTitleServiceSpy).toHaveBeenCalledOnce();
                 expect(setTitleOnTitleServiceSpy).toHaveBeenCalledWith('artemisApp');
             }),
         ));
@@ -221,7 +221,7 @@ describe('User Management Update Component', () => {
 
         comp.openOrganizationsModal();
 
-        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(openSpy).toHaveBeenCalledOnce();
         expect(openSpy).toHaveBeenCalledWith(OrganizationSelectorComponent, { size: 'xl', backdrop: 'static' });
         expect(modalRef.componentInstance.organizations).toBe(orgs);
 
@@ -252,8 +252,8 @@ describe('User Management Update Component', () => {
         comp.onGroupAdd(comp.user, event);
 
         expect(comp.user.groups).toEqual([newGroup]);
-        expect(event.chipInput!.clear).toHaveBeenCalledTimes(1);
-        expect(groupCtrlSetValueSpy).toHaveBeenCalledTimes(1);
+        expect(event.chipInput!.clear).toHaveBeenCalledOnce();
+        expect(groupCtrlSetValueSpy).toHaveBeenCalledOnce();
         expect(groupCtrlSetValueSpy).toHaveBeenCalledWith(null);
     });
 });

--- a/src/test/javascript/spec/component/admin/user-management-update.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/user-management-update.component.spec.ts
@@ -196,7 +196,7 @@ describe('User Management Update Component', () => {
         comp.isSaving = true;
         // @ts-ignore
         comp.onSaveError();
-        expect(comp.isSaving).toBe(false);
+        expect(comp.isSaving).toBeFalse();
     });
 
     it('should set password to undefined if random password should be used', () => {

--- a/src/test/javascript/spec/component/admin/user-management.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/user-management.component.spec.ts
@@ -101,7 +101,7 @@ describe('UserManagementComponent', () => {
         expect(comp.users).toHaveLength(1);
         expect(comp.users[0].id).toBe(1);
         expect(comp.totalItems).toBe(1);
-        expect(comp.loadingSearchResult).toBe(false);
+        expect(comp.loadingSearchResult).toBeFalse();
     }));
 
     describe('setActive', () => {

--- a/src/test/javascript/spec/component/admin/user-management.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/user-management.component.spec.ts
@@ -127,7 +127,7 @@ describe('UserManagementComponent', () => {
 
                 // THEN
                 expect(userService.update).toHaveBeenCalledWith({ ...user, activated: true });
-                expect(userService.query).toHaveBeenCalledTimes(1);
+                expect(userService.query).toHaveBeenCalledOnce();
                 expect(comp.users && comp.users[0]).toEqual(expect.objectContaining({ id: 123 }));
             }),
         ));
@@ -146,14 +146,14 @@ describe('UserManagementComponent', () => {
         comp.ngOnInit();
         tick(1000);
 
-        expect(identitySpy).toHaveBeenCalledTimes(1);
+        expect(identitySpy).toHaveBeenCalledOnce();
         expect(comp.currentAccount).toEqual({ id: 99 });
 
         expect(comp.page).toBe(1);
         expect(comp.predicate).toBe('id');
-        expect(comp.ascending).toBe(true);
+        expect(comp.ascending).toBeTrue();
 
-        expect(querySpy).toHaveBeenCalledTimes(1);
+        expect(querySpy).toHaveBeenCalledOnce();
     }));
 
     it('should destroy the user list subscription on destroy', () => {
@@ -162,7 +162,7 @@ describe('UserManagementComponent', () => {
 
         const destroySpy = jest.spyOn(eventManager, 'destroy').mockImplementation(jest.fn());
         comp.ngOnDestroy();
-        expect(destroySpy).toHaveBeenCalledTimes(1);
+        expect(destroySpy).toHaveBeenCalledOnce();
         expect(destroySpy).toHaveBeenCalledWith(object);
     });
 
@@ -181,13 +181,13 @@ describe('UserManagementComponent', () => {
         comp.dialogError.subscribe((text) => (errorText = text));
 
         comp.deleteUser('test');
-        expect(deleteSpy).toHaveBeenCalledTimes(1);
+        expect(deleteSpy).toHaveBeenCalledOnce();
         expect(deleteSpy).toHaveBeenCalledWith('test');
         const reqD = httpMock.expectOne(SERVER_API_URL + 'api/users/test');
         reqD.flush(null, { status, statusText });
 
         if (status === 200) {
-            expect(broadcastSpy).toHaveBeenCalledTimes(1);
+            expect(broadcastSpy).toHaveBeenCalledOnce();
             expect(broadcastSpy).toHaveBeenCalledWith({ name: 'userListModification', content: 'Deleted a user' });
         } else {
             expect(broadcastSpy).not.toHaveBeenCalled();

--- a/src/test/javascript/spec/component/assessment-dashboard/assessment-dashboard-information.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/assessment-dashboard-information.component.spec.ts
@@ -49,9 +49,9 @@ describe('AssessmentDashboardInformationComponent', () => {
 
         component.ngOnInit();
 
-        expect(setupSpy).toHaveBeenCalledTimes(1);
-        expect(setupLinksSpy).toHaveBeenCalledTimes(1);
-        expect(setupGraphSpy).toHaveBeenCalledTimes(1);
+        expect(setupSpy).toHaveBeenCalledOnce();
+        expect(setupLinksSpy).toHaveBeenCalledOnce();
+        expect(setupGraphSpy).toHaveBeenCalledOnce();
 
         expect(component.customColors[0].name).toBe('artemisApp.exerciseAssessmentDashboard.openAssessments');
         expect(component.customColors[1].name).toBe('artemisApp.exerciseAssessmentDashboard.closedAssessments');

--- a/src/test/javascript/spec/component/assessment-dashboard/assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/assessment-dashboard.component.spec.ts
@@ -211,11 +211,11 @@ describe('AssessmentDashboardInformationComponent', () => {
         expect(comp.isExamMode).toBeTrue();
         expect(comp.courseId).toBe(10);
         expect(comp.examId).toBe(20);
-        expect(comp.isTestRun).toBe(false);
+        expect(comp.isTestRun).toBeFalse();
         expect(getExamWithInterestingExercisesForAssessmentDashboardStub).toHaveBeenCalledOnce();
         expect(getStatsForExamAssessmentDashboardStub).toHaveBeenCalledOnce();
         expect(comp.exam).toEqual(exam);
-        expect(comp.hideFinishedExercises).toBe(false);
+        expect(comp.hideFinishedExercises).toBeFalse();
         expect(comp.allExercises).toHaveLength(4);
         expect(comp.currentlyShownExercises).toHaveLength(4);
     }));
@@ -234,7 +234,7 @@ describe('AssessmentDashboardInformationComponent', () => {
         comp.ngOnInit();
         tick();
 
-        expect(comp.isExamMode).toBe(false);
+        expect(comp.isExamMode).toBeFalse();
         expect(comp.courseId).toBe(10);
         expect(comp.examId).toBe(0);
         expect(getCourseWithInterestingExercisesForTutorsStub).toHaveBeenCalledOnce();
@@ -252,7 +252,7 @@ describe('AssessmentDashboardInformationComponent', () => {
         expect(comp.currentlyShownExercises.find((exercise) => exercise.id === fileUploadExercise.id!)!.secondCorrectionEnabled).toBeTrue();
         toggleSecondCorrectionStub.mockReturnValue(of(false));
         comp.toggleSecondCorrection(fileUploadExercise.id!);
-        expect(comp.currentlyShownExercises.find((exercise) => exercise.id === fileUploadExercise.id!)!.secondCorrectionEnabled).toBe(false);
+        expect(comp.currentlyShownExercises.find((exercise) => exercise.id === fileUploadExercise.id!)!.secondCorrectionEnabled).toBeFalse();
     });
 
     it('should update exercises when finished exercises are filtered', () => {
@@ -390,9 +390,9 @@ describe('AssessmentDashboardInformationComponent', () => {
                     const ratingCheckerA = new TutorIssueRatingChecker(1, 3, 0, tutorName, tutorId);
                     const ratingCheckerB = new TutorIssueRatingChecker(1, 3.2, 4, tutorName, tutorId);
                     const ratingCheckerC = new TutorIssueRatingChecker(1, 5, 3, tutorName, tutorId);
-                    expect(ratingCheckerA.isPerformanceIssue).toBe(false);
-                    expect(ratingCheckerB.isPerformanceIssue).toBe(false);
-                    expect(ratingCheckerC.isPerformanceIssue).toBe(false);
+                    expect(ratingCheckerA.isPerformanceIssue).toBeFalse();
+                    expect(ratingCheckerB.isPerformanceIssue).toBeFalse();
+                    expect(ratingCheckerC.isPerformanceIssue).toBeFalse();
                 });
             });
 
@@ -410,10 +410,10 @@ describe('AssessmentDashboardInformationComponent', () => {
                     const ratingCheckerB = new TutorIssueScoreChecker(1, 66, 80, tutorName, tutorId);
                     const ratingCheckerC = new TutorIssueScoreChecker(1, 90, 80, tutorName, tutorId);
                     const ratingCheckerD = new TutorIssueScoreChecker(1, 96.009, 80, tutorName, tutorId);
-                    expect(ratingCheckerA.isPerformanceIssue).toBe(false);
-                    expect(ratingCheckerB.isPerformanceIssue).toBe(false);
-                    expect(ratingCheckerC.isPerformanceIssue).toBe(false);
-                    expect(ratingCheckerD.isPerformanceIssue).toBe(false);
+                    expect(ratingCheckerA.isPerformanceIssue).toBeFalse();
+                    expect(ratingCheckerB.isPerformanceIssue).toBeFalse();
+                    expect(ratingCheckerC.isPerformanceIssue).toBeFalse();
+                    expect(ratingCheckerD.isPerformanceIssue).toBeFalse();
                 });
             });
 
@@ -431,10 +431,10 @@ describe('AssessmentDashboardInformationComponent', () => {
                     const ratingCheckerB = new TutorIssueComplaintsChecker(1, 8, 10, tutorName, tutorId);
                     const ratingCheckerC = new TutorIssueComplaintsChecker(1, 0, 10, tutorName, tutorId);
                     const ratingCheckerD = new TutorIssueComplaintsChecker(1, 12.001, 10, tutorName, tutorId);
-                    expect(ratingCheckerA.isPerformanceIssue).toBe(false);
-                    expect(ratingCheckerB.isPerformanceIssue).toBe(false);
-                    expect(ratingCheckerC.isPerformanceIssue).toBe(false);
-                    expect(ratingCheckerD.isPerformanceIssue).toBe(false);
+                    expect(ratingCheckerA.isPerformanceIssue).toBeFalse();
+                    expect(ratingCheckerB.isPerformanceIssue).toBeFalse();
+                    expect(ratingCheckerC.isPerformanceIssue).toBeFalse();
+                    expect(ratingCheckerD.isPerformanceIssue).toBeFalse();
                 });
             });
         });

--- a/src/test/javascript/spec/component/assessment-dashboard/assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/assessment-dashboard.component.spec.ts
@@ -208,12 +208,12 @@ describe('AssessmentDashboardInformationComponent', () => {
         comp.ngOnInit();
         tick();
 
-        expect(comp.isExamMode).toBe(true);
+        expect(comp.isExamMode).toBeTrue();
         expect(comp.courseId).toBe(10);
         expect(comp.examId).toBe(20);
         expect(comp.isTestRun).toBe(false);
-        expect(getExamWithInterestingExercisesForAssessmentDashboardStub).toHaveBeenCalledTimes(1);
-        expect(getStatsForExamAssessmentDashboardStub).toHaveBeenCalledTimes(1);
+        expect(getExamWithInterestingExercisesForAssessmentDashboardStub).toHaveBeenCalledOnce();
+        expect(getStatsForExamAssessmentDashboardStub).toHaveBeenCalledOnce();
         expect(comp.exam).toEqual(exam);
         expect(comp.hideFinishedExercises).toBe(false);
         expect(comp.allExercises).toHaveLength(4);
@@ -237,8 +237,8 @@ describe('AssessmentDashboardInformationComponent', () => {
         expect(comp.isExamMode).toBe(false);
         expect(comp.courseId).toBe(10);
         expect(comp.examId).toBe(0);
-        expect(getCourseWithInterestingExercisesForTutorsStub).toHaveBeenCalledTimes(1);
-        expect(getStatsForTutorsStub).toHaveBeenCalledTimes(1);
+        expect(getCourseWithInterestingExercisesForTutorsStub).toHaveBeenCalledOnce();
+        expect(getStatsForTutorsStub).toHaveBeenCalledOnce();
         expect(comp.course).toEqual(Course.from(course));
         expect(comp.allExercises).toHaveLength(5);
         expect(comp.currentlyShownExercises).toHaveLength(4);
@@ -249,7 +249,7 @@ describe('AssessmentDashboardInformationComponent', () => {
         const toggleSecondCorrectionStub = jest.spyOn(exerciseService, 'toggleSecondCorrection');
         toggleSecondCorrectionStub.mockReturnValue(of(true));
         comp.toggleSecondCorrection(fileUploadExercise.id!);
-        expect(comp.currentlyShownExercises.find((exercise) => exercise.id === fileUploadExercise.id!)!.secondCorrectionEnabled).toBe(true);
+        expect(comp.currentlyShownExercises.find((exercise) => exercise.id === fileUploadExercise.id!)!.secondCorrectionEnabled).toBeTrue();
         toggleSecondCorrectionStub.mockReturnValue(of(false));
         comp.toggleSecondCorrection(fileUploadExercise.id!);
         expect(comp.currentlyShownExercises.find((exercise) => exercise.id === fileUploadExercise.id!)!.secondCorrectionEnabled).toBe(false);
@@ -281,7 +281,7 @@ describe('AssessmentDashboardInformationComponent', () => {
 
         comp.sortRows();
 
-        expect(sortServiceSpy).toHaveBeenCalledTimes(1);
+        expect(sortServiceSpy).toHaveBeenCalledOnce();
         expect(sortServiceSpy).toHaveBeenCalledWith([textExercise], 'assessmentDueDate', false);
     });
 
@@ -367,9 +367,9 @@ describe('AssessmentDashboardInformationComponent', () => {
 
                 // then
                 expect(comp.tutorIssues).toHaveLength(4);
-                expect(comp.stats.tutorLeaderboardEntries[0].hasIssuesWithPerformance).toBe(true); // rating
-                expect(comp.stats.tutorLeaderboardEntries[1].hasIssuesWithPerformance).toBe(true); // complaints, score
-                expect(comp.stats.tutorLeaderboardEntries[2].hasIssuesWithPerformance).toBe(true); // score
+                expect(comp.stats.tutorLeaderboardEntries[0].hasIssuesWithPerformance).toBeTrue(); // rating
+                expect(comp.stats.tutorLeaderboardEntries[1].hasIssuesWithPerformance).toBeTrue(); // complaints, score
+                expect(comp.stats.tutorLeaderboardEntries[2].hasIssuesWithPerformance).toBeTrue(); // score
             });
         });
 
@@ -383,7 +383,7 @@ describe('AssessmentDashboardInformationComponent', () => {
                     const tutorAverageValue = 2.25;
                     const courseAverageValue = 4;
                     const ratingChecker = new TutorIssueRatingChecker(ratingsCount, tutorAverageValue, courseAverageValue, tutorName, tutorId);
-                    expect(ratingChecker.isPerformanceIssue).toBe(true);
+                    expect(ratingChecker.isPerformanceIssue).toBeTrue();
                 });
 
                 it('tutors value is within allowed range', () => {
@@ -402,7 +402,7 @@ describe('AssessmentDashboardInformationComponent', () => {
                     const tutorAverageValue = 40;
                     const courseAverageValue = 80;
                     const ratingChecker = new TutorIssueScoreChecker(submissionsCount, tutorAverageValue, courseAverageValue, tutorName, tutorId);
-                    expect(ratingChecker.isPerformanceIssue).toBe(true);
+                    expect(ratingChecker.isPerformanceIssue).toBeTrue();
                 });
 
                 it('tutors value is within allowed range', () => {
@@ -423,7 +423,7 @@ describe('AssessmentDashboardInformationComponent', () => {
                     const tutorAverageValue = 14;
                     const courseAverageValue = 10;
                     const ratingChecker = new TutorIssueComplaintsChecker(submissionsCount, tutorAverageValue, courseAverageValue, tutorName, tutorId);
-                    expect(ratingChecker.isPerformanceIssue).toBe(true);
+                    expect(ratingChecker.isPerformanceIssue).toBeTrue();
                 });
 
                 it('tutors value is within allowed range', () => {

--- a/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
@@ -350,7 +350,7 @@ describe('ExerciseAssessmentDashboardComponent', () => {
         const setupGraphSpy = jest.spyOn(comp, 'setupGraph');
 
         translateService.use('en'); // Change language.
-        expect(setupGraphSpy).toHaveBeenCalledTimes(1);
+        expect(setupGraphSpy).toHaveBeenCalledOnce();
     }));
 
     it('should initialize with tutor leaderboard entry', () => {
@@ -381,7 +381,7 @@ describe('ExerciseAssessmentDashboardComponent', () => {
         const setupGraphSpy = jest.spyOn(comp, 'setupGraph');
 
         translateService.use('en'); // Change language.
-        expect(setupGraphSpy).toHaveBeenCalledTimes(1);
+        expect(setupGraphSpy).toHaveBeenCalledOnce();
     });
 
     it('should set unassessedSubmission if lock limit is not reached', () => {
@@ -413,7 +413,7 @@ describe('ExerciseAssessmentDashboardComponent', () => {
         expect(modelingSubmissionStubWithoutAssessment).toHaveBeenNthCalledWith(2, modelingExercise.id, undefined, 1);
 
         expect(comp.unassessedSubmissionByCorrectionRound?.get(1)).toBe(undefined);
-        expect(comp.submissionLockLimitReached).toBe(true);
+        expect(comp.submissionLockLimitReached).toBeTrue();
         expect(comp.submissionsByCorrectionRound?.get(1)).toHaveLength(0);
     });
 
@@ -470,19 +470,19 @@ describe('ExerciseAssessmentDashboardComponent', () => {
 
     it('should calculateStatus DRAFT', () => {
         expect(modelingSubmission.latestResult).toBe(undefined);
-        expect(comp.calculateSubmissionStatusIsDraft(modelingSubmission)).toBe(true);
+        expect(comp.calculateSubmissionStatusIsDraft(modelingSubmission)).toBeTrue();
     });
 
     it('should call hasBeenCompletedByTutor', () => {
         comp.exampleSubmissionsCompletedByTutor = [{ id: 1 }, { id: 2 }];
-        expect(comp.hasBeenCompletedByTutor(1)).toBe(true);
+        expect(comp.hasBeenCompletedByTutor(1)).toBeTrue();
     });
 
     it('should call readInstruction', () => {
         const tutorParticipationServiceCreateStub = jest.spyOn(tutorParticipationService, 'create');
         const tutorParticipation = { id: 1, status: TutorParticipationStatus.REVIEWED_INSTRUCTIONS };
         tutorParticipationServiceCreateStub.mockImplementation(() => {
-            expect(comp.isLoading).toBe(true);
+            expect(comp.isLoading).toBeTrue();
             return of(new HttpResponse({ body: tutorParticipation, headers: new HttpHeaders() }));
         });
 
@@ -792,7 +792,7 @@ describe('ExerciseAssessmentDashboardComponent', () => {
 
         fixture.detectChanges();
 
-        expect(sortMoreFeedbackRowsSpy).toHaveBeenCalledTimes(1);
+        expect(sortMoreFeedbackRowsSpy).toHaveBeenCalledOnce();
 
         submissionServiceSpy.mockReturnValue(throwError(() => errorResponse));
 
@@ -804,7 +804,7 @@ describe('ExerciseAssessmentDashboardComponent', () => {
 
         comp.loadAll();
 
-        expect(alertServiceSpy).toHaveBeenCalledTimes(1);
+        expect(alertServiceSpy).toHaveBeenCalledOnce();
         expect(alertServiceSpy).toHaveBeenCalledWith('error.http.400');
     });
 

--- a/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/exercise-assessment-dashboard.component.spec.ts
@@ -398,7 +398,7 @@ describe('ExerciseAssessmentDashboardComponent', () => {
 
         expect(comp.unassessedSubmissionByCorrectionRound?.get(0)).toEqual(modelingSubmission);
         expect(comp.unassessedSubmissionByCorrectionRound?.get(0)?.latestResult).toBe(undefined);
-        expect(comp.submissionLockLimitReached).toBe(false);
+        expect(comp.submissionLockLimitReached).toBeFalse();
         expect(comp.submissionsByCorrectionRound?.get(0)).toHaveLength(0);
     });
 
@@ -487,11 +487,11 @@ describe('ExerciseAssessmentDashboardComponent', () => {
         });
 
         expect(comp.tutorParticipation).toBe(undefined);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
 
         comp.readInstruction();
 
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
 
         expect(comp.tutorParticipation).toEqual(tutorParticipation);
         expect(comp.tutorParticipationStatus).toEqual(TutorParticipationStatus.REVIEWED_INSTRUCTIONS);
@@ -768,7 +768,7 @@ describe('ExerciseAssessmentDashboardComponent', () => {
 
         comp.toggleSecondCorrection();
 
-        expect(comp.togglingSecondCorrectionButton).toBe(false);
+        expect(comp.togglingSecondCorrectionButton).toBeFalse();
         expect(comp.secondCorrectionEnabled).toBe(secondCorrectionEnabled);
         expect(comp.numberOfCorrectionRoundsEnabled).toBe(2);
     });

--- a/src/test/javascript/spec/component/assessment-dashboard/tutor-participation-graph.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-dashboard/tutor-participation-graph.component.spec.ts
@@ -161,8 +161,8 @@ describe('TutorParticipationGraphComponent', () => {
 
         comp.ngOnInit();
 
-        expect(calculatePercentageAssessmentProgressStub).toHaveBeenCalledTimes(1);
-        expect(calculatePercentageComplaintsProgressStub).toHaveBeenCalledTimes(1);
+        expect(calculatePercentageAssessmentProgressStub).toHaveBeenCalledOnce();
+        expect(calculatePercentageComplaintsProgressStub).toHaveBeenCalledOnce();
 
         calculatePercentageAssessmentProgressStub.mockRestore();
         calculatePercentageComplaintsProgressStub.mockRestore();

--- a/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assesment-filter-component.spec.ts
@@ -56,7 +56,7 @@ describe('AssessmentFiltersComponent', () => {
         component.updateFilter(component.FilterProp.LOCKED);
         expect(component.filterProp).toBe(component.FilterProp.LOCKED);
         expect(component.submissions).toBe(submissions);
-        expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledOnce();
         expect(emitSpy).toHaveBeenCalledWith(expectedResult);
     });
 });

--- a/src/test/javascript/spec/component/assessment-shared/assessment-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-detail.component.spec.ts
@@ -70,7 +70,7 @@ describe('Assessment Detail Component', () => {
         comp.delete();
         fixture.detectChanges();
 
-        expect(emitSpy).toHaveBeenCalledTimes(1);
-        expect(confirmStub).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledOnce();
+        expect(confirmStub).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/assessment-shared/assessment-header.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-header.component.spec.ts
@@ -170,16 +170,16 @@ describe('AssessmentHeaderComponent', () => {
 
         jest.spyOn(component.save, 'emit');
         saveButtonSpan.nativeElement.click();
-        expect(component.save.emit).toHaveBeenCalledTimes(1);
+        expect(component.save.emit).toHaveBeenCalledOnce();
 
         jest.spyOn(component.submit, 'emit');
         submitButtonSpan.nativeElement.click();
-        expect(component.submit.emit).toHaveBeenCalledTimes(1);
+        expect(component.submit.emit).toHaveBeenCalledOnce();
 
         const cancelButtonSpan = fixture.debugElement.query(By.css('[jhiTranslate$=cancel]'));
         jest.spyOn(component.cancel, 'emit');
         cancelButtonSpan.nativeElement.click();
-        expect(component.cancel.emit).toHaveBeenCalledTimes(1);
+        expect(component.cancel.emit).toHaveBeenCalledOnce();
     });
 
     it('should show override button when result is present', () => {
@@ -204,7 +204,7 @@ describe('AssessmentHeaderComponent', () => {
 
         jest.spyOn(component.submit, 'emit');
         overrideAssessmentButtonSpan.nativeElement.click();
-        expect(component.submit.emit).toHaveBeenCalledTimes(1);
+        expect(component.submit.emit).toHaveBeenCalledOnce();
     });
 
     it('should show next submission if assessor or instructor, result is present and no complaint', () => {
@@ -259,7 +259,7 @@ describe('AssessmentHeaderComponent', () => {
         fixture.detectChanges();
         nextSubmissionButtonSpan = fixture.debugElement.query(By.css('[jhiTranslate$=nextSubmission]'));
         nextSubmissionButtonSpan.nativeElement.click();
-        expect(component.nextSubmission.emit).toHaveBeenCalledTimes(1);
+        expect(component.nextSubmission.emit).toHaveBeenCalledOnce();
     });
     it('should not show assess next button if is test run mode', () => {
         component.isTestRun = true;
@@ -343,8 +343,8 @@ describe('AssessmentHeaderComponent', () => {
         const saveSpy = jest.spyOn(component.save, 'emit');
         document.dispatchEvent(eventMock);
 
-        expect(spyOnControlAndS).toHaveBeenCalledTimes(1);
-        expect(saveSpy).toHaveBeenCalledTimes(1);
+        expect(spyOnControlAndS).toHaveBeenCalledOnce();
+        expect(saveSpy).toHaveBeenCalledOnce();
     });
 
     it('should submit assessment on control and enter', () => {
@@ -361,8 +361,8 @@ describe('AssessmentHeaderComponent', () => {
         const submitSpy = jest.spyOn(component.submit, 'emit');
         document.dispatchEvent(eventMock);
 
-        expect(spyOnControlAndEnter).toHaveBeenCalledTimes(1);
-        expect(submitSpy).toHaveBeenCalledTimes(1);
+        expect(spyOnControlAndEnter).toHaveBeenCalledOnce();
+        expect(submitSpy).toHaveBeenCalledOnce();
     });
 
     it('should override assessment on control and enter', () => {
@@ -378,8 +378,8 @@ describe('AssessmentHeaderComponent', () => {
         const submitSpy = jest.spyOn(component.submit, 'emit');
         document.dispatchEvent(eventMock);
 
-        expect(spyOnControlAndEnter).toHaveBeenCalledTimes(1);
-        expect(submitSpy).toHaveBeenCalledTimes(1);
+        expect(spyOnControlAndEnter).toHaveBeenCalledOnce();
+        expect(submitSpy).toHaveBeenCalledOnce();
     });
 
     it('should assess next submission on control, shift and arrow right', () => {
@@ -395,7 +395,7 @@ describe('AssessmentHeaderComponent', () => {
         const nextSpy = jest.spyOn(component.nextSubmission, 'emit');
         document.dispatchEvent(eventMock);
 
-        expect(spyOnControlShiftAndArrowRight).toHaveBeenCalledTimes(1);
-        expect(nextSpy).toHaveBeenCalledTimes(1);
+        expect(spyOnControlShiftAndArrowRight).toHaveBeenCalledOnce();
+        expect(nextSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/assessment-shared/assessment-locks.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-locks.component.spec.ts
@@ -77,34 +77,34 @@ describe('AssessmentLocksComponent', () => {
     it('should call getAllLockedSubmissions on init', () => {
         const courseServiceStub = jest.spyOn(courseService, 'findAllLockedSubmissionsOfCourse').mockReturnValue(of());
         component.ngOnInit();
-        expect(courseServiceStub).toHaveBeenCalledTimes(1);
+        expect(courseServiceStub).toHaveBeenCalledOnce();
     });
 
     it('should release lock for programming exercise', () => {
         const cancelAssessmentStub = jest.spyOn(programmingAssessmentService, 'cancelAssessment').mockReturnValue(of());
         component.cancelAssessment(programmingSubmission);
         expect(windowConfirmStub).toBeCalledTimes(1);
-        expect(cancelAssessmentStub).toHaveBeenCalledTimes(1);
+        expect(cancelAssessmentStub).toHaveBeenCalledOnce();
     });
 
     it('should release lock for modeling exercise', () => {
         const cancelAssessmentStub = jest.spyOn(modelingAssessmentService, 'cancelAssessment').mockReturnValue(of());
         component.cancelAssessment(modelingSubmission);
         expect(windowConfirmStub).toBeCalledTimes(1);
-        expect(cancelAssessmentStub).toHaveBeenCalledTimes(1);
+        expect(cancelAssessmentStub).toHaveBeenCalledOnce();
     });
 
     it('should release lock for text exercise', () => {
         const cancelAssessmentStub = jest.spyOn(textAssessmentService, 'cancelAssessment').mockReturnValue(of());
         component.cancelAssessment(textSubmission);
         expect(windowConfirmStub).toBeCalledTimes(1);
-        expect(cancelAssessmentStub).toHaveBeenCalledTimes(1);
+        expect(cancelAssessmentStub).toHaveBeenCalledOnce();
     });
 
     it('should release lock for the file upload exercise', () => {
         const cancelAssessmentStub = jest.spyOn(fileUploadAssessmentService, 'cancelAssessment').mockReturnValue(of());
         component.cancelAssessment(fileUploadSubmission);
         expect(windowConfirmStub).toBeCalledTimes(1);
-        expect(cancelAssessmentStub).toHaveBeenCalledTimes(1);
+        expect(cancelAssessmentStub).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/assessment-shared/assessment-warning.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-warning.component.spec.ts
@@ -39,8 +39,8 @@ describe('AssessmentWarningComponent', function () {
 
         component.ngOnChanges();
 
-        expect(component.isBeforeExerciseDueDate).toBe(true);
-        expect(component.isBeforeLatestDueDate).toBe(true);
+        expect(component.isBeforeExerciseDueDate).toBeTrue();
+        expect(component.isBeforeLatestDueDate).toBeTrue();
     });
 
     it('should be before the latest due date if the exercise due date is in the past but individual due dates in the future', () => {
@@ -70,6 +70,6 @@ describe('AssessmentWarningComponent', function () {
         component.ngOnChanges();
 
         expect(component.isBeforeExerciseDueDate).toBe(false);
-        expect(component.isBeforeLatestDueDate).toBe(true);
+        expect(component.isBeforeLatestDueDate).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/assessment-shared/assessment-warning.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/assessment-warning.component.spec.ts
@@ -28,8 +28,8 @@ describe('AssessmentWarningComponent', function () {
 
         component.ngOnChanges();
 
-        expect(component.isBeforeExerciseDueDate).toBe(false);
-        expect(component.isBeforeLatestDueDate).toBe(false);
+        expect(component.isBeforeExerciseDueDate).toBeFalse();
+        expect(component.isBeforeLatestDueDate).toBeFalse();
     });
 
     it('should be before the exercise due date if the exercise due date is in the future', () => {
@@ -69,7 +69,7 @@ describe('AssessmentWarningComponent', function () {
         component.submissions = [submission2, submission4, submission3, submission1];
         component.ngOnChanges();
 
-        expect(component.isBeforeExerciseDueDate).toBe(false);
+        expect(component.isBeforeExerciseDueDate).toBeFalse();
         expect(component.isBeforeLatestDueDate).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/assessment-shared/structured-grading-instructions-assessment-layout.component.spec.ts
+++ b/src/test/javascript/spec/component/assessment-shared/structured-grading-instructions-assessment-layout.component.spec.ts
@@ -25,8 +25,8 @@ describe('StructuredGradingInstructionsAssessmentLayoutComponent', () => {
     it('should initialize', () => {
         comp.readonly = true;
         comp.ngOnInit();
-        expect(comp.allowDrop).toBe(false);
-        expect(comp.disableDrag()).toBe(false);
+        expect(comp.allowDrop).toBeFalse();
+        expect(comp.disableDrag()).toBeFalse();
     });
 
     it('should set display elements', () => {

--- a/src/test/javascript/spec/component/code-editor/code-editor-ace.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-ace.component.spec.ts
@@ -61,7 +61,7 @@ describe('CodeEditorAceComponent', () => {
         const placeholder = debugElement.query(By.css('#no-file-selected'));
         expect(placeholder).not.toBe(null);
         const aceEditor = debugElement.query(By.css('#ace-code-editor'));
-        expect(aceEditor.nativeElement.hasAttribute('hidden')).toBe(true);
+        expect(aceEditor.nativeElement.hasAttribute('hidden')).toBeTrue();
     });
 
     it('if the component is loading a file from server, it should show the editor in a readonly state', () => {
@@ -71,8 +71,8 @@ describe('CodeEditorAceComponent', () => {
         const placeholder = debugElement.query(By.css('#no-file-selected'));
         expect(placeholder).toBe(null);
         const aceEditor = debugElement.query(By.css('#ace-code-editor'));
-        expect(aceEditor.nativeElement.hasAttribute('hidden')).toBe(true);
-        expect(comp.editor.getEditor().getReadOnly()).toBe(true);
+        expect(aceEditor.nativeElement.hasAttribute('hidden')).toBeTrue();
+        expect(comp.editor.getEditor().getReadOnly()).toBeTrue();
 
         comp.isLoading = false;
         fixture.detectChanges();
@@ -103,7 +103,7 @@ describe('CodeEditorAceComponent', () => {
         triggerChanges(comp, { property: 'selectedFile', currentValue: selectedFile });
         fixture.detectChanges();
 
-        expect(comp.isLoading).toBe(true);
+        expect(comp.isLoading).toBeTrue();
         expect(loadRepositoryFileStub).toHaveBeenCalledWith(selectedFile);
         expect(initEditorAfterFileChangeSpy).not.toHaveBeenCalled();
         loadFileSubject.next({ fileName: selectedFile, fileContent: 'lorem ipsum' });
@@ -197,8 +197,8 @@ describe('CodeEditorAceComponent', () => {
         const displayFeedbacksSpy = jest.spyOn(comp, 'displayFeedbacks');
         comp.onFileTextChanged('newFileContent');
 
-        expect(comp.editor.getEditor().getReadOnly()).toBe(true);
-        expect(displayFeedbacksSpy).toHaveBeenCalledTimes(1);
+        expect(comp.editor.getEditor().getReadOnly()).toBeTrue();
+        expect(displayFeedbacksSpy).toHaveBeenCalledOnce();
     });
 
     it('should setup inline comment buttons in gutter', () => {

--- a/src/test/javascript/spec/component/code-editor/code-editor-ace.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-ace.component.spec.ts
@@ -76,8 +76,8 @@ describe('CodeEditorAceComponent', () => {
 
         comp.isLoading = false;
         fixture.detectChanges();
-        expect(aceEditor.nativeElement.hasAttribute('hidden')).toBe(false);
-        expect(comp.editor.getEditor().getReadOnly()).toBe(false);
+        expect(aceEditor.nativeElement.hasAttribute('hidden')).toBeFalse();
+        expect(comp.editor.getEditor().getReadOnly()).toBeFalse();
     });
 
     it('if a file is selected and the component is not loading a file from server, the editor should be usable', () => {
@@ -87,8 +87,8 @@ describe('CodeEditorAceComponent', () => {
         const placeholder = debugElement.query(By.css('#no-file-selected'));
         expect(placeholder).toBe(null);
         const aceEditor = debugElement.query(By.css('#ace-code-editor'));
-        expect(aceEditor.nativeElement.hasAttribute('hidden')).toBe(false);
-        expect(comp.editor.getEditor().getReadOnly()).toBe(false);
+        expect(aceEditor.nativeElement.hasAttribute('hidden')).toBeFalse();
+        expect(comp.editor.getEditor().getReadOnly()).toBeFalse();
     });
 
     it('should not load the file from server on selected file change if the file is already in session', () => {
@@ -109,7 +109,7 @@ describe('CodeEditorAceComponent', () => {
         loadFileSubject.next({ fileName: selectedFile, fileContent: 'lorem ipsum' });
         fixture.detectChanges();
 
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
         expect(initEditorAfterFileChangeSpy).toHaveBeenCalledWith();
     });
 

--- a/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
@@ -174,12 +174,12 @@ describe('CodeEditorActionsComponent', () => {
         commitStub.mockReturnValue(commitObservable);
 
         const commitButton = fixture.debugElement.query(By.css('#submit_button'));
-        expect(commitButton.nativeElement.disabled).toBe(false);
+        expect(commitButton.nativeElement.disabled).toBeFalse();
 
         // start commit, wait for result
         commitButton.nativeElement.click();
         expect(commitStub).toHaveBeenNthCalledWith(1);
-        expect(comp.isBuilding).toBe(false);
+        expect(comp.isBuilding).toBeFalse();
         expect(comp.commitState).toEqual(CommitState.COMMITTING);
 
         fixture.detectChanges();
@@ -191,7 +191,7 @@ describe('CodeEditorActionsComponent', () => {
         expect(comp.commitState).toEqual(CommitState.CLEAN);
 
         fixture.detectChanges();
-        expect(commitButton.nativeElement.disabled).toBe(false);
+        expect(commitButton.nativeElement.disabled).toBeFalse();
     });
 
     it('should commit if no unsaved changes exist and emit an error on error response', () => {
@@ -206,12 +206,12 @@ describe('CodeEditorActionsComponent', () => {
         commitStub.mockReturnValue(commitObservable);
 
         const commitButton = fixture.debugElement.query(By.css('#submit_button'));
-        expect(commitButton.nativeElement.disabled).toBe(false);
+        expect(commitButton.nativeElement.disabled).toBeFalse();
 
         // start commit, wait for result
         commitButton.nativeElement.click();
         expect(commitStub).toHaveBeenNthCalledWith(1);
-        expect(comp.isBuilding).toBe(false);
+        expect(comp.isBuilding).toBeFalse();
         expect(comp.commitState).toEqual(CommitState.COMMITTING);
 
         fixture.detectChanges();
@@ -219,12 +219,12 @@ describe('CodeEditorActionsComponent', () => {
 
         // commit result mockReturnValue an error
         commitObservable.error('error!');
-        expect(comp.isBuilding).toBe(false);
+        expect(comp.isBuilding).toBeFalse();
         expect(comp.commitState).toEqual(CommitState.UNCOMMITTED_CHANGES);
         expect(onErrorSpy).toHaveBeenNthCalledWith(1, 'commitFailed');
 
         fixture.detectChanges();
-        expect(commitButton.nativeElement.disabled).toBe(false);
+        expect(commitButton.nativeElement.disabled).toBeFalse();
     });
 
     it('should not commit if unsavedFiles exist, instead should save files with commit set to true', fakeAsync(() => {
@@ -241,7 +241,7 @@ describe('CodeEditorActionsComponent', () => {
         saveChangedFilesStub.mockReturnValue(saveObservable);
 
         const commitButton = fixture.debugElement.query(By.css('#submit_button'));
-        expect(commitButton.nativeElement.disabled).toBe(false);
+        expect(commitButton.nativeElement.disabled).toBeFalse();
 
         // unsaved changes exist, needs to save files first
         commitButton.nativeElement.click();
@@ -265,7 +265,7 @@ describe('CodeEditorActionsComponent', () => {
         expect(comp.commitState).toEqual(CommitState.CLEAN);
 
         fixture.detectChanges();
-        expect(commitButton.nativeElement.disabled).toBe(false);
+        expect(commitButton.nativeElement.disabled).toBeFalse();
 
         fixture.destroy();
         flush();

--- a/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-actions.component.spec.ts
@@ -183,11 +183,11 @@ describe('CodeEditorActionsComponent', () => {
         expect(comp.commitState).toEqual(CommitState.COMMITTING);
 
         fixture.detectChanges();
-        expect(commitButton.nativeElement.disabled).toBe(true);
+        expect(commitButton.nativeElement.disabled).toBeTrue();
 
         // commit result mockReturnValue
         commitObservable.next(null);
-        expect(comp.isBuilding).toBe(true);
+        expect(comp.isBuilding).toBeTrue();
         expect(comp.commitState).toEqual(CommitState.CLEAN);
 
         fixture.detectChanges();
@@ -215,7 +215,7 @@ describe('CodeEditorActionsComponent', () => {
         expect(comp.commitState).toEqual(CommitState.COMMITTING);
 
         fixture.detectChanges();
-        expect(commitButton.nativeElement.disabled).toBe(true);
+        expect(commitButton.nativeElement.disabled).toBeTrue();
 
         // commit result mockReturnValue an error
         commitObservable.error('error!');
@@ -261,7 +261,7 @@ describe('CodeEditorActionsComponent', () => {
 
         tick();
 
-        expect(comp.isBuilding).toBe(true);
+        expect(comp.isBuilding).toBeTrue();
         expect(comp.commitState).toEqual(CommitState.CLEAN);
 
         fixture.detectChanges();

--- a/src/test/javascript/spec/component/code-editor/code-editor-build-output.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-build-output.component.spec.ts
@@ -124,10 +124,10 @@ describe('CodeEditorBuildOutputComponent', () => {
         triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
 
-        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledTimes(1);
+        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledOnce();
         expect(getFeedbackDetailsForResultStub).toHaveBeenCalledWith(participation.id, result.id);
-        expect(getBuildLogsStub).toHaveBeenCalledTimes(1);
-        expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledTimes(1);
+        expect(getBuildLogsStub).toHaveBeenCalledOnce();
+        expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledOnce();
         expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledWith(participation.id, true);
         expect(comp.rawBuildLogs).toStrictEqual(BuildLogEntryArray.fromBuildLogs(buildLogs));
         expect(comp.rawBuildLogs.extractErrors(ProgrammingLanguage.JAVA, ProjectType.PLAIN_MAVEN)).toIncludeSameMembers(expectedBuildLogErrors);
@@ -167,7 +167,7 @@ describe('CodeEditorBuildOutputComponent', () => {
         getFeedbackDetailsForResultStub.mockReturnValue(of({ ...result, feedbacks: [] }));
         triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
-        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledTimes(1);
+        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledOnce();
         expect(getFeedbackDetailsForResultStub).toHaveBeenCalledWith(participation.id!, result.id!);
         expect(getBuildLogsStub).not.toHaveBeenCalled();
         expect(comp.rawBuildLogs).toStrictEqual(new BuildLogEntryArray());
@@ -191,7 +191,7 @@ describe('CodeEditorBuildOutputComponent', () => {
         triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
 
-        expect(getBuildLogsStub).toHaveBeenCalledTimes(1);
+        expect(getBuildLogsStub).toHaveBeenCalledOnce();
         expect(getBuildLogsStub).toHaveBeenCalledWith();
         expect(getFeedbackDetailsForResultStub).not.toHaveBeenCalled();
         expect(comp.rawBuildLogs).toStrictEqual(BuildLogEntryArray.fromBuildLogs(buildLogs));
@@ -218,7 +218,7 @@ describe('CodeEditorBuildOutputComponent', () => {
         triggerChanges(comp, { property: 'participation', currentValue: participation });
         fixture.detectChanges();
 
-        expect(getBuildLogsStub).toHaveBeenCalledTimes(1);
+        expect(getBuildLogsStub).toHaveBeenCalledOnce();
         expect(getBuildLogsStub).toHaveBeenCalledWith();
         expect(getFeedbackDetailsForResultStub).not.toHaveBeenCalled();
         expect(comp.rawBuildLogs).toStrictEqual(BuildLogEntryArray.fromBuildLogs(buildLogs));

--- a/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
@@ -82,7 +82,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
 
-        expect(comp.isLoadingFiles).toBe(false);
+        expect(comp.isLoadingFiles).toBeFalse();
         expect(comp.repositoryFiles).toEqual(repositoryContent);
         expect(comp.filesTreeViewItem).toEqual(expectedFileTreeItems);
         const renderedFolders = debugElement.queryAll(By.css('jhi-code-editor-file-browser-folder'));
@@ -99,7 +99,7 @@ describe('CodeEditorFileBrowserComponent', () => {
 
         triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
-        expect(comp.isLoadingFiles).toBe(false);
+        expect(comp.isLoadingFiles).toBeFalse();
         expect(comp.repositoryFiles).toEqual(repositoryContent);
         const renderedFolders = debugElement.queryAll(By.css('jhi-code-editor-file-browser-folder'));
         const renderedFiles = debugElement.queryAll(By.css('jhi-code-editor-file-browser-file'));
@@ -217,7 +217,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         comp.commitState = CommitState.UNDEFINED;
         triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
-        expect(comp.isLoadingFiles).toBe(false);
+        expect(comp.isLoadingFiles).toBeFalse();
         expect(comp.repositoryFiles).toEqual(allowedFiles);
         expect(comp.filesTreeViewItem.map((x) => x.toString())).toEqual(expectedFileTreeItems);
         const renderedFolders = debugElement.queryAll(By.css('jhi-code-editor-file-browser-folder'));
@@ -264,7 +264,7 @@ describe('CodeEditorFileBrowserComponent', () => {
 
         fixture.detectChanges();
         expect(comp.commitState).toEqual(CommitState.COULD_NOT_BE_RETRIEVED);
-        expect(comp.isLoadingFiles).toBe(false);
+        expect(comp.isLoadingFiles).toBeFalse();
         expect(comp.repositoryFiles).toBe(undefined);
         expect(comp.filesTreeViewItem).toBe(undefined);
         expect(onErrorSpy).toHaveBeenCalledOnce();
@@ -290,7 +290,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         getRepositoryContentSubject.error('fatal error');
 
         fixture.detectChanges();
-        expect(comp.isLoadingFiles).toBe(false);
+        expect(comp.isLoadingFiles).toBeFalse();
         expect(comp.repositoryFiles).toBe(undefined);
         expect(comp.filesTreeViewItem).toBe(undefined);
         expect(onErrorSpy).toHaveBeenCalledOnce();
@@ -764,7 +764,7 @@ describe('CodeEditorFileBrowserComponent', () => {
 
         expect(debugElement.query(By.css(createFileRoot)).nativeElement.disabled).toBeTrue();
         expect(debugElement.query(By.css(createFolderRoot)).nativeElement.disabled).toBeTrue();
-        expect(debugElement.query(By.css(compressTree)).nativeElement.disabled).toBe(false);
+        expect(debugElement.query(By.css(compressTree)).nativeElement.disabled).toBeFalse();
 
         // Resolve conflict.
         conflictService.notifyConflictState(GitConflictState.OK);
@@ -777,9 +777,9 @@ describe('CodeEditorFileBrowserComponent', () => {
 
         expect(comp.commitState).toEqual(CommitState.CLEAN);
 
-        expect(debugElement.query(By.css(createFileRoot)).nativeElement.disabled).toBe(false);
-        expect(debugElement.query(By.css(createFolderRoot)).nativeElement.disabled).toBe(false);
-        expect(debugElement.query(By.css(compressTree)).nativeElement.disabled).toBe(false);
+        expect(debugElement.query(By.css(createFileRoot)).nativeElement.disabled).toBeFalse();
+        expect(debugElement.query(By.css(createFolderRoot)).nativeElement.disabled).toBeFalse();
+        expect(debugElement.query(By.css(compressTree)).nativeElement.disabled).toBeFalse();
 
         expect(getRepositoryContentStub).toHaveBeenCalledOnce();
         expect(comp.selectedFile).toBe(undefined);

--- a/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-file-browser.component.spec.ts
@@ -258,7 +258,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         comp.commitState = CommitState.UNDEFINED;
         triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
-        expect(comp.isLoadingFiles).toBe(true);
+        expect(comp.isLoadingFiles).toBeTrue();
         expect(comp.commitState).toEqual(CommitState.UNDEFINED);
         isCleanSubject.error('fatal error');
 
@@ -267,7 +267,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         expect(comp.isLoadingFiles).toBe(false);
         expect(comp.repositoryFiles).toBe(undefined);
         expect(comp.filesTreeViewItem).toBe(undefined);
-        expect(onErrorSpy).toHaveBeenCalledTimes(1);
+        expect(onErrorSpy).toHaveBeenCalledOnce();
         expect(loadFilesSpy).not.toHaveBeenCalled();
         const renderedFolders = debugElement.queryAll(By.css('jhi-code-editor-file-browser-folder'));
         const renderedFiles = debugElement.queryAll(By.css('jhi-code-editor-file-browser-file'));
@@ -284,7 +284,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         comp.commitState = CommitState.UNDEFINED;
         triggerChanges(comp, { property: 'commitState', currentValue: CommitState.UNDEFINED });
         fixture.detectChanges();
-        expect(comp.isLoadingFiles).toBe(true);
+        expect(comp.isLoadingFiles).toBeTrue();
         expect(comp.commitState).toEqual(CommitState.UNDEFINED);
         isCleanSubject.next({ isClean: true });
         getRepositoryContentSubject.error('fatal error');
@@ -293,7 +293,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         expect(comp.isLoadingFiles).toBe(false);
         expect(comp.repositoryFiles).toBe(undefined);
         expect(comp.filesTreeViewItem).toBe(undefined);
-        expect(onErrorSpy).toHaveBeenCalledTimes(1);
+        expect(onErrorSpy).toHaveBeenCalledOnce();
         const renderedFolders = debugElement.queryAll(By.css('jhi-code-editor-file-browser-folder'));
         const renderedFiles = debugElement.queryAll(By.css('jhi-code-editor-file-browser-file'));
         expect(renderedFolders).toHaveLength(0);
@@ -331,7 +331,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         expect(comp.selectedFile).toEqual(selectedFile);
         const selectedTreeItem = comp.filesTreeViewItem.find(({ value }) => value === 'folder')!.children.find(({ value }) => value === selectedFile)!;
         expect(selectedTreeItem).not.toBe(undefined);
-        expect(selectedTreeItem.checked).toBe(true);
+        expect(selectedTreeItem.checked).toBeTrue();
         const renderedFolders = debugElement.queryAll(By.css('jhi-code-editor-file-browser-folder'));
         const renderedFiles = debugElement.queryAll(By.css('jhi-code-editor-file-browser-file'));
         expect(renderedFolders).toHaveLength(2);
@@ -339,10 +339,10 @@ describe('CodeEditorFileBrowserComponent', () => {
 
         const selectedFileHtml = renderedFiles[0];
         const isSelected = !!selectedFileHtml.query(By.css('.node-selected'));
-        expect(isSelected).toBe(true);
+        expect(isSelected).toBeTrue();
         const notSelectedFilesHtml = [renderedFiles[1], ...renderedFolders];
         const areUnSelected = !notSelectedFilesHtml.some((el) => !!el.query(By.css('.node-selected')));
-        expect(areUnSelected).toBe(true);
+        expect(areUnSelected).toBeTrue();
     });
 
     it('should add file to node tree if created', fakeAsync(() => {
@@ -385,12 +385,12 @@ describe('CodeEditorFileBrowserComponent', () => {
         fixture.detectChanges();
         tick();
 
-        expect(createFileStub).toHaveBeenCalledTimes(1);
+        expect(createFileStub).toHaveBeenCalledOnce();
         expect(createFileStub).toHaveBeenCalledWith(filePath);
         expect(comp.creatingFile).toBe(undefined);
-        expect(setupTreeviewSpy).toHaveBeenCalledTimes(1);
+        expect(setupTreeviewSpy).toHaveBeenCalledOnce();
         expect(setupTreeviewSpy).toHaveBeenCalledWith();
-        expect(onFileChangeSpy).toHaveBeenCalledTimes(1);
+        expect(onFileChangeSpy).toHaveBeenCalledOnce();
         expect(comp.repositoryFiles).toEqual({ ...repositoryFiles, [filePath]: FileType.FILE });
         creatingElement = debugElement.query(By.css('jhi-code-editor-file-browser-create-node'));
         expect(creatingElement).toBe(null);
@@ -437,12 +437,12 @@ describe('CodeEditorFileBrowserComponent', () => {
         fixture.detectChanges();
         tick();
 
-        expect(createFolderStub).toHaveBeenCalledTimes(1);
+        expect(createFolderStub).toHaveBeenCalledOnce();
         expect(createFolderStub).toHaveBeenCalledWith(filePath);
         expect(comp.creatingFile).toBe(undefined);
-        expect(setupTreeviewSpy).toHaveBeenCalledTimes(1);
+        expect(setupTreeviewSpy).toHaveBeenCalledOnce();
         expect(setupTreeviewSpy).toHaveBeenCalledWith();
-        expect(onFileChangeSpy).toHaveBeenCalledTimes(1);
+        expect(onFileChangeSpy).toHaveBeenCalledOnce();
         expect(comp.repositoryFiles).toEqual({ ...repositoryFiles, [filePath]: FileType.FOLDER });
         creatingElement = debugElement.query(By.css('jhi-code-editor-file-browser-create-node'));
         expect(creatingElement).toBe(null);
@@ -454,7 +454,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         comp.creatingFile = ['', FileType.FILE];
         comp.onCreateFile(fileName);
         fixture.detectChanges();
-        expect(onErrorSpy).toHaveBeenCalledTimes(1);
+        expect(onErrorSpy).toHaveBeenCalledOnce();
         expect(createFileStub).not.toHaveBeenCalled();
     });
 
@@ -479,7 +479,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         comp.onCreateFile(name);
         fixture.detectChanges();
 
-        expect(onErrorSpy).toHaveBeenCalledTimes(1);
+        expect(onErrorSpy).toHaveBeenCalledOnce();
         expect(onErrorSpy).toHaveBeenCalledWith('unsupportedFile');
     });
 
@@ -491,7 +491,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         comp.repositoryFiles = repositoryFiles;
         comp.onCreateFile(fileName);
         fixture.detectChanges();
-        expect(onErrorSpy).toHaveBeenCalledTimes(1);
+        expect(onErrorSpy).toHaveBeenCalledOnce();
         expect(createFileStub).not.toHaveBeenCalled();
     });
 
@@ -538,10 +538,10 @@ describe('CodeEditorFileBrowserComponent', () => {
         renamingInput.nativeElement.dispatchEvent(new Event('focusout'));
         fixture.detectChanges();
 
-        expect(renameFileStub).toHaveBeenCalledTimes(1);
+        expect(renameFileStub).toHaveBeenCalledOnce();
         expect(renameFileStub).toHaveBeenCalledWith(fileName, afterRename);
         expect(comp.renamingFile).toBe(undefined);
-        expect(onFileChangeSpy).toHaveBeenCalledTimes(1);
+        expect(onFileChangeSpy).toHaveBeenCalledOnce();
         expect(comp.repositoryFiles).toEqual({ folder2: FileType.FOLDER, [afterRename]: FileType.FILE });
 
         filesInTreeHtml = debugElement.queryAll(By.css('jhi-code-editor-file-browser-file'));
@@ -611,10 +611,10 @@ describe('CodeEditorFileBrowserComponent', () => {
         renamingInput.nativeElement.dispatchEvent(new Event('input'));
         renamingInput.nativeElement.dispatchEvent(new Event('focusout'));
 
-        expect(renameFileStub).toHaveBeenCalledTimes(1);
+        expect(renameFileStub).toHaveBeenCalledOnce();
         expect(renameFileStub).toHaveBeenCalledWith(folderName, afterRename);
         expect(comp.renamingFile).toBe(undefined);
-        expect(onFileChangeSpy).toHaveBeenCalledTimes(1);
+        expect(onFileChangeSpy).toHaveBeenCalledOnce();
         expect(comp.repositoryFiles).toEqual({
             [[afterRename, 'file1'].join('/')]: FileType.FILE,
             [[afterRename, 'file2'].join('/')]: FileType.FILE,
@@ -719,7 +719,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         comp.onRenameFile(newName);
         fixture.detectChanges();
 
-        expect(onErrorSpy).toHaveBeenCalledTimes(1);
+        expect(onErrorSpy).toHaveBeenCalledOnce();
         expect(onErrorSpy).toHaveBeenCalledWith('unsupportedFile');
     });
 
@@ -762,8 +762,8 @@ describe('CodeEditorFileBrowserComponent', () => {
 
         expect(comp.commitState).toEqual(CommitState.CONFLICT);
 
-        expect(debugElement.query(By.css(createFileRoot)).nativeElement.disabled).toBe(true);
-        expect(debugElement.query(By.css(createFolderRoot)).nativeElement.disabled).toBe(true);
+        expect(debugElement.query(By.css(createFileRoot)).nativeElement.disabled).toBeTrue();
+        expect(debugElement.query(By.css(createFolderRoot)).nativeElement.disabled).toBeTrue();
         expect(debugElement.query(By.css(compressTree)).nativeElement.disabled).toBe(false);
 
         // Resolve conflict.
@@ -781,7 +781,7 @@ describe('CodeEditorFileBrowserComponent', () => {
         expect(debugElement.query(By.css(createFolderRoot)).nativeElement.disabled).toBe(false);
         expect(debugElement.query(By.css(compressTree)).nativeElement.disabled).toBe(false);
 
-        expect(getRepositoryContentStub).toHaveBeenCalledTimes(1);
+        expect(getRepositoryContentStub).toHaveBeenCalledOnce();
         expect(comp.selectedFile).toBe(undefined);
     });
 
@@ -806,7 +806,7 @@ describe('CodeEditorFileBrowserComponent', () => {
 
         tick();
 
-        expect(getFilesWithChangeInfoStub).toHaveBeenCalledTimes(1);
+        expect(getFilesWithChangeInfoStub).toHaveBeenCalledOnce();
 
         loadFiles.unsubscribe();
     }));

--- a/src/test/javascript/spec/component/code-editor/code-editor-grid.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-grid.component.spec.ts
@@ -79,7 +79,7 @@ describe('CodeEditorGridComponent', () => {
             switch (windowName) {
                 case fileBrowserWindowName: {
                     if (collapsed) {
-                        expect(comp.fileBrowserIsCollapsed).toBe(true);
+                        expect(comp.fileBrowserIsCollapsed).toBeTrue();
                         expect(comp.rightPanelIsCollapsed).toBe(false);
                         expect(comp.buildOutputIsCollapsed).toBe(false);
                     } else {
@@ -90,7 +90,7 @@ describe('CodeEditorGridComponent', () => {
                 case instructionsWindowName: {
                     if (collapsed) {
                         expect(comp.fileBrowserIsCollapsed).toBe(false);
-                        expect(comp.rightPanelIsCollapsed).toBe(true);
+                        expect(comp.rightPanelIsCollapsed).toBeTrue();
                         expect(comp.buildOutputIsCollapsed).toBe(false);
                     } else {
                         expectAllWindowsToNotBeCollapsed();
@@ -101,7 +101,7 @@ describe('CodeEditorGridComponent', () => {
                     if (collapsed) {
                         expect(comp.fileBrowserIsCollapsed).toBe(false);
                         expect(comp.rightPanelIsCollapsed).toBe(false);
-                        expect(comp.buildOutputIsCollapsed).toBe(true);
+                        expect(comp.buildOutputIsCollapsed).toBeTrue();
                     } else {
                         expectAllWindowsToNotBeCollapsed();
                     }

--- a/src/test/javascript/spec/component/code-editor/code-editor-grid.component.spec.ts
+++ b/src/test/javascript/spec/component/code-editor/code-editor-grid.component.spec.ts
@@ -70,9 +70,9 @@ describe('CodeEditorGridComponent', () => {
         };
 
         const expectAllWindowsToNotBeCollapsed = () => {
-            expect(comp.fileBrowserIsCollapsed).toBe(false);
-            expect(comp.rightPanelIsCollapsed).toBe(false);
-            expect(comp.buildOutputIsCollapsed).toBe(false);
+            expect(comp.fileBrowserIsCollapsed).toBeFalse();
+            expect(comp.rightPanelIsCollapsed).toBeFalse();
+            expect(comp.buildOutputIsCollapsed).toBeFalse();
         };
 
         const expectWindowToBeCollapsed = (windowName: string, collapsed: boolean) => {
@@ -80,8 +80,8 @@ describe('CodeEditorGridComponent', () => {
                 case fileBrowserWindowName: {
                     if (collapsed) {
                         expect(comp.fileBrowserIsCollapsed).toBeTrue();
-                        expect(comp.rightPanelIsCollapsed).toBe(false);
-                        expect(comp.buildOutputIsCollapsed).toBe(false);
+                        expect(comp.rightPanelIsCollapsed).toBeFalse();
+                        expect(comp.buildOutputIsCollapsed).toBeFalse();
                     } else {
                         expectAllWindowsToNotBeCollapsed();
                     }
@@ -89,9 +89,9 @@ describe('CodeEditorGridComponent', () => {
                 }
                 case instructionsWindowName: {
                     if (collapsed) {
-                        expect(comp.fileBrowserIsCollapsed).toBe(false);
+                        expect(comp.fileBrowserIsCollapsed).toBeFalse();
                         expect(comp.rightPanelIsCollapsed).toBeTrue();
-                        expect(comp.buildOutputIsCollapsed).toBe(false);
+                        expect(comp.buildOutputIsCollapsed).toBeFalse();
                     } else {
                         expectAllWindowsToNotBeCollapsed();
                     }
@@ -99,8 +99,8 @@ describe('CodeEditorGridComponent', () => {
                 }
                 case buildOutputWindowName: {
                     if (collapsed) {
-                        expect(comp.fileBrowserIsCollapsed).toBe(false);
-                        expect(comp.rightPanelIsCollapsed).toBe(false);
+                        expect(comp.fileBrowserIsCollapsed).toBeFalse();
+                        expect(comp.rightPanelIsCollapsed).toBeFalse();
                         expect(comp.buildOutputIsCollapsed).toBeTrue();
                     } else {
                         expectAllWindowsToNotBeCollapsed();

--- a/src/test/javascript/spec/component/complaints/complaint-response.service.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint-response.service.spec.ts
@@ -64,7 +64,7 @@ describe('ComplaintResponseService', () => {
     it('should correctly calculate that complaint response is locked for user', () => {
         const lockedComplaintResponse = setupLockTest('test', false, 'test2', true);
         const isLocked = complaintResponseService.isComplaintResponseLockedForLoggedInUser(lockedComplaintResponse, new TextExercise(undefined, undefined));
-        expect(isLocked).toBe(true);
+        expect(isLocked).toBeTrue();
     });
 
     it('should correctly calculate that complaint response is not locked for instructor', () => {

--- a/src/test/javascript/spec/component/complaints/complaint-response.service.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint-response.service.spec.ts
@@ -70,13 +70,13 @@ describe('ComplaintResponseService', () => {
     it('should correctly calculate that complaint response is not locked for instructor', () => {
         const lockedComplaintResponse = setupLockTest('test', true, 'test2', true);
         const isLocked = complaintResponseService.isComplaintResponseLockedForLoggedInUser(lockedComplaintResponse, new TextExercise(undefined, undefined));
-        expect(isLocked).toBe(false);
+        expect(isLocked).toBeFalse();
     });
 
     it('should correctly calculate that complaint response is not locked for reviewer', () => {
         const lockedComplaintResponse = setupLockTest('test', false, 'test', true);
         const isLocked = complaintResponseService.isComplaintResponseLockedForLoggedInUser(lockedComplaintResponse, new TextExercise(undefined, undefined));
-        expect(isLocked).toBe(false);
+        expect(isLocked).toBeFalse();
     });
 
     it('should call refreshLock', async () => {

--- a/src/test/javascript/spec/component/complaints/complaint-student-view.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint-student-view.component.spec.ts
@@ -108,9 +108,9 @@ describe('ComplaintsStudentViewComponent', () => {
 
             expectExamDefault();
             expect(component.complaint).toBe(undefined);
-            expect(complaintBySubmissionMock).toHaveBeenCalledTimes(1);
-            expect(numberOfAllowedComplaintsMock).toHaveBeenCalledTimes(1);
-            expect(userMock).toHaveBeenCalledTimes(1);
+            expect(complaintBySubmissionMock).toHaveBeenCalledOnce();
+            expect(numberOfAllowedComplaintsMock).toHaveBeenCalledOnce();
+            expect(userMock).toHaveBeenCalledOnce();
         }));
 
         it('should initialize with complaint', fakeAsync(() => {
@@ -126,9 +126,9 @@ describe('ComplaintsStudentViewComponent', () => {
 
             expectExamDefault();
             expect(component.complaint).toStrictEqual(complaint);
-            expect(complaintBySubmissionMock).toHaveBeenCalledTimes(1);
-            expect(numberOfAllowedComplaintsMock).toHaveBeenCalledTimes(1);
-            expect(userMock).toHaveBeenCalledTimes(1);
+            expect(complaintBySubmissionMock).toHaveBeenCalledOnce();
+            expect(numberOfAllowedComplaintsMock).toHaveBeenCalledOnce();
+            expect(userMock).toHaveBeenCalledOnce();
         }));
 
         it('should be visible on test run', fakeAsync(() => {
@@ -143,7 +143,7 @@ describe('ComplaintsStudentViewComponent', () => {
             fixture.detectChanges();
             tick(100);
 
-            expect(component.showSection).toBe(true);
+            expect(component.showSection).toBeTrue();
             expect(serverDateStub).not.toHaveBeenCalled();
         }));
 
@@ -159,9 +159,9 @@ describe('ComplaintsStudentViewComponent', () => {
 
         function expectExamDefault() {
             expectDefault();
-            expect(component.isExamMode).toBe(true);
+            expect(component.isExamMode).toBeTrue();
             expect(component.timeOfFeedbackRequestValid).toBe(false);
-            expect(component.timeOfComplaintValid).toBe(true);
+            expect(component.timeOfComplaintValid).toBeTrue();
         }
 
         function testVisibilityToBeHiddenWithExam(exam: Exam) {
@@ -244,8 +244,8 @@ describe('ComplaintsStudentViewComponent', () => {
             fixture.detectChanges();
             tick(100);
 
-            expect(component.showSection).toBe(true);
-            expect(component.timeOfComplaintValid).toBe(true);
+            expect(component.showSection).toBeTrue();
+            expect(component.timeOfComplaintValid).toBeTrue();
             expect(component.timeOfFeedbackRequestValid).toBe(false);
         }));
 
@@ -267,9 +267,9 @@ describe('ComplaintsStudentViewComponent', () => {
             fixture.detectChanges();
             tick(100);
 
-            expect(component.showSection).toBe(true);
+            expect(component.showSection).toBeTrue();
             expect(component.timeOfComplaintValid).toBe(false);
-            expect(component.timeOfFeedbackRequestValid).toBe(true);
+            expect(component.timeOfFeedbackRequestValid).toBeTrue();
         }));
 
         it('no action should be allowed if the result is automatic for a non automatic exercise', fakeAsync(() => {
@@ -279,7 +279,7 @@ describe('ComplaintsStudentViewComponent', () => {
             fixture.detectChanges();
             tick(100);
 
-            expect(component.showSection).toBe(true);
+            expect(component.showSection).toBeTrue();
             expect(component.timeOfComplaintValid).toBe(false);
             expect(component.timeOfFeedbackRequestValid).toBe(false);
         }));
@@ -287,8 +287,8 @@ describe('ComplaintsStudentViewComponent', () => {
         function expectCourseDefault() {
             expectDefault();
             expect(component.isExamMode).toBe(false);
-            expect(component.timeOfFeedbackRequestValid).toBe(true);
-            expect(component.timeOfComplaintValid).toBe(true);
+            expect(component.timeOfFeedbackRequestValid).toBeTrue();
+            expect(component.timeOfComplaintValid).toBeTrue();
         }
 
         function testInitWithResultStub(content: Observable<EntityResponseType>) {
@@ -301,19 +301,19 @@ describe('ComplaintsStudentViewComponent', () => {
             tick(100);
 
             expectCourseDefault();
-            expect(complaintBySubmissionStub).toHaveBeenCalledTimes(1);
-            expect(numberOfAllowedComplaintsStub).toHaveBeenCalledTimes(1);
-            expect(userStub).toHaveBeenCalledTimes(1);
+            expect(complaintBySubmissionStub).toHaveBeenCalledOnce();
+            expect(numberOfAllowedComplaintsStub).toHaveBeenCalledOnce();
+            expect(userStub).toHaveBeenCalledOnce();
         }
     });
 
     function expectDefault() {
         expect(component.submission).toStrictEqual(submission);
         expect(component.course).toStrictEqual(course);
-        expect(component.showSection).toBe(true);
+        expect(component.showSection).toBeTrue();
         expect(component.formComplaintType).toBe(undefined);
         expect(component.remainingNumberOfComplaints).toStrictEqual(numberOfComplaints);
-        expect(component.isCorrectUserToFileAction).toBe(true);
+        expect(component.isCorrectUserToFileAction).toBeTrue();
         expect(result.participation).toStrictEqual(participation);
     }
 
@@ -336,8 +336,8 @@ describe('ComplaintsStudentViewComponent', () => {
         fixture.detectChanges();
         tick(100);
 
-        expect(component.showSection).toBe(true);
-        expect(component.timeOfComplaintValid).toBe(true);
-        expect(component.timeOfFeedbackRequestValid).toBe(true);
+        expect(component.showSection).toBeTrue();
+        expect(component.timeOfComplaintValid).toBeTrue();
+        expect(component.timeOfFeedbackRequestValid).toBeTrue();
     }));
 });

--- a/src/test/javascript/spec/component/complaints/complaint-student-view.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint-student-view.component.spec.ts
@@ -160,7 +160,7 @@ describe('ComplaintsStudentViewComponent', () => {
         function expectExamDefault() {
             expectDefault();
             expect(component.isExamMode).toBeTrue();
-            expect(component.timeOfFeedbackRequestValid).toBe(false);
+            expect(component.timeOfFeedbackRequestValid).toBeFalse();
             expect(component.timeOfComplaintValid).toBeTrue();
         }
 
@@ -174,7 +174,7 @@ describe('ComplaintsStudentViewComponent', () => {
             fixture.detectChanges();
             tick(100);
 
-            expect(component.showSection).toBe(false);
+            expect(component.showSection).toBeFalse();
         }
     });
 
@@ -198,8 +198,8 @@ describe('ComplaintsStudentViewComponent', () => {
             fixture.detectChanges();
             tick(100);
 
-            expect(component.timeOfFeedbackRequestValid).toBe(false);
-            expect(component.timeOfComplaintValid).toBe(false);
+            expect(component.timeOfFeedbackRequestValid).toBeFalse();
+            expect(component.timeOfComplaintValid).toBeFalse();
         }));
 
         it('should not be available if assessment due date not set and completion date is out of period', fakeAsync(() => {
@@ -211,8 +211,8 @@ describe('ComplaintsStudentViewComponent', () => {
             fixture.detectChanges();
             tick(100);
 
-            expect(component.timeOfFeedbackRequestValid).toBe(false);
-            expect(component.timeOfComplaintValid).toBe(false);
+            expect(component.timeOfFeedbackRequestValid).toBeFalse();
+            expect(component.timeOfComplaintValid).toBeFalse();
         }));
 
         it('should not be available if completionDate after assessment due date and date is out of period', fakeAsync(() => {
@@ -229,8 +229,8 @@ describe('ComplaintsStudentViewComponent', () => {
             fixture.detectChanges();
             tick(100);
 
-            expect(component.timeOfFeedbackRequestValid).toBe(false);
-            expect(component.timeOfComplaintValid).toBe(false);
+            expect(component.timeOfFeedbackRequestValid).toBeFalse();
+            expect(component.timeOfComplaintValid).toBeFalse();
         }));
 
         it('complaints should be available if feedback requests disabled', fakeAsync(() => {
@@ -246,7 +246,7 @@ describe('ComplaintsStudentViewComponent', () => {
 
             expect(component.showSection).toBeTrue();
             expect(component.timeOfComplaintValid).toBeTrue();
-            expect(component.timeOfFeedbackRequestValid).toBe(false);
+            expect(component.timeOfFeedbackRequestValid).toBeFalse();
         }));
 
         it('feedback requests should be available if complaints are disabled', fakeAsync(() => {
@@ -268,7 +268,7 @@ describe('ComplaintsStudentViewComponent', () => {
             tick(100);
 
             expect(component.showSection).toBeTrue();
-            expect(component.timeOfComplaintValid).toBe(false);
+            expect(component.timeOfComplaintValid).toBeFalse();
             expect(component.timeOfFeedbackRequestValid).toBeTrue();
         }));
 
@@ -280,13 +280,13 @@ describe('ComplaintsStudentViewComponent', () => {
             tick(100);
 
             expect(component.showSection).toBeTrue();
-            expect(component.timeOfComplaintValid).toBe(false);
-            expect(component.timeOfFeedbackRequestValid).toBe(false);
+            expect(component.timeOfComplaintValid).toBeFalse();
+            expect(component.timeOfFeedbackRequestValid).toBeFalse();
         }));
 
         function expectCourseDefault() {
             expectDefault();
-            expect(component.isExamMode).toBe(false);
+            expect(component.isExamMode).toBeFalse();
             expect(component.timeOfFeedbackRequestValid).toBeTrue();
             expect(component.timeOfComplaintValid).toBeTrue();
         }
@@ -326,7 +326,7 @@ describe('ComplaintsStudentViewComponent', () => {
         fixture.detectChanges();
         tick(100);
 
-        expect(component.timeOfComplaintValid).toBe(false);
+        expect(component.timeOfComplaintValid).toBeFalse();
     }));
 
     it('complaint should be possible with long assessment periods', fakeAsync(() => {

--- a/src/test/javascript/spec/component/complaints/complaint.service.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint.service.spec.ts
@@ -58,7 +58,7 @@ describe('ComplaintService', () => {
     describe('isComplaintLockedForLoggedInUser', () => {
         it('should be false if no visible lock is present', () => {
             const result = complaintService.isComplaintLockedForLoggedInUser(new Complaint(), new TextExercise(undefined, undefined));
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should be false if user has the lock', () => {
@@ -71,7 +71,7 @@ describe('ComplaintService', () => {
 
             const result = complaintService.isComplaintLockedForLoggedInUser(_complaint, new TextExercise(undefined, undefined));
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should be true if user has not the lock', () => {
@@ -101,14 +101,14 @@ describe('ComplaintService', () => {
 
             const result = complaintService.isComplaintLockedForLoggedInUser(_complaint, new TextExercise(undefined, undefined));
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
     });
 
     describe('isComplaintLockedByLoggedInUser', () => {
         it('should be false if no visible lock is present', () => {
             const result = complaintService.isComplaintLockedByLoggedInUser(new Complaint());
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should be false if the complaint is not locked', () => {
@@ -116,7 +116,7 @@ describe('ComplaintService', () => {
             _complaint.complaintResponse = new ComplaintResponse();
 
             const result = complaintService.isComplaintLockedByLoggedInUser(_complaint);
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should be false if the complaint has been handled', () => {
@@ -127,7 +127,7 @@ describe('ComplaintService', () => {
             _complaint.complaintResponse.submittedTime = dayjs();
 
             const result = complaintService.isComplaintLockedByLoggedInUser(_complaint);
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should be false if another user has the lock', () => {
@@ -140,7 +140,7 @@ describe('ComplaintService', () => {
             accountService.userIdentity = { login: anotherLogin } as User;
 
             const result = complaintService.isComplaintLockedByLoggedInUser(_complaint);
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should be true if the same user has the lock', () => {
@@ -159,7 +159,7 @@ describe('ComplaintService', () => {
     describe('isComplaintLocked', () => {
         it('should be false if no visible lock is present', () => {
             const result = complaintService.isComplaintLocked(new Complaint());
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should be true if locked', () => {
@@ -210,7 +210,7 @@ describe('ComplaintService', () => {
 
             const result = complaintService.shouldHighlightComplaint(complaint);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should not highlight recent complaints', () => {
@@ -221,7 +221,7 @@ describe('ComplaintService', () => {
 
             const result = complaintService.shouldHighlightComplaint(complaint);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should highlight old complaints', () => {

--- a/src/test/javascript/spec/component/complaints/complaint.service.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaint.service.spec.ts
@@ -86,7 +86,7 @@ describe('ComplaintService', () => {
 
             const result = complaintService.isComplaintLockedForLoggedInUser(_complaint, new TextExercise(undefined, undefined));
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should be false if user is instructor', () => {
@@ -152,7 +152,7 @@ describe('ComplaintService', () => {
             accountService.userIdentity = { login } as User;
 
             const result = complaintService.isComplaintLockedByLoggedInUser(_complaint);
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -168,7 +168,7 @@ describe('ComplaintService', () => {
             _complaint.complaintResponse.isCurrentlyLocked = true;
 
             const result = complaintService.isComplaintLocked(_complaint);
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -232,7 +232,7 @@ describe('ComplaintService', () => {
 
             const result = complaintService.shouldHighlightComplaint(complaint);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 

--- a/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
@@ -277,8 +277,8 @@ describe('ComplaintsForTutorComponent', () => {
         complaintForTutorComponentFixture.detectChanges();
         tick();
 
-        expect(rejectComplaintButton.disabled).toBe(true);
-        expect(acceptComplaintButton.disabled).toBe(true);
+        expect(rejectComplaintButton.disabled).toBeTrue();
+        expect(acceptComplaintButton.disabled).toBeTrue();
     }));
 
     it('text area should have the correct max length', fakeAsync(() => {

--- a/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-for-tutor.component.spec.ts
@@ -267,8 +267,8 @@ describe('ComplaintsForTutorComponent', () => {
 
         const rejectComplaintButton = complaintForTutorComponentFixture.debugElement.query(By.css('#rejectComplaintButton')).nativeElement;
         const acceptComplaintButton = complaintForTutorComponentFixture.debugElement.query(By.css('#acceptComplaintButton')).nativeElement;
-        expect(rejectComplaintButton.disabled).toBe(false);
-        expect(acceptComplaintButton.disabled).toBe(false);
+        expect(rejectComplaintButton.disabled).toBeFalse();
+        expect(acceptComplaintButton.disabled).toBeFalse();
 
         responseTextArea.value = responseTextArea.value + 'A';
         expect(responseTextArea.value.length).toBe(27);

--- a/src/test/javascript/spec/component/complaints/complaints-form.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-form.component.spec.ts
@@ -143,7 +143,7 @@ describe('ComplaintsFormComponent', () => {
         tick(100);
 
         expect(responseTextArea.maxLength).toBe(20);
-        expect(complaintButton.disabled).toBe(false);
+        expect(complaintButton.disabled).toBeFalse();
     }));
 
     it('submit complaint button should be disabled', fakeAsync(() => {

--- a/src/test/javascript/spec/component/complaints/complaints-form.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/complaints-form.component.spec.ts
@@ -81,8 +81,8 @@ describe('ComplaintsFormComponent', () => {
         const createMock = jest.spyOn(complaintService, 'create').mockReturnValue(of({} as EntityResponseType));
         const submitSpy = jest.spyOn(component.submit, 'emit');
         component.createComplaint();
-        expect(createMock).toHaveBeenCalledTimes(1);
-        expect(submitSpy).toHaveBeenCalledTimes(1);
+        expect(createMock).toHaveBeenCalledOnce();
+        expect(submitSpy).toHaveBeenCalledOnce();
         expect(submitSpy).toHaveBeenCalledWith();
     });
 
@@ -91,9 +91,9 @@ describe('ComplaintsFormComponent', () => {
         const submitSpy = jest.spyOn(component.submit, 'emit');
         const errorSpy = jest.spyOn(alertService, 'error');
         component.createComplaint();
-        expect(createMock).toHaveBeenCalledTimes(1);
+        expect(createMock).toHaveBeenCalledOnce();
         expect(submitSpy).not.toHaveBeenCalled();
-        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy).toHaveBeenCalledOnce();
     });
 
     it('should throw known error after complaint creation', () => {
@@ -104,9 +104,9 @@ describe('ComplaintsFormComponent', () => {
         const numberOfComplaints = 42;
         component.maxComplaintsPerCourse = numberOfComplaints;
         component.createComplaint();
-        expect(createMock).toHaveBeenCalledTimes(1);
+        expect(createMock).toHaveBeenCalledOnce();
         expect(submitSpy).not.toHaveBeenCalled();
-        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy).toHaveBeenCalledOnce();
         expect(errorSpy).toHaveBeenCalledWith('artemisApp.complaint.tooManyComplaints', { maxComplaintNumber: numberOfComplaints });
     });
 
@@ -121,7 +121,7 @@ describe('ComplaintsFormComponent', () => {
         component.complaintText = 'abcdefghijklmnopqrstuvwxyz';
         component.createComplaint();
         expect(submitSpy).not.toHaveBeenCalled();
-        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy).toHaveBeenCalledOnce();
         expect(errorSpy).toHaveBeenCalledWith('artemisApp.complaint.exceededComplaintTextLimit', { maxComplaintTextLimit: 20 });
     });
 
@@ -164,6 +164,6 @@ describe('ComplaintsFormComponent', () => {
         fixture.detectChanges();
         tick(100);
 
-        expect(complaintButton.disabled).toBe(true);
+        expect(complaintButton.disabled).toBeTrue();
     }));
 });

--- a/src/test/javascript/spec/component/complaints/list-of-complaints.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/list-of-complaints.component.spec.ts
@@ -158,7 +158,7 @@ describe('ListOfComplaintsComponent', () => {
             comp.loadComplaints();
 
             expect(comp.complaintsToShow).toIncludeSameMembers([complaint3]);
-            expect(comp.hasStudentInformation).toBe(false);
+            expect(comp.hasStudentInformation).toBeFalse();
         });
 
         it('process complaints with student information', () => {
@@ -181,7 +181,7 @@ describe('ListOfComplaintsComponent', () => {
         const freeComplaints = [complaint3, complaint4];
         findAllByCourseIdStub.mockReturnValue(of({ body: complaints } as EntityResponseTypeArray));
         comp.loadComplaints();
-        expect(comp.showAddressedComplaints).toBe(false);
+        expect(comp.showAddressedComplaints).toBeFalse();
         expect(comp.complaintsToShow).toIncludeSameMembers(freeComplaints);
 
         comp.triggerAddressedComplaints();
@@ -191,7 +191,7 @@ describe('ListOfComplaintsComponent', () => {
 
         comp.triggerAddressedComplaints();
 
-        expect(comp.showAddressedComplaints).toBe(false);
+        expect(comp.showAddressedComplaints).toBeFalse();
         expect(comp.complaintsToShow).toIncludeSameMembers(freeComplaints);
     });
 

--- a/src/test/javascript/spec/component/complaints/list-of-complaints.component.spec.ts
+++ b/src/test/javascript/spec/component/complaints/list-of-complaints.component.spec.ts
@@ -103,7 +103,7 @@ describe('ListOfComplaintsComponent', () => {
             activatedRoute.setParameters({ tutorId: 12, courseId: 34, exerciseId: 56, complaintType: ComplaintType.MORE_FEEDBACK });
             comp.ngOnInit();
 
-            expect(findAllByTutorIdForExerciseIdStub).toHaveBeenCalledTimes(1);
+            expect(findAllByTutorIdForExerciseIdStub).toHaveBeenCalledOnce();
             expect(findAllByTutorIdForExerciseIdStub).toHaveBeenCalledWith(12, 56, ComplaintType.MORE_FEEDBACK);
             verifyNotCalled(findAllByTutorIdForCourseIdStub, findAllByExerciseIdStub, findAllByCourseIdAndExamIdStub, findAllByCourseIdStub);
         });
@@ -112,7 +112,7 @@ describe('ListOfComplaintsComponent', () => {
             activatedRoute.setParameters({ tutorId: 12, courseId: 34, examId: 56, complaintType: ComplaintType.MORE_FEEDBACK });
             comp.ngOnInit();
 
-            expect(findAllByTutorIdForCourseIdStub).toHaveBeenCalledTimes(1);
+            expect(findAllByTutorIdForCourseIdStub).toHaveBeenCalledOnce();
             expect(findAllByTutorIdForCourseIdStub).toHaveBeenCalledWith(12, 34, ComplaintType.MORE_FEEDBACK);
             verifyNotCalled(findAllByTutorIdForExerciseIdStub, findAllByExerciseIdStub, findAllByCourseIdAndExamIdStub, findAllByCourseIdStub);
         });
@@ -121,7 +121,7 @@ describe('ListOfComplaintsComponent', () => {
             activatedRoute.setParameters({ tutorId: 12, courseId: 34, complaintType: ComplaintType.MORE_FEEDBACK });
             comp.ngOnInit();
 
-            expect(findAllByTutorIdForCourseIdStub).toHaveBeenCalledTimes(1);
+            expect(findAllByTutorIdForCourseIdStub).toHaveBeenCalledOnce();
             expect(findAllByTutorIdForCourseIdStub).toHaveBeenCalledWith(12, 34, ComplaintType.MORE_FEEDBACK);
             verifyNotCalled(findAllByTutorIdForExerciseIdStub, findAllByExerciseIdStub, findAllByCourseIdAndExamIdStub, findAllByCourseIdStub);
         });
@@ -130,7 +130,7 @@ describe('ListOfComplaintsComponent', () => {
             activatedRoute.setParameters({ courseId: 12, exerciseId: 34, complaintType: ComplaintType.MORE_FEEDBACK });
             comp.ngOnInit();
 
-            expect(findAllByExerciseIdStub).toHaveBeenCalledTimes(1);
+            expect(findAllByExerciseIdStub).toHaveBeenCalledOnce();
             expect(findAllByExerciseIdStub).toHaveBeenCalledWith(34, ComplaintType.MORE_FEEDBACK);
             verifyNotCalled(findAllByTutorIdForCourseIdStub, findAllByTutorIdForCourseIdStub, findAllByCourseIdAndExamIdStub, findAllByCourseIdStub);
         });
@@ -139,7 +139,7 @@ describe('ListOfComplaintsComponent', () => {
             activatedRoute.setParameters({ courseId: 12, examId: 34, complaintType: ComplaintType.MORE_FEEDBACK });
             comp.ngOnInit();
 
-            expect(findAllByCourseIdAndExamIdStub).toHaveBeenCalledTimes(1);
+            expect(findAllByCourseIdAndExamIdStub).toHaveBeenCalledOnce();
             expect(findAllByCourseIdAndExamIdStub).toHaveBeenCalledWith(12, 34);
             verifyNotCalled(findAllByTutorIdForCourseIdStub, findAllByTutorIdForCourseIdStub, findAllByExerciseIdStub, findAllByCourseIdStub);
         });
@@ -148,7 +148,7 @@ describe('ListOfComplaintsComponent', () => {
             activatedRoute.setParameters({ courseId: 12, complaintType: ComplaintType.MORE_FEEDBACK });
             comp.ngOnInit();
 
-            expect(findAllByCourseIdStub).toHaveBeenCalledTimes(1);
+            expect(findAllByCourseIdStub).toHaveBeenCalledOnce();
             expect(findAllByCourseIdStub).toHaveBeenCalledWith(12, ComplaintType.MORE_FEEDBACK);
             verifyNotCalled(findAllByTutorIdForExerciseIdStub, findAllByTutorIdForCourseIdStub, findAllByExerciseIdStub, findAllByCourseIdAndExamIdStub);
         });
@@ -166,13 +166,13 @@ describe('ListOfComplaintsComponent', () => {
             comp.loadComplaints();
 
             expect(comp.complaintsToShow).toIncludeSameMembers([complaint3, complaint4]);
-            expect(comp.hasStudentInformation).toBe(true);
+            expect(comp.hasStudentInformation).toBeTrue();
 
             findAllByCourseIdStub.mockReturnValue(of({ body: [complaint1, complaint2, complaint3, complaint5] } as EntityResponseTypeArray));
             comp.loadComplaints();
 
             expect(comp.complaintsToShow).toIncludeSameMembers([complaint3]);
-            expect(comp.hasStudentInformation).toBe(true);
+            expect(comp.hasStudentInformation).toBeTrue();
         });
     });
 
@@ -186,7 +186,7 @@ describe('ListOfComplaintsComponent', () => {
 
         comp.triggerAddressedComplaints();
 
-        expect(comp.showAddressedComplaints).toBe(true);
+        expect(comp.showAddressedComplaints).toBeTrue();
         expect(comp.complaintsToShow).toIncludeSameMembers(complaints);
 
         comp.triggerAddressedComplaints();
@@ -206,7 +206,7 @@ describe('ListOfComplaintsComponent', () => {
 
             comp.calculateComplaintLockStatus(complaint);
 
-            expect(translateService.instant).toHaveBeenCalledTimes(1);
+            expect(translateService.instant).toHaveBeenCalledOnce();
             expect(translateService.instant).toHaveBeenCalledWith('artemisApp.locks.notUnlocked');
         });
 
@@ -228,7 +228,7 @@ describe('ListOfComplaintsComponent', () => {
 
             comp.calculateComplaintLockStatus(complaint);
 
-            expect(translateService.instant).toHaveBeenCalledTimes(1);
+            expect(translateService.instant).toHaveBeenCalledOnce();
             expect(translateService.instant).toHaveBeenCalledWith('artemisApp.locks.lockInformationYou', { endDate: `${endDate.valueOf()}` });
         });
 
@@ -250,7 +250,7 @@ describe('ListOfComplaintsComponent', () => {
 
             comp.calculateComplaintLockStatus(complaint);
 
-            expect(translateService.instant).toHaveBeenCalledTimes(1);
+            expect(translateService.instant).toHaveBeenCalledOnce();
             expect(translateService.instant).toHaveBeenCalledWith('artemisApp.locks.lockInformation', { endDate: `${endDate.valueOf()}`, user: reviewLogin });
         });
     });
@@ -286,7 +286,7 @@ describe('ListOfComplaintsComponent', () => {
         comp.openAssessmentEditor(complaint);
 
         expect(comp.correctionRound).toBe(0);
-        expect(router.navigate).toHaveBeenCalledTimes(1);
+        expect(router.navigate).toHaveBeenCalledOnce();
         expect(router.navigate).toHaveBeenCalledWith(
             ['/course-management', `${courseId}`, 'text-exercises', `${exerciseId}`, 'participations', `${participationId}`, 'submissions', `${submissionId}`, 'assessment'],
             { queryParams: { 'correction-round': 0 } },

--- a/src/test/javascript/spec/component/consistency-check/consistency-check.component.spec.ts
+++ b/src/test/javascript/spec/component/consistency-check/consistency-check.component.spec.ts
@@ -61,7 +61,7 @@ describe('ConsistencyCheckComponent', () => {
         fixture.detectChanges();
 
         // THEN
-        expect(checkConsistencyForProgrammingExerciseStub).toHaveBeenCalledTimes(1);
+        expect(checkConsistencyForProgrammingExerciseStub).toHaveBeenCalledOnce();
         expect(component.inconsistencies).toEqual(consistencyErrors);
     });
 

--- a/src/test/javascript/spec/component/course-registration/course-registration.component.spec.ts
+++ b/src/test/javascript/spec/component/course-registration/course-registration.component.spec.ts
@@ -76,23 +76,23 @@ describe('CourseRegistrationComponent', () => {
     it('should initialize', fakeAsync(() => {
         component.ngOnInit();
         tick();
-        expect(identityStub).toHaveBeenCalledTimes(1);
-        expect(getProfileInfoStub).toHaveBeenCalledTimes(1);
-        expect(component.userIsAllowedToRegister).toBe(true);
+        expect(identityStub).toHaveBeenCalledOnce();
+        expect(getProfileInfoStub).toHaveBeenCalledOnce();
+        expect(component.userIsAllowedToRegister).toBeTrue();
     }));
 
     it('should show registrable courses', () => {
         component.loadRegistrableCourses();
 
         expect(component.coursesToSelect).toHaveLength(1);
-        expect(findAllToRegisterStub).toHaveBeenCalledTimes(1);
+        expect(findAllToRegisterStub).toHaveBeenCalledOnce();
     });
 
     it('should register for course', () => {
         component.coursesToSelect = [course1, course2];
         component.registerForCourse(1);
 
-        expect(registerForCourseStub).toHaveBeenCalledTimes(1);
+        expect(registerForCourseStub).toHaveBeenCalledOnce();
         expect(component.coursesToSelect).toEqual([course2]);
     });
 
@@ -102,7 +102,7 @@ describe('CourseRegistrationComponent', () => {
 
         component.showPrerequisites(course1.id!);
 
-        expect(openModalSpy).toHaveBeenCalledTimes(1);
+        expect(openModalSpy).toHaveBeenCalledOnce();
         expect(openModalSpy).toHaveBeenCalledWith(CoursePrerequisitesModalComponent, { size: 'xl' });
     });
 });

--- a/src/test/javascript/spec/component/course/course-exercises.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-exercises.component.spec.ts
@@ -205,7 +205,7 @@ describe('CourseExercisesComponent', () => {
 
         component.toggleFilters(filters);
 
-        expect(localStorageSpy).toHaveBeenCalledTimes(1);
+        expect(localStorageSpy).toHaveBeenCalledOnce();
         expect(component.activeFilters).toEqual(new Set());
 
         for (let i = 1; i < 8; i++) {

--- a/src/test/javascript/spec/component/course/course-group.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-group.component.spec.ts
@@ -120,7 +120,7 @@ describe('Course Management Detail Component', () => {
                 expect(users).toEqual([courseGroupUser]);
             });
             expect(searchStub).toHaveBeenCalledWith(loginOrName);
-            expect(searchStub).toHaveBeenCalledTimes(1);
+            expect(searchStub).toHaveBeenCalledOnce();
         });
 
         it('should set search no results if search returns no result', () => {
@@ -128,9 +128,9 @@ describe('Course Management Detail Component', () => {
             comp.searchAllUsers(loginStream).subscribe((users: any) => {
                 expect(users).toEqual([]);
             });
-            expect(comp.searchNoResults).toBe(true);
+            expect(comp.searchNoResults).toBeTrue();
             expect(searchStub).toHaveBeenCalledWith(loginOrName);
-            expect(searchStub).toHaveBeenCalledTimes(1);
+            expect(searchStub).toHaveBeenCalledOnce();
         });
 
         it('should return empty if search text is shorter than three characters', () => {
@@ -147,9 +147,9 @@ describe('Course Management Detail Component', () => {
             comp.searchAllUsers(loginStream).subscribe((users: any) => {
                 expect(users).toEqual([]);
             });
-            expect(comp.searchFailed).toBe(true);
+            expect(comp.searchFailed).toBeTrue();
             expect(searchStub).toHaveBeenCalledWith(loginOrName);
-            expect(searchStub).toHaveBeenCalledTimes(1);
+            expect(searchStub).toHaveBeenCalledOnce();
         });
     });
 
@@ -169,10 +169,10 @@ describe('Course Management Detail Component', () => {
             const fake = jest.fn();
             comp.onAutocompleteSelect(user, fake);
             expect(addUserStub).toHaveBeenCalledWith(course.id, courseGroup, user.login);
-            expect(addUserStub).toHaveBeenCalledTimes(1);
+            expect(addUserStub).toHaveBeenCalledOnce();
             expect(comp.allCourseGroupUsers).toEqual([courseGroupUser]);
             expect(fake).toHaveBeenCalledWith(user);
-            expect(fake).toHaveBeenCalledTimes(1);
+            expect(fake).toHaveBeenCalledOnce();
         });
 
         it('should call callback if user is already in the group', () => {
@@ -182,7 +182,7 @@ describe('Course Management Detail Component', () => {
             expect(addUserStub).not.toHaveBeenCalled();
             expect(comp.allCourseGroupUsers).toEqual([courseGroupUser]);
             expect(fake).toHaveBeenCalledWith(user);
-            expect(fake).toHaveBeenCalledTimes(1);
+            expect(fake).toHaveBeenCalledOnce();
         });
     });
 
@@ -199,7 +199,7 @@ describe('Course Management Detail Component', () => {
         it('should given user from group', () => {
             comp.removeFromGroup(courseGroupUser);
             expect(removeUserStub).toHaveBeenCalledWith(course.id, courseGroup, courseGroupUser.login);
-            expect(removeUserStub).toHaveBeenCalledTimes(1);
+            expect(removeUserStub).toHaveBeenCalledOnce();
             expect(comp.allCourseGroupUsers).toEqual([courseGroupUser2]);
         });
 
@@ -271,7 +271,7 @@ describe('Course Management Detail Component', () => {
 
         comp.exportUserInformation();
 
-        expect(exportAsCsvMock).toHaveBeenCalledTimes(1);
+        expect(exportAsCsvMock).toHaveBeenCalledOnce();
         const generatedRows = exportAsCsvMock.mock.calls[0][0];
 
         const expectedRow1 = {};

--- a/src/test/javascript/spec/component/course/course-management-exercises-search.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management-exercises-search.component.spec.ts
@@ -52,7 +52,7 @@ describe('Course Management Exercises Search Component', () => {
         const button = fixture.debugElement.nativeElement.querySelector('#saveFilterButton');
         comp.exerciseNameSearch = filter.exerciseNameSearch;
         button.click();
-        expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledOnce();
         expect(emitSpy).toHaveBeenCalledWith(filter);
     });
 
@@ -63,7 +63,7 @@ describe('Course Management Exercises Search Component', () => {
         const button = fixture.debugElement.nativeElement.querySelector('#saveFilterButton');
         comp.exerciseCategorySearch = filter.exerciseCategorySearch;
         button.click();
-        expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledOnce();
         expect(emitSpy).toHaveBeenCalledWith(filter);
     });
 
@@ -74,7 +74,7 @@ describe('Course Management Exercises Search Component', () => {
         const button = fixture.debugElement.nativeElement.querySelector('#saveFilterButton');
         comp.exerciseTypeSearch = filter.exerciseTypeSearch;
         button.click();
-        expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledOnce();
         expect(emitSpy).toHaveBeenCalledWith(filter);
     });
 });

--- a/src/test/javascript/spec/component/course/course-management-exercises.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management-exercises.component.spec.ts
@@ -69,7 +69,7 @@ describe('Course Management Exercises Component', () => {
         comp.ngOnInit();
         expect(comp.courseId).toBe(course.id);
         expect(findStub).toHaveBeenCalledWith(course.id);
-        expect(findStub).toHaveBeenCalledTimes(1);
+        expect(findStub).toHaveBeenCalledOnce();
     });
 
     it('should open search bar on button click', () => {
@@ -80,7 +80,7 @@ describe('Course Management Exercises Component', () => {
 
         const searchBar = fixture.debugElement.nativeElement.querySelector('jhi-course-management-exercises-search');
 
-        expect(comp.showSearch).toBe(true);
+        expect(comp.showSearch).toBeTrue();
         expect(searchBar).not.toBe(null);
     });
 });

--- a/src/test/javascript/spec/component/course/course-management-overview-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management-overview-statistics.component.spec.ts
@@ -63,7 +63,7 @@ describe('CourseManagementOverviewStatisticsComponent', () => {
 
         component.ngOnChanges();
 
-        expect(component.loading).toBe(false);
+        expect(component.loading).toBeFalse();
         expect(component.ngxData[0].series[0].value).toBe(0);
         expect(component.ngxData[0].series[1].value).toBe(0);
         expect(component.ngxData[0].series[2].value).toBe(0);
@@ -76,7 +76,7 @@ describe('CourseManagementOverviewStatisticsComponent', () => {
 
         component.ngOnInit();
 
-        expect(component.startDateAlreadyPassed).toBe(false);
+        expect(component.startDateAlreadyPassed).toBeFalse();
     });
 
     it('should show only 2 weeks if start date is 1 week ago', () => {

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -186,8 +186,8 @@ describe('CourseOverviewComponent', () => {
 
         component.ngOnInit();
 
-        expect(component.enableShowMore).toBe(true);
-        expect(component.longDescriptionShown).toBe(true);
+        expect(component.enableShowMore).toBeTrue();
+        expect(component.longDescriptionShown).toBeTrue();
 
         component.toggleCourseDescription();
 
@@ -196,7 +196,7 @@ describe('CourseOverviewComponent', () => {
 
         component.toggleCourseDescription();
 
-        expect(component.longDescriptionShown).toBe(true);
+        expect(component.longDescriptionShown).toBeTrue();
         expect(component.courseDescription).toBe(course1.description);
     });
 
@@ -210,7 +210,7 @@ describe('CourseOverviewComponent', () => {
 
         const bool = component.hasVisibleExams();
 
-        expect(bool).toBe(true);
+        expect(bool).toBeTrue();
     });
 
     it('should not have visible exams', () => {
@@ -250,7 +250,7 @@ describe('CourseOverviewComponent', () => {
 
         expect(adjustCourseDescriptionStub).toHaveBeenCalled();
         expect(component.enableShowMore).toBe(false);
-        expect(component.longDescriptionShown).toBe(true);
+        expect(component.longDescriptionShown).toBeTrue();
         expect(component.courseDescription).toBe(course2.description);
         expect(localStorage.getItem('isDescriptionRead' + course2.shortName)).toBe('true');
     });

--- a/src/test/javascript/spec/component/course/course-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-overview.component.spec.ts
@@ -191,7 +191,7 @@ describe('CourseOverviewComponent', () => {
 
         component.toggleCourseDescription();
 
-        expect(component.longDescriptionShown).toBe(false);
+        expect(component.longDescriptionShown).toBeFalse();
         expect(component.courseDescription).toBe('Nihilne te nocturnum praesidium Palati, nihil urbi…');
 
         component.toggleCourseDescription();
@@ -223,7 +223,7 @@ describe('CourseOverviewComponent', () => {
 
         const bool = component.hasVisibleExams();
 
-        expect(bool).toBe(false);
+        expect(bool).toBeFalse();
     });
 
     it('should subscribeToTeamAssignmentUpdates', () => {
@@ -249,7 +249,7 @@ describe('CourseOverviewComponent', () => {
         component.ngOnInit();
 
         expect(adjustCourseDescriptionStub).toHaveBeenCalled();
-        expect(component.enableShowMore).toBe(false);
+        expect(component.enableShowMore).toBeFalse();
         expect(component.longDescriptionShown).toBeTrue();
         expect(component.courseDescription).toBe(course2.description);
         expect(localStorage.getItem('isDescriptionRead' + course2.shortName)).toBe('true');

--- a/src/test/javascript/spec/component/course/course-statistics/course-management-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-statistics/course-management-statistics.component.spec.ts
@@ -59,7 +59,7 @@ describe('CourseManagementStatisticsComponent', () => {
     it('should initialize', () => {
         const statisticsService = jest.spyOn(service, 'getCourseStatistics').mockReturnValue(of(returnValue));
         fixture.detectChanges();
-        expect(statisticsService).toHaveBeenCalledTimes(1);
+        expect(statisticsService).toHaveBeenCalledOnce();
     });
 
     it('should trigger when tab changed', fakeAsync(() => {
@@ -71,7 +71,7 @@ describe('CourseManagementStatisticsComponent', () => {
         button.click();
 
         tick();
-        expect(tabSpy).toHaveBeenCalledTimes(1);
+        expect(tabSpy).toHaveBeenCalledOnce();
         expect(component.currentSpan).toBe(SpanType.MONTH);
     }));
 });

--- a/src/test/javascript/spec/component/course/course-update.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-update.component.spec.ts
@@ -202,7 +202,7 @@ describe('Course Management Update Component', () => {
             // THEN
             expect(updateStub).toHaveBeenCalledOnce();
             expect(updateStub).toHaveBeenCalledWith({ ...entity });
-            expect(comp.isSaving).toBe(false);
+            expect(comp.isSaving).toBeFalse();
         }));
 
         it('Should call create service on save for new entity', fakeAsync(() => {
@@ -235,7 +235,7 @@ describe('Course Management Update Component', () => {
             // THEN
             expect(createStub).toHaveBeenCalledOnce();
             expect(createStub).toHaveBeenCalledWith({ ...entity });
-            expect(comp.isSaving).toBe(false);
+            expect(comp.isSaving).toBeFalse();
         }));
     });
 
@@ -266,7 +266,7 @@ describe('Course Management Update Component', () => {
 
     describe('imageLoaded', () => {
         it('should show cropper', () => {
-            expect(comp.showCropper).toBe(false);
+            expect(comp.showCropper).toBeFalse();
             comp.imageLoaded();
             expect(comp.showCropper).toBeTrue();
         });
@@ -287,7 +287,7 @@ describe('Course Management Update Component', () => {
             const file = base64StringToBlob(croppedImage, 'image/*');
             file['name'] = comp.courseImageFileName;
             expect(uploadStub.mock.calls[0][1]).toBe(comp.courseImageFileName);
-            expect(comp.showCropper).toBe(false);
+            expect(comp.showCropper).toBeFalse();
         });
         it('should set image name to course icon if upload fails', () => {
             uploadStub.mockRejectedValue({} as FileUploadResponse);
@@ -296,7 +296,7 @@ describe('Course Management Update Component', () => {
             comp.uploadCourseImage();
             expect(uploadStub.mock.calls[0][1]).toBe(comp.courseImageFileName);
             expect(comp.courseImageFileName).toBe(comp.course.courseIcon);
-            expect(comp.showCropper).toBe(false);
+            expect(comp.showCropper).toBeFalse();
         });
     });
 
@@ -309,7 +309,7 @@ describe('Course Management Update Component', () => {
             });
             expect(comp.courseForm.controls['presentationScore'].disabled).toBeTrue();
             comp.changePresentationScoreInput();
-            expect(comp.courseForm.controls['presentationScore'].disabled).toBe(false);
+            expect(comp.courseForm.controls['presentationScore'].disabled).toBeFalse();
             expect(comp.presentationScoreEnabled).toBeTrue();
         });
         it('should reset if control has value', () => {
@@ -317,11 +317,11 @@ describe('Course Management Update Component', () => {
             comp.courseForm = new FormGroup({
                 presentationScore: control,
             });
-            expect(comp.courseForm.controls['presentationScore'].disabled).toBe(false);
+            expect(comp.courseForm.controls['presentationScore'].disabled).toBeFalse();
             comp.changePresentationScoreInput();
             expect(comp.courseForm.controls['presentationScore'].disabled).toBeTrue();
             expect(comp.courseForm.controls['presentationScore'].value).toBe(0);
-            expect(comp.presentationScoreEnabled).toBe(false);
+            expect(comp.presentationScoreEnabled).toBeFalse();
         });
     });
 
@@ -334,9 +334,9 @@ describe('Course Management Update Component', () => {
                 registrationEnabled: new FormControl(true),
             });
             expect(comp.courseForm.controls['registrationEnabled'].value).toBeTrue();
-            expect(comp.courseForm.controls['onlineCourse'].value).toBe(false);
+            expect(comp.courseForm.controls['onlineCourse'].value).toBeFalse();
             comp.changeOnlineCourse();
-            expect(comp.courseForm.controls['registrationEnabled'].value).toBe(false);
+            expect(comp.courseForm.controls['registrationEnabled'].value).toBeFalse();
             expect(comp.courseForm.controls['onlineCourse'].value).toBeTrue();
             expect(comp.course.onlineCourse).toBeTrue();
         });
@@ -350,10 +350,10 @@ describe('Course Management Update Component', () => {
                 registrationEnabled: new FormControl(false),
                 onlineCourse: new FormControl(true),
             });
-            expect(comp.courseForm.controls['registrationEnabled'].value).toBe(false);
+            expect(comp.courseForm.controls['registrationEnabled'].value).toBeFalse();
             expect(comp.courseForm.controls['onlineCourse'].value).toBeTrue();
             comp.changeRegistrationEnabled();
-            expect(comp.courseForm.controls['onlineCourse'].value).toBe(false);
+            expect(comp.courseForm.controls['onlineCourse'].value).toBeFalse();
             expect(comp.courseForm.controls['registrationEnabled'].value).toBeTrue();
             expect(comp.course.registrationEnabled).toBeTrue();
         });
@@ -382,7 +382,7 @@ describe('Course Management Update Component', () => {
             expect(comp.courseForm.controls['maxComplaintTimeDays'].value).toBe(0);
             expect(comp.courseForm.controls['maxComplaintTextLimit'].value).toBe(0);
             expect(comp.courseForm.controls['maxComplaintResponseTextLimit'].value).toBe(0);
-            expect(comp.complaintsEnabled).toBe(false);
+            expect(comp.complaintsEnabled).toBeFalse();
         });
     });
 
@@ -397,7 +397,7 @@ describe('Course Management Update Component', () => {
             expect(comp.requestMoreFeedbackEnabled).toBeTrue();
             comp.changeRequestMoreFeedbackEnabled();
             expect(comp.courseForm.controls['maxRequestMoreFeedbackTimeDays'].value).toBe(0);
-            expect(comp.requestMoreFeedbackEnabled).toBe(false);
+            expect(comp.requestMoreFeedbackEnabled).toBeFalse();
         });
     });
 
@@ -421,7 +421,7 @@ describe('Course Management Update Component', () => {
             expect(comp.courseForm.controls['teachingAssistantGroupName'].value).toBe(undefined);
             expect(comp.courseForm.controls['editorGroupName'].value).toBe(undefined);
             expect(comp.courseForm.controls['instructorGroupName'].value).toBe(undefined);
-            expect(comp.customizeGroupNames).toBe(false);
+            expect(comp.customizeGroupNames).toBeFalse();
         });
     });
 
@@ -431,7 +431,7 @@ describe('Course Management Update Component', () => {
             comp.course.testCourse = true;
             expect(comp.course.testCourse).toBeTrue();
             comp.changeTestCourseEnabled();
-            expect(comp.course.testCourse).toBe(false);
+            expect(comp.course.testCourse).toBeFalse();
             comp.changeTestCourseEnabled();
             expect(comp.course.testCourse).toBeTrue();
         });

--- a/src/test/javascript/spec/component/course/course-update.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-update.component.spec.ts
@@ -130,11 +130,11 @@ describe('Course Management Update Component', () => {
             comp.ngOnInit();
             expect(comp.course).toEqual(course);
             expect(comp.courseOrganizations).toEqual([organization]);
-            expect(comp.presentationScoreEnabled).toBe(true);
-            expect(getOrganizationsStub).toHaveBeenCalledTimes(1);
+            expect(comp.presentationScoreEnabled).toBeTrue();
+            expect(getOrganizationsStub).toHaveBeenCalledOnce();
             expect(getOrganizationsStub).toHaveBeenCalledWith(course.id);
-            expect(getProfileStub).toHaveBeenCalledTimes(1);
-            expect(comp.customizeGroupNames).toBe(true);
+            expect(getProfileStub).toHaveBeenCalledOnce();
+            expect(comp.customizeGroupNames).toBeTrue();
             expect(comp.course.studentGroupName).toBe('artemis-dev');
             expect(comp.course.teachingAssistantGroupName).toBe('artemis-dev');
             expect(comp.course.editorGroupName).toBe('artemis-dev');
@@ -200,7 +200,7 @@ describe('Course Management Update Component', () => {
             tick(); // simulate async
 
             // THEN
-            expect(updateStub).toHaveBeenCalledTimes(1);
+            expect(updateStub).toHaveBeenCalledOnce();
             expect(updateStub).toHaveBeenCalledWith({ ...entity });
             expect(comp.isSaving).toBe(false);
         }));
@@ -233,7 +233,7 @@ describe('Course Management Update Component', () => {
             tick(); // simulate async
 
             // THEN
-            expect(createStub).toHaveBeenCalledTimes(1);
+            expect(createStub).toHaveBeenCalledOnce();
             expect(createStub).toHaveBeenCalledWith({ ...entity });
             expect(comp.isSaving).toBe(false);
         }));
@@ -268,7 +268,7 @@ describe('Course Management Update Component', () => {
         it('should show cropper', () => {
             expect(comp.showCropper).toBe(false);
             comp.imageLoaded();
-            expect(comp.showCropper).toBe(true);
+            expect(comp.showCropper).toBeTrue();
         });
     });
 
@@ -307,10 +307,10 @@ describe('Course Management Update Component', () => {
             comp.courseForm = new FormGroup({
                 presentationScore: control,
             });
-            expect(comp.courseForm.controls['presentationScore'].disabled).toBe(true);
+            expect(comp.courseForm.controls['presentationScore'].disabled).toBeTrue();
             comp.changePresentationScoreInput();
             expect(comp.courseForm.controls['presentationScore'].disabled).toBe(false);
-            expect(comp.presentationScoreEnabled).toBe(true);
+            expect(comp.presentationScoreEnabled).toBeTrue();
         });
         it('should reset if control has value', () => {
             const control = new FormControl(12);
@@ -319,7 +319,7 @@ describe('Course Management Update Component', () => {
             });
             expect(comp.courseForm.controls['presentationScore'].disabled).toBe(false);
             comp.changePresentationScoreInput();
-            expect(comp.courseForm.controls['presentationScore'].disabled).toBe(true);
+            expect(comp.courseForm.controls['presentationScore'].disabled).toBeTrue();
             expect(comp.courseForm.controls['presentationScore'].value).toBe(0);
             expect(comp.presentationScoreEnabled).toBe(false);
         });
@@ -333,12 +333,12 @@ describe('Course Management Update Component', () => {
                 onlineCourse: new FormControl(false),
                 registrationEnabled: new FormControl(true),
             });
-            expect(comp.courseForm.controls['registrationEnabled'].value).toBe(true);
+            expect(comp.courseForm.controls['registrationEnabled'].value).toBeTrue();
             expect(comp.courseForm.controls['onlineCourse'].value).toBe(false);
             comp.changeOnlineCourse();
             expect(comp.courseForm.controls['registrationEnabled'].value).toBe(false);
-            expect(comp.courseForm.controls['onlineCourse'].value).toBe(true);
-            expect(comp.course.onlineCourse).toBe(true);
+            expect(comp.courseForm.controls['onlineCourse'].value).toBeTrue();
+            expect(comp.course.onlineCourse).toBeTrue();
         });
     });
 
@@ -351,11 +351,11 @@ describe('Course Management Update Component', () => {
                 onlineCourse: new FormControl(true),
             });
             expect(comp.courseForm.controls['registrationEnabled'].value).toBe(false);
-            expect(comp.courseForm.controls['onlineCourse'].value).toBe(true);
+            expect(comp.courseForm.controls['onlineCourse'].value).toBeTrue();
             comp.changeRegistrationEnabled();
             expect(comp.courseForm.controls['onlineCourse'].value).toBe(false);
-            expect(comp.courseForm.controls['registrationEnabled'].value).toBe(true);
-            expect(comp.course.registrationEnabled).toBe(true);
+            expect(comp.courseForm.controls['registrationEnabled'].value).toBeTrue();
+            expect(comp.course.registrationEnabled).toBeTrue();
         });
     });
 
@@ -375,7 +375,7 @@ describe('Course Management Update Component', () => {
             expect(comp.courseForm.controls['maxComplaintTimeDays'].value).toBe(7);
             expect(comp.courseForm.controls['maxComplaintTextLimit'].value).toBe(2000);
             expect(comp.courseForm.controls['maxComplaintResponseTextLimit'].value).toBe(2000);
-            expect(comp.complaintsEnabled).toBe(true);
+            expect(comp.complaintsEnabled).toBeTrue();
             comp.changeComplaintsEnabled();
             expect(comp.courseForm.controls['maxComplaints'].value).toBe(0);
             expect(comp.courseForm.controls['maxTeamComplaints'].value).toBe(0);
@@ -394,7 +394,7 @@ describe('Course Management Update Component', () => {
             comp.requestMoreFeedbackEnabled = false;
             comp.changeRequestMoreFeedbackEnabled();
             expect(comp.courseForm.controls['maxRequestMoreFeedbackTimeDays'].value).toBe(7);
-            expect(comp.requestMoreFeedbackEnabled).toBe(true);
+            expect(comp.requestMoreFeedbackEnabled).toBeTrue();
             comp.changeRequestMoreFeedbackEnabled();
             expect(comp.courseForm.controls['maxRequestMoreFeedbackTimeDays'].value).toBe(0);
             expect(comp.requestMoreFeedbackEnabled).toBe(false);
@@ -415,7 +415,7 @@ describe('Course Management Update Component', () => {
             expect(comp.courseForm.controls['teachingAssistantGroupName'].value).toBe('artemis-dev');
             expect(comp.courseForm.controls['editorGroupName'].value).toBe('artemis-dev');
             expect(comp.courseForm.controls['instructorGroupName'].value).toBe('artemis-dev');
-            expect(comp.customizeGroupNames).toBe(true);
+            expect(comp.customizeGroupNames).toBeTrue();
             comp.changeCustomizeGroupNames();
             expect(comp.courseForm.controls['studentGroupName'].value).toBe(undefined);
             expect(comp.courseForm.controls['teachingAssistantGroupName'].value).toBe(undefined);
@@ -429,11 +429,11 @@ describe('Course Management Update Component', () => {
         it('should toggle test course', () => {
             comp.course = new Course();
             comp.course.testCourse = true;
-            expect(comp.course.testCourse).toBe(true);
+            expect(comp.course.testCourse).toBeTrue();
             comp.changeTestCourseEnabled();
             expect(comp.course.testCourse).toBe(false);
             comp.changeTestCourseEnabled();
-            expect(comp.course.testCourse).toBe(true);
+            expect(comp.course.testCourse).toBeTrue();
         });
     });
 

--- a/src/test/javascript/spec/component/course/detail/course-detail-line-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/course/detail/course-detail-line-chart.component.spec.ts
@@ -116,7 +116,7 @@ describe('CourseDetailLineChartComponent', () => {
         expect(component.data[0].series[0].value).toBe(24);
         expect(component.data[0].series[1].value).toBe(84);
         expect(component.data[0].series[1].name).toBe('calendar_week ' + endDate.isoWeek());
-        expect(component.startDateDisplayed).toBe(true);
+        expect(component.startDateDisplayed).toBeTrue();
     });
 
     it('should limit the next view if start date is reached', () => {
@@ -135,7 +135,7 @@ describe('CourseDetailLineChartComponent', () => {
         expect(component.data[0].series).toHaveLength(1);
         expect(component.data[0].series[0].value).toBe(84);
         expect(component.data[0].series[0].name).toBe('calendar_week ' + startDate.isoWeek());
-        expect(getStatisticsDataMock).toHaveBeenCalledTimes(1);
+        expect(getStatisticsDataMock).toHaveBeenCalledOnce();
         expect(getStatisticsDataMock).toHaveBeenCalledWith(42, -1);
     });
 });

--- a/src/test/javascript/spec/component/course/detail/course-detail-line-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/course/detail/course-detail-line-chart.component.spec.ts
@@ -81,7 +81,7 @@ describe('CourseDetailLineChartComponent', () => {
 
         component.ngOnChanges();
 
-        expect(component.startDateAlreadyPassed).toBe(false);
+        expect(component.startDateAlreadyPassed).toBeFalse();
     });
 
     it('should show only 2 weeks if start date is 1 week ago', () => {

--- a/src/test/javascript/spec/component/course/detail/course-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/course/detail/course-detail.component.spec.ts
@@ -134,12 +134,12 @@ describe('Course Management Detail Component', () => {
     it('should toggle course description', () => {
         component.ngOnInit();
 
-        expect(component.enableShowMore).toBe(true);
+        expect(component.enableShowMore).toBeTrue();
         expect(component.longDescriptionShown).toBe(false);
 
         component.toggleCourseDescription();
 
-        expect(component.longDescriptionShown).toBe(true);
+        expect(component.longDescriptionShown).toBeTrue();
         expect(component.courseDescription).toBe(course.description);
 
         component.toggleCourseDescription();

--- a/src/test/javascript/spec/component/course/detail/course-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/course/detail/course-detail.component.spec.ts
@@ -135,7 +135,7 @@ describe('Course Management Detail Component', () => {
         component.ngOnInit();
 
         expect(component.enableShowMore).toBeTrue();
-        expect(component.longDescriptionShown).toBe(false);
+        expect(component.longDescriptionShown).toBeFalse();
 
         component.toggleCourseDescription();
 
@@ -144,7 +144,7 @@ describe('Course Management Detail Component', () => {
 
         component.toggleCourseDescription();
 
-        expect(component.longDescriptionShown).toBe(false);
+        expect(component.longDescriptionShown).toBeFalse();
         expect(component.courseDescription).toBe('Cras mattis iudicium purus sit amet fermentum. Gal…');
     });
 });

--- a/src/test/javascript/spec/component/course/exercise-filter.model.spec.ts
+++ b/src/test/javascript/spec/component/course/exercise-filter.model.spec.ts
@@ -31,7 +31,7 @@ describe('Exercise Filter Test', () => {
 
     it('should be empty on create', () => {
         const filter = new ExerciseFilter();
-        expect(filter.isEmpty()).toBe(true);
+        expect(filter.isEmpty()).toBeTrue();
     });
 
     it('should filter by name', () => {

--- a/src/test/javascript/spec/component/drag-and-drop-question/drag-and-drop-question-edit.component.spec.ts
+++ b/src/test/javascript/spec/component/drag-and-drop-question/drag-and-drop-question-edit.component.spec.ts
@@ -82,8 +82,8 @@ describe('DragAndDropQuestionEditComponent', () => {
     });
 
     it('should initialize', () => {
-        expect(component.isQuestionCollapsed).toBe(false);
-        expect(component.isUploadingDragItemFile).toBe(false);
+        expect(component.isQuestionCollapsed).toBeFalse();
+        expect(component.isUploadingDragItemFile).toBeFalse();
         expect(component.mouse).toStrictEqual(new DragAndDropMouseEvent());
     });
 
@@ -146,7 +146,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         expect(component.backgroundFile).toBe(undefined);
         expect(component.question.backgroundFilePath).toBe(newPath);
-        expect(component.isUploadingBackgroundFile).toBe(false);
+        expect(component.isUploadingBackgroundFile).toBeFalse();
     }));
 
     it('should move the mouse in different situations', () => {
@@ -272,7 +272,7 @@ describe('DragAndDropQuestionEditComponent', () => {
         component.drag();
         expect(component.dropAllowed).toBeTrue();
         component.drop();
-        expect(component.dropAllowed).toBe(false);
+        expect(component.dropAllowed).toBeFalse();
     });
 
     it('should duplicate drop location', () => {
@@ -371,7 +371,7 @@ describe('DragAndDropQuestionEditComponent', () => {
             component.uploadDragItem();
             tick();
         } catch (error) {
-            expect(component.isUploadingDragItemFile).toBe(false);
+            expect(component.isUploadingDragItemFile).toBeFalse();
             // Once because spy has been called in first execution of uploadDragItem()
             expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         }
@@ -389,7 +389,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         expect(component.dragItemPicture).toBe(newPath);
-        expect(component.isUploadingDragItemFile).toBe(false);
+        expect(component.isUploadingDragItemFile).toBeFalse();
     }));
 
     it('should delete drag item', () => {
@@ -471,7 +471,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         expect(component.dragItemPicture).toBe(newPath);
         expect(questionUpdatedSpy).toHaveBeenCalledOnce();
-        expect(component.isUploadingDragItemFile).toBe(false);
+        expect(component.isUploadingDragItemFile).toBeFalse();
     }));
 
     it('should change question title', () => {
@@ -529,7 +529,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         component.resetDragItem(firstItem);
 
-        expect(component.question.dragItems[2].invalid).toBe(false);
+        expect(component.question.dragItems[2].invalid).toBeFalse();
     });
 
     it('should reset drop location', () => {
@@ -546,7 +546,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         component.resetDropLocation(firstItem);
 
-        expect(component.question.dropLocations[2].invalid).toBe(false);
+        expect(component.question.dropLocations[2].invalid).toBeFalse();
     });
 
     it('should toggle preview', () => {
@@ -556,7 +556,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         component.togglePreview();
 
-        expect(component.showPreview).toBe(false);
+        expect(component.showPreview).toBeFalse();
         expect(component.question.text).toBe(undefined);
     });
 

--- a/src/test/javascript/spec/component/drag-and-drop-question/drag-and-drop-question-edit.component.spec.ts
+++ b/src/test/javascript/spec/component/drag-and-drop-question/drag-and-drop-question-edit.component.spec.ts
@@ -93,7 +93,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         fixture.detectChanges();
 
-        expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+        expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         expect(component.backupQuestion).toEqual(question1);
     });
 
@@ -106,9 +106,9 @@ describe('DragAndDropQuestionEditComponent', () => {
         component.moveDownQuestion();
         component.deleteQuestion();
 
-        expect(eventUpSpy).toHaveBeenCalledTimes(1);
-        expect(eventDownSpy).toHaveBeenCalledTimes(1);
-        expect(eventDeleteSpy).toHaveBeenCalledTimes(1);
+        expect(eventUpSpy).toHaveBeenCalledOnce();
+        expect(eventDownSpy).toHaveBeenCalledOnce();
+        expect(eventDeleteSpy).toHaveBeenCalledOnce();
     });
 
     it('should set background file', () => {
@@ -215,7 +215,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         component.mouseUp();
 
-        expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+        expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         expect(component.draggingState).toBe(DragState.NONE);
         expect(component.currentDropLocation).toBe(undefined);
 
@@ -268,9 +268,9 @@ describe('DragAndDropQuestionEditComponent', () => {
         const modalServiceSpy = jest.spyOn(modalService, 'open');
 
         component.open(content);
-        expect(modalServiceSpy).toHaveBeenCalledTimes(1);
+        expect(modalServiceSpy).toHaveBeenCalledOnce();
         component.drag();
-        expect(component.dropAllowed).toBe(true);
+        expect(component.dropAllowed).toBeTrue();
         component.drop();
         expect(component.dropAllowed).toBe(false);
     });
@@ -328,7 +328,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         component.addTextDragItem();
 
-        expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+        expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         const firstDragItemOfQuestion = component.question.dragItems![0];
         expect(firstDragItemOfQuestion.text).toBe('Text');
     });
@@ -359,7 +359,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
             const expectedItem = component.question.dragItems![0];
             expect(expectedItem!.pictureFilePath).toBe('alwaysGoYourPath');
-            expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+            expect(questionUpdatedSpy).toHaveBeenCalledOnce();
             expect(component.dragItemFileName).toBe('');
             expect(component.dragItemFile).toBe(undefined);
             jest.restoreAllMocks();
@@ -373,7 +373,7 @@ describe('DragAndDropQuestionEditComponent', () => {
         } catch (error) {
             expect(component.isUploadingDragItemFile).toBe(false);
             // Once because spy has been called in first execution of uploadDragItem()
-            expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+            expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         }
     }));
 
@@ -387,7 +387,7 @@ describe('DragAndDropQuestionEditComponent', () => {
         component.uploadPictureForDragItemChange();
         tick();
 
-        expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+        expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         expect(component.dragItemPicture).toBe(newPath);
         expect(component.isUploadingDragItemFile).toBe(false);
     }));
@@ -435,7 +435,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         component.onDragDrop(alternativeLocation, event);
 
-        expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+        expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         expect(component.question.correctMappings).toEqual([mapping, expectedMapping]);
     });
 
@@ -470,7 +470,7 @@ describe('DragAndDropQuestionEditComponent', () => {
         tick();
 
         expect(component.dragItemPicture).toBe(newPath);
-        expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+        expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         expect(component.isUploadingDragItemFile).toBe(false);
     }));
 
@@ -567,7 +567,7 @@ describe('DragAndDropQuestionEditComponent', () => {
 
         component.changesInMarkdown();
 
-        expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+        expect(questionUpdatedSpy).toHaveBeenCalledOnce();
         expect(component.question.text).toBe(undefined);
     });
 

--- a/src/test/javascript/spec/component/drag-and-drop-question/drag-and-drop-question.component.spec.ts
+++ b/src/test/javascript/spec/component/drag-and-drop-question/drag-and-drop-question.component.spec.ts
@@ -135,7 +135,7 @@ describe('DragAndDropQuestionComponent', () => {
     it('should hide sample solutions', () => {
         comp.showingSampleSolution = true;
         comp.hideSampleSolution();
-        expect(comp.showingSampleSolution).toBe(false);
+        expect(comp.showingSampleSolution).toBeFalse();
     });
 
     it('should return unassigned drag items', () => {
@@ -150,7 +150,7 @@ describe('DragAndDropQuestionComponent', () => {
         const { dropLocation: dropLocation1, mapping: mapping1 } = getDropLocationMappingAndItem();
         const { dropLocation: dropLocation2, mapping: mapping2, dragItem: dragItem2 } = getDropLocationMappingAndItem();
         comp.mappings = [mapping1, mapping2];
-        expect(comp.invalidDragItemForDropLocation(dropLocation1)).toBe(false);
+        expect(comp.invalidDragItemForDropLocation(dropLocation1)).toBeFalse();
         dragItem2.invalid = true;
         expect(comp.invalidDragItemForDropLocation(dropLocation2)).toBeTrue();
     });

--- a/src/test/javascript/spec/component/drag-and-drop-question/drag-and-drop-question.component.spec.ts
+++ b/src/test/javascript/spec/component/drag-and-drop-question/drag-and-drop-question.component.spec.ts
@@ -126,10 +126,10 @@ describe('DragAndDropQuestionComponent', () => {
         const solveSpy = jest.spyOn(dragAndDropQuestionUtil, 'solve').mockReturnValue(mappings);
         comp.mappings = mappings;
         comp.forceSampleSolution = true;
-        expect(comp.forceSampleSolution).toBe(true);
+        expect(comp.forceSampleSolution).toBeTrue();
         expect(solveSpy).toHaveBeenCalledWith(comp.question, mappings);
         expect(comp.sampleSolutionMappings).toEqual(mappings);
-        expect(comp.showingSampleSolution).toBe(true);
+        expect(comp.showingSampleSolution).toBeTrue();
     });
 
     it('should hide sample solutions', () => {
@@ -152,7 +152,7 @@ describe('DragAndDropQuestionComponent', () => {
         comp.mappings = [mapping1, mapping2];
         expect(comp.invalidDragItemForDropLocation(dropLocation1)).toBe(false);
         dragItem2.invalid = true;
-        expect(comp.invalidDragItemForDropLocation(dropLocation2)).toBe(true);
+        expect(comp.invalidDragItemForDropLocation(dropLocation2)).toBeTrue();
     });
 
     it('should return no drag item if there is no mapping', () => {
@@ -207,7 +207,7 @@ describe('DragAndDropQuestionComponent', () => {
     it('should set drop allowed to true when dragged', () => {
         comp.dropAllowed = false;
         comp.drag();
-        expect(comp.dropAllowed).toBe(true);
+        expect(comp.dropAllowed).toBeTrue();
     });
 
     const getDropLocationMappingAndItem = () => {

--- a/src/test/javascript/spec/component/exam-exercise-row-buttons/exam-exercise-row-buttons.component.spec.ts
+++ b/src/test/javascript/spec/component/exam-exercise-row-buttons/exam-exercise-row-buttons.component.spec.ts
@@ -120,15 +120,15 @@ describe('ExamExerciseRowButtonsComponent', () => {
                 deleteTextExerciseStub.mockReturnValue(of({}));
                 component.exercise = textExercise;
                 component.deleteExercise();
-                expect(deleteTextExerciseStub).toHaveBeenCalledTimes(1);
-                expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(1);
+                expect(deleteTextExerciseStub).toHaveBeenCalledOnce();
+                expect(onDeleteExerciseEmitSpy).toHaveBeenCalledOnce();
             });
             it('should handle error for textexercise', () => {
                 const error = { message: 'error occurred!' } as HttpErrorResponse;
                 deleteTextExerciseStub.mockReturnValue(throwError(() => error));
                 component.exercise = textExercise;
                 component.deleteExercise();
-                expect(deleteTextExerciseStub).toHaveBeenCalledTimes(1);
+                expect(deleteTextExerciseStub).toHaveBeenCalledOnce();
                 expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(0);
             });
         });
@@ -137,15 +137,15 @@ describe('ExamExerciseRowButtonsComponent', () => {
                 deleteModelingExerciseStub.mockReturnValue(of({}));
                 component.exercise = modelingExercise;
                 component.deleteExercise();
-                expect(deleteModelingExerciseStub).toHaveBeenCalledTimes(1);
-                expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(1);
+                expect(deleteModelingExerciseStub).toHaveBeenCalledOnce();
+                expect(onDeleteExerciseEmitSpy).toHaveBeenCalledOnce();
             });
             it('should handle error for modelingexercise', () => {
                 const error = { message: 'error occurred!' } as HttpErrorResponse;
                 deleteModelingExerciseStub.mockReturnValue(throwError(() => error));
                 component.exercise = modelingExercise;
                 component.deleteExercise();
-                expect(deleteModelingExerciseStub).toHaveBeenCalledTimes(1);
+                expect(deleteModelingExerciseStub).toHaveBeenCalledOnce();
                 expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(0);
             });
         });
@@ -154,15 +154,15 @@ describe('ExamExerciseRowButtonsComponent', () => {
                 deleteFileUploadExerciseStub.mockReturnValue(of({}));
                 component.exercise = fileUploadExercise;
                 component.deleteExercise();
-                expect(deleteFileUploadExerciseStub).toHaveBeenCalledTimes(1);
-                expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(1);
+                expect(deleteFileUploadExerciseStub).toHaveBeenCalledOnce();
+                expect(onDeleteExerciseEmitSpy).toHaveBeenCalledOnce();
             });
             it('should handle error for fileupload exercise', () => {
                 const error = { message: 'error occurred!' } as HttpErrorResponse;
                 deleteFileUploadExerciseStub.mockReturnValue(throwError(() => error));
                 component.exercise = fileUploadExercise;
                 component.deleteExercise();
-                expect(deleteFileUploadExerciseStub).toHaveBeenCalledTimes(1);
+                expect(deleteFileUploadExerciseStub).toHaveBeenCalledOnce();
                 expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(0);
             });
         });
@@ -171,15 +171,15 @@ describe('ExamExerciseRowButtonsComponent', () => {
                 deleteQuizExerciseStub.mockReturnValue(of({}));
                 component.exercise = quizExercise;
                 component.deleteExercise();
-                expect(deleteQuizExerciseStub).toHaveBeenCalledTimes(1);
-                expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(1);
+                expect(deleteQuizExerciseStub).toHaveBeenCalledOnce();
+                expect(onDeleteExerciseEmitSpy).toHaveBeenCalledOnce();
             });
             it('should handle error for quizexercise', () => {
                 const error = { message: 'error occurred!' } as HttpErrorResponse;
                 deleteQuizExerciseStub.mockReturnValue(throwError(() => error));
                 component.exercise = quizExercise;
                 component.deleteExercise();
-                expect(deleteQuizExerciseStub).toHaveBeenCalledTimes(1);
+                expect(deleteQuizExerciseStub).toHaveBeenCalledOnce();
                 expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(0);
             });
         });
@@ -189,15 +189,15 @@ describe('ExamExerciseRowButtonsComponent', () => {
             deleteProgrammingExerciseStub.mockReturnValue(of({}));
             component.exercise = programmingExercise;
             component.deleteProgrammingExercise({});
-            expect(deleteProgrammingExerciseStub).toHaveBeenCalledTimes(1);
-            expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(1);
+            expect(deleteProgrammingExerciseStub).toHaveBeenCalledOnce();
+            expect(onDeleteExerciseEmitSpy).toHaveBeenCalledOnce();
         });
         it('should handle error for programmingExercise', () => {
             const error = { message: 'error occurred!' } as HttpErrorResponse;
             deleteProgrammingExerciseStub.mockReturnValue(throwError(() => error));
             component.exercise = programmingExercise;
             component.deleteProgrammingExercise({});
-            expect(deleteProgrammingExerciseStub).toHaveBeenCalledTimes(1);
+            expect(deleteProgrammingExerciseStub).toHaveBeenCalledOnce();
             expect(onDeleteExerciseEmitSpy).toHaveBeenCalledTimes(0);
         });
     });

--- a/src/test/javascript/spec/component/exam/exam-scores/exam-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/exam-scores/exam-scores.component.spec.ts
@@ -622,7 +622,7 @@ describe('ExamScoresComponent', () => {
         jest.spyOn(gradingSystemService, 'findMatchingGradeStep').mockReturnValue(gradingScale.gradeSteps[0]);
         fixture.detectChanges();
 
-        expect(comp.gradingScaleExists).toBe(true);
+        expect(comp.gradingScaleExists).toBeTrue();
         expect(comp.gradingScale).toEqual(gradingScale);
         expect(comp.isBonus).toBe(false);
     });
@@ -641,7 +641,7 @@ describe('ExamScoresComponent', () => {
 
         comp.toggleFilterForNonEmptySubmission();
 
-        expect(comp.filterForNonEmptySubmissions).toBe(true);
+        expect(comp.filterForNonEmptySubmissions).toBeTrue();
     });
 
     describe('test table filtering', () => {
@@ -811,7 +811,7 @@ describe('ExamScoresComponent', () => {
         comp.isBonus = false;
         fixture.detectChanges();
 
-        expect(comp.showPassedMedian).toBe(true);
+        expect(comp.showPassedMedian).toBeTrue();
 
         comp.toggleMedian(MedianType.PASSED);
 
@@ -820,11 +820,11 @@ describe('ExamScoresComponent', () => {
         comp.toggleMedian(MedianType.OVERALL);
 
         expect(comp.overallChartMedian).toBe(50);
-        expect(comp.showOverallMedian).toBe(true);
+        expect(comp.showOverallMedian).toBeTrue();
 
         comp.toggleMedian(MedianType.PASSED);
 
-        expect(comp.showPassedMedian).toBe(true);
+        expect(comp.showPassedMedian).toBeTrue();
         expect(comp.showOverallMedian).toBe(false);
     });
 

--- a/src/test/javascript/spec/component/exam/exam-scores/exam-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/exam-scores/exam-scores.component.spec.ts
@@ -624,7 +624,7 @@ describe('ExamScoresComponent', () => {
 
         expect(comp.gradingScaleExists).toBeTrue();
         expect(comp.gradingScale).toEqual(gradingScale);
-        expect(comp.isBonus).toBe(false);
+        expect(comp.isBonus).toBeFalse();
     });
 
     it('should filter non-empty submissions', () => {
@@ -815,7 +815,7 @@ describe('ExamScoresComponent', () => {
 
         comp.toggleMedian(MedianType.PASSED);
 
-        expect(comp.showPassedMedian).toBe(false);
+        expect(comp.showPassedMedian).toBeFalse();
 
         comp.toggleMedian(MedianType.OVERALL);
 
@@ -825,7 +825,7 @@ describe('ExamScoresComponent', () => {
         comp.toggleMedian(MedianType.PASSED);
 
         expect(comp.showPassedMedian).toBeTrue();
-        expect(comp.showOverallMedian).toBe(false);
+        expect(comp.showOverallMedian).toBeFalse();
     });
 
     it('should return data label correctly if noOfExamsFiltered is 0', () => {

--- a/src/test/javascript/spec/component/exam/exam-update.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/exam-update.component.spec.ts
@@ -198,7 +198,7 @@ describe('Exam Update Component', () => {
         // trigger save
         component.save();
         tick();
-        expect(updateSpy).toHaveBeenCalledTimes(1);
+        expect(updateSpy).toHaveBeenCalledOnce();
         expect(component.isSaving).toBeFalse();
     }));
 
@@ -293,7 +293,7 @@ describe('Exam Update Component', () => {
         // trigger save
         component.save();
         tick();
-        expect(alertServiceSpy).toHaveBeenCalledTimes(1);
+        expect(alertServiceSpy).toHaveBeenCalledOnce();
         expect(component.isSaving).toBeFalse();
 
         updateStub.mockRestore();
@@ -308,7 +308,7 @@ describe('Exam Update Component', () => {
         // trigger save
         component.save();
         tick();
-        expect(createSpy).toHaveBeenCalledTimes(1);
+        expect(createSpy).toHaveBeenCalledOnce();
         expect(component.isSaving).toBeFalse();
     }));
 
@@ -323,7 +323,7 @@ describe('Exam Update Component', () => {
         // trigger save
         component.save();
         tick();
-        expect(alertServiceSpy).toHaveBeenCalledTimes(1);
+        expect(alertServiceSpy).toHaveBeenCalledOnce();
         expect(component.isSaving).toBeFalse();
 
         createStub.mockRestore();

--- a/src/test/javascript/spec/component/exam/manage/exam-management-resolve.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-management-resolve.spec.ts
@@ -46,7 +46,7 @@ describe('Exam Resolve', () => {
         examObservable.subscribe((exam) => (receivedExam = exam));
         tick();
 
-        expect(findSpy).toHaveBeenCalledTimes(1);
+        expect(findSpy).toHaveBeenCalledOnce();
         expect(findSpy).toHaveBeenCalledWith(1, 2, true, true);
         expect(receivedExam).toEqual({ id: 1 });
     }));
@@ -102,7 +102,7 @@ describe('Exam Group Resolve', () => {
         examObservable.subscribe((exam) => (receivedExamGroup = exam));
         tick();
 
-        expect(findSpy).toHaveBeenCalledTimes(1);
+        expect(findSpy).toHaveBeenCalledOnce();
         expect(findSpy).toHaveBeenCalledWith(1, 2, 3);
         expect(receivedExamGroup).toEqual({ id: 1 });
     }));
@@ -152,7 +152,7 @@ describe('Student Exam Resolve', () => {
         examObservable.subscribe((exam) => (receivedExam = exam));
         tick();
 
-        expect(findSpy).toHaveBeenCalledTimes(1);
+        expect(findSpy).toHaveBeenCalledOnce();
         expect(findSpy).toHaveBeenCalledWith(1, 2, 3);
         expect(receivedExam).toEqual({ id: 1 });
     }));

--- a/src/test/javascript/spec/component/exam/manage/exam-management.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-management.component.spec.ts
@@ -84,7 +84,7 @@ describe('Exam Management Component', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(courseManagementService.find).toHaveBeenCalledTimes(1);
+        expect(courseManagementService.find).toHaveBeenCalledOnce();
         expect(comp.course).toEqual(course);
     });
 
@@ -99,7 +99,7 @@ describe('Exam Management Component', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(service.findAllExamsForCourse).toHaveBeenCalledTimes(1);
+        expect(service.findAllExamsForCourse).toHaveBeenCalledOnce();
         expect(comp.exams).toEqual([exam]);
     });
 
@@ -119,7 +119,7 @@ describe('Exam Management Component', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(service.getLatestIndividualEndDateOfExam).toHaveBeenCalledTimes(1);
+        expect(service.getLatestIndividualEndDateOfExam).toHaveBeenCalledOnce();
         expect(comp.exams[0].latestIndividualEndDate).toEqual(examInformationDTO.latestIndividualEndDate);
     });
 
@@ -134,7 +134,7 @@ describe('Exam Management Component', () => {
         eventManager.broadcast({ name: 'examListModification', content: 'dummy' });
 
         // THEN
-        expect(service.findAllExamsForCourse).toHaveBeenCalledTimes(1);
+        expect(service.findAllExamsForCourse).toHaveBeenCalledOnce();
         expect(comp.exams).toEqual([exam]);
     });
 
@@ -187,6 +187,6 @@ describe('Exam Management Component', () => {
         comp.sortRows();
 
         // THEN
-        expect(sortService.sortByProperty).toHaveBeenCalledTimes(1);
+        expect(sortService.sortByProperty).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/exam/manage/exam-students.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-students.component.spec.ts
@@ -98,7 +98,7 @@ describe('ExamStudentsComponent', () => {
         expect(examServiceStub).toHaveBeenCalledWith(course.id, examWithCourse.id, user3.login);
         expect(component.allRegisteredUsers).toEqual([user1, user2, user3]);
         expect(callbackSpy).toHaveBeenCalledWith(user3);
-        expect(flashSpy).toHaveBeenCalledTimes(1);
+        expect(flashSpy).toHaveBeenCalledOnce();
         expect(component.isTransitioning).toBeFalse();
     });
 
@@ -116,7 +116,7 @@ describe('ExamStudentsComponent', () => {
             expect(component.searchFailed).toBeFalse();
         });
 
-        expect(userServiceStub).toHaveBeenCalledTimes(1);
+        expect(userServiceStub).toHaveBeenCalledOnce();
     });
 
     it('should reload with only registered users', () => {

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-checklist.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-checklist.component.spec.ts
@@ -75,7 +75,7 @@ describe('ExamChecklistComponent', () => {
         component.ngOnChanges();
 
         expect(component.countMandatoryExercises).toBe(0);
-        expect(component.hasOptionalExercises).toBe(true);
+        expect(component.hasOptionalExercises).toBeTrue();
 
         component.exam.exerciseGroups[0].isMandatory = true;
 
@@ -93,7 +93,7 @@ describe('ExamChecklistComponent', () => {
         component.ngOnChanges();
 
         expect(component.countMandatoryExercises).toBe(1);
-        expect(component.hasOptionalExercises).toBe(true);
+        expect(component.hasOptionalExercises).toBeTrue();
     });
 
     it('should set exam checklist correctly', () => {
@@ -101,7 +101,7 @@ describe('ExamChecklistComponent', () => {
 
         component.ngOnChanges();
 
-        expect(getExamStatisticsStub).toHaveBeenCalledTimes(1);
+        expect(getExamStatisticsStub).toHaveBeenCalledOnce();
         expect(getExamStatisticsStub).toHaveBeenCalledWith(exam);
         expect(component.examChecklist).toEqual(examChecklist);
     });

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-checklist.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-checklist.component.spec.ts
@@ -82,7 +82,7 @@ describe('ExamChecklistComponent', () => {
         component.ngOnChanges();
 
         expect(component.countMandatoryExercises).toBe(1);
-        expect(component.hasOptionalExercises).toBe(false);
+        expect(component.hasOptionalExercises).toBeFalse();
 
         const additionalExerciseGroup = {
             id: 13,

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
@@ -213,7 +213,7 @@ describe('ExamDetailComponent', () => {
         examDetailComponent.resetExam();
 
         // THEN
-        expect(service.reset).toHaveBeenCalledTimes(1);
+        expect(service.reset).toHaveBeenCalledOnce();
         expect(examDetailComponent.exam).toEqual(exam);
     });
 
@@ -229,6 +229,6 @@ describe('ExamDetailComponent', () => {
         examDetailComponent.deleteExam(exam.id!);
 
         // THEN
-        expect(service.delete).toHaveBeenCalledTimes(1);
+        expect(service.delete).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/exam/manage/exercise-groups/exercise-group-update.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exercise-groups/exercise-group-update.component.spec.ts
@@ -107,7 +107,7 @@ describe('ExerciseGroupUpdateComponent', () => {
 
         expect(component.isSaving).toBeFalse();
         expect(component.exam).toEqual(exam);
-        expect(alertServiceStub).toHaveBeenCalledTimes(1);
+        expect(alertServiceStub).toHaveBeenCalledOnce();
         flush();
     }));
 });

--- a/src/test/javascript/spec/component/exam/manage/exercise-groups/exercise-group.service.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exercise-groups/exercise-group.service.spec.ts
@@ -18,7 +18,7 @@ describe('Exercise Group Service', () => {
 
     it('should set additional parameters correctly in delete', () => {
         service.delete(1, 2, 3, true, false);
-        expect(httpClientDeleteSpy).toHaveBeenCalledTimes(1);
+        expect(httpClientDeleteSpy).toHaveBeenCalledOnce();
         expect(httpClientDeleteSpy.mock.calls[0]).toHaveLength(2);
         expect(httpClientDeleteSpy.mock.calls[0][1].params.updates).toContainAllValues([
             { op: 's', param: 'deleteStudentReposBuildPlans', value: 'true' },

--- a/src/test/javascript/spec/component/exam/manage/student-exams/exam-status.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/exam-status.component.spec.ts
@@ -131,12 +131,12 @@ describe('ExamStatusComponent', () => {
 
         component.ngOnChanges();
 
-        expect(component.configuredExercises).toBe(true);
-        expect(component.registeredStudents).toBe(true);
-        expect(component.generatedStudentExams).toBe(true);
-        expect(component.preparedExerciseStart).toBe(true);
+        expect(component.configuredExercises).toBeTrue();
+        expect(component.registeredStudents).toBeTrue();
+        expect(component.generatedStudentExams).toBeTrue();
+        expect(component.preparedExerciseStart).toBeTrue();
         expect(component.numberOfGeneratedStudentExams).toBe(42);
-        expect(component.examPreparationFinished).toBe(true);
+        expect(component.examPreparationFinished).toBeTrue();
         expect(getExamStatisticsStub).toHaveBeenCalledWith(exam);
 
         examChecklist.numberOfGeneratedStudentExams = undefined;

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail-table-row.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail-table-row.component.spec.ts
@@ -88,7 +88,7 @@ describe('StudentExamDetailTableRowComponent', () => {
             type: ExerciseType.PROGRAMMING,
         };
         const route = studentExamDetailTableRowComponent.getAssessmentLink(programmingExercise);
-        expect(getAssessmentLinkSpy).toHaveBeenCalledTimes(1);
+        expect(getAssessmentLinkSpy).toHaveBeenCalledOnce();
         expect(route).toEqual(['/course-management', '23', 'exams', '1', 'exercise-groups', '13', 'programming-exercises', '12', 'submissions']);
     });
 
@@ -107,7 +107,7 @@ describe('StudentExamDetailTableRowComponent', () => {
         };
         const submission = { id: 14 };
         const route = studentExamDetailTableRowComponent.getAssessmentLink(modelingExercise, submission);
-        expect(getAssessmentLinkSpy).toHaveBeenCalledTimes(1);
+        expect(getAssessmentLinkSpy).toHaveBeenCalledOnce();
         expect(route).toEqual(['/course-management', '23', 'exams', '1', 'exercise-groups', '12', 'modeling-exercises', '12', 'submissions', '14', 'assessment']);
     });
 });

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
@@ -187,7 +187,7 @@ describe('StudentExamDetailComponent', () => {
         const gradeSpy = jest.spyOn(gradingSystemService, 'matchPercentageToGradeStepForExam');
         studentExamDetailComponentFixture.detectChanges();
 
-        expect(gradeSpy).toHaveBeenCalledTimes(1);
+        expect(gradeSpy).toHaveBeenCalledOnce();
         expect(course.id).toBe(1);
         expect(studentExamDetailComponent.achievedTotalPoints).toBe(40);
 
@@ -200,7 +200,7 @@ describe('StudentExamDetailComponent', () => {
         studentExamDetailComponentFixture.detectChanges();
 
         studentExamDetailComponent.saveWorkingTime();
-        expect(studentExamSpy).toHaveBeenCalledTimes(1);
+        expect(studentExamSpy).toHaveBeenCalledOnce();
         expect(studentExamDetailComponent.isSavingWorkingTime).toBe(false);
         expect(course.id).toBe(1);
         expect(studentExamDetailComponent.achievedTotalPoints).toBe(40);
@@ -222,7 +222,7 @@ describe('StudentExamDetailComponent', () => {
 
     it('should disable the working time form while saving', () => {
         studentExamDetailComponent.isSavingWorkingTime = true;
-        expect(studentExamDetailComponent.isFormDisabled()).toBe(true);
+        expect(studentExamDetailComponent.isFormDisabled()).toBeTrue();
     });
 
     it('should disable the working time form after a test run is submitted', () => {
@@ -233,7 +233,7 @@ describe('StudentExamDetailComponent', () => {
         expect(studentExamDetailComponent.isFormDisabled()).toBe(false);
 
         studentExamDetailComponent.studentExam.submitted = true;
-        expect(studentExamDetailComponent.isFormDisabled()).toBe(true);
+        expect(studentExamDetailComponent.isFormDisabled()).toBeTrue();
     });
 
     it('should disable the working time form after the exam is visible to a student', () => {
@@ -244,7 +244,7 @@ describe('StudentExamDetailComponent', () => {
         expect(studentExamDetailComponent.isFormDisabled()).toBe(false);
 
         studentExamDetailComponent.studentExam.exam!.visibleDate = dayjs().subtract(1, 'hour');
-        expect(studentExamDetailComponent.isFormDisabled()).toBe(true);
+        expect(studentExamDetailComponent.isFormDisabled()).toBeTrue();
     });
 
     it('should disable the working time form if there is no exam', () => {
@@ -252,7 +252,7 @@ describe('StudentExamDetailComponent', () => {
         studentExamDetailComponent.studentExam = studentExam;
 
         studentExamDetailComponent.studentExam.exam = undefined;
-        expect(studentExamDetailComponent.isFormDisabled()).toBe(true);
+        expect(studentExamDetailComponent.isFormDisabled()).toBeTrue();
     });
 
     it('should get examIsOver', () => {
@@ -262,7 +262,7 @@ describe('StudentExamDetailComponent', () => {
         studentExam.exam!.endDate = dayjs().add(-20, 'seconds');
         expect(studentExamDetailComponent.examIsOver()).toBe(false);
         studentExam.exam!.endDate = dayjs().add(-200, 'seconds');
-        expect(studentExamDetailComponent.examIsOver()).toBe(true);
+        expect(studentExamDetailComponent.examIsOver()).toBeTrue();
         studentExam.exam = undefined;
         expect(studentExamDetailComponent.examIsOver()).toBe(false);
     });
@@ -275,8 +275,8 @@ describe('StudentExamDetailComponent', () => {
 
         studentExamDetailComponent.toggle();
 
-        expect(toggleSubmittedStateSpy).toHaveBeenCalledTimes(1);
-        expect(studentExamDetailComponent.studentExam.submitted).toBe(true);
+        expect(toggleSubmittedStateSpy).toHaveBeenCalledOnce();
+        expect(studentExamDetailComponent.studentExam.submitted).toBeTrue();
         // the toggle uses the current time as submission date,
         // therefore no useful assertion about a concrete value is possible here
         expect(studentExamDetailComponent.studentExam.submissionDate).not.toBe(undefined);

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
@@ -201,7 +201,7 @@ describe('StudentExamDetailComponent', () => {
 
         studentExamDetailComponent.saveWorkingTime();
         expect(studentExamSpy).toHaveBeenCalledOnce();
-        expect(studentExamDetailComponent.isSavingWorkingTime).toBe(false);
+        expect(studentExamDetailComponent.isSavingWorkingTime).toBeFalse();
         expect(course.id).toBe(1);
         expect(studentExamDetailComponent.achievedTotalPoints).toBe(40);
         expect(studentExamDetailComponent.maxTotalPoints).toBe(100);
@@ -214,7 +214,7 @@ describe('StudentExamDetailComponent', () => {
         studentExamDetailComponent.saveWorkingTime();
         studentExamDetailComponent.saveWorkingTime();
         expect(studentExamSpy).toHaveBeenCalledTimes(3);
-        expect(studentExamDetailComponent.isSavingWorkingTime).toBe(false);
+        expect(studentExamDetailComponent.isSavingWorkingTime).toBeFalse();
         expect(course.id).toBe(1);
         expect(studentExamDetailComponent.achievedTotalPoints).toBe(40);
         expect(studentExamDetailComponent.maxTotalPoints).toBe(100);
@@ -230,7 +230,7 @@ describe('StudentExamDetailComponent', () => {
         studentExamDetailComponent.studentExam = studentExam;
 
         studentExamDetailComponent.studentExam.submitted = false;
-        expect(studentExamDetailComponent.isFormDisabled()).toBe(false);
+        expect(studentExamDetailComponent.isFormDisabled()).toBeFalse();
 
         studentExamDetailComponent.studentExam.submitted = true;
         expect(studentExamDetailComponent.isFormDisabled()).toBeTrue();
@@ -241,7 +241,7 @@ describe('StudentExamDetailComponent', () => {
         studentExamDetailComponent.studentExam = studentExam;
 
         studentExamDetailComponent.studentExam.exam!.visibleDate = dayjs().add(1, 'hour');
-        expect(studentExamDetailComponent.isFormDisabled()).toBe(false);
+        expect(studentExamDetailComponent.isFormDisabled()).toBeFalse();
 
         studentExamDetailComponent.studentExam.exam!.visibleDate = dayjs().subtract(1, 'hour');
         expect(studentExamDetailComponent.isFormDisabled()).toBeTrue();
@@ -258,13 +258,13 @@ describe('StudentExamDetailComponent', () => {
     it('should get examIsOver', () => {
         studentExamDetailComponent.studentExam = studentExam;
         studentExam.exam!.gracePeriod = 100;
-        expect(studentExamDetailComponent.examIsOver()).toBe(false);
+        expect(studentExamDetailComponent.examIsOver()).toBeFalse();
         studentExam.exam!.endDate = dayjs().add(-20, 'seconds');
-        expect(studentExamDetailComponent.examIsOver()).toBe(false);
+        expect(studentExamDetailComponent.examIsOver()).toBeFalse();
         studentExam.exam!.endDate = dayjs().add(-200, 'seconds');
         expect(studentExamDetailComponent.examIsOver()).toBeTrue();
         studentExam.exam = undefined;
-        expect(studentExamDetailComponent.examIsOver()).toBe(false);
+        expect(studentExamDetailComponent.examIsOver()).toBeFalse();
     });
 
     it('should toggle to unsubmitted', () => {

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam.service.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam.service.spec.ts
@@ -31,14 +31,14 @@ describe('Student Exam Service', () => {
 
     it('should call correct url if toggling submitted state and unsubmit is false', () => {
         service.toggleSubmittedState(1, 2, 3, false);
-        expect(httpClientPutSpy).toHaveBeenCalledTimes(1);
+        expect(httpClientPutSpy).toHaveBeenCalledOnce();
         expect(httpClientPutSpy.mock.calls[0]).toHaveLength(3);
         expect(httpClientPutSpy.mock.calls[0][0]).toContain('toggle-to-submitted');
     });
 
     it('should call correct url if toggling submitted state and unsubmit is true', () => {
         service.toggleSubmittedState(1, 2, 3, true);
-        expect(httpClientPutSpy).toHaveBeenCalledTimes(1);
+        expect(httpClientPutSpy).toHaveBeenCalledOnce();
         expect(httpClientPutSpy.mock.calls[0]).toHaveLength(3);
         expect(httpClientPutSpy.mock.calls[0][0]).toContain('toggle-to-unsubmitted');
     });
@@ -67,7 +67,7 @@ describe('Student Exam Service', () => {
         let returnedExam;
         service.find(1, 2, 3).subscribe((result) => (returnedExam = result));
 
-        expect(getSpy).toHaveBeenCalledTimes(1);
+        expect(getSpy).toHaveBeenCalledOnce();
         expect(getSpy).toHaveBeenCalledWith(`${SERVER_API_URL}api/courses/1/exams/2/student-exams/3`, { observe: 'response' });
         expect(returnedExam).toBe(response);
         expect(accountService.setAccessRightsForCourse).toHaveBeenCalledTimes(payload?.exam?.course ? 1 : 0);
@@ -75,7 +75,7 @@ describe('Student Exam Service', () => {
         const patchSpy = jest.spyOn(httpClient, 'patch').mockReturnValue(of(response));
         service.updateWorkingTime(1, 2, 3, 10).subscribe((result) => (returnedExam = result));
 
-        expect(patchSpy).toHaveBeenCalledTimes(1);
+        expect(patchSpy).toHaveBeenCalledOnce();
         expect(patchSpy).toHaveBeenCalledWith(`${SERVER_API_URL}api/courses/1/exams/2/student-exams/3/working-time`, 10, { observe: 'response' });
         expect(returnedExam).toBe(response);
         expect(accountService.setAccessRightsForCourse).toHaveBeenCalledTimes(payload?.exam?.course ? 2 : 0);
@@ -112,7 +112,7 @@ describe('Student Exam Service', () => {
         let returnedExams;
         service.findAllForExam(1, 2).subscribe((result) => (returnedExams = result));
 
-        expect(getSpy).toHaveBeenCalledTimes(1);
+        expect(getSpy).toHaveBeenCalledOnce();
         expect(getSpy).toHaveBeenCalledWith(`${SERVER_API_URL}api/courses/1/exams/2/student-exams`, { observe: 'response' });
         expect(returnedExams).toBe(response);
         expect(accountService.setAccessRightsForCourse).toHaveBeenCalledTimes(2);

--- a/src/test/javascript/spec/component/exam/manage/student-exams/user-import-button.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/user-import-button.component.spec.ts
@@ -39,6 +39,6 @@ describe('UsersImportButtonComponent', () => {
         comp.openUsersImportDialog(new MouseEvent('click'));
         const openStudentsExamImportDialogButton = fixture.debugElement.query(By.css('jhi-button'));
         expect(openStudentsExamImportDialogButton).not.toBe(null);
-        expect(modalServiceOpenStub).toHaveBeenCalledTimes(1);
+        expect(modalServiceOpenStub).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/exam/manage/student-exams/user-import-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/user-import-dialog.component.spec.ts
@@ -120,7 +120,7 @@ describe('UsersImportButtonComponent', () => {
         component.importUsers();
 
         expect(examManagementService.addStudentsToExam).toHaveBeenCalledOnce();
-        expect(component.isImporting).toBe(false);
+        expect(component.isImporting).toBeFalse();
         expect(component.hasImported).toBeTrue();
         expect(component.notFoundUsers).toHaveLength(studentsNotFound.length);
     });
@@ -183,7 +183,7 @@ describe('UsersImportButtonComponent', () => {
         component.importUsers();
 
         importedStudents.forEach((student) => expect(component.wasImported(student)).toBeTrue());
-        notImportedStudents.forEach((student) => expect(component.wasImported(student)).toBe(false));
+        notImportedStudents.forEach((student) => expect(component.wasImported(student)).toBeFalse());
         expect(component.numberOfUsersImported).toBe(importedStudents.length);
         expect(component.numberOfUsersNotImported).toBe(notImportedStudents.length);
     });
@@ -202,8 +202,8 @@ describe('UsersImportButtonComponent', () => {
 
         fixture.detectChanges();
 
-        expect(component.hasImported).toBe(false);
-        expect(component.isSubmitDisabled).toBe(false);
+        expect(component.hasImported).toBeFalse();
+        expect(component.isSubmitDisabled).toBeFalse();
         const importButton = fixture.debugElement.query(By.css('#import'));
 
         expect(importButton).not.toBe(null);
@@ -211,7 +211,7 @@ describe('UsersImportButtonComponent', () => {
         importButton.nativeElement.click();
 
         expect(examManagementService.addStudentsToExam).toHaveBeenCalledOnce();
-        expect(component.isImporting).toBe(false);
+        expect(component.isImporting).toBeFalse();
         expect(component.hasImported).toBeTrue();
         expect(component.notFoundUsers).toHaveLength(studentsNotFound.length);
 

--- a/src/test/javascript/spec/component/exam/manage/student-exams/user-import-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/user-import-dialog.component.spec.ts
@@ -119,9 +119,9 @@ describe('UsersImportButtonComponent', () => {
         component.usersToImport = studentsToImport;
         component.importUsers();
 
-        expect(examManagementService.addStudentsToExam).toHaveBeenCalledTimes(1);
+        expect(examManagementService.addStudentsToExam).toHaveBeenCalledOnce();
         expect(component.isImporting).toBe(false);
-        expect(component.hasImported).toBe(true);
+        expect(component.hasImported).toBeTrue();
         expect(component.notFoundUsers).toHaveLength(studentsNotFound.length);
     });
 
@@ -182,7 +182,7 @@ describe('UsersImportButtonComponent', () => {
         component.usersToImport = importedStudents.concat(notImportedStudents);
         component.importUsers();
 
-        importedStudents.forEach((student) => expect(component.wasImported(student)).toBe(true));
+        importedStudents.forEach((student) => expect(component.wasImported(student)).toBeTrue());
         notImportedStudents.forEach((student) => expect(component.wasImported(student)).toBe(false));
         expect(component.numberOfUsersImported).toBe(importedStudents.length);
         expect(component.numberOfUsersNotImported).toBe(notImportedStudents.length);
@@ -210,9 +210,9 @@ describe('UsersImportButtonComponent', () => {
 
         importButton.nativeElement.click();
 
-        expect(examManagementService.addStudentsToExam).toHaveBeenCalledTimes(1);
+        expect(examManagementService.addStudentsToExam).toHaveBeenCalledOnce();
         expect(component.isImporting).toBe(false);
-        expect(component.hasImported).toBe(true);
+        expect(component.hasImported).toBeTrue();
         expect(component.notFoundUsers).toHaveLength(studentsNotFound.length);
 
         jest.spyOn(examManagementService, 'addStudentsToExam').mockReturnValue(of(fakeResponse));
@@ -224,6 +224,6 @@ describe('UsersImportButtonComponent', () => {
         expect(finishButton).not.toBeNull;
 
         finishButton.nativeElement.click();
-        expect(examManagementService.addStudentsToExam).toHaveBeenCalledTimes(1);
+        expect(examManagementService.addStudentsToExam).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
@@ -136,13 +136,13 @@ describe('Exam Navigation Bar Component', () => {
     it('should tell the type of the selected text exercise', () => {
         comp.exerciseIndex = 1;
 
-        expect(comp.isProgrammingExercise()).toBe(false);
+        expect(comp.isProgrammingExercise()).toBeFalse();
     });
 
     it('should tell the type of the selected modeling exercise', () => {
         comp.exerciseIndex = 2;
 
-        expect(comp.isProgrammingExercise()).toBe(false);
+        expect(comp.isProgrammingExercise()).toBeFalse();
     });
 
     it('save the exercise with changeExercise', () => {

--- a/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
@@ -130,7 +130,7 @@ describe('Exam Navigation Bar Component', () => {
     it('should tell the type of the selected programming exercise', () => {
         comp.exerciseIndex = 0;
 
-        expect(comp.isProgrammingExercise()).toBe(true);
+        expect(comp.isProgrammingExercise()).toBeTrue();
     });
 
     it('should tell the type of the selected text exercise', () => {

--- a/src/test/javascript/spec/component/exam/participate/exam-participation-cover.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation-cover.component.spec.ts
@@ -137,7 +137,7 @@ describe('ExamParticipationCoverComponent', () => {
 
         component.startExam();
 
-        expect(saveStudentExamSpy).toHaveBeenCalledTimes(1);
+        expect(saveStudentExamSpy).toHaveBeenCalledOnce();
         expect(saveStudentExamSpy).toHaveBeenCalledWith(exam!.course!.id, exam!.id, studentExam);
 
         component.testRun = false;
@@ -156,7 +156,7 @@ describe('ExamParticipationCoverComponent', () => {
         component.startExam();
         tick();
         jest.advanceTimersByTime(UI_RELOAD_TIME + 1); // simulate setInterval time passing
-        expect(component.waitingForExamStart).toBe(true);
+        expect(component.waitingForExamStart).toBeTrue();
         const difference = Math.ceil(component.exam.startDate.diff(now, 'seconds') / 60);
         expect(component.timeUntilStart).toBe(difference + ' min');
 
@@ -164,13 +164,13 @@ describe('ExamParticipationCoverComponent', () => {
         component.startExam();
         tick();
         jest.advanceTimersByTime(UI_RELOAD_TIME + 1); // simulate setInterval time passing
-        expect(component.waitingForExamStart).toBe(true);
+        expect(component.waitingForExamStart).toBeTrue();
         expect(component.timeUntilStart).toBe('');
     }));
 
     it('test run should always have already started', () => {
         component.testRun = true;
-        expect(component.hasStarted()).toBe(true);
+        expect(component.hasStarted()).toBeTrue();
     });
 
     it('should update displayed times if exam suddenly started ', () => {
@@ -180,7 +180,7 @@ describe('ExamParticipationCoverComponent', () => {
         const eventSpy = jest.spyOn(component.onExamStarted, 'emit');
 
         component.updateDisplayedTimes(studentExam);
-        expect(eventSpy).toHaveBeenCalledTimes(1);
+        expect(eventSpy).toHaveBeenCalledOnce();
     });
 
     it('should create the relative time text correctly', () => {
@@ -194,14 +194,14 @@ describe('ExamParticipationCoverComponent', () => {
         component.onExamEnded = new EventEmitter<StudentExam>();
         const saveStudentExamSpy = jest.spyOn(component.onExamEnded, 'emit');
         component.submitExam();
-        expect(saveStudentExamSpy).toHaveBeenCalledTimes(1);
+        expect(saveStudentExamSpy).toHaveBeenCalledOnce();
     });
 
     it('should continue after handing in early', () => {
         component.onExamContinueAfterHandInEarly = new EventEmitter<void>();
         const saveStudentExamSpy = jest.spyOn(component.onExamContinueAfterHandInEarly, 'emit');
         component.continueAfterHandInEarly();
-        expect(saveStudentExamSpy).toHaveBeenCalledTimes(1);
+        expect(saveStudentExamSpy).toHaveBeenCalledOnce();
     });
 
     it('should get start button enabled and end button enabled', () => {
@@ -216,15 +216,15 @@ describe('ExamParticipationCoverComponent', () => {
         component.accountName = 'admin';
         component.confirmed = true;
         component.exam.visibleDate = dayjs().subtract(1, 'hours');
-        expect(component.startButtonEnabled).toBe(true);
+        expect(component.startButtonEnabled).toBeTrue();
 
         component.handInPossible = true;
-        expect(component.endButtonEnabled).toBe(true);
+        expect(component.endButtonEnabled).toBeTrue();
     });
 
     it('should get end button enabled', () => {
         component.enteredName = 'admin';
-        expect(component.inserted).toBe(true);
+        expect(component.inserted).toBeTrue();
     });
 
     it('should disable exam button', () => {
@@ -252,6 +252,6 @@ describe('ExamParticipationCoverComponent', () => {
         component.studentExam.workingTime = 3600;
         component.exam.gracePeriod = 1;
         component.studentExam.submitted = false;
-        expect(component.studentFailedToSubmit).toBe(true);
+        expect(component.studentFailedToSubmit).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/exam/participate/exam-participation-cover.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation-cover.component.spec.ts
@@ -121,11 +121,11 @@ describe('ExamParticipationCoverComponent', () => {
 
         component.startView = true;
         component.updateConfirmation();
-        expect(component.startEnabled).toBe(false);
+        expect(component.startEnabled).toBeFalse();
 
         component.startView = false;
         component.updateConfirmation();
-        expect(component.endEnabled).toBe(false);
+        expect(component.endEnabled).toBeFalse();
     });
 
     it('should start exam', fakeAsync(() => {
@@ -207,7 +207,7 @@ describe('ExamParticipationCoverComponent', () => {
     it('should get start button enabled and end button enabled', () => {
         fixture.detectChanges();
         component.testRun = true;
-        expect(component.startButtonEnabled).toBe(false);
+        expect(component.startButtonEnabled).toBeFalse();
 
         const now = dayjs();
         jest.spyOn(artemisServerDateService, 'now').mockReturnValue(now);
@@ -237,12 +237,12 @@ describe('ExamParticipationCoverComponent', () => {
         component.confirmed = true;
         component.exam.visibleDate = dayjs().subtract(1, 'hours');
         component.exam.visibleDate = dayjs().add(1, 'hours');
-        expect(component.startButtonEnabled).toBe(false);
+        expect(component.startButtonEnabled).toBeFalse();
     });
 
     it('should get whether student failed to submit', () => {
         component.testRun = true;
-        expect(component.studentFailedToSubmit).toBe(false);
+        expect(component.studentFailedToSubmit).toBeFalse();
 
         component.testRun = false;
         const startDate = dayjs();

--- a/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
@@ -135,7 +135,7 @@ describe('ExamParticipationComponent', () => {
             comp.ngOnInit();
             fixture.detectChanges();
             expect(fixture).toBeTruthy();
-            expect(!!comp.testRunId).toBe(false);
+            expect(!!comp.testRunId).toBeFalse();
             const testRunRibbon = fixture.debugElement.query(By.css('#testRunRibbon'));
             expect(testRunRibbon).toBeNull();
         });
@@ -148,14 +148,14 @@ describe('ExamParticipationComponent', () => {
         });
         it('should return false if active exercise is not a programming exercise', () => {
             comp.activeExamPage.exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, new Course(), undefined);
-            expect(comp.isProgrammingExercise()).toBe(false);
+            expect(comp.isProgrammingExercise()).toBeFalse();
         });
     });
 
     describe('isProgrammingExerciseWithCodeEditor', () => {
         it('should return true if programming exercise is with code editor', () => {
             comp.activeExamPage.exercise = new ProgrammingExercise(new Course(), undefined);
-            expect(comp.isProgrammingExerciseWithCodeEditor()).toBe(false);
+            expect(comp.isProgrammingExerciseWithCodeEditor()).toBeFalse();
             (comp.activeExamPage.exercise as ProgrammingExercise).allowOnlineEditor = true;
             expect(comp.isProgrammingExerciseWithCodeEditor()).toBeTrue();
         });
@@ -166,7 +166,7 @@ describe('ExamParticipationComponent', () => {
             comp.activeExamPage.exercise = new ProgrammingExercise(new Course(), undefined);
             expect(comp.isProgrammingExerciseWithOfflineIDE()).toBeTrue();
             (comp.activeExamPage.exercise as ProgrammingExercise).allowOfflineIde = false;
-            expect(comp.isProgrammingExerciseWithOfflineIDE()).toBe(false);
+            expect(comp.isProgrammingExerciseWithOfflineIDE()).toBeFalse();
         });
     });
 
@@ -272,7 +272,7 @@ describe('ExamParticipationComponent', () => {
         // Sync exercises with submission
         const secondSubmission = secondExercise.studentParticipations![0].submissions![0];
         expect(secondSubmission.isSynced).toBeTrue();
-        expect(secondSubmission.submitted).toBe(false);
+        expect(secondSubmission.submitted).toBeFalse();
 
         // Initialize Exam Overview Page
         expect(comp.activeExamPage.exercise).toBeUndefined();
@@ -353,7 +353,7 @@ describe('ExamParticipationComponent', () => {
             expect(submission.isSynced).toBeTrue();
             expect(submission.submitted).toBeTrue();
             expect(syncedSubmission.isSynced).toBeTrue();
-            expect(syncedSubmission.submitted).toBe(false);
+            expect(syncedSubmission.submitted).toBeFalse();
         };
 
         it('should sync text submissions', () => {
@@ -456,7 +456,7 @@ describe('ExamParticipationComponent', () => {
             const date = dayjs();
             comp.individualStudentEndDate = endDate;
             const serverNowSpy = jest.spyOn(artemisServerDateService, 'now').mockReturnValue(date);
-            expect(comp.isOver()).toBe(false);
+            expect(comp.isOver()).toBeFalse();
             expect(serverNowSpy).toHaveBeenCalled();
         });
     });
@@ -471,7 +471,7 @@ describe('ExamParticipationComponent', () => {
         it('should be visible if test run', () => {
             expect(comp.isVisible()).toBeTrue();
             setComponentWithoutTestRun();
-            expect(comp.isVisible()).toBe(false);
+            expect(comp.isVisible()).toBeFalse();
         });
 
         it('should be visible if visible date is before server date', () => {
@@ -490,7 +490,7 @@ describe('ExamParticipationComponent', () => {
             const date = dayjs();
             comp.exam.visibleDate = visibleDate;
             const serverNowSpy = jest.spyOn(artemisServerDateService, 'now').mockReturnValue(date);
-            expect(comp.isVisible()).toBe(false);
+            expect(comp.isVisible()).toBeFalse();
             expect(serverNowSpy).toHaveBeenCalled();
         });
     });
@@ -499,7 +499,7 @@ describe('ExamParticipationComponent', () => {
         it('should be active if test run', () => {
             expect(comp.isActive()).toBeTrue();
             setComponentWithoutTestRun();
-            expect(comp.isActive()).toBe(false);
+            expect(comp.isActive()).toBeFalse();
         });
 
         it('should be active if start date is before server date', () => {
@@ -518,7 +518,7 @@ describe('ExamParticipationComponent', () => {
             const date = dayjs();
             comp.exam.startDate = startDate;
             const serverNowSpy = jest.spyOn(artemisServerDateService, 'now').mockReturnValue(date);
-            expect(comp.isActive()).toBe(false);
+            expect(comp.isActive()).toBeFalse();
             expect(serverNowSpy).toHaveBeenCalled();
         });
     });

--- a/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
@@ -126,7 +126,7 @@ describe('ExamParticipationComponent', () => {
         it('should initialize and display test run ribbon', () => {
             fixture.detectChanges();
             expect(fixture).toBeTruthy();
-            expect(!!comp.testRunId).toBe(true);
+            expect(!!comp.testRunId).toBeTrue();
             const testRunRibbon = fixture.debugElement.query(By.css('#testRunRibbon'));
             expect(testRunRibbon).toBeDefined();
         });
@@ -144,7 +144,7 @@ describe('ExamParticipationComponent', () => {
     describe('isProgrammingExercise', () => {
         it('should return true if active exercise is a programming exercise', () => {
             comp.activeExamPage.exercise = new ProgrammingExercise(new Course(), undefined);
-            expect(comp.isProgrammingExercise()).toBe(true);
+            expect(comp.isProgrammingExercise()).toBeTrue();
         });
         it('should return false if active exercise is not a programming exercise', () => {
             comp.activeExamPage.exercise = new ModelingExercise(UMLDiagramType.ClassDiagram, new Course(), undefined);
@@ -157,14 +157,14 @@ describe('ExamParticipationComponent', () => {
             comp.activeExamPage.exercise = new ProgrammingExercise(new Course(), undefined);
             expect(comp.isProgrammingExerciseWithCodeEditor()).toBe(false);
             (comp.activeExamPage.exercise as ProgrammingExercise).allowOnlineEditor = true;
-            expect(comp.isProgrammingExerciseWithCodeEditor()).toBe(true);
+            expect(comp.isProgrammingExerciseWithCodeEditor()).toBeTrue();
         });
     });
 
     describe('isProgrammingExerciseWithOfflineIDE', () => {
         it('should return true if active exercise is with offline ide', () => {
             comp.activeExamPage.exercise = new ProgrammingExercise(new Course(), undefined);
-            expect(comp.isProgrammingExerciseWithOfflineIDE()).toBe(true);
+            expect(comp.isProgrammingExerciseWithOfflineIDE()).toBeTrue();
             (comp.activeExamPage.exercise as ProgrammingExercise).allowOfflineIde = false;
             expect(comp.isProgrammingExerciseWithOfflineIDE()).toBe(false);
         });
@@ -267,16 +267,16 @@ describe('ExamParticipationComponent', () => {
         expect(firstParticipation.submissions).toBeDefined();
         expect(firstParticipation.submissions!.length).toBeGreaterThan(0);
         expect(latestPendingSubmissionSpy).toHaveBeenCalled();
-        expect(firstExercise.studentParticipations![0].submissions![0].submitted).toBe(true);
+        expect(firstExercise.studentParticipations![0].submissions![0].submitted).toBeTrue();
 
         // Sync exercises with submission
         const secondSubmission = secondExercise.studentParticipations![0].submissions![0];
-        expect(secondSubmission.isSynced).toBe(true);
+        expect(secondSubmission.isSynced).toBeTrue();
         expect(secondSubmission.submitted).toBe(false);
 
         // Initialize Exam Overview Page
         expect(comp.activeExamPage.exercise).toBeUndefined();
-        expect(comp.activeExamPage.isOverviewPage).toBe(true);
+        expect(comp.activeExamPage.isOverviewPage).toBeTrue();
     };
 
     it('should initialize exercises when exam starts', () => {
@@ -318,7 +318,7 @@ describe('ExamParticipationComponent', () => {
 
         comp.createParticipationForExercise(exercise).subscribe((participation) => {
             expect(createdParticipation.exercise).toBeUndefined();
-            expect(programmingSubmission.isSynced).toBe(true);
+            expect(programmingSubmission.isSynced).toBeTrue();
             expect(participation).toEqual(createdParticipation);
         });
         expect(courseExerciseServiceStub).toHaveBeenCalled();
@@ -350,9 +350,9 @@ describe('ExamParticipationComponent', () => {
         });
 
         const expectSyncedSubmissions = (submission: Submission, syncedSubmission: Submission) => {
-            expect(submission.isSynced).toBe(true);
-            expect(submission.submitted).toBe(true);
-            expect(syncedSubmission.isSynced).toBe(true);
+            expect(submission.isSynced).toBeTrue();
+            expect(submission.submitted).toBeTrue();
+            expect(syncedSubmission.isSynced).toBeTrue();
             expect(syncedSubmission.submitted).toBe(false);
         };
 
@@ -431,24 +431,24 @@ describe('ExamParticipationComponent', () => {
             const studentExam = new StudentExam();
             studentExam.ended = true;
             comp.studentExam = studentExam;
-            expect(comp.isOver()).toBe(true);
+            expect(comp.isOver()).toBeTrue();
         });
         it('should return true when handed in early', () => {
             comp.handInEarly = true;
-            expect(comp.isOver()).toBe(true);
+            expect(comp.isOver()).toBeTrue();
         });
         it('should return true if student exam has been submitted', () => {
             const studentExam = new StudentExam();
             studentExam.submitted = true;
             comp.studentExam = studentExam;
-            expect(comp.isOver()).toBe(true);
+            expect(comp.isOver()).toBeTrue();
         });
         it('should be over if individual end date is before server date', () => {
             const endDate = dayjs().subtract(1, 'days');
             const date = dayjs();
             comp.individualStudentEndDate = endDate;
             const serverNowSpy = jest.spyOn(artemisServerDateService, 'now').mockReturnValue(date);
-            expect(comp.isOver()).toBe(true);
+            expect(comp.isOver()).toBeTrue();
             expect(serverNowSpy).toHaveBeenCalled();
         });
         it('should not be over if individual end date is after server date', () => {
@@ -469,7 +469,7 @@ describe('ExamParticipationComponent', () => {
 
     describe('isVisible', () => {
         it('should be visible if test run', () => {
-            expect(comp.isVisible()).toBe(true);
+            expect(comp.isVisible()).toBeTrue();
             setComponentWithoutTestRun();
             expect(comp.isVisible()).toBe(false);
         });
@@ -480,7 +480,7 @@ describe('ExamParticipationComponent', () => {
             const date = dayjs();
             comp.exam.visibleDate = visibleDate;
             const serverNowSpy = jest.spyOn(artemisServerDateService, 'now').mockReturnValue(date);
-            expect(comp.isVisible()).toBe(true);
+            expect(comp.isVisible()).toBeTrue();
             expect(serverNowSpy).toHaveBeenCalled();
         });
 
@@ -497,7 +497,7 @@ describe('ExamParticipationComponent', () => {
 
     describe('isActive', () => {
         it('should be active if test run', () => {
-            expect(comp.isActive()).toBe(true);
+            expect(comp.isActive()).toBeTrue();
             setComponentWithoutTestRun();
             expect(comp.isActive()).toBe(false);
         });
@@ -508,7 +508,7 @@ describe('ExamParticipationComponent', () => {
             const date = dayjs();
             comp.exam.startDate = startDate;
             const serverNowSpy = jest.spyOn(artemisServerDateService, 'now').mockReturnValue(date);
-            expect(comp.isActive()).toBe(true);
+            expect(comp.isActive()).toBeTrue();
             expect(serverNowSpy).toHaveBeenCalled();
         });
 

--- a/src/test/javascript/spec/component/exam/participate/exercises/file-upload-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/file-upload-exam-submission.component.spec.ts
@@ -224,7 +224,7 @@ describe('FileUploadExamSubmissionComponent', () => {
         fixture.detectChanges();
 
         // check that properties are set properly
-        expect(jhiErrorSpy).toHaveBeenCalledTimes(1);
+        expect(jhiErrorSpy).toHaveBeenCalledOnce();
         expect(comp.submissionFile).toBeUndefined();
         expect(comp.studentSubmission!.filePath).toBeUndefined();
 
@@ -252,7 +252,7 @@ describe('FileUploadExamSubmissionComponent', () => {
         fixture.detectChanges();
 
         // check that properties are set properly
-        expect(jhiErrorSpy).toHaveBeenCalledTimes(1);
+        expect(jhiErrorSpy).toHaveBeenCalledOnce();
         expect(comp.submissionFile).toBeUndefined();
         expect(comp.studentSubmission!.filePath).toBeUndefined();
 

--- a/src/test/javascript/spec/component/exam/participate/exercises/programming-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/programming-exam-submission.component.spec.ts
@@ -83,7 +83,7 @@ describe('ProgrammingExamSubmissionComponent', () => {
         expect(domainServiceSetDomainSpy).toHaveBeenCalledOnce();
         expect(domainServiceSetDomainSpy).toHaveBeenCalledWith([DomainType.PARTICIPATION, { exercise }]);
 
-        expect(component.repositoryIsLocked).toBe(false);
+        expect(component.repositoryIsLocked).toBeFalse();
         expect(component.getExercise()).toEqual(newExercise());
     });
 
@@ -102,7 +102,7 @@ describe('ProgrammingExamSubmissionComponent', () => {
         component.studentParticipation = newParticipation();
 
         component.onCommitStateChange(CommitState.UNDEFINED);
-        expect(component.hasSubmittedOnce).toBe(false);
+        expect(component.hasSubmittedOnce).toBeFalse();
 
         component.onCommitStateChange(CommitState.CLEAN);
 
@@ -121,7 +121,7 @@ describe('ProgrammingExamSubmissionComponent', () => {
         component.studentParticipation.submissions![0].isSynced = true;
         component.onFileChanged();
 
-        expect(component.studentParticipation.submissions![0].isSynced).toBe(false);
+        expect(component.studentParticipation.submissions![0].isSynced).toBeFalse();
     });
 
     it('should get submission', () => {
@@ -138,6 +138,6 @@ describe('ProgrammingExamSubmissionComponent', () => {
         exercise.allowOnlineEditor = false;
         component.exercise = exercise;
 
-        expect(component.hasUnsavedChanges()).toBe(false);
+        expect(component.hasUnsavedChanges()).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/exam/participate/exercises/programming-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/programming-exam-submission.component.spec.ts
@@ -80,7 +80,7 @@ describe('ProgrammingExamSubmissionComponent', () => {
 
         fixture.detectChanges();
 
-        expect(domainServiceSetDomainSpy).toHaveBeenCalledTimes(1);
+        expect(domainServiceSetDomainSpy).toHaveBeenCalledOnce();
         expect(domainServiceSetDomainSpy).toHaveBeenCalledWith([DomainType.PARTICIPATION, { exercise }]);
 
         expect(component.repositoryIsLocked).toBe(false);
@@ -95,7 +95,7 @@ describe('ProgrammingExamSubmissionComponent', () => {
         component.exercise = programmingExercise;
         fixture.detectChanges();
 
-        expect(component.repositoryIsLocked).toBe(true);
+        expect(component.repositoryIsLocked).toBeTrue();
     });
 
     it('should change state on commit', () => {
@@ -107,12 +107,12 @@ describe('ProgrammingExamSubmissionComponent', () => {
         component.onCommitStateChange(CommitState.CLEAN);
 
         // After the first call with CommitState.CLEAN, component.hasSubmittedOnce must be now true
-        expect(component.hasSubmittedOnce).toBe(true);
+        expect(component.hasSubmittedOnce).toBeTrue();
 
         component.onCommitStateChange(CommitState.CLEAN);
 
-        expect(component.studentParticipation.submissions![0].submitted).toBe(true);
-        expect(component.studentParticipation.submissions![0].isSynced).toBe(true);
+        expect(component.studentParticipation.submissions![0].submitted).toBeTrue();
+        expect(component.studentParticipation.submissions![0].isSynced).toBeTrue();
     });
 
     it('should desync on file change', () => {

--- a/src/test/javascript/spec/component/exam/participate/exercises/quiz-exam-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exercises/quiz-exam-submission.component.spec.ts
@@ -79,7 +79,7 @@ describe('QuizExamSubmissionComponent', () => {
         fixture.detectChanges();
 
         expect(fixture).toBeDefined();
-        expect(quizServiceSpy).toHaveBeenCalledTimes(1);
+        expect(quizServiceSpy).toHaveBeenCalledOnce();
         expect(component.selectedAnswerOptions.has(1)).toEqual(true);
         expect(component.selectedAnswerOptions.size).toEqual(1);
         expect(component.dragAndDropMappings.has(2)).toEqual(true);

--- a/src/test/javascript/spec/component/exam/participate/information/exam-information.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/information/exam-information.component.spec.ts
@@ -96,11 +96,11 @@ describe('ExamInformationComponent', () => {
         component.exam = exam;
         fixture.detectChanges();
         expect(fixture).not.toBeUndefined();
-        expect(component.isExamOverMultipleDays).toBe(false);
+        expect(component.isExamOverMultipleDays).toBeFalse();
 
         component.studentExam = studentExam;
         fixture.detectChanges();
         expect(fixture).not.toBeUndefined();
-        expect(component.isExamOverMultipleDays).toBe(false);
+        expect(component.isExamOverMultipleDays).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/exam/participate/information/exam-information.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/information/exam-information.component.spec.ts
@@ -80,7 +80,7 @@ describe('ExamInformationComponent', () => {
         exam.endDate = dayjs(exam.startDate).add(2, 'days');
         fixture.detectChanges();
         expect(fixture).not.toBeUndefined();
-        expect(component.isExamOverMultipleDays).toBe(true);
+        expect(component.isExamOverMultipleDays).toBeTrue();
     });
 
     it('should detect if the working time extends to another day', () => {
@@ -89,7 +89,7 @@ describe('ExamInformationComponent', () => {
         studentExam.workingTime = 24 * 60 * 60;
         fixture.detectChanges();
         expect(fixture).not.toBeUndefined();
-        expect(component.isExamOverMultipleDays).toBe(true);
+        expect(component.isExamOverMultipleDays).toBeTrue();
     });
 
     it('should return false for exams that only last one day', () => {

--- a/src/test/javascript/spec/component/exam/participate/summary/exercises/file-upload-summary.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/exercises/file-upload-summary.component.spec.ts
@@ -43,6 +43,6 @@ describe('FileUploadExamSummaryComponent', () => {
         const downloadFile = fixture.debugElement.query(By.css('#downloadFileButton'));
         expect(downloadFile).not.toBeNull();
         downloadFile.nativeElement.click();
-        expect(downloadFileSpy).toHaveBeenCalledTimes(1);
+        expect(downloadFileSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/exam/participate/summary/points-summary/exam-points-summary.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/summary/points-summary/exam-points-summary.component.spec.ts
@@ -161,7 +161,7 @@ describe('ExamPointsSummaryComponent', () => {
         fixture.detectChanges();
 
         expect(fixture).not.toBeNull();
-        expect(gradingSystemServiceMatchPercentageErrorStub).toHaveBeenCalledTimes(1);
+        expect(gradingSystemServiceMatchPercentageErrorStub).toHaveBeenCalledOnce();
         expect(component.gradingScaleExists).toBeFalse();
     });
 

--- a/src/test/javascript/spec/component/exam/shared/student-exam-working-time.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/shared/student-exam-working-time.component.spec.ts
@@ -73,6 +73,6 @@ describe('StudentExamWorkingTimeComponent', () => {
 
         studentExam.testRun = true;
         comp.ngOnInit();
-        expect(comp.isTestRun).toBe(true);
+        expect(comp.isTestRun).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/exam/shared/student-exam-working-time.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/shared/student-exam-working-time.component.spec.ts
@@ -65,11 +65,11 @@ describe('StudentExamWorkingTimeComponent', () => {
 
         studentExam.testRun = undefined;
         comp.ngOnInit();
-        expect(comp.isTestRun).toBe(false);
+        expect(comp.isTestRun).toBeFalse();
 
         studentExam.testRun = false;
         comp.ngOnInit();
-        expect(comp.isTestRun).toBe(false);
+        expect(comp.isTestRun).toBeFalse();
 
         studentExam.testRun = true;
         comp.ngOnInit();

--- a/src/test/javascript/spec/component/exam/test-run/test-run-management.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/test-run/test-run-management.component.spec.ts
@@ -93,7 +93,7 @@ describe('Test Run Management Component', () => {
 
             expect(examManagementService.find).toHaveBeenCalledWith(course.id!, exam.id!, false, true);
             expect(examManagementService.findAllTestRunsForExam).toHaveBeenCalledWith(course.id!, exam.id!);
-            expect(userSpy).toHaveBeenCalledTimes(1);
+            expect(userSpy).toHaveBeenCalledOnce();
 
             expect(component.exam).toEqual(exam);
             expect(component.isExamStarted).toEqual(exam.started!);

--- a/src/test/javascript/spec/component/example-modeling/example-modeling-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/example-modeling/example-modeling-submission.component.spec.ts
@@ -130,7 +130,7 @@ describe('Example Modeling Submission Component', () => {
         fixture.detectChanges();
 
         // THEN
-        expect(comp.isNewSubmission).toBe(true);
+        expect(comp.isNewSubmission).toBeTrue();
         expect(comp.exampleSubmission).toEqual(new ExampleSubmission());
     });
 
@@ -146,9 +146,9 @@ describe('Example Modeling Submission Component', () => {
 
         // THEN
         expect(comp.isNewSubmission).toBe(false);
-        expect(serviceSpy).toHaveBeenCalledTimes(1);
+        expect(serviceSpy).toHaveBeenCalledOnce();
 
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('artemisApp.modelingEditor.saveSuccessful');
     });
 
@@ -170,7 +170,7 @@ describe('Example Modeling Submission Component', () => {
         comp.upsertExampleModelingSubmission();
 
         // Ensure calls are not concurrent, new one should start after first one ends.
-        expect(serviceSpy).toHaveBeenCalledTimes(1);
+        expect(serviceSpy).toHaveBeenCalledOnce();
         tick(1);
 
         // This service request should also start after the previous one ends.
@@ -180,8 +180,8 @@ describe('Example Modeling Submission Component', () => {
         // THEN
         expect(comp.isNewSubmission).toBe(false);
         expect(serviceSpy).toHaveBeenCalledTimes(2);
-        expect(modelingAssessmentServiceSpy).toHaveBeenCalledTimes(1);
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(modelingAssessmentServiceSpy).toHaveBeenCalledOnce();
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('artemisApp.modelingEditor.saveSuccessful');
     }));
 
@@ -197,8 +197,8 @@ describe('Example Modeling Submission Component', () => {
         comp.checkAssessment();
 
         // THEN
-        expect(comp.assessmentsAreValid).toBe(true);
-        expect(assessExampleSubmissionSpy).toHaveBeenCalledTimes(1);
+        expect(comp.assessmentsAreValid).toBeTrue();
+        expect(assessExampleSubmissionSpy).toHaveBeenCalledOnce();
         expect(assessExampleSubmissionSpy).toHaveBeenCalledWith(exampleSubmission, exerciseId);
     });
 
@@ -212,7 +212,7 @@ describe('Example Modeling Submission Component', () => {
         comp.checkAssessment();
 
         // THEN
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('artemisApp.modelingAssessment.invalidAssessments');
     });
 
@@ -230,9 +230,9 @@ describe('Example Modeling Submission Component', () => {
         comp.readAndUnderstood();
 
         // THEN
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('artemisApp.exampleSubmission.readSuccessfully');
-        expect(routerSpy).toHaveBeenCalledTimes(1);
+        expect(routerSpy).toHaveBeenCalledOnce();
     });
 
     it('should handle referenced feedback change', () => {
@@ -244,8 +244,8 @@ describe('Example Modeling Submission Component', () => {
         comp.onReferencedFeedbackChanged(feedbacks);
 
         // THEN
-        expect(comp.feedbackChanged).toBe(true);
-        expect(comp.assessmentsAreValid).toBe(true);
+        expect(comp.feedbackChanged).toBeTrue();
+        expect(comp.assessmentsAreValid).toBeTrue();
         expect(comp.referencedFeedback).toEqual(feedbacks);
     });
 
@@ -258,8 +258,8 @@ describe('Example Modeling Submission Component', () => {
         comp.onUnReferencedFeedbackChanged(feedbacks);
 
         // THEN
-        expect(comp.feedbackChanged).toBe(true);
-        expect(comp.assessmentsAreValid).toBe(true);
+        expect(comp.feedbackChanged).toBeTrue();
+        expect(comp.assessmentsAreValid).toBeTrue();
         expect(comp.unreferencedFeedback).toEqual(feedbacks);
     });
 
@@ -290,7 +290,7 @@ describe('Example Modeling Submission Component', () => {
         comp.saveExampleAssessment();
 
         // THEN
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('modelingAssessment.invalidAssessments');
     });
 
@@ -312,7 +312,7 @@ describe('Example Modeling Submission Component', () => {
 
         // THEN
         expect(comp.result).toBe(result);
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('modelingAssessmentEditor.messages.saveSuccessful');
     });
 
@@ -332,7 +332,7 @@ describe('Example Modeling Submission Component', () => {
 
         // THEN
         expect(comp.result).toBe(undefined);
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('modelingAssessmentEditor.messages.saveFailed');
     });
 
@@ -353,7 +353,7 @@ describe('Example Modeling Submission Component', () => {
 
         // THEN
         expect(comp.referencedFeedback.every((feedback) => feedback.correctionStatus === 'CORRECT')).toBeTrue();
-        expect(resultFeedbacksSetterSpy).toHaveBeenCalledTimes(1);
+        expect(resultFeedbacksSetterSpy).toHaveBeenCalledOnce();
         expect(resultFeedbacksSetterSpy).toHaveBeenCalledWith(comp.referencedFeedback);
     });
 
@@ -374,7 +374,7 @@ describe('Example Modeling Submission Component', () => {
 
         // THEN
         expect(comp.referencedFeedback[0].correctionStatus).toBe(mockFeedbackCorrectionError.type);
-        expect(resultFeedbacksSetterSpy).toHaveBeenCalledTimes(1);
+        expect(resultFeedbacksSetterSpy).toHaveBeenCalledOnce();
         expect(resultFeedbacksSetterSpy).toHaveBeenCalledWith(comp.referencedFeedback);
     });
 
@@ -394,7 +394,7 @@ describe('Example Modeling Submission Component', () => {
 
         // THEN
         comp.result = result;
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('modelingAssessmentEditor.messages.saveSuccessful');
     });
 
@@ -412,7 +412,7 @@ describe('Example Modeling Submission Component', () => {
         comp.saveExampleAssessment();
 
         // THEN
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('modelingAssessmentEditor.messages.saveFailed');
     });
 
@@ -450,8 +450,8 @@ describe('Example Modeling Submission Component', () => {
         comp.showAssessment();
 
         // THEN
-        expect(assessmentSpy).toHaveBeenCalledTimes(1);
-        expect(comp.assessmentMode).toBe(true);
+        expect(assessmentSpy).toHaveBeenCalledOnce();
+        expect(comp.assessmentMode).toBeTrue();
         expect(result.feedbacks).toEqual(comp.assessments);
     });
 });

--- a/src/test/javascript/spec/component/example-modeling/example-modeling-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/example-modeling/example-modeling-submission.component.spec.ts
@@ -145,7 +145,7 @@ describe('Example Modeling Submission Component', () => {
         comp.upsertExampleModelingSubmission();
 
         // THEN
-        expect(comp.isNewSubmission).toBe(false);
+        expect(comp.isNewSubmission).toBeFalse();
         expect(serviceSpy).toHaveBeenCalledOnce();
 
         expect(alertSpy).toHaveBeenCalledOnce();
@@ -178,7 +178,7 @@ describe('Example Modeling Submission Component', () => {
         tick(1);
 
         // THEN
-        expect(comp.isNewSubmission).toBe(false);
+        expect(comp.isNewSubmission).toBeFalse();
         expect(serviceSpy).toHaveBeenCalledTimes(2);
         expect(modelingAssessmentServiceSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledOnce();
@@ -274,8 +274,8 @@ describe('Example Modeling Submission Component', () => {
         comp.showSubmission();
 
         // THEN
-        expect(comp.feedbackChanged).toBe(false);
-        expect(comp.assessmentMode).toBe(false);
+        expect(comp.feedbackChanged).toBeFalse();
+        expect(comp.assessmentMode).toBeFalse();
         expect(comp.totalScore).toBe(mockFeedbackWithReference.credits);
     });
 

--- a/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint-update.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint-update.component.spec.ts
@@ -79,7 +79,7 @@ describe('ExerciseHint Management Update Component', () => {
 
         comp.ngOnInit();
 
-        expect(findByExerciseIdSpy).toHaveBeenCalledTimes(1);
+        expect(findByExerciseIdSpy).toHaveBeenCalledOnce();
         expect(findByExerciseIdSpy).toHaveBeenCalledWith(15);
         expect(comp.exerciseHint.exercise).toEqual(exercise);
         expect(comp.exerciseHint).toEqual(exerciseHint);
@@ -95,7 +95,7 @@ describe('ExerciseHint Management Update Component', () => {
 
         comp.ngOnInit();
 
-        expect(getTasksSpy).toHaveBeenCalledTimes(1);
+        expect(getTasksSpy).toHaveBeenCalledOnce();
         expect(getTasksSpy).toHaveBeenCalledWith(15);
         tick();
         expect(comp.tasks).toEqual([task1, task2]);
@@ -108,7 +108,7 @@ describe('ExerciseHint Management Update Component', () => {
 
         comp.ngOnInit();
 
-        expect(getTasksSpy).toHaveBeenCalledTimes(1);
+        expect(getTasksSpy).toHaveBeenCalledOnce();
         expect(getTasksSpy).toHaveBeenCalledWith(15);
         tick();
         expect(comp.tasks).toEqual([task1, task2]);

--- a/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/manage/exercise-hint.component.spec.ts
@@ -54,7 +54,7 @@ describe('ExerciseHint Management Component', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(service.findByExerciseId).toHaveBeenCalledTimes(1);
+        expect(service.findByExerciseId).toHaveBeenCalledOnce();
         expect(service.findByExerciseId).toHaveBeenCalledWith(15);
         expect(comp.exerciseHints[0]).toEqual(expect.objectContaining({ id: 123 }));
     });
@@ -69,9 +69,9 @@ describe('ExerciseHint Management Component', () => {
 
         comp.deleteExerciseHint(123);
 
-        expect(deleteHintMock).toHaveBeenCalledTimes(1);
+        expect(deleteHintMock).toHaveBeenCalledOnce();
         expect(deleteHintMock).toHaveBeenCalledWith(15, 123);
-        expect(broadcastSpy).toHaveBeenCalledTimes(1);
+        expect(broadcastSpy).toHaveBeenCalledOnce();
         expect(broadcastSpy).toHaveBeenCalledWith({
             name: 'exerciseHintListModification',
             content: 'Deleted an exerciseHint',

--- a/src/test/javascript/spec/component/exercise-hint/participate/exercise-hint-button-overlay.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/participate/exercise-hint-button-overlay.component.spec.ts
@@ -49,7 +49,7 @@ describe('Exercise Hint Button Overlay Component', () => {
 
         comp.openModal();
 
-        expect(openModalSpy).toHaveBeenCalledTimes(1);
+        expect(openModalSpy).toHaveBeenCalledOnce();
         expect(openModalSpy).toHaveBeenCalledWith(ExerciseHintStudentDialogComponent, { size: 'lg', backdrop: 'static' });
         expect(componentInstance.availableExerciseHints).toEqual([availableExerciseHint]);
         expect(componentInstance.activatedExerciseHints).toEqual([activatedExerciseHint]);

--- a/src/test/javascript/spec/component/exercise-hint/participate/exercise-hint-expandable.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/participate/exercise-hint-expandable.component.spec.ts
@@ -49,7 +49,7 @@ describe('Exercise Hint Expandable Component', () => {
     it('should load available exercise hint content', () => {
         const activateHintSpy = jest.spyOn(service, 'activateExerciseHint').mockReturnValue(of({ body: availableExerciseHint } as ExerciseHintResponse));
         comp.displayHintContent();
-        expect(activateHintSpy).toHaveBeenCalledTimes(1);
+        expect(activateHintSpy).toHaveBeenCalledOnce();
         expect(activateHintSpy).toHaveBeenCalledWith(1, 2);
         expect(comp.expanded).toBeTrue();
         expect(comp.isLoading).toBeFalse();
@@ -74,7 +74,7 @@ describe('Exercise Hint Expandable Component', () => {
         comp.exerciseHint = availableExerciseHint;
         comp.onRate({ oldValue: 0, newValue: 4, starRating: new StarRatingComponent() });
 
-        expect(rateSpy).toHaveBeenCalledTimes(1);
+        expect(rateSpy).toHaveBeenCalledOnce();
         expect(rateSpy).toHaveBeenCalledWith(1, 2, 4);
         expect(comp.exerciseHint.currentUserRating).toBe(4);
     });

--- a/src/test/javascript/spec/component/exercise-hint/shared/code-hint-container.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/shared/code-hint-container.component.spec.ts
@@ -85,7 +85,7 @@ describe('ExerciseHint Management Component', () => {
 
         comp.removeEntryFromCodeHint(solutionEntry1.id);
 
-        expect(removeEntrySpy).toHaveBeenCalledTimes(1);
+        expect(removeEntrySpy).toHaveBeenCalledOnce();
         expect(removeEntrySpy).toHaveBeenCalledWith(2, 3, 1);
     });
 });

--- a/src/test/javascript/spec/component/exercise-hint/shared/solution-entry.component.spec.ts
+++ b/src/test/javascript/spec/component/exercise-hint/shared/solution-entry.component.spec.ts
@@ -35,14 +35,14 @@ describe('Solution Entry Component', () => {
 
         comp.ngOnInit();
 
-        expect(comp.editor.getEditor().setOptions).toHaveBeenCalledTimes(1);
+        expect(comp.editor.getEditor().setOptions).toHaveBeenCalledOnce();
         expect(comp.editor.getEditor().setOptions).toHaveBeenCalledWith({
             animatedScroll: true,
             maxLines: Infinity,
             showPrintMargin: false,
         });
 
-        expect(comp.editor.getEditor().getSession().setValue).toHaveBeenCalledTimes(1);
+        expect(comp.editor.getEditor().getSession().setValue).toHaveBeenCalledOnce();
         expect(comp.editor.getEditor().getSession().setValue).toHaveBeenCalledWith('ABC');
     });
 

--- a/src/test/javascript/spec/component/exercises/quiz/manage/re-evaluate/re-evaluate-multiple-choice-question.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/re-evaluate/re-evaluate-multiple-choice-question.component.spec.ts
@@ -79,7 +79,7 @@ describe('ReEvaluateMultipleChoiceQuestionComponent', () => {
             button.click();
             fixture.detectChanges();
 
-            expect(emitSpy).toHaveBeenCalledTimes(1);
+            expect(emitSpy).toHaveBeenCalledOnce();
         });
 
         it('move-down', () => {
@@ -90,7 +90,7 @@ describe('ReEvaluateMultipleChoiceQuestionComponent', () => {
             button.click();
             fixture.detectChanges();
 
-            expect(emitSpy).toHaveBeenCalledTimes(1);
+            expect(emitSpy).toHaveBeenCalledOnce();
         });
 
         it('delete', () => {
@@ -101,7 +101,7 @@ describe('ReEvaluateMultipleChoiceQuestionComponent', () => {
             button.click();
             fixture.detectChanges();
 
-            expect(emitSpy).toHaveBeenCalledTimes(1);
+            expect(emitSpy).toHaveBeenCalledOnce();
         });
 
         it('reset', () => {

--- a/src/test/javascript/spec/component/exercises/quiz/quiz-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/quiz-participation.component.spec.ts
@@ -216,7 +216,7 @@ describe('QuizParticipationComponent', () => {
             refreshButton.click();
             fixture.detectChanges();
 
-            expect(initLiveModeSpy).toHaveBeenCalledTimes(1);
+            expect(initLiveModeSpy).toHaveBeenCalledOnce();
             expect(findStudentSpy).toHaveBeenCalledWith(quizExercise.id);
             expect(participationSpy).toHaveBeenCalledWith(quizExercise.id);
         });
@@ -273,7 +273,7 @@ describe('QuizParticipationComponent', () => {
 
         it('should return true if student didnt interact with any question', () => {
             component.quizExercise = { ...quizExercise, quizQuestions: undefined };
-            expect(component.areAllQuestionsAnswered()).toBe(true);
+            expect(component.areAllQuestionsAnswered()).toBeTrue();
 
             component.quizExercise = quizExercise;
             component.selectedAnswerOptions = new Map<number, AnswerOption[]>();
@@ -327,7 +327,7 @@ describe('QuizParticipationComponent', () => {
             expect(participationSpy).toHaveBeenCalledWith(quizExercise.id);
             expect(component.questionScores[question2.id!]).toBe(answer.scoreInPoints);
             expect(component.userScore).toBe(quizSubmission.scoreInPoints);
-            expect(component.showingResult).toBe(true);
+            expect(component.showingResult).toBeTrue();
         });
 
         it('should update on selection changes', () => {
@@ -352,7 +352,7 @@ describe('QuizParticipationComponent', () => {
 
             component.onSaveError('error');
             expect(component.isSubmitting).toBe(false);
-            expect(component.unsavedChanges).toBe(true);
+            expect(component.unsavedChanges).toBeTrue();
 
             expect(alertSpy).toHaveBeenCalled();
         });
@@ -383,7 +383,7 @@ describe('QuizParticipationComponent', () => {
             component.updateParticipationFromServer(participation);
 
             expect(component.submission.id).toBe(submission.id);
-            expect(component.quizExercise.quizEnded).toBe(true);
+            expect(component.quizExercise.quizEnded).toBeTrue();
         });
     });
 
@@ -596,7 +596,7 @@ describe('QuizParticipationComponent', () => {
             fixture.detectChanges();
 
             expect(resultForSolutionServiceSpy).toHaveBeenCalledWith(quizExerciseForPractice.id);
-            expect(component.showingResult).toBe(true);
+            expect(component.showingResult).toBeTrue();
             expect(component.totalScore).toBe(6);
         });
 

--- a/src/test/javascript/spec/component/exercises/quiz/quiz-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/quiz-participation.component.spec.ts
@@ -177,7 +177,7 @@ describe('QuizParticipationComponent', () => {
 
             expect(participationSpy).toHaveBeenCalledWith(quizExercise.id);
             expect(component.quizExercise).toEqual(quizExercise);
-            expect(component.waitingForQuizStart).toBe(false);
+            expect(component.waitingForQuizStart).toBeFalse();
             expect(component.totalScore).toBe(6);
             expect(component.dragAndDropMappings.get(question1.id!)).toEqual([]);
             expect(component.selectedAnswerOptions.get(question2.id!)).toEqual([]);
@@ -268,7 +268,7 @@ describe('QuizParticipationComponent', () => {
             fixture.detectChanges();
 
             expect(participationSpy).toHaveBeenCalledWith(quizExercise.id);
-            expect(component.isSubmitting).toBe(false);
+            expect(component.isSubmitting).toBeFalse();
         });
 
         it('should return true if student didnt interact with any question', () => {
@@ -278,18 +278,18 @@ describe('QuizParticipationComponent', () => {
             component.quizExercise = quizExercise;
             component.selectedAnswerOptions = new Map<number, AnswerOption[]>();
             component.selectedAnswerOptions.set(2, []);
-            expect(component.areAllQuestionsAnswered()).toBe(false);
+            expect(component.areAllQuestionsAnswered()).toBeFalse();
 
             component.selectedAnswerOptions = new Map<number, AnswerOption[]>();
             component.dragAndDropMappings = new Map<number, DragAndDropMapping[]>();
             component.dragAndDropMappings.set(1, []);
-            expect(component.areAllQuestionsAnswered()).toBe(false);
+            expect(component.areAllQuestionsAnswered()).toBeFalse();
 
             component.selectedAnswerOptions = new Map<number, AnswerOption[]>();
             component.dragAndDropMappings = new Map<number, DragAndDropMapping[]>();
             component.shortAnswerSubmittedTexts = new Map<number, ShortAnswerSubmittedText[]>();
             component.shortAnswerSubmittedTexts.set(3, []);
-            expect(component.areAllQuestionsAnswered()).toBe(false);
+            expect(component.areAllQuestionsAnswered()).toBeFalse();
         });
 
         it('should show warning on submit', () => {
@@ -312,7 +312,7 @@ describe('QuizParticipationComponent', () => {
 
             expect(confirmSpy).toHaveBeenCalled();
             expect(participationSpy).toHaveBeenCalledWith(quizExercise.id);
-            expect(component.isSubmitting).toBe(false);
+            expect(component.isSubmitting).toBeFalse();
         });
 
         it('should show results after ending', () => {
@@ -348,10 +348,10 @@ describe('QuizParticipationComponent', () => {
             fixture.detectChanges();
 
             component.onSubmitError({ message: 'error' } as any);
-            expect(component.isSubmitting).toBe(false);
+            expect(component.isSubmitting).toBeFalse();
 
             component.onSaveError('error');
-            expect(component.isSubmitting).toBe(false);
+            expect(component.isSubmitting).toBeFalse();
             expect(component.unsavedChanges).toBeTrue();
 
             expect(alertSpy).toHaveBeenCalled();

--- a/src/test/javascript/spec/component/exercises/quiz/quiz-scoring-info-student-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/quiz-scoring-info-student-modal.component.spec.ts
@@ -76,7 +76,7 @@ describe('Quiz Scoring Info Student Modal Component', () => {
 
         comp.open(content);
 
-        expect(openModalSpy).toHaveBeenCalledTimes(1);
+        expect(openModalSpy).toHaveBeenCalledOnce();
         expect(openModalSpy).toHaveBeenCalledWith(content, { size: 'lg' });
     });
 

--- a/src/test/javascript/spec/component/exercises/shared/example-submission-import.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/example-submission-import.component.spec.ts
@@ -116,7 +116,7 @@ describe('ExampleSubmissionImportComponent', () => {
             component.listSorting = true;
             tick(10);
             expect(searchForSubmissionsSpy).toHaveBeenCalledWith({ ...state, sortingOrder: SortingOrder.ASCENDING }, exercise.id);
-            expect(component.listSorting).toBe(true);
+            expect(component.listSorting).toBeTrue();
         });
     }));
 

--- a/src/test/javascript/spec/component/exercises/shared/example-submission-import.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/example-submission-import.component.spec.ts
@@ -111,7 +111,7 @@ describe('ExampleSubmissionImportComponent', () => {
     };
 
     it('should set content to paging result on sort', fakeAsync(() => {
-        expect(component.listSorting).toBe(false);
+        expect(component.listSorting).toBeFalse();
         setStateAndCallOnInit(() => {
             component.listSorting = true;
             tick(10);

--- a/src/test/javascript/spec/component/exercises/shared/example-submissions.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/example-submissions.component.spec.ts
@@ -79,7 +79,7 @@ describe('Example Submission Component', () => {
         component.deleteExampleSubmission(0);
 
         // THEN
-        expect(deleteStub).toHaveBeenCalledTimes(1);
+        expect(deleteStub).toHaveBeenCalledOnce();
         expect(exercise.exampleSubmissions?.length).toBe(1);
     });
 
@@ -90,7 +90,7 @@ describe('Example Submission Component', () => {
         const alertServiceSpy = jest.spyOn(alertService, 'error');
         component.deleteExampleSubmission(0);
 
-        expect(alertServiceSpy).toHaveBeenCalledTimes(1);
+        expect(alertServiceSpy).toHaveBeenCalledOnce();
     });
 
     it('should get the submission size', () => {
@@ -110,7 +110,7 @@ describe('Example Submission Component', () => {
         component.ngOnInit();
         expect(component.exercise.exampleSubmissions).not.toBe(undefined);
         expect(component.exercise.exampleSubmissions![0].submission?.submissionSize).toBe(2);
-        expect(getSubmissionSizeSpy).toHaveBeenCalledTimes(1);
+        expect(getSubmissionSizeSpy).toHaveBeenCalledOnce();
     });
 
     it('should not open import modal', () => {
@@ -122,7 +122,7 @@ describe('Example Submission Component', () => {
 
         component.openImportModal();
 
-        expect(modalServiceStub).toHaveBeenCalledTimes(1);
+        expect(modalServiceStub).toHaveBeenCalledOnce();
         expect(importStub).not.toHaveBeenCalled();
     });
 
@@ -132,7 +132,7 @@ describe('Example Submission Component', () => {
 
         component.ngOnDestroy();
 
-        expect(modalServiceStub).toHaveBeenCalledTimes(1);
-        expect(modalServiceDismissSpy).toHaveBeenCalledTimes(1);
+        expect(modalServiceStub).toHaveBeenCalledOnce();
+        expect(modalServiceDismissSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/exercises/shared/exercise-details.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/exercise-details.component.spec.ts
@@ -61,9 +61,9 @@ describe('ExerciseDetailsComponent', () => {
         fixture.detectChanges();
         expect(component).not.toBe(null);
         expect(component.programmingExercise).not.toBe(null);
-        expect(isAtLeastTutor).toHaveBeenCalledTimes(1);
-        expect(isAtLeastEditor).toHaveBeenCalledTimes(1);
-        expect(isAtLeastInstructor).toHaveBeenCalledTimes(1);
+        expect(isAtLeastTutor).toHaveBeenCalledOnce();
+        expect(isAtLeastEditor).toHaveBeenCalledOnce();
+        expect(isAtLeastInstructor).toHaveBeenCalledOnce();
     });
 
     it('should show timeline', () => {
@@ -98,9 +98,9 @@ describe('ExerciseDetailsComponent', () => {
             component.exercise = textExercise;
             fixture.detectChanges();
             expect(component.programmingExercise).toBe(undefined);
-            expect(isAtLeastTutor).toHaveBeenCalledTimes(1);
-            expect(isAtLeastEditor).toHaveBeenCalledTimes(1);
-            expect(isAtLeastInstructor).toHaveBeenCalledTimes(1);
+            expect(isAtLeastTutor).toHaveBeenCalledOnce();
+            expect(isAtLeastEditor).toHaveBeenCalledOnce();
+            expect(isAtLeastInstructor).toHaveBeenCalledOnce();
         });
 
         it('should show grading criteria', () => {

--- a/src/test/javascript/spec/component/exercises/shared/exercise-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/exercise-scores.component.spec.ts
@@ -158,7 +158,7 @@ describe('Exercise Scores Component', () => {
         expect(component.isLoading).toBeTrue();
         tick();
         expect(component.resultCriteria.filterProp).toBe(component.FilterProp.SUCCESSFUL);
-        expect(component.isLoading).toBe(false);
+        expect(component.isLoading).toBeFalse();
     }));
 
     it('should filter result prop "successful"', () => {
@@ -172,13 +172,13 @@ describe('Exercise Scores Component', () => {
         component.resultCriteria.filterProp = component.FilterProp.UNSUCCESSFUL;
         result.successful = true;
 
-        expect(component.filterResultByProp(result)).toBe(false);
+        expect(component.filterResultByProp(result)).toBeFalse();
     });
 
     it('should filter result prop "build failed"', () => {
         component.resultCriteria.filterProp = component.FilterProp.BUILD_FAILED;
 
-        expect(component.filterResultByProp(result)).toBe(false);
+        expect(component.filterResultByProp(result)).toBeFalse();
     });
 
     it('should filter result prop "manual"', () => {
@@ -190,7 +190,7 @@ describe('Exercise Scores Component', () => {
     it('should filter result prop "automatic"', () => {
         component.resultCriteria.filterProp = component.FilterProp.AUTOMATIC;
 
-        expect(component.filterResultByProp(result)).toBe(false);
+        expect(component.filterResultByProp(result)).toBeFalse();
     });
 
     it('should filter result prop default value', () => {
@@ -284,7 +284,7 @@ describe('Exercise Scores Component', () => {
         expect(resultServiceStub).toHaveBeenCalledOnce();
         expect(resultServiceStub).toHaveBeenCalledWith(component.exercise);
         expect(component.results).toEqual([result]);
-        expect(component.isLoading).toBe(false);
+        expect(component.isLoading).toBeFalse();
     });
 
     it('should format date correctly', () => {

--- a/src/test/javascript/spec/component/exercises/shared/exercise-scores.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/exercise-scores.component.spec.ts
@@ -155,7 +155,7 @@ describe('Exercise Scores Component', () => {
     it('should update result', fakeAsync(() => {
         component.updateResultFilter(component.FilterProp.SUCCESSFUL);
 
-        expect(component.isLoading).toBe(true);
+        expect(component.isLoading).toBeTrue();
         tick();
         expect(component.resultCriteria.filterProp).toBe(component.FilterProp.SUCCESSFUL);
         expect(component.isLoading).toBe(false);
@@ -165,7 +165,7 @@ describe('Exercise Scores Component', () => {
         component.resultCriteria.filterProp = component.FilterProp.SUCCESSFUL;
         result.successful = true;
 
-        expect(component.filterResultByProp(result)).toBe(true);
+        expect(component.filterResultByProp(result)).toBeTrue();
     });
 
     it('should filter result prop "unsuccessful"', () => {
@@ -184,7 +184,7 @@ describe('Exercise Scores Component', () => {
     it('should filter result prop "manual"', () => {
         component.resultCriteria.filterProp = component.FilterProp.MANUAL;
 
-        expect(component.filterResultByProp(result)).toBe(true);
+        expect(component.filterResultByProp(result)).toBeTrue();
     });
 
     it('should filter result prop "automatic"', () => {
@@ -194,7 +194,7 @@ describe('Exercise Scores Component', () => {
     });
 
     it('should filter result prop default value', () => {
-        expect(component.filterResultByProp(result)).toBe(true);
+        expect(component.filterResultByProp(result)).toBeTrue();
     });
 
     it('should handle result size change', () => {
@@ -229,7 +229,7 @@ describe('Exercise Scores Component', () => {
 
         component.exportNames();
 
-        expect(resultServiceStub).toHaveBeenCalledTimes(1);
+        expect(resultServiceStub).toHaveBeenCalledOnce();
         expect(resultServiceStub).toHaveBeenCalledWith(rows, 'results-names.csv');
     });
 
@@ -241,7 +241,7 @@ describe('Exercise Scores Component', () => {
 
         component.exportNames();
 
-        expect(resultServiceStub).toHaveBeenCalledTimes(1);
+        expect(resultServiceStub).toHaveBeenCalledOnce();
         expect(resultServiceStub).toHaveBeenCalledWith(rows, 'results-names.csv');
         participation.team = undefined;
     });
@@ -281,7 +281,7 @@ describe('Exercise Scores Component', () => {
 
         component.refresh();
 
-        expect(resultServiceStub).toHaveBeenCalledTimes(1);
+        expect(resultServiceStub).toHaveBeenCalledOnce();
         expect(resultServiceStub).toHaveBeenCalledWith(component.exercise);
         expect(component.results).toEqual([result]);
         expect(component.isLoading).toBe(false);

--- a/src/test/javascript/spec/component/exercises/shared/exercise-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/exercise-statistics.component.spec.ts
@@ -84,8 +84,8 @@ describe('ExerciseStatisticsComponent', () => {
     it('should initialize', () => {
         fixture.detectChanges();
         expect(component).not.toBeNull();
-        expect(statisticsSpy).toHaveBeenCalledTimes(1);
-        expect(exerciseSpy).toHaveBeenCalledTimes(1);
+        expect(statisticsSpy).toHaveBeenCalledOnce();
+        expect(exerciseSpy).toHaveBeenCalledOnce();
         expect(component.exerciseStatistics.participationsInPercent).toEqual(100);
         expect(component.exerciseStatistics.resolvedPostsInPercent).toEqual(50);
         expect(component.exerciseStatistics.absoluteAveragePoints).toEqual(5);
@@ -99,10 +99,10 @@ describe('ExerciseStatisticsComponent', () => {
         button.click();
 
         tick();
-        expect(tabSpy).toHaveBeenCalledTimes(1);
+        expect(tabSpy).toHaveBeenCalledOnce();
         expect(component.currentSpan).toEqual(SpanType.MONTH);
-        expect(statisticsSpy).toHaveBeenCalledTimes(1);
-        expect(exerciseSpy).toHaveBeenCalledTimes(1);
+        expect(statisticsSpy).toHaveBeenCalledOnce();
+        expect(exerciseSpy).toHaveBeenCalledOnce();
         expect(component.exerciseStatistics.participationsInPercent).toEqual(100);
         expect(component.exerciseStatistics.resolvedPostsInPercent).toEqual(50);
         expect(component.exerciseStatistics.absoluteAveragePoints).toEqual(5);

--- a/src/test/javascript/spec/component/exercises/shared/external-submission-button.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/external-submission-button.component.spec.ts
@@ -53,7 +53,7 @@ describe('External Submission Dialog', () => {
         fixture.detectChanges();
         fixture.debugElement.query(By.css('.btn')).nativeElement.click();
 
-        expect(openMock).toHaveBeenCalledTimes(1);
+        expect(openMock).toHaveBeenCalledOnce();
         expect(openMock).toHaveBeenCalledWith(ExternalSubmissionDialogComponent, { keyboard: true, size: 'lg', backdrop: 'static' });
         expect(modalRefMock.componentInstance.exercise).toBe(exercise);
     });

--- a/src/test/javascript/spec/component/exercises/shared/external-submission-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/external-submission-dialog.component.spec.ts
@@ -45,13 +45,13 @@ describe('External Submission Dialog', () => {
         const result = new Result();
         const extServiceSpy = jest.spyOn(externalSubmissionService, 'generateInitialManualResult').mockReturnValue(result);
         component.ngOnInit();
-        expect(extServiceSpy).toHaveBeenCalledTimes(1);
+        expect(extServiceSpy).toHaveBeenCalledOnce();
         expect(component.result).toBe(result);
     });
 
     it('should dismiss the modal on clear', () => {
         component.clear();
-        expect(activeModal.dismiss).toHaveBeenCalledTimes(1);
+        expect(activeModal.dismiss).toHaveBeenCalledOnce();
         expect(activeModal.dismiss).toHaveBeenCalledWith('cancel');
     });
 
@@ -74,19 +74,19 @@ describe('External Submission Dialog', () => {
 
         component.save();
 
-        expect(component.isSaving).toBe(true);
+        expect(component.isSaving).toBeTrue();
         expect(result.feedbacks).toBe(component.feedbacks);
         expect(result.feedbacks).toSatisfyAll((feedback) => feedback.type === FeedbackType.MANUAL);
-        expect(createMock).toHaveBeenCalledTimes(1);
+        expect(createMock).toHaveBeenCalledOnce();
         expect(createMock).toHaveBeenCalledWith(component.exercise, component.student, result);
         expect(activeModal.close).toHaveBeenCalledTimes(0);
 
         subject.next(new HttpResponse<Result>({ body: result }));
 
-        expect(activeModal.close).toHaveBeenCalledTimes(1);
+        expect(activeModal.close).toHaveBeenCalledOnce();
         expect(activeModal.close).toHaveBeenCalledWith(result);
         expect(component.isSaving).toBe(false);
-        expect(eventManagerSpy).toHaveBeenCalledTimes(1);
+        expect(eventManagerSpy).toHaveBeenCalledOnce();
         expect(eventManagerSpy).toHaveBeenCalledWith({ name: 'resultListModification', content: 'Added a manual result' });
     });
 
@@ -98,8 +98,8 @@ describe('External Submission Dialog', () => {
         const onSaveErrorSpy = jest.spyOn(component, 'onSaveError');
 
         component.save();
-        expect(createMock).toHaveBeenCalledTimes(1);
-        expect(onSaveErrorSpy).toHaveBeenCalledTimes(1);
+        expect(createMock).toHaveBeenCalledOnce();
+        expect(onSaveErrorSpy).toHaveBeenCalledOnce();
         expect(component.isSaving).toBe(false);
     });
 

--- a/src/test/javascript/spec/component/exercises/shared/external-submission-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/external-submission-dialog.component.spec.ts
@@ -85,7 +85,7 @@ describe('External Submission Dialog', () => {
 
         expect(activeModal.close).toHaveBeenCalledOnce();
         expect(activeModal.close).toHaveBeenCalledWith(result);
-        expect(component.isSaving).toBe(false);
+        expect(component.isSaving).toBeFalse();
         expect(eventManagerSpy).toHaveBeenCalledOnce();
         expect(eventManagerSpy).toHaveBeenCalledWith({ name: 'resultListModification', content: 'Added a manual result' });
     });
@@ -100,7 +100,7 @@ describe('External Submission Dialog', () => {
         component.save();
         expect(createMock).toHaveBeenCalledOnce();
         expect(onSaveErrorSpy).toHaveBeenCalledOnce();
-        expect(component.isSaving).toBe(false);
+        expect(component.isSaving).toBeFalse();
     });
 
     it('should add a new feedback on pushFeedback and remove last on popFeedback', () => {

--- a/src/test/javascript/spec/component/exercises/shared/headers/header-exercise-page-with-details.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/headers/header-exercise-page-with-details.component.spec.ts
@@ -68,7 +68,7 @@ describe('HeaderExercisePageWithDetails', () => {
 
         component.ngOnChanges();
 
-        expect(component.isExamMode).toBe(true);
+        expect(component.isExamMode).toBeTrue();
         expect(component.exerciseCategories).toEqual(categories);
         expect(component.exerciseStatusBadge).toBe('bg-danger');
     });

--- a/src/test/javascript/spec/component/exercises/shared/headers/header-exercise-page-with-details.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/headers/header-exercise-page-with-details.component.spec.ts
@@ -52,7 +52,7 @@ describe('HeaderExercisePageWithDetails', () => {
     it('should initialise badges, icons, and categories', () => {
         component.ngOnChanges();
 
-        expect(component.isExamMode).toBe(false);
+        expect(component.isExamMode).toBeFalse();
         expect(component.exerciseCategories).toEqual([]);
         expect(component.exerciseStatusBadge).toBe('bg-success');
         // @ts-ignore

--- a/src/test/javascript/spec/component/exercises/shared/headers/header-participation-page.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/headers/header-participation-page.component.spec.ts
@@ -63,10 +63,10 @@ describe('HeaderParticipationPage', () => {
     });
 
     it('should always publish the results for regular exercises', () => {
-        expect(component.resultsPublished).toBe(true);
+        expect(component.resultsPublished).toBeTrue();
 
         exercise.exerciseGroup = new ExerciseGroup();
-        expect(component.resultsPublished).toBe(true);
+        expect(component.resultsPublished).toBeTrue();
     });
 
     it('should only publish the results for exam exercises after the publishing date', () => {
@@ -80,7 +80,7 @@ describe('HeaderParticipationPage', () => {
         expect(component.resultsPublished).toBe(false);
 
         exam.publishResultsDate = dayjs().subtract(1, 'day');
-        expect(component.resultsPublished).toBe(true);
+        expect(component.resultsPublished).toBeTrue();
 
         exam.publishResultsDate = dayjs().add(1, 'day');
         expect(component.resultsPublished).toBe(false);

--- a/src/test/javascript/spec/component/exercises/shared/headers/header-participation-page.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/headers/header-participation-page.component.spec.ts
@@ -77,13 +77,13 @@ describe('HeaderParticipationPage', () => {
         exercise.exerciseGroup = exerciseGroup;
 
         // no publishing date => do not publish
-        expect(component.resultsPublished).toBe(false);
+        expect(component.resultsPublished).toBeFalse();
 
         exam.publishResultsDate = dayjs().subtract(1, 'day');
         expect(component.resultsPublished).toBeTrue();
 
         exam.publishResultsDate = dayjs().add(1, 'day');
-        expect(component.resultsPublished).toBe(false);
+        expect(component.resultsPublished).toBeFalse();
     });
 
     it('should not apply changes if no exercise is set', () => {

--- a/src/test/javascript/spec/component/exercises/shared/submission-export-button.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/submission-export-button.component.spec.ts
@@ -57,8 +57,8 @@ describe('Submission Export Button Component', () => {
 
         component.openSubmissionExportDialog(mouseEvent);
 
-        expect(mouseEventSpy).toHaveBeenCalledTimes(1);
-        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(mouseEventSpy).toHaveBeenCalledOnce();
+        expect(openSpy).toHaveBeenCalledOnce();
         expect(openSpy).toHaveBeenCalledWith(SubmissionExportDialogComponent, { keyboard: true, size: 'lg' });
     });
 

--- a/src/test/javascript/spec/component/exercises/shared/submission-export-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/submission-export-dialog.component.spec.ts
@@ -64,8 +64,8 @@ describe('Submission Export Dialog Component', () => {
         const findSpy = jest.spyOn(exerciseService, 'find');
         component.ngOnInit();
 
-        expect(component.isLoading).toBe(false);
-        expect(component.exportInProgress).toBe(false);
+        expect(component.isLoading).toBeFalse();
+        expect(component.exportInProgress).toBeFalse();
         expect(component.submissionExportOptions).toEqual(submissionExportOptions);
         expect(component.exercise).toEqual({ id: exerciseId } as Exercise);
         expect(findSpy).toHaveBeenCalledOnce();
@@ -84,7 +84,7 @@ describe('Submission Export Dialog Component', () => {
         expect(alertSpy).toHaveBeenCalledWith('instructorDashboard.exportSubmissions.successMessage');
         expect(modalSpy).toHaveBeenCalledOnce();
         expect(modalSpy).toHaveBeenCalledWith(true);
-        expect(component.exportInProgress).toBe(false);
+        expect(component.exportInProgress).toBeFalse();
         expect(downloadSpy).toHaveBeenCalledOnce();
         expect(downloadSpy).toHaveBeenCalledWith(response);
     });

--- a/src/test/javascript/spec/component/exercises/shared/submission-export-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/submission-export-dialog.component.spec.ts
@@ -68,7 +68,7 @@ describe('Submission Export Dialog Component', () => {
         expect(component.exportInProgress).toBe(false);
         expect(component.submissionExportOptions).toEqual(submissionExportOptions);
         expect(component.exercise).toEqual({ id: exerciseId } as Exercise);
-        expect(findSpy).toHaveBeenCalledTimes(1);
+        expect(findSpy).toHaveBeenCalledOnce();
         expect(findSpy).toHaveBeenCalledWith(exerciseId);
     });
 
@@ -80,12 +80,12 @@ describe('Submission Export Dialog Component', () => {
 
         component.handleExportResponse(response);
 
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('instructorDashboard.exportSubmissions.successMessage');
-        expect(modalSpy).toHaveBeenCalledTimes(1);
+        expect(modalSpy).toHaveBeenCalledOnce();
         expect(modalSpy).toHaveBeenCalledWith(true);
         expect(component.exportInProgress).toBe(false);
-        expect(downloadSpy).toHaveBeenCalledTimes(1);
+        expect(downloadSpy).toHaveBeenCalledOnce();
         expect(downloadSpy).toHaveBeenCalledWith(response);
     });
 
@@ -93,7 +93,7 @@ describe('Submission Export Dialog Component', () => {
         const modalSpy = jest.spyOn(component.activeModal, 'dismiss');
         component.clear();
 
-        expect(modalSpy).toHaveBeenCalledTimes(1);
+        expect(modalSpy).toHaveBeenCalledOnce();
         expect(modalSpy).toHaveBeenCalledWith('cancel');
     });
 
@@ -112,10 +112,10 @@ describe('Submission Export Dialog Component', () => {
 
             component.exportSubmissions(exerciseId);
 
-            expect(exportSubmissionServiceMock).toHaveBeenCalledTimes(1);
+            expect(exportSubmissionServiceMock).toHaveBeenCalledOnce();
             expect(exportSubmissionServiceMock).toHaveBeenCalledWith(exerciseId, validExerciseType, submissionExportOptions);
-            expect(component.exportInProgress).toBe(true);
-            expect(handleExportResponseMock).toHaveBeenCalledTimes(1);
+            expect(component.exportInProgress).toBeTrue();
+            expect(handleExportResponseMock).toHaveBeenCalledOnce();
             expect(handleExportResponseMock).toHaveBeenCalledWith({ body: {} });
         });
 
@@ -130,7 +130,7 @@ describe('Submission Export Dialog Component', () => {
                 component.exportSubmissions(exerciseId);
             }).toThrow('Export not implemented for exercise type ' + invalidExerciseType);
 
-            expect(exportSubmissionServiceMock).toHaveBeenCalledTimes(1);
+            expect(exportSubmissionServiceMock).toHaveBeenCalledOnce();
             expect(exportSubmissionServiceMock).toHaveBeenCalledWith(exerciseId, invalidExerciseType, submissionExportOptions);
             expect(handleExportResponseMock).toHaveBeenCalledTimes(0);
         });

--- a/src/test/javascript/spec/component/exercises/shared/team-config-form-group.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/team-config-form-group.component.spec.ts
@@ -97,13 +97,13 @@ describe('Team Config Form Group Component', () => {
 
     it('exercise mode should be editable for existing non-exam exercise', () => {
         component.isImport = false;
-        expect(component.changeExerciseModeDisabled).toBe(true);
+        expect(component.changeExerciseModeDisabled).toBeTrue();
     });
 
     it('exercise mode should be editable for existing exam exercise', () => {
         component.isImport = false;
         component.exercise.exerciseGroup = new ExerciseGroup();
-        expect(component.changeExerciseModeDisabled).toBe(true);
+        expect(component.changeExerciseModeDisabled).toBeTrue();
     });
 
     it('exercise mode should be non-editable for non-exam and imported exercise', () => {

--- a/src/test/javascript/spec/component/exercises/shared/team-config-form-group.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/team-config-form-group.component.spec.ts
@@ -108,6 +108,6 @@ describe('Team Config Form Group Component', () => {
 
     it('exercise mode should be non-editable for non-exam and imported exercise', () => {
         component.isImport = true;
-        expect(component.changeExerciseModeDisabled).toBe(false);
+        expect(component.changeExerciseModeDisabled).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/exercises/shared/team-submission-sync.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/shared/team-submission-sync.component.spec.ts
@@ -82,20 +82,20 @@ describe('Team Submission Sync Component', () => {
         component.ngOnInit();
 
         expect(component.websocketTopic).toBe(expectedWebsocketTopic);
-        expect(websocketSubscribeSpy).toHaveBeenCalledTimes(1);
+        expect(websocketSubscribeSpy).toHaveBeenCalledOnce();
         expect(websocketSubscribeSpy).toHaveBeenCalledWith(expectedWebsocketTopic);
 
         // checks for setupReceiver
-        expect(websocketReceiveMock).toHaveBeenCalledTimes(1);
+        expect(websocketReceiveMock).toHaveBeenCalledOnce();
         expect(websocketReceiveMock).toHaveBeenCalledWith(expectedWebsocketTopic);
-        expect(receiveSubmissionEventEmitter).toHaveBeenCalledTimes(1);
+        expect(receiveSubmissionEventEmitter).toHaveBeenCalledOnce();
         expect(receiveSubmissionEventEmitter).toHaveBeenCalledWith(submissionSyncPayload?.submission);
 
         // checks for setupSender
         expect(textSubmissionWithParticipation).not.toBe(undefined);
         expect(textSubmissionWithParticipation?.participation?.exercise).toBe(undefined);
         expect(textSubmissionWithParticipation?.participation?.submissions).toBeEmpty();
-        expect(websocketSendSpy).toHaveBeenCalledTimes(1);
+        expect(websocketSendSpy).toHaveBeenCalledOnce();
         expect(websocketSendSpy).toHaveBeenCalledWith(expectedWebsocketTopic + '/update', textSubmissionWithParticipation);
     });
 });

--- a/src/test/javascript/spec/component/file-upload-exercise/file-upload-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-exercise/file-upload-exercise.component.spec.ts
@@ -89,7 +89,7 @@ describe('FileUploadExercise Management Component', () => {
         comp.ngOnInit();
         comp.deleteFileUploadExercise(456);
         expect(fileUploadExerciseService.delete).toHaveBeenCalledWith(456);
-        expect(fileUploadExerciseService.delete).toHaveBeenCalledTimes(1);
+        expect(fileUploadExerciseService.delete).toHaveBeenCalledOnce();
     });
 
     it('Should return exercise id', () => {

--- a/src/test/javascript/spec/component/file-upload-submission/file-upload-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-submission/file-upload-submission.component.spec.ts
@@ -110,7 +110,7 @@ describe('FileUploadSubmissionComponent', () => {
         // check if properties where assigned correctly on init
         expect(comp.acceptedFileExtensions.replace(/\./g, '')).toEqual(fileUploadExercise.filePattern);
         expect(comp.fileUploadExercise).toEqual(fileUploadExercise);
-        expect(comp.isAfterAssessmentDueDate).toBe(true);
+        expect(comp.isAfterAssessmentDueDate).toBeTrue();
 
         // check if fileUploadInput is available
         const fileUploadInput = debugElement.query(By.css('#fileUploadInput'));
@@ -235,7 +235,7 @@ describe('FileUploadSubmissionComponent', () => {
         fixture.detectChanges();
         tick();
 
-        expect(comp.isLate).toBe(true);
+        expect(comp.isLate).toBeTrue();
         const submitButton = debugElement.query(By.css('jhi-button'));
         expect(submitButton).toBeDefined();
         expect(submitButton.attributes['ng-reflect-disabled']).toEqual('false');
@@ -274,7 +274,7 @@ describe('FileUploadSubmissionComponent', () => {
         tick();
         comp.participation.initializationDate = dayjs();
 
-        expect(comp.isActive).toBe(true);
+        expect(comp.isActive).toBeTrue();
 
         comp.fileUploadExercise.dueDate = dayjs().subtract(1, 'days');
 
@@ -323,7 +323,7 @@ describe('FileUploadSubmissionComponent', () => {
         expect(unreferencedFeedback).not.toBe(undefined);
         expect(unreferencedFeedback).toHaveLength(2);
         expect(unreferencedFeedback![0].isSubsequent).toBe(undefined);
-        expect(unreferencedFeedback![1].isSubsequent).toBe(true);
+        expect(unreferencedFeedback![1].isSubsequent).toBeTrue();
     });
 
     it('should download file', () => {
@@ -332,22 +332,22 @@ describe('FileUploadSubmissionComponent', () => {
 
         comp.downloadFile('');
 
-        expect(fileServiceStub).toHaveBeenCalledTimes(1);
+        expect(fileServiceStub).toHaveBeenCalledOnce();
     });
 
     it('should decide over deactivation correctly', () => {
         const submission = createFileUploadSubmission();
 
-        expect(comp.canDeactivate()).toBe(true);
+        expect(comp.canDeactivate()).toBeTrue();
 
         submission.submitted = true;
         comp.submission = submission;
 
-        expect(comp.canDeactivate()).toBe(true);
+        expect(comp.canDeactivate()).toBeTrue();
 
         comp.submissionFile = new File([''], 'exampleSubmission.png');
 
-        expect(comp.canDeactivate()).toBe(true);
+        expect(comp.canDeactivate()).toBeTrue();
 
         submission.submitted = false;
         comp.submission = submission;

--- a/src/test/javascript/spec/component/file-upload-submission/file-upload-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/file-upload-submission/file-upload-submission.component.spec.ts
@@ -115,7 +115,7 @@ describe('FileUploadSubmissionComponent', () => {
         // check if fileUploadInput is available
         const fileUploadInput = debugElement.query(By.css('#fileUploadInput'));
         expect(fileUploadInput).not.toBe(null);
-        expect(fileUploadInput.nativeElement.disabled).toBe(false);
+        expect(fileUploadInput.nativeElement.disabled).toBeFalse();
 
         // check if extension elements are set
         const extension = debugElement.query(By.css('.ms-1.badge.bg-info'));
@@ -171,7 +171,7 @@ describe('FileUploadSubmissionComponent', () => {
         // check if fileUploadInput is available
         const fileUploadInput = debugElement.query(By.css('#fileUploadInput'));
         expect(fileUploadInput).toBeDefined();
-        expect(fileUploadInput.nativeElement.disabled).toBe(false);
+        expect(fileUploadInput.nativeElement.disabled).toBeFalse();
         expect(fileUploadInput.nativeElement.value).toEqual('');
     }));
 
@@ -198,7 +198,7 @@ describe('FileUploadSubmissionComponent', () => {
         // check if fileUploadInput is available
         const fileUploadInput = debugElement.query(By.css('#fileUploadInput'));
         expect(fileUploadInput).toBeDefined();
-        expect(fileUploadInput.nativeElement.disabled).toBe(false);
+        expect(fileUploadInput.nativeElement.disabled).toBeFalse();
         expect(fileUploadInput.nativeElement.value).toEqual('');
 
         tick();
@@ -281,7 +281,7 @@ describe('FileUploadSubmissionComponent', () => {
         fixture.detectChanges();
         tick();
 
-        expect(comp.isActive).toBe(false);
+        expect(comp.isActive).toBeFalse();
 
         tick();
         fixture.destroy();
@@ -352,7 +352,7 @@ describe('FileUploadSubmissionComponent', () => {
         submission.submitted = false;
         comp.submission = submission;
 
-        expect(comp.canDeactivate()).toBe(false);
+        expect(comp.canDeactivate()).toBeFalse();
     });
 
     it('should set alert correctly', () => {
@@ -373,7 +373,7 @@ describe('FileUploadSubmissionComponent', () => {
 
         comp.submitExercise();
 
-        expect(comp.isActive).toBe(false);
+        expect(comp.isActive).toBeFalse();
         expect(jhiWarningSpy).toHaveBeenCalledWith('artemisApp.fileUploadExercise.submitDeadlineMissed');
 
         submission.participation.exercise = undefined;
@@ -381,7 +381,7 @@ describe('FileUploadSubmissionComponent', () => {
         fixture.detectChanges();
         comp.submitExercise();
 
-        expect(comp.isActive).toBe(false);
+        expect(comp.isActive).toBeFalse();
         expect(jhiWarningSpy).toHaveBeenCalledWith('artemisApp.fileUploadExercise.submitDeadlineMissed');
     });
 

--- a/src/test/javascript/spec/component/grading-system/detailed-grading-system.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/detailed-grading-system.component.spec.ts
@@ -153,7 +153,7 @@ describe('Detailed Grading System Component', () => {
             if (gradeStep.upperBoundPercentage === 100) {
                 expect(gradeStep.upperBoundInclusive).toBeTrue();
             } else {
-                expect(gradeStep.upperBoundInclusive).toBe(false);
+                expect(gradeStep.upperBoundInclusive).toBeFalse();
             }
             if (gradeStep.lowerBoundPercentage >= 50) {
                 expect(gradeStep.isPassingGrade).toBeTrue();
@@ -215,7 +215,7 @@ describe('Detailed Grading System Component', () => {
         comp.setPassingGrades(comp.gradingScale.gradeSteps);
 
         comp.gradingScale.gradeSteps.forEach((gradeStep) => {
-            expect(gradeStep.isPassingGrade).toBe(false);
+            expect(gradeStep.isPassingGrade).toBeFalse();
         });
     });
 
@@ -235,7 +235,7 @@ describe('Detailed Grading System Component', () => {
             if (gradeStep.lowerBoundPercentage === 0) {
                 expect(gradeStep.lowerBoundInclusive).toBeTrue();
             } else {
-                expect(gradeStep.lowerBoundInclusive).toBe(false);
+                expect(gradeStep.lowerBoundInclusive).toBeFalse();
             }
         });
     });
@@ -259,7 +259,7 @@ describe('Detailed Grading System Component', () => {
             if (gradeStep.lowerBoundPercentage === 0) {
                 expect(gradeStep.lowerBoundInclusive).toBeTrue();
             } else {
-                expect(gradeStep.lowerBoundInclusive).toBe(false);
+                expect(gradeStep.lowerBoundInclusive).toBeFalse();
             }
         });
     });
@@ -291,7 +291,7 @@ describe('Detailed Grading System Component', () => {
 
         expect(gradingSystemDeleteForCourseStub).toHaveBeenNthCalledWith(1, comp.courseId);
         expect(gradingSystemDeleteForCourseStub).toHaveBeenCalledOnce();
-        expect(comp.existingGradingScale).toBe(false);
+        expect(comp.existingGradingScale).toBeFalse();
     });
 
     it('should delete grading scale for exam', () => {
@@ -303,7 +303,7 @@ describe('Detailed Grading System Component', () => {
 
         expect(gradingSystemDeleteForExamStub).toHaveBeenNthCalledWith(1, comp.courseId, comp.examId);
         expect(gradingSystemDeleteForExamStub).toHaveBeenCalledOnce();
-        expect(comp.existingGradingScale).toBe(false);
+        expect(comp.existingGradingScale).toBeFalse();
     });
 
     it('should not update grading scale', () => {
@@ -316,7 +316,7 @@ describe('Detailed Grading System Component', () => {
 
         expect(gradingSystemServiceStub).toHaveBeenNthCalledWith(1, comp.courseId, comp.gradingScale);
         expect(gradingSystemServiceStub).toHaveBeenCalledOnce();
-        expect(comp.existingGradingScale).toBe(false);
+        expect(comp.existingGradingScale).toBeFalse();
     });
 
     it('should create grading scale correctly for course', () => {
@@ -406,7 +406,7 @@ describe('Detailed Grading System Component', () => {
         comp.gradingScale.gradeSteps = [];
         translateStub.mockReturnValue('empty set');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('empty set');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.empty');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -417,7 +417,7 @@ describe('Detailed Grading System Component', () => {
         comp.maxPoints = -10;
         translateStub.mockReturnValue('negative max points');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('negative max points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.negativeMaxPoints');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -428,7 +428,7 @@ describe('Detailed Grading System Component', () => {
         comp.gradingScale.gradeSteps[0].gradeName = '';
         translateStub.mockReturnValue('empty field');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('empty field');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.emptyFields');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -439,7 +439,7 @@ describe('Detailed Grading System Component', () => {
         comp.maxPoints = 100;
         translateStub.mockReturnValue('empty field for points');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('empty field for points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.emptyFields');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -449,7 +449,7 @@ describe('Detailed Grading System Component', () => {
         comp.gradingScale.gradeSteps[0].lowerBoundPercentage = -10;
         translateStub.mockReturnValue('invalid percentage');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid percentage');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.invalidMinMaxPercentages');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -465,7 +465,7 @@ describe('Detailed Grading System Component', () => {
         comp.gradingScale.gradeSteps[2].upperBoundPoints = 100;
         translateStub.mockReturnValue('invalid points');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.invalidMinMaxPoints');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -474,7 +474,7 @@ describe('Detailed Grading System Component', () => {
     it('should validate invalid grading scale with set points when all should be undefined', () => {
         comp.gradingScale.gradeSteps[0].upperBoundPoints = 70;
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
     });
 
     it('should validate invalid grading scale with non-unique grade names', () => {
@@ -482,7 +482,7 @@ describe('Detailed Grading System Component', () => {
         comp.gradingScale.gradeSteps[1].gradeName = 'Fail';
         translateStub.mockReturnValue('non-unique grade names');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('non-unique grade names');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.nonUniqueGradeNames');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -493,7 +493,7 @@ describe('Detailed Grading System Component', () => {
         comp.firstPassingGrade = undefined;
         translateStub.mockReturnValue('unset first passing grade');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('unset first passing grade');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.unsetFirstPassingGrade');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -504,7 +504,7 @@ describe('Detailed Grading System Component', () => {
         comp.gradingScale.gradeType = GradeType.BONUS;
         translateStub.mockReturnValue('invalid bonus points');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid bonus points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.invalidBonusPoints');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -517,7 +517,7 @@ describe('Detailed Grading System Component', () => {
         comp.gradingScale.gradeType = GradeType.BONUS;
         translateStub.mockReturnValue('descending bonus points');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('descending bonus points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.nonStrictlyIncreasingBonusPoints');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -535,7 +535,7 @@ describe('Detailed Grading System Component', () => {
         translateStub.mockReturnValue('invalid adjacency');
         jest.spyOn(gradingSystemService, 'sortGradeSteps').mockReturnValue([gradeStep, gradeStep2, gradeStep3]);
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid adjacency');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.invalidAdjacency');
         expect(translateStub).toHaveBeenCalledOnce();
@@ -554,7 +554,7 @@ describe('Detailed Grading System Component', () => {
         comp.gradingScale.gradeSteps[0].lowerBoundPercentage = 10;
         translateStub.mockReturnValue('invalid first grade step');
 
-        expect(comp.validGradeSteps()).toBe(false);
+        expect(comp.validGradeSteps()).toBeFalse();
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid first grade step');
         expect(translateStub).toHaveBeenCalledWith('artemisApp.gradingSystem.error.invalidFirstAndLastStep');
         expect(translateStub).toHaveBeenCalledOnce();

--- a/src/test/javascript/spec/component/grading-system/detailed-grading-system.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/detailed-grading-system.component.spec.ts
@@ -117,10 +117,10 @@ describe('Detailed Grading System Component', () => {
 
         fixture.detectChanges();
 
-        expect(comp.isExam).toBe(true);
+        expect(comp.isExam).toBeTrue();
         expect(findGradingScaleForExamStub).toHaveBeenNthCalledWith(1, 1, 1);
-        expect(findGradingScaleForExamStub).toHaveBeenCalledTimes(1);
-        expect(findExamStub).toHaveBeenCalledTimes(1);
+        expect(findGradingScaleForExamStub).toHaveBeenCalledOnce();
+        expect(findExamStub).toHaveBeenCalledOnce();
         expect(comp.exam).toStrictEqual(exam);
         expect(comp.maxPoints).toBe(exam.maxPoints);
     });
@@ -133,7 +133,7 @@ describe('Detailed Grading System Component', () => {
         fixture.detectChanges();
 
         expect(findGradingScaleForExamAndReturnNotFoundStub).toHaveBeenNthCalledWith(1, 1, 1);
-        expect(findGradingScaleForExamAndReturnNotFoundStub).toHaveBeenCalledTimes(1);
+        expect(findGradingScaleForExamAndReturnNotFoundStub).toHaveBeenCalledOnce();
     });
 
     it('should generate default grading scale', () => {
@@ -141,22 +141,22 @@ describe('Detailed Grading System Component', () => {
 
         expect(comp.gradingScale.gradeType).toStrictEqual(GradeType.GRADE);
         expect(comp.firstPassingGrade).toStrictEqual('4.0');
-        expect(comp.lowerBoundInclusivity).toBe(true);
+        expect(comp.lowerBoundInclusivity).toBeTrue();
         expect(comp.gradingScale.gradeSteps).toHaveLength(13);
         comp.gradingScale.gradeSteps.forEach((gradeStep) => {
             expect(gradeStep.id).toBe(undefined);
             expect(gradeStep.gradeName).not.toBe(undefined);
-            expect(gradeStep.lowerBoundInclusive).toBe(true);
+            expect(gradeStep.lowerBoundInclusive).toBeTrue();
             expect(gradeStep.lowerBoundPercentage).toBeWithin(0, 101);
             expect(gradeStep.upperBoundPercentage).toBeWithin(0, 101);
             expect(gradeStep.lowerBoundPercentage).toBeLessThanOrEqual(gradeStep.upperBoundPercentage);
             if (gradeStep.upperBoundPercentage === 100) {
-                expect(gradeStep.upperBoundInclusive).toBe(true);
+                expect(gradeStep.upperBoundInclusive).toBeTrue();
             } else {
                 expect(gradeStep.upperBoundInclusive).toBe(false);
             }
             if (gradeStep.lowerBoundPercentage >= 50) {
-                expect(gradeStep.isPassingGrade).toBe(true);
+                expect(gradeStep.isPassingGrade).toBeTrue();
             }
         });
     });
@@ -178,9 +178,9 @@ describe('Detailed Grading System Component', () => {
         expect(comp.gradingScale.gradeSteps[3].gradeName).toStrictEqual('');
         expect(comp.gradingScale.gradeSteps[3].lowerBoundPercentage).toBe(100);
         expect(comp.gradingScale.gradeSteps[3].upperBoundPercentage).toBe(100);
-        expect(comp.gradingScale.gradeSteps[3].isPassingGrade).toBe(true);
-        expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBe(true);
-        expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBe(true);
+        expect(comp.gradingScale.gradeSteps[3].isPassingGrade).toBeTrue();
+        expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBeTrue();
+        expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBeTrue();
     });
 
     it('should delete grade names correctly', () => {
@@ -207,7 +207,7 @@ describe('Detailed Grading System Component', () => {
         comp.setPassingGrades(comp.gradingScale.gradeSteps);
 
         comp.gradingScale.gradeSteps.forEach((gradeStep) => {
-            expect(gradeStep.isPassingGrade).toBe(true);
+            expect(gradeStep.isPassingGrade).toBeTrue();
         });
 
         comp.firstPassingGrade = '';
@@ -231,9 +231,9 @@ describe('Detailed Grading System Component', () => {
         comp.setInclusivity();
 
         comp.gradingScale.gradeSteps.forEach((gradeStep) => {
-            expect(gradeStep.upperBoundInclusive).toBe(true);
+            expect(gradeStep.upperBoundInclusive).toBeTrue();
             if (gradeStep.lowerBoundPercentage === 0) {
-                expect(gradeStep.lowerBoundInclusive).toBe(true);
+                expect(gradeStep.lowerBoundInclusive).toBeTrue();
             } else {
                 expect(gradeStep.lowerBoundInclusive).toBe(false);
             }
@@ -255,9 +255,9 @@ describe('Detailed Grading System Component', () => {
         comp.setInclusivity();
 
         comp.gradingScale.gradeSteps.forEach((gradeStep) => {
-            expect(gradeStep.upperBoundInclusive).toBe(true);
+            expect(gradeStep.upperBoundInclusive).toBeTrue();
             if (gradeStep.lowerBoundPercentage === 0) {
-                expect(gradeStep.lowerBoundInclusive).toBe(true);
+                expect(gradeStep.lowerBoundInclusive).toBeTrue();
             } else {
                 expect(gradeStep.lowerBoundInclusive).toBe(false);
             }
@@ -267,7 +267,7 @@ describe('Detailed Grading System Component', () => {
     it('should determine lower bound inclusivity correctly', () => {
         comp.setBoundInclusivity();
 
-        expect(comp.lowerBoundInclusivity).toBe(true);
+        expect(comp.lowerBoundInclusivity).toBeTrue();
     });
 
     it('should not delete non-existing grading scale', () => {
@@ -290,7 +290,7 @@ describe('Detailed Grading System Component', () => {
         comp.delete();
 
         expect(gradingSystemDeleteForCourseStub).toHaveBeenNthCalledWith(1, comp.courseId);
-        expect(gradingSystemDeleteForCourseStub).toHaveBeenCalledTimes(1);
+        expect(gradingSystemDeleteForCourseStub).toHaveBeenCalledOnce();
         expect(comp.existingGradingScale).toBe(false);
     });
 
@@ -302,7 +302,7 @@ describe('Detailed Grading System Component', () => {
         comp.delete();
 
         expect(gradingSystemDeleteForExamStub).toHaveBeenNthCalledWith(1, comp.courseId, comp.examId);
-        expect(gradingSystemDeleteForExamStub).toHaveBeenCalledTimes(1);
+        expect(gradingSystemDeleteForExamStub).toHaveBeenCalledOnce();
         expect(comp.existingGradingScale).toBe(false);
     });
 
@@ -315,7 +315,7 @@ describe('Detailed Grading System Component', () => {
         comp.save();
 
         expect(gradingSystemServiceStub).toHaveBeenNthCalledWith(1, comp.courseId, comp.gradingScale);
-        expect(gradingSystemServiceStub).toHaveBeenCalledTimes(1);
+        expect(gradingSystemServiceStub).toHaveBeenCalledOnce();
         expect(comp.existingGradingScale).toBe(false);
     });
 
@@ -331,8 +331,8 @@ describe('Detailed Grading System Component', () => {
         comp.save();
 
         expect(gradingSystemCreateForCourseMock).toHaveBeenNthCalledWith(1, comp.courseId, comp.gradingScale);
-        expect(gradingSystemCreateForCourseMock).toHaveBeenCalledTimes(1);
-        expect(comp.existingGradingScale).toBe(true);
+        expect(gradingSystemCreateForCourseMock).toHaveBeenCalledOnce();
+        expect(comp.existingGradingScale).toBeTrue();
         expect(comp.gradingScale).toStrictEqual(createdGradingScaleForCourse);
     });
 
@@ -349,8 +349,8 @@ describe('Detailed Grading System Component', () => {
         comp.save();
 
         expect(gradingSystemCreateForExamMock).toHaveBeenNthCalledWith(1, comp.courseId, comp.examId, comp.gradingScale);
-        expect(gradingSystemCreateForExamMock).toHaveBeenCalledTimes(1);
-        expect(comp.existingGradingScale).toBe(true);
+        expect(gradingSystemCreateForExamMock).toHaveBeenCalledOnce();
+        expect(comp.existingGradingScale).toBeTrue();
         expect(comp.gradingScale).toStrictEqual(createdGradingScaleForExam);
     });
 
@@ -366,8 +366,8 @@ describe('Detailed Grading System Component', () => {
         comp.save();
 
         expect(gradingSystemUpdateForCourseMock).toHaveBeenNthCalledWith(1, comp.courseId, comp.gradingScale);
-        expect(gradingSystemUpdateForCourseMock).toHaveBeenCalledTimes(1);
-        expect(comp.existingGradingScale).toBe(true);
+        expect(gradingSystemUpdateForCourseMock).toHaveBeenCalledOnce();
+        expect(comp.existingGradingScale).toBeTrue();
         expect(comp.gradingScale).toStrictEqual(updateGradingScaleFoCourse);
     });
 
@@ -384,8 +384,8 @@ describe('Detailed Grading System Component', () => {
         comp.save();
 
         expect(gradingSystemUpdateForCourseMock).toHaveBeenNthCalledWith(1, comp.courseId, comp.examId, comp.gradingScale);
-        expect(gradingSystemUpdateForCourseMock).toHaveBeenCalledTimes(1);
-        expect(comp.existingGradingScale).toBe(true);
+        expect(gradingSystemUpdateForCourseMock).toHaveBeenCalledOnce();
+        expect(comp.existingGradingScale).toBeTrue();
         expect(comp.gradingScale).toStrictEqual(updatedGradingScaleForExam);
     });
 
@@ -393,12 +393,12 @@ describe('Detailed Grading System Component', () => {
         comp.handleFindResponse(comp.gradingScale);
 
         expect(comp.firstPassingGrade).toStrictEqual('Pass');
-        expect(comp.lowerBoundInclusivity).toBe(true);
-        expect(comp.existingGradingScale).toBe(true);
+        expect(comp.lowerBoundInclusivity).toBeTrue();
+        expect(comp.existingGradingScale).toBeTrue();
     });
 
     it('should validate valid grading scale correctly', () => {
-        expect(comp.validGradeSteps()).toBe(true);
+        expect(comp.validGradeSteps()).toBeTrue();
         expect(comp.invalidGradeStepsMessage).toBe(undefined);
     });
 
@@ -409,7 +409,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('empty set');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.empty');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale with negative max points', () => {
@@ -420,7 +420,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('negative max points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.negativeMaxPoints');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
         course.maxPoints = 100;
     });
 
@@ -431,7 +431,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('empty field');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.emptyFields');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale with empty grade step point fields correctly', () => {
@@ -442,7 +442,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('empty field for points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.emptyFields');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale with invalid percentages', () => {
@@ -452,7 +452,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid percentage');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.invalidMinMaxPercentages');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale with invalid points', () => {
@@ -468,7 +468,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.invalidMinMaxPoints');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale with set points when all should be undefined', () => {
@@ -485,7 +485,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('non-unique grade names');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.nonUniqueGradeNames');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale with unset first passing grade', () => {
@@ -496,7 +496,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('unset first passing grade');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.unsetFirstPassingGrade');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale with invalid bonus points', () => {
@@ -507,7 +507,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid bonus points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.invalidBonusPoints');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale without strictly ascending bonus points', () => {
@@ -520,7 +520,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('descending bonus points');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.nonStrictlyIncreasingBonusPoints');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale with invalid adjacency', () => {
@@ -538,7 +538,7 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid adjacency');
         expect(translateStub).toHaveBeenNthCalledWith(1, 'artemisApp.gradingSystem.error.invalidAdjacency');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should validate invalid grading scale with invalid first grade step', () => {
@@ -557,13 +557,13 @@ describe('Detailed Grading System Component', () => {
         expect(comp.validGradeSteps()).toBe(false);
         expect(comp.invalidGradeStepsMessage).toStrictEqual('invalid first grade step');
         expect(translateStub).toHaveBeenCalledWith('artemisApp.gradingSystem.error.invalidFirstAndLastStep');
-        expect(translateStub).toHaveBeenCalledTimes(1);
+        expect(translateStub).toHaveBeenCalledOnce();
     });
 
     it('should detect that max points are valid', () => {
         comp.maxPoints = 100;
 
-        expect(comp.maxPointsValid()).toBe(true);
+        expect(comp.maxPointsValid()).toBeTrue();
     });
 
     it('should set points correctly', () => {
@@ -736,7 +736,7 @@ describe('Detailed Grading System Component', () => {
 
         comp.exportGradingStepsToCsv();
 
-        expect(exportAsCsvMock).toHaveBeenCalledTimes(1);
+        expect(exportAsCsvMock).toHaveBeenCalledOnce();
         const generatedRows = exportAsCsvMock.mock.calls[0][0];
         expect(generatedRows).toHaveLength(numberOfGradeSteps);
 

--- a/src/test/javascript/spec/component/grading-system/interval-grading-system.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/interval-grading-system.component.spec.ts
@@ -121,7 +121,7 @@ describe('Interval Grading System Component', () => {
 
         expect(comp.gradingScale.gradeType).toStrictEqual(GradeType.GRADE);
         expect(comp.firstPassingGrade).toStrictEqual('4.0');
-        expect(comp.lowerBoundInclusivity).toBe(true);
+        expect(comp.lowerBoundInclusivity).toBeTrue();
         expect(comp.gradingScale.gradeSteps).toHaveLength(14);
         comp.gradingScale.gradeSteps.forEach((gradeStep) => {
             expect(gradeStep.id).toBe(undefined);
@@ -172,9 +172,9 @@ describe('Interval Grading System Component', () => {
         expect(newGradeStep.gradeName).toStrictEqual('');
         expect(newGradeStep.lowerBoundPercentage).toBe(100);
         expect(newGradeStep.upperBoundPercentage).toBe(100);
-        expect(newGradeStep.isPassingGrade).toBe(true);
-        expect(newGradeStep.lowerBoundInclusive).toBe(true);
-        expect(newGradeStep.upperBoundInclusive).toBe(true);
+        expect(newGradeStep.isPassingGrade).toBeTrue();
+        expect(newGradeStep.lowerBoundInclusive).toBeTrue();
+        expect(newGradeStep.upperBoundInclusive).toBeTrue();
 
         // Previous gradeStep.upperBoundPercentage is already 100.
         expect(comp.getPercentageInterval(newGradeStep)).toBe(0);
@@ -354,33 +354,33 @@ describe('Interval Grading System Component', () => {
         comp.lowerBoundInclusivity = true;
         comp.setInclusivity();
 
-        expect(comp.gradingScale.gradeSteps[0].lowerBoundInclusive).toBe(true);
+        expect(comp.gradingScale.gradeSteps[0].lowerBoundInclusive).toBeTrue();
         expect(comp.gradingScale.gradeSteps[0].upperBoundInclusive).toBe(false);
 
-        expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBe(true);
+        expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBeTrue();
         expect(comp.gradingScale.gradeSteps[1].upperBoundInclusive).toBe(false);
 
-        expect(comp.gradingScale.gradeSteps[2].lowerBoundInclusive).toBe(true);
-        expect(comp.gradingScale.gradeSteps[2].upperBoundInclusive).toBe(true);
+        expect(comp.gradingScale.gradeSteps[2].lowerBoundInclusive).toBeTrue();
+        expect(comp.gradingScale.gradeSteps[2].upperBoundInclusive).toBeTrue();
 
         expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBe(false);
-        expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBe(true);
+        expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBeTrue();
     });
 
     it('should set inclusivity to upper bound inclusive', () => {
         comp.lowerBoundInclusivity = false;
         comp.setInclusivity();
 
-        expect(comp.gradingScale.gradeSteps[0].lowerBoundInclusive).toBe(true);
-        expect(comp.gradingScale.gradeSteps[0].upperBoundInclusive).toBe(true);
+        expect(comp.gradingScale.gradeSteps[0].lowerBoundInclusive).toBeTrue();
+        expect(comp.gradingScale.gradeSteps[0].upperBoundInclusive).toBeTrue();
 
         expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBe(false);
-        expect(comp.gradingScale.gradeSteps[1].upperBoundInclusive).toBe(true);
+        expect(comp.gradingScale.gradeSteps[1].upperBoundInclusive).toBeTrue();
 
         expect(comp.gradingScale.gradeSteps[2].lowerBoundInclusive).toBe(false);
-        expect(comp.gradingScale.gradeSteps[2].upperBoundInclusive).toBe(true);
+        expect(comp.gradingScale.gradeSteps[2].upperBoundInclusive).toBeTrue();
 
         expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBe(false);
-        expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBe(true);
+        expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/grading-system/interval-grading-system.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/interval-grading-system.component.spec.ts
@@ -338,7 +338,7 @@ describe('Interval Grading System Component', () => {
 
         comp.createGradeStep();
 
-        expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBe(false);
+        expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBeFalse();
         expect(comp.gradingScale.gradeSteps).toHaveLength(2);
     });
 
@@ -355,15 +355,15 @@ describe('Interval Grading System Component', () => {
         comp.setInclusivity();
 
         expect(comp.gradingScale.gradeSteps[0].lowerBoundInclusive).toBeTrue();
-        expect(comp.gradingScale.gradeSteps[0].upperBoundInclusive).toBe(false);
+        expect(comp.gradingScale.gradeSteps[0].upperBoundInclusive).toBeFalse();
 
         expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBeTrue();
-        expect(comp.gradingScale.gradeSteps[1].upperBoundInclusive).toBe(false);
+        expect(comp.gradingScale.gradeSteps[1].upperBoundInclusive).toBeFalse();
 
         expect(comp.gradingScale.gradeSteps[2].lowerBoundInclusive).toBeTrue();
         expect(comp.gradingScale.gradeSteps[2].upperBoundInclusive).toBeTrue();
 
-        expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBe(false);
+        expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBeFalse();
         expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBeTrue();
     });
 
@@ -374,13 +374,13 @@ describe('Interval Grading System Component', () => {
         expect(comp.gradingScale.gradeSteps[0].lowerBoundInclusive).toBeTrue();
         expect(comp.gradingScale.gradeSteps[0].upperBoundInclusive).toBeTrue();
 
-        expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBe(false);
+        expect(comp.gradingScale.gradeSteps[1].lowerBoundInclusive).toBeFalse();
         expect(comp.gradingScale.gradeSteps[1].upperBoundInclusive).toBeTrue();
 
-        expect(comp.gradingScale.gradeSteps[2].lowerBoundInclusive).toBe(false);
+        expect(comp.gradingScale.gradeSteps[2].lowerBoundInclusive).toBeFalse();
         expect(comp.gradingScale.gradeSteps[2].upperBoundInclusive).toBeTrue();
 
-        expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBe(false);
+        expect(comp.gradingScale.gradeSteps[3].lowerBoundInclusive).toBeFalse();
         expect(comp.gradingScale.gradeSteps[3].upperBoundInclusive).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
+++ b/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
@@ -224,7 +224,7 @@ describe('GuidedTourComponent', () => {
         });
 
         it('should determine if the tour step has bottom orientation', () => {
-            expect(guidedTourComponent['isBottom']()).toBe(false);
+            expect(guidedTourComponent['isBottom']()).toBeFalse();
 
             guidedTourComponent.currentTourStep!.orientation = Orientation.BOTTOM;
             expect(guidedTourComponent['isBottom']()).toBeTrue();

--- a/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
+++ b/src/test/javascript/spec/component/guided-tour/guided-tour.component.spec.ts
@@ -84,17 +84,17 @@ describe('GuidedTourComponent', () => {
 
         guidedTourComponent.ngAfterViewInit();
 
-        expect(currentStepSpy).toHaveBeenCalledTimes(1);
-        expect(resizeEventSpy).toHaveBeenCalledTimes(1);
-        expect(scrollEventSpy).toHaveBeenCalledTimes(1);
-        expect(dotNavigationStub).toHaveBeenCalledTimes(1);
-        expect(guidedTourInitStub).toHaveBeenCalledTimes(1);
+        expect(currentStepSpy).toHaveBeenCalledOnce();
+        expect(resizeEventSpy).toHaveBeenCalledOnce();
+        expect(scrollEventSpy).toHaveBeenCalledOnce();
+        expect(dotNavigationStub).toHaveBeenCalledOnce();
+        expect(guidedTourInitStub).toHaveBeenCalledOnce();
     });
 
     it('should handle user permissions', () => {
         guidedTourComponent.currentTourStep = tourStep;
         const permission = guidedTourComponent['hasUserPermissionForCurrentTourStep']();
-        expect(permission).toBe(true);
+        expect(permission).toBeTrue();
     });
 
     describe('Keydown Element', () => {
@@ -144,7 +144,7 @@ describe('GuidedTourComponent', () => {
             const nextStepSpy = jest.spyOn(guidedTourService, 'nextStep');
             const eventMock = new KeyboardEvent('keydown', { code: 'ArrowRight' });
             guidedTourComponent.handleKeyboardEvent(eventMock);
-            expect(nextStepSpy).toHaveBeenCalledTimes(1);
+            expect(nextStepSpy).toHaveBeenCalledOnce();
         });
 
         it('should navigate back with the left arrow key', () => {
@@ -158,7 +158,7 @@ describe('GuidedTourComponent', () => {
             guidedTourComponent.handleKeyboardEvent(eventMockRight);
 
             guidedTourComponent.handleKeyboardEvent(eventMockLeft);
-            expect(backStepStub).toHaveBeenCalledTimes(1);
+            expect(backStepStub).toHaveBeenCalledOnce();
         });
 
         it('should skip the tour with the escape key', () => {
@@ -167,7 +167,7 @@ describe('GuidedTourComponent', () => {
             const eventMock = new KeyboardEvent('keydown', { code: 'Escape' });
 
             guidedTourComponent.handleKeyboardEvent(eventMock);
-            expect(skipTourStub).toHaveBeenCalledTimes(1);
+            expect(skipTourStub).toHaveBeenCalledOnce();
 
             // Reset component
             skipTourStub.mockReset();
@@ -190,7 +190,7 @@ describe('GuidedTourComponent', () => {
 
             guidedTourComponent.handleKeyboardEvent(eventMock);
             expect(skipTourStub).not.toHaveBeenCalled();
-            expect(finishTourStub).toHaveBeenCalledTimes(1);
+            expect(finishTourStub).toHaveBeenCalledOnce();
         });
     });
 
@@ -227,7 +227,7 @@ describe('GuidedTourComponent', () => {
             expect(guidedTourComponent['isBottom']()).toBe(false);
 
             guidedTourComponent.currentTourStep!.orientation = Orientation.BOTTOM;
-            expect(guidedTourComponent['isBottom']()).toBe(true);
+            expect(guidedTourComponent['isBottom']()).toBeTrue();
         });
 
         it('should determine the highlight padding of the tour step', () => {
@@ -318,7 +318,7 @@ describe('GuidedTourComponent', () => {
 
             jest.advanceTimersByTime(300);
             guidedTourComponent['scrollToAndSetElement']();
-            expect(flipOrientationStub).toHaveBeenCalledTimes(1);
+            expect(flipOrientationStub).toHaveBeenCalledOnce();
         });
 
         it('should flip orientation', () => {

--- a/src/test/javascript/spec/component/hestia/git-diff-report/full-git-diff-entry.component.spec.ts
+++ b/src/test/javascript/spec/component/hestia/git-diff-report/full-git-diff-entry.component.spec.ts
@@ -41,20 +41,20 @@ describe('ProgrammingExerciseFullGitDiffEntry Component', () => {
 
         comp.ngOnInit();
 
-        expect(comp.editorNow.getEditor().setOptions).toHaveBeenCalledTimes(1);
+        expect(comp.editorNow.getEditor().setOptions).toHaveBeenCalledOnce();
         expect(comp.editorNow.getEditor().setOptions).toHaveBeenCalledWith({
             animatedScroll: true,
             maxLines: Infinity,
         });
-        expect(comp.editorPrevious.getEditor().setOptions).toHaveBeenCalledTimes(1);
+        expect(comp.editorPrevious.getEditor().setOptions).toHaveBeenCalledOnce();
         expect(comp.editorPrevious.getEditor().setOptions).toHaveBeenCalledWith({
             animatedScroll: true,
             maxLines: Infinity,
         });
 
-        expect(comp.editorNow.getEditor().getSession().setValue).toHaveBeenCalledTimes(1);
+        expect(comp.editorNow.getEditor().getSession().setValue).toHaveBeenCalledOnce();
         expect(comp.editorNow.getEditor().getSession().setValue).toHaveBeenCalledWith('DEF');
-        expect(comp.editorPrevious.getEditor().getSession().setValue).toHaveBeenCalledTimes(1);
+        expect(comp.editorPrevious.getEditor().getSession().setValue).toHaveBeenCalledOnce();
         expect(comp.editorPrevious.getEditor().getSession().setValue).toHaveBeenCalledWith('ABC');
 
         expect(comp.editorNow.getEditor().container.style.background).toBe('rgba(63, 185, 80, 0.5)');

--- a/src/test/javascript/spec/component/hestia/testwise-coverage-report/testwise-coverage-file.component.spec.ts
+++ b/src/test/javascript/spec/component/hestia/testwise-coverage-report/testwise-coverage-file.component.spec.ts
@@ -98,7 +98,7 @@ describe('TestwiseCoverageFile Component', () => {
         fixture.detectChanges();
 
         expect(comp.proportionCoveredLines).toBe(0.2);
-        expect(addMarkerSpy).toHaveBeenCalledTimes(1);
+        expect(addMarkerSpy).toHaveBeenCalledOnce();
         expect(addMarkerSpy).toHaveBeenCalledWith(range1, 'ace_highlight-marker', 'fullLine');
     });
 });

--- a/src/test/javascript/spec/component/hestia/testwise-coverage-report/testwise-coverage-report.component.spec.ts
+++ b/src/test/javascript/spec/component/hestia/testwise-coverage-report/testwise-coverage-report.component.spec.ts
@@ -114,7 +114,7 @@ describe('TestwiseCoverageReport Component', () => {
 
     it('should filter coverage file reports for test case', () => {
         comp.changeReportsBySelectedTestCases('testBubbleSort()');
-        expect(comp.displayedTestCaseNames.get('testBubbleSort()')).toBe(false);
+        expect(comp.displayedTestCaseNames.get('testBubbleSort()')).toBeFalse();
         expect(comp.fileReportByFileName.size).toBe(2);
         expect(comp.fileReportByFileName.get('src/de/tum/in/ase/BubbleSort.java')?.testwiseCoverageEntries).toEqual([reportEntries[1]]);
     });

--- a/src/test/javascript/spec/component/learning-goals/create-learning-goal.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-goals/create-learning-goal.component.spec.ts
@@ -108,8 +108,8 @@ describe('CreateLearningGoal', () => {
             learningGoal.lectureUnits = formData.connectedLectureUnits;
 
             expect(createSpy).toHaveBeenCalledWith(learningGoal, 1);
-            expect(createSpy).toHaveBeenCalledTimes(1);
-            expect(navigateSpy).toHaveBeenCalledTimes(1);
+            expect(createSpy).toHaveBeenCalledOnce();
+            expect(navigateSpy).toHaveBeenCalledOnce();
         });
     });
 });

--- a/src/test/javascript/spec/component/learning-goals/edit-learning-goal.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-goals/edit-learning-goal.component.spec.ts
@@ -117,8 +117,8 @@ describe('EditLearningGoalComponent', () => {
         const learningGoalFormStubComponent: LearningGoalFormStubComponent = editLearningGoalComponentFixture.debugElement.query(
             By.directive(LearningGoalFormStubComponent),
         ).componentInstance;
-        expect(findByIdSpy).toHaveBeenCalledTimes(1);
-        expect(findAllByCourseSpy).toHaveBeenCalledTimes(1);
+        expect(findByIdSpy).toHaveBeenCalledOnce();
+        expect(findAllByCourseSpy).toHaveBeenCalledOnce();
 
         expect(editLearningGoalComponent.formData.title).toEqual(learningGoalOfResponse.title);
         expect(editLearningGoalComponent.formData.description).toEqual(learningGoalOfResponse.description);
@@ -154,7 +154,7 @@ describe('EditLearningGoalComponent', () => {
             ),
         );
         editLearningGoalComponentFixture.detectChanges();
-        expect(findByIdSpy).toHaveBeenCalledTimes(1);
+        expect(findByIdSpy).toHaveBeenCalledOnce();
         expect(editLearningGoalComponent.learningGoal).toEqual(learningGoalDatabase);
 
         const changedUnit: LearningGoal = {
@@ -176,7 +176,7 @@ describe('EditLearningGoalComponent', () => {
             connectedLectureUnits: changedUnit.lectureUnits,
         });
 
-        expect(updatedSpy).toHaveBeenCalledTimes(1);
-        expect(navigateSpy).toHaveBeenCalledTimes(1);
+        expect(updatedSpy).toHaveBeenCalledOnce();
+        expect(navigateSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/learning-goals/learning-goal-card.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-goals/learning-goal-card.component.spec.ts
@@ -83,6 +83,6 @@ describe('LearningGoalCardComponent', () => {
         const modalService = TestBed.inject(NgbModal);
         const openSpy = jest.spyOn(modalService, 'open');
         card.click();
-        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(openSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/learning-goals/learning-goal-course-detail-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-goals/learning-goal-course-detail-modal.component.spec.ts
@@ -74,6 +74,6 @@ describe('LearningGoalCourseDetailModalComponent', () => {
         const sortService = TestBed.inject(SortService);
         const sortByPropertySpy = jest.spyOn(sortService, 'sortByProperty');
         learningGoalCourseDetailModal.sortConnectedLectureUnits();
-        expect(sortByPropertySpy).toHaveBeenCalledTimes(1);
+        expect(sortByPropertySpy).toHaveBeenCalledOnce();
     }));
 });

--- a/src/test/javascript/spec/component/learning-goals/learning-goal-form.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-goals/learning-goal-form.component.spec.ts
@@ -77,7 +77,7 @@ describe('LearningGoalFormComponent', () => {
         learningGoalFormComponentFixture.detectChanges();
         tick(250); // async validator fires after 250ms and fully filled in form should now be valid!
         expect(learningGoalFormComponent.form.valid).toBeTrue();
-        expect(getAllForCourseSpy).toHaveBeenCalledTimes(1);
+        expect(getAllForCourseSpy).toHaveBeenCalledOnce();
         const submitFormSpy = jest.spyOn(learningGoalFormComponent, 'submitForm');
         const submitFormEventSpy = jest.spyOn(learningGoalFormComponent.formSubmitted, 'emit');
 
@@ -85,7 +85,7 @@ describe('LearningGoalFormComponent', () => {
         submitButton.click();
 
         learningGoalFormComponentFixture.whenStable().then(() => {
-            expect(submitFormSpy).toHaveBeenCalledTimes(1);
+            expect(submitFormSpy).toHaveBeenCalledOnce();
             expect(submitFormEventSpy).toHaveBeenCalledWith({
                 title: exampleTitle,
                 description: exampleDescription,

--- a/src/test/javascript/spec/component/learning-goals/learning-goal-management.component.spec.ts
+++ b/src/test/javascript/spec/component/learning-goals/learning-goal-management.component.spec.ts
@@ -119,12 +119,12 @@ describe('LearningGoalManagementComponent', () => {
 
         const learningGoalCards = learningGoalManagementComponentFixture.debugElement.queryAll(By.directive(LearningGoalCardStubComponent));
         expect(learningGoalCards).toHaveLength(2);
-        expect(getAllForCourseSpy).toHaveBeenCalledTimes(1);
+        expect(getAllForCourseSpy).toHaveBeenCalledOnce();
         expect(getProgressSpy).toHaveBeenCalledTimes(4);
         expect(learningGoalManagementComponent.learningGoals).toHaveLength(2);
         expect(learningGoalManagementComponent.learningGoalIdToLearningGoalCourseProgress.has(1)).toEqual(true);
         expect(learningGoalManagementComponent.learningGoalIdToLearningGoalCourseProgressUsingParticipantScoresTables.has(1)).toEqual(true);
-        expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+        expect(captureExceptionSpy).toHaveBeenCalledOnce();
     });
 
     it('should load prerequisites and display a card for each of them', () => {
@@ -149,7 +149,7 @@ describe('LearningGoalManagementComponent', () => {
 
         const prerequisiteCards = learningGoalManagementComponentFixture.debugElement.queryAll(By.directive(LearningGoalCardStubComponent));
         expect(prerequisiteCards).toHaveLength(2);
-        expect(getAllPrerequisitesForCourseSpy).toHaveBeenCalledTimes(1);
+        expect(getAllPrerequisitesForCourseSpy).toHaveBeenCalledOnce();
         expect(learningGoalManagementComponent.prerequisites).toHaveLength(2);
     });
 });

--- a/src/test/javascript/spec/component/lecture/lecture-attachments.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture/lecture-attachments.component.spec.ts
@@ -132,7 +132,7 @@ describe('LectureAttachmentsComponent', () => {
         fixture.detectChanges();
         tick();
         expect(comp.attachments.length).toBe(3);
-        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledTimes(1);
+        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledOnce();
     }));
 
     it('should not accept too large file', fakeAsync(() => {
@@ -156,14 +156,14 @@ describe('LectureAttachmentsComponent', () => {
         const fileAlert = fixture.debugElement.query(By.css('#too-large-file-alert'));
         expect(comp.attachments.length).toBe(2);
         expect(fileAlert).not.toBe(null);
-        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledTimes(1);
+        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledOnce();
     }));
 
     it('should exit saveAttachment', fakeAsync(() => {
         fixture.detectChanges();
         comp.attachmentToBeCreated = undefined;
         comp.saveAttachment();
-        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledTimes(1);
+        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledOnce();
         expect(comp.attachmentToBeCreated).toEqual({
             lecture: comp.lecture,
             attachmentType: AttachmentType.FILE,
@@ -197,9 +197,9 @@ describe('LectureAttachmentsComponent', () => {
             ),
         );
         comp.saveAttachment();
-        expect(attachmentServiceUpdateStub).toHaveBeenCalledTimes(1);
+        expect(attachmentServiceUpdateStub).toHaveBeenCalledOnce();
         expect(comp.attachments[1].version).toBe(2);
-        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledTimes(1);
+        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledOnce();
     }));
 
     it('should edit attachment', fakeAsync(() => {
@@ -209,7 +209,7 @@ describe('LectureAttachmentsComponent', () => {
         comp.editAttachment(newAttachment);
         expect(comp.attachmentToBeCreated).toBe(newAttachment);
         expect(comp.attachmentBackup).toEqual(newAttachment);
-        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledTimes(1);
+        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledOnce();
     }));
 
     it('should delete attachment', fakeAsync(() => {
@@ -225,8 +225,8 @@ describe('LectureAttachmentsComponent', () => {
         const attachmentServiceDeleteStub = jest.spyOn(attachmentService, 'delete').mockReturnValue(of(new HttpResponse({ body: null })));
         comp.deleteAttachment(toDelete);
         expect(comp.attachments.length).toBe(1);
-        expect(attachmentServiceDeleteStub).toHaveBeenCalledTimes(1);
-        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledTimes(1);
+        expect(attachmentServiceDeleteStub).toHaveBeenCalledOnce();
+        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledOnce();
     }));
 
     it('should call cancel', fakeAsync(() => {
@@ -242,7 +242,7 @@ describe('LectureAttachmentsComponent', () => {
         comp.attachmentBackup = toCancel;
         comp.cancel();
         expect(comp.attachments[1]).toBe(toCancel);
-        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledTimes(1);
+        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledOnce();
     }));
 
     it('should download attachment', fakeAsync(() => {
@@ -266,6 +266,6 @@ describe('LectureAttachmentsComponent', () => {
         comp.setLectureAttachment(object);
         expect(comp.attachmentFile).toBe(myBlob1);
         expect(comp.attachmentToBeCreated.link).toBe(myBlob1.name);
-        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledTimes(1);
+        expect(attachmentServiceFindAllByLectureIdStub).toHaveBeenCalledOnce();
     }));
 });

--- a/src/test/javascript/spec/component/markdown-editor/fullscreen-command.spec.ts
+++ b/src/test/javascript/spec/component/markdown-editor/fullscreen-command.spec.ts
@@ -36,8 +36,8 @@ describe('FullscreenCommand', () => {
         comp.ngAfterViewInit();
 
         command.execute();
-        expect(FullscreenUtil.isFullScreen).toHaveBeenCalledTimes(1);
-        expect(FullscreenUtil.enterFullscreen).toHaveBeenCalledTimes(1);
+        expect(FullscreenUtil.isFullScreen).toHaveBeenCalledOnce();
+        expect(FullscreenUtil.enterFullscreen).toHaveBeenCalledOnce();
     });
 
     it('should disable fullscreen on execute', () => {
@@ -50,7 +50,7 @@ describe('FullscreenCommand', () => {
         comp.ngAfterViewInit();
 
         command.execute();
-        expect(FullscreenUtil.isFullScreen).toHaveBeenCalledTimes(1);
-        expect(FullscreenUtil.exitFullscreen).toHaveBeenCalledTimes(1);
+        expect(FullscreenUtil.isFullScreen).toHaveBeenCalledOnce();
+        expect(FullscreenUtil.exitFullscreen).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-assessment-editor/modeling-assessment-editor.component.spec.ts
@@ -156,7 +156,7 @@ describe('ModelingAssessmentEditorComponent', () => {
 
             component.ngOnInit();
             tick(500);
-            expect(modelingSubmissionSpy).toHaveBeenCalledTimes(1);
+            expect(modelingSubmissionSpy).toHaveBeenCalledOnce();
             expect(component.isLoading).toBeFalse();
             expect(component.complaint).toEqual(complaint);
             modelingSubmissionSpy.mockRestore();
@@ -170,7 +170,7 @@ describe('ModelingAssessmentEditorComponent', () => {
 
             component.ngOnInit();
             tick(500);
-            expect(modelingSubmissionSpy).toHaveBeenCalledTimes(1);
+            expect(modelingSubmissionSpy).toHaveBeenCalledOnce();
             modelingSubmissionSpy.mockRestore();
         }));
     });
@@ -239,7 +239,7 @@ describe('ModelingAssessmentEditorComponent', () => {
         component.ngOnInit();
         tick(500);
         component.onSaveAssessment();
-        expect(saveAssessmentSpy).toHaveBeenCalledTimes(1);
+        expect(saveAssessmentSpy).toHaveBeenCalledOnce();
     }));
 
     it('should try to submit assessment', fakeAsync(() => {
@@ -282,7 +282,7 @@ describe('ModelingAssessmentEditorComponent', () => {
 
         component.onSubmitAssessment();
 
-        expect(window.confirm).toHaveBeenCalledTimes(1);
+        expect(window.confirm).toHaveBeenCalledOnce();
         expect(component.highlightMissingFeedback).toBeTrue();
     }));
 
@@ -327,7 +327,7 @@ describe('ModelingAssessmentEditorComponent', () => {
         tick(500);
 
         component.onUpdateAssessmentAfterComplaint(complaintResponse);
-        expect(serviceSpy).toHaveBeenCalledTimes(1);
+        expect(serviceSpy).toHaveBeenCalledOnce();
         expect(component.result?.participation?.results).toEqual([changedResult]);
     }));
 
@@ -347,8 +347,8 @@ describe('ModelingAssessmentEditorComponent', () => {
         tick(500);
 
         component.onCancelAssessment();
-        expect(windowSpy).toHaveBeenCalledTimes(1);
-        expect(serviceSpy).toHaveBeenCalledTimes(1);
+        expect(windowSpy).toHaveBeenCalledOnce();
+        expect(serviceSpy).toHaveBeenCalledOnce();
     }));
 
     it('should handle changed feedback', fakeAsync(() => {
@@ -375,7 +375,7 @@ describe('ModelingAssessmentEditorComponent', () => {
         component.onFeedbackChanged(feedbacks);
         expect(component.referencedFeedback).toHaveLength(1);
         expect(component.totalScore).toBe(3);
-        expect(handleFeedbackSpy).toHaveBeenCalledTimes(1);
+        expect(handleFeedbackSpy).toHaveBeenCalledOnce();
     }));
 
     describe('test assessNext', () => {
@@ -404,7 +404,7 @@ describe('ModelingAssessmentEditorComponent', () => {
             component.assessNext();
             tick(500);
 
-            expect(serviceSpy).toHaveBeenCalledTimes(1);
+            expect(serviceSpy).toHaveBeenCalledOnce();
             expect(routerSpy).toHaveBeenCalledWith(url, queryParams);
         }));
 
@@ -421,7 +421,7 @@ describe('ModelingAssessmentEditorComponent', () => {
             component.ngOnInit();
             tick(500);
             component.assessNext();
-            expect(serviceSpy).toHaveBeenCalledTimes(1);
+            expect(serviceSpy).toHaveBeenCalledOnce();
         }));
     });
 
@@ -440,7 +440,7 @@ describe('ModelingAssessmentEditorComponent', () => {
 
         component.useStudentSubmissionAsExampleSubmission();
 
-        expect(importSpy).toHaveBeenCalledTimes(1);
+        expect(importSpy).toHaveBeenCalledOnce();
         expect(importSpy).toHaveBeenCalledWith(component.submission.id, component.modelingExercise!.id);
     });
 });

--- a/src/test/javascript/spec/component/modeling-editor/modeling-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-editor/modeling-editor.component.spec.ts
@@ -235,7 +235,7 @@ describe('ModelingEditorComponent', () => {
         const newExplanation = 'New Explanation';
         component.onExplanationInput(newExplanation);
 
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
         expect(spy).toHaveBeenCalledWith(newExplanation);
         expect(component.explanation).toBe(newExplanation);
     });

--- a/src/test/javascript/spec/component/modeling-editor/modeling-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-editor/modeling-editor.component.spec.ts
@@ -107,7 +107,7 @@ describe('ModelingEditorComponent', () => {
     it('isFullScreen false', () => {
         // test
         const fullScreen = component.isFullScreen;
-        expect(fullScreen).toBe(false);
+        expect(fullScreen).toBeFalse();
     });
 
     it('getCurrentModel', () => {

--- a/src/test/javascript/spec/component/modeling-exercise/modeling-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-exercise/modeling-exercise.component.spec.ts
@@ -101,7 +101,7 @@ describe('ModelingExercise Management Component', () => {
         comp.ngOnInit();
         comp.deleteModelingExercise(456);
         expect(modelingExerciseService.delete).toHaveBeenCalledWith(456);
-        expect(modelingExerciseService.delete).toHaveBeenCalledTimes(1);
+        expect(modelingExerciseService.delete).toHaveBeenCalledOnce();
     });
 
     it('Should open modal', () => {
@@ -110,7 +110,7 @@ describe('ModelingExercise Management Component', () => {
 
         comp.openImportModal();
         expect(modalService.open).toHaveBeenCalledWith(ModelingExerciseImportComponent, { size: 'lg', backdrop: 'static' });
-        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledOnce();
     });
 
     it('Should return exercise id', () => {
@@ -148,7 +148,7 @@ describe('ModelingExercise Management Component', () => {
         const broadcastSpy = jest.spyOn(eventManager, 'broadcast');
         comp.deleteModelingExercise(2);
         expect(deleteStub).toHaveBeenCalledWith(2);
-        expect(deleteStub).toHaveBeenCalledTimes(1);
+        expect(deleteStub).toHaveBeenCalledOnce();
         tick();
         expect(broadcastSpy).toHaveBeenCalledWith({
             name: 'modelingExerciseListModification',
@@ -165,6 +165,6 @@ describe('ModelingExercise Management Component', () => {
         comp.exerciseFilter = new ExerciseFilter();
         comp.sortRows();
         expect(sortSpy).toHaveBeenCalledWith(comp.modelingExercises, comp.predicate, comp.reverse);
-        expect(sortSpy).toHaveBeenCalledTimes(1);
+        expect(sortSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
@@ -123,7 +123,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(getLatestSubmissionForModelingEditorStub).toHaveBeenCalledTimes(1);
+        expect(getLatestSubmissionForModelingEditorStub).toHaveBeenCalledOnce();
         expect(comp.submission.id).toBe(20);
     });
 
@@ -140,7 +140,7 @@ describe('ModelingSubmission Management Component', () => {
         const submitButton = debugElement.query(By.css('jhi-button'));
         expect(submitButton).not.toBe(null);
         expect(submitButton.attributes['ng-reflect-disabled']).toBe('false');
-        expect(comp.isActive).toBe(true);
+        expect(comp.isActive).toBeTrue();
     });
 
     it('should not allow to submit after the deadline if the initialization date is before the due date', () => {
@@ -163,7 +163,7 @@ describe('ModelingSubmission Management Component', () => {
 
         fixture.detectChanges();
 
-        expect(comp.isLate).toBe(true);
+        expect(comp.isLate).toBeTrue();
         const submitButton = debugElement.query(By.css('jhi-button'));
         expect(submitButton).not.toBe(null);
         expect(submitButton.attributes['ng-reflect-disabled']).toBe('false');
@@ -188,7 +188,7 @@ describe('ModelingSubmission Management Component', () => {
         fixture.detectChanges();
         comp.participation.initializationDate = dayjs();
 
-        expect(comp.isActive).toBe(true);
+        expect(comp.isActive).toBeTrue();
 
         comp.modelingExercise.dueDate = dayjs().subtract(1, 'days');
 
@@ -200,7 +200,7 @@ describe('ModelingSubmission Management Component', () => {
         jest.spyOn(service, 'getLatestSubmissionForModelingEditor').mockReturnValue(throwError(() => ({ status: 403 })));
         const routerStub = jest.spyOn(router, 'navigate').mockReturnValue(new Promise(() => true));
         fixture.detectChanges();
-        expect(routerStub).toHaveBeenCalledTimes(1);
+        expect(routerStub).toHaveBeenCalledOnce();
     });
 
     it('should set correct properties on modeling exercise update when saving', () => {
@@ -209,7 +209,7 @@ describe('ModelingSubmission Management Component', () => {
 
         const updateStub = jest.spyOn(service, 'update').mockReturnValue(of(new HttpResponse({ body: submission })));
         comp.saveDiagram();
-        expect(updateStub).toHaveBeenCalledTimes(1);
+        expect(updateStub).toHaveBeenCalledOnce();
         expect(comp.submission).toEqual(submission);
     });
 
@@ -220,7 +220,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.modelingExercise = new ModelingExercise(UMLDiagramType.DeploymentDiagram, undefined, undefined);
         comp.modelingExercise.id = 1;
         comp.saveDiagram();
-        expect(createStub).toHaveBeenCalledTimes(1);
+        expect(createStub).toHaveBeenCalledOnce();
         expect(comp.submission).toEqual(submission);
     });
 
@@ -233,7 +233,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.modelingExercise = new ModelingExercise(UMLDiagramType.DeploymentDiagram, undefined, undefined);
         comp.modelingExercise.id = 1;
         comp.submit();
-        expect(createStub).toHaveBeenCalledTimes(1);
+        expect(createStub).toHaveBeenCalledOnce();
         expect(comp.submission).toEqual(submission);
     });
 
@@ -245,7 +245,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.modelingExercise = new ModelingExercise(UMLDiagramType.DeploymentDiagram, undefined, undefined);
         comp.modelingExercise.id = 1;
         comp.submit();
-        expect(alertServiceSpy).toHaveBeenCalledTimes(1);
+        expect(alertServiceSpy).toHaveBeenCalledOnce();
         expect(comp.submission).toBe(modelSubmission);
     });
 
@@ -271,7 +271,7 @@ describe('ModelingSubmission Management Component', () => {
             .spyOn(participationWebSocketService, 'subscribeForLatestResultOfParticipation')
             .mockReturnValue(subscribeForLatestResultOfParticipationSubject);
         fixture.detectChanges();
-        expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledTimes(1);
+        expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledOnce();
         expect(comp.assessmentResult).toEqual(newResult);
     });
 
@@ -289,7 +289,7 @@ describe('ModelingSubmission Management Component', () => {
         const receiveStub = jest.spyOn(websocketService, 'receive').mockReturnValue(of(modelSubmission));
         fixture.detectChanges();
         expect(comp.submission).toEqual(modelSubmission);
-        expect(receiveStub).toHaveBeenCalledTimes(1);
+        expect(receiveStub).toHaveBeenCalledOnce();
     });
 
     it('should set correct properties on modeling exercise update when submitting', () => {
@@ -304,7 +304,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.modelingExercise.id = 1;
         fixture.detectChanges();
         comp.submit();
-        expect(updateStub).toHaveBeenCalledTimes(1);
+        expect(updateStub).toHaveBeenCalledOnce();
         expect(comp.submission).toEqual(submission);
     });
 
@@ -334,7 +334,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.selectedEntities = [];
         comp.selectedRelationships = [];
         fixture.detectChanges();
-        expect(comp.shouldBeDisplayed(feedback)).toBe(true);
+        expect(comp.shouldBeDisplayed(feedback)).toBeTrue();
         comp.selectedEntities = ['3'];
         fixture.detectChanges();
         expect(comp.shouldBeDisplayed(feedback)).toBe(false);
@@ -346,7 +346,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.selectedEntities = [id];
         comp.selectedRelationships = [];
         fixture.detectChanges();
-        expect(comp.shouldBeDisplayed(feedback)).toBe(true);
+        expect(comp.shouldBeDisplayed(feedback)).toBeTrue();
         comp.selectedEntities = [];
         comp.selectedRelationships = [id];
         fixture.detectChanges();
@@ -361,7 +361,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.explanation = 'Explanation Test';
         comp.updateSubmissionWithCurrentValues();
         expect(currentModelStub).toHaveBeenCalledTimes(2);
-        expect(comp.hasElements).toBe(true);
+        expect(comp.hasElements).toBeTrue();
         expect(comp.submission).not.toBe(undefined);
         expect(comp.submission.model).toBe(JSON.stringify(model));
         expect(comp.submission.explanationText).toBe('Explanation Test');
@@ -407,7 +407,7 @@ describe('ModelingSubmission Management Component', () => {
 
         const canDeactivate = comp.canDeactivate();
 
-        expect(currentModelStub).toHaveBeenCalledTimes(1);
+        expect(currentModelStub).toHaveBeenCalledOnce();
         expect(canDeactivate).toBe(false);
     });
 
@@ -467,6 +467,6 @@ describe('ModelingSubmission Management Component', () => {
         expect(unreferencedFeedback![0].isSubsequent).toBe(undefined);
         expect(referencedFeedback).not.toBe(undefined);
         expect(referencedFeedback).toHaveLength(1);
-        expect(referencedFeedback![0].isSubsequent).toBe(true);
+        expect(referencedFeedback![0].isSubsequent).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/modeling-submission/modeling-submission.component.spec.ts
@@ -193,7 +193,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.modelingExercise.dueDate = dayjs().subtract(1, 'days');
 
         fixture.detectChanges();
-        expect(comp.isActive).toBe(false);
+        expect(comp.isActive).toBeFalse();
     });
 
     it('should navigate to access denied page on 403 error status', () => {
@@ -337,7 +337,7 @@ describe('ModelingSubmission Management Component', () => {
         expect(comp.shouldBeDisplayed(feedback)).toBeTrue();
         comp.selectedEntities = ['3'];
         fixture.detectChanges();
-        expect(comp.shouldBeDisplayed(feedback)).toBe(false);
+        expect(comp.shouldBeDisplayed(feedback)).toBeFalse();
     });
 
     it('should shouldBeDisplayed return true if feedback reference is in selectedEntities or selectedRelationships', () => {
@@ -350,7 +350,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.selectedEntities = [];
         comp.selectedRelationships = [id];
         fixture.detectChanges();
-        expect(comp.shouldBeDisplayed(feedback)).toBe(false);
+        expect(comp.shouldBeDisplayed(feedback)).toBeFalse();
     });
 
     it('should update submission with current values', () => {
@@ -408,7 +408,7 @@ describe('ModelingSubmission Management Component', () => {
         const canDeactivate = comp.canDeactivate();
 
         expect(currentModelStub).toHaveBeenCalledOnce();
-        expect(canDeactivate).toBe(false);
+        expect(canDeactivate).toBeFalse();
     });
 
     it('should set isChanged property to false after saving', () => {
@@ -424,7 +424,7 @@ describe('ModelingSubmission Management Component', () => {
         comp.modelingExercise.id = 1;
         fixture.detectChanges();
         comp.saveDiagram();
-        expect(comp.isChanged).toBe(false);
+        expect(comp.isChanged).toBeFalse();
     });
 
     it('should mark the subsequent feedback', () => {

--- a/src/test/javascript/spec/component/multiple-choice-question/multiple-choice-question-edit.component.spec.ts
+++ b/src/test/javascript/spec/component/multiple-choice-question/multiple-choice-question-edit.component.spec.ts
@@ -155,7 +155,7 @@ describe('MultipleChoiceQuestionEditComponent', () => {
         component.changesInMarkdown();
 
         expectCleanupQuestion();
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
     });
 
     function expectCleanupQuestion() {
@@ -170,6 +170,6 @@ describe('MultipleChoiceQuestionEditComponent', () => {
         const spy = jest.spyOn(component, 'deleteQuestion');
         const deleteButton = fixture.debugElement.query(By.css(`.delete-button`));
         deleteButton.nativeElement.click();
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/organization/organization-management-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/organization/organization-management-detail.component.spec.ts
@@ -149,10 +149,10 @@ describe('OrganizationManagementDetailComponent', () => {
         });
 
         tick();
-        expect(userService.search).toHaveBeenCalledTimes(1);
+        expect(userService.search).toHaveBeenCalledOnce();
 
         typeAheadButtons.forEach((button) => {
-            expect(button.insertAdjacentHTML).toHaveBeenCalledTimes(1);
+            expect(button.insertAdjacentHTML).toHaveBeenCalledOnce();
             expect(button.insertAdjacentHTML).toHaveBeenCalledWith('beforeend', iconsAsHTML['users-plus']);
         });
 
@@ -165,11 +165,11 @@ describe('OrganizationManagementDetailComponent', () => {
         component.searchAllUsers(of({ text: 'user', entities: [] })).subscribe();
         tick();
 
-        expect(typeAheadButtons[0].insertAdjacentHTML).toHaveBeenCalledTimes(1);
+        expect(typeAheadButtons[0].insertAdjacentHTML).toHaveBeenCalledOnce();
         expect(typeAheadButtons[0].insertAdjacentHTML).toHaveBeenCalledWith('beforeend', iconsAsHTML['users']);
-        expect(typeAheadButtons[0].classList.add).toHaveBeenCalledTimes(1);
+        expect(typeAheadButtons[0].classList.add).toHaveBeenCalledOnce();
         expect(typeAheadButtons[0].classList.add).toHaveBeenCalledWith('already-member');
-        expect(typeAheadButtons[1].insertAdjacentHTML).toHaveBeenCalledTimes(1);
+        expect(typeAheadButtons[1].insertAdjacentHTML).toHaveBeenCalledOnce();
         expect(typeAheadButtons[1].insertAdjacentHTML).toHaveBeenCalledWith('beforeend', iconsAsHTML['users-plus']);
         expect(typeAheadButtons[1].classList.add).not.toHaveBeenCalled();
     }));
@@ -201,12 +201,12 @@ describe('OrganizationManagementDetailComponent', () => {
 
         result.subscribe((a) => {
             expect(a).toStrictEqual([]);
-            expect(component.searchNoResults).toBe(true);
+            expect(component.searchNoResults).toBeTrue();
             expect(component.searchFailed).toBe(false);
         });
 
         tick();
-        expect(userService.search).toHaveBeenCalledTimes(1);
+        expect(userService.search).toHaveBeenCalledOnce();
     }));
 
     it('should set the search failed flag if search failed', fakeAsync(() => {
@@ -218,11 +218,11 @@ describe('OrganizationManagementDetailComponent', () => {
         result.subscribe((a) => {
             expect(a).toStrictEqual([]);
             expect(component.searchNoResults).toBe(false);
-            expect(component.searchFailed).toBe(true);
+            expect(component.searchFailed).toBeTrue();
         });
 
         tick();
-        expect(userService.search).toHaveBeenCalledTimes(1);
+        expect(userService.search).toHaveBeenCalledOnce();
     }));
 
     it('should add the user to organization on autocomplete select', fakeAsync(() => {
@@ -234,12 +234,12 @@ describe('OrganizationManagementDetailComponent', () => {
         const newUser = { id: 2, login: 'test' } as User;
         component.onAutocompleteSelect(newUser, callback);
         tick();
-        expect(addUserSpy).toHaveBeenCalledTimes(1);
+        expect(addUserSpy).toHaveBeenCalledOnce();
         expect(addUserSpy).toHaveBeenCalledWith(7, 'test');
         expect(component.organization.users).toContain(newUser);
-        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledOnce();
         expect(callback).toHaveBeenCalledWith(newUser);
-        expect(flashSpy).toHaveBeenCalledTimes(1);
+        expect(flashSpy).toHaveBeenCalledOnce();
         expect(flashSpy).toHaveBeenCalledWith('newly-added-member');
 
         const existingUser = { id: 1 } as User;
@@ -247,7 +247,7 @@ describe('OrganizationManagementDetailComponent', () => {
         tick();
         expect(callback).toHaveBeenCalledTimes(2);
         expect(callback).toHaveBeenCalledWith(existingUser);
-        expect(addUserSpy).toHaveBeenCalledTimes(1);
+        expect(addUserSpy).toHaveBeenCalledOnce();
     }));
 
     function createTestUsers() {

--- a/src/test/javascript/spec/component/organization/organization-management-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/organization/organization-management-detail.component.spec.ts
@@ -144,8 +144,8 @@ describe('OrganizationManagementDetailComponent', () => {
                 { id: user1.id, login: user1.login },
                 { id: user2.id, login: user2.login },
             ]);
-            expect(component.searchNoResults).toBe(false);
-            expect(component.searchFailed).toBe(false);
+            expect(component.searchNoResults).toBeFalse();
+            expect(component.searchFailed).toBeFalse();
         });
 
         tick();
@@ -185,8 +185,8 @@ describe('OrganizationManagementDetailComponent', () => {
 
         result.subscribe((a) => {
             expect(a).toStrictEqual([]);
-            expect(component.searchNoResults).toBe(false);
-            expect(component.searchFailed).toBe(false);
+            expect(component.searchNoResults).toBeFalse();
+            expect(component.searchFailed).toBeFalse();
         });
 
         tick();
@@ -202,7 +202,7 @@ describe('OrganizationManagementDetailComponent', () => {
         result.subscribe((a) => {
             expect(a).toStrictEqual([]);
             expect(component.searchNoResults).toBeTrue();
-            expect(component.searchFailed).toBe(false);
+            expect(component.searchFailed).toBeFalse();
         });
 
         tick();
@@ -217,7 +217,7 @@ describe('OrganizationManagementDetailComponent', () => {
 
         result.subscribe((a) => {
             expect(a).toStrictEqual([]);
-            expect(component.searchNoResults).toBe(false);
+            expect(component.searchNoResults).toBeFalse();
             expect(component.searchFailed).toBeTrue();
         });
 

--- a/src/test/javascript/spec/component/organization/organization-management-resolve.spec.ts
+++ b/src/test/javascript/spec/component/organization/organization-management-resolve.spec.ts
@@ -21,7 +21,7 @@ describe('OrganizationManagementResolve', () => {
         // @ts-ignore
         organizationManagementResolve.resolve({ params: { id: 1 } } as any as ActivatedRouteSnapshot).subscribe((org) => (result = org));
         expect(result).toBe(toReturn);
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
         expect(spy).toHaveBeenCalledWith(1);
     });
 

--- a/src/test/javascript/spec/component/orion/modal-confirm-autofocus.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/modal-confirm-autofocus.component.spec.ts
@@ -29,6 +29,6 @@ describe('ModalConfirmAutofocusComponent', () => {
 
         const closeSpy = jest.spyOn(modal, 'close').mockImplementation();
         closeButton.nativeElement.click();
-        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(closeSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/orion/orion-button.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-button.component.spec.ts
@@ -24,7 +24,7 @@ describe('OrionButtonComponent', () => {
 
     it('should calculate btnPrimary correctly', () => {
         comp.outlined = true;
-        expect(comp.btnPrimary).toBe(false);
+        expect(comp.btnPrimary).toBeFalse();
     });
 
     it('should not forward click if buttonLoading', () => {

--- a/src/test/javascript/spec/component/orion/orion-button.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-button.component.spec.ts
@@ -48,6 +48,6 @@ describe('OrionButtonComponent', () => {
 
         buttonElement.nativeElement.click();
 
-        expect(emitSpy).toHaveBeenCalledTimes(1);
+        expect(emitSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/orion/orion-code-editor-instructor-and-editor-container.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-code-editor-instructor-and-editor-container.component.spec.ts
@@ -67,7 +67,7 @@ describe('CodeEditorInstructorAndEditorOrionContainerComponent', () => {
         // @ts-ignore
         comp.applyDomainChange({}, {});
 
-        expect(selectRepositorySpy).toHaveBeenCalledTimes(1);
+        expect(selectRepositorySpy).toHaveBeenCalledOnce();
         expect(selectRepositorySpy).toHaveBeenCalledWith(REPOSITORY.TEST);
     });
 
@@ -77,7 +77,7 @@ describe('CodeEditorInstructorAndEditorOrionContainerComponent', () => {
 
         comp.ngOnInit();
 
-        expect(orionStateStub).toHaveBeenCalledTimes(1);
+        expect(orionStateStub).toHaveBeenCalledOnce();
         expect(orionStateStub).toHaveBeenCalledWith();
         expect(comp.orionState).toEqual(orionState);
     });
@@ -88,9 +88,9 @@ describe('CodeEditorInstructorAndEditorOrionContainerComponent', () => {
 
         comp.buildLocally();
 
-        expect(isBuildingSpy).toHaveBeenCalledTimes(1);
+        expect(isBuildingSpy).toHaveBeenCalledOnce();
         expect(isBuildingSpy).toHaveBeenCalledWith(true);
-        expect(buildLocallySpy).toHaveBeenCalledTimes(1);
+        expect(buildLocallySpy).toHaveBeenCalledOnce();
         expect(buildLocallySpy).toHaveBeenCalledWith();
     });
 
@@ -107,11 +107,11 @@ describe('CodeEditorInstructorAndEditorOrionContainerComponent', () => {
 
         comp.submit();
 
-        expect(submitSpy).toHaveBeenCalledTimes(1);
+        expect(submitSpy).toHaveBeenCalledOnce();
         expect(submitSpy).toHaveBeenCalledWith();
-        expect(isBuildingSpy).toHaveBeenCalledTimes(1);
+        expect(isBuildingSpy).toHaveBeenCalledOnce();
         expect(isBuildingSpy).toHaveBeenCalledWith(true);
-        expect(listenOnBuildOutputSpy).toHaveBeenCalledTimes(1);
+        expect(listenOnBuildOutputSpy).toHaveBeenCalledOnce();
         expect(listenOnBuildOutputSpy).toHaveBeenCalledWith(exercise, participation);
     });
 });

--- a/src/test/javascript/spec/component/orion/orion-exercise-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-exercise-assessment-dashboard.component.spec.ts
@@ -69,7 +69,7 @@ describe('OrionExerciseAssessmentDashboardComponent', () => {
 
         comp.openAssessmentInOrion();
 
-        expect(assessExerciseSpy).toHaveBeenCalledTimes(1);
+        expect(assessExerciseSpy).toHaveBeenCalledOnce();
         expect(assessExerciseSpy).toHaveBeenCalledWith(programmingExercise);
     });
 
@@ -78,7 +78,7 @@ describe('OrionExerciseAssessmentDashboardComponent', () => {
 
         comp.downloadSubmissionInOrion(programmingSubmission, 2);
 
-        expect(downloadSubmissionSpy).toHaveBeenCalledTimes(1);
+        expect(downloadSubmissionSpy).toHaveBeenCalledOnce();
         expect(downloadSubmissionSpy).toHaveBeenCalledWith(comp.exerciseId, programmingSubmission, 2, false);
     });
 
@@ -97,9 +97,9 @@ describe('OrionExerciseAssessmentDashboardComponent', () => {
         expect(comp.exercise).toEqual(programmingExercise);
         expect(comp.orionState).toEqual(orionState);
 
-        expect(getForTutorsStub).toHaveBeenCalledTimes(1);
+        expect(getForTutorsStub).toHaveBeenCalledOnce();
         expect(getForTutorsStub).toHaveBeenCalledWith(10);
-        expect(orionStateStub).toHaveBeenCalledTimes(1);
+        expect(orionStateStub).toHaveBeenCalledOnce();
         expect(orionStateStub).toHaveBeenCalledWith();
     }));
 
@@ -122,11 +122,11 @@ describe('OrionExerciseAssessmentDashboardComponent', () => {
         expect(comp.exercise).toBe(undefined);
         expect(comp.orionState).toEqual(orionState);
 
-        expect(getForTutorsStub).toHaveBeenCalledTimes(1);
+        expect(getForTutorsStub).toHaveBeenCalledOnce();
         expect(getForTutorsStub).toHaveBeenCalledWith(10);
-        expect(orionStateStub).toHaveBeenCalledTimes(1);
+        expect(orionStateStub).toHaveBeenCalledOnce();
         expect(orionStateStub).toHaveBeenCalledWith();
-        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy).toHaveBeenCalledOnce();
         expect(errorSpy).toHaveBeenCalledWith('error.http.400');
     }));
 });

--- a/src/test/javascript/spec/component/orion/orion-exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-exercise-details-student-actions.component.spec.ts
@@ -61,7 +61,7 @@ describe('OrionExerciseDetailsStudentActionsComponent', () => {
     it('ngOnInit should subscribe to state', () => {
         comp.ngOnInit();
 
-        expect(orionStateStub).toHaveBeenCalledTimes(1);
+        expect(orionStateStub).toHaveBeenCalledOnce();
         expect(orionStateStub).toHaveBeenCalledWith();
         expect(comp.orionState).toEqual(orionState);
     });
@@ -74,7 +74,7 @@ describe('OrionExerciseDetailsStudentActionsComponent', () => {
         comp.courseId = 456;
 
         comp.importIntoIDE();
-        expect(cloneSpy).toHaveBeenCalledTimes(1);
+        expect(cloneSpy).toHaveBeenCalledOnce();
         expect(cloneSpy).toHaveBeenCalledWith('testUrl', programmingExercise);
     });
 
@@ -82,8 +82,8 @@ describe('OrionExerciseDetailsStudentActionsComponent', () => {
         comp.exercise = exercise;
         comp.submitChanges();
 
-        expect(submitSpy).toHaveBeenCalledTimes(1);
-        expect(forwardBuildSpy).toHaveBeenCalledTimes(1);
+        expect(submitSpy).toHaveBeenCalledOnce();
+        expect(forwardBuildSpy).toHaveBeenCalledOnce();
         // asserts forwardBuild has been called directly after submit
         expect(forwardBuildSpy.mock.invocationCallOrder[0]).toBe(submitSpy.mock.invocationCallOrder[0] + 1);
     });
@@ -91,7 +91,7 @@ describe('OrionExerciseDetailsStudentActionsComponent', () => {
     it('isOfflineIdeAllowed should reflect exercise state', () => {
         comp.exercise = { allowOfflineIde: true } as any;
 
-        expect(comp.isOfflineIdeAllowed).toBe(true);
+        expect(comp.isOfflineIdeAllowed).toBeTrue();
     });
 
     it('should submit if stated in route', () => {
@@ -99,7 +99,7 @@ describe('OrionExerciseDetailsStudentActionsComponent', () => {
 
         comp.ngOnInit();
 
-        expect(submitChangesSpy).toHaveBeenCalledTimes(1);
+        expect(submitChangesSpy).toHaveBeenCalledOnce();
         expect(submitChangesSpy).toHaveBeenCalledWith();
     });
 });

--- a/src/test/javascript/spec/component/orion/orion-programming-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-programming-exercise.component.spec.ts
@@ -43,7 +43,7 @@ describe('OrionProgrammingExerciseComponent', () => {
 
         comp.ngOnInit();
 
-        expect(orionStateStub).toHaveBeenCalledTimes(1);
+        expect(orionStateStub).toHaveBeenCalledOnce();
         expect(orionStateStub).toHaveBeenCalledWith();
         expect(comp.orionState).toEqual(orionState);
     });
@@ -54,7 +54,7 @@ describe('OrionProgrammingExerciseComponent', () => {
 
         comp.editInIDE(programmingExercise);
 
-        expect(editExerciseSpy).toHaveBeenCalledTimes(1);
+        expect(editExerciseSpy).toHaveBeenCalledOnce();
         expect(editExerciseSpy).toHaveBeenCalledWith(programmingExercise);
     });
 
@@ -62,7 +62,7 @@ describe('OrionProgrammingExerciseComponent', () => {
         const navigateSpy = jest.spyOn(router, 'navigate');
         comp.openOrionEditor({ ...programmingExercise, templateParticipation: { id: 1234 } });
 
-        expect(navigateSpy).toHaveBeenCalledTimes(1);
+        expect(navigateSpy).toHaveBeenCalledOnce();
         expect(navigateSpy).toHaveBeenCalledWith(['code-editor', 'ide', 456, 'admin', 1234]);
     });
 
@@ -73,7 +73,7 @@ describe('OrionProgrammingExerciseComponent', () => {
 
         comp.openOrionEditor(programmingExercise);
 
-        expect(navigateStub).toHaveBeenCalledTimes(1);
+        expect(navigateStub).toHaveBeenCalledOnce();
         expect(navigateStub).toHaveBeenCalledWith(['code-editor', 'ide', 456, 'admin', undefined]);
     });
 });

--- a/src/test/javascript/spec/component/orion/orion-tutor-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/orion/orion-tutor-assessment.component.spec.ts
@@ -52,7 +52,7 @@ describe('OrionTutorAssessmentComponent', () => {
 
         comp.initializeFeedback();
 
-        expect(initializeAssessmentSpy).toHaveBeenCalledTimes(1);
+        expect(initializeAssessmentSpy).toHaveBeenCalledOnce();
         expect(initializeAssessmentSpy).toHaveBeenCalledWith(5, [{ id: 5 }, { id: 6 }]);
     });
 
@@ -61,7 +61,7 @@ describe('OrionTutorAssessmentComponent', () => {
 
         comp.updateFeedback(5, [{ id: 1 }]);
 
-        expect(updateFeedbackSpy).toHaveBeenCalledTimes(1);
+        expect(updateFeedbackSpy).toHaveBeenCalledOnce();
         expect(updateFeedbackSpy).toHaveBeenCalledWith([{ id: 1 }]);
     });
 
@@ -70,7 +70,7 @@ describe('OrionTutorAssessmentComponent', () => {
 
         comp.updateFeedback(10, [{ id: 1 }]);
 
-        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy).toHaveBeenCalledOnce();
         expect(errorSpy).toHaveBeenCalledWith('artemisApp.orion.assessment.submissionIdDontMatch');
     });
 
@@ -79,7 +79,7 @@ describe('OrionTutorAssessmentComponent', () => {
 
         comp.openNextSubmission(2);
 
-        expect(sendSubmissionToOrionCancellableSpy).toHaveBeenCalledTimes(1);
+        expect(sendSubmissionToOrionCancellableSpy).toHaveBeenCalledOnce();
         expect(sendSubmissionToOrionCancellableSpy).toHaveBeenCalledWith(15, 2, 1, false);
     });
 });

--- a/src/test/javascript/spec/component/overview/course-discussion/course-discussion.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-discussion/course-discussion.component.spec.ts
@@ -221,7 +221,7 @@ describe('CourseDiscussionComponent', () => {
         tick();
         fixture.detectChanges();
         expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledTimes(3);
-        expect(component.currentPostContextFilter.filterToUnresolved).toBe(true);
+        expect(component.currentPostContextFilter.filterToUnresolved).toBeTrue();
         // actual post filtering done at server side, tested by AnswerPostIntegrationTest
     }));
 
@@ -243,8 +243,8 @@ describe('CourseDiscussionComponent', () => {
         tick();
         fixture.detectChanges();
         expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledTimes(4);
-        expect(component.currentPostContextFilter.filterToUnresolved).toBe(true);
-        expect(component.currentPostContextFilter.filterToOwn).toBe(true);
+        expect(component.currentPostContextFilter.filterToUnresolved).toBeTrue();
+        expect(component.currentPostContextFilter.filterToOwn).toBeTrue();
         expect(component.currentPostContextFilter.filterToAnsweredOrReacted).toBe(false);
         // actual post filtering done at server side, tested by AnswerPostIntegrationTest
     }));
@@ -266,7 +266,7 @@ describe('CourseDiscussionComponent', () => {
         fixture.detectChanges();
         expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledTimes(3);
         expect(component.currentPostContextFilter.filterToUnresolved).toBe(false);
-        expect(component.currentPostContextFilter.filterToOwn).toBe(true);
+        expect(component.currentPostContextFilter.filterToOwn).toBeTrue();
         expect(component.currentPostContextFilter.filterToAnsweredOrReacted).toBe(false);
         // actual post filtering done at server side, tested by PostIntegrationTest
     }));
@@ -388,19 +388,19 @@ describe('CourseDiscussionComponent', () => {
     describe('sorting of posts', () => {
         it('should distinguish context filter options for properly show them in form', () => {
             let result = component.compareContextFilterOptionFn({ courseId: metisCourse.id }, { courseId: metisCourse.id });
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
             result = component.compareContextFilterOptionFn({ courseId: metisCourse.id }, { courseId: 99 });
             expect(result).toBe(false);
             result = component.compareContextFilterOptionFn({ lectureId: metisLecture.id }, { lectureId: metisLecture.id });
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
             result = component.compareContextFilterOptionFn({ lectureId: metisLecture.id }, { lectureId: 99 });
             expect(result).toBe(false);
             result = component.compareContextFilterOptionFn({ exerciseId: metisExercise.id }, { exerciseId: metisExercise.id });
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
             result = component.compareContextFilterOptionFn({ exerciseId: metisExercise.id }, { exerciseId: 99 });
             expect(result).toBe(false);
             result = component.compareContextFilterOptionFn({ courseWideContext: CourseWideContext.ORGANIZATION }, { courseWideContext: CourseWideContext.ORGANIZATION });
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
             result = component.compareContextFilterOptionFn({ courseWideContext: CourseWideContext.ORGANIZATION }, { courseWideContext: CourseWideContext.TECH_SUPPORT });
             expect(result).toBe(false);
         });

--- a/src/test/javascript/spec/component/overview/course-discussion/course-discussion.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-discussion/course-discussion.component.spec.ts
@@ -137,9 +137,9 @@ describe('CourseDiscussionComponent', () => {
             sortingOrder: SortDirection.DESCENDING,
         });
         expect(component.formGroup.get('sortBy')?.value).toBe(PostSortCriterion.CREATION_DATE);
-        expect(component.formGroup.get('filterToUnresolved')?.value).toBe(false);
-        expect(component.formGroup.get('filterToOwn')?.value).toBe(false);
-        expect(component.formGroup.get('filterToAnsweredOrReacted')?.value).toBe(false);
+        expect(component.formGroup.get('filterToUnresolved')?.value).toBeFalse();
+        expect(component.formGroup.get('filterToOwn')?.value).toBeFalse();
+        expect(component.formGroup.get('filterToAnsweredOrReacted')?.value).toBeFalse();
     }));
 
     it('should initialize overview page with course posts for default settings correctly', fakeAsync(() => {
@@ -245,7 +245,7 @@ describe('CourseDiscussionComponent', () => {
         expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledTimes(4);
         expect(component.currentPostContextFilter.filterToUnresolved).toBeTrue();
         expect(component.currentPostContextFilter.filterToOwn).toBeTrue();
-        expect(component.currentPostContextFilter.filterToAnsweredOrReacted).toBe(false);
+        expect(component.currentPostContextFilter.filterToAnsweredOrReacted).toBeFalse();
         // actual post filtering done at server side, tested by AnswerPostIntegrationTest
     }));
 
@@ -265,9 +265,9 @@ describe('CourseDiscussionComponent', () => {
         tick();
         fixture.detectChanges();
         expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledTimes(3);
-        expect(component.currentPostContextFilter.filterToUnresolved).toBe(false);
+        expect(component.currentPostContextFilter.filterToUnresolved).toBeFalse();
         expect(component.currentPostContextFilter.filterToOwn).toBeTrue();
-        expect(component.currentPostContextFilter.filterToAnsweredOrReacted).toBe(false);
+        expect(component.currentPostContextFilter.filterToAnsweredOrReacted).toBeFalse();
         // actual post filtering done at server side, tested by PostIntegrationTest
     }));
 
@@ -390,19 +390,19 @@ describe('CourseDiscussionComponent', () => {
             let result = component.compareContextFilterOptionFn({ courseId: metisCourse.id }, { courseId: metisCourse.id });
             expect(result).toBeTrue();
             result = component.compareContextFilterOptionFn({ courseId: metisCourse.id }, { courseId: 99 });
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
             result = component.compareContextFilterOptionFn({ lectureId: metisLecture.id }, { lectureId: metisLecture.id });
             expect(result).toBeTrue();
             result = component.compareContextFilterOptionFn({ lectureId: metisLecture.id }, { lectureId: 99 });
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
             result = component.compareContextFilterOptionFn({ exerciseId: metisExercise.id }, { exerciseId: metisExercise.id });
             expect(result).toBeTrue();
             result = component.compareContextFilterOptionFn({ exerciseId: metisExercise.id }, { exerciseId: 99 });
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
             result = component.compareContextFilterOptionFn({ courseWideContext: CourseWideContext.ORGANIZATION }, { courseWideContext: CourseWideContext.ORGANIZATION });
             expect(result).toBeTrue();
             result = component.compareContextFilterOptionFn({ courseWideContext: CourseWideContext.ORGANIZATION }, { courseWideContext: CourseWideContext.TECH_SUPPORT });
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
     });
 });

--- a/src/test/javascript/spec/component/overview/course-exams/course-exams.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-exams/course-exams.component.spec.ts
@@ -48,7 +48,7 @@ describe('CourseExamsComponent', () => {
 
     it('exam should be visible', () => {
         componentFixture.detectChanges();
-        expect(component.isVisible(visibleExam)).toBe(true);
+        expect(component.isVisible(visibleExam)).toBeTrue();
     });
 
     it('exam should not be visible', () => {

--- a/src/test/javascript/spec/component/overview/course-exams/course-exams.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-exams/course-exams.component.spec.ts
@@ -53,6 +53,6 @@ describe('CourseExamsComponent', () => {
 
     it('exam should not be visible', () => {
         componentFixture.detectChanges();
-        expect(component.isVisible(notVisibleExam)).toBe(false);
+        expect(component.isVisible(notVisibleExam)).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/overview/course-lectures/course-lecture-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-lectures/course-lecture-details.component.spec.ts
@@ -186,7 +186,7 @@ describe('CourseLectureDetails', () => {
         expect(downloadButton).not.toBeNull();
 
         downloadButton.nativeElement.click();
-        expect(downloadAttachmentStub).toHaveBeenCalledTimes(1);
+        expect(downloadAttachmentStub).toHaveBeenCalledOnce();
     }));
 });
 

--- a/src/test/javascript/spec/component/overview/course-statistics/course-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-statistics/course-statistics.component.spec.ts
@@ -376,7 +376,7 @@ describe('CourseStatisticsComponent', () => {
         // as it is not included, the presentation score should be 0
         expect(programming.presentationScore).toBe(0);
         expect(programming.series).toHaveLength(6);
-        expect(programming.series[2].isProgrammingExercise).toBe(true);
+        expect(programming.series[2].isProgrammingExercise).toBeTrue();
         expect(programming.series[2].absoluteValue).toBe(17);
 
         const quiz: any = comp.ngxExerciseGroups[1][0];
@@ -550,9 +550,9 @@ describe('CourseStatisticsComponent', () => {
 
         // 3 Filters: Hide optional, Exercises with no categories and quiz1
         expect(comp.numberOfAppliedFilters).toBe(3);
-        expect(comp.exerciseCategoryFilters.get('quiz1')).toBe(true);
+        expect(comp.exerciseCategoryFilters.get('quiz1')).toBeTrue();
         expect(comp.exerciseCategoryFilters.get('programming1')).toBe(undefined);
-        expect(comp.allCategoriesSelected).toBe(true);
+        expect(comp.allCategoriesSelected).toBeTrue();
 
         comp.toggleAllCategories();
 
@@ -565,8 +565,8 @@ describe('CourseStatisticsComponent', () => {
 
         comp.toggleAllCategories();
 
-        expect(comp.allCategoriesSelected).toBe(true);
-        expect(comp.exerciseCategoryFilters.get('quiz1')).toBe(true);
+        expect(comp.allCategoriesSelected).toBeTrue();
+        expect(comp.exerciseCategoryFilters.get('quiz1')).toBeTrue();
         expect(comp.numberOfAppliedFilters).toBe(3);
         expect(comp.ngxExerciseGroups).toHaveLength(2);
     });
@@ -578,8 +578,8 @@ describe('CourseStatisticsComponent', () => {
 
         expect(comp.currentlyHidingNotIncludedInScoreExercises).toBe(false);
         expect(comp.numberOfAppliedFilters).toBe(3);
-        expect(comp.exerciseCategoryFilters.get('programming1')).toBe(true);
-        expect(comp.exerciseCategoryFilters.get('quiz1')).toBe(true);
+        expect(comp.exerciseCategoryFilters.get('programming1')).toBeTrue();
+        expect(comp.exerciseCategoryFilters.get('quiz1')).toBeTrue();
         expect(comp.ngxExerciseGroups).toHaveLength(3);
         expect(comp.ngxExerciseGroups[0][0].name).toBe('Until 18:20 too');
 
@@ -607,7 +607,7 @@ describe('CourseStatisticsComponent', () => {
         comp.toggleCategory('programming1');
 
         expect(comp.numberOfAppliedFilters).toBe(1);
-        expect(comp.exerciseCategoryFilters.get('programming1')).toBe(true);
+        expect(comp.exerciseCategoryFilters.get('programming1')).toBeTrue();
         expect(comp.ngxExerciseGroups).toHaveLength(1);
     });
 

--- a/src/test/javascript/spec/component/overview/course-statistics/course-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-statistics/course-statistics.component.spec.ts
@@ -556,8 +556,8 @@ describe('CourseStatisticsComponent', () => {
 
         comp.toggleAllCategories();
 
-        expect(comp.allCategoriesSelected).toBe(false);
-        expect(comp.exerciseCategoryFilters.get('quiz1')).toBe(false);
+        expect(comp.allCategoriesSelected).toBeFalse();
+        expect(comp.exerciseCategoryFilters.get('quiz1')).toBeFalse();
         expect(comp.numberOfAppliedFilters).toBe(1);
         comp.ngxExerciseGroups.forEach((group) => {
             expect(group).toHaveLength(0);
@@ -576,7 +576,7 @@ describe('CourseStatisticsComponent', () => {
 
         comp.toggleNotIncludedInScoreExercises();
 
-        expect(comp.currentlyHidingNotIncludedInScoreExercises).toBe(false);
+        expect(comp.currentlyHidingNotIncludedInScoreExercises).toBeFalse();
         expect(comp.numberOfAppliedFilters).toBe(3);
         expect(comp.exerciseCategoryFilters.get('programming1')).toBeTrue();
         expect(comp.exerciseCategoryFilters.get('quiz1')).toBeTrue();
@@ -586,15 +586,15 @@ describe('CourseStatisticsComponent', () => {
         comp.toggleCategory('programming1');
 
         expect(comp.numberOfAppliedFilters).toBe(2);
-        expect(comp.exerciseCategoryFilters.get('programming1')).toBe(false);
+        expect(comp.exerciseCategoryFilters.get('programming1')).toBeFalse();
         expect(comp.ngxExerciseGroups).toHaveLength(2);
         expect(comp.ngxExerciseGroups.filter((group) => group[0].type === ExerciseType.PROGRAMMING)).toHaveLength(0);
 
         comp.toggleCategory('quiz1');
 
         expect(comp.numberOfAppliedFilters).toBe(1);
-        expect(comp.exerciseCategoryFilters.get('programming1')).toBe(false);
-        expect(comp.exerciseCategoryFilters.get('quiz1')).toBe(false);
+        expect(comp.exerciseCategoryFilters.get('programming1')).toBeFalse();
+        expect(comp.exerciseCategoryFilters.get('quiz1')).toBeFalse();
         expect(comp.ngxExerciseGroups).toHaveLength(1);
         expect(comp.ngxExerciseGroups.filter((group) => group[0].type === ExerciseType.PROGRAMMING)).toHaveLength(0);
         expect(comp.ngxExerciseGroups.filter((group) => group[0].type === ExerciseType.QUIZ)).toHaveLength(0);

--- a/src/test/javascript/spec/component/overview/course-statistics/visualizations/exercise-scores-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-statistics/visualizations/exercise-scores-chart.component.spec.ts
@@ -181,7 +181,7 @@ describe('ExerciseScoresChartComponent', () => {
             component.toggleType(type);
 
             expect(component.numberOfActiveFilters).toBe(4 - index);
-            expect(component.chartFilter.get(type)).toBe(false);
+            expect(component.chartFilter.get(type)).toBeFalse();
 
             component.ngxData.forEach((line: any) => {
                 expect(line.series.filter((exerciseEntry: any) => exerciseEntry.exerciseType === exerciseDTOs[index].exerciseType)).toHaveLength(0);

--- a/src/test/javascript/spec/component/overview/course-statistics/visualizations/exercise-scores-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/course-statistics/visualizations/exercise-scores-chart.component.spec.ts
@@ -78,7 +78,7 @@ describe('ExerciseScoresChartComponent', () => {
         const secondExercise = generateExerciseScoresDTO(ExerciseType.QUIZ, 2, 40, 80, 90, dayjs().add(5, 'days'), 'Second Exercise');
 
         const getScoresStub = setUpServiceAndStartComponent([firstExercise, secondExercise]);
-        expect(getScoresStub).toHaveBeenCalledTimes(1);
+        expect(getScoresStub).toHaveBeenCalledOnce();
         expect(component.ngxData).toHaveLength(3);
 
         // datasets[0] is student score
@@ -111,19 +111,19 @@ describe('ExerciseScoresChartComponent', () => {
 
         const getScoresStub = setUpServiceAndStartComponent(exercises);
 
-        expect(getScoresStub).toHaveBeenCalledTimes(1);
+        expect(getScoresStub).toHaveBeenCalledOnce();
         expect(component.ngxData[0].series.map((exercise: any) => exercise.exerciseId)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
         component.filteredExerciseIDs = [2, 4, 5];
         component.ngOnChanges();
         // should not have to reload the data from the server
-        expect(getScoresStub).toHaveBeenCalledTimes(1);
+        expect(getScoresStub).toHaveBeenCalledOnce();
         // should only contain the not filtered exercises
         expect(component.ngxData[0].series.map((exercise: any) => exercise.exerciseId)).toEqual([0, 1, 3, 6, 7, 8, 9]);
 
         component.filteredExerciseIDs = [];
         component.ngOnChanges();
-        expect(getScoresStub).toHaveBeenCalledTimes(1);
+        expect(getScoresStub).toHaveBeenCalledOnce();
         expect(component.ngxData[0].series.map((exercise: any) => exercise.exerciseId)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     });
 
@@ -175,8 +175,8 @@ describe('ExerciseScoresChartComponent', () => {
         expect(component.numberOfActiveFilters).toBe(5);
 
         exerciseTypes.forEach((type, index) => {
-            expect(component.typeSet.has(type)).toBe(true);
-            expect(component.chartFilter.get(type)).toBe(true);
+            expect(component.typeSet.has(type)).toBeTrue();
+            expect(component.chartFilter.get(type)).toBeTrue();
 
             component.toggleType(type);
 

--- a/src/test/javascript/spec/component/overview/discussion-section/discussion-section.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/discussion-section/discussion-section.component.spec.ts
@@ -181,9 +181,9 @@ describe('PageDiscussionSectionComponent', () => {
         component.exercise = metisExercise;
         component.ngOnInit();
         tick();
-        expect(component.formGroup.get('filterToUnresolved')?.value).toBe(false);
-        expect(component.formGroup.get('filterToOwn')?.value).toBe(false);
-        expect(component.formGroup.get('filterToAnsweredOrReacted')?.value).toBe(false);
+        expect(component.formGroup.get('filterToUnresolved')?.value).toBeFalse();
+        expect(component.formGroup.get('filterToOwn')?.value).toBeFalse();
+        expect(component.formGroup.get('filterToAnsweredOrReacted')?.value).toBeFalse();
         fixture.detectChanges();
         const searchInput = getElement(fixture.debugElement, 'input[name=searchText]');
         expect(searchInput.textContent).toBe('');

--- a/src/test/javascript/spec/component/overview/discussion-section/discussion-section.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/discussion-section/discussion-section.component.spec.ts
@@ -264,9 +264,9 @@ describe('PageDiscussionSectionComponent', () => {
         tick();
         fixture.detectChanges();
 
-        expect(component.currentPostContextFilter.filterToUnresolved).toBe(true);
-        expect(component.currentPostContextFilter.filterToOwn).toBe(true);
-        expect(component.currentPostContextFilter.filterToAnsweredOrReacted).toBe(true);
+        expect(component.currentPostContextFilter.filterToUnresolved).toBeTrue();
+        expect(component.currentPostContextFilter.filterToOwn).toBeTrue();
+        expect(component.currentPostContextFilter.filterToAnsweredOrReacted).toBeTrue();
         expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledTimes(5);
     }));
 });

--- a/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
@@ -198,10 +198,10 @@ describe('CourseExerciseDetailsComponent', () => {
     it('should initialize', fakeAsync(() => {
         fixture.detectChanges();
         tick(500);
-        expect(comp.inProductionEnvironment).toBe(false);
+        expect(comp.inProductionEnvironment).toBeFalse();
         expect(comp.courseId).toBe(1);
         expect(comp.exercise).toStrictEqual(exercise);
-        expect(comp.hasMoreResults).toBe(false);
+        expect(comp.hasMoreResults).toBeFalse();
     }));
 
     it('should have student participations', fakeAsync(() => {
@@ -241,7 +241,7 @@ describe('CourseExerciseDetailsComponent', () => {
         expect(comp.courseId).toBe(1);
         expect(comp.studentParticipation?.exercise?.id).toBe(exerciseDetail.id);
         expect(comp.exercise!.studentParticipations![0].results![0]).toStrictEqual(changedResult);
-        expect(comp.hasMoreResults).toBe(false);
+        expect(comp.hasMoreResults).toBeFalse();
         expect(comp.exerciseRatedBadge(result)).toBe('bg-info');
     }));
 
@@ -274,7 +274,7 @@ describe('CourseExerciseDetailsComponent', () => {
         tick();
         flush();
 
-        expect(comp.wasSubmissionSimulated).toBe(false);
+        expect(comp.wasSubmissionSimulated).toBeFalse();
         expect(comp.exercise?.participationStatus).toBe(ParticipationStatus.EXERCISE_SUBMITTED);
     }));
 
@@ -282,36 +282,36 @@ describe('CourseExerciseDetailsComponent', () => {
         comp.showIfExampleSolutionPresent({ ...modelingExercise });
         expect(comp.exampleSolution).toBe(undefined);
         expect(comp.exampleSolutionUML).toEqual(JSON.parse(modelingExercise.exampleSolutionModel!));
-        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBe(false);
+        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBeFalse();
 
         comp.showIfExampleSolutionPresent({ ...exercise });
         expect(comp.exampleSolution).toBe(undefined);
         expect(comp.exampleSolutionUML).toBe(undefined);
-        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBe(false);
+        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBeFalse();
     });
 
     it('should fill & empty sample text solution', () => {
         comp.showIfExampleSolutionPresent({ ...textExercise });
         expect(comp.exampleSolution).not.toBe(undefined);
         expect(comp.exampleSolutionUML).toBe(undefined);
-        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBe(false);
+        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBeFalse();
 
         comp.showIfExampleSolutionPresent({ ...exercise });
         expect(comp.exampleSolution).toBe(undefined);
         expect(comp.exampleSolutionUML).toBe(undefined);
-        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBe(false);
+        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBeFalse();
     });
 
     it('should fill & empty sample file upload solution', () => {
         comp.showIfExampleSolutionPresent({ ...fileUploadExercise });
         expect(comp.exampleSolution).not.toBe(undefined);
         expect(comp.exampleSolutionUML).toBe(undefined);
-        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBe(false);
+        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBeFalse();
 
         comp.showIfExampleSolutionPresent({ ...exercise });
         expect(comp.exampleSolution).toBe(undefined);
         expect(comp.exampleSolutionUML).toBe(undefined);
-        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBe(false);
+        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBeFalse();
     });
 
     it('should fill & empty sample programming exercise solution', () => {
@@ -323,11 +323,11 @@ describe('CourseExerciseDetailsComponent', () => {
         comp.showIfExampleSolutionPresent({ ...programmingExercise, exampleSolutionPublished: false });
         expect(comp.exampleSolution).toBe(undefined);
         expect(comp.exampleSolutionUML).toBe(undefined);
-        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBe(false);
+        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBeFalse();
 
         comp.showIfExampleSolutionPresent({ ...exercise });
         expect(comp.exampleSolution).toBe(undefined);
         expect(comp.exampleSolutionUML).toBe(undefined);
-        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBe(false);
+        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/course-exercise-details.component.spec.ts
@@ -261,7 +261,7 @@ describe('CourseExerciseDetailsComponent', () => {
         );
         comp.simulateSubmission();
 
-        expect(comp.wasSubmissionSimulated).toBe(true);
+        expect(comp.wasSubmissionSimulated).toBeTrue();
     });
 
     it('should simulate a result', fakeAsync(() => {
@@ -318,7 +318,7 @@ describe('CourseExerciseDetailsComponent', () => {
         comp.showIfExampleSolutionPresent({ ...programmingExercise });
         expect(comp.exampleSolution).toBe(undefined);
         expect(comp.exampleSolutionUML).toBe(undefined);
-        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBe(true);
+        expect(comp.isProgrammingExerciseExampleSolutionPublished).toBeTrue();
 
         comp.showIfExampleSolutionPresent({ ...programmingExercise, exampleSolutionPublished: false });
         expect(comp.exampleSolution).toBe(undefined);

--- a/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/exercise-details-student-actions.component.spec.ts
@@ -147,7 +147,7 @@ describe('ExerciseDetailsStudentActionsComponent', () => {
         tick();
 
         expect(comp.participationStatusWrapper()).toEqual(ParticipationStatus.UNINITIALIZED);
-        expect(startExerciseStub).toHaveBeenCalledTimes(1);
+        expect(startExerciseStub).toHaveBeenCalledOnce();
         participationSubject.next(initPart);
 
         fixture.detectChanges();

--- a/src/test/javascript/spec/component/overview/exercise-details/lti-initializer.component.spec.ts
+++ b/src/test/javascript/spec/component/overview/exercise-details/lti-initializer.component.spec.ts
@@ -64,7 +64,7 @@ describe('LtiInitializerComponent', () => {
         initializeLTIUserStub.mockReturnValue(of({ body: { password: returnedPassword } }));
 
         comp.ngOnInit();
-        expect(initializeLTIUserStub).toHaveBeenCalledTimes(1);
+        expect(initializeLTIUserStub).toHaveBeenCalledOnce();
         expect(infoSpy).not.toHaveBeenCalled();
         expect(navigateSpy).not.toHaveBeenCalled();
         expect(comp.modalRef).not.toBe(undefined); // External reference
@@ -75,9 +75,9 @@ describe('LtiInitializerComponent', () => {
         initializeLTIUserStub.mockReturnValue(of({ body: { password: undefined } }));
 
         comp.ngOnInit();
-        expect(initializeLTIUserStub).toHaveBeenCalledTimes(1);
-        expect(infoSpy).toHaveBeenCalledTimes(1);
-        expect(navigateSpy).toHaveBeenCalledTimes(1);
+        expect(initializeLTIUserStub).toHaveBeenCalledOnce();
+        expect(infoSpy).toHaveBeenCalledOnce();
+        expect(navigateSpy).toHaveBeenCalledOnce();
         expect(comp.modalRef).toBe(undefined);
     });
 });

--- a/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/participation-submission/participation-submission.component.spec.ts
@@ -170,7 +170,7 @@ describe('ParticipationSubmissionComponent', () => {
         fixture.detectChanges();
         tick();
 
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
         // check if findAllSubmissionsOfParticipationStub() is called and works
         expect(findAllSubmissionsOfParticipationStub).toHaveBeenCalled();
         expect(comp.participation).toEqual(participation);
@@ -211,7 +211,7 @@ describe('ParticipationSubmissionComponent', () => {
         fixture.detectChanges();
         tick();
 
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
         expect(findWithTemplateAndSolutionParticipationStub).toHaveBeenCalled();
         expect(comp.exercise).toEqual(programmingExercise);
         expect(comp.participation).toEqual(templateParticipation);
@@ -248,7 +248,7 @@ describe('ParticipationSubmissionComponent', () => {
         fixture.detectChanges();
         tick();
 
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
         expect(findWithTemplateAndSolutionParticipationStub).toHaveBeenCalled();
         expect(comp.participation).toEqual(solutionParticipation);
         expect(comp.submissions).toEqual(solutionParticipation.submissions);

--- a/src/test/javascript/spec/component/participation/participation.component.spec.ts
+++ b/src/test/javascript/spec/component/participation/participation.component.spec.ts
@@ -95,11 +95,11 @@ describe('ParticipationComponent', () => {
         component.ngOnInit();
         tick();
 
-        expect(component.isLoading).toBe(false);
+        expect(component.isLoading).toBeFalse();
         expect(component.participations.length).toBe(1);
         expect(component.participations[0].id).toBe(participation.id);
-        expect(component.newManualResultAllowed).toBe(false);
-        expect(component.presentationScoreEnabled).toBe(false);
+        expect(component.newManualResultAllowed).toBeFalse();
+        expect(component.presentationScoreEnabled).toBeFalse();
 
         expect(exerciseFindStub).toHaveBeenCalledOnce();
         expect(exerciseFindStub).toHaveBeenCalledWith(theExercise.id);
@@ -121,11 +121,11 @@ describe('ParticipationComponent', () => {
         component.ngOnInit();
         tick();
 
-        expect(component.isLoading).toBe(false);
+        expect(component.isLoading).toBeFalse();
         expect(component.participations.length).toBe(1);
         expect(component.participations[0].id).toBe(participation.id);
-        expect(component.newManualResultAllowed).toBe(false);
-        expect(component.presentationScoreEnabled).toBe(false);
+        expect(component.newManualResultAllowed).toBeFalse();
+        expect(component.presentationScoreEnabled).toBeFalse();
         expect(component.exerciseSubmissionState).toEqual(submissionState);
 
         expect(exerciseFindStub).toHaveBeenCalledOnce();
@@ -187,15 +187,15 @@ describe('ParticipationComponent', () => {
 
         // Returns true only if submission count is 0
         component.participationCriteria.filterProp = component.FilterProp.NO_SUBMISSIONS;
-        expect(component.filterParticipationByProp(participation)).toBe(false);
+        expect(component.filterParticipationByProp(participation)).toBeFalse();
         participation.submissionCount = 0;
         expect(component.filterParticipationByProp(participation)).toBeTrue();
         participation.submissionCount = 1;
-        expect(component.filterParticipationByProp(participation)).toBe(false);
+        expect(component.filterParticipationByProp(participation)).toBeFalse();
 
         component.exerciseSubmissionState = {};
         component.participationCriteria.filterProp = component.FilterProp.FAILED;
-        expect(component.filterParticipationByProp(participation)).toBe(false);
+        expect(component.filterParticipationByProp(participation)).toBeFalse();
 
         // Test different submission states
         Object.values(ProgrammingSubmissionState).forEach((programmingSubmissionState) => {
@@ -269,7 +269,7 @@ describe('ParticipationComponent', () => {
         expect(updateDueDateStub).toHaveBeenCalledWith(component.exercise, expectedSent);
         expect(component.participations).toEqual(expectedSent);
         expect(component.participationsChangedDueDate).toEqual(new Map());
-        expect(component.isSaving).toBe(false);
+        expect(component.isSaving).toBeFalse();
     }));
 
     it('should remove a participation from the change map when it has been deleted', fakeAsync(() => {
@@ -388,7 +388,7 @@ describe('ParticipationComponent', () => {
             expect(component.checkPresentationScoreConfig()).toBeTrue();
 
             component.exercise = exercise2;
-            expect(component.checkPresentationScoreConfig()).toBe(false);
+            expect(component.checkPresentationScoreConfig()).toBeFalse();
         });
     });
 });

--- a/src/test/javascript/spec/component/participation/participation.component.spec.ts
+++ b/src/test/javascript/spec/component/participation/participation.component.spec.ts
@@ -101,9 +101,9 @@ describe('ParticipationComponent', () => {
         expect(component.newManualResultAllowed).toBe(false);
         expect(component.presentationScoreEnabled).toBe(false);
 
-        expect(exerciseFindStub).toHaveBeenCalledTimes(1);
+        expect(exerciseFindStub).toHaveBeenCalledOnce();
         expect(exerciseFindStub).toHaveBeenCalledWith(theExercise.id);
-        expect(participationFindStub).toHaveBeenCalledTimes(1);
+        expect(participationFindStub).toHaveBeenCalledOnce();
         expect(participationFindStub).toHaveBeenCalledWith(participation.id, true);
     }));
 
@@ -128,11 +128,11 @@ describe('ParticipationComponent', () => {
         expect(component.presentationScoreEnabled).toBe(false);
         expect(component.exerciseSubmissionState).toEqual(submissionState);
 
-        expect(exerciseFindStub).toHaveBeenCalledTimes(1);
+        expect(exerciseFindStub).toHaveBeenCalledOnce();
         expect(exerciseFindStub).toHaveBeenCalledWith(theExercise.id);
-        expect(participationFindStub).toHaveBeenCalledTimes(1);
+        expect(participationFindStub).toHaveBeenCalledOnce();
         expect(participationFindStub).toHaveBeenCalledWith(participation.id, true);
-        expect(submissionGetStateStub).toHaveBeenCalledTimes(1);
+        expect(submissionGetStateStub).toHaveBeenCalledOnce();
         expect(submissionGetStateStub).toHaveBeenCalledWith(participation.id);
     }));
 
@@ -183,13 +183,13 @@ describe('ParticipationComponent', () => {
         const participation: StudentParticipation = { id: 1, student, team };
 
         component.participationCriteria.filterProp = component.FilterProp.ALL;
-        expect(component.filterParticipationByProp(participation)).toBe(true);
+        expect(component.filterParticipationByProp(participation)).toBeTrue();
 
         // Returns true only if submission count is 0
         component.participationCriteria.filterProp = component.FilterProp.NO_SUBMISSIONS;
         expect(component.filterParticipationByProp(participation)).toBe(false);
         participation.submissionCount = 0;
-        expect(component.filterParticipationByProp(participation)).toBe(true);
+        expect(component.filterParticipationByProp(participation)).toBeTrue();
         participation.submissionCount = 1;
         expect(component.filterParticipationByProp(participation)).toBe(false);
 
@@ -265,7 +265,7 @@ describe('ParticipationComponent', () => {
         component.saveChangedDueDates();
         tick();
 
-        expect(updateDueDateStub).toHaveBeenCalledTimes(1);
+        expect(updateDueDateStub).toHaveBeenCalledOnce();
         expect(updateDueDateStub).toHaveBeenCalledWith(component.exercise, expectedSent);
         expect(component.participations).toEqual(expectedSent);
         expect(component.participationsChangedDueDate).toEqual(new Map());
@@ -285,7 +285,7 @@ describe('ParticipationComponent', () => {
         component.deleteParticipation(1, {});
         tick();
 
-        expect(deleteStub).toHaveBeenCalledTimes(1);
+        expect(deleteStub).toHaveBeenCalledOnce();
         expect(component.participationsChangedDueDate).toEqual(new Map());
     }));
 
@@ -348,7 +348,7 @@ describe('ParticipationComponent', () => {
             component.addPresentation(participation);
             tick();
 
-            expect(updateStub).toHaveBeenCalledTimes(1);
+            expect(updateStub).toHaveBeenCalledOnce();
             expect(updateStub).toHaveBeenCalledWith(exercise1, participation);
         }));
 
@@ -369,7 +369,7 @@ describe('ParticipationComponent', () => {
             component.removePresentation(participation);
             tick();
 
-            expect(updateStub).toHaveBeenCalledTimes(1);
+            expect(updateStub).toHaveBeenCalledOnce();
             expect(updateStub).toHaveBeenCalledWith(exercise1, participation);
         }));
 
@@ -385,7 +385,7 @@ describe('ParticipationComponent', () => {
 
         it('should check if the presentation score actions should be displayed', () => {
             component.exercise = exercise1;
-            expect(component.checkPresentationScoreConfig()).toBe(true);
+            expect(component.checkPresentationScoreConfig()).toBeTrue();
 
             component.exercise = exercise2;
             expect(component.checkPresentationScoreConfig()).toBe(false);

--- a/src/test/javascript/spec/component/plagiarism/plagiarism-cases-instructor-view.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/plagiarism-cases-instructor-view.component.spec.ts
@@ -140,8 +140,8 @@ describe('Plagiarism Cases Student View Component', () => {
 
     it('should check if student has responded for a plagiarism case', () => {
         expect(component.hasStudentAnswer(plagiarismCase1)).toBeTrue();
-        expect(component.hasStudentAnswer(plagiarismCase2)).toBe(false);
-        expect(component.hasStudentAnswer(plagiarismCase3)).toBe(false);
+        expect(component.hasStudentAnswer(plagiarismCase2)).toBeFalse();
+        expect(component.hasStudentAnswer(plagiarismCase3)).toBeFalse();
     });
 
     it('should export plagiarism cases as CSV', () => {

--- a/src/test/javascript/spec/component/plagiarism/plagiarism-cases-instructor-view.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/plagiarism-cases-instructor-view.component.spec.ts
@@ -139,7 +139,7 @@ describe('Plagiarism Cases Student View Component', () => {
     });
 
     it('should check if student has responded for a plagiarism case', () => {
-        expect(component.hasStudentAnswer(plagiarismCase1)).toBe(true);
+        expect(component.hasStudentAnswer(plagiarismCase1)).toBeTrue();
         expect(component.hasStudentAnswer(plagiarismCase2)).toBe(false);
         expect(component.hasStudentAnswer(plagiarismCase3)).toBe(false);
     });
@@ -153,7 +153,7 @@ describe('Plagiarism Cases Student View Component', () => {
             'Student 2, Test Exercise 2, No verdict yet, -, -\n',
         ];
         component.exportPlagiarismCases();
-        expect(downloadSpy).toHaveBeenCalledTimes(1);
+        expect(downloadSpy).toHaveBeenCalledOnce();
         expect(downloadSpy).toHaveBeenCalledWith(new Blob(expectedBlob, { type: 'text/csv' }), 'plagiarism-cases.csv');
     });
 });

--- a/src/test/javascript/spec/component/plagiarism/plagiarism-inspector.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/plagiarism-inspector.component.spec.ts
@@ -261,7 +261,7 @@ describe('Plagiarism Inspector Component', () => {
     it('should be programming exercise', () => {
         comp.exercise = { type: ExerciseType.PROGRAMMING } as ProgrammingExercise;
 
-        expect(comp.isProgrammingExercise()).toBe(true);
+        expect(comp.isProgrammingExercise()).toBeTrue();
     });
 
     it('should not be programming exercise', () => {
@@ -276,9 +276,9 @@ describe('Plagiarism Inspector Component', () => {
 
         comp.showSimilarityDistribution(true);
 
-        expect(resetFilterStub).toHaveBeenCalledTimes(1);
-        expect(getLatestPlagiarismResultStub).toHaveBeenCalledTimes(1);
-        expect(comp.showRunDetails).toBe(true);
+        expect(resetFilterStub).toHaveBeenCalledOnce();
+        expect(getLatestPlagiarismResultStub).toHaveBeenCalledOnce();
+        expect(comp.showRunDetails).toBeTrue();
     });
 
     describe('test chart interactivity', () => {
@@ -289,11 +289,11 @@ describe('Plagiarism Inspector Component', () => {
 
             comp.filterByChart(range);
 
-            expect(filterComparisonsMock).toHaveBeenCalledTimes(1);
+            expect(filterComparisonsMock).toHaveBeenCalledOnce();
             expect(filterComparisonsMock).toHaveBeenCalledWith(range, comparisons);
             expect(comp.visibleComparisons).toEqual([]);
             expect(comp.sidebarOffset).toBe(0);
-            expect(comp.chartFilterApplied).toBe(true);
+            expect(comp.chartFilterApplied).toBeTrue();
 
             comp.resetFilter();
 

--- a/src/test/javascript/spec/component/plagiarism/plagiarism-inspector.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/plagiarism-inspector.component.spec.ts
@@ -126,7 +126,7 @@ describe('Plagiarism Inspector Component', () => {
 
         expect(websocketServiceSpy).toHaveBeenCalledWith(comp.getPlagarismDetectionTopic());
         expect(comp.getPlagarismDetectionTopic()).toEqual(`/topic/modeling-exercises/${modelingExercise.id}/plagiarism-check`);
-        expect(comp.detectionInProgress).toBe(false);
+        expect(comp.detectionInProgress).toBeFalse();
         expect(comp.plagiarismResult).toBe(modelingPlagiarismResult);
     }));
 
@@ -220,7 +220,7 @@ describe('Plagiarism Inspector Component', () => {
         jest.spyOn(comp, 'handlePlagiarismResult');
 
         comp.getLatestPlagiarismResult();
-        expect(comp.detectionInProgress).toBe(false);
+        expect(comp.detectionInProgress).toBeFalse();
 
         tick();
 
@@ -235,7 +235,7 @@ describe('Plagiarism Inspector Component', () => {
         jest.spyOn(comp, 'handlePlagiarismResult');
 
         comp.getLatestPlagiarismResult();
-        expect(comp.detectionInProgress).toBe(false);
+        expect(comp.detectionInProgress).toBeFalse();
 
         tick();
 
@@ -250,7 +250,7 @@ describe('Plagiarism Inspector Component', () => {
         jest.spyOn(comp, 'handlePlagiarismResult');
 
         comp.getLatestPlagiarismResult();
-        expect(comp.detectionInProgress).toBe(false);
+        expect(comp.detectionInProgress).toBeFalse();
 
         tick();
 
@@ -267,7 +267,7 @@ describe('Plagiarism Inspector Component', () => {
     it('should not be programming exercise', () => {
         comp.exercise = { type: ExerciseType.TEXT } as TextExercise;
 
-        expect(comp.isProgrammingExercise()).toBe(false);
+        expect(comp.isProgrammingExercise()).toBeFalse();
     });
 
     it('should trigger similarity distribution', () => {
@@ -299,7 +299,7 @@ describe('Plagiarism Inspector Component', () => {
 
             expect(comp.visibleComparisons).toEqual(comparisons);
             expect(comp.sidebarOffset).toBe(0);
-            expect(comp.chartFilterApplied).toBe(false);
+            expect(comp.chartFilterApplied).toBeFalse();
         });
 
         it('should return the selected comparison', () => {

--- a/src/test/javascript/spec/component/plagiarism/plagiarism-run-details.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/plagiarism-run-details.component.spec.ts
@@ -79,7 +79,7 @@ describe('Plagiarism Run Details', () => {
 
         comp.onSelect(event);
 
-        expect(similaritySelectedStub).toHaveBeenCalledTimes(1);
+        expect(similaritySelectedStub).toHaveBeenCalledOnce();
         expect(similaritySelectedStub).toHaveBeenCalledWith({ minimumSimilarity: minimumBorder, maximumSimilarity: maximumBorder });
         jest.restoreAllMocks();
     });

--- a/src/test/javascript/spec/component/plagiarism/plagiarism-split-view.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/plagiarism-split-view.component.spec.ts
@@ -108,9 +108,9 @@ describe('Plagiarism Split View Component', () => {
 
         tick();
 
-        expect(comp.isProgrammingOrTextExercise).toBe(true);
+        expect(comp.isProgrammingOrTextExercise).toBeTrue();
         expect(comp.isModelingExercise).toBe(false);
-        expect(comp.parseTextMatches).toHaveBeenCalledTimes(1);
+        expect(comp.parseTextMatches).toHaveBeenCalledOnce();
     }));
 
     it('should subscribe to the split control subject', () => {
@@ -120,7 +120,7 @@ describe('Plagiarism Split View Component', () => {
         comp.ngOnInit();
 
         // eslint-disable-next-line deprecation/deprecation
-        expect(comp.splitControlSubject.subscribe).toHaveBeenCalledTimes(1);
+        expect(comp.splitControlSubject.subscribe).toHaveBeenCalledOnce();
     });
 
     it('should collapse the left pane', () => {

--- a/src/test/javascript/spec/component/plagiarism/plagiarism-split-view.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/plagiarism-split-view.component.spec.ts
@@ -109,7 +109,7 @@ describe('Plagiarism Split View Component', () => {
         tick();
 
         expect(comp.isProgrammingOrTextExercise).toBeTrue();
-        expect(comp.isModelingExercise).toBe(false);
+        expect(comp.isModelingExercise).toBeFalse();
         expect(comp.parseTextMatches).toHaveBeenCalledOnce();
     }));
 

--- a/src/test/javascript/spec/component/plagiarism/split-pane-header.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/split-pane-header.component.spec.ts
@@ -61,7 +61,7 @@ describe('Plagiarism Split Pane Header Component', () => {
             files: { currentValue: files } as SimpleChange,
         });
 
-        expect(comp.selectFile.emit).toHaveBeenCalledTimes(1);
+        expect(comp.selectFile.emit).toHaveBeenCalledOnce();
         expect(comp.selectFile.emit).toHaveBeenCalledWith(files[0]);
     });
 
@@ -87,7 +87,7 @@ describe('Plagiarism Split Pane Header Component', () => {
 
         expect(comp.activeFileIndex).toBe(idx);
         expect(comp.showFiles).toBe(false);
-        expect(comp.selectFile.emit).toHaveBeenCalledTimes(1);
+        expect(comp.selectFile.emit).toHaveBeenCalledOnce();
         expect(comp.selectFile.emit).toHaveBeenCalledWith(files[idx]);
     });
 
@@ -98,7 +98,7 @@ describe('Plagiarism Split Pane Header Component', () => {
     it('has files', () => {
         comp.files = files;
 
-        expect(comp.hasFiles()).toBe(true);
+        expect(comp.hasFiles()).toBeTrue();
     });
 
     it('toggles "show files"', () => {
@@ -107,7 +107,7 @@ describe('Plagiarism Split Pane Header Component', () => {
 
         comp.toggleShowFiles();
 
-        expect(comp.showFiles).toBe(true);
+        expect(comp.showFiles).toBeTrue();
     });
 
     it('does not toggle "show files"', () => {

--- a/src/test/javascript/spec/component/plagiarism/split-pane-header.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/split-pane-header.component.spec.ts
@@ -68,7 +68,7 @@ describe('Plagiarism Split Pane Header Component', () => {
     it('does not find an active file', () => {
         const activeFile = comp.getActiveFile();
 
-        expect(activeFile).toBe(false);
+        expect(activeFile).toBeFalse();
     });
 
     it('returns the active file', () => {
@@ -86,13 +86,13 @@ describe('Plagiarism Split Pane Header Component', () => {
         comp.handleFileSelect(files[idx], idx);
 
         expect(comp.activeFileIndex).toBe(idx);
-        expect(comp.showFiles).toBe(false);
+        expect(comp.showFiles).toBeFalse();
         expect(comp.selectFile.emit).toHaveBeenCalledOnce();
         expect(comp.selectFile.emit).toHaveBeenCalledWith(files[idx]);
     });
 
     it('has no files', () => {
-        expect(comp.hasFiles()).toBe(false);
+        expect(comp.hasFiles()).toBeFalse();
     });
 
     it('has files', () => {
@@ -115,6 +115,6 @@ describe('Plagiarism Split Pane Header Component', () => {
 
         comp.toggleShowFiles();
 
-        expect(comp.showFiles).toBe(false);
+        expect(comp.showFiles).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
@@ -72,7 +72,7 @@ describe('Text Submission Viewer Component', () => {
         });
 
         expect(repositoryService.getRepositoryContent).toHaveBeenCalled();
-        expect(comp.isProgrammingExercise).toBe(true);
+        expect(comp.isProgrammingExercise).toBeTrue();
     });
 
     it('filters files of type FILE', () => {

--- a/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
@@ -60,7 +60,7 @@ describe('Text Submission Viewer Component', () => {
         });
 
         expect(textSubmissionService.getTextSubmission).toHaveBeenCalledWith(2);
-        expect(comp.isProgrammingExercise).toBe(false);
+        expect(comp.isProgrammingExercise).toBeFalse();
     });
 
     it('fetches a programming submission', () => {

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-inline-feedback.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-inline-feedback.component.spec.ts
@@ -57,7 +57,7 @@ describe('CodeEditorTutorAssessmentInlineFeedbackComponent', () => {
         expect(comp.feedback.reference).toBe(`file:${fileName}_line:${codeLine}`);
         expect(comp.feedback.type).toBe(FeedbackType.MANUAL);
 
-        expect(onUpdateFeedbackSpy).toHaveBeenCalledTimes(1);
+        expect(onUpdateFeedbackSpy).toHaveBeenCalledOnce();
         expect(onUpdateFeedbackSpy).toHaveBeenCalledWith(comp.feedback);
     });
 
@@ -65,7 +65,7 @@ describe('CodeEditorTutorAssessmentInlineFeedbackComponent', () => {
         const onEditFeedbackSpy = jest.spyOn(comp.onEditFeedback, 'emit');
         comp.editFeedback(codeLine);
 
-        expect(onEditFeedbackSpy).toHaveBeenCalledTimes(1);
+        expect(onEditFeedbackSpy).toHaveBeenCalledOnce();
         expect(onEditFeedbackSpy).toHaveBeenCalledWith(codeLine);
     });
 
@@ -73,7 +73,7 @@ describe('CodeEditorTutorAssessmentInlineFeedbackComponent', () => {
         const onCancelFeedbackSpy = jest.spyOn(comp.onCancelFeedback, 'emit');
         comp.cancelFeedback();
 
-        expect(onCancelFeedbackSpy).toHaveBeenCalledTimes(1);
+        expect(onCancelFeedbackSpy).toHaveBeenCalledOnce();
         expect(onCancelFeedbackSpy).toHaveBeenCalledWith(codeLine);
     });
 
@@ -83,10 +83,10 @@ describe('CodeEditorTutorAssessmentInlineFeedbackComponent', () => {
         const confirmSpy = jest.spyOn(window, 'confirm');
         comp.deleteFeedback();
 
-        expect(confirmSpy).toHaveBeenCalledTimes(1);
+        expect(confirmSpy).toHaveBeenCalledOnce();
         expect(confirmSpy).toHaveBeenCalledWith('artemisApp.feedback.delete.question');
 
-        expect(onDeleteFeedbackSpy).toHaveBeenCalledTimes(1);
+        expect(onDeleteFeedbackSpy).toHaveBeenCalledOnce();
         expect(onDeleteFeedbackSpy).toHaveBeenCalledWith(comp.feedback);
     });
 
@@ -111,7 +111,7 @@ describe('CodeEditorTutorAssessmentInlineFeedbackComponent', () => {
 
         comp.updateFeedback();
 
-        expect(comp.feedback.positive).toBe(true);
+        expect(comp.feedback.positive).toBeTrue();
     });
 
     it('should display the feedback text properly', () => {

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
@@ -414,7 +414,7 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
 
         expect(confirmSpy).toHaveBeenCalledOnce();
         tick(100);
-        expect(comp.cancelBusy).toBe(false);
+        expect(comp.cancelBusy).toBeFalse();
         expect(navigateBackStub).toHaveBeenCalledOnce();
         expect(cancelBackStub).toHaveBeenCalledOnce();
         flush();

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-manual-result.component.spec.ts
@@ -241,10 +241,10 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
         comp.ngOnInit();
         tick(100);
 
-        expect(getIdentityStub).toHaveBeenCalledTimes(1);
-        expect(lockAndGetProgrammingSubmissionParticipationStub).toHaveBeenCalledTimes(1);
-        expect(findBySubmissionIdStub).toHaveBeenCalledTimes(1);
-        expect(comp.isAssessor).toBe(true);
+        expect(getIdentityStub).toHaveBeenCalledOnce();
+        expect(lockAndGetProgrammingSubmissionParticipationStub).toHaveBeenCalledOnce();
+        expect(findBySubmissionIdStub).toHaveBeenCalledOnce();
+        expect(comp.isAssessor).toBeTrue();
         expect(comp.complaint).not.toBe(null);
         fixture.detectChanges();
 
@@ -266,7 +266,7 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
 
         comp.ngOnInit();
         tick(100);
-        expect(getProgrammingSubmissionForExerciseWithoutAssessmentStub).toHaveBeenCalledTimes(1);
+        expect(getProgrammingSubmissionForExerciseWithoutAssessmentStub).toHaveBeenCalledOnce();
         flush();
     }));
 
@@ -275,9 +275,9 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
         comp.ngOnInit();
         tick(100);
 
-        expect(getIdentityStub).toHaveBeenCalledTimes(1);
-        expect(lockAndGetProgrammingSubmissionParticipationStub).toHaveBeenCalledTimes(1);
-        expect(findBySubmissionIdStub).toHaveBeenCalledTimes(1);
+        expect(getIdentityStub).toHaveBeenCalledOnce();
+        expect(lockAndGetProgrammingSubmissionParticipationStub).toHaveBeenCalledOnce();
+        expect(findBySubmissionIdStub).toHaveBeenCalledOnce();
         expect(comp.complaint).toBe(undefined);
         fixture.detectChanges();
 
@@ -384,9 +384,9 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
         const alertElement = debugElement.queryAll(By.css('jhi-alert'));
 
         expect(comp.manualResult?.feedbacks?.length).toBe(3);
-        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.AUTOMATIC)).toBe(true);
-        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.MANUAL)).toBe(true);
-        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.MANUAL_UNREFERENCED)).toBe(true);
+        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.AUTOMATIC)).toBeTrue();
+        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.MANUAL)).toBeTrue();
+        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.MANUAL_UNREFERENCED)).toBeTrue();
         expect(alertElement).not.toBe(null);
 
         // Reset feedbacks
@@ -396,9 +396,9 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
         const alertElementSubmit = debugElement.queryAll(By.css('jhi-alert'));
 
         expect(comp.manualResult?.feedbacks?.length).toBe(3);
-        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.AUTOMATIC)).toBe(true);
-        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.MANUAL)).toBe(true);
-        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.MANUAL_UNREFERENCED)).toBe(true);
+        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.AUTOMATIC)).toBeTrue();
+        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.MANUAL)).toBeTrue();
+        expect(comp.manualResult?.feedbacks!.some((feedback) => feedback.type === FeedbackType.MANUAL_UNREFERENCED)).toBeTrue();
         expect(alertElementSubmit).not.toBe(null);
         flush();
     }));
@@ -412,11 +412,11 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
         const confirmSpy = jest.spyOn(window, 'confirm');
         comp.cancel();
 
-        expect(confirmSpy).toHaveBeenCalledTimes(1);
+        expect(confirmSpy).toHaveBeenCalledOnce();
         tick(100);
         expect(comp.cancelBusy).toBe(false);
-        expect(navigateBackStub).toHaveBeenCalledTimes(1);
-        expect(cancelBackStub).toHaveBeenCalledTimes(1);
+        expect(navigateBackStub).toHaveBeenCalledOnce();
+        expect(cancelBackStub).toHaveBeenCalledOnce();
         flush();
     }));
 
@@ -440,7 +440,7 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
             'assessment',
         ];
         const queryParams = { queryParams: { 'correction-round': 0 } };
-        expect(getProgrammingSubmissionForExerciseWithoutAssessmentStub).toHaveBeenCalledTimes(1);
+        expect(getProgrammingSubmissionForExerciseWithoutAssessmentStub).toHaveBeenCalledOnce();
         expect(routerStub).toHaveBeenCalledWith(url, queryParams);
         flush();
     }));
@@ -503,7 +503,7 @@ describe('CodeEditorTutorAssessmentContainerComponent', () => {
         comp.ngOnInit();
         tick(100);
         comp.onUpdateAssessmentAfterComplaint(new ComplaintResponse());
-        expect(updateAfterComplaintStub).toHaveBeenCalledTimes(1);
+        expect(updateAfterComplaintStub).toHaveBeenCalledOnce();
         expect(comp.manualResult!.score).toBe(100);
         flush();
     }));

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-repo-export-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-repo-export-dialog.component.spec.ts
@@ -107,9 +107,9 @@ describe('ProgrammingAssessmentRepoExportDialogComponent', () => {
 
         comp.exportRepos(exerciseId);
         tick();
-        expect(comp.repositoryExportOptions.addParticipantName).toBe(false);
+        expect(comp.repositoryExportOptions.addParticipantName).toBeFalse();
         expect(comp.repositoryExportOptions.hideStudentNameInZippedFolder).toBeTrue();
-        expect(comp.exportInProgress).toBe(false);
+        expect(comp.exportInProgress).toBeFalse();
         expect(exportReposStub).toHaveBeenCalledOnce();
     }));
 
@@ -123,7 +123,7 @@ describe('ProgrammingAssessmentRepoExportDialogComponent', () => {
         comp.exportRepos(exerciseId);
         tick();
         expect(comp.repositoryExportOptions.addParticipantName).toBeTrue();
-        expect(comp.exportInProgress).toBe(false);
+        expect(comp.exportInProgress).toBeFalse();
         expect(exportReposStub).toHaveBeenCalledOnce();
     }));
 
@@ -140,7 +140,7 @@ describe('ProgrammingAssessmentRepoExportDialogComponent', () => {
         comp.bulkExportRepos();
         tick();
         expect(comp.repositoryExportOptions.exportAllParticipants).toBeTrue();
-        expect(comp.exportInProgress).toBe(false);
+        expect(comp.exportInProgress).toBeFalse();
         expect(exportReposStub).toHaveBeenCalledTimes(2);
     }));
 });

--- a/src/test/javascript/spec/component/programming-assessment/programming-assessment-repo-export-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-assessment/programming-assessment-repo-export-dialog.component.spec.ts
@@ -108,7 +108,7 @@ describe('ProgrammingAssessmentRepoExportDialogComponent', () => {
         comp.exportRepos(exerciseId);
         tick();
         expect(comp.repositoryExportOptions.addParticipantName).toBe(false);
-        expect(comp.repositoryExportOptions.hideStudentNameInZippedFolder).toBe(true);
+        expect(comp.repositoryExportOptions.hideStudentNameInZippedFolder).toBeTrue();
         expect(comp.exportInProgress).toBe(false);
         expect(exportReposStub).toHaveBeenCalledOnce();
     }));
@@ -122,7 +122,7 @@ describe('ProgrammingAssessmentRepoExportDialogComponent', () => {
 
         comp.exportRepos(exerciseId);
         tick();
-        expect(comp.repositoryExportOptions.addParticipantName).toBe(true);
+        expect(comp.repositoryExportOptions.addParticipantName).toBeTrue();
         expect(comp.exportInProgress).toBe(false);
         expect(exportReposStub).toHaveBeenCalledOnce();
     }));
@@ -139,7 +139,7 @@ describe('ProgrammingAssessmentRepoExportDialogComponent', () => {
 
         comp.bulkExportRepos();
         tick();
-        expect(comp.repositoryExportOptions.exportAllParticipants).toBe(true);
+        expect(comp.repositoryExportOptions.exportAllParticipants).toBeTrue();
         expect(comp.exportInProgress).toBe(false);
         expect(exportReposStub).toHaveBeenCalledTimes(2);
     }));

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-configure-grading.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-configure-grading.component.spec.ts
@@ -322,7 +322,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         const saveButton = debugElement.query(By.css(saveTableButton));
         expect(saveButton).not.toBe(null);
-        expect(saveButton.nativeElement.disabled).toBe(true);
+        expect(saveButton.nativeElement.disabled).toBeTrue();
     });
 
     it('should create a datatable with the correct amount of rows when test cases come in (show inactive tests)', () => {
@@ -338,7 +338,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         const saveButton = debugElement.query(By.css(saveTableButton));
         expect(saveButton).not.toBe(null);
-        expect(saveButton.nativeElement.disabled).toBe(true);
+        expect(saveButton.nativeElement.disabled).toBeTrue();
     });
 
     it('should update test case when an input field is updated', () => {
@@ -391,7 +391,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
         fixture.detectChanges();
 
         let testThatWasUpdated = sortedTestCases(comp.testCases)[0];
-        expect(updateTestCasesStub).toHaveBeenCalledTimes(1);
+        expect(updateTestCasesStub).toHaveBeenCalledOnce();
         expect(updateTestCasesStub).toHaveBeenCalledWith(exerciseId, [new ProgrammingExerciseTestCaseUpdate(testThatWasUpdated.id, 20, 1, 2, testThatWasUpdated.visibility)]);
         expect(testThatWasUpdated.weight).toBe(20);
         expect(testThatWasUpdated.bonusMultiplier).toBe(2);
@@ -400,7 +400,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         testCasesChangedSubject.next(true);
         // Trigger button is now enabled because the tests were saved.
-        expect(comp.hasUpdatedGradingConfig).toBe(true);
+        expect(comp.hasUpdatedGradingConfig).toBeTrue();
 
         fixture.detectChanges();
 
@@ -432,7 +432,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
         fixture.detectChanges();
 
         testThatWasUpdated = sortedTestCases(comp.testCases)[0];
-        expect(updateTestCasesStub).toHaveBeenCalledTimes(1);
+        expect(updateTestCasesStub).toHaveBeenCalledOnce();
         expect(updateTestCasesStub).toHaveBeenCalledWith(exerciseId, [new ProgrammingExerciseTestCaseUpdate(testThatWasUpdated.id, 20, 1, 1, testThatWasUpdated.visibility)]);
         expect(testThatWasUpdated.weight).toBe(20);
         expect(testThatWasUpdated.bonusMultiplier).toBe(1);
@@ -486,7 +486,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
         saveButton.click();
 
         if (assessmentType === AssessmentType.AUTOMATIC) {
-            expect(alertServiceSpy).toHaveBeenCalledTimes(1);
+            expect(alertServiceSpy).toHaveBeenCalledOnce();
             expect(alertServiceSpy).toHaveBeenCalledWith('artemisApp.programmingExercise.configureGrading.testCases.weightSumError');
         } else {
             expect(alertServiceSpy).not.toHaveBeenCalled();
@@ -536,7 +536,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
         fixture.detectChanges();
 
         const testThatWasUpdated = sortedTestCases(comp.testCases)[0];
-        expect(updateTestCasesStub).toHaveBeenCalledTimes(1);
+        expect(updateTestCasesStub).toHaveBeenCalledOnce();
         expect(updateTestCasesStub).toHaveBeenCalledWith(exerciseId, [ProgrammingExerciseTestCaseUpdate.from(testThatWasUpdated)]);
     });
 
@@ -613,13 +613,13 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         fixture.detectChanges();
 
-        expect(updateTestCasesStub).toHaveBeenCalledTimes(1);
+        expect(updateTestCasesStub).toHaveBeenCalledOnce();
 
         expect(comp.changedTestCaseIds).toHaveLength(0);
         testCasesChangedSubject.next(true);
 
         // Reset button is now enabled because the tests were saved.
-        expect(comp.hasUpdatedGradingConfig).toBe(true);
+        expect(comp.hasUpdatedGradingConfig).toBeTrue();
 
         fixture.detectChanges();
 
@@ -631,7 +631,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         fixture.detectChanges();
 
-        expect(resetTestCasesStub).toHaveBeenCalledTimes(1);
+        expect(resetTestCasesStub).toHaveBeenCalledOnce();
         expect(resetTestCasesStub).toHaveBeenCalledWith(exerciseId);
         expect(comp.testCases).toEqual(testCases1);
         expect(comp.changedTestCaseIds).toHaveLength(0);
@@ -662,13 +662,13 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         fixture.detectChanges();
 
-        expect(updateCategoriesStub).toHaveBeenCalledTimes(1);
+        expect(updateCategoriesStub).toHaveBeenCalledOnce();
         expect(comp.changedCategoryIds).toHaveLength(0);
 
         testCasesChangedSubject.next(true);
 
         // Reset button is now enabled because the categories were saved.
-        expect(comp.hasUpdatedGradingConfig).toBe(true);
+        expect(comp.hasUpdatedGradingConfig).toBeTrue();
 
         fixture.detectChanges();
 
@@ -683,9 +683,9 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         fixture.detectChanges();
 
-        expect(resetCategoriesStub).toHaveBeenCalledTimes(1);
+        expect(resetCategoriesStub).toHaveBeenCalledOnce();
         expect(resetCategoriesStub).toHaveBeenCalledWith(exerciseId);
-        expect(loadStatisticsStub).toHaveBeenCalledTimes(1);
+        expect(loadStatisticsStub).toHaveBeenCalledOnce();
         expect(loadStatisticsStub).toHaveBeenCalledWith(exerciseId);
         expect(comp.staticCodeAnalysisCategoriesForTable).toEqual(codeAnalysisCategories1);
         expect(comp.changedCategoryIds).toHaveLength(0);
@@ -734,7 +734,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         fixture.detectChanges();
 
-        expect(updateCategoriesStub).toHaveBeenCalledTimes(1);
+        expect(updateCategoriesStub).toHaveBeenCalledOnce();
         expect(updateCategoriesStub).toHaveBeenCalledWith(exerciseId, [StaticCodeAnalysisCategoryUpdate.from(updatedCategory)]);
 
         const categoryThatWasUpdated = comp.staticCodeAnalysisCategoriesForTable.find((category) => category.id === updatedCategory.id)!;
@@ -744,7 +744,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
 
         testCasesChangedSubject.next(true);
         // Trigger button is now enabled because the tests were saved.
-        expect(comp.hasUpdatedGradingConfig).toBe(true);
+        expect(comp.hasUpdatedGradingConfig).toBeTrue();
     });
 
     it('should load the grading statistics correctly', () => {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-configure-grading.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-configure-grading.component.spec.ts
@@ -530,7 +530,7 @@ describe('ProgrammingExerciseConfigureGradingComponent', () => {
         updateTestCasesStub.mockReturnValue(of({ ...orderedTests[0], afterDueDate: true }));
         const saveTestCases = debugElement.query(By.css(saveTableButton));
         expect(saveTestCases).not.toBe(null);
-        expect(saveTestCases.nativeElement.disabled).toBe(false);
+        expect(saveTestCases.nativeElement.disabled).toBeFalse();
         saveTestCases.nativeElement.click();
 
         fixture.detectChanges();

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-detail.component.spec.ts
@@ -105,7 +105,7 @@ describe('ProgrammingExercise Management Detail Component', () => {
 
         comp.getAndShowFullDiff();
 
-        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledOnce();
         expect(modalService.open).toHaveBeenCalledWith(FullGitDiffReportModalComponent, { size: 'xl', backdrop: 'static' });
     });
 
@@ -123,8 +123,8 @@ describe('ProgrammingExercise Management Detail Component', () => {
             comp.ngOnInit();
 
             // THEN
-            expect(statisticsServiceStub).toHaveBeenCalledTimes(1);
-            expect(gitDiffReportStub).toHaveBeenCalledTimes(1);
+            expect(statisticsServiceStub).toHaveBeenCalledOnce();
+            expect(gitDiffReportStub).toHaveBeenCalledOnce();
             expect(comp.programmingExercise).toEqual(programmingExercise);
             expect(comp.isExamExercise).toBeFalse();
             expect(comp.doughnutStats.participationsInPercent).toEqual(100);
@@ -152,8 +152,8 @@ describe('ProgrammingExercise Management Detail Component', () => {
             comp.ngOnInit();
 
             // THEN
-            expect(statisticsServiceStub).toHaveBeenCalledTimes(1);
-            expect(gitDiffReportStub).toHaveBeenCalledTimes(1);
+            expect(statisticsServiceStub).toHaveBeenCalledOnce();
+            expect(gitDiffReportStub).toHaveBeenCalledOnce();
             expect(comp.programmingExercise).toEqual(programmingExercise);
             expect(comp.isExamExercise).toBeTrue();
             expect(comp.programmingExercise.gitDiffReport).not.toBe(undefined);
@@ -171,8 +171,8 @@ describe('ProgrammingExercise Management Detail Component', () => {
 
         comp.createStructuralSolutionEntries();
 
-        expect(exerciseService.createStructuralSolutionEntries).toHaveBeenCalledTimes(1);
-        expect(alertService.addAlert).toHaveBeenCalledTimes(1);
+        expect(exerciseService.createStructuralSolutionEntries).toHaveBeenCalledOnce();
+        expect(alertService.addAlert).toHaveBeenCalledOnce();
         expect(alertService.addAlert).toHaveBeenCalledWith({
             type: AlertType.SUCCESS,
             message: 'artemisApp.programmingExercise.createStructuralSolutionEntriesSuccess',
@@ -189,8 +189,8 @@ describe('ProgrammingExercise Management Detail Component', () => {
 
         comp.createBehavioralSolutionEntries();
 
-        expect(exerciseService.createBehavioralSolutionEntries).toHaveBeenCalledTimes(1);
-        expect(alertService.addAlert).toHaveBeenCalledTimes(1);
+        expect(exerciseService.createBehavioralSolutionEntries).toHaveBeenCalledOnce();
+        expect(alertService.addAlert).toHaveBeenCalledOnce();
         expect(alertService.addAlert).toHaveBeenCalledWith({
             type: AlertType.SUCCESS,
             message: 'artemisApp.programmingExercise.createBehavioralSolutionEntriesSuccess',

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-editable-instruction.component.spec.ts
@@ -206,7 +206,7 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
 
         forceRenderSubject.next();
 
-        expect(generateHtmlSubjectStub).toHaveBeenCalledTimes(1);
+        expect(generateHtmlSubjectStub).toHaveBeenCalledOnce();
 
         fixture.destroy();
         flush();
@@ -241,8 +241,8 @@ describe('ProgrammingExerciseEditableInstructionComponent', () => {
         comp.onAnalysisUpdate(analysis);
         tick();
 
-        expect(session.clearAnnotations).toHaveBeenCalledTimes(1);
-        expect(session.setAnnotations).toHaveBeenCalledTimes(1);
+        expect(session.clearAnnotations).toHaveBeenCalledOnce();
+        expect(session.setAnnotations).toHaveBeenCalledOnce();
         expect(session.setAnnotations).toHaveBeenCalledWith(expectedWarnings);
 
         fixture.destroy();

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction-analysis.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction-analysis.component.spec.ts
@@ -83,7 +83,7 @@ describe('ProgrammingExerciseInstructionInstructorAnalysis', () => {
             expect(comp.invalidTestCases).toEqual(invalidTestCases);
 
             // Check that an event with the updated analysis is emitted.
-            expect(emitAnalysisSpy).toHaveBeenCalledTimes(1);
+            expect(emitAnalysisSpy).toHaveBeenCalledOnce();
             expect(emitAnalysisSpy).toHaveBeenCalledWith(completeAnalysis);
 
             // Check rendered html.

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
@@ -147,8 +147,8 @@ describe('ProgrammingExerciseInstructionComponent', () => {
         expect(loadInitialResultStub).toHaveBeenCalledOnce();
         expect(comp.latestResult).toEqual(result);
         expect(updateMarkdownStub).toHaveBeenCalledOnce();
-        expect(comp.isInitial).toBe(false);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isInitial).toBeFalse();
+        expect(comp.isLoading).toBeFalse();
         fixture.detectChanges();
         expect(debugElement.query(By.css('#programming-exercise-instructions-loading'))).toBe(null);
         expect(debugElement.query(By.css('#programming-exercise-instructions-content'))).not.toBe(null);
@@ -174,8 +174,8 @@ describe('ProgrammingExerciseInstructionComponent', () => {
         expect(loadInitialResultStub).toHaveBeenCalledOnce();
         expect(comp.latestResult).toEqual(result);
         expect(updateMarkdownStub).toHaveBeenCalledOnce();
-        expect(comp.isInitial).toBe(false);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isInitial).toBeFalse();
+        expect(comp.isLoading).toBeFalse();
         fixture.detectChanges();
         expect(debugElement.query(By.css('#programming-exercise-instructions-loading'))).toBe(null);
         expect(debugElement.query(By.css('#programming-exercise-instructions-content'))).not.toBe(null);
@@ -207,8 +207,8 @@ describe('ProgrammingExerciseInstructionComponent', () => {
         expect(comp.latestResult).toBe(undefined);
         expect(updateMarkdownStub).not.toHaveBeenCalled();
         expect(noInstructionsAvailableSpy).toHaveBeenCalledOnce();
-        expect(comp.isInitial).toBe(false);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isInitial).toBeFalse();
+        expect(comp.isLoading).toBeFalse();
         fixture.detectChanges();
         expect(debugElement.query(By.css('#programming-exercise-instructions-loading'))).toBe(null);
         expect(debugElement.query(By.css('#programming-exercise-instructions-content'))).not.toBe(null);
@@ -269,8 +269,8 @@ describe('ProgrammingExerciseInstructionComponent', () => {
         expect(getLatestResultWithFeedbacks).toHaveBeenCalledOnce();
         expect(getLatestResultWithFeedbacks).toHaveBeenCalledWith(participation.id);
         expect(updateMarkdownStub).toHaveBeenCalledOnce();
-        expect(comp.isInitial).toBe(false);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isInitial).toBeFalse();
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('should create the steps task icons for the tasks in problem statement markdown (non legacy case)', fakeAsync(() => {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
@@ -117,7 +117,7 @@ describe('ProgrammingExerciseInstructionComponent', () => {
         expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledOnce();
         expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledWith(participation.id, true, exercise.id);
         expect(comp.participationSubscription).not.toEqual(oldSubscription);
-        expect(comp.isInitial).toBe(true);
+        expect(comp.isInitial).toBeTrue();
     });
 
     it('should try to fetch README.md from assignment repository if no problemStatement was provided', () => {
@@ -136,7 +136,7 @@ describe('ProgrammingExerciseInstructionComponent', () => {
         fixture.detectChanges();
         triggerChanges(comp);
         fixture.detectChanges();
-        expect(comp.isLoading).toBe(true);
+        expect(comp.isLoading).toBeTrue();
         expect(debugElement.query(By.css('#programming-exercise-instructions-loading'))).not.toBe(null);
         expect(debugElement.query(By.css('#programming-exercise-instructions-content'))).toBe(null);
         expect(getFileStub).toHaveBeenCalledOnce();
@@ -197,7 +197,7 @@ describe('ProgrammingExerciseInstructionComponent', () => {
 
         fixture.detectChanges();
         triggerChanges(comp);
-        expect(comp.isLoading).toBe(true);
+        expect(comp.isLoading).toBeTrue();
         expect(getFileStub).toHaveBeenCalledOnce();
         expect(getFileStub).toHaveBeenCalledWith(participation.id, 'README.md');
 

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-exercise-download-component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-exercise-download-component.spec.ts
@@ -45,7 +45,7 @@ describe('ProgrammingExerciseInstructorExerciseDownloadComponent', () => {
         const spy = jest.spyOn(service, 'exportInstructorExercise');
         component.exerciseId = 1;
         component.exportExercise();
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
         spy.mockRestore();
     });
 });

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-repo-download-component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-repo-download-component.spec.ts
@@ -47,7 +47,7 @@ describe('ProgrammingExerciseInstructorRepoDownloadComponent', () => {
             const exportInstructorRepositorySpy = jest.spyOn(service, 'exportInstructorRepository');
             component.repositoryType = repoType;
             component.exportRepository();
-            expect(exportInstructorRepositorySpy).toHaveBeenCalledTimes(1);
+            expect(exportInstructorRepositorySpy).toHaveBeenCalledOnce();
             exportInstructorRepositorySpy.mockRestore();
         });
     });

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-submission-state.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-submission-state.component.spec.ts
@@ -160,7 +160,7 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
 
         fixture.detectChanges();
 
-        expect(getExerciseSubmissionStateStub).toHaveBeenCalledTimes(1);
+        expect(getExerciseSubmissionStateStub).toHaveBeenCalledOnce();
         expect(getExerciseSubmissionStateStub).toHaveBeenCalledWith(exercise.id);
 
         expect(comp.hasFailedSubmissions).toBe(false);
@@ -170,7 +170,7 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
         expect(getTriggerAllButton()).not.toBe(null);
         expect(getTriggerAllButton().disabled).toBe(false);
         expect(getTriggerFailedButton()).not.toBe(null);
-        expect(getTriggerFailedButton().disabled).toBe(true);
+        expect(getTriggerFailedButton().disabled).toBeTrue();
         expect(getBuildState()).not.toBe(null);
     }));
 
@@ -197,7 +197,7 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
 
         expect(getExerciseSubmissionStateStub).toHaveBeenCalledWith(exercise.id);
 
-        expect(comp.hasFailedSubmissions).toBe(true);
+        expect(comp.hasFailedSubmissions).toBeTrue();
         expect(comp.isBuildingFailedSubmissions).toBe(false);
         expect(comp.buildingSummary).toEqual(compressedSummary);
 
@@ -228,7 +228,7 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
         // Button is clicked.
         triggerButton.click();
 
-        expect(comp.isBuildingFailedSubmissions).toBe(true);
+        expect(comp.isBuildingFailedSubmissions).toBeTrue();
         expect(getFailedSubmissionParticipationsForExerciseStub).toHaveBeenCalledWith(comp.exercise.id, ProgrammingSubmissionState.HAS_FAILED_SUBMISSION);
         expect(triggerAllStub).toHaveBeenCalledWith(comp.exercise.id, failedSubmissionParticipationIds);
 
@@ -262,7 +262,7 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
         getBuildRunStateSubject.next(BuildRunState.RUNNING);
         fixture.detectChanges();
 
-        expect(getTriggerAllButton().disabled).toBe(true);
+        expect(getTriggerAllButton().disabled).toBeTrue();
 
         getBuildRunStateSubject.next(BuildRunState.COMPLETED);
         fixture.detectChanges();

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-submission-state.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-submission-state.component.spec.ts
@@ -163,12 +163,12 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
         expect(getExerciseSubmissionStateStub).toHaveBeenCalledOnce();
         expect(getExerciseSubmissionStateStub).toHaveBeenCalledWith(exercise.id);
 
-        expect(comp.hasFailedSubmissions).toBe(false);
-        expect(comp.isBuildingFailedSubmissions).toBe(false);
+        expect(comp.hasFailedSubmissions).toBeFalse();
+        expect(comp.isBuildingFailedSubmissions).toBeFalse();
         expect(comp.buildingSummary).toEqual(compressedSummary);
 
         expect(getTriggerAllButton()).not.toBe(null);
-        expect(getTriggerAllButton().disabled).toBe(false);
+        expect(getTriggerAllButton().disabled).toBeFalse();
         expect(getTriggerFailedButton()).not.toBe(null);
         expect(getTriggerFailedButton().disabled).toBeTrue();
         expect(getBuildState()).not.toBe(null);
@@ -198,14 +198,14 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
         expect(getExerciseSubmissionStateStub).toHaveBeenCalledWith(exercise.id);
 
         expect(comp.hasFailedSubmissions).toBeTrue();
-        expect(comp.isBuildingFailedSubmissions).toBe(false);
+        expect(comp.isBuildingFailedSubmissions).toBeFalse();
         expect(comp.buildingSummary).toEqual(compressedSummary);
 
         expect(getResultEtaContainer()).not.toBe(null);
         expect(getTriggerAllButton()).not.toBe(null);
-        expect(getTriggerAllButton().disabled).toBe(false);
+        expect(getTriggerAllButton().disabled).toBeFalse();
         expect(getTriggerFailedButton()).not.toBe(null);
-        expect(getTriggerFailedButton().disabled).toBe(false);
+        expect(getTriggerFailedButton().disabled).toBeFalse();
         expect(getBuildState()).not.toBe(null);
     }));
 
@@ -223,7 +223,7 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
 
         const triggerButton = getTriggerFailedButton();
         expect(triggerButton).not.toBe(null);
-        expect(triggerButton.disabled).toBe(false);
+        expect(triggerButton.disabled).toBeFalse();
 
         // Button is clicked.
         triggerButton.click();
@@ -239,7 +239,7 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
 
         fixture.detectChanges();
 
-        expect(comp.isBuildingFailedSubmissions).toBe(false);
+        expect(comp.isBuildingFailedSubmissions).toBeFalse();
     });
 
     it('should disable the trigger all button while a build is running and re-enable it when it is complete', fakeAsync(() => {
@@ -257,7 +257,7 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
 
         fixture.detectChanges();
 
-        expect(getTriggerAllButton().disabled).toBe(false);
+        expect(getTriggerAllButton().disabled).toBeFalse();
 
         getBuildRunStateSubject.next(BuildRunState.RUNNING);
         fixture.detectChanges();
@@ -267,6 +267,6 @@ describe('ProgrammingExerciseInstructorSubmissionStateComponent', () => {
         getBuildRunStateSubject.next(BuildRunState.COMPLETED);
         fixture.detectChanges();
 
-        expect(getTriggerAllButton().disabled).toBe(false);
+        expect(getTriggerAllButton().disabled).toBeFalse();
     }));
 });

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-trigger-build-button.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instructor-trigger-build-button.component.spec.ts
@@ -66,13 +66,13 @@ describe('ProgrammingExercise Instructor Trigger Build Component', () => {
 
         comp.triggerBuild({ stopPropagation: jest.fn() });
 
-        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledOnce();
         expect(modalService.open).toHaveBeenCalledWith(ConfirmAutofocusModalComponent, {
             size: 'lg',
             keyboard: true,
         });
 
-        expect(submissionService.triggerBuild).toHaveBeenCalledTimes(1);
+        expect(submissionService.triggerBuild).toHaveBeenCalledOnce();
         expect(submissionService.triggerBuild).toHaveBeenCalledWith(participation.id, SubmissionType.INSTRUCTOR);
     });
 });

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-lifecycle.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-lifecycle.component.spec.ts
@@ -95,7 +95,7 @@ describe('ProgrammingExerciseLifecycleComponent', () => {
         comp.toggleAssessmentType();
 
         expect(comp.exercise.assessmentType).toBe(AssessmentType.SEMI_AUTOMATIC);
-        expect(comp.exercise.allowComplaintsForAutomaticAssessments).toBe(false);
+        expect(comp.exercise.allowComplaintsForAutomaticAssessments).toBeFalse();
     });
 
     it('should change assessment type from semi-automatic to automatic after toggling', () => {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-lifecycle.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-lifecycle.component.spec.ts
@@ -86,7 +86,7 @@ describe('ProgrammingExerciseLifecycleComponent', () => {
         comp.exercise.assessmentType = AssessmentType.AUTOMATIC;
         comp.toggleComplaintsType();
 
-        expect(comp.exercise.allowComplaintsForAutomaticAssessments).toBe(true);
+        expect(comp.exercise.allowComplaintsForAutomaticAssessments).toBeTrue();
     });
 
     it('should change assessment type from automatic to semi-automatic after toggling', () => {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-re-evaluate-button.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-re-evaluate-button.component.spec.ts
@@ -48,7 +48,7 @@ describe('ProgrammingExercise Re-Evaluate Button Component', () => {
         const button = fixture.debugElement.nativeElement.querySelector('#re-evaluate-button button');
         button.click();
 
-        expect(gradingService.reEvaluate).toHaveBeenCalledTimes(1);
+        expect(gradingService.reEvaluate).toHaveBeenCalledOnce();
         expect(gradingService.reEvaluate).toHaveBeenCalledWith(programmingExercise.id);
     });
 });

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-test-schedule-date-picker.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-test-schedule-date-picker.component.spec.ts
@@ -71,7 +71,7 @@ describe('ProgrammingExerciseTestScheduleDatePickerComponent', () => {
         comp.writeValue(updatedDayJsTime);
 
         expect(comp.selectedDate?.getDate()).toBe(updatedDateNumber);
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
     });
 
     it('should update date with date object and invoke change', () => {
@@ -81,7 +81,7 @@ describe('ProgrammingExerciseTestScheduleDatePickerComponent', () => {
         comp.writeValue(updatedDayJsTime);
 
         expect(comp.selectedDate?.getDate()).toBe(updatedDateNumber);
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledOnce();
     });
 
     it('should reset date and emit reset event', () => {

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-all-button.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-all-button.component.spec.ts
@@ -62,13 +62,13 @@ describe('ProgrammingExercise Trigger All Button Component', () => {
         const button = fixture.debugElement.nativeElement.querySelector('#trigger-all-button button');
         button.click();
 
-        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledOnce();
         expect(modalService.open).toHaveBeenCalledWith(ProgrammingExerciseInstructorTriggerAllDialogComponent, {
             size: 'lg',
             backdrop: 'static',
         });
 
-        expect(submissionService.triggerInstructorBuildForAllParticipationsOfExercise).toHaveBeenCalledTimes(1);
+        expect(submissionService.triggerInstructorBuildForAllParticipationsOfExercise).toHaveBeenCalledOnce();
         expect(submissionService.triggerInstructorBuildForAllParticipationsOfExercise).toHaveBeenCalledWith(programmingExercise.id);
     });
 });

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-build-button.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-trigger-build-button.component.spec.ts
@@ -121,7 +121,7 @@ describe('TriggerBuildButtonSpec', () => {
 
         // Click the button to start a build.
         triggerButton.click();
-        expect(triggerFailedBuildSpy).toHaveBeenCalledTimes(1);
+        expect(triggerFailedBuildSpy).toHaveBeenCalledOnce();
         expect(triggerBuildSpy).toHaveBeenCalledTimes(0);
 
         // After some time the created submission comes through the websocket, button is disabled until the build is done.

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -135,7 +135,7 @@ describe('ProgrammingExercise Management Update Component', () => {
 
             // THEN
             expect(programmingExerciseService.update).toHaveBeenCalledWith(entity, {});
-            expect(comp.isSaving).toBe(false);
+            expect(comp.isSaving).toBeFalse();
         }));
 
         it('Should call create service on save for new entity', fakeAsync(() => {
@@ -151,7 +151,7 @@ describe('ProgrammingExercise Management Update Component', () => {
 
             // THEN
             expect(programmingExerciseService.automaticSetup).toHaveBeenCalledWith(entity);
-            expect(comp.isSaving).toBe(false);
+            expect(comp.isSaving).toBeFalse();
         }));
 
         it('Should trim the exercise title before saving', fakeAsync(() => {
@@ -199,7 +199,7 @@ describe('ProgrammingExercise Management Update Component', () => {
 
             // THEN
             expect(exerciseGroupService.find).toHaveBeenCalledWith(courseId, examId, exerciseGroupId);
-            expect(comp.isSaving).toBe(false);
+            expect(comp.isSaving).toBeFalse();
             expect(comp.programmingExercise).toStrictEqual(expectedExamProgrammingExercise);
             expect(comp.isExamMode).toBeTrue();
         }));
@@ -227,9 +227,9 @@ describe('ProgrammingExercise Management Update Component', () => {
 
             // THEN
             expect(courseService.find).toHaveBeenCalledWith(courseId);
-            expect(comp.isSaving).toBe(false);
+            expect(comp.isSaving).toBeFalse();
             expect(comp.programmingExercise).toStrictEqual(expectedProgrammingExercise);
-            expect(comp.isExamMode).toBe(false);
+            expect(comp.isExamMode).toBeFalse();
         }));
     });
 
@@ -303,7 +303,7 @@ describe('ProgrammingExercise Management Update Component', () => {
             scaCheckbox = fixture.nativeElement.querySelector('#field_staticCodeAnalysisEnabled');
 
             expect(scaCheckbox).toBe(null);
-            expect(comp.programmingExercise.staticCodeAnalysisEnabled).toBe(false);
+            expect(comp.programmingExercise.staticCodeAnalysisEnabled).toBeFalse();
             expect(comp.programmingExercise.maxStaticCodeAnalysisPenalty).toBe(undefined);
             expect(comp.programmingExercise.programmingLanguage).toBe(ProgrammingLanguage.HASKELL);
         }));
@@ -357,7 +357,7 @@ describe('ProgrammingExercise Management Update Component', () => {
             // THEN
             expect(comp.selectedProgrammingLanguage).toBe(ProgrammingLanguage.C);
             expect(comp.selectedProjectType).toBe(ProjectType.FACT);
-            expect(comp.programmingExercise.staticCodeAnalysisEnabled).toBe(false);
+            expect(comp.programmingExercise.staticCodeAnalysisEnabled).toBeFalse();
             expect(comp.programmingExercise.maxStaticCodeAnalysisPenalty).toBe(undefined);
         }));
     });
@@ -401,8 +401,8 @@ describe('ProgrammingExercise Management Update Component', () => {
                 expect(comp.programmingExercise.maxStaticCodeAnalysisPenalty).toBe(maxPenalty);
                 expect(scaCheckbox.checked).toBe(scaActivatedOriginal);
                 expect(!!maxPenaltyInput).toBe(scaActivatedOriginal);
-                expect(recreateBuildPlanCheckbox.checked).toBe(false);
-                expect(updateTemplateCheckbox.checked).toBe(false);
+                expect(recreateBuildPlanCheckbox.checked).toBeFalse();
+                expect(updateTemplateCheckbox.checked).toBeFalse();
                 expect(comp.programmingExercise).toBe(programmingExercise);
                 expect(courseService.find).toHaveBeenCalledWith(courseId);
 

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -201,7 +201,7 @@ describe('ProgrammingExercise Management Update Component', () => {
             expect(exerciseGroupService.find).toHaveBeenCalledWith(courseId, examId, exerciseGroupId);
             expect(comp.isSaving).toBe(false);
             expect(comp.programmingExercise).toStrictEqual(expectedExamProgrammingExercise);
-            expect(comp.isExamMode).toBe(true);
+            expect(comp.isExamMode).toBeTrue();
         }));
     });
 
@@ -290,8 +290,8 @@ describe('ProgrammingExercise Management Update Component', () => {
             fixture.detectChanges();
             tick();
 
-            expect(scaCheckbox.checked).toBe(true);
-            expect(comp.programmingExercise.staticCodeAnalysisEnabled).toBe(true);
+            expect(scaCheckbox.checked).toBeTrue();
+            expect(comp.programmingExercise.staticCodeAnalysisEnabled).toBeTrue();
             expect(comp.programmingExercise.maxStaticCodeAnalysisPenalty).toBe(50);
 
             // Switch to another programming language not supporting sca
@@ -317,7 +317,7 @@ describe('ProgrammingExercise Management Update Component', () => {
             // THEN
             expect(courseService.find).toHaveBeenCalledWith(courseId);
             expect(comp.selectedProgrammingLanguage).toBe(ProgrammingLanguage.SWIFT);
-            expect(comp.staticCodeAnalysisAllowed).toBe(true);
+            expect(comp.staticCodeAnalysisAllowed).toBeTrue();
             expect(comp.packageNamePattern).toBe(comp.appNamePatternForSwift);
         }));
 
@@ -332,7 +332,7 @@ describe('ProgrammingExercise Management Update Component', () => {
             expect(courseService.find).toHaveBeenCalledWith(courseId);
             expect(comp.selectedProgrammingLanguage).toBe(ProgrammingLanguage.C);
             expect(comp.selectedProjectType).toBe(ProjectType.GCC);
-            expect(comp.staticCodeAnalysisAllowed).toBe(true);
+            expect(comp.staticCodeAnalysisAllowed).toBeTrue();
         }));
 
         it('Should activate SCA for Java', fakeAsync(() => {
@@ -343,7 +343,7 @@ describe('ProgrammingExercise Management Update Component', () => {
 
             // THEN
             expect(comp.selectedProgrammingLanguage).toBe(ProgrammingLanguage.JAVA);
-            expect(comp.staticCodeAnalysisAllowed).toBe(true);
+            expect(comp.staticCodeAnalysisAllowed).toBeTrue();
             expect(comp.packageNamePattern).toBe(comp.packageNamePatternForJavaKotlin);
         }));
 
@@ -395,7 +395,7 @@ describe('ProgrammingExercise Management Update Component', () => {
                 const recreateBuildPlanCheckbox = fixture.nativeElement.querySelector('#field_recreateBuildPlans');
                 const updateTemplateCheckbox = fixture.nativeElement.querySelector('#field_updateTemplateFiles');
 
-                expect(comp.isImport).toBe(true);
+                expect(comp.isImport).toBeTrue();
                 expect(comp.originalStaticCodeAnalysisEnabled).toBe(scaActivatedOriginal);
                 expect(comp.programmingExercise.staticCodeAnalysisEnabled).toBe(scaActivatedOriginal);
                 expect(comp.programmingExercise.maxStaticCodeAnalysisPenalty).toBe(maxPenalty);
@@ -428,8 +428,8 @@ describe('ProgrammingExercise Management Update Component', () => {
                 expect(scaCheckbox.checked).toBe(!scaActivatedOriginal);
                 expect(comp.programmingExercise.staticCodeAnalysisEnabled).toBe(!scaActivatedOriginal);
                 expect(comp.programmingExercise.maxStaticCodeAnalysisPenalty).toBe(scaActivatedOriginal ? undefined : newMaxPenalty);
-                expect(comp.recreateBuildPlans).toBe(true);
-                expect(comp.updateTemplate).toBe(true);
+                expect(comp.recreateBuildPlans).toBeTrue();
+                expect(comp.updateTemplate).toBeTrue();
 
                 // Deactivate recreation of build plans
                 recreateBuildPlanCheckbox.click();

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise.component.spec.ts
@@ -279,7 +279,7 @@ describe('ProgrammingExercise Management Component', () => {
 
             // THEN
             expect(comp.isExerciseSelected(programmingExercise)).toBeTrue();
-            expect(comp.isExerciseSelected(programmingExercise2)).toBe(false);
+            expect(comp.isExerciseSelected(programmingExercise2)).toBeFalse();
         });
     });
 });

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise.component.spec.ts
@@ -112,9 +112,9 @@ describe('ProgrammingExercise Management Component', () => {
         comp.ngOnInit();
         comp.resetProgrammingExercise(456);
         expect(exerciseService.reset).toHaveBeenCalledWith(456);
-        expect(exerciseService.reset).toHaveBeenCalledTimes(1);
+        expect(exerciseService.reset).toHaveBeenCalledOnce();
         expect(mockSubscriber).toHaveBeenCalledWith('');
-        expect(mockSubscriber).toHaveBeenCalledTimes(1);
+        expect(mockSubscriber).toHaveBeenCalledOnce();
     });
 
     it('Should not reset exercise on error', () => {
@@ -127,9 +127,9 @@ describe('ProgrammingExercise Management Component', () => {
         comp.ngOnInit();
         comp.resetProgrammingExercise(456);
         expect(exerciseService.reset).toHaveBeenCalledWith(456);
-        expect(exerciseService.reset).toHaveBeenCalledTimes(1);
+        expect(exerciseService.reset).toHaveBeenCalledOnce();
         expect(mockSubscriber).toHaveBeenCalledWith(httpErrorResponse.message);
-        expect(mockSubscriber).toHaveBeenCalledTimes(1);
+        expect(mockSubscriber).toHaveBeenCalledOnce();
     });
 
     it('Should delete exercise', () => {
@@ -149,9 +149,9 @@ describe('ProgrammingExercise Management Component', () => {
         comp.ngOnInit();
         comp.deleteProgrammingExercise(456, { deleteStudentReposBuildPlans: true, deleteBaseReposBuildPlans: true });
         expect(programmingExerciseService.delete).toHaveBeenCalledWith(456, true, true);
-        expect(programmingExerciseService.delete).toHaveBeenCalledTimes(1);
+        expect(programmingExerciseService.delete).toHaveBeenCalledOnce();
         expect(mockSubscriber).toHaveBeenCalledWith('');
-        expect(mockSubscriber).toHaveBeenCalledTimes(1);
+        expect(mockSubscriber).toHaveBeenCalledOnce();
     });
 
     it('Should not delete exercise on error', () => {
@@ -164,9 +164,9 @@ describe('ProgrammingExercise Management Component', () => {
         comp.ngOnInit();
         comp.deleteProgrammingExercise(456, { deleteStudentReposBuildPlans: true, deleteBaseReposBuildPlans: true });
         expect(programmingExerciseService.delete).toHaveBeenCalledWith(456, true, true);
-        expect(programmingExerciseService.delete).toHaveBeenCalledTimes(1);
+        expect(programmingExerciseService.delete).toHaveBeenCalledOnce();
         expect(mockSubscriber).toHaveBeenCalledWith(httpErrorResponse.message);
-        expect(mockSubscriber).toHaveBeenCalledTimes(1);
+        expect(mockSubscriber).toHaveBeenCalledOnce();
     });
 
     it('Should open import modal', () => {
@@ -175,7 +175,7 @@ describe('ProgrammingExercise Management Component', () => {
 
         comp.openImportModal();
         expect(modalService.open).toHaveBeenCalledWith(ProgrammingExerciseImportComponent, { size: 'lg', backdrop: 'static' });
-        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledOnce();
     });
 
     it('Should open edit selected modal', () => {
@@ -184,7 +184,7 @@ describe('ProgrammingExercise Management Component', () => {
 
         comp.openEditSelectedModal();
         expect(modalService.open).toHaveBeenCalledWith(ProgrammingExerciseEditSelectedComponent, { size: 'xl', backdrop: 'static' });
-        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledOnce();
     });
 
     it('Should open repo export modal', () => {
@@ -193,7 +193,7 @@ describe('ProgrammingExercise Management Component', () => {
 
         comp.openRepoExportModal();
         expect(modalService.open).toHaveBeenCalledWith(ProgrammingAssessmentRepoExportDialogComponent, { size: 'lg', backdrop: 'static' });
-        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledOnce();
     });
 
     it('Should return exercise id', () => {
@@ -278,7 +278,7 @@ describe('ProgrammingExercise Management Component', () => {
             comp.toggleProgrammingExercise(programmingExercise);
 
             // THEN
-            expect(comp.isExerciseSelected(programmingExercise)).toBe(true);
+            expect(comp.isExerciseSelected(programmingExercise)).toBeTrue();
             expect(comp.isExerciseSelected(programmingExercise2)).toBe(false);
         });
     });

--- a/src/test/javascript/spec/component/programming-exercise/sca-category-distribution-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/sca-category-distribution-chart.component.spec.ts
@@ -153,7 +153,7 @@ describe('SCA category distribution chart', () => {
             component.onSelect(event);
 
             expect(emitStub).toHaveBeenCalledWith(77);
-            expect(component.tableFiltered).toBe(true);
+            expect(component.tableFiltered).toBeTrue();
         });
 
         it('should reset the table correctly', () => {

--- a/src/test/javascript/spec/component/programming-exercise/sca-category-distribution-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/sca-category-distribution-chart.component.spec.ts
@@ -162,7 +162,7 @@ describe('SCA category distribution chart', () => {
             component.resetTableFilter();
 
             expect(emitStub).toHaveBeenCalledWith(-5);
-            expect(component.tableFiltered).toBe(false);
+            expect(component.tableFiltered).toBeFalse();
         });
     });
 });

--- a/src/test/javascript/spec/component/programming-exercise/test-case-distribution-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/test-case-distribution-chart.component.spec.ts
@@ -191,7 +191,7 @@ describe('Test case distribution chart', () => {
         component.onSelectWeight(event);
 
         expect(emitStub).toHaveBeenCalledWith(5);
-        expect(component.tableFiltered).toBe(true);
+        expect(component.tableFiltered).toBeTrue();
     });
 
     it('should reset table correctly', () => {

--- a/src/test/javascript/spec/component/programming-exercise/test-case-distribution-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/test-case-distribution-chart.component.spec.ts
@@ -201,6 +201,6 @@ describe('Test case distribution chart', () => {
         component.resetTableFilter();
 
         expect(emitStub).toHaveBeenCalledWith(-5);
-        expect(component.tableFiltered).toBe(false);
+        expect(component.tableFiltered).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
@@ -300,20 +300,20 @@ describe('QuizExercise Management Detail Component', () => {
                 comp.quizExercise.releaseDate = now;
 
                 comp.validateDate();
-                expect(comp.quizExercise.dueDateError).toBe(false);
-                expect(comp.hasErrorInQuizBatches()).toBe(false);
+                expect(comp.quizExercise.dueDateError).toBeFalse();
+                expect(comp.hasErrorInQuizBatches()).toBeFalse();
 
                 comp.quizExercise!.quizBatches![0].startTime = now.add(1, 'days');
 
                 comp.validateDate();
-                expect(comp.quizExercise.dueDateError).toBe(false);
-                expect(comp.hasErrorInQuizBatches()).toBe(false);
+                expect(comp.quizExercise.dueDateError).toBeFalse();
+                expect(comp.hasErrorInQuizBatches()).toBeFalse();
 
                 comp.quizExercise.dueDate = now.add(2, 'days');
 
                 comp.validateDate();
-                expect(comp.quizExercise.dueDateError).toBe(false);
-                expect(comp.hasErrorInQuizBatches()).toBe(false);
+                expect(comp.quizExercise.dueDateError).toBeFalse();
+                expect(comp.hasErrorInQuizBatches()).toBeFalse();
             });
 
             it.each([[QuizMode.SYNCHRONIZED], [QuizMode.BATCHED], [QuizMode.INDIVIDUAL]])('should set errors to true for invalid dates for %s mode', (quizMode) => {
@@ -330,7 +330,7 @@ describe('QuizExercise Management Detail Component', () => {
                 comp.quizExercise!.quizBatches![0].startTime = now.add(-1, 'days');
 
                 comp.validateDate();
-                expect(comp.quizExercise.dueDateError).toBe(false);
+                expect(comp.quizExercise.dueDateError).toBeFalse();
                 expect(comp.hasErrorInQuizBatches()).toBeTrue();
 
                 comp.quizExercise.dueDate = now.add(-2, 'days');
@@ -343,7 +343,7 @@ describe('QuizExercise Management Detail Component', () => {
                 comp.quizExercise.dueDate = now.add(1, 'days');
 
                 comp.validateDate();
-                expect(comp.quizExercise.dueDateError).toBe(false);
+                expect(comp.quizExercise.dueDateError).toBeFalse();
                 if (quizMode !== QuizMode.SYNCHRONIZED) {
                     // dueDate for SYNCHRONIZED quizzes are calculated so no need to validate.
                     expect(comp.hasErrorInQuizBatches()).toBeTrue();
@@ -526,7 +526,7 @@ describe('QuizExercise Management Detail Component', () => {
         describe('unloading notification and can deactivate', () => {
             it('should return opposite of pendingChangesCache', () => {
                 comp.pendingChangesCache = true;
-                expect(comp.canDeactivate()).toBe(false);
+                expect(comp.canDeactivate()).toBeFalse();
                 comp.pendingChangesCache = false;
                 expect(comp.canDeactivate()).toBeTrue();
             });
@@ -560,7 +560,7 @@ describe('QuizExercise Management Detail Component', () => {
             });
 
             it('should return false if given month is same or after month we are in', () => {
-                expect(comp.isDateInPast(tomorrow, { month: 11 })).toBe(false);
+                expect(comp.isDateInPast(tomorrow, { month: 11 })).toBeFalse();
             });
 
             it('should return true if given date is before now', () => {
@@ -569,7 +569,7 @@ describe('QuizExercise Management Detail Component', () => {
             });
 
             it('should return false if given date is before now', () => {
-                expect(comp.isDateInPast(tomorrow, { month: 11 })).toBe(false);
+                expect(comp.isDateInPast(tomorrow, { month: 11 })).toBeFalse();
             });
         });
 
@@ -663,7 +663,7 @@ describe('QuizExercise Management Detail Component', () => {
                 comp.addExistingQuestions();
                 expect(verifyAndImportQuestionsStub).toBeCalledWith([exportedQuestion]);
                 expect(cacheValidationStub).toBeCalled();
-                expect(comp.showExistingQuestions).toBe(false);
+                expect(comp.showExistingQuestions).toBeFalse();
                 expect(comp.showExistingQuestionsFromCourse).toBeTrue();
                 expect(comp.selectedCourseId).toBeUndefined();
                 expect(comp.allExistingQuestions).toEqual([]);
@@ -924,14 +924,14 @@ describe('QuizExercise Management Detail Component', () => {
                 question.title = '';
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             };
 
             const removeCorrectMappingsAndExpectInvalidQuiz = (question: DragAndDropQuestion | ShortAnswerQuestion) => {
                 question.correctMappings = [];
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             };
 
             beforeEach(() => {
@@ -947,7 +947,7 @@ describe('QuizExercise Management Detail Component', () => {
             it('should not be valid without a quiz title', () => {
                 quizExercise.title = '';
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             describe('unknown question type', () => {
@@ -968,7 +968,7 @@ describe('QuizExercise Management Detail Component', () => {
                 it('should not be valid if a question has unknown type and no title', () => {
                     question.title = '';
                     comp.cacheValidation();
-                    expect(comp.quizIsValid).toBe(false);
+                    expect(comp.quizIsValid).toBeFalse();
                 });
             });
 
@@ -977,7 +977,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.points = -1;
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('should be valid with valid MC question', () => {
@@ -997,7 +997,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.answerOptions = [];
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('should be valid if MC question hint is <= 255 characters', () => {
@@ -1037,7 +1037,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.hint = 'f'.repeat(255 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('should not be valid if MC question explanation has more than 500 characters', () => {
@@ -1045,7 +1045,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.explanation = 'f'.repeat(500 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('should be valid if MC answer option hint has exactly 255 characters', () => {
@@ -1069,7 +1069,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.answerOptions![0]!.hint = 'f'.repeat(255 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('should not be valid if MC answer option explanation has more than 1000 characters', () => {
@@ -1077,7 +1077,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.answerOptions![0]!.explanation = 'f'.repeat(500 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('should be valid if MC question has scoring type single choice', () => {
@@ -1094,7 +1094,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.answerOptions![1]!.isCorrect = true;
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('should be valid with valid DnD question', () => {
@@ -1135,7 +1135,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.hint = 'f'.repeat(255 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('should not be valid if DnD question explanation has more than 500 characters', () => {
@@ -1143,7 +1143,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.explanation = 'f'.repeat(500 + 1);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('should be valid with valid SA question', () => {
@@ -1189,7 +1189,7 @@ describe('QuizExercise Management Detail Component', () => {
                 alertServiceStub = jest.spyOn(alertService, 'error');
                 saveQuizWithPendingChangesCache();
                 expect(alertServiceStub).toBeCalled();
-                expect(comp.isSaving).toBe(false);
+                expect(comp.isSaving).toBeFalse();
                 jestExpect(console.error).toHaveBeenCalled();
             };
 
@@ -1409,7 +1409,7 @@ describe('QuizExercise Management Detail Component', () => {
             it('should hide existing questions if already shown', () => {
                 comp.showExistingQuestions = true;
                 comp.showHideExistingQuestions();
-                expect(comp.showExistingQuestions).toBe(false);
+                expect(comp.showExistingQuestions).toBeFalse();
             });
 
             it('should set showExistingQuestionsFromCourse to given value', () => {
@@ -1418,15 +1418,15 @@ describe('QuizExercise Management Detail Component', () => {
                 const getElementStub = jest.spyOn(document, 'getElementById').mockReturnValue(control);
                 comp.setExistingQuestionSourceToCourse();
                 expect(comp.showExistingQuestionsFromCourse).toBeTrue();
-                expect(comp.showExistingQuestionsFromFile).toBe(false);
-                expect(comp.showExistingQuestionsFromExam).toBe(false);
+                expect(comp.showExistingQuestionsFromFile).toBeFalse();
+                expect(comp.showExistingQuestionsFromExam).toBeFalse();
                 comp.setExistingQuestionSourceToFile();
-                expect(comp.showExistingQuestionsFromCourse).toBe(false);
+                expect(comp.showExistingQuestionsFromCourse).toBeFalse();
                 expect(comp.showExistingQuestionsFromFile).toBeTrue();
-                expect(comp.showExistingQuestionsFromExam).toBe(false);
+                expect(comp.showExistingQuestionsFromExam).toBeFalse();
                 comp.setExistingQuestionSourceToExam();
-                expect(comp.showExistingQuestionsFromCourse).toBe(false);
-                expect(comp.showExistingQuestionsFromFile).toBe(false);
+                expect(comp.showExistingQuestionsFromCourse).toBeFalse();
+                expect(comp.showExistingQuestionsFromFile).toBeFalse();
                 expect(comp.showExistingQuestionsFromExam).toBeTrue();
                 expect(getElementStub).toBeCalled();
                 expect(control.value).toBe('');

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-exercise-detail.component.spec.ts
@@ -331,13 +331,13 @@ describe('QuizExercise Management Detail Component', () => {
 
                 comp.validateDate();
                 expect(comp.quizExercise.dueDateError).toBe(false);
-                expect(comp.hasErrorInQuizBatches()).toBe(true);
+                expect(comp.hasErrorInQuizBatches()).toBeTrue();
 
                 comp.quizExercise.dueDate = now.add(-2, 'days');
 
                 comp.validateDate();
-                expect(comp.quizExercise.dueDateError).toBe(true);
-                expect(comp.hasErrorInQuizBatches()).toBe(true);
+                expect(comp.quizExercise.dueDateError).toBeTrue();
+                expect(comp.hasErrorInQuizBatches()).toBeTrue();
 
                 comp.quizExercise!.quizBatches![0].startTime = now.add(1, 'days');
                 comp.quizExercise.dueDate = now.add(1, 'days');
@@ -346,7 +346,7 @@ describe('QuizExercise Management Detail Component', () => {
                 expect(comp.quizExercise.dueDateError).toBe(false);
                 if (quizMode !== QuizMode.SYNCHRONIZED) {
                     // dueDate for SYNCHRONIZED quizzes are calculated so no need to validate.
-                    expect(comp.hasErrorInQuizBatches()).toBe(true);
+                    expect(comp.hasErrorInQuizBatches()).toBeTrue();
                 }
             });
         });
@@ -528,7 +528,7 @@ describe('QuizExercise Management Detail Component', () => {
                 comp.pendingChangesCache = true;
                 expect(comp.canDeactivate()).toBe(false);
                 comp.pendingChangesCache = false;
-                expect(comp.canDeactivate()).toBe(true);
+                expect(comp.canDeactivate()).toBeTrue();
             });
 
             it('should set event return value to translate if not canDeactivate', () => {
@@ -556,7 +556,7 @@ describe('QuizExercise Management Detail Component', () => {
             });
 
             it('should return true if given month is before month we are in', () => {
-                expect(comp.isDateInPast(tomorrow, { month: 10 })).toBe(true);
+                expect(comp.isDateInPast(tomorrow, { month: 10 })).toBeTrue();
             });
 
             it('should return false if given month is same or after month we are in', () => {
@@ -565,7 +565,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should return true if given date is before now', () => {
                 const past = new NgbDate(2020, 11, 10);
-                expect(comp.isDateInPast(past, { month: 11 })).toBe(true);
+                expect(comp.isDateInPast(past, { month: 11 })).toBeTrue();
             });
 
             it('should return false if given date is before now', () => {
@@ -664,7 +664,7 @@ describe('QuizExercise Management Detail Component', () => {
                 expect(verifyAndImportQuestionsStub).toBeCalledWith([exportedQuestion]);
                 expect(cacheValidationStub).toBeCalled();
                 expect(comp.showExistingQuestions).toBe(false);
-                expect(comp.showExistingQuestionsFromCourse).toBe(true);
+                expect(comp.showExistingQuestionsFromCourse).toBeTrue();
                 expect(comp.selectedCourseId).toBeUndefined();
                 expect(comp.allExistingQuestions).toEqual([]);
                 expect(comp.existingQuestions).toEqual([]);
@@ -941,7 +941,7 @@ describe('QuizExercise Management Detail Component', () => {
 
             it('should be valid with default test setting', () => {
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should not be valid without a quiz title', () => {
@@ -962,7 +962,7 @@ describe('QuizExercise Management Detail Component', () => {
                 it('should be valid if a question has unknown type and a title', () => {
                     question.title = 'test';
                     comp.cacheValidation();
-                    expect(comp.quizIsValid).toBe(true);
+                    expect(comp.quizIsValid).toBeTrue();
                 });
 
                 it('should not be valid if a question has unknown type and no title', () => {
@@ -984,7 +984,7 @@ describe('QuizExercise Management Detail Component', () => {
                 const { question } = createValidMCQuestion();
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should not be valid if MC question has no title', () => {
@@ -1005,7 +1005,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.hint = 'This is an example hint';
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should be valid if MC question explanation is <= 500 characters', () => {
@@ -1013,7 +1013,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.explanation = 'This is an example explanation';
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should be valid if MC question hint has exactly 255 characters', () => {
@@ -1021,7 +1021,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.hint = 'f'.repeat(255);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should be valid if MC question explanation has exactly 500 characters', () => {
@@ -1029,7 +1029,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.explanation = 'f'.repeat(500);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should not be valid if MC question hint has more than 255 characters', () => {
@@ -1053,7 +1053,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.answerOptions![0]!.hint = 'f'.repeat(255);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should be valid if MC answer option explanation has exactly 500 characters', () => {
@@ -1061,7 +1061,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.answerOptions![0]!.explanation = 'f'.repeat(500);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should not be valid if MC answer option hint has more than 255 characters', () => {
@@ -1085,7 +1085,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.singleChoice = true;
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should not be valid if MC single choice question has multiple correct answers', () => {
@@ -1101,7 +1101,7 @@ describe('QuizExercise Management Detail Component', () => {
                 const { question } = createValidDnDQuestion();
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should not be valid if DnD question has no title', () => {
@@ -1119,7 +1119,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.hint = 'f'.repeat(255);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should be valid if DnD question explanation has exactly 500 characters', () => {
@@ -1127,7 +1127,7 @@ describe('QuizExercise Management Detail Component', () => {
                 question.explanation = 'f'.repeat(500);
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should not be valid if DnD question hint has more than 255 characters', () => {
@@ -1150,7 +1150,7 @@ describe('QuizExercise Management Detail Component', () => {
                 const { question } = createValidSAQuestion();
                 comp.quizExercise.quizQuestions = [question];
                 comp.cacheValidation();
-                expect(comp.quizIsValid).toBe(true);
+                expect(comp.quizIsValid).toBeTrue();
             });
 
             it('should not be valid if SA question has no title', () => {
@@ -1386,7 +1386,7 @@ describe('QuizExercise Management Detail Component', () => {
                 comp.showHideExistingQuestions();
                 expect(courseManagementServiceStub).toBeCalled();
                 expect(examManagementServiceStub).toBeCalled();
-                expect(comp.showExistingQuestions).toBe(true);
+                expect(comp.showExistingQuestions).toBeTrue();
                 expect(setQuestionsFromCourseSpy).toBeCalled();
             });
 
@@ -1417,17 +1417,17 @@ describe('QuizExercise Management Detail Component', () => {
                 const control = { ...element, value: 'test' };
                 const getElementStub = jest.spyOn(document, 'getElementById').mockReturnValue(control);
                 comp.setExistingQuestionSourceToCourse();
-                expect(comp.showExistingQuestionsFromCourse).toBe(true);
+                expect(comp.showExistingQuestionsFromCourse).toBeTrue();
                 expect(comp.showExistingQuestionsFromFile).toBe(false);
                 expect(comp.showExistingQuestionsFromExam).toBe(false);
                 comp.setExistingQuestionSourceToFile();
                 expect(comp.showExistingQuestionsFromCourse).toBe(false);
-                expect(comp.showExistingQuestionsFromFile).toBe(true);
+                expect(comp.showExistingQuestionsFromFile).toBeTrue();
                 expect(comp.showExistingQuestionsFromExam).toBe(false);
                 comp.setExistingQuestionSourceToExam();
                 expect(comp.showExistingQuestionsFromCourse).toBe(false);
                 expect(comp.showExistingQuestionsFromFile).toBe(false);
-                expect(comp.showExistingQuestionsFromExam).toBe(true);
+                expect(comp.showExistingQuestionsFromExam).toBeTrue();
                 expect(getElementStub).toBeCalled();
                 expect(control.value).toBe('');
             });

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-exercise.component.spec.ts
@@ -320,7 +320,7 @@ describe('QuizExercise Management Component', () => {
 
     it('Should return quiz is not over', () => {
         quizExercise.quizEnded = false;
-        expect(comp.quizIsOver(quizExercise)).toBe(false);
+        expect(comp.quizIsOver(quizExercise)).toBeFalse();
     });
 
     it('Should return quiz id', () => {

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-exercise.component.spec.ts
@@ -77,7 +77,7 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(service.findForCourse).toHaveBeenCalledTimes(1);
+        expect(service.findForCourse).toHaveBeenCalledOnce();
         expect(comp.quizExercises[0]).toEqual(quizExercise);
     });
 
@@ -96,7 +96,7 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.resetQuizExercise(456);
         expect(service.reset).toHaveBeenCalledWith(456);
-        expect(service.reset).toHaveBeenCalledTimes(1);
+        expect(service.reset).toHaveBeenCalledOnce();
     });
 
     it('Should open modal', () => {
@@ -105,7 +105,7 @@ describe('QuizExercise Management Component', () => {
 
         comp.openImportModal();
         expect(modalService.open).toHaveBeenCalledWith(QuizExerciseImportComponent, { size: 'lg', backdrop: 'static' });
-        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledOnce();
     });
 
     it('Should open quiz for practice', () => {
@@ -122,7 +122,7 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.openForPractice(456);
         expect(service.openForPractice).toHaveBeenCalledWith(456);
-        expect(service.openForPractice).toHaveBeenCalledTimes(1);
+        expect(service.openForPractice).toHaveBeenCalledOnce();
     });
 
     it('Should not open quiz for practice on error', () => {
@@ -141,10 +141,10 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.openForPractice(456);
         expect(service.openForPractice).toHaveBeenCalledWith(456);
-        expect(service.openForPractice).toHaveBeenCalledTimes(1);
-        expect(alertService.error).toHaveBeenCalledTimes(1);
+        expect(service.openForPractice).toHaveBeenCalledOnce();
+        expect(alertService.error).toHaveBeenCalledOnce();
         expect(service.find).toHaveBeenCalledWith(456);
-        expect(service.find).toHaveBeenCalledTimes(1);
+        expect(service.find).toHaveBeenCalledOnce();
     });
 
     it('Should start quiz', () => {
@@ -161,7 +161,7 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.startQuiz(456);
         expect(service.start).toHaveBeenCalledWith(456);
-        expect(service.start).toHaveBeenCalledTimes(1);
+        expect(service.start).toHaveBeenCalledOnce();
     });
 
     it('Should not start quiz on error', () => {
@@ -180,10 +180,10 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.startQuiz(456);
         expect(service.start).toHaveBeenCalledWith(456);
-        expect(service.start).toHaveBeenCalledTimes(1);
-        expect(alertService.error).toHaveBeenCalledTimes(1);
+        expect(service.start).toHaveBeenCalledOnce();
+        expect(alertService.error).toHaveBeenCalledOnce();
         expect(service.find).toHaveBeenCalledWith(456);
-        expect(service.find).toHaveBeenCalledTimes(1);
+        expect(service.find).toHaveBeenCalledOnce();
     });
 
     it('Should end quiz', () => {
@@ -200,7 +200,7 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.endQuiz(456);
         expect(service.end).toHaveBeenCalledWith(456);
-        expect(service.end).toHaveBeenCalledTimes(1);
+        expect(service.end).toHaveBeenCalledOnce();
     });
 
     it('Should add quiz batch', () => {
@@ -217,7 +217,7 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.addBatch(456);
         expect(service.addBatch).toHaveBeenCalledWith(456);
-        expect(service.addBatch).toHaveBeenCalledTimes(1);
+        expect(service.addBatch).toHaveBeenCalledOnce();
     });
 
     it('Should start quiz batch', () => {
@@ -234,7 +234,7 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.startBatch(456, 567);
         expect(service.startBatch).toHaveBeenCalledWith(567);
-        expect(service.startBatch).toHaveBeenCalledTimes(1);
+        expect(service.startBatch).toHaveBeenCalledOnce();
     });
 
     it('Should make quiz visible', () => {
@@ -251,7 +251,7 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.showQuiz(456);
         expect(service.setVisible).toHaveBeenCalledWith(456);
-        expect(service.setVisible).toHaveBeenCalledTimes(1);
+        expect(service.setVisible).toHaveBeenCalledOnce();
     });
 
     it('Should not make quiz visible on error', () => {
@@ -270,10 +270,10 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.showQuiz(456);
         expect(service.setVisible).toHaveBeenCalledWith(456);
-        expect(service.setVisible).toHaveBeenCalledTimes(1);
-        expect(alertService.error).toHaveBeenCalledTimes(1);
+        expect(service.setVisible).toHaveBeenCalledOnce();
+        expect(alertService.error).toHaveBeenCalledOnce();
         expect(service.find).toHaveBeenCalledWith(456);
-        expect(service.find).toHaveBeenCalledTimes(1);
+        expect(service.find).toHaveBeenCalledOnce();
     });
 
     it('Should delete quiz', () => {
@@ -290,7 +290,7 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.deleteQuizExercise(456);
         expect(service.delete).toHaveBeenCalledWith(456);
-        expect(service.delete).toHaveBeenCalledTimes(1);
+        expect(service.delete).toHaveBeenCalledOnce();
     });
 
     it('Should export quiz', () => {
@@ -308,14 +308,14 @@ describe('QuizExercise Management Component', () => {
         comp.ngOnInit();
         comp.exportQuizById(456, true);
         expect(service.find).toHaveBeenCalledWith(456);
-        expect(service.find).toHaveBeenCalledTimes(1);
+        expect(service.find).toHaveBeenCalledOnce();
         expect(service.exportQuiz).toHaveBeenCalledWith(undefined, true, 'Quiz Exercise');
-        expect(service.exportQuiz).toHaveBeenCalledTimes(1);
+        expect(service.exportQuiz).toHaveBeenCalledOnce();
     });
 
     it('Should return quiz is over', () => {
         quizExercise.quizEnded = true;
-        expect(comp.quizIsOver(quizExercise)).toBe(true);
+        expect(comp.quizIsOver(quizExercise)).toBeTrue();
     });
 
     it('Should return quiz is not over', () => {

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-re-evaluate.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-re-evaluate.component.spec.ts
@@ -123,9 +123,9 @@ describe('QuizExercise Re-evaluate Component', () => {
 
     it('Should initialize quiz exercise', () => {
         comp.ngOnInit();
-        expect(comp.isValidQuiz()).toBe(true);
+        expect(comp.isValidQuiz()).toBeTrue();
         expect(comp.quizExercise).toEqual(quizExercise);
-        expect(quizServiceFindStub).toHaveBeenCalledTimes(1);
+        expect(quizServiceFindStub).toHaveBeenCalledOnce();
     });
 
     it('Should create correct duration strings', () => {
@@ -164,7 +164,7 @@ describe('QuizExercise Re-evaluate Component', () => {
     it('Should have pending changes', () => {
         comp.ngOnInit();
         comp.quizExercise.quizQuestions![0].points = 5;
-        expect(comp.pendingChanges()).toBe(true);
+        expect(comp.pendingChanges()).toBeTrue();
     });
 
     it('Should move down the quiz question', () => {
@@ -199,7 +199,7 @@ describe('QuizExercise Re-evaluate Component', () => {
             comp.resetAll();
             comp.onQuestionUpdated();
 
-            expect(comp.quizIsValid).toBe(true);
+            expect(comp.quizIsValid).toBeTrue();
         });
 
         describe('Quiz mc question validation', () => {

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-re-evaluate.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-re-evaluate.component.spec.ts
@@ -216,7 +216,7 @@ describe('QuizExercise Re-evaluate Component', () => {
 
                 comp.onQuestionUpdated();
 
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('Should be invalid if quiz explanation is too long', () => {
@@ -225,7 +225,7 @@ describe('QuizExercise Re-evaluate Component', () => {
 
                 comp.onQuestionUpdated();
 
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('Should be invalid if answer option hint is too long', () => {
@@ -233,7 +233,7 @@ describe('QuizExercise Re-evaluate Component', () => {
 
                 comp.onQuestionUpdated();
 
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('Should be invalid if answer option explanation is too long', () => {
@@ -241,7 +241,7 @@ describe('QuizExercise Re-evaluate Component', () => {
 
                 comp.onQuestionUpdated();
 
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
         });
 
@@ -257,7 +257,7 @@ describe('QuizExercise Re-evaluate Component', () => {
 
                 comp.onQuestionUpdated();
 
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
 
             it('Should be invalid if question explanation is invalid', () => {
@@ -266,7 +266,7 @@ describe('QuizExercise Re-evaluate Component', () => {
 
                 comp.onQuestionUpdated();
 
-                expect(comp.quizIsValid).toBe(false);
+                expect(comp.quizIsValid).toBeFalse();
             });
         });
     });

--- a/src/test/javascript/spec/component/quiz-statistic/quiz-point-statistic.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-statistic/quiz-point-statistic.component.spec.ts
@@ -184,7 +184,7 @@ describe('QuizExercise Point Statistic Component', () => {
             // check
             expect(routerSpy).not.toHaveBeenCalled();
             expect(comp.quizExercise).toEqual(quizExercise);
-            expect(comp.waitingForQuizStart).toBe(false);
+            expect(comp.waitingForQuizStart).toBeFalse();
             expect(loadDataSpy).toHaveBeenCalled();
         });
     });

--- a/src/test/javascript/spec/component/quiz-statistic/quiz-point-statistic.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-statistic/quiz-point-statistic.component.spec.ts
@@ -100,7 +100,7 @@ describe('QuizExercise Point Statistic Component', () => {
             expect(quizServiceFindSpy).toHaveBeenCalledWith(42);
             expect(loadQuizSuccessSpy).toHaveBeenCalledWith(quizExercise);
             expect(comp.quizExerciseChannel).toEqual('/topic/courses/2/quizExercises');
-            expect(updateDisplayedTimesSpy).toHaveBeenCalledTimes(1);
+            expect(updateDisplayedTimesSpy).toHaveBeenCalledOnce();
             discardPeriodicTasks();
         }));
 

--- a/src/test/javascript/spec/component/quiz-statistic/quiz-statistics-footer.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-statistic/quiz-statistics-footer.component.spec.ts
@@ -82,7 +82,7 @@ describe('QuizExercise Statistic Footer Component', () => {
         expect(quizServiceFindSpy).toHaveBeenCalledWith(42);
         expect(loadSpy).toHaveBeenCalledWith(quizExercise);
         expect(comp.question).toEqual(question);
-        expect(updateDisplayedTimesSpy).toHaveBeenCalledTimes(1);
+        expect(updateDisplayedTimesSpy).toHaveBeenCalledOnce();
     }));
 
     it('should set quiz and update properties', () => {

--- a/src/test/javascript/spec/component/rating/rating.component.spec.ts
+++ b/src/test/javascript/spec/component/rating/rating.component.spec.ts
@@ -42,7 +42,7 @@ describe('RatingComponent', () => {
     it('should get rating', () => {
         jest.spyOn(ratingService, 'getRating');
         ratingComponent.ngOnInit();
-        expect(ratingService.getRating).toHaveBeenCalledTimes(1);
+        expect(ratingService.getRating).toHaveBeenCalledOnce();
         expect(ratingComponent.result?.id).toBe(89);
     });
 
@@ -97,7 +97,7 @@ describe('RatingComponent', () => {
                 newValue: 2,
                 starRating: new StarRatingComponent(),
             });
-            expect(ratingService.createRating).toHaveBeenCalledTimes(1);
+            expect(ratingService.createRating).toHaveBeenCalledOnce();
             expect(ratingService.updateRating).toHaveBeenCalledTimes(0);
             expect(ratingComponent.rating.result?.id).toBe(89);
             expect(ratingComponent.rating.rating).toBe(2);
@@ -110,7 +110,7 @@ describe('RatingComponent', () => {
                 newValue: 2,
                 starRating: new StarRatingComponent(),
             });
-            expect(ratingService.updateRating).toHaveBeenCalledTimes(1);
+            expect(ratingService.updateRating).toHaveBeenCalledOnce();
             expect(ratingService.createRating).toHaveBeenCalledTimes(0);
             expect(ratingComponent.rating.result?.id).toBe(89);
             expect(ratingComponent.rating.rating).toBe(2);

--- a/src/test/javascript/spec/component/shared/alert-overlay.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/alert-overlay.component.spec.ts
@@ -70,7 +70,7 @@ describe('Alert Overlay Component Tests', () => {
         btn.nativeElement.click();
 
         expect(callback).toHaveBeenCalledWith(alert);
-        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledOnce();
     });
 
     it('Should close the alert if the close icon is clicked', () => {
@@ -92,7 +92,7 @@ describe('Alert Overlay Component Tests', () => {
         btn.nativeElement.click();
 
         expect(onClose).toHaveBeenCalledWith(alert);
-        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledOnce();
         expect(alertService.get()).toHaveLength(0);
     });
 

--- a/src/test/javascript/spec/component/shared/button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/button.component.spec.ts
@@ -109,7 +109,7 @@ describe('ButtonComponent', () => {
 
         const button = getButton();
         expect(button).not.toBe(null);
-        expect(button.disabled).toBe(true);
+        expect(button.disabled).toBeTrue();
         button.click();
         tick();
 
@@ -129,7 +129,7 @@ describe('ButtonComponent', () => {
         button.click();
         tick();
 
-        expect(clickSpy).toHaveBeenCalledTimes(1);
+        expect(clickSpy).toHaveBeenCalledOnce();
     }));
 
     it('should show loading indicator when loading is set', fakeAsync(() => {
@@ -141,7 +141,7 @@ describe('ButtonComponent', () => {
 
         const button = getButton();
         expect(button).not.toBe(null);
-        expect(button.disabled).toBe(true);
+        expect(button.disabled).toBeTrue();
         const loadingIcon = getLoading();
         expect(loadingIcon).not.toBe(null);
 

--- a/src/test/javascript/spec/component/shared/button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/button.component.spec.ts
@@ -125,7 +125,7 @@ describe('ButtonComponent', () => {
 
         const button = getButton();
         expect(button).not.toBe(null);
-        expect(button.disabled).toBe(false);
+        expect(button.disabled).toBeFalse();
         button.click();
         tick();
 

--- a/src/test/javascript/spec/component/shared/category-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/category-selector.component.spec.ts
@@ -84,7 +84,7 @@ describe('Category Selector Component', () => {
         comp.onItemRemove(category2);
 
         expect(comp.categories).toEqual([category1, category3]);
-        expect(cancelColorSelectorSpy).toHaveBeenCalledTimes(1);
+        expect(cancelColorSelectorSpy).toHaveBeenCalledOnce();
         expect(emitSpy).toHaveBeenCalledWith([category1, category3]);
     });
 
@@ -143,7 +143,7 @@ describe('Category Selector Component', () => {
         comp.onItemAdd(event);
 
         expect(comp.categories).toEqual([category6]);
-        expect(emitSpy).not.toHaveBeenCalledTimes(1);
+        expect(emitSpy).not.toHaveBeenCalledOnce();
         expect(comp.categoryCtrl.value).toBe(null);
     });
 

--- a/src/test/javascript/spec/component/shared/color-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/color-selector.component.spec.ts
@@ -36,7 +36,7 @@ describe('ColorSelectorComponent', () => {
 
         expect(component.colorSelectorPosition).toEqual({ left: 0, top: 10 });
         expect(component.height).toBe(7);
-        expect(component.showColorSelector).toBe(true);
+        expect(component.showColorSelector).toBeTrue();
 
         component.showColorSelector = false;
 
@@ -44,7 +44,7 @@ describe('ColorSelectorComponent', () => {
 
         expect(component.colorSelectorPosition).toEqual({ left: 0, top: 65 });
         expect(component.height).toBe(7);
-        expect(component.showColorSelector).toBe(true);
+        expect(component.showColorSelector).toBeTrue();
     });
 
     it('should set the tag colors correctly', () => {
@@ -95,13 +95,13 @@ describe('ColorSelectorComponent', () => {
 
         component.clickOutside(event);
 
-        expect(component.showColorSelector).toBe(true);
+        expect(component.showColorSelector).toBeTrue();
 
         target.className = 'color-preview';
 
         component.clickOutside(event);
 
-        expect(component.showColorSelector).toBe(true);
+        expect(component.showColorSelector).toBeTrue();
 
         target.className = 'jhi-alert';
 

--- a/src/test/javascript/spec/component/shared/color-selector.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/color-selector.component.spec.ts
@@ -72,7 +72,7 @@ describe('ColorSelectorComponent', () => {
         DEFAULT_COLORS.forEach((color) => {
             component.showColorSelector = true;
             component.selectColorForTag(color);
-            expect(component.showColorSelector).toBe(false);
+            expect(component.showColorSelector).toBeFalse();
             expect(emitMock).toHaveBeenCalledWith(color);
         });
     });
@@ -81,7 +81,7 @@ describe('ColorSelectorComponent', () => {
         component.showColorSelector = true;
         component.cancelColorSelector();
 
-        expect(component.showColorSelector).toBe(false);
+        expect(component.showColorSelector).toBeFalse();
     });
 
     it('should close the color selector correctly', () => {
@@ -107,6 +107,6 @@ describe('ColorSelectorComponent', () => {
 
         component.clickOutside(event);
 
-        expect(component.showColorSelector).toBe(false);
+        expect(component.showColorSelector).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/shared/course-exam-archive-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/course-exam-archive-button.component.spec.ts
@@ -194,7 +194,7 @@ describe('Course Exam Archive Button Component', () => {
             const archiveState: CourseExamArchiveState = { exportState: 'COMPLETED', message: '' };
             comp.handleArchiveStateChanges(archiveState);
 
-            expect(comp.isBeingArchived).toBe(false);
+            expect(comp.isBeingArchived).toBeFalse();
             expect(comp.archiveButtonText).toEqual(comp.getArchiveButtonText());
             expect(alertServiceSpy).toBeCalled();
             expect(comp.course).toBeDefined();
@@ -210,7 +210,7 @@ describe('Course Exam Archive Button Component', () => {
             const archiveState: CourseExamArchiveState = { exportState: 'COMPLETED_WITH_WARNINGS', message: 'warning 1\nwarning 2' };
             comp.handleArchiveStateChanges(archiveState);
 
-            expect(comp.isBeingArchived).toBe(false);
+            expect(comp.isBeingArchived).toBeFalse();
             expect(comp.archiveButtonText).toEqual(comp.getArchiveButtonText());
             expect(comp.archiveWarnings).toEqual(archiveState.message.split('\n'));
             expect(comp.course).toBeDefined();
@@ -248,7 +248,7 @@ describe('Course Exam Archive Button Component', () => {
             comp.cleanupCourse();
 
             expect(cleanupStub).toBeCalledTimes(0);
-            expect(comp.canCleanupCourse()).toBe(false);
+            expect(comp.canCleanupCourse()).toBeFalse();
         }));
 
         it('should download archive for exam', fakeAsync(() => {
@@ -278,7 +278,7 @@ describe('Course Exam Archive Button Component', () => {
             const archiveState: CourseExamArchiveState = { exportState: 'COMPLETED', message: '' };
             comp.handleArchiveStateChanges(archiveState);
 
-            expect(comp.isBeingArchived).toBe(false);
+            expect(comp.isBeingArchived).toBeFalse();
             expect(comp.archiveButtonText).toEqual(comp.getArchiveButtonText());
             expect(alertServiceSpy).toBeCalled();
             expect(comp.exam).toBeDefined();

--- a/src/test/javascript/spec/component/shared/date-time-picker.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/date-time-picker.component.spec.ts
@@ -50,7 +50,7 @@ describe('FormDateTimePickerComponent', () => {
         it('should return null if dayjs is invalid', () => {
             const unconvertedDate = dayjs('2022-31-02T00:00+00:00');
 
-            expect(unconvertedDate.isValid()).toBe(false);
+            expect(unconvertedDate.isValid()).toBeFalse();
 
             convertedDate = component.convert(unconvertedDate);
 

--- a/src/test/javascript/spec/component/shared/date-time-picker.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/date-time-picker.component.spec.ts
@@ -30,7 +30,7 @@ describe('FormDateTimePickerComponent', () => {
 
         component.valueChanged();
 
-        expect(emitStub).toHaveBeenCalledTimes(1);
+        expect(emitStub).toHaveBeenCalledOnce();
     });
 
     describe('test date conversion', () => {
@@ -89,8 +89,8 @@ describe('FormDateTimePickerComponent', () => {
         component.updateField(newDate);
 
         expect(component.value).toEqual(newDate);
-        expect(onChangeSpy).toHaveBeenCalledTimes(1);
+        expect(onChangeSpy).toHaveBeenCalledOnce();
         expect(onChangeSpy).toHaveBeenCalledWith(newDate);
-        expect(valueChangedStub).toHaveBeenCalledTimes(1);
+        expect(valueChangedStub).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/shared/delete-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/delete-dialog.component.spec.ts
@@ -52,7 +52,7 @@ describe('DeleteDialogComponent', () => {
         const closeButton = fixture.debugElement.query(By.css('.btn-close'));
         expect(closeButton).not.toBeNull();
         closeButton.nativeElement.click();
-        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(closeSpy).toHaveBeenCalledOnce();
 
         const cancelButton = fixture.debugElement.query(By.css('.btn.btn-secondary'));
         expect(cancelButton).not.toBeNull();
@@ -114,7 +114,7 @@ describe('DeleteDialogComponent', () => {
         const clearStub = jest.spyOn(comp, 'clear');
         clearStub.mockReturnValue();
         dialogErrorSource.next('');
-        expect(clearStub).toHaveBeenCalledTimes(1);
+        expect(clearStub).toHaveBeenCalledOnce();
 
         fixture.destroy();
         flush();

--- a/src/test/javascript/spec/component/shared/exercise-scores-export-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/exercise-scores-export-button.component.spec.ts
@@ -227,8 +227,8 @@ describe('ExerciseScoresExportButtonComponent', () => {
         fixture.detectChanges();
 
         // THEN
-        expect(getResultsStub).toHaveBeenCalledTimes(1);
-        expect(exportAsCsvStub).toHaveBeenCalledTimes(1);
+        expect(getResultsStub).toHaveBeenCalledOnce();
+        expect(exportAsCsvStub).toHaveBeenCalledOnce();
         expect(exportAsCsvStub).toHaveBeenCalledWith(expectedCsvFilename, expectedCsvColumns, expectedCsvRows);
     }
 

--- a/src/test/javascript/spec/component/shared/exercise-update-warning.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/exercise-update-warning.component.spec.ts
@@ -38,7 +38,7 @@ describe('Exercise Update Warning Component Tests', () => {
 
         fixture.detectChanges();
 
-        expect(saveExerciseWithoutReevaluationSpy).toHaveBeenCalledTimes(1);
+        expect(saveExerciseWithoutReevaluationSpy).toHaveBeenCalledOnce();
         expect(emitSpy).toHaveBeenCalled();
     });
 
@@ -51,7 +51,7 @@ describe('Exercise Update Warning Component Tests', () => {
 
         fixture.detectChanges();
 
-        expect(reEvaluateExerciseSpy).toHaveBeenCalledTimes(1);
+        expect(reEvaluateExerciseSpy).toHaveBeenCalledOnce();
         expect(emitSpy).toHaveBeenCalled();
     });
 
@@ -64,8 +64,8 @@ describe('Exercise Update Warning Component Tests', () => {
 
         fixture.detectChanges();
 
-        expect(clearSpy).toHaveBeenCalledTimes(1);
-        expect(cancelledEmitSpy).toHaveBeenCalledTimes(1);
+        expect(clearSpy).toHaveBeenCalledOnce();
+        expect(cancelledEmitSpy).toHaveBeenCalledOnce();
     });
 
     it('should toggle deleteFeedback', () => {
@@ -73,6 +73,6 @@ describe('Exercise Update Warning Component Tests', () => {
 
         fixture.detectChanges();
 
-        expect(comp.deleteFeedback).toBe(true);
+        expect(comp.deleteFeedback).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/shared/export/export-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/export/export-button.component.spec.ts
@@ -34,6 +34,6 @@ describe('ExportButtonComponent', () => {
         comp.openExportModal(new MouseEvent('click'));
         const csvExportButton = fixture.debugElement.query(By.css('jhi-button'));
         expect(csvExportButton).not.toBe(null);
-        expect(modalServiceOpenStub).toHaveBeenCalledTimes(1);
+        expect(modalServiceOpenStub).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/shared/export/export-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/export/export-modal.component.spec.ts
@@ -64,7 +64,7 @@ describe('ExportModalComponent', () => {
         const closeButton = fixture.debugElement.query(By.css('button.btn-close'));
         expect(closeButton).not.toBeNull();
         closeButton.nativeElement.click();
-        expect(dismissSpy).toHaveBeenCalledTimes(1);
+        expect(dismissSpy).toHaveBeenCalledOnce();
 
         const cancelButton = fixture.debugElement.query(By.css('button.cancel'));
         expect(cancelButton).not.toBeNull();

--- a/src/test/javascript/spec/component/shared/metis/post/post.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/post/post.component.spec.ts
@@ -61,7 +61,7 @@ describe('PostComponent', () => {
         metisServiceIsPostResolvedStub.mockReturnValue(false);
         component.posting = metisPostExerciseUser1;
         component.ngOnInit();
-        expect(component.postIsResolved).toBe(false);
+        expect(component.postIsResolved).toBeFalse();
     });
 
     it('should be re-evaluated on changes', () => {

--- a/src/test/javascript/spec/component/shared/metis/post/post.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/post/post.component.spec.ts
@@ -71,7 +71,7 @@ describe('PostComponent', () => {
         component.ngOnInit();
         metisServiceIsPostResolvedStub.mockReturnValue(true);
         component.ngOnChanges();
-        expect(component.postIsResolved).toBe(true);
+        expect(component.postIsResolved).toBeTrue();
     });
 
     it('should contain a post header', () => {

--- a/src/test/javascript/spec/component/shared/metis/postings-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.spec.ts
@@ -126,7 +126,7 @@ describe('PostCreateEditModalComponent', () => {
         });
         tick();
         expect(component.isLoading).toBe(false);
-        expect(onCreateSpy).toHaveBeenCalledTimes(1);
+        expect(onCreateSpy).toHaveBeenCalledOnce();
     }));
 
     it('should invoke metis service with created announcement in overview', fakeAsync(() => {
@@ -157,7 +157,7 @@ describe('PostCreateEditModalComponent', () => {
         // debounce time of title input field
         tick(800);
         expect(component.isLoading).toBe(false);
-        expect(onCreateSpy).toHaveBeenCalledTimes(1);
+        expect(onCreateSpy).toHaveBeenCalledOnce();
     }));
 
     it('should invoke metis service with updated post in page section', fakeAsync(() => {

--- a/src/test/javascript/spec/component/shared/metis/postings-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.spec.ts
@@ -125,7 +125,7 @@ describe('PostCreateEditModalComponent', () => {
             metisLecture,
         });
         tick();
-        expect(component.isLoading).toBe(false);
+        expect(component.isLoading).toBeFalse();
         expect(onCreateSpy).toHaveBeenCalledOnce();
     }));
 
@@ -156,7 +156,7 @@ describe('PostCreateEditModalComponent', () => {
         });
         // debounce time of title input field
         tick(800);
-        expect(component.isLoading).toBe(false);
+        expect(component.isLoading).toBeFalse();
         expect(onCreateSpy).toHaveBeenCalledOnce();
     }));
 
@@ -183,7 +183,7 @@ describe('PostCreateEditModalComponent', () => {
             title: updatedTitle,
         });
         tick();
-        expect(component.isLoading).toBe(false);
+        expect(component.isLoading).toBeFalse();
     }));
 
     it('should invoke the modalService', () => {

--- a/src/test/javascript/spec/component/shared/metis/postings-header/post-header/post-header.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/metis/postings-header/post-header/post-header.component.spec.ts
@@ -76,7 +76,7 @@ describe('PostHeaderComponent', () => {
         fixture.detectChanges();
         expect(getElement(debugElement, '.deleteIcon')).not.toBe(null);
         component.deletePosting();
-        expect(metisServiceDeletePostMock).toHaveBeenCalledTimes(1);
+        expect(metisServiceDeletePostMock).toHaveBeenCalledOnce();
     });
 
     it('should not display edit and delete options to tutor if posting is announcement', () => {

--- a/src/test/javascript/spec/component/shared/notification/notification-popup.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/notification/notification-popup.component.spec.ts
@@ -72,13 +72,13 @@ describe('Notification Popup Component', () => {
         it('should get authentication state', () => {
             jest.spyOn(accountService, 'getAuthenticationState');
             notificationPopupComponent.ngOnInit();
-            expect(accountService.getAuthenticationState).toHaveBeenCalledTimes(1);
+            expect(accountService.getAuthenticationState).toHaveBeenCalledOnce();
         });
 
         it('should subscribe to notification updates', () => {
             jest.spyOn(notificationService, 'subscribeToNotificationUpdates');
             notificationPopupComponent.ngOnInit();
-            expect(notificationService.subscribeToNotificationUpdates).toHaveBeenCalledTimes(1);
+            expect(notificationService.subscribeToNotificationUpdates).toHaveBeenCalledOnce();
         });
     });
 
@@ -103,9 +103,9 @@ describe('Notification Popup Component', () => {
                 jest.spyOn(notificationPopupComponent, 'navigateToTarget').mockReturnValue();
                 const notificationElement = notificationPopupComponentFixture.debugElement.query(By.css('.notification-popup-container > div'));
                 notificationElement.nativeElement.click();
-                expect(notificationPopupComponent.removeNotification).toHaveBeenCalledTimes(1);
+                expect(notificationPopupComponent.removeNotification).toHaveBeenCalledOnce();
                 expect(notificationPopupComponent.notifications).toBeEmpty();
-                expect(notificationPopupComponent.navigateToTarget).toHaveBeenCalledTimes(1);
+                expect(notificationPopupComponent.navigateToTarget).toHaveBeenCalledOnce();
             });
 
             it('should navigate to quiz target when quiz notification is clicked', () => {
@@ -113,8 +113,8 @@ describe('Notification Popup Component', () => {
                 jest.spyOn(router, 'navigateByUrl');
                 const button = notificationPopupComponentFixture.debugElement.query(By.css('.notification-popup-container > div button'));
                 button.nativeElement.click();
-                expect(notificationPopupComponent.navigateToTarget).toHaveBeenCalledTimes(1);
-                expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
+                expect(notificationPopupComponent.navigateToTarget).toHaveBeenCalledOnce();
+                expect(router.navigateByUrl).toHaveBeenCalledOnce();
             });
         });
 
@@ -126,8 +126,8 @@ describe('Notification Popup Component', () => {
             jest.spyOn(examExerciseUpdateService, 'navigateToExamExercise').mockReturnValue();
             const button = notificationPopupComponentFixture.debugElement.query(By.css('.notification-popup-container > div button'));
             button.nativeElement.click();
-            expect(notificationPopupComponent.navigateToTarget).toHaveBeenCalledTimes(1);
-            expect(examExerciseUpdateService.navigateToExamExercise).toHaveBeenCalledTimes(1);
+            expect(notificationPopupComponent.navigateToTarget).toHaveBeenCalledOnce();
+            expect(examExerciseUpdateService.navigateToExamExercise).toHaveBeenCalledOnce();
         });
     });
 

--- a/src/test/javascript/spec/component/shared/notification/notification-sidebar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/notification/notification-sidebar.component.spec.ts
@@ -133,7 +133,7 @@ describe('Notification Sidebar Component', () => {
             const overlay = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('.notification-overlay');
             overlay.click();
             expect(notificationSidebarComponent.toggleSidebar).toHaveBeenCalledOnce();
-            expect(notificationSidebarComponent.showSidebar).toBe(false);
+            expect(notificationSidebarComponent.showSidebar).toBeFalse();
         });
 
         it('should close sidebar when user clicks on close button', () => {
@@ -142,7 +142,7 @@ describe('Notification Sidebar Component', () => {
             const close = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('.close');
             close.click();
             expect(notificationSidebarComponent.toggleSidebar).toHaveBeenCalledOnce();
-            expect(notificationSidebarComponent.showSidebar).toBe(false);
+            expect(notificationSidebarComponent.showSidebar).toBeFalse();
         });
 
         it('should close sidebar when user clicks on a notification', () => {
@@ -151,7 +151,7 @@ describe('Notification Sidebar Component', () => {
             notificationSidebarComponent.showSidebar = true;
             const notification = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('.notification-item');
             notification.click();
-            expect(notificationSidebarComponent.showSidebar).toBe(false);
+            expect(notificationSidebarComponent.showSidebar).toBeFalse();
         });
     });
 
@@ -303,7 +303,7 @@ describe('Notification Sidebar Component', () => {
             jest.spyOn(userService, 'updateNotificationVisibility');
             const hideUntilToggle = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('#hide-until-toggle');
             hideUntilToggle.click();
-            expect(notificationSidebarComponent.showButtonToHideCurrentlyDisplayedNotifications).toBe(false);
+            expect(notificationSidebarComponent.showButtonToHideCurrentlyDisplayedNotifications).toBeFalse();
             expect(notificationSidebarComponent.toggleNotificationDisplay).toHaveBeenCalledOnce();
             expect(userService.updateNotificationVisibility).toHaveBeenCalledOnce();
         });

--- a/src/test/javascript/spec/component/shared/notification/notification-sidebar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/notification/notification-sidebar.component.spec.ts
@@ -101,20 +101,20 @@ describe('Notification Sidebar Component', () => {
             getAuthenticationStateStub.mockReturnValue(of({ lastNotificationRead } as User));
 
             notificationSidebarComponent.ngOnInit();
-            expect(accountService.getAuthenticationState).toHaveBeenCalledTimes(1);
+            expect(accountService.getAuthenticationState).toHaveBeenCalledOnce();
             expect(notificationSidebarComponent.lastNotificationRead).toBe(lastNotificationRead);
         });
 
         it('should query notifications', () => {
             jest.spyOn(notificationService, 'queryNotificationsFilteredBySettings');
             notificationSidebarComponent.ngOnInit();
-            expect(notificationService.queryNotificationsFilteredBySettings).toHaveBeenCalledTimes(1);
+            expect(notificationService.queryNotificationsFilteredBySettings).toHaveBeenCalledOnce();
         });
 
         it('should subscribe to notification updates for user', () => {
             jest.spyOn(notificationService, 'subscribeToNotificationUpdates');
             notificationSidebarComponent.ngOnInit();
-            expect(notificationService.subscribeToNotificationUpdates).toHaveBeenCalledTimes(1);
+            expect(notificationService.subscribeToNotificationUpdates).toHaveBeenCalledOnce();
         });
     });
 
@@ -123,8 +123,8 @@ describe('Notification Sidebar Component', () => {
             jest.spyOn(notificationSidebarComponent, 'toggleSidebar');
             const bell = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('.notification-button');
             bell.click();
-            expect(notificationSidebarComponent.toggleSidebar).toHaveBeenCalledTimes(1);
-            expect(notificationSidebarComponent.showSidebar).toBe(true);
+            expect(notificationSidebarComponent.toggleSidebar).toHaveBeenCalledOnce();
+            expect(notificationSidebarComponent.showSidebar).toBeTrue();
         });
 
         it('should close sidebar when user clicks on notification overlay', () => {
@@ -132,7 +132,7 @@ describe('Notification Sidebar Component', () => {
             jest.spyOn(notificationSidebarComponent, 'toggleSidebar');
             const overlay = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('.notification-overlay');
             overlay.click();
-            expect(notificationSidebarComponent.toggleSidebar).toHaveBeenCalledTimes(1);
+            expect(notificationSidebarComponent.toggleSidebar).toHaveBeenCalledOnce();
             expect(notificationSidebarComponent.showSidebar).toBe(false);
         });
 
@@ -141,7 +141,7 @@ describe('Notification Sidebar Component', () => {
             jest.spyOn(notificationSidebarComponent, 'toggleSidebar');
             const close = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('.close');
             close.click();
-            expect(notificationSidebarComponent.toggleSidebar).toHaveBeenCalledTimes(1);
+            expect(notificationSidebarComponent.toggleSidebar).toHaveBeenCalledOnce();
             expect(notificationSidebarComponent.showSidebar).toBe(false);
         });
 
@@ -162,7 +162,7 @@ describe('Notification Sidebar Component', () => {
             notificationSidebarComponentFixture.detectChanges();
             const notification = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('.notification-item');
             notification.click();
-            expect(notificationService.interpretNotification).toHaveBeenCalledTimes(1);
+            expect(notificationService.interpretNotification).toHaveBeenCalledOnce();
         });
     });
 
@@ -173,8 +173,8 @@ describe('Notification Sidebar Component', () => {
             const bell = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('.notification-button');
             bell.click();
             tick(2000);
-            expect(notificationSidebarComponent.updateLastNotificationRead).toHaveBeenCalledTimes(1);
-            expect(userService.updateLastNotificationRead).toHaveBeenCalledTimes(1);
+            expect(notificationSidebarComponent.updateLastNotificationRead).toHaveBeenCalledOnce();
+            expect(userService.updateLastNotificationRead).toHaveBeenCalledOnce();
         }));
 
         it('should update components last notification read two seconds after the user opened the sidebar', fakeAsync(() => {
@@ -205,7 +205,7 @@ describe('Notification Sidebar Component', () => {
             const queryNotificationsFilteredBySettingsStub = jest.spyOn(notificationService, 'queryNotificationsFilteredBySettings');
             queryNotificationsFilteredBySettingsStub.mockReturnValue(of(generateQueryResponse([notificationPast, notificationNow])));
             notificationSidebarComponent.ngOnInit();
-            expect(notificationService.queryNotificationsFilteredBySettings).toHaveBeenCalledTimes(1);
+            expect(notificationService.queryNotificationsFilteredBySettings).toHaveBeenCalledOnce();
             expect(notificationSidebarComponent.sortedNotifications[0]).toBe(notificationNow);
             expect(notificationSidebarComponent.sortedNotifications[1]).toBe(notificationPast);
         });
@@ -214,7 +214,7 @@ describe('Notification Sidebar Component', () => {
             const queryNotificationsFilteredBySettingsStub = jest.spyOn(notificationService, 'queryNotificationsFilteredBySettings');
             queryNotificationsFilteredBySettingsStub.mockReturnValue(of(generateQueryResponse(notifications)));
             notificationSidebarComponent.ngOnInit();
-            expect(notificationService.queryNotificationsFilteredBySettings).toHaveBeenCalledTimes(1);
+            expect(notificationService.queryNotificationsFilteredBySettings).toHaveBeenCalledOnce();
             expect(notificationSidebarComponent.totalNotifications).toBe(notifications.length);
         });
 
@@ -252,7 +252,7 @@ describe('Notification Sidebar Component', () => {
             queryNotificationsFilteredBySettingsStub.mockReturnValue(of(generateQueryResponse(notifications)));
 
             notificationSidebarComponent.ngOnInit();
-            expect(notificationService.queryNotificationsFilteredBySettings).toHaveBeenCalledTimes(1);
+            expect(notificationService.queryNotificationsFilteredBySettings).toHaveBeenCalledOnce();
             expect(notificationSidebarComponent.recentNotificationCount).toBe(1);
         });
 
@@ -298,14 +298,14 @@ describe('Notification Sidebar Component', () => {
         it('should toggle which notifications are displayed (hide until property) when user clicks on archive button', () => {
             notificationSidebarComponent.ngOnInit();
             notificationSidebarComponent.notifications = notifications;
-            expect(notificationSidebarComponent.showButtonToHideCurrentlyDisplayedNotifications).toBe(true);
+            expect(notificationSidebarComponent.showButtonToHideCurrentlyDisplayedNotifications).toBeTrue();
             jest.spyOn(notificationSidebarComponent, 'toggleNotificationDisplay');
             jest.spyOn(userService, 'updateNotificationVisibility');
             const hideUntilToggle = notificationSidebarComponentFixture.debugElement.nativeElement.querySelector('#hide-until-toggle');
             hideUntilToggle.click();
             expect(notificationSidebarComponent.showButtonToHideCurrentlyDisplayedNotifications).toBe(false);
-            expect(notificationSidebarComponent.toggleNotificationDisplay).toHaveBeenCalledTimes(1);
-            expect(userService.updateNotificationVisibility).toHaveBeenCalledTimes(1);
+            expect(notificationSidebarComponent.toggleNotificationDisplay).toHaveBeenCalledOnce();
+            expect(userService.updateNotificationVisibility).toHaveBeenCalledOnce();
         });
     });
 

--- a/src/test/javascript/spec/component/shared/notification/system-notification.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/notification/system-notification.component.spec.ts
@@ -56,7 +56,7 @@ describe('System Notification Component', () => {
             const getActiveNotificationSpy = jest.spyOn(systemNotificationService, 'getActiveNotification').mockReturnValue(of(notification));
             systemNotificationComponent.ngOnInit();
             tick(500);
-            expect(getActiveNotificationSpy).toHaveBeenCalledTimes(1);
+            expect(getActiveNotificationSpy).toHaveBeenCalledOnce();
             expect(systemNotificationComponent.notification).toEqual(notification);
             expect(systemNotificationComponent.alertClass).toEqual('alert-warning');
             expect(systemNotificationComponent.alertIcon).toEqual(faExclamationTriangle);
@@ -67,7 +67,7 @@ describe('System Notification Component', () => {
             const getActiveNotificationSpy = jest.spyOn(systemNotificationService, 'getActiveNotification').mockReturnValue(of(notification));
             systemNotificationComponent.ngOnInit();
             tick(500);
-            expect(getActiveNotificationSpy).toHaveBeenCalledTimes(1);
+            expect(getActiveNotificationSpy).toHaveBeenCalledOnce();
             expect(systemNotificationComponent.notification).toEqual(notification);
             expect(systemNotificationComponent.alertClass).toEqual('alert-info');
             expect(systemNotificationComponent.alertIcon).toEqual(faInfoCircle);
@@ -85,10 +85,10 @@ describe('System Notification Component', () => {
             const receiveSpy = jest.spyOn(jhiWebsocketService, 'receive');
             systemNotificationComponent.ngOnInit();
             tick(500);
-            expect(connectionStateSubscribeSpy).toHaveBeenCalledTimes(1);
+            expect(connectionStateSubscribeSpy).toHaveBeenCalledOnce();
             expect(systemNotificationComponent.websocketChannel).toEqual('/topic/system-notification');
-            expect(subscribeSpy).toHaveBeenCalledTimes(1);
-            expect(receiveSpy).toHaveBeenCalledTimes(1);
+            expect(subscribeSpy).toHaveBeenCalledOnce();
+            expect(receiveSpy).toHaveBeenCalledOnce();
         }));
 
         it('should delete notification when "deleted" is received via websocket', fakeAsync(() => {
@@ -97,7 +97,7 @@ describe('System Notification Component', () => {
             systemNotificationComponent.notification = createActiveNotification(SystemNotificationType.WARNING);
             systemNotificationComponent.ngOnInit();
             tick(500);
-            expect(receiveSpy).toHaveBeenCalledTimes(1);
+            expect(receiveSpy).toHaveBeenCalledOnce();
             expect(systemNotificationComponent.notification).toEqual(undefined);
             expect(getActiveNotificationSpy).toHaveBeenCalledTimes(2);
         }));
@@ -108,8 +108,8 @@ describe('System Notification Component', () => {
             const receiveSpy = jest.spyOn(jhiWebsocketService, 'receive').mockReturnValue(of(notification));
             systemNotificationComponent.ngOnInit();
             tick(500);
-            expect(subscribeSpy).toHaveBeenCalledTimes(1);
-            expect(receiveSpy).toHaveBeenCalledTimes(1);
+            expect(subscribeSpy).toHaveBeenCalledOnce();
+            expect(receiveSpy).toHaveBeenCalledOnce();
             expect(systemNotificationComponent.notification).toEqual(notification);
             expect(systemNotificationComponent.alertClass).toEqual('alert-warning');
             expect(systemNotificationComponent.alertIcon).toEqual(faExclamationTriangle);
@@ -123,8 +123,8 @@ describe('System Notification Component', () => {
             const getActiveNotificationSpy = jest.spyOn(systemNotificationService, 'getActiveNotification').mockReturnValue(of());
             systemNotificationComponent.ngOnInit();
             tick(500);
-            expect(subscribeSpy).toHaveBeenCalledTimes(1);
-            expect(receiveSpy).toHaveBeenCalledTimes(1);
+            expect(subscribeSpy).toHaveBeenCalledOnce();
+            expect(receiveSpy).toHaveBeenCalledOnce();
             expect(getActiveNotificationSpy).toHaveBeenCalledTimes(2);
             expect(systemNotificationComponent.notification).toEqual(undefined);
             expect(systemNotificationComponent.alertClass).toEqual(undefined);
@@ -139,9 +139,9 @@ describe('System Notification Component', () => {
             const getActiveNotificationSpy = jest.spyOn(systemNotificationService, 'getActiveNotification').mockReturnValue(of(notification));
             systemNotificationComponent.ngOnInit();
             tick(500);
-            expect(subscribeSpy).toHaveBeenCalledTimes(1);
-            expect(receiveSpy).toHaveBeenCalledTimes(1);
-            expect(getActiveNotificationSpy).toHaveBeenCalledTimes(1);
+            expect(subscribeSpy).toHaveBeenCalledOnce();
+            expect(receiveSpy).toHaveBeenCalledOnce();
+            expect(getActiveNotificationSpy).toHaveBeenCalledOnce();
             expect(systemNotificationComponent.notification).toEqual(changedNotification);
         }));
 
@@ -156,9 +156,9 @@ describe('System Notification Component', () => {
             const getActiveNotificationSpy = jest.spyOn(systemNotificationService, 'getActiveNotification').mockReturnValue(of(notification));
             systemNotificationComponent.ngOnInit();
             tick(500);
-            expect(subscribeSpy).toHaveBeenCalledTimes(1);
-            expect(receiveSpy).toHaveBeenCalledTimes(1);
-            expect(getActiveNotificationSpy).toHaveBeenCalledTimes(1);
+            expect(subscribeSpy).toHaveBeenCalledOnce();
+            expect(receiveSpy).toHaveBeenCalledOnce();
+            expect(getActiveNotificationSpy).toHaveBeenCalledOnce();
             expect(systemNotificationComponent.notification).toEqual(newNotification);
         }));
     });

--- a/src/test/javascript/spec/component/shared/participant-scores-distribution.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/participant-scores-distribution.component.spec.ts
@@ -129,7 +129,7 @@ describe('ParticipantScoresDistributionComponent', () => {
 
         component.ngOnChanges();
 
-        expect(component.gradingScaleExists).toBe(true);
+        expect(component.gradingScaleExists).toBeTrue();
         expect(component.xAxisLabel).toBe('artemisApp.examScores.xAxesartemisApp.examScores.xAxesSuffixNoBonus');
         expect(component.yAxisLabel).toBe('artemisApp.examScores.yAxes');
         expect(component.helpIconTooltip).toBe('instructorDashboard.courseScoreChart.gradingScaleExplanationNotBonus');
@@ -155,8 +155,8 @@ describe('ParticipantScoresDistributionComponent', () => {
 
         component.ngOnChanges();
 
-        expect(component.gradingScaleExists).toBe(true);
-        expect(component.isBonus).toBe(true);
+        expect(component.gradingScaleExists).toBeTrue();
+        expect(component.isBonus).toBeTrue();
         expect(component.xAxisLabel).toBe('artemisApp.examScores.xAxesartemisApp.examScores.xAxesSuffixBonus');
         expect(component.yAxisLabel).toBe('artemisApp.examScores.yAxes');
         expect(component.helpIconTooltip).toBe('artemisApp.examScores.gradingScaleExplanationBonus');

--- a/src/test/javascript/spec/component/shared/result-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/result-detail.component.spec.ts
@@ -274,7 +274,7 @@ describe('ResultDetailComponent', () => {
 
         comp.ngOnInit();
 
-        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledTimes(1);
+        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledOnce();
         expect(getFeedbackDetailsForResultStub).toHaveBeenCalledWith(comp.result.participation!.id!, comp.result.id);
         expect(comp.filteredFeedbackList).toIncludeSameMembers(expectedItems);
         expect(comp.isLoading).toBe(false);
@@ -285,7 +285,7 @@ describe('ResultDetailComponent', () => {
 
         comp.ngOnInit();
 
-        expect(buildlogsStub).toHaveBeenCalledTimes(1);
+        expect(buildlogsStub).toHaveBeenCalledOnce();
         expect(buildlogsStub).toHaveBeenCalledWith(comp.result.participation!.id, comp.result.id);
         expect(comp.buildLogs).toBeArrayOfSize(0);
         expect(comp.isLoading).toBe(false);
@@ -297,7 +297,7 @@ describe('ResultDetailComponent', () => {
 
         comp.ngOnInit();
 
-        expect(buildlogsStub).toHaveBeenCalledTimes(1);
+        expect(buildlogsStub).toHaveBeenCalledOnce();
         expect(buildlogsStub).toHaveBeenCalledWith(comp.result.participation!.id, comp.result.id);
         expect(comp.buildLogs).toBeArrayOfSize(0);
         expect(comp.isLoading).toBe(false);
@@ -332,7 +332,7 @@ describe('ResultDetailComponent', () => {
 
         comp.ngOnInit();
 
-        expect(buildlogsStub).toHaveBeenCalledTimes(1);
+        expect(buildlogsStub).toHaveBeenCalledOnce();
         expect(buildlogsStub).toHaveBeenCalledWith(comp.result.participation!.id, comp.result.id);
         expect(comp.loadingFailed).toBe(false);
         expect(comp.isLoading).toBe(false);
@@ -345,9 +345,9 @@ describe('ResultDetailComponent', () => {
 
         comp.ngOnInit();
 
-        expect(buildlogsStub).toHaveBeenCalledTimes(1);
+        expect(buildlogsStub).toHaveBeenCalledOnce();
         expect(buildlogsStub).toHaveBeenCalledWith(comp.result.participation!.id, comp.result.id);
-        expect(comp.loadingFailed).toBe(true);
+        expect(comp.loadingFailed).toBeTrue();
         expect(comp.isLoading).toBe(false);
     });
 
@@ -623,7 +623,7 @@ describe('ResultDetailComponent', () => {
 
         expect(comp.filteredFeedbackList).toEqual(expectedItems);
         expect(comp.backupFilteredFeedbackList).toEqual(expectedItems);
-        expect(comp.showScoreChartTooltip).toBe(true);
+        expect(comp.showScoreChartTooltip).toBeTrue();
 
         checkChartPreset(5, 5, '10', '5 of 6');
         expect(comp.isLoading).toBe(false);
@@ -661,7 +661,7 @@ describe('ResultDetailComponent', () => {
 
         comp.onSelect(event);
 
-        expect(comp.showOnlyPositiveFeedback).toBe(true);
+        expect(comp.showOnlyPositiveFeedback).toBeTrue();
         expect(comp.showOnlyNegativeFeedback).toBe(false);
         expect(comp.filteredFeedbackList).toEqual(currentlyVisibleItems);
 
@@ -670,7 +670,7 @@ describe('ResultDetailComponent', () => {
 
         comp.onSelect(event);
 
-        expect(comp.showOnlyNegativeFeedback).toBe(true);
+        expect(comp.showOnlyNegativeFeedback).toBeTrue();
         expect(comp.showOnlyPositiveFeedback).toBe(false);
         expect(comp.filteredFeedbackList).toEqual(currentlyVisibleItems);
 

--- a/src/test/javascript/spec/component/shared/result-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/result-detail.component.spec.ts
@@ -264,7 +264,7 @@ describe('ResultDetailComponent', () => {
 
         expect(getFeedbackDetailsForResultStub).not.toHaveBeenCalled();
         expect(comp.filteredFeedbackList).toEqual(expectedItems);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('should try to retrieve the feedbacks from the server if provided result does not have feedbacks', () => {
@@ -277,7 +277,7 @@ describe('ResultDetailComponent', () => {
         expect(getFeedbackDetailsForResultStub).toHaveBeenCalledOnce();
         expect(getFeedbackDetailsForResultStub).toHaveBeenCalledWith(comp.result.participation!.id!, comp.result.id);
         expect(comp.filteredFeedbackList).toIncludeSameMembers(expectedItems);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('should try to retrieve build logs if the exercise type is PROGRAMMING and no submission was provided.', () => {
@@ -288,7 +288,7 @@ describe('ResultDetailComponent', () => {
         expect(buildlogsStub).toHaveBeenCalledOnce();
         expect(buildlogsStub).toHaveBeenCalledWith(comp.result.participation!.id, comp.result.id);
         expect(comp.buildLogs).toBeArrayOfSize(0);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('should try to retrieve build logs if the exercise type is PROGRAMMING and a submission was provided which was marked with build failed.', () => {
@@ -300,7 +300,7 @@ describe('ResultDetailComponent', () => {
         expect(buildlogsStub).toHaveBeenCalledOnce();
         expect(buildlogsStub).toHaveBeenCalledWith(comp.result.participation!.id, comp.result.id);
         expect(comp.buildLogs).toBeArrayOfSize(0);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('should not try to retrieve build logs if the exercise type is not PROGRAMMING', () => {
@@ -311,7 +311,7 @@ describe('ResultDetailComponent', () => {
 
         expect(buildlogsStub).not.toHaveBeenCalled();
         expect(comp.feedbackList).toBe(undefined);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('should not try to retrieve build logs if submission was not marked with build failed', () => {
@@ -322,7 +322,7 @@ describe('ResultDetailComponent', () => {
 
         expect(buildlogsStub).not.toHaveBeenCalled();
         expect(comp.buildLogs).toBe(undefined);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('fetchBuildLogs should suppress 403 error', () => {
@@ -334,8 +334,8 @@ describe('ResultDetailComponent', () => {
 
         expect(buildlogsStub).toHaveBeenCalledOnce();
         expect(buildlogsStub).toHaveBeenCalledWith(comp.result.participation!.id, comp.result.id);
-        expect(comp.loadingFailed).toBe(false);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.loadingFailed).toBeFalse();
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('fetchBuildLogs should not suppress errors with status other than 403', () => {
@@ -348,7 +348,7 @@ describe('ResultDetailComponent', () => {
         expect(buildlogsStub).toHaveBeenCalledOnce();
         expect(buildlogsStub).toHaveBeenCalledWith(comp.result.participation!.id, comp.result.id);
         expect(comp.loadingFailed).toBeTrue();
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('should show test names if showTestDetails is set to true', () => {
@@ -361,7 +361,7 @@ describe('ResultDetailComponent', () => {
 
         expect(getFeedbackDetailsForResultStub).not.toHaveBeenCalled();
         expect(comp.filteredFeedbackList).toEqual(expectedItems);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('should show a replacement title if automatic feedback is neither positive nor negative', () => {
@@ -584,7 +584,7 @@ describe('ResultDetailComponent', () => {
 
         expect(getFeedbackDetailsForResultStub).not.toHaveBeenCalled();
         expect(comp.filteredFeedbackList).toEqual([expectedFeedbackItem]);
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     };
 
     it('should filter the correct feedbacks when a filter is set', () => {
@@ -597,7 +597,7 @@ describe('ResultDetailComponent', () => {
 
         expect(getFeedbackDetailsForResultStub).not.toHaveBeenCalled;
         expect(comp.filteredFeedbackList).toEqual(expectedItems.filter((item) => item.type === FeedbackItemType.Test));
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
     });
 
     it('should generate correct class names for feedback items', () => {
@@ -626,7 +626,7 @@ describe('ResultDetailComponent', () => {
         expect(comp.showScoreChartTooltip).toBeTrue();
 
         checkChartPreset(5, 5, '10', '5 of 6');
-        expect(comp.isLoading).toBe(false);
+        expect(comp.isLoading).toBeFalse();
 
         // test score exceeding exercise maxpoints
 
@@ -662,7 +662,7 @@ describe('ResultDetailComponent', () => {
         comp.onSelect(event);
 
         expect(comp.showOnlyPositiveFeedback).toBeTrue();
-        expect(comp.showOnlyNegativeFeedback).toBe(false);
+        expect(comp.showOnlyNegativeFeedback).toBeFalse();
         expect(comp.filteredFeedbackList).toEqual(currentlyVisibleItems);
 
         event.isPositive = false;
@@ -671,12 +671,12 @@ describe('ResultDetailComponent', () => {
         comp.onSelect(event);
 
         expect(comp.showOnlyNegativeFeedback).toBeTrue();
-        expect(comp.showOnlyPositiveFeedback).toBe(false);
+        expect(comp.showOnlyPositiveFeedback).toBeFalse();
         expect(comp.filteredFeedbackList).toEqual(currentlyVisibleItems);
 
         comp.resetChartFilter();
 
-        expect(comp.showOnlyNegativeFeedback).toBe(false);
+        expect(comp.showOnlyNegativeFeedback).toBeFalse();
         expect(comp.filteredFeedbackList).toEqual(expectedItems);
     });
 

--- a/src/test/javascript/spec/component/shared/submission-policy-update.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/submission-policy-update.component.spec.ts
@@ -138,13 +138,13 @@ describe('Submission Policy Update Form Component', () => {
         component.programmingExercise.submissionPolicy = undefined;
         component.ngOnInit();
         fixture.detectChanges();
-        expect(component.invalid).toBe(false);
+        expect(component.invalid).toBeFalse();
     });
 
     it('Should not be invalid when no policy is of type none', () => {
         component.programmingExercise.submissionPolicy = { type: SubmissionPolicyType.NONE };
         component.ngOnInit();
         fixture.detectChanges();
-        expect(component.invalid).toBe(false);
+        expect(component.invalid).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/shared/treeview/treeview-item.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/treeview/treeview-item.component.spec.ts
@@ -158,7 +158,7 @@ describe('TreeviewItemComponent', () => {
             });
 
             it('should raise event checkedChange', () => {
-                expect(checkedChangeSpy).toHaveBeenCalledTimes(1);
+                expect(checkedChangeSpy).toHaveBeenCalledOnce();
                 expect(checkedChangeSpy).toHaveBeenCalledWith(true);
             });
 
@@ -175,7 +175,7 @@ describe('TreeviewItemComponent', () => {
                 });
 
                 it('should raise event checkedChange', () => {
-                    expect(checkedChangeSpy).toHaveBeenCalledTimes(1);
+                    expect(checkedChangeSpy).toHaveBeenCalledOnce();
                     expect(checkedChangeSpy).toHaveBeenCalledWith(true);
                 });
             });
@@ -197,7 +197,7 @@ describe('TreeviewItemComponent', () => {
                 });
 
                 it('should raise event checkedChange', () => {
-                    expect(checkedChangeSpy).toHaveBeenCalledTimes(1);
+                    expect(checkedChangeSpy).toHaveBeenCalledOnce();
                     expect(checkedChangeSpy).toHaveBeenCalledWith(false);
                 });
             });

--- a/src/test/javascript/spec/component/shared/treeview/treeview-item.spec.ts
+++ b/src/test/javascript/spec/component/shared/treeview/treeview-item.spec.ts
@@ -50,7 +50,7 @@ describe('TreeviewItem', () => {
             });
             expect(treeviewItem.children[0].collapsed).toBe(false);
             treeviewItem.setCollapsedRecursive(true);
-            expect(treeviewItem.children[0].collapsed).toBe(true);
+            expect(treeviewItem.children[0].collapsed).toBeTrue();
         });
     });
 
@@ -78,9 +78,9 @@ describe('TreeviewItem', () => {
             });
             expect(treeviewItem.children[0].disabled).toBe(false);
             treeviewItem.disabled = true;
-            expect(treeviewItem.children[0].disabled).toBe(true);
+            expect(treeviewItem.children[0].disabled).toBeTrue();
             treeviewItem.disabled = true;
-            expect(treeviewItem.children[0].disabled).toBe(true);
+            expect(treeviewItem.children[0].disabled).toBeTrue();
         });
     });
 

--- a/src/test/javascript/spec/component/shared/treeview/treeview-item.spec.ts
+++ b/src/test/javascript/spec/component/shared/treeview/treeview-item.spec.ts
@@ -48,7 +48,7 @@ describe('TreeviewItem', () => {
                 collapsed: false,
                 children: [{ text: 'Child 1', value: 11, collapsed: false } as TreeviewItem<number>],
             });
-            expect(treeviewItem.children[0].collapsed).toBe(false);
+            expect(treeviewItem.children[0].collapsed).toBeFalse();
             treeviewItem.setCollapsedRecursive(true);
             expect(treeviewItem.children[0].collapsed).toBeTrue();
         });
@@ -76,7 +76,7 @@ describe('TreeviewItem', () => {
                 value: 1,
                 children: [{ text: 'Child 1', value: 11 } as TreeviewItem<number>],
             });
-            expect(treeviewItem.children[0].disabled).toBe(false);
+            expect(treeviewItem.children[0].disabled).toBeFalse();
             treeviewItem.disabled = true;
             expect(treeviewItem.children[0].disabled).toBeTrue();
             treeviewItem.disabled = true;

--- a/src/test/javascript/spec/component/shared/unreferenced-feedback.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/unreferenced-feedback.component.spec.ts
@@ -25,7 +25,7 @@ describe('UnreferencedFeedbackComponent', () => {
 
     it('should validate feedback', () => {
         comp.validateFeedback();
-        expect(comp.assessmentsAreValid).toBe(false);
+        expect(comp.assessmentsAreValid).toBeFalse();
 
         const feedback = new Feedback();
         feedback.credits = undefined;
@@ -33,7 +33,7 @@ describe('UnreferencedFeedbackComponent', () => {
 
         fixture.detectChanges();
         comp.validateFeedback();
-        expect(comp.assessmentsAreValid).toBe(false);
+        expect(comp.assessmentsAreValid).toBeFalse();
 
         feedback.credits = 1;
         fixture.detectChanges();

--- a/src/test/javascript/spec/component/shared/unreferenced-feedback.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/unreferenced-feedback.component.spec.ts
@@ -39,7 +39,7 @@ describe('UnreferencedFeedbackComponent', () => {
         fixture.detectChanges();
 
         comp.validateFeedback();
-        expect(comp.assessmentsAreValid).toBe(true);
+        expect(comp.assessmentsAreValid).toBeTrue();
     });
 
     it('should add unreferenced feedback', () => {

--- a/src/test/javascript/spec/component/shared/updating-result.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/updating-result.component.spec.ts
@@ -98,14 +98,14 @@ describe('UpdatingResultComponent', () => {
 
     it('should use the newest rated result of the provided participation and subscribe for new results', () => {
         cleanInitializeGraded();
-        expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledTimes(1);
+        expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledOnce();
         expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledWith(initialParticipation.id, true, undefined);
         expect(comp.result!.id).toBe(gradedResult2.id);
     });
 
     it('should use the newest (un)rated result of the provided participation and subscribe for new results', () => {
         cleanInitializeUngraded();
-        expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledTimes(1);
+        expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledOnce();
         expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledWith(initialParticipation.id, true, undefined);
         expect(comp.result!.id).toBe(ungradedResult2.id);
     });
@@ -145,7 +145,7 @@ describe('UpdatingResultComponent', () => {
     it('should subscribe to fetching the latest pending submission when the exerciseType is PROGRAMMING', () => {
         comp.exercise = { id: 99, type: ExerciseType.PROGRAMMING } as Exercise;
         cleanInitializeGraded();
-        expect(getLatestPendingSubmissionStub).toHaveBeenCalledTimes(1);
+        expect(getLatestPendingSubmissionStub).toHaveBeenCalledOnce();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledWith(comp.participation.id, comp.exercise.id, true);
         expect(comp.isBuilding).toBe(false);
     });
@@ -154,9 +154,9 @@ describe('UpdatingResultComponent', () => {
         comp.exercise = { id: 99, type: ExerciseType.PROGRAMMING } as Exercise;
         getLatestPendingSubmissionStub.mockReturnValue(of({ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission, participationId: 3 }));
         cleanInitializeGraded();
-        expect(getLatestPendingSubmissionStub).toHaveBeenCalledTimes(1);
+        expect(getLatestPendingSubmissionStub).toHaveBeenCalledOnce();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledWith(comp.participation.id, comp.exercise.id, true);
-        expect(comp.isBuilding).toBe(true);
+        expect(comp.isBuilding).toBeTrue();
         expect(comp.missingResultInfo).toBe(MissingResultInfo.NONE);
     });
 
@@ -165,7 +165,7 @@ describe('UpdatingResultComponent', () => {
         comp.isBuilding = true;
         getLatestPendingSubmissionStub.mockReturnValue(of({ submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION, submission: undefined, participationId: 3 }));
         cleanInitializeGraded();
-        expect(getLatestPendingSubmissionStub).toHaveBeenCalledTimes(1);
+        expect(getLatestPendingSubmissionStub).toHaveBeenCalledOnce();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledWith(comp.participation.id, comp.exercise.id, true);
         expect(comp.isBuilding).toBe(false);
         expect(comp.missingResultInfo).toBe(MissingResultInfo.NONE);
@@ -176,7 +176,7 @@ describe('UpdatingResultComponent', () => {
         comp.isBuilding = true;
         getLatestPendingSubmissionStub.mockReturnValue(of({ submissionState: ProgrammingSubmissionState.HAS_FAILED_SUBMISSION, submission: undefined, participationId: 3 }));
         cleanInitializeGraded();
-        expect(getLatestPendingSubmissionStub).toHaveBeenCalledTimes(1);
+        expect(getLatestPendingSubmissionStub).toHaveBeenCalledOnce();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledWith(comp.participation.id, comp.exercise.id, true);
         expect(comp.isBuilding).toBe(false);
         expect(comp.missingResultInfo).toBe(MissingResultInfo.FAILED_PROGRAMMING_SUBMISSION_OFFLINE_IDE);
@@ -186,7 +186,7 @@ describe('UpdatingResultComponent', () => {
         comp.exercise = { id: 99, type: ExerciseType.PROGRAMMING, allowOfflineIde: false } as ProgrammingExercise;
         getLatestPendingSubmissionStub.mockReturnValue(of({ submissionState: ProgrammingSubmissionState.HAS_FAILED_SUBMISSION, submission: undefined, participationId: 3 }));
         cleanInitializeGraded();
-        expect(getLatestPendingSubmissionStub).toHaveBeenCalledTimes(1);
+        expect(getLatestPendingSubmissionStub).toHaveBeenCalledOnce();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledWith(comp.participation.id, comp.exercise.id, true);
         expect(comp.missingResultInfo).toBe(MissingResultInfo.FAILED_PROGRAMMING_SUBMISSION_ONLINE_IDE);
     });
@@ -204,7 +204,7 @@ describe('UpdatingResultComponent', () => {
         comp.exercise = { id: 99, type: ExerciseType.PROGRAMMING, dueDate: submission.submissionDate.add(1, 'hour') } as Exercise;
         getLatestPendingSubmissionStub.mockReturnValue(of({ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission, participationId: 3 }));
         cleanInitializeGraded();
-        expect(comp.isBuilding).toBe(true);
+        expect(comp.isBuilding).toBeTrue();
         expect(comp.missingResultInfo).toBe(MissingResultInfo.NONE);
     });
 

--- a/src/test/javascript/spec/component/shared/updating-result.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/updating-result.component.spec.ts
@@ -147,7 +147,7 @@ describe('UpdatingResultComponent', () => {
         cleanInitializeGraded();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledOnce();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledWith(comp.participation.id, comp.exercise.id, true);
-        expect(comp.isBuilding).toBe(false);
+        expect(comp.isBuilding).toBeFalse();
     });
 
     it('should set the isBuilding attribute to true if exerciseType is PROGRAMMING and there is a latest pending submission', () => {
@@ -167,7 +167,7 @@ describe('UpdatingResultComponent', () => {
         cleanInitializeGraded();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledOnce();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledWith(comp.participation.id, comp.exercise.id, true);
-        expect(comp.isBuilding).toBe(false);
+        expect(comp.isBuilding).toBeFalse();
         expect(comp.missingResultInfo).toBe(MissingResultInfo.NONE);
     });
 
@@ -178,7 +178,7 @@ describe('UpdatingResultComponent', () => {
         cleanInitializeGraded();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledOnce();
         expect(getLatestPendingSubmissionStub).toHaveBeenCalledWith(comp.participation.id, comp.exercise.id, true);
-        expect(comp.isBuilding).toBe(false);
+        expect(comp.isBuilding).toBeFalse();
         expect(comp.missingResultInfo).toBe(MissingResultInfo.FAILED_PROGRAMMING_SUBMISSION_OFFLINE_IDE);
     });
 

--- a/src/test/javascript/spec/component/shared/user-settings/notification-settings.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/user-settings/notification-settings.component.spec.ts
@@ -58,8 +58,8 @@ describe('NotificationSettingsComponent', () => {
                 id: settingId,
             },
         };
-        expect(comp.settingsChanged).toBe(false);
-        expect(notificationSettingA.changed).toBe(false);
+        expect(comp.settingsChanged).toBeFalse();
+        expect(notificationSettingA.changed).toBeFalse();
 
         comp.toggleSetting(event, NotificationSettingsCommunicationChannel.WEBAPP);
 

--- a/src/test/javascript/spec/component/shared/user-settings/notification-settings.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/user-settings/notification-settings.component.spec.ts
@@ -64,14 +64,14 @@ describe('NotificationSettingsComponent', () => {
         comp.toggleSetting(event, NotificationSettingsCommunicationChannel.WEBAPP);
 
         expect(notificationSettingA.webapp).not.toEqual(webappStatus);
-        expect(notificationSettingA.changed).toBe(true);
-        expect(comp.settingsChanged).toBe(true);
+        expect(notificationSettingA.changed).toBeTrue();
+        expect(comp.settingsChanged).toBeTrue();
     });
 
     it('should reuse settings via service if they were already loaded', () => {
         const settingGetMock = jest.spyOn(notificationSettingsServiceMock, 'getNotificationSettings').mockReturnValue([notificationSettingA]);
         comp.ngOnInit();
-        expect(settingGetMock).toHaveBeenCalledTimes(1);
+        expect(settingGetMock).toHaveBeenCalledOnce();
         // check if current settings are not empty
         expect(comp.userSettings).toEqual(notificationSettingsStructure);
     });

--- a/src/test/javascript/spec/component/shared/user-settings/notification-settings.service.spec.ts
+++ b/src/test/javascript/spec/component/shared/user-settings/notification-settings.service.spec.ts
@@ -77,9 +77,9 @@ describe('User Settings Service', () => {
 
             const resultMap = notificationSettingsService.createUpdatedNotificationTitleActivationMap(notificationSettingsForTesting);
 
-            expect(resultMap.has(type1)).toBe(true);
-            expect(resultMap.has(type2)).toBe(true);
-            expect(resultMap.has(type3)).toBe(true);
+            expect(resultMap.has(type1)).toBeTrue();
+            expect(resultMap.has(type2)).toBeTrue();
+            expect(resultMap.has(type3)).toBeTrue();
 
             expect(resultMap.size).toEqual(3);
 

--- a/src/test/javascript/spec/component/shared/user-settings/user-settings.directive.spec.ts
+++ b/src/test/javascript/spec/component/shared/user-settings/user-settings.directive.spec.ts
@@ -103,8 +103,8 @@ describe('User Settings Directive', () => {
 
                 comp.ngOnInit();
 
-                expect(loadSettingsSuccessAsSettingsStructureSpy).toHaveBeenCalledTimes(1);
-                expect(extractIndividualSettingsFromSettingsStructureSpy).toHaveBeenCalledTimes(1);
+                expect(loadSettingsSuccessAsSettingsStructureSpy).toHaveBeenCalledOnce();
+                expect(extractIndividualSettingsFromSettingsStructureSpy).toHaveBeenCalledOnce();
                 expect(changeDetectorDetectChangesSpy).toHaveBeenCalled();
             });
 
@@ -129,9 +129,9 @@ describe('User Settings Directive', () => {
 
                 comp.saveSettings();
 
-                expect(saveSettingsSuccessSpy).toHaveBeenCalledTimes(1);
-                expect(extractIndividualSettingsFromSettingsStructureSpy).toHaveBeenCalledTimes(1);
-                expect(createApplyChangesEventSpy).toHaveBeenCalledTimes(1);
+                expect(saveSettingsSuccessSpy).toHaveBeenCalledOnce();
+                expect(extractIndividualSettingsFromSettingsStructureSpy).toHaveBeenCalledOnce();
+                expect(createApplyChangesEventSpy).toHaveBeenCalledOnce();
                 expect(alertServiceSuccessSpy).toHaveBeenCalled();
             });
         });

--- a/src/test/javascript/spec/component/short-answer-question/short-answer-question-edit.component.spec.ts
+++ b/src/test/javascript/spec/component/short-answer-question/short-answer-question-edit.component.spec.ts
@@ -270,7 +270,7 @@ describe('ShortAnswerQuestionEditComponent', () => {
 
         const expectedMapping = new ShortAnswerMapping(spot, shortAnswerSolution1);
         expect(component.shortAnswerQuestion.correctMappings.pop()).toEqual(expectedMapping);
-        expect(questionUpdatedSpy).toHaveBeenCalledTimes(1);
+        expect(questionUpdatedSpy).toHaveBeenCalledOnce();
     });
 
     it('should setup question editor', () => {
@@ -291,7 +291,7 @@ describe('ShortAnswerQuestionEditComponent', () => {
         const modalService = TestBed.inject(NgbModal);
         const modalSpy = jest.spyOn(modalService, 'open');
         component.open(content);
-        expect(modalSpy).toHaveBeenCalledTimes(1);
+        expect(modalSpy).toHaveBeenCalledOnce();
     });
 
     it('should add spot to cursor', () => {
@@ -405,7 +405,7 @@ describe('ShortAnswerQuestionEditComponent', () => {
     it('should delete question', () => {
         const questionDeleted = jest.spyOn(component.questionDeleted, 'emit');
         component.deleteQuestion();
-        expect(questionDeleted).toHaveBeenCalledTimes(1);
+        expect(questionDeleted).toHaveBeenCalledOnce();
     });
 
     it('should toggle preview', () => {
@@ -432,8 +432,8 @@ describe('ShortAnswerQuestionEditComponent', () => {
         component.moveUp();
         component.moveDown();
 
-        expect(eventUpSpy).toHaveBeenCalledTimes(1);
-        expect(eventDownSpy).toHaveBeenCalledTimes(1);
+        expect(eventUpSpy).toHaveBeenCalledOnce();
+        expect(eventDownSpy).toHaveBeenCalledOnce();
     });
 
     it('should reset the question', () => {
@@ -486,7 +486,7 @@ describe('ShortAnswerQuestionEditComponent', () => {
 
         component.setQuestionText('0-0-0-0');
 
-        expect(getNavigationSpy).toHaveBeenCalledTimes(1);
+        expect(getNavigationSpy).toHaveBeenCalledOnce();
         const splitString = ['This', 'is', 'a', 'text', 'for', 'a', 'test'];
         expect(component.textParts.pop()).toEqual(splitString);
     });
@@ -497,6 +497,6 @@ describe('ShortAnswerQuestionEditComponent', () => {
         component.toggleExactMatchCheckbox(true);
 
         expect(component.shortAnswerQuestion.similarityValue).toBe(100);
-        expect(questionUpdated).toHaveBeenCalledTimes(1);
+        expect(questionUpdated).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/short-answer-question/short-answer-question.component.spec.ts
+++ b/src/test/javascript/spec/component/short-answer-question/short-answer-question.component.spec.ts
@@ -86,7 +86,7 @@ describe('ShortAnswerQuestionComponent', () => {
         component.question = alternativeQuestion;
         component.setSubmittedText();
 
-        expect(getNavigationStub).toHaveBeenCalledTimes(1);
+        expect(getNavigationStub).toHaveBeenCalledOnce();
         expect(component.submittedTexts.length).toBe(1);
         expect(component.submittedTexts[0].text).toStrictEqual(text);
         expect(component.submittedTexts[0].spot).toStrictEqual(spot);
@@ -110,7 +110,7 @@ describe('ShortAnswerQuestionComponent', () => {
 
         expect(component.sampleSolutions.length).toBe(1);
         expect(component.sampleSolutions[0]).toStrictEqual(solution);
-        expect(component.showingSampleSolution).toBe(true);
+        expect(component.showingSampleSolution).toBeTrue();
     });
 
     it('should toggle show sample solution', () => {
@@ -120,7 +120,7 @@ describe('ShortAnswerQuestionComponent', () => {
         component.showResult = true;
         component.showingSampleSolution = true;
         component.forceSampleSolution = true;
-        expect(component.showingSampleSolution).toBe(true);
+        expect(component.showingSampleSolution).toBeTrue();
         component.forceSampleSolution = false;
         component.hideSampleSolution();
 

--- a/src/test/javascript/spec/component/short-answer-question/short-answer-question.component.spec.ts
+++ b/src/test/javascript/spec/component/short-answer-question/short-answer-question.component.spec.ts
@@ -124,7 +124,7 @@ describe('ShortAnswerQuestionComponent', () => {
         component.forceSampleSolution = false;
         component.hideSampleSolution();
 
-        expect(component.showingSampleSolution).toBe(false);
+        expect(component.showingSampleSolution).toBeFalse();
     });
 
     it('should get submitted text size for spot', () => {

--- a/src/test/javascript/spec/component/statistics/doughnut-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/statistics/doughnut-chart.component.spec.ts
@@ -84,6 +84,6 @@ describe('DoughnutChartComponent', () => {
         component.ngOnInit();
         component.openCorrespondingPage();
 
-        expect(navigateSpy).toHaveBeenCalledTimes(1);
+        expect(navigateSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/statistics/statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/statistics/statistics.component.spec.ts
@@ -54,7 +54,7 @@ describe('StatisticsComponent', () => {
         button.click();
 
         tick();
-        expect(tabSpy).toHaveBeenCalledTimes(1);
+        expect(tabSpy).toHaveBeenCalledOnce();
         expect(component.currentSpan).toEqual(SpanType.MONTH);
         tabSpy.mockRestore();
     }));

--- a/src/test/javascript/spec/component/team/team-owner-search.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team-owner-search.component.spec.ts
@@ -56,14 +56,14 @@ describe('Team Owner Search Component', () => {
         let onSearchResult: User[] | undefined = undefined;
         comp.onSearch(of(searchText)).subscribe((result) => (onSearchResult = result));
 
-        expect(searchFailedSpy).toHaveBeenCalledTimes(1);
+        expect(searchFailedSpy).toHaveBeenCalledOnce();
         expect(searchFailedSpy).toHaveBeenCalledWith(false);
 
         expect(searchingSpy).toHaveBeenCalledTimes(2);
         expect(searchingSpy).toHaveBeenNthCalledWith(1, true);
         expect(searchingSpy).toHaveBeenNthCalledWith(2, false);
 
-        expect(searchNoResultsSpy).toHaveBeenCalledTimes(1);
+        expect(searchNoResultsSpy).toHaveBeenCalledOnce();
         expect(searchNoResultsSpy).toHaveBeenCalledWith(undefined);
 
         expect(onSearchResult).toEqual([owner]);
@@ -84,7 +84,7 @@ describe('Team Owner Search Component', () => {
         let onSearchResult: User[] | undefined = undefined;
         comp.onSearch(of(searchText)).subscribe((result) => (onSearchResult = result));
 
-        expect(searchFailedSpy).toHaveBeenCalledTimes(1);
+        expect(searchFailedSpy).toHaveBeenCalledOnce();
         expect(searchFailedSpy).toHaveBeenCalledWith(false);
 
         expect(searchingSpy).toHaveBeenCalledTimes(2);
@@ -109,7 +109,7 @@ describe('Team Owner Search Component', () => {
         let loadOwnerOptionsResult: User[] | undefined = [owner];
         comp.loadOwnerOptions().subscribe((result) => (loadOwnerOptionsResult = result));
 
-        expect(searchFailedSpy).toHaveBeenCalledTimes(1);
+        expect(searchFailedSpy).toHaveBeenCalledOnce();
         expect(searchFailedSpy).toHaveBeenCalledWith(true);
 
         expect(comp.ownerOptionsLoaded).toBe(false);

--- a/src/test/javascript/spec/component/team/team-owner-search.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team-owner-search.component.spec.ts
@@ -112,7 +112,7 @@ describe('Team Owner Search Component', () => {
         expect(searchFailedSpy).toHaveBeenCalledOnce();
         expect(searchFailedSpy).toHaveBeenCalledWith(true);
 
-        expect(comp.ownerOptionsLoaded).toBe(false);
+        expect(comp.ownerOptionsLoaded).toBeFalse();
         expect(loadOwnerOptionsResult).toBe(undefined);
     });
 });

--- a/src/test/javascript/spec/component/team/team-participation-table.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team-participation-table.component.spec.ts
@@ -223,7 +223,7 @@ describe('TeamParticipationTableComponent', () => {
         const participation = exercise2.studentParticipations![0];
         comp.openAssessmentEditor(exercise2, participation, 'new');
         tick();
-        expect(router.navigate).toHaveBeenCalledTimes(1);
+        expect(router.navigate).toHaveBeenCalledOnce();
         expect(router.navigate).toHaveBeenCalledWith([
             '/course-management',
             course.id!.toString(),
@@ -247,7 +247,7 @@ describe('TeamParticipationTableComponent', () => {
 
     it('Check disabled assessment button for exercises without submission', () => {
         const expectedAssessmentActionButtonDisabled = comp.isAssessmentButtonDisabled(exercise1, undefined);
-        expect(expectedAssessmentActionButtonDisabled).toBe(true);
+        expect(expectedAssessmentActionButtonDisabled).toBeTrue();
     });
 
     it('Check disabled assessment button for exercises before due date as tutor', () => {
@@ -258,7 +258,7 @@ describe('TeamParticipationTableComponent', () => {
             },
             submission4,
         );
-        expect(expectedAssessmentActionButtonDisabled).toBe(true);
+        expect(expectedAssessmentActionButtonDisabled).toBeTrue();
     });
 
     it('Check disabled assessment button for programming exercises before due date as instructor', () => {
@@ -269,7 +269,7 @@ describe('TeamParticipationTableComponent', () => {
             },
             submission4,
         );
-        expect(expectedAssessmentActionButtonDisabled).toBe(true);
+        expect(expectedAssessmentActionButtonDisabled).toBeTrue();
     });
 
     it('Check enabled assessment button for exercises before due date as instructor', () => {

--- a/src/test/javascript/spec/component/team/team-participation-table.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team-participation-table.component.spec.ts
@@ -237,12 +237,12 @@ describe('TeamParticipationTableComponent', () => {
 
     it('Check enabled assessment button for exercises without due date', () => {
         const expectedAssessmentActionButtonDisabled = comp.isAssessmentButtonDisabled(exercise2, submission2);
-        expect(expectedAssessmentActionButtonDisabled).toBe(false);
+        expect(expectedAssessmentActionButtonDisabled).toBeFalse();
     });
 
     it('Check enabled assessment button for exercises with submission and passed due date', () => {
         const expectedAssessmentActionButtonDisabled = comp.isAssessmentButtonDisabled(exercise3, submission3);
-        expect(expectedAssessmentActionButtonDisabled).toBe(false);
+        expect(expectedAssessmentActionButtonDisabled).toBeFalse();
     });
 
     it('Check disabled assessment button for exercises without submission', () => {
@@ -280,6 +280,6 @@ describe('TeamParticipationTableComponent', () => {
             },
             submission5,
         );
-        expect(expectedAssessmentActionButtonDisabled).toBe(false);
+        expect(expectedAssessmentActionButtonDisabled).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/team/team-update-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team-update-dialog.component.spec.ts
@@ -60,7 +60,7 @@ describe('TeamUpdateDialogComponent', () => {
         const closeButton = debugElement.query(By.css('button.btn-close'));
         expect(closeButton).not.toBeNull();
         closeButton.nativeElement.click();
-        expect(dismissSpy).toHaveBeenCalledTimes(1);
+        expect(dismissSpy).toHaveBeenCalledOnce();
 
         const cancelButton = debugElement.query(By.css('button.cancel'));
         expect(cancelButton).not.toBeNull();

--- a/src/test/javascript/spec/component/team/team.component.spec.ts
+++ b/src/test/javascript/spec/component/team/team.component.spec.ts
@@ -149,7 +149,7 @@ describe('TeamComponent', () => {
             comp.ngOnInit();
             jest.spyOn(router, 'navigate');
             comp.onTeamDelete();
-            expect(router['navigate']).toHaveBeenCalledTimes(1);
+            expect(router['navigate']).toHaveBeenCalledOnce();
             expect(router['navigate']).toHaveBeenCalledWith(['/course-management', mockExercise.course?.id, 'exercises', mockExercise.id, 'teams']);
         });
     });

--- a/src/test/javascript/spec/component/team/teams-import-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/team/teams-import-dialog.component.spec.ts
@@ -110,8 +110,8 @@ describe('TeamsImportDialogComponent', () => {
             const sourceExercise = mockSourceExercise;
             comp.sourceTeams = [];
             comp.loadSourceTeams(sourceExercise);
-            expect(comp.loadingSourceTeams).toBe(false);
-            expect(comp.loadingSourceTeamsFailed).toBe(false);
+            expect(comp.loadingSourceTeams).toBeFalse();
+            expect(comp.loadingSourceTeamsFailed).toBeFalse();
             expect(teamServiceStub).toHaveBeenCalledWith(sourceExercise.id);
             expect(comp.sourceTeams).toBe(mockSourceTeams);
             expect(computeSourceSpy).toHaveBeenCalledOnce();
@@ -123,7 +123,7 @@ describe('TeamsImportDialogComponent', () => {
             comp.sourceTeams = [];
             comp.loadSourceTeams(sourceExercise);
             expect(comp.sourceTeams).toBe(undefined);
-            expect(comp.loadingSourceTeams).toBe(false);
+            expect(comp.loadingSourceTeams).toBeFalse();
             expect(comp.loadingSourceTeamsFailed).toBeTrue();
             expect(teamServiceStub).toHaveBeenCalledWith(sourceExercise.id);
             expect(computeSourceSpy).not.toHaveBeenCalled();
@@ -204,7 +204,7 @@ describe('TeamsImportDialogComponent', () => {
 
         it('returns false if short name is in already existing short names', () => {
             comp.teamShortNamesAlreadyExistingInExercise = [mockTeam.shortName!];
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(false);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeFalse();
         });
 
         it('returns true if short name is not in already existing short names', () => {
@@ -214,7 +214,7 @@ describe('TeamsImportDialogComponent', () => {
 
         it('Import from exercise: returns false if one of the students login is in already existing students', () => {
             comp.conflictingLoginsSet = new Set([mockTeamStudents[0].login!]);
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(false);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeFalse();
         });
 
         it('Import from exercise: returns true if none of the students login is in already existing students', () => {
@@ -224,7 +224,7 @@ describe('TeamsImportDialogComponent', () => {
         it('Import from file: returns false if one of the students login is in already existing students', () => {
             comp.conflictingLoginsSet = new Set([mockTeamStudents[0].login!]);
             comp.showImportFromExercise = false;
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(false);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeFalse();
         });
 
         it('Import from exercise: returns true if one of the students registration number is in already existing students', () => {
@@ -235,7 +235,7 @@ describe('TeamsImportDialogComponent', () => {
         it('Import from file: returns false if one of the students registration number is in already existing students', () => {
             comp.conflictingRegistrationNumbersSet = new Set([mockTeamStudents[0].visibleRegistrationNumber!]);
             comp.showImportFromExercise = false;
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(false);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeFalse();
         });
 
         it('Import from exercise: returns true if one of the students registration number is in already other source teams', () => {
@@ -248,14 +248,14 @@ describe('TeamsImportDialogComponent', () => {
             comp.conflictingRegistrationNumbersSet = new Set([mockTeamStudents[0].visibleRegistrationNumber!]);
             comp.studentsAppearInMultipleTeams = true;
             comp.showImportFromExercise = false;
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(false);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeFalse();
         });
 
         it('Import from file: returns false if one of the students login is in already other source teams', () => {
             comp.conflictingLoginsSet = new Set([mockTeamStudents[0].login!]);
             comp.studentsAppearInMultipleTeams = true;
             comp.showImportFromExercise = false;
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(false);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeFalse();
         });
 
         it('Import from file: returns true if no student is in multiple teams', () => {
@@ -330,7 +330,7 @@ describe('TeamsImportDialogComponent', () => {
 
         it('Import from exercise: should return false if there is no sourceExercise', () => {
             comp.sourceExercise = undefined;
-            expect(comp.showImportStrategyChoices).toBe(false);
+            expect(comp.showImportStrategyChoices).toBeFalse();
         });
 
         it('Import from exercise: should return true if there is a sourceExercise and source team', () => {
@@ -339,18 +339,18 @@ describe('TeamsImportDialogComponent', () => {
 
         it('should return false if there is no source team', () => {
             comp.sourceTeams = [];
-            expect(comp.showImportStrategyChoices).toBe(false);
+            expect(comp.showImportStrategyChoices).toBeFalse();
         });
 
         it('should return false if there is no existing team', () => {
             comp.teams = [];
-            expect(comp.showImportStrategyChoices).toBe(false);
+            expect(comp.showImportStrategyChoices).toBeFalse();
         });
 
         it('Import from file: should return false if source teams undefined', () => {
             comp.sourceTeams = undefined;
             comp.showImportFromExercise = false;
-            expect(comp.showImportStrategyChoices).toBe(false);
+            expect(comp.showImportStrategyChoices).toBeFalse();
         });
 
         it('Import from file: should return true if source exercise undefined', () => {
@@ -383,7 +383,7 @@ describe('TeamsImportDialogComponent', () => {
             });
 
             it('Import from exercise: should return false if there is no sourceExercise', () => {
-                expect(comp.showImportPreviewNumbers).toBe(false);
+                expect(comp.showImportPreviewNumbers).toBeFalse();
             });
 
             it('Import from exercise: should return true if there is a sourceExercise and source team', () => {
@@ -393,11 +393,11 @@ describe('TeamsImportDialogComponent', () => {
             });
 
             it('should return false if there is no source team', () => {
-                expect(comp.showImportPreviewNumbers).toBe(false);
+                expect(comp.showImportPreviewNumbers).toBeFalse();
             });
 
             it('Import from exercise: should return false if there is no import strategy', () => {
-                expect(comp.showImportPreviewNumbers).toBe(false);
+                expect(comp.showImportPreviewNumbers).toBeFalse();
             });
         });
 
@@ -410,12 +410,12 @@ describe('TeamsImportDialogComponent', () => {
             });
 
             it('Import from file: should return false if there is no import strategy', () => {
-                expect(comp.showImportPreviewNumbers).toBe(false);
+                expect(comp.showImportPreviewNumbers).toBeFalse();
             });
 
             it('Import from file: should return false if no students in multiple teams and no import strategy', () => {
                 comp.importStrategy = undefined;
-                expect(comp.showImportPreviewNumbers).toBe(false);
+                expect(comp.showImportPreviewNumbers).toBeFalse();
             });
 
             it('Import from file: should return true if there are students appear in multiple teams and conflicting registration numbers', () => {
@@ -443,7 +443,7 @@ describe('TeamsImportDialogComponent', () => {
         });
 
         it('should return false', () => {
-            expect(comp.isSubmitDisabled).toBe(false);
+            expect(comp.isSubmitDisabled).toBeFalse();
         });
 
         it('Import from exercise: should return true if importing', () => {
@@ -469,13 +469,13 @@ describe('TeamsImportDialogComponent', () => {
         it('Import from file: should return false if importing', () => {
             comp.isImporting = true;
             comp.showImportFromExercise = false;
-            expect(comp.isSubmitDisabled).toBe(false);
+            expect(comp.isSubmitDisabled).toBeFalse();
         });
 
         it('Import from file: should return false if it has no source exercise', () => {
             comp.sourceExercise = undefined;
             comp.showImportFromExercise = false;
-            expect(comp.isSubmitDisabled).toBe(false);
+            expect(comp.isSubmitDisabled).toBeFalse();
         });
 
         it('Import from file: should return true if it has source teams', () => {
@@ -550,7 +550,7 @@ describe('TeamsImportDialogComponent', () => {
             expect(importTeamsStub).not.toHaveBeenCalled();
             expect(onSuccessStub).not.toHaveBeenCalled();
             expect(onErrorStub).not.toHaveBeenCalled();
-            expect(comp.isImporting).toBe(false);
+            expect(comp.isImporting).toBeFalse();
         });
 
         it('should call importTeamsFromSourceExercise if show import from exercise and call save success', () => {
@@ -580,7 +580,7 @@ describe('TeamsImportDialogComponent', () => {
             expect(importTeamsStub).toHaveBeenCalledWith(comp.exercise, comp.sourceTeams, comp.importStrategy);
             expect(onSuccessStub).toHaveBeenCalledWith(fromFileResponse);
             expect(onErrorStub).not.toHaveBeenCalled();
-            expect(comp.isImporting).toBe(false);
+            expect(comp.isImporting).toBeFalse();
         });
 
         it('should call importTeamsFromFile if not show import from exercise and call save error on Error', () => {
@@ -592,7 +592,7 @@ describe('TeamsImportDialogComponent', () => {
             expect(importTeamsStub).toHaveBeenCalledWith(comp.exercise, comp.sourceTeams, comp.importStrategy);
             expect(onSuccessStub).not.toHaveBeenCalled();
             expect(onErrorStub).toHaveBeenCalledWith(error);
-            expect(comp.isImporting).toBe(false);
+            expect(comp.isImporting).toBeFalse();
         });
     });
 
@@ -643,7 +643,7 @@ describe('TeamsImportDialogComponent', () => {
             comp.onSaveSuccess(response);
             tick(500);
             expect(modalStub).toHaveBeenCalledWith(mockSourceTeams);
-            expect(comp.isImporting).toBe(false);
+            expect(comp.isImporting).toBeFalse();
             expect(alertServiceStub).toHaveBeenCalledWith('artemisApp.team.importSuccess', { numberOfImportedTeams: comp.numberOfTeamsToBeImported });
         }));
     });
@@ -661,7 +661,7 @@ describe('TeamsImportDialogComponent', () => {
             response = new HttpErrorResponse({ error: {} });
             comp.isImporting = true;
             comp.onSaveError(response);
-            expect(comp.isImporting).toBe(false);
+            expect(comp.isImporting).toBeFalse();
             expect(alertServiceStub).toHaveBeenCalledWith('artemisApp.team.importError');
         });
 
@@ -671,7 +671,7 @@ describe('TeamsImportDialogComponent', () => {
             response = new HttpErrorResponse({ error: { errorKey: 'studentsNotFound', params: { registrationNumbers: notFoundRegistrationNumbers, logins: notFoundLogins } } });
             comp.isImporting = true;
             comp.onSaveError(response);
-            expect(comp.isImporting).toBe(false);
+            expect(comp.isImporting).toBeFalse();
             expect(alertServiceStub).toHaveBeenCalledWith('artemisApp.team.errors.registrationNumbersNotFound', { registrationNumbers: notFoundRegistrationNumbers });
             expect(alertServiceStub).toHaveBeenCalledWith('artemisApp.team.errors.loginsNotFound', { logins: notFoundLogins });
         });
@@ -686,7 +686,7 @@ describe('TeamsImportDialogComponent', () => {
             response = new HttpErrorResponse({ error: { errorKey: 'studentsAppearMultipleTimes', params: { students } } });
             comp.isImporting = true;
             comp.onSaveError(response);
-            expect(comp.isImporting).toBe(false);
+            expect(comp.isImporting).toBeFalse();
             expect(alertServiceStub).toHaveBeenCalledWith('artemisApp.team.errors.studentsAppearMultipleTimes', { students: message });
         });
     });
@@ -696,7 +696,7 @@ describe('TeamsImportDialogComponent', () => {
         const expectValuesToBeReset = () => {
             expect(comp.sourceTeams).toBe(undefined);
             expect(comp.sourceExercise).toBe(undefined);
-            expect(comp.isImporting).toBe(false);
+            expect(comp.isImporting).toBeFalse();
             expect(comp.conflictingLoginsSet).toEqual(new Set(logins));
             expect(comp.conflictingRegistrationNumbersSet).toEqual(new Set(registrationNumbers));
             expect(initImportStrategyStub).toHaveBeenCalledOnce();
@@ -722,7 +722,7 @@ describe('TeamsImportDialogComponent', () => {
 
         it('should set show import from exercise to false', () => {
             comp.setShowImportFromExercise(false);
-            expect(comp.showImportFromExercise).toBe(false);
+            expect(comp.showImportFromExercise).toBeFalse();
             expectValuesToBeReset();
         });
     });
@@ -757,12 +757,12 @@ describe('TeamsImportDialogComponent', () => {
 
         it('should return false no source teams', () => {
             comp.sourceTeams = undefined;
-            expect(comp.showLegend).toBe(false);
+            expect(comp.showLegend).toBeFalse();
         });
 
         it('should return false source teams length is equal to conflict free teams length', () => {
             comp.sourceTeamsFreeOfConflicts = mockSourceTeams;
-            expect(comp.showLegend).toBe(false);
+            expect(comp.showLegend).toBeFalse();
         });
 
         it('should return true source teams length not equal to conflict free teams length', () => {

--- a/src/test/javascript/spec/component/team/teams-import-dialog.component.spec.ts
+++ b/src/test/javascript/spec/component/team/teams-import-dialog.component.spec.ts
@@ -92,7 +92,7 @@ describe('TeamsImportDialogComponent', () => {
         it('should compute potential conflicts based on existing teams', () => {
             const potentialConflictSpy = jest.spyOn(comp, 'computePotentialConflictsBasedOnExistingTeams');
             comp.ngOnInit();
-            expect(potentialConflictSpy).toHaveBeenCalledTimes(1);
+            expect(potentialConflictSpy).toHaveBeenCalledOnce();
         });
     });
 
@@ -114,7 +114,7 @@ describe('TeamsImportDialogComponent', () => {
             expect(comp.loadingSourceTeamsFailed).toBe(false);
             expect(teamServiceStub).toHaveBeenCalledWith(sourceExercise.id);
             expect(comp.sourceTeams).toBe(mockSourceTeams);
-            expect(computeSourceSpy).toHaveBeenCalledTimes(1);
+            expect(computeSourceSpy).toHaveBeenCalledOnce();
         });
 
         it('should not load teams of given exercise if find failed', () => {
@@ -124,7 +124,7 @@ describe('TeamsImportDialogComponent', () => {
             comp.loadSourceTeams(sourceExercise);
             expect(comp.sourceTeams).toBe(undefined);
             expect(comp.loadingSourceTeams).toBe(false);
-            expect(comp.loadingSourceTeamsFailed).toBe(true);
+            expect(comp.loadingSourceTeamsFailed).toBeTrue();
             expect(teamServiceStub).toHaveBeenCalledWith(sourceExercise.id);
             expect(computeSourceSpy).not.toHaveBeenCalled();
         });
@@ -144,7 +144,7 @@ describe('TeamsImportDialogComponent', () => {
             const sourceExercise = mockSourceExercise;
             comp.onSelectSourceExercise(sourceExercise);
             expect(comp.sourceExercise).toBe(sourceExercise);
-            expect(initImportStrategyStub).toHaveBeenCalledTimes(1);
+            expect(initImportStrategyStub).toHaveBeenCalledOnce();
             expect(loadSourceStub).toHaveBeenCalledWith(sourceExercise);
         });
     });
@@ -209,7 +209,7 @@ describe('TeamsImportDialogComponent', () => {
 
         it('returns true if short name is not in already existing short names', () => {
             comp.teamShortNamesAlreadyExistingInExercise = [];
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(true);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeTrue();
         });
 
         it('Import from exercise: returns false if one of the students login is in already existing students', () => {
@@ -218,7 +218,7 @@ describe('TeamsImportDialogComponent', () => {
         });
 
         it('Import from exercise: returns true if none of the students login is in already existing students', () => {
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(true);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeTrue();
         });
 
         it('Import from file: returns false if one of the students login is in already existing students', () => {
@@ -229,7 +229,7 @@ describe('TeamsImportDialogComponent', () => {
 
         it('Import from exercise: returns true if one of the students registration number is in already existing students', () => {
             comp.conflictingRegistrationNumbersSet = new Set([mockTeamStudents[0].visibleRegistrationNumber!]);
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(true);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeTrue();
         });
 
         it('Import from file: returns false if one of the students registration number is in already existing students', () => {
@@ -241,7 +241,7 @@ describe('TeamsImportDialogComponent', () => {
         it('Import from exercise: returns true if one of the students registration number is in already other source teams', () => {
             comp.conflictingRegistrationNumbersSet = new Set([mockTeamStudents[0].visibleRegistrationNumber!]);
             comp.studentsAppearInMultipleTeams = true;
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(true);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeTrue();
         });
 
         it('Import from file: returns false if one of the students registration number is in already other source teams', () => {
@@ -260,7 +260,7 @@ describe('TeamsImportDialogComponent', () => {
 
         it('Import from file: returns true if no student is in multiple teams', () => {
             comp.showImportFromExercise = false;
-            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBe(true);
+            expect(comp.isSourceTeamFreeOfAnyConflicts(mockTeam)).toBeTrue();
         });
     });
 
@@ -334,7 +334,7 @@ describe('TeamsImportDialogComponent', () => {
         });
 
         it('Import from exercise: should return true if there is a sourceExercise and source team', () => {
-            expect(comp.showImportStrategyChoices).toBe(true);
+            expect(comp.showImportStrategyChoices).toBeTrue();
         });
 
         it('should return false if there is no source team', () => {
@@ -356,7 +356,7 @@ describe('TeamsImportDialogComponent', () => {
         it('Import from file: should return true if source exercise undefined', () => {
             comp.sourceExercise = undefined;
             comp.showImportFromExercise = false;
-            expect(comp.showImportStrategyChoices).toBe(true);
+            expect(comp.showImportStrategyChoices).toBeTrue();
         });
     });
 
@@ -389,7 +389,7 @@ describe('TeamsImportDialogComponent', () => {
             it('Import from exercise: should return true if there is a sourceExercise and source team', () => {
                 comp.sourceExercise = mockSourceExercise;
                 comp.sourceTeams = mockSourceTeams;
-                expect(comp.showImportPreviewNumbers).toBe(true);
+                expect(comp.showImportPreviewNumbers).toBeTrue();
             });
 
             it('should return false if there is no source team', () => {
@@ -422,14 +422,14 @@ describe('TeamsImportDialogComponent', () => {
                 comp.conflictingRegistrationNumbersSet = new Set(['1', '2']);
                 comp.studentsAppearInMultipleTeams = true;
                 comp.importStrategy = undefined;
-                expect(comp.showImportPreviewNumbers).toBe(true);
+                expect(comp.showImportPreviewNumbers).toBeTrue();
             });
 
             it('Import from file: should return true if there are students appear in multiple teams and conflicting logins', () => {
                 comp.conflictingLoginsSet = new Set(['l1', 'l2']);
                 comp.studentsAppearInMultipleTeams = true;
                 comp.importStrategy = undefined;
-                expect(comp.showImportPreviewNumbers).toBe(true);
+                expect(comp.showImportPreviewNumbers).toBeTrue();
             });
         });
     });
@@ -448,22 +448,22 @@ describe('TeamsImportDialogComponent', () => {
 
         it('Import from exercise: should return true if importing', () => {
             comp.isImporting = true;
-            expect(comp.isSubmitDisabled).toBe(true);
+            expect(comp.isSubmitDisabled).toBeTrue();
         });
 
         it('Import from exercise: should return true if it has source exercise', () => {
             comp.sourceExercise = undefined;
-            expect(comp.isSubmitDisabled).toBe(true);
+            expect(comp.isSubmitDisabled).toBeTrue();
         });
 
         it('Import from exercise: should return true if it has source teams', () => {
             comp.sourceTeams = undefined;
-            expect(comp.isSubmitDisabled).toBe(true);
+            expect(comp.isSubmitDisabled).toBeTrue();
         });
 
         it('Import from exercise: should return true if it has import strategy', () => {
             comp.importStrategy = undefined;
-            expect(comp.isSubmitDisabled).toBe(true);
+            expect(comp.isSubmitDisabled).toBeTrue();
         });
 
         it('Import from file: should return false if importing', () => {
@@ -481,20 +481,20 @@ describe('TeamsImportDialogComponent', () => {
         it('Import from file: should return true if it has source teams', () => {
             comp.sourceTeams = undefined;
             comp.showImportFromExercise = false;
-            expect(comp.isSubmitDisabled).toBe(true);
+            expect(comp.isSubmitDisabled).toBeTrue();
         });
 
         it('Import from file: should return true if it has import strategy', () => {
             comp.importStrategy = undefined;
             comp.showImportFromExercise = false;
-            expect(comp.isSubmitDisabled).toBe(true);
+            expect(comp.isSubmitDisabled).toBeTrue();
         });
 
         it('Import from file: should return true if there same registration number is in two teams', () => {
             comp.conflictingRegistrationNumbersSet = new Set(['1', '2']);
             comp.studentsAppearInMultipleTeams = true;
             comp.showImportFromExercise = false;
-            expect(comp.isSubmitDisabled).toBe(true);
+            expect(comp.isSubmitDisabled).toBeTrue();
         });
     });
 
@@ -518,7 +518,7 @@ describe('TeamsImportDialogComponent', () => {
         it('should return false', () => {
             const importTeamsStub = jest.spyOn(comp, 'importTeams');
             comp.purgeAndImportTeams();
-            expect(importTeamsStub).toHaveBeenCalledTimes(1);
+            expect(importTeamsStub).toHaveBeenCalledOnce();
         });
     });
 
@@ -559,7 +559,7 @@ describe('TeamsImportDialogComponent', () => {
             expect(importTeamsStub).not.toHaveBeenCalled();
             expect(onSuccessStub).toHaveBeenCalledWith(fromExerciseResponse);
             expect(onErrorStub).not.toHaveBeenCalled();
-            expect(comp.isImporting).toBe(true);
+            expect(comp.isImporting).toBeTrue();
         });
 
         it('should call importTeamsFromSourceExercise if show import from exercise and call save error on Error', () => {
@@ -570,7 +570,7 @@ describe('TeamsImportDialogComponent', () => {
             expect(importTeamsStub).not.toHaveBeenCalled();
             expect(onSuccessStub).not.toHaveBeenCalled();
             expect(onErrorStub).toHaveBeenCalledWith(error);
-            expect(comp.isImporting).toBe(true);
+            expect(comp.isImporting).toBeTrue();
         });
 
         it('should call importTeamsFromFile if not show import from exercise and call save success', () => {
@@ -608,11 +608,11 @@ describe('TeamsImportDialogComponent', () => {
 
         it('change component files and convert file teams to normal teams', () => {
             comp.onTeamsChanged(mockSourceTeams);
-            expect(initImportStub).toHaveBeenCalledTimes(1);
+            expect(initImportStub).toHaveBeenCalledOnce();
             expect(comp.sourceTeams).toEqual(mockSourceTeams);
             expect(comp.conflictingRegistrationNumbersSet).toEqual(new Set(registrationNumbers));
             expect(comp.conflictingLoginsSet).toEqual(new Set(logins));
-            expect(computeSourceFreeOfConflictsStub).toHaveBeenCalledTimes(1);
+            expect(computeSourceFreeOfConflictsStub).toHaveBeenCalledOnce();
         });
 
         it('adds registration number if a student is in two or more teams', () => {
@@ -699,7 +699,7 @@ describe('TeamsImportDialogComponent', () => {
             expect(comp.isImporting).toBe(false);
             expect(comp.conflictingLoginsSet).toEqual(new Set(logins));
             expect(comp.conflictingRegistrationNumbersSet).toEqual(new Set(registrationNumbers));
-            expect(initImportStrategyStub).toHaveBeenCalledTimes(1);
+            expect(initImportStrategyStub).toHaveBeenCalledOnce();
         };
 
         beforeEach(() => {
@@ -716,7 +716,7 @@ describe('TeamsImportDialogComponent', () => {
         it('should set show import from exercise to true', () => {
             comp.showImportFromExercise = false;
             comp.setShowImportFromExercise(true);
-            expect(comp.showImportFromExercise).toBe(true);
+            expect(comp.showImportFromExercise).toBeTrue();
             expectValuesToBeReset();
         });
 
@@ -767,7 +767,7 @@ describe('TeamsImportDialogComponent', () => {
 
         it('should return true source teams length not equal to conflict free teams length', () => {
             comp.sourceTeamsFreeOfConflicts = [];
-            expect(comp.showLegend).toBe(true);
+            expect(comp.showLegend).toBeTrue();
         });
     });
 

--- a/src/test/javascript/spec/component/team/teams-import-from-file-form.component.spec.ts
+++ b/src/test/javascript/spec/component/team/teams-import-from-file-form.component.spec.ts
@@ -87,7 +87,7 @@ describe('TeamsImportFromFileFormComponent', () => {
             expect(comp.importedTeams).toEqual(mockFileStudents);
             expect(comp.sourceTeams).toStrictEqual(mockFileTeamsConverted);
             expect(teams).toStrictEqual(mockFileTeamsConverted);
-            expect(comp.loading).toBe(false);
+            expect(comp.loading).toBeFalse();
             expect(comp.importFile).toBe(undefined);
             expect(comp.importFileName).toBe('');
             expect(getElementStub).toHaveBeenCalledOnce();

--- a/src/test/javascript/spec/component/team/teams-import-from-file-form.component.spec.ts
+++ b/src/test/javascript/spec/component/team/teams-import-from-file-form.component.spec.ts
@@ -52,7 +52,7 @@ describe('TeamsImportFromFileFormComponent', () => {
             const setImportStub = jest.spyOn(comp, 'setImportFile');
             const inputElement = debugElement.query(By.css('input')).nativeElement;
             inputElement.dispatchEvent(new Event('change'));
-            expect(setImportStub).toHaveBeenCalledTimes(1);
+            expect(setImportStub).toHaveBeenCalledOnce();
         });
     });
 
@@ -83,14 +83,14 @@ describe('TeamsImportFromFileFormComponent', () => {
         });
 
         afterEach(() => {
-            expect(convertTeamsStub).toHaveBeenCalledTimes(1);
+            expect(convertTeamsStub).toHaveBeenCalledOnce();
             expect(comp.importedTeams).toEqual(mockFileStudents);
             expect(comp.sourceTeams).toStrictEqual(mockFileTeamsConverted);
             expect(teams).toStrictEqual(mockFileTeamsConverted);
             expect(comp.loading).toBe(false);
             expect(comp.importFile).toBe(undefined);
             expect(comp.importFileName).toBe('');
-            expect(getElementStub).toHaveBeenCalledTimes(1);
+            expect(getElementStub).toHaveBeenCalledOnce();
             expect(control.value).toBe('');
         });
 
@@ -130,7 +130,7 @@ describe('TeamsImportFromFileFormComponent', () => {
             comp.setImportFile(ev);
             expect(comp.importFile).toStrictEqual(file);
             expect(comp.importFileName).toBe('testFileName');
-            expect(changeDetectorDetectChangesSpy).toHaveBeenCalledTimes(1);
+            expect(changeDetectorDetectChangesSpy).toHaveBeenCalledOnce();
         });
 
         it('should set import file correctly', () => {

--- a/src/test/javascript/spec/component/text-assessment-dashboard/text-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/text-assessment-dashboard/text-assessment-dashboard.component.spec.ts
@@ -124,7 +124,7 @@ describe('TextAssessmentDashboardComponent', () => {
         component.ngOnInit();
 
         // check
-        expect(getTextSubmissionStub).toHaveBeenCalledTimes(1);
+        expect(getTextSubmissionStub).toHaveBeenCalledOnce();
         expect(getTextSubmissionStub).toHaveBeenCalledWith(textExercise.id, { submittedOnly: true });
         expect(component.exercise).toEqual(textExercise);
         expect(component.examId).toBe(2);
@@ -142,7 +142,7 @@ describe('TextAssessmentDashboardComponent', () => {
         component.ngOnInit();
         tick(100);
         // check
-        expect(getTextSubmissionStub).toHaveBeenCalledTimes(1);
+        expect(getTextSubmissionStub).toHaveBeenCalledOnce();
         expect(getTextSubmissionStub).toHaveBeenCalledWith(textExercise.id, { submittedOnly: true });
         expect(component.submissions).toEqual([textSubmission]);
         expect(component.filteredSubmissions).toEqual([textSubmission]);
@@ -159,7 +159,7 @@ describe('TextAssessmentDashboardComponent', () => {
         component.ngOnInit();
 
         // check
-        expect(findExerciseStub).toHaveBeenCalledTimes(1);
+        expect(findExerciseStub).toHaveBeenCalledOnce();
         expect(getTextSubmissionStub).toHaveBeenCalledWith(textExercise.id, { submittedOnly: true });
         expect(component.submissions).toEqual([]);
         expect(component.filteredSubmissions).toEqual([]);
@@ -184,9 +184,9 @@ describe('TextAssessmentDashboardComponent', () => {
         tick();
 
         // check
-        expect(cancelAssessmentStub).toHaveBeenCalledTimes(1);
+        expect(cancelAssessmentStub).toHaveBeenCalledOnce();
         expect(cancelAssessmentStub).toHaveBeenCalledWith(textSubmission.participation.id, textSubmission.id);
-        expect(windowSpy).toHaveBeenCalledTimes(1);
+        expect(windowSpy).toHaveBeenCalledOnce();
     }));
 
     it('should sort rows', () => {
@@ -197,7 +197,7 @@ describe('TextAssessmentDashboardComponent', () => {
         component.submissions = [textSubmission];
         component.sortRows();
 
-        expect(sortServiceSpy).toHaveBeenCalledTimes(1);
+        expect(sortServiceSpy).toHaveBeenCalledOnce();
         expect(sortServiceSpy).toHaveBeenCalledWith([textSubmission], 'predicate', false);
     });
 

--- a/src/test/javascript/spec/component/text-assessment-dashboard/text-assessment-dashboard.component.spec.ts
+++ b/src/test/javascript/spec/component/text-assessment-dashboard/text-assessment-dashboard.component.spec.ts
@@ -116,7 +116,7 @@ describe('TextAssessmentDashboardComponent', () => {
         // test for init values
         expect(component).toBeTruthy();
         expect(component.submissions).toEqual([]);
-        expect(component.reverse).toBe(false);
+        expect(component.reverse).toBeFalse();
         expect(component.predicate).toBe('id');
         expect(component.filteredSubmissions).toEqual([]);
 

--- a/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/text-editor/text-editor.component.spec.ts
@@ -238,7 +238,7 @@ describe('TextEditorComponent', () => {
         comp.answer = 'abc';
         jest.spyOn(textSubmissionService, 'update');
         comp.submit();
-        expect(textSubmissionService.update).toHaveBeenCalledTimes(1);
+        expect(textSubmissionService.update).toHaveBeenCalledOnce();
         expect(comp.isSaving).toBeFalsy();
     });
 
@@ -281,7 +281,7 @@ describe('TextEditorComponent', () => {
         // @ts-ignore
         jest.spyOn(comp, 'updateParticipation');
         comp.onReceiveSubmissionFromTeam(submission);
-        expect(comp['updateParticipation']).toHaveBeenCalledTimes(1);
+        expect(comp['updateParticipation']).toHaveBeenCalledOnce();
         expect(comp.answer).toEqual('abc');
     });
 

--- a/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
@@ -464,7 +464,7 @@ describe('ExampleTextSubmissionComponent', () => {
         // THEN
         expect(exampleSubmissionServiceSpy).toHaveBeenCalledOnce();
         expect(comp.exampleSubmission).toEqual(exampleSubmission);
-        expect(comp.unsavedSubmissionChanges).toBe(false);
+        expect(comp.unsavedSubmissionChanges).toBeFalse();
         expect(alertSuccessSpy).toHaveBeenCalledOnce();
         expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.exampleSubmission.saveSuccessful');
     });

--- a/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/example-text-submission.component.spec.ts
@@ -218,7 +218,7 @@ describe('ExampleTextSubmissionComponent', () => {
         const alertErrorSpy = jest.spyOn(alertService, 'error');
         comp.saveAssessments();
 
-        expect(alertErrorSpy).toHaveBeenCalledTimes(1);
+        expect(alertErrorSpy).toHaveBeenCalledOnce();
     });
 
     it('editing submission from assessment state switches state', fakeAsync(() => {
@@ -309,7 +309,7 @@ describe('ExampleTextSubmissionComponent', () => {
         const alertErrorSpy = jest.spyOn(alertService, 'error');
         comp.checkAssessment();
 
-        expect(alertErrorSpy).toHaveBeenCalledTimes(1);
+        expect(alertErrorSpy).toHaveBeenCalledOnce();
     });
 
     it('when wrong tutor assessment, upon server response should mark feedback as incorrect', fakeAsync(() => {
@@ -365,8 +365,8 @@ describe('ExampleTextSubmissionComponent', () => {
         comp.createNewExampleTextSubmission();
         tick();
 
-        expect(createStub).toHaveBeenCalledTimes(1);
-        expect(alertSuccessSpy).toHaveBeenCalledTimes(1);
+        expect(createStub).toHaveBeenCalledOnce();
+        expect(alertSuccessSpy).toHaveBeenCalledOnce();
     }));
 
     it('should not create example submission', fakeAsync(() => {
@@ -378,8 +378,8 @@ describe('ExampleTextSubmissionComponent', () => {
         comp.createNewExampleTextSubmission();
         tick();
 
-        expect(createStub).toHaveBeenCalledTimes(1);
-        expect(alertErrorSpy).toHaveBeenCalledTimes(1);
+        expect(createStub).toHaveBeenCalledOnce();
+        expect(alertErrorSpy).toHaveBeenCalledOnce();
     }));
 
     it('should read and understood', () => {
@@ -398,9 +398,9 @@ describe('ExampleTextSubmissionComponent', () => {
         comp.readAndUnderstood();
 
         // THEN
-        expect(alertSpy).toHaveBeenCalledTimes(1);
+        expect(alertSpy).toHaveBeenCalledOnce();
         expect(alertSpy).toHaveBeenCalledWith('artemisApp.exampleSubmission.readSuccessfully');
-        expect(routerSpy).toHaveBeenCalledTimes(1);
+        expect(routerSpy).toHaveBeenCalledOnce();
     });
 
     it('should go back with exam', fakeAsync(() => {
@@ -462,10 +462,10 @@ describe('ExampleTextSubmissionComponent', () => {
         comp.updateExampleTextSubmission();
 
         // THEN
-        expect(exampleSubmissionServiceSpy).toHaveBeenCalledTimes(1);
+        expect(exampleSubmissionServiceSpy).toHaveBeenCalledOnce();
         expect(comp.exampleSubmission).toEqual(exampleSubmission);
         expect(comp.unsavedSubmissionChanges).toBe(false);
-        expect(alertSuccessSpy).toHaveBeenCalledTimes(1);
+        expect(alertSuccessSpy).toHaveBeenCalledOnce();
         expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.exampleSubmission.saveSuccessful');
     });
 

--- a/src/test/javascript/spec/component/text-exercise/text-exercise-import.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/text-exercise-import.component.spec.ts
@@ -69,7 +69,7 @@ describe('TextExercise Import Component', () => {
         comp.clear();
 
         // THEN
-        expect(activeModalSpy).toHaveBeenCalledTimes(1);
+        expect(activeModalSpy).toHaveBeenCalledOnce();
         expect(activeModalSpy).toHaveBeenCalledWith('cancel');
     });
 
@@ -81,7 +81,7 @@ describe('TextExercise Import Component', () => {
         comp.openImport(exercise);
 
         // THEN
-        expect(activeModalSpy).toHaveBeenCalledTimes(1);
+        expect(activeModalSpy).toHaveBeenCalledOnce();
         expect(activeModalSpy).toHaveBeenCalledWith(exercise);
     });
 
@@ -120,7 +120,7 @@ describe('TextExercise Import Component', () => {
         fixture.detectChanges();
         comp.sortRows();
 
-        expect(sortServiceSpy).toHaveBeenCalledTimes(1);
+        expect(sortServiceSpy).toHaveBeenCalledOnce();
         expect(sortServiceSpy).toHaveBeenCalledWith([], comp.column.ID, false);
     });
 
@@ -140,6 +140,6 @@ describe('TextExercise Import Component', () => {
 
         tick(300);
 
-        expect(pagingServiceSpy).toHaveBeenCalledTimes(1);
+        expect(pagingServiceSpy).toHaveBeenCalledOnce();
     }));
 });

--- a/src/test/javascript/spec/component/text-exercise/text-exercise.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/text-exercise.component.spec.ts
@@ -70,7 +70,7 @@ describe('TextExercise Management Component', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(courseExerciseService.findAllTextExercisesForCourse).toHaveBeenCalledTimes(1);
+        expect(courseExerciseService.findAllTextExercisesForCourse).toHaveBeenCalledOnce();
     });
 
     it('Should open modal', () => {
@@ -79,7 +79,7 @@ describe('TextExercise Management Component', () => {
 
         comp.openImportModal();
         expect(modalService.open).toHaveBeenCalledWith(TextExerciseImportComponent, { size: 'lg', backdrop: 'static' });
-        expect(modalService.open).toHaveBeenCalledTimes(1);
+        expect(modalService.open).toHaveBeenCalledOnce();
     });
 
     it('Should return exercise id', () => {

--- a/src/test/javascript/spec/component/text-exercise/tutor-effort-statistics.component.spec.ts
+++ b/src/test/javascript/spec/component/text-exercise/tutor-effort-statistics.component.spec.ts
@@ -151,7 +151,7 @@ describe('TutorEffortStatisticsComponent', () => {
 
         component.onSelect();
 
-        expect(navigateSpy).toHaveBeenCalledTimes(1);
+        expect(navigateSpy).toHaveBeenCalledOnce();
         expect(navigateSpy).toHaveBeenCalledWith(expectedArray);
     });
 

--- a/src/test/javascript/spec/component/text-result/text-result.component.spec.ts
+++ b/src/test/javascript/spec/component/text-result/text-result.component.spec.ts
@@ -232,6 +232,6 @@ describe('TextResultComponent', () => {
         expect(component.textResults[0].feedback).not.toBe(undefined);
         expect(component.textResults[0].feedback!.isSubsequent).toBe(undefined);
         expect(component.textResults[1].feedback).not.toBe(undefined);
-        expect(component.textResults[1].feedback!.isSubsequent).toBe(true);
+        expect(component.textResults[1].feedback!.isSubsequent).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/text-submission-assessment/text-assessment-area.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-assessment-area.component.spec.ts
@@ -58,7 +58,7 @@ describe('TextAssessmentAreaComponent', () => {
 
         component.onAltToggle(eventMock, false);
         expect(spyOnAlt).toHaveBeenCalledOnce();
-        expect(component.autoTextBlockAssessment).toBe(false);
+        expect(component.autoTextBlockAssessment).toBeFalse();
     });
 
     it('should add TextBlockRef if text block is added manually', () => {

--- a/src/test/javascript/spec/component/text-submission-assessment/text-assessment-area.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-assessment-area.component.spec.ts
@@ -57,7 +57,7 @@ describe('TextAssessmentAreaComponent', () => {
         const eventMock = new KeyboardEvent('keydown', { key: 'Alt' });
 
         component.onAltToggle(eventMock, false);
-        expect(spyOnAlt).toHaveBeenCalledTimes(1);
+        expect(spyOnAlt).toHaveBeenCalledOnce();
         expect(component.autoTextBlockAssessment).toBe(false);
     });
 
@@ -68,7 +68,7 @@ describe('TextAssessmentAreaComponent', () => {
         component.addTextBlockRef(TextBlockRef.new());
         fixture.detectChanges();
 
-        expect(component.textBlockRefsAddedRemoved.emit).toHaveBeenCalledTimes(1);
+        expect(component.textBlockRefsAddedRemoved.emit).toHaveBeenCalledOnce();
         expect(component.textBlockRefs).toHaveLength(5);
     });
 
@@ -79,7 +79,7 @@ describe('TextAssessmentAreaComponent', () => {
         component.removeTextBlockRef(component.textBlockRefs[0]);
         fixture.detectChanges();
 
-        expect(component.textBlockRefsAddedRemoved.emit).toHaveBeenCalledTimes(1);
+        expect(component.textBlockRefsAddedRemoved.emit).toHaveBeenCalledOnce();
         expect(component.textBlockRefs).toHaveLength(3);
     });
 });

--- a/src/test/javascript/spec/component/text-submission-assessment/text-feedback-conflicts.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-feedback-conflicts.component.spec.ts
@@ -210,7 +210,7 @@ describe('TextFeedbackConflictsComponent', () => {
         component['setPropertiesFromServerResponse']([conflictingSubmission]);
         fixture.detectChanges();
 
-        expect(component.isOverrideDisabled).toBe(true);
+        expect(component.isOverrideDisabled).toBeTrue();
 
         const textAssessmentArea = fixture.debugElement.query(By.directive(TextAssessmentAreaComponent));
         const textAssessmentAreaComponent = textAssessmentArea.componentInstance as TextAssessmentAreaComponent;
@@ -313,8 +313,8 @@ describe('TextFeedbackConflictsComponent', () => {
         const solveConflictStub = jest.spyOn(textAssessmentService, 'solveFeedbackConflict').mockReturnValue(throwError(() => errorResponse));
         component.discardConflict();
 
-        expect(solveConflictStub).toHaveBeenCalledTimes(1);
-        expect(component.isMarkingDisabled).toBe(true);
+        expect(solveConflictStub).toHaveBeenCalledOnce();
+        expect(component.isMarkingDisabled).toBeTrue();
         expect(component.markBusy).toBe(false);
     });
 
@@ -343,7 +343,7 @@ describe('TextFeedbackConflictsComponent', () => {
         expect(button).not.toBe(null);
         button.triggerEventHandler('click', null);
 
-        expect(clickSpy).toHaveBeenCalledTimes(1);
+        expect(clickSpy).toHaveBeenCalledOnce();
     });
 
     it('should handle error correctly when submitting left submission', () => {
@@ -353,7 +353,7 @@ describe('TextFeedbackConflictsComponent', () => {
 
         component.overrideLeftSubmission();
 
-        expect(errorStub).toHaveBeenCalledTimes(1);
-        expect(component.isOverrideDisabled).toBe(true);
+        expect(errorStub).toHaveBeenCalledOnce();
+        expect(component.isOverrideDisabled).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/component/text-submission-assessment/text-feedback-conflicts.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-feedback-conflicts.component.spec.ts
@@ -220,7 +220,7 @@ describe('TextFeedbackConflictsComponent', () => {
         textAssessmentAreaComponent.textBlockRefsChangeEmit();
 
         expect(component.leftTotalScore).toBe(2);
-        expect(component.isOverrideDisabled).toBe(false);
+        expect(component.isOverrideDisabled).toBeFalse();
 
         jest.spyOn(textAssessmentService, 'submit').mockReturnValue(
             of(
@@ -315,7 +315,7 @@ describe('TextFeedbackConflictsComponent', () => {
 
         expect(solveConflictStub).toHaveBeenCalledOnce();
         expect(component.isMarkingDisabled).toBeTrue();
-        expect(component.markBusy).toBe(false);
+        expect(component.markBusy).toBeFalse();
     });
 
     it('should switch submissions when it changed in the header', () => {

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -180,7 +180,7 @@ describe('TextSubmissionAssessmentComponent', () => {
         component['activatedRoute'] = route();
         component.ngOnInit();
         tick();
-        expect(component.isTestRun).toBe(false);
+        expect(component.isTestRun).toBeFalse();
         expect(component.exerciseId).toBe(1);
         expect(component.examId).toBe(2);
     }));
@@ -323,7 +323,7 @@ describe('TextSubmissionAssessmentComponent', () => {
         component.save();
 
         expect(errorStub).toHaveBeenCalledOnce();
-        expect(component.saveBusy).toBe(false);
+        expect(component.saveBusy).toBeFalse();
     });
 
     it('should invoke import example submission', () => {

--- a/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/text-submission-assessment.component.spec.ts
@@ -322,7 +322,7 @@ describe('TextSubmissionAssessmentComponent', () => {
 
         component.save();
 
-        expect(errorStub).toHaveBeenCalledTimes(1);
+        expect(errorStub).toHaveBeenCalledOnce();
         expect(component.saveBusy).toBe(false);
     });
 
@@ -335,7 +335,7 @@ describe('TextSubmissionAssessmentComponent', () => {
 
         component.useStudentSubmissionAsExampleSubmission();
 
-        expect(importStub).toHaveBeenCalledTimes(1);
+        expect(importStub).toHaveBeenCalledOnce();
         expect(importStub).toHaveBeenCalledWith(submission.id, exercise.id);
     });
 
@@ -349,9 +349,9 @@ describe('TextSubmissionAssessmentComponent', () => {
 
         component.cancel();
 
-        expect(windowConfirmStub).toHaveBeenCalledTimes(1);
-        expect(navigateBackSpy).toHaveBeenCalledTimes(1);
-        expect(cancelAssessmentStub).toHaveBeenCalledTimes(1);
+        expect(windowConfirmStub).toHaveBeenCalledOnce();
+        expect(navigateBackSpy).toHaveBeenCalledOnce();
+        expect(cancelAssessmentStub).toHaveBeenCalledOnce();
         expect(cancelAssessmentStub).toHaveBeenCalledWith(participation?.id, submission.id);
     });
 
@@ -380,7 +380,7 @@ describe('TextSubmissionAssessmentComponent', () => {
         const queryParams = { queryParams: { 'correction-round': 0 } };
 
         component.nextSubmission();
-        expect(routerSpy).toHaveBeenCalledTimes(1);
+        expect(routerSpy).toHaveBeenCalledOnce();
         expect(routerSpy).toHaveBeenCalledWith(url, queryParams);
     }));
 
@@ -404,7 +404,7 @@ describe('TextSubmissionAssessmentComponent', () => {
 
         component.navigateToConflictingSubmissions(1);
 
-        expect(routerSpy).toHaveBeenCalledTimes(1);
+        expect(routerSpy).toHaveBeenCalledOnce();
         expect(routerSpy).toHaveBeenCalledWith(url, { state: { submission } });
     });
 });

--- a/src/test/javascript/spec/component/text-submission-assessment/textblock-assessment-card.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/textblock-assessment-card.component.spec.ts
@@ -87,7 +87,7 @@ describe('TextblockAssessmentCardComponent', () => {
         feedbackEditorComponent.dismiss();
 
         expect(component.textBlockRef.feedback).toBe(undefined);
-        expect(component.didDelete.emit).toHaveBeenCalledTimes(1);
+        expect(component.didDelete.emit).toHaveBeenCalledOnce();
         expect(component.didDelete.emit).toHaveBeenCalledWith(component.textBlockRef);
     });
 

--- a/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-dropdown.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-dropdown.component.spec.ts
@@ -48,7 +48,7 @@ describe('TextblockFeedbackDropdownComponent', () => {
         const changeSpy = jest.spyOn(component.didChange, 'emit');
         component.updateAssessmentWithDropdown(gradingInstruction);
 
-        expect(changeSpy).toHaveBeenCalledTimes(1);
+        expect(changeSpy).toHaveBeenCalledOnce();
         expect(component.feedback.gradingInstruction).toEqual(gradingInstruction);
     });
 

--- a/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-editor.component.spec.ts
+++ b/src/test/javascript/spec/component/text-submission-assessment/textblock-feedback-editor.component.spec.ts
@@ -186,7 +186,7 @@ describe('TextblockFeedbackEditorComponent', () => {
 
         component.escKeyup();
         fixture.detectChanges();
-        expect(confirmSpy).toHaveBeenCalledTimes(1);
+        expect(confirmSpy).toHaveBeenCalledOnce();
     });
 
     it('should show feedback impact warning when numberOfAffectedSubmissions > 0', () => {
@@ -225,7 +225,7 @@ describe('TextblockFeedbackEditorComponent', () => {
         const modalServiceSpy = jest.spyOn(modalService, 'open');
 
         component.openOriginOfFeedbackModal(content).then(() => {
-            expect(modalServiceSpy).toHaveBeenCalledTimes(1);
+            expect(modalServiceSpy).toHaveBeenCalledOnce();
         });
     });
 
@@ -277,7 +277,7 @@ describe('TextblockFeedbackEditorComponent', () => {
         component.connectAutomaticFeedbackOriginBlocksWithFeedback();
         tick();
 
-        expect(participationStub).toHaveBeenCalledTimes(1);
+        expect(participationStub).toHaveBeenCalledOnce();
         expect(component.listOfBlocksWithFeedback).toEqual([
             {
                 text: 'First text.',
@@ -357,6 +357,6 @@ describe('TextblockFeedbackEditorComponent', () => {
         component.feedback.type = FeedbackType.AUTOMATIC;
         const typeSpy = jest.spyOn(component.textAssessmentAnalytics, 'sendAssessmentEvent');
         component.didChange();
-        expect(typeSpy).toHaveBeenCalledTimes(1);
+        expect(typeSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/component/text/manual-text-selection.component.spec.ts
+++ b/src/test/javascript/spec/component/text/manual-text-selection.component.spec.ts
@@ -78,7 +78,7 @@ describe('ManualTextSelectionComponent', () => {
         const sendAssessmentEventSpy = jest.spyOn(component.textAssessmentAnalytics, 'sendAssessmentEvent');
         component.selectWord('lastWord');
         fixture.detectChanges();
-        expect(sendAssessmentEventSpy).toHaveBeenCalledTimes(1);
+        expect(sendAssessmentEventSpy).toHaveBeenCalledOnce();
         expect(sendAssessmentEventSpy).toHaveBeenCalledWith(TextAssessmentEventType.ADD_FEEDBACK_MANUALLY_SELECTED_BLOCK, FeedbackType.MANUAL, TextBlockType.MANUAL);
     });
 });

--- a/src/test/javascript/spec/component/tutor-leaderboard/tutor-leaderboard.component.spec.ts
+++ b/src/test/javascript/spec/component/tutor-leaderboard/tutor-leaderboard.component.spec.ts
@@ -55,7 +55,7 @@ describe('TutorLeaderboardComponent', () => {
             testIsAtLeastInstructor((component) => {
                 component.course = course;
             });
-            expect(comp.isExerciseDashboard).toBe(false);
+            expect(comp.isExerciseDashboard).toBeFalse();
             expect(comp.course).toBe(course);
             expect(comp.exercise).toBe(undefined);
         });
@@ -72,9 +72,9 @@ describe('TutorLeaderboardComponent', () => {
         });
 
         it('sets isExamMode if exam is set', () => {
-            expect(comp.isExamMode).toBe(false);
+            expect(comp.isExamMode).toBeFalse();
             comp.ngOnInit();
-            expect(comp.isExamMode).toBe(false);
+            expect(comp.isExamMode).toBeFalse();
 
             const exam = {} as Exam;
             const course = { exams: [exam] } as Course;
@@ -90,10 +90,10 @@ describe('TutorLeaderboardComponent', () => {
         });
 
         function testIsAtLeastInstructor(setupComponent: (comp: TutorLeaderboardComponent) => void): void {
-            expect(comp.isAtLeastInstructor).toBe(false);
+            expect(comp.isAtLeastInstructor).toBeFalse();
             comp.ngOnInit();
-            expect(comp.isAtLeastInstructor).toBe(false);
-            expect(comp.isExerciseDashboard).toBe(false);
+            expect(comp.isAtLeastInstructor).toBeFalse();
+            expect(comp.isExerciseDashboard).toBeFalse();
             expect(comp.course).toBe(undefined);
             expect(isAtLeastInstructorInCourseStub).not.toBeCalled();
 

--- a/src/test/javascript/spec/component/tutor-leaderboard/tutor-leaderboard.component.spec.ts
+++ b/src/test/javascript/spec/component/tutor-leaderboard/tutor-leaderboard.component.spec.ts
@@ -66,7 +66,7 @@ describe('TutorLeaderboardComponent', () => {
             testIsAtLeastInstructor((component) => {
                 component.exercise = exercise;
             });
-            expect(comp.isExerciseDashboard).toBe(true);
+            expect(comp.isExerciseDashboard).toBeTrue();
             expect(comp.course).toBe(course);
             expect(comp.exercise).toBe(exercise);
         });
@@ -81,12 +81,12 @@ describe('TutorLeaderboardComponent', () => {
             comp.exam = exam;
             comp.course = course;
             comp.ngOnInit();
-            expect(comp.isExamMode).toBe(true);
+            expect(comp.isExamMode).toBeTrue();
         });
 
         it('should sort rows', () => {
             comp.ngOnInit();
-            expect(sortByPropertySpy).toHaveBeenCalledTimes(1);
+            expect(sortByPropertySpy).toHaveBeenCalledOnce();
         });
 
         function testIsAtLeastInstructor(setupComponent: (comp: TutorLeaderboardComponent) => void): void {
@@ -99,8 +99,8 @@ describe('TutorLeaderboardComponent', () => {
 
             setupComponent(comp);
             comp.ngOnInit();
-            expect(comp.isAtLeastInstructor).toBe(true);
-            expect(isAtLeastInstructorInCourseStub).toHaveBeenCalledTimes(1);
+            expect(comp.isAtLeastInstructor).toBeTrue();
+            expect(isAtLeastInstructorInCourseStub).toHaveBeenCalledOnce();
         }
     });
 

--- a/src/test/javascript/spec/component/utils/exercise.utils.spec.ts
+++ b/src/test/javascript/spec/component/utils/exercise.utils.spec.ts
@@ -53,8 +53,8 @@ describe('ExerciseUtils', () => {
         const exercise = exerciseWithDueDate(dayjs().subtract(1, 'hour'));
         const participation = participationWithDueDate(undefined);
 
-        expect(hasExerciseDueDatePassed(exercise)).toBe(true);
-        expect(hasExerciseDueDatePassed(exercise, participation)).toBe(true);
+        expect(hasExerciseDueDatePassed(exercise)).toBeTrue();
+        expect(hasExerciseDueDatePassed(exercise, participation)).toBeTrue();
     });
 
     it('the due date should not have passed if the individual due date is in the future', () => {

--- a/src/test/javascript/spec/component/utils/exercise.utils.spec.ts
+++ b/src/test/javascript/spec/component/utils/exercise.utils.spec.ts
@@ -43,10 +43,10 @@ describe('ExerciseUtils', () => {
 
     it('the due date should not have passed if the exercise has no due date', () => {
         const exercise = exerciseWithDueDate(undefined);
-        expect(hasExerciseDueDatePassed(exercise)).toBe(false);
+        expect(hasExerciseDueDatePassed(exercise)).toBeFalse();
 
         const participation = participationWithDueDate(dayjs().subtract(1, 'hour'));
-        expect(hasExerciseDueDatePassed(exercise, participation)).toBe(false);
+        expect(hasExerciseDueDatePassed(exercise, participation)).toBeFalse();
     });
 
     it('the due date should have passed if the exercise due date has passed and no individual due date exists', () => {
@@ -61,6 +61,6 @@ describe('ExerciseUtils', () => {
         const exercise = exerciseWithDueDate(dayjs().subtract(1, 'hour'));
         const participation = participationWithDueDate(dayjs().add(1, 'hour'));
 
-        expect(hasExerciseDueDatePassed(exercise, participation)).toBe(false);
+        expect(hasExerciseDueDatePassed(exercise, participation)).toBeFalse();
     });
 });

--- a/src/test/javascript/spec/component/utils/programming-exercise.utils.spec.ts
+++ b/src/test/javascript/spec/component/utils/programming-exercise.utils.spec.ts
@@ -212,7 +212,7 @@ describe('ProgrammingExerciseUtils', () => {
         it('returns true on legacy result', () => {
             const result = new Result();
             result.completionDate = legacyDate;
-            expect(isLegacyResult(result)).toBe(true);
+            expect(isLegacyResult(result)).toBeTrue();
         });
 
         it('returns false on non legacy result', () => {
@@ -315,7 +315,7 @@ describe('ProgrammingExerciseUtils', () => {
     describe('isProgrammingExerciseStudentParticipation', () => {
         it('returns true for a programming exercise participation', () => {
             const participation = new ProgrammingExerciseStudentParticipation();
-            expect(isProgrammingExerciseStudentParticipation(participation)).toBe(true);
+            expect(isProgrammingExerciseStudentParticipation(participation)).toBeTrue();
         });
 
         it('returns false for another participation', () => {
@@ -332,17 +332,17 @@ describe('ProgrammingExerciseUtils', () => {
 
         it('returns true for a student programming exercise participation', () => {
             const participation = new ProgrammingExerciseStudentParticipation();
-            expect(isProgrammingExerciseParticipation(participation)).toBe(true);
+            expect(isProgrammingExerciseParticipation(participation)).toBeTrue();
         });
 
         it('returns true for a template programming exercise participation', () => {
             const participation = new TemplateProgrammingExerciseParticipation();
-            expect(isProgrammingExerciseParticipation(participation)).toBe(true);
+            expect(isProgrammingExerciseParticipation(participation)).toBeTrue();
         });
 
         it('returns true for a solution programming exercise participation', () => {
             const participation = new SolutionProgrammingExerciseParticipation();
-            expect(isProgrammingExerciseParticipation(participation)).toBe(true);
+            expect(isProgrammingExerciseParticipation(participation)).toBeTrue();
         });
 
         it('returns false for a normal student participation', () => {
@@ -370,7 +370,7 @@ describe('ProgrammingExerciseUtils', () => {
 
         it('returns true on date in the past', () => {
             exercise.dueDate = dayjs().subtract(1, 'hour');
-            expect(hasDeadlinePassed(exercise)).toBe(true);
+            expect(hasDeadlinePassed(exercise)).toBeTrue();
         });
 
         it('returns false on date in the future', () => {
@@ -394,12 +394,12 @@ describe('ProgrammingExerciseUtils', () => {
         });
 
         it('return true if the result completion date is not set', () => {
-            expect(isResultPreliminary(result, exercise)).toBe(true);
+            expect(isResultPreliminary(result, exercise)).toBeTrue();
         });
 
         it('return true on invalid date', () => {
             result.completionDate = dayjs('Invalid date');
-            expect(isResultPreliminary(result, exercise)).toBe(true);
+            expect(isResultPreliminary(result, exercise)).toBeTrue();
         });
 
         describe('manual assessment set for the exercise', () => {
@@ -410,7 +410,7 @@ describe('ProgrammingExerciseUtils', () => {
 
             it('return true if the assessment due date is set and in the future', () => {
                 exercise.assessmentDueDate = dayjs().add(5, 'hours');
-                expect(isResultPreliminary(result, exercise)).toBe(true);
+                expect(isResultPreliminary(result, exercise)).toBeTrue();
             });
 
             it('return false if the assessment due date is set and in the past', () => {
@@ -420,7 +420,7 @@ describe('ProgrammingExerciseUtils', () => {
 
             it('return true if the assessment due date is not set and the latest result is an automatic assessment', () => {
                 result.assessmentType = AssessmentType.AUTOMATIC;
-                expect(isResultPreliminary(result, exercise)).toBe(true);
+                expect(isResultPreliminary(result, exercise)).toBeTrue();
             });
 
             it('return false if the assessment due date is not set and the latest result is not an automatic assessment', () => {
@@ -432,7 +432,7 @@ describe('ProgrammingExerciseUtils', () => {
         it('return true if buildAndTest date is set and in the future', () => {
             result.completionDate = dayjs();
             exercise.buildAndTestStudentSubmissionsAfterDueDate = dayjs().add(5, 'hours');
-            expect(isResultPreliminary(result, exercise)).toBe(true);
+            expect(isResultPreliminary(result, exercise)).toBeTrue();
         });
 
         it('return false if buildAndTest date is set and in the past', () => {

--- a/src/test/javascript/spec/component/utils/programming-exercise.utils.spec.ts
+++ b/src/test/javascript/spec/component/utils/programming-exercise.utils.spec.ts
@@ -206,7 +206,7 @@ describe('ProgrammingExerciseUtils', () => {
 
         it('returns false when the completion date is not set', () => {
             const result = new Result();
-            expect(isLegacyResult(result)).toBe(false);
+            expect(isLegacyResult(result)).toBeFalse();
         });
 
         it('returns true on legacy result', () => {
@@ -218,7 +218,7 @@ describe('ProgrammingExerciseUtils', () => {
         it('returns false on non legacy result', () => {
             const result = new Result();
             result.completionDate = legacyDate.add(1, 'second');
-            expect(isLegacyResult(result)).toBe(false);
+            expect(isLegacyResult(result)).toBeFalse();
         });
     });
 
@@ -320,14 +320,14 @@ describe('ProgrammingExerciseUtils', () => {
 
         it('returns false for another participation', () => {
             const participation = new TemplateProgrammingExerciseParticipation();
-            expect(isProgrammingExerciseStudentParticipation(participation)).toBe(false);
+            expect(isProgrammingExerciseStudentParticipation(participation)).toBeFalse();
         });
     });
 
     describe('isProgrammingExerciseParticipation', () => {
         it('returns false for an undefined participation', () => {
             const participation = undefined;
-            expect(isProgrammingExerciseParticipation(participation)).toBe(false);
+            expect(isProgrammingExerciseParticipation(participation)).toBeFalse();
         });
 
         it('returns true for a student programming exercise participation', () => {
@@ -347,7 +347,7 @@ describe('ProgrammingExerciseUtils', () => {
 
         it('returns false for a normal student participation', () => {
             const participation = new StudentParticipation();
-            expect(isProgrammingExerciseParticipation(participation)).toBe(false);
+            expect(isProgrammingExerciseParticipation(participation)).toBeFalse();
         });
     });
 
@@ -359,13 +359,13 @@ describe('ProgrammingExerciseUtils', () => {
         });
 
         it('returns false if no due date is set', () => {
-            expect(hasDeadlinePassed(exercise)).toBe(false);
+            expect(hasDeadlinePassed(exercise)).toBeFalse();
         });
 
         it('buildAndTestDate takes precedence over normal exercise due date', () => {
             exercise.buildAndTestStudentSubmissionsAfterDueDate = dayjs().add(5, 'hours');
             exercise.dueDate = dayjs().subtract(5, 'hours');
-            expect(hasDeadlinePassed(exercise)).toBe(false);
+            expect(hasDeadlinePassed(exercise)).toBeFalse();
         });
 
         it('returns true on date in the past', () => {
@@ -375,7 +375,7 @@ describe('ProgrammingExerciseUtils', () => {
 
         it('returns false on date in the future', () => {
             exercise.dueDate = dayjs().add(1, 'hour');
-            expect(hasDeadlinePassed(exercise)).toBe(false);
+            expect(hasDeadlinePassed(exercise)).toBeFalse();
         });
     });
 
@@ -390,7 +390,7 @@ describe('ProgrammingExerciseUtils', () => {
         });
 
         it('returns false on undefined exercise', () => {
-            expect(isResultPreliminary(result, undefined)).toBe(false);
+            expect(isResultPreliminary(result, undefined)).toBeFalse();
         });
 
         it('return true if the result completion date is not set', () => {
@@ -415,7 +415,7 @@ describe('ProgrammingExerciseUtils', () => {
 
             it('return false if the assessment due date is set and in the past', () => {
                 exercise.assessmentDueDate = dayjs().subtract(5, 'hours');
-                expect(isResultPreliminary(result, exercise)).toBe(false);
+                expect(isResultPreliminary(result, exercise)).toBeFalse();
             });
 
             it('return true if the assessment due date is not set and the latest result is an automatic assessment', () => {
@@ -425,7 +425,7 @@ describe('ProgrammingExerciseUtils', () => {
 
             it('return false if the assessment due date is not set and the latest result is not an automatic assessment', () => {
                 result.assessmentType = AssessmentType.SEMI_AUTOMATIC;
-                expect(isResultPreliminary(result, exercise)).toBe(false);
+                expect(isResultPreliminary(result, exercise)).toBeFalse();
             });
         });
 
@@ -438,12 +438,12 @@ describe('ProgrammingExerciseUtils', () => {
         it('return false if buildAndTest date is set and in the past', () => {
             result.completionDate = dayjs();
             exercise.buildAndTestStudentSubmissionsAfterDueDate = dayjs().subtract(5, 'hours');
-            expect(isResultPreliminary(result, exercise)).toBe(false);
+            expect(isResultPreliminary(result, exercise)).toBeFalse();
         });
 
         it('return false if completion date is valid and buildAndTest date is not set', () => {
             result.completionDate = dayjs();
-            expect(isResultPreliminary(result, exercise)).toBe(false);
+            expect(isResultPreliminary(result, exercise)).toBeFalse();
         });
     });
 });

--- a/src/test/javascript/spec/directive/custom-pattern-validator.directive.spec.ts
+++ b/src/test/javascript/spec/directive/custom-pattern-validator.directive.spec.ts
@@ -53,7 +53,7 @@ describe('CustomPatternValidatorDirective', () => {
 
             const patternEl = fixture.debugElement.query(By.css('input[name=pattern]')).references['patternModel'];
 
-            expect(patternEl.errors.validPattern).toBe(true);
+            expect(patternEl.errors.validPattern).toBeTrue();
         });
     }));
 });

--- a/src/test/javascript/spec/directive/delete-dialog.directive.spec.ts
+++ b/src/test/javascript/spec/directive/delete-dialog.directive.spec.ts
@@ -54,7 +54,7 @@ describe('DeleteDialogDirective', () => {
 
     it('directive should be correctly initialized', () => {
         fixture.detectChanges();
-        expect(translateSpy).toHaveBeenCalledTimes(1);
+        expect(translateSpy).toHaveBeenCalledOnce();
         expect(translateSpy).toHaveBeenCalledWith('entity.action.delete');
 
         // Check that button was assigned with proper classes and type.
@@ -83,21 +83,21 @@ describe('DeleteDialogDirective', () => {
         const directiveEl = debugElement.query(By.directive(DeleteButtonDirective));
         directiveEl.nativeElement.click();
         fixture.detectChanges();
-        expect(deleteDialogSpy).toHaveBeenCalledTimes(1);
+        expect(deleteDialogSpy).toHaveBeenCalledOnce();
         discardPeriodicTasks();
     }));
 
     it('action type cleanup should change button title', () => {
         comp.actionType = ActionType.Cleanup;
         fixture.detectChanges();
-        expect(translateSpy).toHaveBeenCalledTimes(1);
+        expect(translateSpy).toHaveBeenCalledOnce();
         expect(translateSpy).toHaveBeenCalledWith('entity.action.cleanup');
     });
 
     it('action type reset should change button title', () => {
         comp.actionType = ActionType.Reset;
         fixture.detectChanges();
-        expect(translateSpy).toHaveBeenCalledTimes(1);
+        expect(translateSpy).toHaveBeenCalledOnce();
         expect(translateSpy).toHaveBeenCalledWith('entity.action.reset');
     });
 });

--- a/src/test/javascript/spec/integration/code-editor/code-editor-container.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-container.integration.spec.ts
@@ -213,8 +213,8 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.unsavedFiles).toStrictEqual({});
 
         // file browser
-        expect(checkIfRepositoryIsCleanStub).toHaveBeenCalledTimes(1);
-        expect(getRepositoryContentStub).toHaveBeenCalledTimes(1);
+        expect(checkIfRepositoryIsCleanStub).toHaveBeenCalledOnce();
+        expect(getRepositoryContentStub).toHaveBeenCalledOnce();
         expect(container.fileBrowser.errorFiles).toEqual(extractedErrorFiles);
         expect(container.fileBrowser.unsavedFiles).toHaveLength(0);
 
@@ -232,7 +232,7 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.fileBrowser.status.editorState).toBe(EditorState.CLEAN);
 
         // build output
-        expect(getBuildLogsStub).toHaveBeenCalledTimes(1);
+        expect(getBuildLogsStub).toHaveBeenCalledOnce();
         expect(container.buildOutput.rawBuildLogs.extractErrors(ProgrammingLanguage.JAVA, ProjectType.PLAIN_MAVEN)).toEqual(extractedBuildLogErrors);
         expect(container.buildOutput.isBuilding).toBe(false);
 
@@ -240,7 +240,7 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.instructions).not.toBe(undefined); // Have to use this as it's a component
 
         // called by build output
-        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledTimes(1);
+        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledOnce();
         expect(getFeedbackDetailsForResultStub).toHaveBeenCalledWith(participation.id!, participation.results![0].id);
     };
 
@@ -252,7 +252,7 @@ describe('CodeEditorContainerIntegration', () => {
     it('should initialize all components correctly if all server calls are successful', (done) => {
         cleanInitialize();
         setTimeout(() => {
-            expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledTimes(1);
+            expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledOnce();
             done();
         }, 0);
     });
@@ -288,7 +288,7 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.unsavedFiles).toStrictEqual({});
 
         // file browser
-        expect(checkIfRepositoryIsCleanStub).toHaveBeenCalledTimes(1);
+        expect(checkIfRepositoryIsCleanStub).toHaveBeenCalledOnce();
         expect(getRepositoryContentStub).not.toHaveBeenCalled();
         expect(container.fileBrowser.errorFiles).toEqual(extractedErrorFiles);
         expect(container.fileBrowser.unsavedFiles).toHaveLength(0);
@@ -308,7 +308,7 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.fileBrowser.status.editorState).toBe(EditorState.CLEAN);
 
         // build output
-        expect(getBuildLogsStub).toHaveBeenCalledTimes(1);
+        expect(getBuildLogsStub).toHaveBeenCalledOnce();
         expect(container.buildOutput.rawBuildLogs.extractErrors(ProgrammingLanguage.JAVA, ProjectType.PLAIN_MAVEN)).toEqual(extractedBuildLogErrors);
         expect(container.buildOutput.isBuilding).toBe(false);
 
@@ -316,12 +316,12 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.instructions).not.toBe(undefined); // Have to use this as it's a component
 
         // called by build output & instructions
-        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledTimes(1);
+        expect(getFeedbackDetailsForResultStub).toHaveBeenCalledOnce();
         expect(getFeedbackDetailsForResultStub).toHaveBeenCalledWith(participation.id!, participation.results![0].id);
 
         setTimeout(() => {
             // called by build output
-            expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledTimes(1);
+            expect(subscribeForLatestResultOfParticipationStub).toHaveBeenCalledOnce();
             done();
         }, 0);
     });
@@ -337,7 +337,7 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.aceEditor.selectedFile).toBe(selectedFile);
         expect(container.aceEditor.isLoading).toBe(false);
         expect(container.aceEditor.fileSession).toContainKey(selectedFile);
-        expect(getFileStub).toHaveBeenCalledTimes(1);
+        expect(getFileStub).toHaveBeenCalledOnce();
         expect(getFileStub).toHaveBeenCalledWith(selectedFile);
 
         containerFixture.detectChanges();
@@ -355,7 +355,7 @@ describe('CodeEditorContainerIntegration', () => {
         container.aceEditor.onFileTextChanged(newFileContent);
         containerFixture.detectChanges();
 
-        expect(getFileStub).toHaveBeenCalledTimes(1);
+        expect(getFileStub).toHaveBeenCalledOnce();
         expect(getFileStub).toHaveBeenCalledWith(selectedFile);
         expect(container.unsavedFiles).toEqual({ [selectedFile]: newFileContent });
         expect(container.fileBrowser.unsavedFiles).toEqual([selectedFile]);
@@ -436,7 +436,7 @@ describe('CodeEditorContainerIntegration', () => {
 
         // waiting for build successfulResult
         expect(container.commitState).toBe(CommitState.CLEAN);
-        expect(container.buildOutput.isBuilding).toBe(true);
+        expect(container.buildOutput.isBuilding).toBeTrue();
 
         getLatestPendingSubmissionSubject.next({
             submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION,
@@ -470,7 +470,7 @@ describe('CodeEditorContainerIntegration', () => {
         containerFixture.detectChanges();
 
         // saving before commit
-        expect(saveFilesStub).toHaveBeenCalledTimes(1);
+        expect(saveFilesStub).toHaveBeenCalledOnce();
         expect(saveFilesStub).toHaveBeenCalledWith([{ fileName: unsavedFile, fileContent: 'lorem ipsum' }], true);
         expect(container.editorState).toBe(EditorState.SAVING);
         expect(container.fileBrowser.status.editorState).toBe(EditorState.SAVING);
@@ -492,7 +492,7 @@ describe('CodeEditorContainerIntegration', () => {
 
         // waiting for build result
         expect(container.commitState).toBe(CommitState.CLEAN);
-        expect(container.buildOutput.isBuilding).toBe(true);
+        expect(container.buildOutput.isBuilding).toBeTrue();
 
         getLatestPendingSubmissionSubject.next({
             submissionState: ProgrammingSubmissionState.HAS_NO_PENDING_SUBMISSION,
@@ -548,7 +548,7 @@ describe('CodeEditorContainerIntegration', () => {
         containerFixture.detectChanges();
 
         expect(container.commitState).toBe(CommitState.CLEAN);
-        expect(getRepositoryContentStub).toHaveBeenCalledTimes(1);
+        expect(getRepositoryContentStub).toHaveBeenCalledOnce();
 
         containerFixture.destroy();
         flush();

--- a/src/test/javascript/spec/integration/code-editor/code-editor-container.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-container.integration.spec.ts
@@ -209,7 +209,7 @@ describe('CodeEditorContainerIntegration', () => {
         // container
         expect(container.commitState).toBe(CommitState.CLEAN);
         expect(container.editorState).toBe(EditorState.CLEAN);
-        expect(container.buildOutput.isBuilding).toBe(false);
+        expect(container.buildOutput.isBuilding).toBeFalse();
         expect(container.unsavedFiles).toStrictEqual({});
 
         // file browser
@@ -219,13 +219,13 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.fileBrowser.unsavedFiles).toHaveLength(0);
 
         // ace editor
-        expect(container.aceEditor.isLoading).toBe(false);
+        expect(container.aceEditor.isLoading).toBeFalse();
         expect(container.aceEditor.commitState).toBe(CommitState.CLEAN);
 
         // actions
         expect(container.actions.commitState).toBe(CommitState.CLEAN);
         expect(container.actions.editorState).toBe(EditorState.CLEAN);
-        expect(container.actions.isBuilding).toBe(false);
+        expect(container.actions.isBuilding).toBeFalse();
 
         // status
         expect(container.fileBrowser.status.commitState).toBe(CommitState.CLEAN);
@@ -234,7 +234,7 @@ describe('CodeEditorContainerIntegration', () => {
         // build output
         expect(getBuildLogsStub).toHaveBeenCalledOnce();
         expect(container.buildOutput.rawBuildLogs.extractErrors(ProgrammingLanguage.JAVA, ProjectType.PLAIN_MAVEN)).toEqual(extractedBuildLogErrors);
-        expect(container.buildOutput.isBuilding).toBe(false);
+        expect(container.buildOutput.isBuilding).toBeFalse();
 
         // instructions
         expect(container.instructions).not.toBe(undefined); // Have to use this as it's a component
@@ -284,7 +284,7 @@ describe('CodeEditorContainerIntegration', () => {
         // container
         expect(container.commitState).toBe(CommitState.COULD_NOT_BE_RETRIEVED);
         expect(container.editorState).toBe(EditorState.CLEAN);
-        expect(container.buildOutput.isBuilding).toBe(false);
+        expect(container.buildOutput.isBuilding).toBeFalse();
         expect(container.unsavedFiles).toStrictEqual({});
 
         // file browser
@@ -294,14 +294,14 @@ describe('CodeEditorContainerIntegration', () => {
         expect(container.fileBrowser.unsavedFiles).toHaveLength(0);
 
         // ace editor
-        expect(container.aceEditor.isLoading).toBe(false);
+        expect(container.aceEditor.isLoading).toBeFalse();
         expect(container.aceEditor.annotationsArray.map((a) => omit(a, 'hash'))).toEqual(extractedBuildLogErrors);
         expect(container.aceEditor.commitState).toBe(CommitState.COULD_NOT_BE_RETRIEVED);
 
         // actions
         expect(container.actions.commitState).toBe(CommitState.COULD_NOT_BE_RETRIEVED);
         expect(container.actions.editorState).toBe(EditorState.CLEAN);
-        expect(container.actions.isBuilding).toBe(false);
+        expect(container.actions.isBuilding).toBeFalse();
 
         // status
         expect(container.fileBrowser.status.commitState).toBe(CommitState.COULD_NOT_BE_RETRIEVED);
@@ -310,7 +310,7 @@ describe('CodeEditorContainerIntegration', () => {
         // build output
         expect(getBuildLogsStub).toHaveBeenCalledOnce();
         expect(container.buildOutput.rawBuildLogs.extractErrors(ProgrammingLanguage.JAVA, ProjectType.PLAIN_MAVEN)).toEqual(extractedBuildLogErrors);
-        expect(container.buildOutput.isBuilding).toBe(false);
+        expect(container.buildOutput.isBuilding).toBeFalse();
 
         // instructions
         expect(container.instructions).not.toBe(undefined); // Have to use this as it's a component
@@ -335,7 +335,7 @@ describe('CodeEditorContainerIntegration', () => {
         containerFixture.detectChanges();
         expect(container.selectedFile).toBe(selectedFile);
         expect(container.aceEditor.selectedFile).toBe(selectedFile);
-        expect(container.aceEditor.isLoading).toBe(false);
+        expect(container.aceEditor.isLoading).toBeFalse();
         expect(container.aceEditor.fileSession).toContainKey(selectedFile);
         expect(getFileStub).toHaveBeenCalledOnce();
         expect(getFileStub).toHaveBeenCalledWith(selectedFile);
@@ -446,7 +446,7 @@ describe('CodeEditorContainerIntegration', () => {
         subscribeForLatestResultOfParticipationSubject.next(successfulResult);
         containerFixture.detectChanges();
 
-        expect(container.buildOutput.isBuilding).toBe(false);
+        expect(container.buildOutput.isBuilding).toBeFalse();
         expect(container.buildOutput.rawBuildLogs).toEqual(expectedBuildLog);
         expect(container.fileBrowser.errorFiles).toHaveLength(0);
     });
@@ -501,7 +501,7 @@ describe('CodeEditorContainerIntegration', () => {
         });
         containerFixture.detectChanges();
 
-        expect(container.buildOutput.isBuilding).toBe(false);
+        expect(container.buildOutput.isBuilding).toBeFalse();
         expect(container.buildOutput.rawBuildLogs).toEqual(expectedBuildLog);
         expect(container.fileBrowser.errorFiles).toHaveLength(0);
 

--- a/src/test/javascript/spec/integration/code-editor/code-editor-instructor.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-instructor.integration.spec.ts
@@ -207,7 +207,7 @@ describe('CodeEditorInstructorIntegration', () => {
         container.ngOnInit();
         routeSubject.next({ exerciseId: 1 });
         expect(container.codeEditorContainer).toBe(undefined); // Have to use this as it's a component
-        expect(findWithParticipationsStub).toHaveBeenCalledTimes(1);
+        expect(findWithParticipationsStub).toHaveBeenCalledOnce();
         expect(findWithParticipationsStub).toHaveBeenCalledWith(exercise.id);
         expect(container.loadingState).toBe(container.LOADING_STATE.INITIALIZING);
     };
@@ -239,7 +239,7 @@ describe('CodeEditorInstructorIntegration', () => {
         findWithParticipationsSubject.next({ body: exercise });
 
         expect(getLatestResultWithFeedbacksStub).not.toHaveBeenCalled();
-        expect(setDomainSpy).toHaveBeenCalledTimes(1);
+        expect(setDomainSpy).toHaveBeenCalledOnce();
         expect(setDomainSpy).toHaveBeenCalledWith([DomainType.PARTICIPATION, exercise.templateParticipation]);
         expect(container.exercise).toEqual(exercise);
         expect(container.selectedRepository).toBe(container.REPOSITORY.TEMPLATE);
@@ -303,7 +303,7 @@ describe('CodeEditorInstructorIntegration', () => {
 
         findWithParticipationsSubject.next({ body: exercise });
 
-        expect(setDomainSpy).toHaveBeenCalledTimes(1);
+        expect(setDomainSpy).toHaveBeenCalledOnce();
         expect(setDomainSpy).toHaveBeenCalledWith([DomainType.TEST_REPOSITORY, exercise]);
         expect(container.selectedParticipation).toBe(undefined);
         expect(container.selectedRepository).toBe(container.REPOSITORY.TEST);
@@ -371,7 +371,7 @@ describe('CodeEditorInstructorIntegration', () => {
 
         checkSolutionRepository(exercise);
 
-        expect(findWithParticipationsStub).toHaveBeenCalledTimes(1);
+        expect(findWithParticipationsStub).toHaveBeenCalledOnce();
         expect(findWithParticipationsStub).toHaveBeenCalledWith(exercise.id);
         expect(setDomainSpy).toHaveBeenCalledTimes(2);
         expect(setDomainSpy).toHaveBeenNthCalledWith(1, [DomainType.PARTICIPATION, exercise.studentParticipations[0]]);
@@ -401,7 +401,7 @@ describe('CodeEditorInstructorIntegration', () => {
 
         containerFixture.detectChanges();
 
-        expect(setDomainSpy).toHaveBeenCalledTimes(1);
+        expect(setDomainSpy).toHaveBeenCalledOnce();
         expect(setDomainSpy).toHaveBeenCalledWith([DomainType.PARTICIPATION, exercise.solutionParticipation]);
         checkSolutionRepository(exercise);
     });

--- a/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
@@ -174,7 +174,7 @@ describe('CodeEditorStudentIntegration', () => {
 
         routeSubject.next({ participationId: 1 });
 
-        expect(container.loadingParticipation).toBe(true);
+        expect(container.loadingParticipation).toBeTrue();
 
         findWithLatestResultSubject.next(participation);
         getFeedbackDetailsForResultSubject.next({ body: feedbacks });
@@ -209,10 +209,10 @@ describe('CodeEditorStudentIntegration', () => {
         isCleanSubject.next({ repositoryStatus: CommitState.CLEAN });
 
         // Repository should be locked, the student can't write into it anymore.
-        expect(container.repositoryIsLocked).toBe(true);
+        expect(container.repositoryIsLocked).toBeTrue();
         expect(getElement(containerDebugElement, '.locked-container').innerHTML).toContain('fa-icon');
-        expect(container.codeEditorContainer.fileBrowser.disableActions).toBe(true);
-        expect(container.codeEditorContainer.actions.disableActions).toBe(true);
+        expect(container.codeEditorContainer.fileBrowser.disableActions).toBeTrue();
+        expect(container.codeEditorContainer.actions.disableActions).toBeTrue();
     });
 
     it('should abort initialization and show error state if participation cannot be retrieved', () => {
@@ -222,12 +222,12 @@ describe('CodeEditorStudentIntegration', () => {
 
         routeSubject.next({ participationId: 1 });
 
-        expect(container.loadingParticipation).toBe(true);
+        expect(container.loadingParticipation).toBeTrue();
 
         findWithLatestResultSubject.error('fatal error');
 
         expect(container.loadingParticipation).toBe(false);
-        expect(container.participationCouldNotBeFetched).toBe(true);
+        expect(container.participationCouldNotBeFetched).toBeTrue();
         expect(getFeedbackDetailsForResultStub).not.toHaveBeenCalled();
         expect(container.participation).toBe(undefined);
     });

--- a/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
+++ b/src/test/javascript/spec/integration/code-editor/code-editor-student.integration.spec.ts
@@ -181,8 +181,8 @@ describe('CodeEditorStudentIntegration', () => {
 
         expect(getStudentParticipationWithLatestResultStub).toHaveBeenNthCalledWith(1, participation.id);
         expect(getFeedbackDetailsForResultStub).toHaveBeenNthCalledWith(1, participation.id, result.id);
-        expect(container.loadingParticipation).toBe(false);
-        expect(container.participationCouldNotBeFetched).toBe(false);
+        expect(container.loadingParticipation).toBeFalse();
+        expect(container.participationCouldNotBeFetched).toBeFalse();
         expect(container.participation).toEqual({ ...participation, results: [{ ...result, feedbacks }] });
     });
 
@@ -226,7 +226,7 @@ describe('CodeEditorStudentIntegration', () => {
 
         findWithLatestResultSubject.error('fatal error');
 
-        expect(container.loadingParticipation).toBe(false);
+        expect(container.loadingParticipation).toBeFalse();
         expect(container.participationCouldNotBeFetched).toBeTrue();
         expect(getFeedbackDetailsForResultStub).not.toHaveBeenCalled();
         expect(container.participation).toBe(undefined);

--- a/src/test/javascript/spec/integration/guided-tour/guided-tour.integration.spec.ts
+++ b/src/test/javascript/spec/integration/guided-tour/guided-tour.integration.spec.ts
@@ -166,7 +166,7 @@ describe('Guided tour integration', () => {
             // Click through tour steps in NavComponent
             for (let i = 1; i < 6; i++) {
                 guidedTourService.nextStep();
-                expect(guidedTourService.isOnFirstStep).toBe(false);
+                expect(guidedTourService.isOnFirstStep).toBeFalse();
                 guidedTourComponent.currentTourStep = guidedTourService['currentStep'];
 
                 if (guidedTourComponent.currentTourStep.highlightSelector) {

--- a/src/test/javascript/spec/integration/guided-tour/guided-tour.integration.spec.ts
+++ b/src/test/javascript/spec/integration/guided-tour/guided-tour.integration.spec.ts
@@ -160,7 +160,7 @@ describe('Guided tour integration', () => {
             courseCardComponentFixture.autoDetectChanges(true);
             navBarComponentFixture.autoDetectChanges(true);
 
-            expect(guidedTourService.isOnFirstStep).toBe(true);
+            expect(guidedTourService.isOnFirstStep).toBeTrue();
             expect(guidedTourSteps).toBe(9);
 
             // Click through tour steps in NavComponent
@@ -197,7 +197,7 @@ describe('Guided tour integration', () => {
                 }
             }
 
-            expect(guidedTourService.isOnLastStep).toBe(true);
+            expect(guidedTourService.isOnLastStep).toBeTrue();
         });
     });
 });

--- a/src/test/javascript/spec/interceptor/artemis-version.interceptor.spec.ts
+++ b/src/test/javascript/spec/interceptor/artemis-version.interceptor.spec.ts
@@ -50,7 +50,7 @@ describe(`ArtemisVersionInterceptor`, () => {
     it('should check for an update immediately and after 60 seconds again if app is stable', fakeAsync(() => {
         new ArtemisVersionInterceptor(appRef, swUpdate as any as SwUpdate, serverDateService, alertService, {} as any as Window);
 
-        expect(checkForUpdateSpy).toHaveBeenCalledTimes(1);
+        expect(checkForUpdateSpy).toHaveBeenCalledOnce();
         tick(60000);
         expect(checkForUpdateSpy).toHaveBeenCalledTimes(2);
         discardPeriodicTasks();
@@ -62,7 +62,7 @@ describe(`ArtemisVersionInterceptor`, () => {
         sub.next(false);
         expect(checkForUpdateSpy).toHaveBeenCalledTimes(0);
         tick(30000);
-        expect(checkForUpdateSpy).toHaveBeenCalledTimes(1);
+        expect(checkForUpdateSpy).toHaveBeenCalledOnce();
         discardPeriodicTasks();
     }));
 
@@ -71,13 +71,13 @@ describe(`ArtemisVersionInterceptor`, () => {
         const addAlertSpy = jest.spyOn(alertService, 'addAlert').mockImplementation(funMock);
         new ArtemisVersionInterceptor(appRef, swUpdate as any as SwUpdate, serverDateService, alertService, { location: { reload: jest.fn() } } as any as Window);
         tick();
-        expect(addAlertSpy).toHaveBeenCalledTimes(1);
-        expect(funMock).toHaveBeenCalledTimes(1);
+        expect(addAlertSpy).toHaveBeenCalledOnce();
+        expect(funMock).toHaveBeenCalledOnce();
         expect(funMock).toHaveBeenCalledWith(expect.objectContaining({ type: AlertType.INFO, message: 'artemisApp.outdatedAlert' }));
 
         expect(activateUpdateSpy).not.toHaveBeenCalled();
         funMock.mock.calls[0][0].action.callback();
-        expect(activateUpdateSpy).toHaveBeenCalledTimes(1);
+        expect(activateUpdateSpy).toHaveBeenCalledOnce();
         discardPeriodicTasks();
     }));
 
@@ -86,14 +86,14 @@ describe(`ArtemisVersionInterceptor`, () => {
 
         const intercept = new ArtemisVersionInterceptor(appRef, swUpdate as any as SwUpdate, serverDateService, alertService, {} as any as Window);
         tick();
-        expect(checkForUpdateSpy).toHaveBeenCalledTimes(1);
+        expect(checkForUpdateSpy).toHaveBeenCalledOnce();
 
         let mockHandler = {
             handle: jest.fn(() => of(new HttpResponse({ status: 200, body: {}, headers: new HttpHeaders({ [ARTEMIS_VERSION_HEADER]: VERSION }) }))),
         };
         intercept.intercept(requestMock, mockHandler).subscribe();
         tick();
-        expect(checkForUpdateSpy).toHaveBeenCalledTimes(1);
+        expect(checkForUpdateSpy).toHaveBeenCalledOnce();
 
         mockHandler = {
             handle: jest.fn(() => of(new HttpResponse({ status: 200, body: {}, headers: new HttpHeaders({ [ARTEMIS_VERSION_HEADER]: '0.0.0' }) }))),

--- a/src/test/javascript/spec/interceptor/auth-expired.interceptor.spec.ts
+++ b/src/test/javascript/spec/interceptor/auth-expired.interceptor.spec.ts
@@ -49,7 +49,7 @@ describe(`AuthExpiredInterceptor`, () => {
 
         authInterceptor.intercept({} as HttpRequest<any>, mockHandler).subscribe();
 
-        expect(tokenSpy).toHaveBeenCalledTimes(1);
+        expect(tokenSpy).toHaveBeenCalledOnce();
         expect(loginServiceMock.logout).toHaveBeenCalledWith(false);
         expect(stateStorageServiceMock.storeUrl).toHaveBeenCalledWith('https://example.com');
     });
@@ -62,7 +62,7 @@ describe(`AuthExpiredInterceptor`, () => {
 
         authInterceptor.intercept({} as HttpRequest<any>, mockHandler).subscribe();
 
-        expect(tokenSpy).toHaveBeenCalledTimes(1);
+        expect(tokenSpy).toHaveBeenCalledOnce();
         expect(loginServiceMock.logout).toHaveBeenCalledTimes(0);
         expect(stateStorageServiceMock.storeUrl).toHaveBeenCalledTimes(0);
     });

--- a/src/test/javascript/spec/interceptor/auth.interceptor.spec.ts
+++ b/src/test/javascript/spec/interceptor/auth.interceptor.spec.ts
@@ -33,13 +33,13 @@ describe(`AuthInterceptor`, () => {
             authInterceptor.intercept(requestMock, mockHandler);
 
             expect(storageSpy).toHaveBeenCalledWith('authenticationToken');
-            expect(cloneSpy).toHaveBeenCalledTimes(1);
+            expect(cloneSpy).toHaveBeenCalledOnce();
             expect(cloneSpy).toHaveBeenCalledWith({
                 setHeaders: {
                     Authorization: 'Bearer ' + token,
                 },
             });
-            expect(mockHandler.handle).toHaveBeenCalledTimes(1);
+            expect(mockHandler.handle).toHaveBeenCalledOnce();
 
             jest.restoreAllMocks();
         });
@@ -60,7 +60,7 @@ describe(`AuthInterceptor`, () => {
         expect(localStorageSpy).toHaveBeenCalledWith('authenticationToken');
         expect(sessionStorageSpy).toHaveBeenCalledWith('authenticationToken');
         expect(cloneSpy).toHaveBeenCalledTimes(0);
-        expect(mockHandler.handle).toHaveBeenCalledTimes(1);
+        expect(mockHandler.handle).toHaveBeenCalledOnce();
     });
 
     it('should not add token to a request if it is not a request to artemis', () => {
@@ -76,6 +76,6 @@ describe(`AuthInterceptor`, () => {
 
         expect(localStorageSpy).toHaveBeenCalledTimes(0);
         expect(cloneSpy).toHaveBeenCalledTimes(0);
-        expect(mockHandler.handle).toHaveBeenCalledTimes(1);
+        expect(mockHandler.handle).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/interceptor/browser-fingerprint.interceptor.spec.ts
+++ b/src/test/javascript/spec/interceptor/browser-fingerprint.interceptor.spec.ts
@@ -31,14 +31,14 @@ describe(`BrowserFingerprintInterceptor`, () => {
 
         fingerprintInterceptor.intercept(requestMock, mockHandler);
 
-        expect(cloneSpy).toHaveBeenCalledTimes(1);
+        expect(cloneSpy).toHaveBeenCalledOnce();
         expect(cloneSpy).toHaveBeenCalledWith({
             setHeaders: {
                 'X-Artemis-Client-Instance-ID': localInstanceIdentifier,
                 'X-Artemis-Client-Fingerprint': localFingerprint,
             },
         });
-        expect(mockHandler.handle).toHaveBeenCalledTimes(1);
+        expect(mockHandler.handle).toHaveBeenCalledOnce();
     };
 
     it('should add fingerprint and instance ID if request goes to artemis', () => {
@@ -60,7 +60,7 @@ describe(`BrowserFingerprintInterceptor`, () => {
         fingerprintInterceptor.intercept(requestMock, mockHandler);
 
         expect(cloneSpy).toHaveBeenCalledTimes(0);
-        expect(mockHandler.handle).toHaveBeenCalledTimes(1);
+        expect(mockHandler.handle).toHaveBeenCalledOnce();
         expect(mockHandler.handle).toHaveBeenCalledWith(requestMock);
     });
 
@@ -74,7 +74,7 @@ describe(`BrowserFingerprintInterceptor`, () => {
         fingerprintInterceptor.intercept(requestMock, mockHandler);
 
         expect(cloneSpy).toHaveBeenCalledTimes(0);
-        expect(mockHandler.handle).toHaveBeenCalledTimes(1);
+        expect(mockHandler.handle).toHaveBeenCalledOnce();
         expect(mockHandler.handle).toHaveBeenCalledWith(requestMock);
     });
 });

--- a/src/test/javascript/spec/interceptor/errorhandler.interceptor.spec.ts
+++ b/src/test/javascript/spec/interceptor/errorhandler.interceptor.spec.ts
@@ -28,7 +28,7 @@ describe(`ErrorHandlerInterceptor`, () => {
 
         errorHandlerInterceptor.intercept({} as HttpRequest<any>, mockHandler).subscribe();
 
-        expect(eventManagerMock.broadcast).toHaveBeenCalledTimes(1);
+        expect(eventManagerMock.broadcast).toHaveBeenCalledOnce();
         expect(eventManagerMock.broadcast).toHaveBeenCalledWith({
             name: 'artemisApp.httpError',
             content: error,

--- a/src/test/javascript/spec/interceptor/notification.interceptor.spec.ts
+++ b/src/test/javascript/spec/interceptor/notification.interceptor.spec.ts
@@ -36,7 +36,7 @@ describe(`NotificationInterceptor`, () => {
 
         notificationInterceptor.intercept(requestMock, mockHandler).subscribe();
 
-        expect(alertServiceMock.success).toHaveBeenCalledTimes(1);
+        expect(alertServiceMock.success).toHaveBeenCalledOnce();
         expect(alertServiceMock.success).toHaveBeenCalledWith('Test', { param: 'ABC' });
     });
 

--- a/src/test/javascript/spec/pipe/reacting-users-on-posting.pipe.spec.ts
+++ b/src/test/javascript/spec/pipe/reacting-users-on-posting.pipe.spec.ts
@@ -35,7 +35,7 @@ describe('ReactingUsersOnPostingsPipe', () => {
         });
         tick();
         expect(transformedStringWithReactingUsers).toBe(metisUser1.name + 'artemisApp.metis.reactedTooltip');
-        expect(updateReactingUsersStringSpy).toHaveBeenCalledTimes(1);
+        expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
     }));
 
     it('Should return string for one user that is "you"', fakeAsync(() => {
@@ -44,7 +44,7 @@ describe('ReactingUsersOnPostingsPipe', () => {
         });
         tick();
         expect(transformedStringWithReactingUsers).toBe('artemisApp.metis.you');
-        expect(updateReactingUsersStringSpy).toHaveBeenCalledTimes(1);
+        expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
     }));
 
     it('Should return string for two users that do not include "you"', fakeAsync(() => {
@@ -54,7 +54,7 @@ describe('ReactingUsersOnPostingsPipe', () => {
         });
         tick();
         expect(transformedStringWithReactingUsers).toBe(metisUser1.name! + 'artemisApp.metis.and' + metisUser2.name! + 'artemisApp.metis.reactedTooltip');
-        expect(updateReactingUsersStringSpy).toHaveBeenCalledTimes(1);
+        expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
     }));
 
     it('Should return string for two users that do include "you"', fakeAsync(() => {
@@ -64,7 +64,7 @@ describe('ReactingUsersOnPostingsPipe', () => {
         });
         tick();
         expect(transformedStringWithReactingUsers).toBe('artemisApp.metis.you' + 'artemisApp.metis.and' + metisUser1.name! + 'artemisApp.metis.reactedTooltip');
-        expect(updateReactingUsersStringSpy).toHaveBeenCalledTimes(1);
+        expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
     }));
 
     it('Should return string for three users that do include "you" and separate the first two users with comma', fakeAsync(() => {
@@ -76,7 +76,7 @@ describe('ReactingUsersOnPostingsPipe', () => {
         expect(transformedStringWithReactingUsers).toBe(
             'artemisApp.metis.you' + ', ' + metisUser1.name! + 'artemisApp.metis.and' + metisTutor.name! + 'artemisApp.metis.reactedTooltip',
         );
-        expect(updateReactingUsersStringSpy).toHaveBeenCalledTimes(1);
+        expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
     }));
 
     it('Should trim list of reacting users but always include "you', fakeAsync(() => {
@@ -120,7 +120,7 @@ describe('ReactingUsersOnPostingsPipe', () => {
                 'userF' +
                 'artemisApp.metis.reactedTooltipTrimmed',
         );
-        expect(updateReactingUsersStringSpy).toHaveBeenCalledTimes(1);
+        expect(updateReactingUsersStringSpy).toHaveBeenCalledOnce();
     }));
 
     it('Should trigger update of reacting users on language change', fakeAsync(() => {

--- a/src/test/javascript/spec/service/account.service.spec.ts
+++ b/src/test/javascript/spec/service/account.service.spec.ts
@@ -60,32 +60,32 @@ describe('AccountService', () => {
 
         const userReceived = await accountService.identity(false);
 
-        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(getStub).toHaveBeenCalledOnce();
         expect(getStub).toHaveBeenCalledWith(getUserUrl, { observe: 'response' });
         expect(userReceived).toEqual(user);
         expect(accountService.userIdentity).toEqual(user);
-        expect(accountService.isAuthenticated()).toBe(true);
+        expect(accountService.isAuthenticated()).toBeTrue();
     });
 
     it('should fetch the user on identity if the userIdentity is defined yet (force=true)', async () => {
         accountService.userIdentity = user;
         expect(accountService.userIdentity).toEqual(user);
-        expect(accountService.isAuthenticated()).toBe(true);
+        expect(accountService.isAuthenticated()).toBeTrue();
         getStub.mockReturnValue(of({ body: user2 }));
 
         const userReceived = await accountService.identity(true);
 
-        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(getStub).toHaveBeenCalledOnce();
         expect(getStub).toHaveBeenCalledWith(getUserUrl, { observe: 'response' });
         expect(userReceived).toEqual(user2);
         expect(accountService.userIdentity).toEqual(user2);
-        expect(accountService.isAuthenticated()).toBe(true);
+        expect(accountService.isAuthenticated()).toBeTrue();
     });
 
     it('should NOT fetch the user on identity if the userIdentity is defined (force=false)', async () => {
         accountService.userIdentity = user;
         expect(accountService.userIdentity).toEqual(user);
-        expect(accountService.isAuthenticated()).toBe(true);
+        expect(accountService.isAuthenticated()).toBeTrue();
         getStub.mockReturnValue(of({ body: user2 }));
 
         const userReceived = await accountService.identity(false);
@@ -93,7 +93,7 @@ describe('AccountService', () => {
         expect(getStub).not.toHaveBeenCalled();
         expect(userReceived).toEqual(user);
         expect(accountService.userIdentity).toEqual(user);
-        expect(accountService.isAuthenticated()).toBe(true);
+        expect(accountService.isAuthenticated()).toBeTrue();
     });
 
     it('should authenticate a user', () => {
@@ -131,13 +131,13 @@ describe('AccountService', () => {
             accountService.userIdentity = user3;
             usedAuthorities.push(authority);
 
-            await expect(accountService.hasAnyAuthority(usedAuthorities)).resolves.toBe(true);
+            await expect(accountService.hasAnyAuthority(usedAuthorities)).resolves.toBeTrue();
         });
 
         it.each(authorities)('should return true if authority matches exactly', async (authority: Authority) => {
             accountService.userIdentity = { id: authorities.indexOf(authority), groups: ['USER'], authorities: [authority] } as User;
 
-            await expect(accountService.hasAnyAuthority([authority])).resolves.toBe(true);
+            await expect(accountService.hasAnyAuthority([authority])).resolves.toBeTrue();
         });
 
         it.each(authorities)('should return false if authority does not match', async (authority: Authority) => {
@@ -188,7 +188,7 @@ describe('AccountService', () => {
 
             result = accountService.hasGroup(group);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -206,7 +206,7 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastTutorInCourse(course);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return true if user is system admin', () => {
@@ -214,7 +214,7 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastTutorInCourse(course);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -232,7 +232,7 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastEditorInCourse(course);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return true if user is system admin', () => {
@@ -240,7 +240,7 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastEditorInCourse(course);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -258,7 +258,7 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastInstructorInCourse(course);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return true if user is system admin', () => {
@@ -266,7 +266,7 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastInstructorInCourse(course);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -288,11 +288,11 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastTutorForExercise(exercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
 
             result = accountService.isAtLeastTutorForExercise(examExercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return true if user is system admin', () => {
@@ -300,11 +300,11 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastTutorForExercise(exercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
 
             result = accountService.isAtLeastTutorForExercise(examExercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -326,11 +326,11 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastEditorForExercise(exercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
 
             result = accountService.isAtLeastEditorForExercise(examExercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return true if user is system admin', () => {
@@ -338,11 +338,11 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastEditorForExercise(exercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
 
             result = accountService.isAtLeastEditorForExercise(examExercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -364,11 +364,11 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastInstructorForExercise(exercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
 
             result = accountService.isAtLeastInstructorForExercise(examExercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return true if user is system admin', () => {
@@ -376,11 +376,11 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastInstructorForExercise(exercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
 
             result = accountService.isAtLeastInstructorForExercise(examExercise);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -398,7 +398,7 @@ describe('AccountService', () => {
 
             result = accountService.isAdmin();
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 
@@ -407,12 +407,12 @@ describe('AccountService', () => {
 
         accountService.setAccessRightsForExerciseAndReferencedCourse(exercise);
 
-        expect(exercise.isAtLeastEditor).toBe(true);
-        expect(exercise.isAtLeastEditor).toBe(true);
-        expect(exercise.isAtLeastInstructor).toBe(true);
-        expect(exercise.course!.isAtLeastEditor).toBe(true);
-        expect(exercise.course!.isAtLeastEditor).toBe(true);
-        expect(exercise.course!.isAtLeastInstructor).toBe(true);
+        expect(exercise.isAtLeastEditor).toBeTrue();
+        expect(exercise.isAtLeastEditor).toBeTrue();
+        expect(exercise.isAtLeastInstructor).toBeTrue();
+        expect(exercise.course!.isAtLeastEditor).toBeTrue();
+        expect(exercise.course!.isAtLeastEditor).toBeTrue();
+        expect(exercise.course!.isAtLeastInstructor).toBeTrue();
     });
 
     it('should set access rights for referenced exercise', () => {
@@ -421,12 +421,12 @@ describe('AccountService', () => {
 
         accountService.setAccessRightsForCourseAndReferencedExercises(course);
 
-        expect(exercise.isAtLeastEditor).toBe(true);
-        expect(exercise.isAtLeastEditor).toBe(true);
-        expect(exercise.isAtLeastInstructor).toBe(true);
-        expect(exercise.course!.isAtLeastEditor).toBe(true);
-        expect(exercise.course!.isAtLeastEditor).toBe(true);
-        expect(exercise.course!.isAtLeastInstructor).toBe(true);
+        expect(exercise.isAtLeastEditor).toBeTrue();
+        expect(exercise.isAtLeastEditor).toBeTrue();
+        expect(exercise.isAtLeastInstructor).toBeTrue();
+        expect(exercise.course!.isAtLeastEditor).toBeTrue();
+        expect(exercise.course!.isAtLeastEditor).toBeTrue();
+        expect(exercise.course!.isAtLeastInstructor).toBeTrue();
     });
 
     describe('test isOwnerOfParticipation', () => {
@@ -448,7 +448,7 @@ describe('AccountService', () => {
 
             result = accountService.isOwnerOfParticipation(participation);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return false if student is not part of the team', () => {
@@ -466,7 +466,7 @@ describe('AccountService', () => {
 
             result = accountService.isOwnerOfParticipation(participation);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
     });
 

--- a/src/test/javascript/spec/service/account.service.spec.ts
+++ b/src/test/javascript/spec/service/account.service.spec.ts
@@ -48,7 +48,7 @@ describe('AccountService', () => {
         getStub = jest.spyOn(httpService, 'get');
 
         expect(accountService.userIdentity).toBe(undefined);
-        expect(accountService.isAuthenticated()).toBe(false);
+        expect(accountService.isAuthenticated()).toBeFalse();
     });
 
     afterEach(() => {
@@ -117,14 +117,14 @@ describe('AccountService', () => {
         it.each(authorities)('should return false if not authenticated, no user id and no authorities are set', async (authority: Authority) => {
             usedAuthorities.push(authority);
 
-            await expect(accountService.hasAnyAuthority(usedAuthorities)).resolves.toBe(false);
+            await expect(accountService.hasAnyAuthority(usedAuthorities)).resolves.toBeFalse();
         });
 
         it.each(authorities)('should return false if authenticated, user id but no authorities are set', async (authority: Authority) => {
             accountService.userIdentity = user;
             usedAuthorities.push(authority);
 
-            await expect(accountService.hasAnyAuthority(usedAuthorities)).resolves.toBe(false);
+            await expect(accountService.hasAnyAuthority(usedAuthorities)).resolves.toBeFalse();
         });
 
         it.each(authorities)('should return true if user is required', async (authority: Authority) => {
@@ -144,11 +144,11 @@ describe('AccountService', () => {
             const index = authorities.indexOf(authority);
             accountService.userIdentity = { id: index + 1, groups: ['USER'], authorities: [authorities[(index + 1) % 5]] } as User;
 
-            await expect(accountService.hasAnyAuthority([authority])).resolves.toBe(false);
+            await expect(accountService.hasAnyAuthority([authority])).resolves.toBeFalse();
         });
 
         it.each(authorities)('should return false if not authenticated', async (authority: Authority) => {
-            await expect(accountService.hasAuthority(authority)).resolves.toBe(false);
+            await expect(accountService.hasAuthority(authority)).resolves.toBeFalse();
         });
     });
 
@@ -157,21 +157,21 @@ describe('AccountService', () => {
         it.each(groups)('should return false if not authenticated', (group: string) => {
             result = accountService.hasGroup(group);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it.each(groups)('should return false if no authorities are set', (group: string) => {
             accountService.userIdentity = user;
             result = accountService.hasGroup(group);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it.each(groups)('should return false if no groups are set', (group: string) => {
             accountService.userIdentity = { id: 10, authorities } as User;
             result = accountService.hasGroup(group);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it.each(groups)('should return false if group does not match', (group: string) => {
@@ -180,7 +180,7 @@ describe('AccountService', () => {
 
             result = accountService.hasGroup(group);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it.each(groups)('should return true if group matchs', (group: string) => {
@@ -198,7 +198,7 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastTutorInCourse(course);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it.each(['TA', 'EDITOR', 'INSTRUCTOR'])('should return true if user is tutor, editor or instructor', (group: string) => {
@@ -224,7 +224,7 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastEditorInCourse(course);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it.each(['EDITOR', 'INSTRUCTOR'])('should return true if user is editor or instructor', (group: string) => {
@@ -250,7 +250,7 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastInstructorInCourse(course);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should return true if user is instructor', () => {
@@ -276,11 +276,11 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastTutorForExercise(exercise);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
 
             result = accountService.isAtLeastTutorForExercise(examExercise);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it.each(['TA', 'EDITOR', 'INSTRUCTOR'])('should return true if user is tutor, editor or instructor', (group: string) => {
@@ -314,11 +314,11 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastEditorForExercise(exercise);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
 
             result = accountService.isAtLeastEditorForExercise(examExercise);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it.each(['EDITOR', 'INSTRUCTOR'])('should return true if user is editor or instructor', (group: string) => {
@@ -352,11 +352,11 @@ describe('AccountService', () => {
 
             result = accountService.isAtLeastInstructorForExercise(exercise);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
 
             result = accountService.isAtLeastInstructorForExercise(examExercise);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should return true if user is editor or instructor', () => {
@@ -390,7 +390,7 @@ describe('AccountService', () => {
 
             result = accountService.isAdmin();
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should return true if user is system admin', () => {
@@ -439,7 +439,7 @@ describe('AccountService', () => {
 
             result = accountService.isOwnerOfParticipation(participation);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should return true if student is owner', () => {
@@ -457,7 +457,7 @@ describe('AccountService', () => {
 
             result = accountService.isOwnerOfParticipation(participation);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should return true if student is part of the team', () => {

--- a/src/test/javascript/spec/service/activate.service.spec.ts
+++ b/src/test/javascript/spec/service/activate.service.spec.ts
@@ -25,7 +25,7 @@ describe('ActivateService', () => {
 
         activateService.get(key).subscribe();
 
-        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(getStub).toHaveBeenCalledOnce();
         expect(getStub).toHaveBeenCalledWith(getURL, {
             params: new HttpParams().set('key', key),
         });

--- a/src/test/javascript/spec/service/alert.service.spec.ts
+++ b/src/test/javascript/spec/service/alert.service.spec.ts
@@ -72,7 +72,7 @@ describe('Alert Service Test', () => {
                 message: 'Hello Jhipster success',
             } as Alert),
         );
-        expect(alert1.onClose).toHaveBeenCalledTimes(1);
+        expect(alert1.onClose).toHaveBeenCalledOnce();
         alert2.close?.();
         expect(service.get()).toHaveLength(1);
         expect(service.get()[0]).toEqual(
@@ -81,11 +81,11 @@ describe('Alert Service Test', () => {
                 message: 'Hello Jhipster info',
             } as Alert),
         );
-        expect(alert2.onClose).toHaveBeenCalledTimes(1);
+        expect(alert2.onClose).toHaveBeenCalledOnce();
 
         alert0.close?.();
         expect(service.get()).toHaveLength(0);
-        expect(alert0.onClose).toHaveBeenCalledTimes(1);
+        expect(alert0.onClose).toHaveBeenCalledOnce();
     });
 
     it('should close an alert on timeout correctly', () => {
@@ -97,7 +97,7 @@ describe('Alert Service Test', () => {
         jest.advanceTimersByTime(16000);
 
         expect(service.get()).toHaveLength(0);
-        expect(alert.onClose).toHaveBeenCalledTimes(1);
+        expect(alert.onClose).toHaveBeenCalledOnce();
     });
 
     it('should clear alerts', () => {
@@ -110,7 +110,7 @@ describe('Alert Service Test', () => {
         expect(service.get()).toHaveLength(3);
         service.closeAll();
         expect(service.get()).toHaveLength(0);
-        alerts.forEach((alert) => expect(alert.onClose).toHaveBeenCalledTimes(1));
+        alerts.forEach((alert) => expect(alert.onClose).toHaveBeenCalledOnce());
     });
 
     it('should produce a success message', () => {

--- a/src/test/javascript/spec/service/assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/assessment.service.spec.ts
@@ -22,8 +22,8 @@ describe('Assessment Service', () => {
         it('should show during assessment', () => {
             const isAllowedBeforeDueDate = isAllowedToModifyFeedback(false, false, true, false, resultLock, undefined, exercise);
             const isAllowedAfterDueDate = isAllowedToModifyFeedback(false, false, true, true, resultLock, undefined, exercise);
-            expect(isAllowedBeforeDueDate).toBe(true);
-            expect(isAllowedAfterDueDate).toBe(true);
+            expect(isAllowedBeforeDueDate).toBeTrue();
+            expect(isAllowedAfterDueDate).toBeTrue();
         });
 
         it('should hide after assessment without complaint', () => {
@@ -35,7 +35,7 @@ describe('Assessment Service', () => {
             const isAllowedAssessor = isAllowedToModifyFeedback(false, false, true, true, result, complaint, exercise);
             const isAllowedNotAssessor = isAllowedToModifyFeedback(false, false, false, true, result, complaint, exercise);
             expect(isAllowedAssessor).toBe(false);
-            expect(isAllowedNotAssessor).toBe(true);
+            expect(isAllowedNotAssessor).toBeTrue();
         });
 
         it('should hide for feedback requests', () => {
@@ -52,8 +52,8 @@ describe('Assessment Service', () => {
         it('should show if no complaint is set and the assessment is still running', () => {
             const isAllowedSubmitted = isAllowedToModifyFeedback(false, false, true, false, resultLock, undefined, exercise);
             const isAllowedNotSubmitted = isAllowedToModifyFeedback(false, false, true, false, result, undefined, exercise);
-            expect(isAllowedSubmitted).toBe(true);
-            expect(isAllowedNotSubmitted).toBe(true);
+            expect(isAllowedSubmitted).toBeTrue();
+            expect(isAllowedNotSubmitted).toBeTrue();
         });
     });
 
@@ -61,8 +61,8 @@ describe('Assessment Service', () => {
         it('should allow if is assessor in teammode', () => {
             const isAllowedComplaint = isAllowedToRespondToComplaintAction(false, false, true, complaint, teamExercise);
             const isAllowedFeedbackRequest = isAllowedToRespondToComplaintAction(false, false, true, feedbackRequest, teamExercise);
-            expect(isAllowedComplaint).toBe(true);
-            expect(isAllowedFeedbackRequest).toBe(true);
+            expect(isAllowedComplaint).toBeTrue();
+            expect(isAllowedFeedbackRequest).toBeTrue();
         });
 
         it('should not allow if is not assessor in teammode', () => {
@@ -75,28 +75,28 @@ describe('Assessment Service', () => {
         it('should allow for assessor if on a test run', () => {
             const isAllowedAssessor = isAllowedToRespondToComplaintAction(false, true, true, complaint, exercise);
             const isAllowedNotAssessor = isAllowedToRespondToComplaintAction(false, true, false, complaint, exercise);
-            expect(isAllowedAssessor).toBe(true);
+            expect(isAllowedAssessor).toBeTrue();
             expect(isAllowedNotAssessor).toBe(false);
         });
 
         it('should allow if assessor is not defined on individual exercises', () => {
             const isAllowedComplaint = isAllowedToRespondToComplaintAction(false, false, true, complaintOnAutomaticResult, exerciseAutomatic);
             const isAllowedFeedbackRequest = isAllowedToRespondToComplaintAction(false, false, true, feedbackRequestOnAutomaticResult, exerciseAutomatic);
-            expect(isAllowedComplaint).toBe(true);
-            expect(isAllowedFeedbackRequest).toBe(true);
+            expect(isAllowedComplaint).toBeTrue();
+            expect(isAllowedFeedbackRequest).toBeTrue();
         });
 
         it('should allow correctly for complaint', () => {
             const isAllowedAssessor = isAllowedToRespondToComplaintAction(false, false, true, complaint, exercise);
             const isAllowedNotAssessor = isAllowedToRespondToComplaintAction(false, false, false, complaint, exercise);
             expect(isAllowedAssessor).toBe(false);
-            expect(isAllowedNotAssessor).toBe(true);
+            expect(isAllowedNotAssessor).toBeTrue();
         });
 
         it('should allow correctly for feedback request', () => {
             const isAllowedAssessor = isAllowedToRespondToComplaintAction(false, false, true, feedbackRequest, exercise);
             const isAllowedNotAssessor = isAllowedToRespondToComplaintAction(false, false, false, feedbackRequest, exercise);
-            expect(isAllowedAssessor).toBe(true);
+            expect(isAllowedAssessor).toBeTrue();
             expect(isAllowedNotAssessor).toBe(false);
         });
     });

--- a/src/test/javascript/spec/service/assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/assessment.service.spec.ts
@@ -28,25 +28,25 @@ describe('Assessment Service', () => {
 
         it('should hide after assessment without complaint', () => {
             const isAllowed = isAllowedToModifyFeedback(false, false, true, true, result, undefined, exercise);
-            expect(isAllowed).toBe(false);
+            expect(isAllowed).toBeFalse();
         });
 
         it('should show correctly after assessment with complaint', () => {
             const isAllowedAssessor = isAllowedToModifyFeedback(false, false, true, true, result, complaint, exercise);
             const isAllowedNotAssessor = isAllowedToModifyFeedback(false, false, false, true, result, complaint, exercise);
-            expect(isAllowedAssessor).toBe(false);
+            expect(isAllowedAssessor).toBeFalse();
             expect(isAllowedNotAssessor).toBeTrue();
         });
 
         it('should hide for feedback requests', () => {
             complaint.result = result;
             const isAllowed = isAllowedToModifyFeedback(false, false, true, true, result, feedbackRequest, exercise);
-            expect(isAllowed).toBe(false);
+            expect(isAllowed).toBeFalse();
         });
 
         it('should hide if no complaint is set', () => {
             const isAllowed = isAllowedToModifyFeedback(false, false, true, true, result, undefined, exercise);
-            expect(isAllowed).toBe(false);
+            expect(isAllowed).toBeFalse();
         });
 
         it('should show if no complaint is set and the assessment is still running', () => {
@@ -68,15 +68,15 @@ describe('Assessment Service', () => {
         it('should not allow if is not assessor in teammode', () => {
             const isAllowedComplaint = isAllowedToRespondToComplaintAction(false, false, false, complaint, teamExercise);
             const isAllowedFeedbackRequest = isAllowedToRespondToComplaintAction(false, false, false, feedbackRequest, teamExercise);
-            expect(isAllowedComplaint).toBe(false);
-            expect(isAllowedFeedbackRequest).toBe(false);
+            expect(isAllowedComplaint).toBeFalse();
+            expect(isAllowedFeedbackRequest).toBeFalse();
         });
 
         it('should allow for assessor if on a test run', () => {
             const isAllowedAssessor = isAllowedToRespondToComplaintAction(false, true, true, complaint, exercise);
             const isAllowedNotAssessor = isAllowedToRespondToComplaintAction(false, true, false, complaint, exercise);
             expect(isAllowedAssessor).toBeTrue();
-            expect(isAllowedNotAssessor).toBe(false);
+            expect(isAllowedNotAssessor).toBeFalse();
         });
 
         it('should allow if assessor is not defined on individual exercises', () => {
@@ -89,7 +89,7 @@ describe('Assessment Service', () => {
         it('should allow correctly for complaint', () => {
             const isAllowedAssessor = isAllowedToRespondToComplaintAction(false, false, true, complaint, exercise);
             const isAllowedNotAssessor = isAllowedToRespondToComplaintAction(false, false, false, complaint, exercise);
-            expect(isAllowedAssessor).toBe(false);
+            expect(isAllowedAssessor).toBeFalse();
             expect(isAllowedNotAssessor).toBeTrue();
         });
 
@@ -97,7 +97,7 @@ describe('Assessment Service', () => {
             const isAllowedAssessor = isAllowedToRespondToComplaintAction(false, false, true, feedbackRequest, exercise);
             const isAllowedNotAssessor = isAllowedToRespondToComplaintAction(false, false, false, feedbackRequest, exercise);
             expect(isAllowedAssessor).toBeTrue();
-            expect(isAllowedNotAssessor).toBe(false);
+            expect(isAllowedNotAssessor).toBeFalse();
         });
     });
 });

--- a/src/test/javascript/spec/service/auth-jwt.service.spec.ts
+++ b/src/test/javascript/spec/service/auth-jwt.service.spec.ts
@@ -51,7 +51,7 @@ describe('AuthServerProvider', () => {
             const returnedToken = service.getToken();
 
             expect(returnedToken).toEqual(storedToken);
-            expect(localStorageRetrieveSpy).toHaveBeenCalledTimes(1);
+            expect(localStorageRetrieveSpy).toHaveBeenCalledOnce();
             expect(localStorageRetrieveSpy).toHaveBeenCalledWith(tokenKey);
         });
 
@@ -62,7 +62,7 @@ describe('AuthServerProvider', () => {
             const returnedToken = service.getToken();
 
             expect(returnedToken).toEqual(storedToken);
-            expect(retrieveMock).toHaveBeenCalledTimes(1);
+            expect(retrieveMock).toHaveBeenCalledOnce();
             expect(retrieveMock).toHaveBeenCalledWith(tokenKey);
         });
     });
@@ -73,7 +73,7 @@ describe('AuthServerProvider', () => {
             credentials = new Credentials('Test user', 'password1234', true);
 
             service.login(credentials).subscribe(() => {
-                expect(localStorageStoreSpy).toHaveBeenCalledTimes(1);
+                expect(localStorageStoreSpy).toHaveBeenCalledOnce();
                 expect(localStorageStoreSpy).toHaveBeenCalledWith(tokenKey, storedToken);
             });
 
@@ -86,7 +86,7 @@ describe('AuthServerProvider', () => {
             credentials = new Credentials('Test user', 'password1234', false);
 
             service.login(credentials).subscribe(() => {
-                expect(sessionStorageStoreSpy).toHaveBeenCalledTimes(1);
+                expect(sessionStorageStoreSpy).toHaveBeenCalledOnce();
                 expect(sessionStorageStoreSpy).toHaveBeenCalledWith(tokenKey, storedToken);
             });
 
@@ -99,7 +99,7 @@ describe('AuthServerProvider', () => {
     describe('test login with SAML2', () => {
         it('should login with SAML2 if login should be remembered', fakeAsync(() => {
             service.loginSAML2(true).subscribe(() => {
-                expect(localStorageStoreSpy).toHaveBeenCalledTimes(1);
+                expect(localStorageStoreSpy).toHaveBeenCalledOnce();
                 expect(localStorageStoreSpy).toHaveBeenCalledWith(tokenKey, storedToken);
             });
 
@@ -110,7 +110,7 @@ describe('AuthServerProvider', () => {
 
         it('should login with SAML2 if login should not be remembered', fakeAsync(() => {
             service.loginSAML2(false).subscribe(() => {
-                expect(sessionStorageStoreSpy).toHaveBeenCalledTimes(1);
+                expect(sessionStorageStoreSpy).toHaveBeenCalledOnce();
                 expect(sessionStorageStoreSpy).toHaveBeenCalledWith(tokenKey, storedToken);
             });
 
@@ -123,7 +123,7 @@ describe('AuthServerProvider', () => {
     describe('test login with token', () => {
         it('should login with token if token is present', async () => {
             await expect(service.loginWithToken(storedToken, true)).resolves.toBe(storedToken);
-            expect(localStorageStoreSpy).toHaveBeenCalledTimes(1);
+            expect(localStorageStoreSpy).toHaveBeenCalledOnce();
             expect(localStorageStoreSpy).toHaveBeenCalledWith(tokenKey, storedToken);
         });
 
@@ -140,9 +140,9 @@ describe('AuthServerProvider', () => {
 
             service.removeAuthTokenFromCaches().subscribe((resp) => {
                 expect(resp).toBe(undefined);
-                expect(sessionStorageClearSpy).toHaveBeenCalledTimes(1);
+                expect(sessionStorageClearSpy).toHaveBeenCalledOnce();
                 expect(sessionStorageClearSpy).toHaveBeenCalledWith(tokenKey);
-                expect(localStorageClearSpy).toHaveBeenCalledTimes(1);
+                expect(localStorageClearSpy).toHaveBeenCalledOnce();
                 expect(localStorageClearSpy).toHaveBeenCalledWith(tokenKey);
             });
             tick();
@@ -154,9 +154,9 @@ describe('AuthServerProvider', () => {
 
             service.clearCaches().subscribe((resp) => {
                 expect(resp).toBe(undefined);
-                expect(sessionStorageClearSpy).toHaveBeenCalledTimes(1);
+                expect(sessionStorageClearSpy).toHaveBeenCalledOnce();
                 expect(sessionStorageClearSpy).toHaveBeenCalledWith();
-                expect(localStorageClearSpy).toHaveBeenCalledTimes(1);
+                expect(localStorageClearSpy).toHaveBeenCalledOnce();
                 expect(localStorageClearSpy).toHaveBeenCalledWith();
             });
             tick();

--- a/src/test/javascript/spec/service/course-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/course-exercise.service.spec.ts
@@ -99,12 +99,12 @@ describe('Course Management Service', () => {
     });
 
     const expectDateConversionToBeDone = (exerciseToCheck: Exercise, withoutAssessmentDueDate?: boolean) => {
-        expect(dayjs.isDayjs(exerciseToCheck.releaseDate)).toBe(true);
+        expect(dayjs.isDayjs(exerciseToCheck.releaseDate)).toBeTrue();
         expect(exerciseToCheck.releaseDate?.toISOString()).toBe(releaseDateString);
-        expect(dayjs.isDayjs(exerciseToCheck.dueDate)).toBe(true);
+        expect(dayjs.isDayjs(exerciseToCheck.dueDate)).toBeTrue();
         expect(exerciseToCheck.dueDate?.toISOString()).toBe(dueDateString);
         if (!withoutAssessmentDueDate) {
-            expect(dayjs.isDayjs(exerciseToCheck.assessmentDueDate)).toBe(true);
+            expect(dayjs.isDayjs(exerciseToCheck.assessmentDueDate)).toBeTrue();
             expect(exerciseToCheck.assessmentDueDate?.toISOString()).toBe(assessmentDueDateString);
         }
     };

--- a/src/test/javascript/spec/service/delete-dialog.service.spec.ts
+++ b/src/test/javascript/spec/service/delete-dialog.service.spec.ts
@@ -45,7 +45,7 @@ describe('Delete Dialog Service', () => {
             result,
         });
         service.openDeleteDialog(data);
-        expect(openModalStub).toHaveBeenCalledTimes(1);
+        expect(openModalStub).toHaveBeenCalledOnce();
         expect(openModalStub).toHaveBeenCalledWith(DeleteDialogComponent, { size: 'lg', backdrop: 'static' });
     });
 });

--- a/src/test/javascript/spec/service/exam-checklist.service.spec.ts
+++ b/src/test/javascript/spec/service/exam-checklist.service.spec.ts
@@ -45,13 +45,13 @@ describe('ExamChecklistService', () => {
     it('should indicate correctly whether all exercises are generated', () => {
         result = service.checkAllExamsGenerated(exam, examChecklist);
 
-        expect(result).toBe(false);
+        expect(result).toBeFalse();
 
         examChecklist.numberOfGeneratedStudentExams = 2;
 
         result = service.checkAllExamsGenerated(exam, examChecklist);
 
-        expect(result).toBe(false);
+        expect(result).toBeFalse();
 
         examChecklist.numberOfGeneratedStudentExams = 3;
 
@@ -78,7 +78,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkTotalPointsMandatory(false, exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should return true if exam points can be reached by mandatory points', () => {
@@ -104,7 +104,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkTotalPointsMandatory(true, exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
     });
 
@@ -114,7 +114,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkPointsExercisesEqual(exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
         it('should return checkPointsExercisesEqual as true if max points equal in each exercise group', () => {
             exam.exerciseGroups = getExerciseGroups(true);
@@ -128,7 +128,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkPointsExercisesEqual(exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
     });
 
@@ -138,7 +138,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkEachGroupContainsExercise(exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should return true if every exercise group contains at least one exercise', () => {
@@ -154,7 +154,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkEachGroupContainsExercise(exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
     });
 
@@ -172,7 +172,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkAtLeastOneExerciseGroup(exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
     });
 
@@ -213,7 +213,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkNumberOfExerciseGroups(exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
 
         it('should return false if number of exam exercises is greater than number of exercise groups', () => {
@@ -221,7 +221,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkNumberOfExerciseGroups(exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
     });
 
@@ -237,7 +237,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkAtLeastOneRegisteredStudent(exam);
 
-            expect(result).toBe(false);
+            expect(result).toBeFalse();
         });
     });
 });

--- a/src/test/javascript/spec/service/exam-checklist.service.spec.ts
+++ b/src/test/javascript/spec/service/exam-checklist.service.spec.ts
@@ -57,7 +57,7 @@ describe('ExamChecklistService', () => {
 
         result = service.checkAllExamsGenerated(exam, examChecklist);
 
-        expect(result).toBe(true);
+        expect(result).toBeTrue();
     });
 
     it('should return exam statistics correctly', () => {
@@ -68,7 +68,7 @@ describe('ExamChecklistService', () => {
             .pipe(take(1))
             .subscribe((checklist) => expect(checklist).toEqual(examChecklist));
 
-        expect(getExamStatisticsStub).toHaveBeenCalledTimes(1);
+        expect(getExamStatisticsStub).toHaveBeenCalledOnce();
         expect(getExamStatisticsStub).toHaveBeenCalledWith(2, 1);
     });
 
@@ -87,7 +87,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkTotalPointsMandatory(true, exam);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return to true if exam points can be reached by optional points', () => {
@@ -95,7 +95,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkTotalPointsMandatory(true, exam);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should set totalPointsMandatoryOptional to false if exam points cannot be reached by mandatory points + optional points', () => {
@@ -121,7 +121,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkPointsExercisesEqual(exam);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
         it('should return checkPointsExercisesEqual as false if max points do not equal in each exercise group', () => {
             exam.exerciseGroups = getExerciseGroups(false);
@@ -146,7 +146,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkEachGroupContainsExercise(exam);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return false if an exercise group does not contain exercises', () => {
@@ -164,7 +164,7 @@ describe('ExamChecklistService', () => {
 
             result = service.checkAtLeastOneExerciseGroup(exam);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return false if no exercise groups exist', () => {
@@ -186,13 +186,13 @@ describe('ExamChecklistService', () => {
             exam.exerciseGroups![0].isMandatory = true;
             result = service.checkNumberOfExerciseGroups(exam);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return true if number of mandatory exercise groups is smaller than number of exam exercises', () => {
             result = service.checkNumberOfExerciseGroups(exam);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return false if number of mandatory exercise groups is greater than number of exam exercises', () => {
@@ -229,7 +229,7 @@ describe('ExamChecklistService', () => {
         it('should return true if at least one student is registered', () => {
             result = service.checkAtLeastOneRegisteredStudent(exam);
 
-            expect(result).toBe(true);
+            expect(result).toBeTrue();
         });
 
         it('should return false if no student is registered', () => {

--- a/src/test/javascript/spec/service/example-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/example-submission.service.spec.ts
@@ -103,7 +103,7 @@ describe('Example Submission Service', () => {
             const req = httpMock.expectOne({ method: 'DELETE' });
             req.flush({ status: 200 });
             tick();
-            expect(expectedResult).toBe(true);
+            expect(expectedResult).toBeTrue();
         }));
 
         it('should return an example submission', fakeAsync(() => {

--- a/src/test/javascript/spec/service/exercise-hint.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-hint.service.spec.ts
@@ -102,7 +102,7 @@ describe('ExerciseHint Service', () => {
 
         const req = httpMock.expectOne({ method: 'DELETE' });
         req.flush({ status: 200 });
-        expect(expectedResult).toBe(true);
+        expect(expectedResult).toBeTrue();
     });
 
     afterEach(() => {

--- a/src/test/javascript/spec/service/exercise-update-warning.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-update-warning.service.spec.ts
@@ -69,9 +69,9 @@ describe('Exercise Update Warning Service', () => {
         backupExercise.gradingCriteria = [gradingCriterion];
         updateWarningService.checkExerciseBeforeUpdate(exercise, backupExercise);
 
-        expect(updateWarningService.instructionDeleted).toBe(false);
-        expect(updateWarningService.creditChanged).toBe(false);
-        expect(updateWarningService.usageCountChanged).toBe(false);
+        expect(updateWarningService.instructionDeleted).toBeFalse();
+        expect(updateWarningService.creditChanged).toBeFalse();
+        expect(updateWarningService.usageCountChanged).toBeFalse();
 
         expect(loadExerciseSpy).toHaveBeenCalledOnce();
         expect(loadExerciseSpy).toHaveBeenCalledWith(exercise, backupExercise);

--- a/src/test/javascript/spec/service/exercise-update-warning.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise-update-warning.service.spec.ts
@@ -40,28 +40,28 @@ describe('Exercise Update Warning Service', () => {
         exercise.gradingCriteria = [gradingCriterionWithoutInstruction];
         backupExercise.gradingCriteria = [gradingCriterion];
         updateWarningService.loadExercise(exercise, backupExercise);
-        expect(updateWarningService.instructionDeleted).toBe(true);
+        expect(updateWarningService.instructionDeleted).toBeTrue();
     });
 
     it('should set instructionDeleted as true when gradingCriteria is undefined', () => {
         exercise.gradingCriteria = undefined;
         backupExercise.gradingCriteria = [gradingCriterion];
         updateWarningService.loadExercise(exercise, backupExercise);
-        expect(updateWarningService.instructionDeleted).toBe(true);
+        expect(updateWarningService.instructionDeleted).toBeTrue();
     });
 
     it('should set creditChanged as true', () => {
         exercise.gradingCriteria = [gradingCriterionCreditsChanged];
         backupExercise.gradingCriteria = [gradingCriterion];
         updateWarningService.loadExercise(exercise, backupExercise);
-        expect(updateWarningService.creditChanged).toBe(true);
+        expect(updateWarningService.creditChanged).toBeTrue();
     });
 
     it('should set usageCountChanged as true', () => {
         exercise.gradingCriteria = [gradingCriterionUsageCountChanged];
         backupExercise.gradingCriteria = [gradingCriterion];
         updateWarningService.loadExercise(exercise, backupExercise);
-        expect(updateWarningService.usageCountChanged).toBe(true);
+        expect(updateWarningService.usageCountChanged).toBeTrue();
     });
 
     it('should loadExercise and not open warning modal', () => {
@@ -73,7 +73,7 @@ describe('Exercise Update Warning Service', () => {
         expect(updateWarningService.creditChanged).toBe(false);
         expect(updateWarningService.usageCountChanged).toBe(false);
 
-        expect(loadExerciseSpy).toHaveBeenCalledTimes(1);
+        expect(loadExerciseSpy).toHaveBeenCalledOnce();
         expect(loadExerciseSpy).toHaveBeenCalledWith(exercise, backupExercise);
         expect(openSpy).toHaveBeenCalledTimes(0);
     });
@@ -84,8 +84,8 @@ describe('Exercise Update Warning Service', () => {
         updateWarningService.checkExerciseBeforeUpdate(exercise, backupExercise);
 
         expect(loadExerciseSpy).toHaveBeenCalledWith(exercise, backupExercise);
-        expect(loadExerciseSpy).toHaveBeenCalledTimes(1);
+        expect(loadExerciseSpy).toHaveBeenCalledOnce();
         expect(openSpy).toHaveBeenCalledWith(ExerciseUpdateWarningComponent as Component);
-        expect(openSpy).toHaveBeenCalledTimes(1);
+        expect(openSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/service/exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise.service.spec.ts
@@ -89,8 +89,8 @@ describe('Exercise Service', () => {
 
         service.validateDate(exercise);
 
-        expect(exercise.dueDateError).toBe(true);
-        expect(exercise.assessmentDueDateError).toBe(true);
+        expect(exercise.dueDateError).toBeTrue();
+        expect(exercise.assessmentDueDateError).toBeTrue();
     });
 
     it('should validate empty example solution publication date', () => {
@@ -139,7 +139,7 @@ describe('Exercise Service', () => {
 
         service.validateDate(exercise);
 
-        expect(exercise.dueDateError).toBe(true);
+        expect(exercise.dueDateError).toBeTrue();
     });
 
     it('should set error when example solution publication date is before release date', () => {
@@ -154,8 +154,8 @@ describe('Exercise Service', () => {
         service.validateDate(exercise);
 
         expect(exercise.dueDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateError).toBe(true);
-        expect(exercise.exampleSolutionPublicationDateWarning).toBe(true);
+        expect(exercise.exampleSolutionPublicationDateError).toBeTrue();
+        expect(exercise.exampleSolutionPublicationDateWarning).toBeTrue();
     });
 
     it('should set error when example solution publication date is before due date', () => {
@@ -170,7 +170,7 @@ describe('Exercise Service', () => {
         service.validateDate(exercise);
 
         expect(exercise.dueDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateError).toBe(true);
+        expect(exercise.exampleSolutionPublicationDateError).toBeTrue();
         expect(exercise.exampleSolutionPublicationDateWarning).toBe(false);
     });
 
@@ -189,6 +189,6 @@ describe('Exercise Service', () => {
 
         expect(exercise.dueDateError).toBe(false);
         expect(exercise.exampleSolutionPublicationDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateWarning).toBe(true);
+        expect(exercise.exampleSolutionPublicationDateWarning).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/service/exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/exercise.service.spec.ts
@@ -52,10 +52,10 @@ describe('Exercise Service', () => {
 
         service.validateDate(exercise);
 
-        expect(exercise.dueDateError).toBe(false);
-        expect(exercise.assessmentDueDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateWarning).toBe(false);
+        expect(exercise.dueDateError).toBeFalse();
+        expect(exercise.assessmentDueDateError).toBeFalse();
+        expect(exercise.exampleSolutionPublicationDateError).toBeFalse();
+        expect(exercise.exampleSolutionPublicationDateWarning).toBeFalse();
     });
 
     it('should validate dates', () => {
@@ -72,10 +72,10 @@ describe('Exercise Service', () => {
 
         service.validateDate(exercise);
 
-        expect(exercise.dueDateError).toBe(false);
-        expect(exercise.assessmentDueDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateWarning).toBe(false);
+        expect(exercise.dueDateError).toBeFalse();
+        expect(exercise.assessmentDueDateError).toBeFalse();
+        expect(exercise.exampleSolutionPublicationDateError).toBeFalse();
+        expect(exercise.exampleSolutionPublicationDateWarning).toBeFalse();
     });
 
     it('should set errors on invalid due and assessment due dates', () => {
@@ -107,10 +107,10 @@ describe('Exercise Service', () => {
 
         service.validateDate(exercise);
 
-        expect(exercise.dueDateError).toBe(false);
-        expect(exercise.assessmentDueDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateWarning).toBe(false);
+        expect(exercise.dueDateError).toBeFalse();
+        expect(exercise.assessmentDueDateError).toBeFalse();
+        expect(exercise.exampleSolutionPublicationDateError).toBeFalse();
+        expect(exercise.exampleSolutionPublicationDateWarning).toBeFalse();
     });
 
     it('should validate empty example solution publication date', () => {
@@ -125,9 +125,9 @@ describe('Exercise Service', () => {
 
         service.validateDate(exercise);
 
-        expect(exercise.dueDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateWarning).toBe(false);
+        expect(exercise.dueDateError).toBeFalse();
+        expect(exercise.exampleSolutionPublicationDateError).toBeFalse();
+        expect(exercise.exampleSolutionPublicationDateWarning).toBeFalse();
     });
 
     it('should set error when due date is before release date', () => {
@@ -153,7 +153,7 @@ describe('Exercise Service', () => {
 
         service.validateDate(exercise);
 
-        expect(exercise.dueDateError).toBe(false);
+        expect(exercise.dueDateError).toBeFalse();
         expect(exercise.exampleSolutionPublicationDateError).toBeTrue();
         expect(exercise.exampleSolutionPublicationDateWarning).toBeTrue();
     });
@@ -169,9 +169,9 @@ describe('Exercise Service', () => {
 
         service.validateDate(exercise);
 
-        expect(exercise.dueDateError).toBe(false);
+        expect(exercise.dueDateError).toBeFalse();
         expect(exercise.exampleSolutionPublicationDateError).toBeTrue();
-        expect(exercise.exampleSolutionPublicationDateWarning).toBe(false);
+        expect(exercise.exampleSolutionPublicationDateWarning).toBeFalse();
     });
 
     it('should allow example solution publication date is before due date with a warning', () => {
@@ -187,8 +187,8 @@ describe('Exercise Service', () => {
 
         service.validateDate(exercise);
 
-        expect(exercise.dueDateError).toBe(false);
-        expect(exercise.exampleSolutionPublicationDateError).toBe(false);
+        expect(exercise.dueDateError).toBeFalse();
+        expect(exercise.exampleSolutionPublicationDateError).toBeFalse();
         expect(exercise.exampleSolutionPublicationDateWarning).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/service/external-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/external-submission.service.spec.ts
@@ -37,7 +37,7 @@ describe('External Submission Service', () => {
         const req = httpMock.expectOne({ url: `${SERVER_API_URL}api/exercises/1/external-submission-results?studentLogin=ab12cde`, method: 'POST' });
         const returned = { ...result, id: 4 };
         req.flush(returned);
-        expect(convertDateFromServerSpy).toHaveBeenCalledTimes(1);
+        expect(convertDateFromServerSpy).toHaveBeenCalledOnce();
         expect(convertDateFromServerSpy).toHaveBeenCalledWith(createResult);
         expect(createResult).not.toBe(undefined);
         expect(createResult!.body).toEqual(returned);
@@ -49,8 +49,8 @@ describe('External Submission Service', () => {
         expect(result.completionDate).not.toBe(undefined);
         // a maximum delay of 1s between creation and assertion is unlikely but accurate enough for an assertion of ‘approximately now’ here
         expect(dayjs().diff(result.completionDate, 'ms')).toBeLessThan(1000);
-        expect(result.successful).toBe(true);
+        expect(result.successful).toBeTrue();
         expect(result.score).toBe(100);
-        expect(result.rated).toBe(true);
+        expect(result.rated).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/service/guided-tour.service.spec.ts
+++ b/src/test/javascript/spec/service/guided-tour.service.spec.ts
@@ -219,7 +219,7 @@ describe('GuidedTourService', () => {
             guidedTourService['startTour']();
             guidedTourComponentFixture.detectChanges();
             expect(guidedTourComponentFixture.debugElement.query(By.css('.tour-step'))).not.toBe(null);
-            expect(guidedTourService.isOnFirstStep).toBe(true);
+            expect(guidedTourService.isOnFirstStep).toBeTrue();
             expect(guidedTourService.currentTourStepDisplay).toBe(1);
             expect(guidedTourService.currentTourStepCount).toBe(2);
         }
@@ -235,7 +235,7 @@ describe('GuidedTourService', () => {
                 const nextButton = guidedTourComponentFixture.debugElement.query(By.css('.next-button'));
                 expect(nextButton).not.toBe(null);
                 nextButton.nativeElement.click();
-                expect(guidedTourService.isOnLastStep).toBe(true);
+                expect(guidedTourService.isOnLastStep).toBeTrue();
 
                 // Finish guided tour
                 nextButton.nativeElement.click();
@@ -260,7 +260,7 @@ describe('GuidedTourService', () => {
                     overlay.nativeElement.click();
                 });
                 guidedTourComponentFixture.detectChanges();
-                expect(guidedTourService.isOnFirstStep).toBe(true);
+                expect(guidedTourService.isOnFirstStep).toBeTrue();
             });
         });
 
@@ -369,7 +369,7 @@ describe('GuidedTourService', () => {
                 course1.exercises!.forEach((exercise) => {
                     exercise.course = course1;
                     if (exercise === exercise1) {
-                        expect(guidedTourService['isGuidedTourAvailableForExercise'](exercise)).toBe(true);
+                        expect(guidedTourService['isGuidedTourAvailableForExercise'](exercise)).toBeTrue();
                     } else {
                         expect(guidedTourService['isGuidedTourAvailableForExercise'](exercise)).toBe(false);
                     }
@@ -416,25 +416,25 @@ describe('GuidedTourService', () => {
                     prepareParticipation(exercise1, studentParticipation1, httpResponse1);
                     guidedTourService.enableTourForExercise(exercise1, tourWithCourseAndExercise, true);
                     guidedTourService.restartTour();
-                    expect(findParticipationStub).toHaveBeenCalledTimes(1);
+                    expect(findParticipationStub).toHaveBeenCalledOnce();
                     expect(findParticipationStub).toHaveBeenCalledWith(1);
-                    expect(deleteParticipationStub).toHaveBeenCalledTimes(1);
+                    expect(deleteParticipationStub).toHaveBeenCalledOnce();
                     expect(deleteParticipationStub).toHaveBeenCalledWith(1, { deleteBuildPlan: true, deleteRepository: true });
-                    expect(deleteGuidedTourSettingStub).toHaveBeenCalledTimes(1);
+                    expect(deleteGuidedTourSettingStub).toHaveBeenCalledOnce();
                     expect(deleteGuidedTourSettingStub).toHaveBeenCalledWith('tour_with_course_and_exercise');
-                    expect(navigateByUrlSpy).toHaveBeenCalledTimes(1);
+                    expect(navigateByUrlSpy).toHaveBeenCalledOnce();
                     expect(navigateByUrlSpy).toHaveBeenCalledWith('/courses/1/exercises');
 
                     prepareParticipation(exercise4, studentParticipation2, httpResponse2);
                     guidedTourService.enableTourForExercise(exercise4, tourWithCourseAndExercise, true);
                     guidedTourService.restartTour();
-                    expect(findParticipationStub).toHaveBeenCalledTimes(1);
+                    expect(findParticipationStub).toHaveBeenCalledOnce();
                     expect(findParticipationStub).toHaveBeenCalledWith(4);
-                    expect(deleteParticipationStub).toHaveBeenCalledTimes(1);
+                    expect(deleteParticipationStub).toHaveBeenCalledOnce();
                     expect(deleteParticipationStub).toHaveBeenCalledWith(2, { deleteBuildPlan: false, deleteRepository: false });
-                    expect(deleteGuidedTourSettingStub).toHaveBeenCalledTimes(1);
+                    expect(deleteGuidedTourSettingStub).toHaveBeenCalledOnce();
                     expect(deleteGuidedTourSettingStub).toHaveBeenCalledWith('tour_with_course_and_exercise');
-                    expect(navigateByUrlSpy).toHaveBeenCalledTimes(1);
+                    expect(navigateByUrlSpy).toHaveBeenCalledOnce();
                     expect(navigateByUrlSpy).toHaveBeenCalledWith('/courses/1/exercises');
 
                     const index = course1.exercises!.findIndex((exercise) => (exercise.id = exercise4.id));
@@ -451,7 +451,7 @@ describe('GuidedTourService', () => {
                     guidedTourService.currentTour = tourWithModelingTask;
                     guidedTourService.updateModelingResult(personUML.name, true);
                     tick(0);
-                    expect(enableNextStep).toHaveBeenCalledTimes(1);
+                    expect(enableNextStep).toHaveBeenCalledOnce();
                 }),
             ));
         });
@@ -470,9 +470,9 @@ describe('GuidedTourService', () => {
             };
             it('should return true if it is the current Step', () => {
                 guidedTourService.currentTour = guidedTour;
-                expect(guidedTourService.isCurrentStep(step1)).toBe(true);
+                expect(guidedTourService.isCurrentStep(step1)).toBeTrue();
                 guidedTourService.currentTourStepIndex += 1;
-                expect(guidedTourService.isCurrentStep(step2)).toBe(true);
+                expect(guidedTourService.isCurrentStep(step2)).toBeTrue();
             });
             it('should return false if it is not the current Step', () => {
                 guidedTourService.currentTour = guidedTour;
@@ -488,7 +488,7 @@ describe('GuidedTourService', () => {
         describe('isCurrentTour', () => {
             it('should return true if it is the current Tour', () => {
                 guidedTourService.currentTour = tour;
-                expect(guidedTourService.isCurrentTour(tour)).toBe(true);
+                expect(guidedTourService.isCurrentTour(tour)).toBeTrue();
             });
             it('should return false if it is not the current Tour', () => {
                 expect(guidedTourService.isCurrentTour(tour)).toBe(false);
@@ -528,8 +528,8 @@ describe('GuidedTourService', () => {
             it('backStep should reset tour if currentTour is defined', () => {
                 guidedTourService.currentTour = tour;
                 guidedTourService.backStep();
-                expect(currentDotSubjectSpy).toHaveBeenCalledTimes(1);
-                expect(resetSpy).toHaveBeenCalledTimes(1);
+                expect(currentDotSubjectSpy).toHaveBeenCalledOnce();
+                expect(resetSpy).toHaveBeenCalledOnce();
             });
             it('nextStep should just return if currentTour is not defined', () => {
                 guidedTourService.nextStep();
@@ -539,7 +539,7 @@ describe('GuidedTourService', () => {
             it('nextStep should reset return if currentTour is defined', () => {
                 guidedTourService.currentTour = tour;
                 guidedTourService.nextStep();
-                expect(currentDotSubjectSpy).toHaveBeenCalledTimes(1);
+                expect(currentDotSubjectSpy).toHaveBeenCalledOnce();
             });
             it('nextStep and backStep should return to initial step', fakeAsync(() => {
                 guidedTourService.currentTour = tour;
@@ -586,7 +586,7 @@ describe('GuidedTourService', () => {
             it('should enableUserInteraction with UserInteractionEvent.WAIT_FOR_SELECTOR', fakeAsync(() => {
                 const userInteractionEvent = UserInteractionEvent.WAIT_FOR_SELECTOR;
                 guidedTourService.enableUserInteraction({} as any, userInteractionEvent);
-                expect(handleWaitForSelectorEventSpy).toHaveBeenCalledTimes(1);
+                expect(handleWaitForSelectorEventSpy).toHaveBeenCalledOnce();
                 expect(querySelectorSpy).toHaveBeenCalledTimes(0);
             }));
             it('should enableUserInteraction with UserInteractionEvent.CLICK', fakeAsync(() => {
@@ -598,19 +598,19 @@ describe('GuidedTourService', () => {
                 const userInteractionEvent = UserInteractionEvent.ACE_EDITOR;
                 observeMutationsStub.mockReturnValue(of({ addedNodes: { length: 0 } as NodeList, removedNodes: { length: 0 } as NodeList } as MutationRecord));
                 guidedTourService.enableUserInteraction(htmlTarget, userInteractionEvent);
-                expect(querySelectorSpy).toHaveBeenCalledTimes(1);
+                expect(querySelectorSpy).toHaveBeenCalledOnce();
             }));
             it('should enableUserInteraction with UserInteractionEvent.MODELING', fakeAsync(() => {
                 const userInteractionEvent = UserInteractionEvent.MODELING;
                 observeMutationsStub.mockReturnValue(of({ addedNodes: { length: 0 } as NodeList, removedNodes: { length: 0 } as NodeList } as MutationRecord));
                 guidedTourService.enableUserInteraction(htmlTarget, userInteractionEvent);
-                expect(querySelectorSpy).toHaveBeenCalledTimes(1);
+                expect(querySelectorSpy).toHaveBeenCalledOnce();
             }));
             it('should enableUserInteraction with UserInteractionEvent.ASSESS_SUBMISSION', fakeAsync(() => {
                 const isAssessmentCorrectSpy = jest.spyOn<any, any>(guidedTourService, 'isAssessmentCorrect');
                 const userInteractionEvent = UserInteractionEvent.ASSESS_SUBMISSION;
                 guidedTourService.enableUserInteraction(htmlTarget, userInteractionEvent);
-                expect(isAssessmentCorrectSpy).toHaveBeenCalledTimes(1);
+                expect(isAssessmentCorrectSpy).toHaveBeenCalledOnce();
                 expect(querySelectorSpy).toHaveBeenCalledTimes(0);
             }));
         });
@@ -654,23 +654,23 @@ describe('GuidedTourService', () => {
             });
             it('should enableTourForExercise for text exercise', fakeAsync(() => {
                 expect(guidedTourService.enableTourForExercise(exerciseText, tour, true)).toEqual(exerciseText);
-                expect(enableTourSpy).toHaveBeenCalledTimes(1);
+                expect(enableTourSpy).toHaveBeenCalledOnce();
                 expect(startTourSpy).toHaveBeenCalledTimes(0);
             }));
             it('should enableTourForExercise for text exercise', fakeAsync(() => {
                 expect(guidedTourService.enableTourForExercise(exerciseText, tour, true)).toEqual(exerciseText);
-                expect(enableTourSpy).toHaveBeenCalledTimes(1);
+                expect(enableTourSpy).toHaveBeenCalledOnce();
                 expect(startTourSpy).toHaveBeenCalledTimes(0);
             }));
             it('should enableTourForExercise for programming exercise', fakeAsync(() => {
                 expect(guidedTourService.enableTourForExercise(exerciseProgramming, tour, true)).toEqual(exerciseProgramming);
-                expect(enableTourSpy).toHaveBeenCalledTimes(1);
+                expect(enableTourSpy).toHaveBeenCalledOnce();
                 expect(startTourSpy).toHaveBeenCalledTimes(0);
             }));
             it('should enableTourForExercise for text exercise with init set to false', fakeAsync(() => {
                 guidedTourService.guidedTourSettings = guidedTourSettings;
                 expect(guidedTourService.enableTourForExercise(exerciseText, tour, false)).toEqual(exerciseText);
-                expect(enableTourSpy).toHaveBeenCalledTimes(1);
+                expect(enableTourSpy).toHaveBeenCalledOnce();
                 expect(startTourSpy).toHaveBeenCalledTimes(0);
             }));
         });
@@ -707,7 +707,7 @@ describe('GuidedTourService', () => {
                 guidedTourService.currentTour = tourWithAssessmentTourSteps;
                 guidedTourService.updateAssessmentResult(2, 3);
                 tick(0);
-                expect(enableNextStepSpy).toHaveBeenCalledTimes(1);
+                expect(enableNextStepSpy).toHaveBeenCalledOnce();
             }));
             it('should updateAssessmentResult and not enableNextStepClick as number of assessments is not correct', fakeAsync(() => {
                 guidedTourService.currentTour = tourWithAssessmentTourSteps;
@@ -731,7 +731,7 @@ describe('GuidedTourService', () => {
                 guidedTourService.currentTour = tourWithAssessmentTourStep;
                 guidedTourService.updateAssessmentResult(2, 0);
                 tick(0);
-                expect(enableNextStepSpy).toHaveBeenCalledTimes(1);
+                expect(enableNextStepSpy).toHaveBeenCalledOnce();
             }));
         });
     });
@@ -778,9 +778,9 @@ describe('GuidedTourService', () => {
             // guidedTourService.init() is called via the component initialization
             guidedTourComponentFixture.detectChanges();
 
-            expect(authStateMock).toHaveBeenCalledTimes(1);
+            expect(authStateMock).toHaveBeenCalledOnce();
             expect(guidedTourService.guidedTourSettings).toEqual(tourSettings);
-            expect(profileInfoMock).toHaveBeenCalledTimes(1);
+            expect(profileInfoMock).toHaveBeenCalledOnce();
             expect(guidedTourService.guidedTourMapping).toEqual(tourMapping);
         }));
     });

--- a/src/test/javascript/spec/service/guided-tour.service.spec.ts
+++ b/src/test/javascript/spec/service/guided-tour.service.spec.ts
@@ -371,7 +371,7 @@ describe('GuidedTourService', () => {
                     if (exercise === exercise1) {
                         expect(guidedTourService['isGuidedTourAvailableForExercise'](exercise)).toBeTrue();
                     } else {
-                        expect(guidedTourService['isGuidedTourAvailableForExercise'](exercise)).toBe(false);
+                        expect(guidedTourService['isGuidedTourAvailableForExercise'](exercise)).toBeFalse();
                     }
                 });
 
@@ -476,12 +476,12 @@ describe('GuidedTourService', () => {
             });
             it('should return false if it is not the current Step', () => {
                 guidedTourService.currentTour = guidedTour;
-                expect(guidedTourService.isCurrentStep(step2)).toBe(false);
+                expect(guidedTourService.isCurrentStep(step2)).toBeFalse();
                 guidedTourService.currentTourStepIndex += 1;
-                expect(guidedTourService.isCurrentStep(step1)).toBe(false);
+                expect(guidedTourService.isCurrentStep(step1)).toBeFalse();
             });
             it('should return false if current Tour is undefined', () => {
-                expect(guidedTourService.isCurrentStep(step1)).toBe(false);
+                expect(guidedTourService.isCurrentStep(step1)).toBeFalse();
             });
         });
 
@@ -491,11 +491,11 @@ describe('GuidedTourService', () => {
                 expect(guidedTourService.isCurrentTour(tour)).toBeTrue();
             });
             it('should return false if it is not the current Tour', () => {
-                expect(guidedTourService.isCurrentTour(tour)).toBe(false);
+                expect(guidedTourService.isCurrentTour(tour)).toBeFalse();
             });
             it('should return false if the current Tour is undefined', () => {
                 guidedTourService.currentTour = tourWithCourseAndExercise;
-                expect(guidedTourService.isCurrentTour(tour)).toBe(false);
+                expect(guidedTourService.isCurrentTour(tour)).toBeFalse();
             });
         });
 

--- a/src/test/javascript/spec/service/login.service.spec.ts
+++ b/src/test/javascript/spec/service/login.service.spec.ts
@@ -78,19 +78,19 @@ describe('LoginService', () => {
         loginService.logout(true);
 
         commonExpects();
-        expect(alertServiceErrorStub).toHaveBeenCalledTimes(1);
+        expect(alertServiceErrorStub).toHaveBeenCalledOnce();
     });
 
     function commonExpects() {
-        expect(removeAuthTokenFromCachesStub).toHaveBeenCalledTimes(1);
+        expect(removeAuthTokenFromCachesStub).toHaveBeenCalledOnce();
         expect(removeAuthTokenFromCachesStub).toHaveBeenCalledWith();
-        expect(authenticateStub).toHaveBeenCalledTimes(1);
+        expect(authenticateStub).toHaveBeenCalledOnce();
         expect(authenticateStub).toHaveBeenCalledWith(undefined);
-        expect(notificationServiceCleanUpStub).toHaveBeenCalledTimes(1);
+        expect(notificationServiceCleanUpStub).toHaveBeenCalledOnce();
         expect(notificationServiceCleanUpStub).toHaveBeenCalledWith();
-        expect(alertServiceClearStub).toHaveBeenCalledTimes(1);
+        expect(alertServiceClearStub).toHaveBeenCalledOnce();
         expect(alertServiceClearStub).toHaveBeenCalledWith();
-        expect(navigateByUrlStub).toHaveBeenCalledTimes(1);
+        expect(navigateByUrlStub).toHaveBeenCalledOnce();
         expect(navigateByUrlStub).toHaveBeenCalledWith('/');
     }
 });

--- a/src/test/javascript/spec/service/metis/answer-post.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/answer-post.service.spec.ts
@@ -54,7 +54,7 @@ describe('AnswerPost Service', () => {
         }));
 
         it('should delete a AnswerPost', fakeAsync(() => {
-            service.delete(1, metisResolvingAnswerPostUser1).subscribe((resp) => expect(resp.ok).toBe(true));
+            service.delete(1, metisResolvingAnswerPostUser1).subscribe((resp) => expect(resp.ok).toBeTrue());
 
             const req = httpMock.expectOne({ method: 'DELETE' });
             req.flush({ status: 200 });

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -291,7 +291,7 @@ describe('Metis Service', () => {
     it('should determine that metis user is not author of post', () => {
         metisServiceUserStub.mockReturnValue(metisUser2);
         const metisUserIsAuthorOfPostingReturn = metisService.metisUserIsAuthorOfPosting(post);
-        expect(metisUserIsAuthorOfPostingReturn).toBe(false);
+        expect(metisUserIsAuthorOfPostingReturn).toBeFalse();
     });
 
     it('should set course information correctly and invoke an update of the post tags in this course', () => {

--- a/src/test/javascript/spec/service/metis/metis.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/metis.service.spec.ts
@@ -285,7 +285,7 @@ describe('Metis Service', () => {
     it('should determine that metis user is author of post', () => {
         metisServiceUserStub.mockReturnValue(metisUser1);
         const metisUserIsAuthorOfPostingReturn = metisService.metisUserIsAuthorOfPosting(post);
-        expect(metisUserIsAuthorOfPostingReturn).toBe(true);
+        expect(metisUserIsAuthorOfPostingReturn).toBeTrue();
     });
 
     it('should determine that metis user is not author of post', () => {
@@ -414,7 +414,7 @@ describe('Metis Service', () => {
             // setup subscription
             metisService.getFilteredPosts({ lectureId: metisLecture.id! });
             expect(metisServiceCreateWebsocketSubscriptionSpy).toHaveBeenCalledWith(MetisWebsocketChannelPrefix + `lectures/${metisLecture.id}`);
-            expect(websocketServiceSubscribeSpy).toHaveBeenCalledTimes(1);
+            expect(websocketServiceSubscribeSpy).toHaveBeenCalledOnce();
             // receive message on channel
             tick();
             expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledWith({ lectureId: metisLecture.id! }, false);
@@ -426,7 +426,7 @@ describe('Metis Service', () => {
             // setup subscription
             metisService.getFilteredPosts({ exerciseId: metisExercise.id!, page: 0, pageSize: ITEMS_PER_PAGE });
             expect(metisServiceCreateWebsocketSubscriptionSpy).toHaveBeenCalledWith(MetisWebsocketChannelPrefix + `exercises/${metisExercise.id}`);
-            expect(websocketServiceSubscribeSpy).toHaveBeenCalledTimes(1);
+            expect(websocketServiceSubscribeSpy).toHaveBeenCalledOnce();
             // receive message on channel
             tick();
             expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledWith({ exerciseId: metisExercise.id!, page: 0, pageSize: ITEMS_PER_PAGE });
@@ -439,7 +439,7 @@ describe('Metis Service', () => {
             // setup subscription
             metisService.getFilteredPosts({ courseWideContext: courseWidePostWithTags.courseWideContext });
             expect(metisServiceCreateWebsocketSubscriptionSpy).toHaveBeenCalledWith(MetisWebsocketChannelPrefix + `courses/${metisCourse.id}`);
-            expect(websocketServiceSubscribeSpy).toHaveBeenCalledTimes(1);
+            expect(websocketServiceSubscribeSpy).toHaveBeenCalledOnce();
             // receive message on channel
             tick();
             expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledWith({ courseWideContext: courseWidePostWithTags.courseWideContext }, false);
@@ -453,7 +453,7 @@ describe('Metis Service', () => {
             // trigger createWebsocketSubscription for the second time with the same context filter. i.e. same channel
             metisService.getFilteredPosts({ exerciseId: metisExercise.id! });
             expect(metisServiceGetFilteredPostsSpy).toHaveBeenCalledWith({ exerciseId: metisExercise.id! }, false);
-            expect(websocketServiceSubscribeSpy).toHaveBeenCalledTimes(1);
+            expect(websocketServiceSubscribeSpy).toHaveBeenCalledOnce();
         }));
     });
 });

--- a/src/test/javascript/spec/service/metis/reaction.service.spec.ts
+++ b/src/test/javascript/spec/service/metis/reaction.service.spec.ts
@@ -31,7 +31,7 @@ describe('Reaction Service', () => {
         }));
 
         it('should delete a Reaction', fakeAsync(() => {
-            service.delete(1, metisReactionUser2).subscribe((resp) => expect(resp.ok).toBe(true));
+            service.delete(1, metisReactionUser2).subscribe((resp) => expect(resp.ok).toBeTrue());
             const req = httpMock.expectOne({ method: 'DELETE' });
             req.flush({ status: 200 });
             tick();

--- a/src/test/javascript/spec/service/navigation-util.service.spec.ts
+++ b/src/test/javascript/spec/service/navigation-util.service.spec.ts
@@ -40,28 +40,28 @@ describe('Navigation Util Service', () => {
 
         service.navigateBack([]);
 
-        expect(backSpy).toHaveBeenCalledTimes(1);
+        expect(backSpy).toHaveBeenCalledOnce();
         expect(backSpy).toHaveBeenCalledWith();
     });
 
     it('should use fallback', () => {
         service.navigateBack(['a', 'b', 'c']);
 
-        expect(router.navigate).toHaveBeenCalledTimes(1);
+        expect(router.navigate).toHaveBeenCalledOnce();
         expect(router.navigate).toHaveBeenCalledWith(['a', 'b', 'c']);
     });
 
     it('should use without optional', () => {
         service.navigateBackWithOptional(['a', 'b', 'c'], undefined);
 
-        expect(router.navigate).toHaveBeenCalledTimes(1);
+        expect(router.navigate).toHaveBeenCalledOnce();
         expect(router.navigate).toHaveBeenCalledWith(['a', 'b', 'c']);
     });
 
     it('should use with optional', () => {
         service.navigateBackWithOptional(['a', 'b', 'c'], 'd');
 
-        expect(router.navigate).toHaveBeenCalledTimes(1);
+        expect(router.navigate).toHaveBeenCalledOnce();
         expect(router.navigate).toHaveBeenCalledWith(['a', 'b', 'c', 'd']);
     });
 
@@ -75,7 +75,7 @@ describe('Navigation Util Service', () => {
         service.routeInNewTab(['course-management', 17]);
 
         expect(creationMock).toHaveBeenCalledWith(route);
-        expect(creationMock).toHaveBeenCalledTimes(1);
+        expect(creationMock).toHaveBeenCalledOnce();
         expect(serializationMock).toHaveBeenCalledWith(urlTreeMock);
         expect(windowStub).toHaveBeenCalledWith('testValue', '_blank');
     });

--- a/src/test/javascript/spec/service/notification.service.spec.ts
+++ b/src/test/javascript/spec/service/notification.service.spec.ts
@@ -118,7 +118,7 @@ describe('Notification Service', () => {
 
             notificationService.interpretNotification(quizNotification);
 
-            expect(router.navigate).toHaveBeenCalledTimes(1);
+            expect(router.navigate).toHaveBeenCalledOnce();
         });
 
         it('should convert date array from server', fakeAsync(() => {
@@ -145,11 +145,11 @@ describe('Notification Service', () => {
 
             const userId = 99; // based on MockAccountService
             const notificationTopic = `/topic/user/${userId}/notifications`;
-            expect(wsSubscribeStub).toHaveBeenCalledTimes(1);
+            expect(wsSubscribeStub).toHaveBeenCalledOnce();
             expect(wsSubscribeStub).toHaveBeenCalledWith(notificationTopic);
             // websocket correctly subscribed to the topic
 
-            expect(wsReceiveNotificationStub).toHaveBeenCalledTimes(1);
+            expect(wsReceiveNotificationStub).toHaveBeenCalledOnce();
             // websocket "receive" called
 
             // add new single user notification
@@ -164,7 +164,7 @@ describe('Notification Service', () => {
 
             tick(); // position of tick is very important here !
 
-            expect(cmGetCoursesForNotificationsStub).toHaveBeenCalledTimes(1);
+            expect(cmGetCoursesForNotificationsStub).toHaveBeenCalledOnce();
             // courseManagementService.getCoursesForNotifications had been successfully subscribed to
 
             // push new courses
@@ -196,7 +196,7 @@ describe('Notification Service', () => {
 
             tick(); // position of tick is very important here !
 
-            expect(cmGetCoursesForNotificationsStub).toHaveBeenCalledTimes(1);
+            expect(cmGetCoursesForNotificationsStub).toHaveBeenCalledOnce();
             // courseManagementService.getCoursesForNotifications had been successfully subscribed to
 
             // push new courses

--- a/src/test/javascript/spec/service/orion/orion-assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/orion/orion-assessment.service.spec.ts
@@ -57,9 +57,9 @@ describe('OrionAssessmentService', () => {
 
         orionAssessmentService.downloadSubmissionInOrion(16, 'new', 0, false);
 
-        expect(getSubmissionStub).toHaveBeenCalledTimes(1);
+        expect(getSubmissionStub).toHaveBeenCalledOnce();
         expect(getSubmissionStub).toHaveBeenCalledWith(16, true, 0);
-        expect(sendSubmissionToOrionSpy).toHaveBeenCalledTimes(1);
+        expect(sendSubmissionToOrionSpy).toHaveBeenCalledOnce();
         expect(sendSubmissionToOrionSpy).toHaveBeenCalledWith(16, programmingSubmission.id, 0, false);
     });
 
@@ -68,7 +68,7 @@ describe('OrionAssessmentService', () => {
 
         orionAssessmentService.downloadSubmissionInOrion(16, programmingSubmission, 0, false);
 
-        expect(sendSubmissionToOrionStub).toHaveBeenCalledTimes(1);
+        expect(sendSubmissionToOrionStub).toHaveBeenCalledOnce();
         expect(sendSubmissionToOrionStub).toHaveBeenCalledWith(16, programmingSubmission.id, 0, false);
     });
 
@@ -87,7 +87,7 @@ describe('OrionAssessmentService', () => {
 
         testConversion(mockReader);
 
-        expect(downloadSubmissionSpy).toHaveBeenCalledTimes(1);
+        expect(downloadSubmissionSpy).toHaveBeenCalledOnce();
         expect(downloadSubmissionSpy).toHaveBeenCalledWith(11, 0, false, 'testBase64');
     });
 
@@ -106,7 +106,7 @@ describe('OrionAssessmentService', () => {
 
         testConversion(mockReader);
 
-        expect(alertErrorSpy).toHaveBeenCalledTimes(1);
+        expect(alertErrorSpy).toHaveBeenCalledOnce();
         expect(alertErrorSpy).toHaveBeenCalledWith('artemisApp.assessmentDashboard.orion.downloadFailed');
     });
 
@@ -129,14 +129,14 @@ describe('OrionAssessmentService', () => {
 
         orionAssessmentService.downloadSubmissionInOrion(16, programmingSubmission, 0, false);
 
-        expect(isCloningSpy).toHaveBeenCalledTimes(1);
+        expect(isCloningSpy).toHaveBeenCalledOnce();
         expect(isCloningSpy).toHaveBeenCalledWith(true);
-        expect(lockAndGetStub).toHaveBeenCalledTimes(1);
+        expect(lockAndGetStub).toHaveBeenCalledOnce();
         expect(lockAndGetStub).toHaveBeenCalledWith(11, 0);
-        expect(exportSubmissionStub).toHaveBeenCalledTimes(1);
+        expect(exportSubmissionStub).toHaveBeenCalledOnce();
         // expect anything as repository export options, since they are hardcoded anyways
         expect(exportSubmissionStub).toHaveBeenCalledWith(16, [1], expect.anything());
-        expect(readerStub).toHaveBeenCalledTimes(1);
+        expect(readerStub).toHaveBeenCalledOnce();
     }
 
     it('should cancel lock correctly', fakeAsync(() => {
@@ -151,7 +151,7 @@ describe('OrionAssessmentService', () => {
         stateObservable.next({ ...orionState, cloning: false });
         tick();
 
-        expect(cancelStub).toHaveBeenCalledTimes(1);
+        expect(cancelStub).toHaveBeenCalledOnce();
         expect(cancelStub).toHaveBeenCalledWith(24);
     }));
 });

--- a/src/test/javascript/spec/service/orion/orion-build-and-test.service.spec.ts
+++ b/src/test/javascript/spec/service/orion/orion-build-and-test.service.spec.ts
@@ -86,13 +86,13 @@ describe('OrionBuildAndTestService', () => {
 
         serviceUnderTest.listenOnBuildOutputAndForwardChanges(exercise);
 
-        expect(participationSubscriptionStub).toHaveBeenCalledTimes(1);
+        expect(participationSubscriptionStub).toHaveBeenCalledOnce();
         expect(participationSubscriptionStub).toHaveBeenCalledWith(exercise.studentParticipations![0].id, true);
-        expect(onBuildStartedSpy).toHaveBeenCalledTimes(1);
+        expect(onBuildStartedSpy).toHaveBeenCalledOnce();
         expect(onTestResultSpy).not.toHaveBeenCalled();
         expect(onBuildFinishedSpy).not.toHaveBeenCalled();
-        expect(onBuildFailedSpy).toHaveBeenCalledTimes(1);
-        expect(buildLogsStub).toHaveBeenCalledTimes(1);
+        expect(onBuildFailedSpy).toHaveBeenCalledOnce();
+        expect(buildLogsStub).toHaveBeenCalledOnce();
     });
 
     it('should fetch the build logs if submission is available and the submission could not be build', () => {
@@ -104,13 +104,13 @@ describe('OrionBuildAndTestService', () => {
 
         serviceUnderTest.listenOnBuildOutputAndForwardChanges(exercise);
 
-        expect(participationSubscriptionStub).toHaveBeenCalledTimes(1);
+        expect(participationSubscriptionStub).toHaveBeenCalledOnce();
         expect(participationSubscriptionStub).toHaveBeenCalledWith(exercise.studentParticipations![0].id, true);
-        expect(onBuildStartedSpy).toHaveBeenCalledTimes(1);
+        expect(onBuildStartedSpy).toHaveBeenCalledOnce();
         expect(onTestResultSpy).not.toHaveBeenCalled();
         expect(onBuildFinishedSpy).not.toHaveBeenCalled();
-        expect(onBuildFailedSpy).toHaveBeenCalledTimes(1);
-        expect(buildLogsStub).toHaveBeenCalledTimes(1);
+        expect(onBuildFailedSpy).toHaveBeenCalledOnce();
+        expect(buildLogsStub).toHaveBeenCalledOnce();
     });
 
     it('should forward all testcase feedback if build was successful', () => {
@@ -121,11 +121,11 @@ describe('OrionBuildAndTestService', () => {
 
         serviceUnderTest.listenOnBuildOutputAndForwardChanges(exercise);
 
-        expect(participationSubscriptionStub).toHaveBeenCalledTimes(1);
+        expect(participationSubscriptionStub).toHaveBeenCalledOnce();
         expect(participationSubscriptionStub).toHaveBeenCalledWith(exercise.studentParticipations![0].id, true);
-        expect(onBuildStartedSpy).toHaveBeenCalledTimes(1);
+        expect(onBuildStartedSpy).toHaveBeenCalledOnce();
         expect(onTestResultSpy).toHaveBeenCalledTimes(2);
-        expect(onBuildFinishedSpy).toHaveBeenCalledTimes(1);
+        expect(onBuildFinishedSpy).toHaveBeenCalledOnce();
         expect(onBuildFailedSpy).not.toHaveBeenCalled();
         expect(buildLogsStub).not.toHaveBeenCalled();
     });
@@ -138,14 +138,14 @@ describe('OrionBuildAndTestService', () => {
 
         serviceUnderTest.listenOnBuildOutputAndForwardChanges(exercise);
 
-        expect(participationSubscriptionStub).toHaveBeenCalledTimes(1);
+        expect(participationSubscriptionStub).toHaveBeenCalledOnce();
         expect(participationSubscriptionStub).toHaveBeenCalledWith(exercise.studentParticipations![0].id, true);
-        expect(onBuildStartedSpy).toHaveBeenCalledTimes(1);
+        expect(onBuildStartedSpy).toHaveBeenCalledOnce();
         expect(onTestResultSpy).toHaveBeenCalledTimes(2);
         feedbacks.forEach((feedback, index) => {
             expect(onTestResultSpy).toHaveBeenNthCalledWith(index + 1, feedback.positive, feedback.text, feedback.detailText);
         });
-        expect(onBuildFinishedSpy).toHaveBeenCalledTimes(1);
+        expect(onBuildFinishedSpy).toHaveBeenCalledOnce();
         expect(onBuildFailedSpy).not.toHaveBeenCalled();
         expect(buildLogsStub).not.toHaveBeenCalled();
     });
@@ -156,10 +156,10 @@ describe('OrionBuildAndTestService', () => {
 
         serviceUnderTest.buildAndTestExercise(exercise);
 
-        expect(listenOnBuildOutputAndForwardChangesSpy).toHaveBeenCalledTimes(1);
+        expect(listenOnBuildOutputAndForwardChangesSpy).toHaveBeenCalledOnce();
         expect(listenOnBuildOutputAndForwardChangesSpy).toHaveBeenCalledWith(exercise);
 
-        expect(triggerBuildStub).toHaveBeenCalledTimes(1);
+        expect(triggerBuildStub).toHaveBeenCalledOnce();
         expect(triggerBuildStub).toHaveBeenCalledWith(32);
     });
 
@@ -176,7 +176,7 @@ describe('OrionBuildAndTestService', () => {
 
         serviceUnderTest.buildAndTestExercise(exercise);
 
-        expect(resultSubscriptionSpy).toHaveBeenCalledTimes(1);
-        expect(buildLogSubscriptionSpy).toHaveBeenCalledTimes(1);
+        expect(resultSubscriptionSpy).toHaveBeenCalledOnce();
+        expect(buildLogSubscriptionSpy).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/service/orion/orion-connector.service.spec.ts
+++ b/src/test/javascript/spec/service/orion/orion-connector.service.spec.ts
@@ -63,28 +63,28 @@ describe('OrionConnectorService', () => {
     it('should forward login', () => {
         serviceUnderTest.login('name', 'pwd');
 
-        expect((window as any).orionSharedUtilConnector.login).toHaveBeenCalledTimes(1);
+        expect((window as any).orionSharedUtilConnector.login).toHaveBeenCalledOnce();
         expect((window as any).orionSharedUtilConnector.login).toHaveBeenCalledWith('name', 'pwd');
     });
 
     it('should forward importParticipation', () => {
         serviceUnderTest.importParticipation('name', exercise);
 
-        expect((window as any).orionExerciseConnector.importParticipation).toHaveBeenCalledTimes(1);
+        expect((window as any).orionExerciseConnector.importParticipation).toHaveBeenCalledOnce();
         expect((window as any).orionExerciseConnector.importParticipation).toHaveBeenCalledWith('name', '{"id":42}');
     });
 
     it('should forward submit', () => {
         serviceUnderTest.submit();
 
-        expect((window as any).orionVCSConnector.submit).toHaveBeenCalledTimes(1);
+        expect((window as any).orionVCSConnector.submit).toHaveBeenCalledOnce();
         expect((window as any).orionVCSConnector.submit).toHaveBeenCalledWith();
     });
 
     it('should forward log', () => {
         serviceUnderTest.log('log string');
 
-        expect((window as any).orionSharedUtilConnector.log).toHaveBeenCalledTimes(1);
+        expect((window as any).orionSharedUtilConnector.log).toHaveBeenCalledOnce();
         expect((window as any).orionSharedUtilConnector.log).toHaveBeenCalledWith('log string');
     });
 
@@ -103,21 +103,21 @@ describe('OrionConnectorService', () => {
     it('should forward onBuildStarted', () => {
         serviceUnderTest.onBuildStarted('problem');
 
-        expect((window as any).orionBuildConnector.onBuildStarted).toHaveBeenCalledTimes(1);
+        expect((window as any).orionBuildConnector.onBuildStarted).toHaveBeenCalledOnce();
         expect((window as any).orionBuildConnector.onBuildStarted).toHaveBeenCalledWith('problem');
     });
 
     it('should forward onBuildFinished', () => {
         serviceUnderTest.onBuildFinished();
 
-        expect((window as any).orionBuildConnector.onBuildFinished).toHaveBeenCalledTimes(1);
+        expect((window as any).orionBuildConnector.onBuildFinished).toHaveBeenCalledOnce();
         expect((window as any).orionBuildConnector.onBuildFinished).toHaveBeenCalledWith();
     });
 
     it('should forward onBuildFailed', () => {
         serviceUnderTest.onBuildFailed([{ fileName: 'file', row: 5, column: 4, text: 'error', type: 'error', timestamp: 0 } as Annotation]);
 
-        expect((window as any).orionBuildConnector.onBuildFailed).toHaveBeenCalledTimes(1);
+        expect((window as any).orionBuildConnector.onBuildFailed).toHaveBeenCalledOnce();
         expect((window as any).orionBuildConnector.onBuildFailed).toHaveBeenCalledWith(
             '{"errors":{"file":[{"row":5,"column":4,"text":"error","type":"error","ts":0}]},"timestamp":0}',
         );
@@ -126,7 +126,7 @@ describe('OrionConnectorService', () => {
     it('should forward onBuildFinished', () => {
         serviceUnderTest.onTestResult(true, 'name', 'message');
 
-        expect((window as any).orionBuildConnector.onTestResult).toHaveBeenCalledTimes(1);
+        expect((window as any).orionBuildConnector.onTestResult).toHaveBeenCalledOnce();
         expect((window as any).orionBuildConnector.onTestResult).toHaveBeenCalledWith(true, 'name', 'message');
     });
 
@@ -157,7 +157,7 @@ describe('OrionConnectorService', () => {
 
         serviceUnderTest.startedBuildInOrion(5, 10);
 
-        expect(navigateSpy).toHaveBeenCalledTimes(1);
+        expect(navigateSpy).toHaveBeenCalledOnce();
         expect(navigateSpy).toHaveBeenCalledWith('/courses/5/exercises/10?withIdeSubmit=true');
     });
 
@@ -166,7 +166,7 @@ describe('OrionConnectorService', () => {
 
         serviceUnderTest.updateAssessment(5, '');
 
-        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy).toHaveBeenCalledOnce();
         expect(errorSpy).toHaveBeenCalledWith('artemisApp.orion.assessment.updateFailed');
     });
 
@@ -175,7 +175,7 @@ describe('OrionConnectorService', () => {
 
         serviceUnderTest.updateAssessment(10, '{"id":5}');
 
-        expect(serviceUnderTest.activeAssessmentComponent!.updateFeedback).toHaveBeenCalledTimes(1);
+        expect(serviceUnderTest.activeAssessmentComponent!.updateFeedback).toHaveBeenCalledOnce();
         expect(serviceUnderTest.activeAssessmentComponent!.updateFeedback).toHaveBeenCalledWith(10, { id: 5 });
     });
 
@@ -188,21 +188,21 @@ describe('OrionConnectorService', () => {
         serviceUnderTest.editExercise(exercise);
 
         expect(localState).toContainEntry(['cloning', true]);
-        expect((window as any).orionExerciseConnector.editExercise).toHaveBeenCalledTimes(1);
+        expect((window as any).orionExerciseConnector.editExercise).toHaveBeenCalledOnce();
         expect((window as any).orionExerciseConnector.editExercise).toHaveBeenCalledWith('{"id":42}');
     });
 
     it('should forward selectRepository', () => {
         serviceUnderTest.selectRepository(REPOSITORY.SOLUTION);
 
-        expect((window as any).orionVCSConnector.selectRepository).toHaveBeenCalledTimes(1);
+        expect((window as any).orionVCSConnector.selectRepository).toHaveBeenCalledOnce();
         expect((window as any).orionVCSConnector.selectRepository).toHaveBeenCalledWith(REPOSITORY.SOLUTION);
     });
 
     it('should forward buildAndTestLocally', () => {
         serviceUnderTest.buildAndTestLocally();
 
-        expect((window as any).orionBuildConnector.buildAndTestLocally).toHaveBeenCalledTimes(1);
+        expect((window as any).orionBuildConnector.buildAndTestLocally).toHaveBeenCalledOnce();
         expect((window as any).orionBuildConnector.buildAndTestLocally).toHaveBeenCalledWith();
     });
 
@@ -215,14 +215,14 @@ describe('OrionConnectorService', () => {
         serviceUnderTest.assessExercise(exercise);
 
         expect(localState).toContainEntry(['cloning', true]);
-        expect((window as any).orionExerciseConnector.assessExercise).toHaveBeenCalledTimes(1);
+        expect((window as any).orionExerciseConnector.assessExercise).toHaveBeenCalledOnce();
         expect((window as any).orionExerciseConnector.assessExercise).toHaveBeenCalledWith('{"id":42}');
     });
 
     it('should forward downloadSubmission', () => {
         serviceUnderTest.downloadSubmission(5, 0, false, 'test');
 
-        expect((window as any).orionExerciseConnector.downloadSubmission).toHaveBeenCalledTimes(1);
+        expect((window as any).orionExerciseConnector.downloadSubmission).toHaveBeenCalledOnce();
         expect((window as any).orionExerciseConnector.downloadSubmission).toHaveBeenCalledWith('5', '0', 'test');
     });
 
@@ -230,7 +230,7 @@ describe('OrionConnectorService', () => {
         const feedbacks = [{ id: 2, positive: false, detailText: 'abc' } as Feedback, { id: 3, positive: true, detailText: 'cde' } as Feedback];
         serviceUnderTest.initializeAssessment(5, feedbacks);
 
-        expect((window as any).orionExerciseConnector.initializeAssessment).toHaveBeenCalledTimes(1);
+        expect((window as any).orionExerciseConnector.initializeAssessment).toHaveBeenCalledOnce();
         expect((window as any).orionExerciseConnector.initializeAssessment).toHaveBeenCalledWith(
             '5',
             '[{"id":2,"positive":false,"detailText":"abc"},{"id":3,"positive":true,"detailText":"cde"}]',

--- a/src/test/javascript/spec/service/orion/orion-version-validator.service.spec.ts
+++ b/src/test/javascript/spec/service/orion/orion-version-validator.service.spec.ts
@@ -62,7 +62,7 @@ describe('OrionValidatorService', () => {
         tick();
 
         expect(profileInfoStub).not.toHaveBeenCalled();
-        expect(navigateSpy).toHaveBeenCalledTimes(1);
+        expect(navigateSpy).toHaveBeenCalledOnce();
         expect(navigateSpy).toHaveBeenCalledWith('/orion-outdated?versionString=soOldThatThereIsNoVersion');
     }));
 
@@ -73,8 +73,8 @@ describe('OrionValidatorService', () => {
         orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBe(false));
         tick();
 
-        expect(profileInfoStub).toHaveBeenCalledTimes(1);
-        expect(navigateSpy).toHaveBeenCalledTimes(1);
+        expect(profileInfoStub).toHaveBeenCalledOnce();
+        expect(navigateSpy).toHaveBeenCalledOnce();
         expect(navigateSpy).toHaveBeenCalledWith(`/orion-outdated?versionString=0.9.0`);
     }));
 
@@ -82,17 +82,17 @@ describe('OrionValidatorService', () => {
         setUserAgent(userAgent + versionCorrect);
         orionVersionValidator.isOrion = true;
 
-        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBe(true));
+        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBeTrue());
         tick();
 
-        expect(profileInfoStub).toHaveBeenCalledTimes(1);
+        expect(profileInfoStub).toHaveBeenCalledOnce();
         expect(navigateSpy).not.toHaveBeenCalled();
     }));
 
     it('should not do anything if a normal browser is connected', fakeAsync(() => {
         setUserAgent(userAgent);
 
-        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBe(true));
+        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBeTrue());
         tick();
 
         expect(profileInfoStub).not.toHaveBeenCalled();
@@ -104,7 +104,7 @@ describe('OrionValidatorService', () => {
         // @ts-ignore
         orionVersionValidator.isValidVersion = true;
 
-        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBe(true));
+        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBeTrue());
         tick();
 
         expect(profileInfoStub).not.toHaveBeenCalled();

--- a/src/test/javascript/spec/service/orion/orion-version-validator.service.spec.ts
+++ b/src/test/javascript/spec/service/orion/orion-version-validator.service.spec.ts
@@ -58,7 +58,7 @@ describe('OrionValidatorService', () => {
         setUserAgent(userAgent + legacy);
         orionVersionValidator.isOrion = true;
 
-        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBe(false));
+        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBeFalse());
         tick();
 
         expect(profileInfoStub).not.toHaveBeenCalled();
@@ -70,7 +70,7 @@ describe('OrionValidatorService', () => {
         setUserAgent(userAgent + versionTooLow);
         orionVersionValidator.isOrion = true;
 
-        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBe(false));
+        orionVersionValidator.validateOrionVersion().subscribe((result) => expect(result).toBeFalse());
         tick();
 
         expect(profileInfoStub).toHaveBeenCalledOnce();

--- a/src/test/javascript/spec/service/participation-websocket.service.spec.ts
+++ b/src/test/javascript/spec/service/participation-websocket.service.spec.ts
@@ -80,9 +80,9 @@ describe('ParticipationWebsocketService', () => {
 
     it('should setup a result subscriptions with the websocket service on subscribeForLatestResult for instructors', () => {
         participationWebsocketService.subscribeForLatestResultOfParticipation(participation.id!, false, exerciseId2);
-        expect(subscribeSpy).toHaveBeenCalledTimes(1);
+        expect(subscribeSpy).toHaveBeenCalledOnce();
         expect(subscribeSpy).toHaveBeenCalledWith(participationInstructorResultTopic);
-        expect(receiveStub).toHaveBeenCalledTimes(1);
+        expect(receiveStub).toHaveBeenCalledOnce();
         expect(receiveStub).toHaveBeenCalledWith(participationInstructorResultTopic);
         expect(unsubscribeSpy).not.toHaveBeenCalled();
 
@@ -92,16 +92,16 @@ describe('ParticipationWebsocketService', () => {
         expect(participationWebsocketService.openPersonalWebsocketSubscription).toBe(undefined);
 
         expect(participationWebsocketService.resultObservables.size).toBe(1);
-        expect(participationWebsocketService.resultObservables.has(participation.id!)).toBe(true);
+        expect(participationWebsocketService.resultObservables.has(participation.id!)).toBeTrue();
 
         expect(participationWebsocketService.participationObservable).toBe(undefined);
     });
 
     it('should setup a result subscriptions with the websocket service on subscribeForLatestResult for students', () => {
         participationWebsocketService.subscribeForLatestResultOfParticipation(participation.id!, true);
-        expect(subscribeSpy).toHaveBeenCalledTimes(1);
+        expect(subscribeSpy).toHaveBeenCalledOnce();
         expect(subscribeSpy).toHaveBeenCalledWith(participationPersonalResultTopic);
-        expect(receiveStub).toHaveBeenCalledTimes(1);
+        expect(receiveStub).toHaveBeenCalledOnce();
         expect(receiveStub).toHaveBeenCalledWith(participationPersonalResultTopic);
         expect(unsubscribeSpy).not.toHaveBeenCalled();
 
@@ -111,7 +111,7 @@ describe('ParticipationWebsocketService', () => {
         expect(participationWebsocketService.openPersonalWebsocketSubscription).toBe(participationPersonalResultTopic);
 
         expect(participationWebsocketService.resultObservables.size).toBe(1);
-        expect(participationWebsocketService.resultObservables.has(participation.id!)).toBe(true);
+        expect(participationWebsocketService.resultObservables.has(participation.id!)).toBeTrue();
 
         expect(participationWebsocketService.participationObservable).toBe(undefined);
     });
@@ -125,7 +125,7 @@ describe('ParticipationWebsocketService', () => {
         // Emit new result from websocket
         receiveResultForParticipationSubject.next(newRatedResult);
 
-        expect(resultSpy).toHaveBeenCalledTimes(1);
+        expect(resultSpy).toHaveBeenCalledOnce();
         expect(resultSpy).toHaveBeenCalledWith(newRatedResult);
     });
 
@@ -138,7 +138,7 @@ describe('ParticipationWebsocketService', () => {
         // Emit new result from websocket
         receiveResultForParticipationSubject.next(newUnratedResult);
 
-        expect(resultSpy).toHaveBeenCalledTimes(1);
+        expect(resultSpy).toHaveBeenCalledOnce();
         expect(resultSpy).toHaveBeenCalledWith(newUnratedResult);
     });
 
@@ -156,9 +156,9 @@ describe('ParticipationWebsocketService', () => {
         // Emit new result from websocket
         receiveResultForParticipationSubject.next(newRatedResult);
 
-        expect(resultSpy).toHaveBeenCalledTimes(1);
+        expect(resultSpy).toHaveBeenCalledOnce();
         expect(resultSpy).toHaveBeenCalledWith(newRatedResult);
-        expect(participationSpy).toHaveBeenCalledTimes(1);
+        expect(participationSpy).toHaveBeenCalledOnce();
         expect(participationSpy).toHaveBeenCalledWith({ ...participation, results: [...participation.results!, newRatedResult] });
         expect(participationWebsocketService.cachedParticipations.get(participation.id!)).toEqual({ ...participation, results: [...participation.results!, newRatedResult] });
     });
@@ -177,9 +177,9 @@ describe('ParticipationWebsocketService', () => {
         // Emit new result from websocket
         receiveResultForParticipationSubject.next(newUnratedResult);
 
-        expect(resultSpy).toHaveBeenCalledTimes(1);
+        expect(resultSpy).toHaveBeenCalledOnce();
         expect(resultSpy).toHaveBeenCalledWith(newUnratedResult);
-        expect(participationSpy).toHaveBeenCalledTimes(1);
+        expect(participationSpy).toHaveBeenCalledOnce();
         expect(participationSpy).toHaveBeenCalledWith({ ...participation, results: [...participation.results!, newUnratedResult] });
         expect(participationWebsocketService.cachedParticipations.get(participation.id!)).toEqual({
             ...participation,
@@ -207,9 +207,9 @@ describe('ParticipationWebsocketService', () => {
         expect(participationWebsocketService.cachedParticipations.get(participation.id!)).toEqual({ ...participation, results: [...participation.results!, newRatedResult] });
         expect(participationWebsocketService.cachedParticipations.get(participation2.id!)).toEqual(participation2);
 
-        expect(resultSpy).toHaveBeenCalledTimes(1);
+        expect(resultSpy).toHaveBeenCalledOnce();
         expect(resultSpy).toHaveBeenCalledWith(newRatedResult);
-        expect(participationSpy).toHaveBeenCalledTimes(1);
+        expect(participationSpy).toHaveBeenCalledOnce();
         expect(participationSpy).toHaveBeenCalledWith({ ...participation, results: [...participation.results!, newRatedResult] });
     });
 
@@ -233,9 +233,9 @@ describe('ParticipationWebsocketService', () => {
         expect(participationWebsocketService.cachedParticipations.size).toBe(1);
         expect(participationWebsocketService.cachedParticipations.get(participationWithoutResult.id!)).toEqual({ ...participationWithoutResult, results: [newRatedResult] });
 
-        expect(resultSpy).toHaveBeenCalledTimes(1);
+        expect(resultSpy).toHaveBeenCalledOnce();
         expect(resultSpy).toHaveBeenCalledWith(newRatedResult);
-        expect(participationSpy).toHaveBeenCalledTimes(1);
+        expect(participationSpy).toHaveBeenCalledOnce();
         expect(participationSpy).toHaveBeenCalledWith({ ...participationWithoutResult, results: [newRatedResult] });
     });
 

--- a/src/test/javascript/spec/service/password.service.spec.ts
+++ b/src/test/javascript/spec/service/password.service.spec.ts
@@ -32,7 +32,7 @@ describe('PasswordService', () => {
 
         passwordService.save(newPassword, currentPassword).subscribe();
 
-        expect(postStub).toHaveBeenCalledTimes(1);
+        expect(postStub).toHaveBeenCalledOnce();
         expect(postStub).toHaveBeenCalledWith(postURL, { currentPassword, newPassword });
     });
 });

--- a/src/test/javascript/spec/service/programming-exercise-grading.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-exercise-grading.service.spec.ts
@@ -86,7 +86,7 @@ describe('ProgrammingExerciseGradingService', () => {
             .pipe(tap((newTestCases) => (testCasesExercise1 = newTestCases)))
             .subscribe();
 
-        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(getStub).toHaveBeenCalledOnce();
         expect(testCasesExercise1).toEqual(testCases1);
         expect(testCasesExercise2).toBe(undefined);
 
@@ -113,7 +113,7 @@ describe('ProgrammingExerciseGradingService', () => {
             .pipe(tap((newTestCases) => (testCasesExercise1 = newTestCases)))
             .subscribe();
 
-        expect(getStub).toHaveBeenCalledTimes(1);
+        expect(getStub).toHaveBeenCalledOnce();
         expect(testCasesExercise1).toEqual(testCases1);
     });
 

--- a/src/test/javascript/spec/service/programming-submission.service.spec.ts
+++ b/src/test/javascript/spec/service/programming-submission.service.spec.ts
@@ -108,11 +108,11 @@ describe('ProgrammingSubmissionService', () => {
         let submission;
         submissionService.getLatestPendingSubmissionByParticipationId(participationId, 10, true).subscribe((sub) => (submission = sub));
         expect(submission).toEqual({ submissionState: ProgrammingSubmissionState.IS_BUILDING_PENDING_SUBMISSION, submission: currentSubmission, participationId });
-        expect(wsSubscribeStub).toHaveBeenCalledTimes(1);
+        expect(wsSubscribeStub).toHaveBeenCalledOnce();
         expect(wsSubscribeStub).toHaveBeenCalledWith(submissionTopic);
-        expect(wsReceiveStub).toHaveBeenCalledTimes(1);
+        expect(wsReceiveStub).toHaveBeenCalledOnce();
         expect(wsReceiveStub).toHaveBeenCalledWith(submissionTopic);
-        expect(participationWsLatestResultStub).toHaveBeenCalledTimes(1);
+        expect(participationWsLatestResultStub).toHaveBeenCalledOnce();
         expect(participationWsLatestResultStub).toHaveBeenCalledWith(participationId, true, 10);
     });
 
@@ -183,7 +183,7 @@ describe('ProgrammingSubmissionService', () => {
         tick(10);
 
         // Expect the fallback mechanism to kick in after the timeout
-        expect(getLatestResultStub).toHaveBeenCalledTimes(1);
+        expect(getLatestResultStub).toHaveBeenCalledOnce();
         expect(getLatestResultStub).toHaveBeenCalledWith(participationId, true);
 
         // HAS_FAILED_SUBMISSION is expected as the result provided by getLatestResult does not match the pending submission
@@ -223,9 +223,9 @@ describe('ProgrammingSubmissionService', () => {
         tick(10);
 
         // Expect the fallback mechanism to kick in after the timeout
-        expect(getLatestResultStub).toHaveBeenCalledTimes(1);
+        expect(getLatestResultStub).toHaveBeenCalledOnce();
         expect(getLatestResultStub).toHaveBeenCalledWith(participationId, true);
-        expect(notifyAllResultSubscribersStub).toHaveBeenCalledTimes(1);
+        expect(notifyAllResultSubscribersStub).toHaveBeenCalledOnce();
         expect(notifyAllResultSubscribersStub).toHaveBeenCalledWith({ ...result, participation: { id: participationId } });
         wsLatestResultSubject.next(result);
 
@@ -267,7 +267,7 @@ describe('ProgrammingSubmissionService', () => {
             submission = sub;
         });
 
-        expect(httpGetStub).toHaveBeenCalledTimes(1);
+        expect(httpGetStub).toHaveBeenCalledOnce();
         expect(httpGetStub).toHaveBeenCalledWith('api/programming-exercises/3/latest-pending-submissions');
         // Fetching the latest pending submission should not trigger a rest call for a cached submission.
         expect(fetchLatestPendingSubmissionSpy).not.toHaveBeenCalled();
@@ -276,7 +276,7 @@ describe('ProgrammingSubmissionService', () => {
 
         // Fetching the latest pending submission should trigger a rest call if the submission is not cached.
         submissionService.getLatestPendingSubmissionByParticipationId(participation3.id!, exerciseId, true).subscribe();
-        expect(fetchLatestPendingSubmissionSpy).toHaveBeenCalledTimes(1);
+        expect(fetchLatestPendingSubmissionSpy).toHaveBeenCalledOnce();
         expect(fetchLatestPendingSubmissionSpy).toHaveBeenCalledWith(participation3.id);
     });
 
@@ -289,10 +289,10 @@ describe('ProgrammingSubmissionService', () => {
 
         let receivedSubmissionState: ExerciseSubmissionState = {};
         submissionService.getSubmissionStateOfExercise(exerciseId).subscribe((state) => (receivedSubmissionState = state));
-        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledTimes(1);
+        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledOnce();
         expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledWith(exerciseId);
         expect(receivedSubmissionState).toEqual(submissionState);
-        expect(httpGetStub).toHaveBeenCalledTimes(1);
+        expect(httpGetStub).toHaveBeenCalledOnce();
         expect(httpGetStub).toHaveBeenCalledWith(SERVER_API_URL + `api/programming-exercises/${exerciseId}/latest-pending-submissions`);
     });
 
@@ -309,10 +309,10 @@ describe('ProgrammingSubmissionService', () => {
 
         let receivedSubmissionState: ExerciseSubmissionState = {};
         submissionService.getSubmissionStateOfExercise(exerciseId).subscribe((state) => (receivedSubmissionState = state));
-        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledTimes(1);
+        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledOnce();
         expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledWith(exerciseId);
         expect(receivedSubmissionState).toEqual(expectedSubmissionState);
-        expect(httpGetStub).toHaveBeenCalledTimes(1);
+        expect(httpGetStub).toHaveBeenCalledOnce();
         expect(httpGetStub).toHaveBeenCalledWith(SERVER_API_URL + `api/programming-exercises/${exerciseId}/latest-pending-submissions`);
     });
 
@@ -333,10 +333,10 @@ describe('ProgrammingSubmissionService', () => {
 
         let receivedSubmissionState: ExerciseSubmissionState = {};
         submissionService.getSubmissionStateOfExercise(exerciseId).subscribe((state) => (receivedSubmissionState = state));
-        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledTimes(1);
+        expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledOnce();
         expect(fetchLatestPendingSubmissionsByExerciseIdSpy).toHaveBeenCalledWith(exerciseId);
         expect(receivedSubmissionState).toEqual(expectedSubmissionState);
-        expect(httpGetStub).toHaveBeenCalledTimes(1);
+        expect(httpGetStub).toHaveBeenCalledOnce();
         expect(httpGetStub).toHaveBeenCalledWith(SERVER_API_URL + `api/programming-exercises/${exerciseId}/latest-pending-submissions`);
 
         let resultEta = -1;
@@ -357,6 +357,6 @@ describe('ProgrammingSubmissionService', () => {
 
         // Should now unsubscribe as last participation for topic was unsubscribed
         submissionService.unsubscribeForLatestSubmissionOfParticipation(2);
-        expect(wsUnsubscribeStub).toHaveBeenCalledTimes(1);
+        expect(wsUnsubscribeStub).toHaveBeenCalledOnce();
     });
 });

--- a/src/test/javascript/spec/service/quiz-exercise.service.spec.ts
+++ b/src/test/javascript/spec/service/quiz-exercise.service.spec.ts
@@ -204,7 +204,7 @@ describe('QuizExercise Service', () => {
         if (count === 0) {
             expect(spy).toHaveBeenCalledTimes(0);
         } else {
-            expect(spy).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledOnce();
             const [blob, file] = spy.mock.calls[0];
             const data = await new Promise((resolve) => {
                 const reader = new FileReader();

--- a/src/test/javascript/spec/service/result.service.spec.ts
+++ b/src/test/javascript/spec/service/result.service.spec.ts
@@ -112,7 +112,7 @@ describe('ResultService', () => {
 
         tick();
 
-        expect(httpStub).toHaveBeenCalledTimes(1);
+        expect(httpStub).toHaveBeenCalledOnce();
         expect(httpStub).toHaveBeenCalledWith(`api/exercises/${exercise.id}/results-with-points-per-criterion`, expect.anything());
     }));
 });

--- a/src/test/javascript/spec/service/state-storage.service.spec.ts
+++ b/src/test/javascript/spec/service/state-storage.service.spec.ts
@@ -39,14 +39,14 @@ describe('StateStorageService', () => {
     it('should retrieve previous state', () => {
         service.getPreviousState();
 
-        expect(retrieveSpy).toHaveBeenCalledTimes(1);
+        expect(retrieveSpy).toHaveBeenCalledOnce();
         expect(retrieveSpy).toHaveBeenCalledWith(previousStateKey);
     });
 
     it('should reset previous state', () => {
         service.resetPreviousState();
 
-        expect(clearSpy).toHaveBeenCalledTimes(1);
+        expect(clearSpy).toHaveBeenCalledOnce();
         expect(clearSpy).toHaveBeenCalledWith(previousStateKey);
     });
 
@@ -56,14 +56,14 @@ describe('StateStorageService', () => {
 
         service.storePreviousState(name, params);
 
-        expect(storeSpy).toHaveBeenCalledTimes(1);
+        expect(storeSpy).toHaveBeenCalledOnce();
         expect(storeSpy).toHaveBeenCalledWith(previousStateKey, expectedState);
     });
 
     it('should retrieve destination state', () => {
         service.getDestinationState();
 
-        expect(retrieveSpy).toHaveBeenCalledTimes(1);
+        expect(retrieveSpy).toHaveBeenCalledOnce();
         expect(retrieveSpy).toHaveBeenCalledWith(destinationStateKey);
     });
 
@@ -72,14 +72,14 @@ describe('StateStorageService', () => {
 
         service.storeUrl(newUrl);
 
-        expect(storeSpy).toHaveBeenCalledTimes(1);
+        expect(storeSpy).toHaveBeenCalledOnce();
         expect(storeSpy).toHaveBeenCalledWith(previousUrlKey, newUrl);
     });
 
     it('should retrieve the previous URL', () => {
         service.getUrl();
 
-        expect(retrieveSpy).toHaveBeenCalledTimes(1);
+        expect(retrieveSpy).toHaveBeenCalledOnce();
         expect(retrieveSpy).toHaveBeenCalledWith(previousUrlKey);
     });
 
@@ -102,7 +102,7 @@ describe('StateStorageService', () => {
 
         service.storeDestinationState(destinationState, params, fromState);
 
-        expect(storeSpy).toHaveBeenCalledTimes(1);
+        expect(storeSpy).toHaveBeenCalledOnce();
         expect(storeSpy).toHaveBeenCalledWith(destinationStateKey, expectedDestinationInfo);
     });
 });

--- a/src/test/javascript/spec/service/submission-export.service.spec.ts
+++ b/src/test/javascript/spec/service/submission-export.service.spec.ts
@@ -65,6 +65,6 @@ describe('Submission Export Service', () => {
             .subscribe((resp) => (expectedResult = resp.ok));
         const req = httpMock.expectOne({ method: 'POST' });
         req.flush(new Blob());
-        expect(expectedResult).toBe(true);
+        expect(expectedResult).toBeTrue();
     });
 });

--- a/src/test/javascript/spec/service/submission-policy.service.spec.ts
+++ b/src/test/javascript/spec/service/submission-policy.service.spec.ts
@@ -40,7 +40,7 @@ describe('Submission Policy Service', () => {
             tick();
 
             const request = httpMock.expectOne({ method: 'POST', url: expectedUrl });
-            expect(lockRepositoryPolicy.active).toBe(false);
+            expect(lockRepositoryPolicy.active).toBeFalse();
             request.flush(lockRepositoryPolicy);
             tick();
 

--- a/src/test/javascript/spec/service/submission-policy.service.spec.ts
+++ b/src/test/javascript/spec/service/submission-policy.service.spec.ts
@@ -81,7 +81,7 @@ describe('Submission Policy Service', () => {
 
         it('should issue delete request', fakeAsync(() => {
             const removePolicySubscription = submissionPolicyService.removeSubmissionPolicyFromProgrammingExercise(programmingExercise.id!).subscribe((response) => {
-                expect(response.ok).toBe(true);
+                expect(response.ok).toBeTrue();
             });
             tick();
 
@@ -94,7 +94,7 @@ describe('Submission Policy Service', () => {
 
         it('should issue enable request', fakeAsync(() => {
             const removePolicySubscription = submissionPolicyService.enableSubmissionPolicyOfProgrammingExercise(programmingExercise.id!).subscribe((response) => {
-                expect(response.ok).toBe(true);
+                expect(response.ok).toBeTrue();
             });
             tick();
 
@@ -106,7 +106,7 @@ describe('Submission Policy Service', () => {
 
         it('should issue disable request', fakeAsync(() => {
             const removePolicySubscription = submissionPolicyService.disableSubmissionPolicyOfProgrammingExercise(programmingExercise.id!).subscribe((response) => {
-                expect(response.ok).toBe(true);
+                expect(response.ok).toBeTrue();
             });
             tick();
 

--- a/src/test/javascript/spec/service/submission.service.spec.ts
+++ b/src/test/javascript/spec/service/submission.service.spec.ts
@@ -72,7 +72,7 @@ describe('Submission Service', () => {
         req.flush({ status: 200 });
         tick();
 
-        expect(expectedResult).toBe(true);
+        expect(expectedResult).toBeTrue();
     }));
 
     it('should find all submissions of a given participation', fakeAsync(() => {

--- a/src/test/javascript/spec/service/text-assessment-analytics.service.spec.ts
+++ b/src/test/javascript/spec/service/text-assessment-analytics.service.spec.ts
@@ -63,7 +63,7 @@ describe('TextAssessmentAnalytics Service', () => {
         const subscribeToRouteParameters = jest.spyOn<any, any>(service, 'subscribeToRouteParameters');
         service.analyticsEnabled = true;
         service.setComponentRoute(route());
-        expect(subscribeToRouteParameters).toHaveBeenCalledTimes(1);
+        expect(subscribeToRouteParameters).toHaveBeenCalledOnce();
         expect(service['courseId']).toBe(1);
     }));
 
@@ -77,8 +77,8 @@ describe('TextAssessmentAnalytics Service', () => {
 
         service.sendAssessmentEvent(TextAssessmentEventType.VIEW_AUTOMATIC_SUGGESTION_ORIGIN, FeedbackType.AUTOMATIC, TextBlockType.AUTOMATIC);
 
-        expect(errorStub).toHaveBeenCalledTimes(1);
-        expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+        expect(errorStub).toHaveBeenCalledOnce();
+        expect(consoleErrorMock).toHaveBeenCalledOnce();
         expect(consoleErrorMock).toHaveBeenCalledWith('Error sending statistics: error occurred');
     });
 

--- a/src/test/javascript/spec/service/text-assessment.service.spec.ts
+++ b/src/test/javascript/spec/service/text-assessment.service.spec.ts
@@ -386,7 +386,7 @@ describe('TextAssessment Service', () => {
 
         resolver.resolve(snapshot);
 
-        expect(newStudentParticipationStub).toHaveBeenCalledTimes(1);
+        expect(newStudentParticipationStub).toHaveBeenCalledOnce();
         expect(newStudentParticipationStub).toHaveBeenCalledWith(1, 'lock', 0);
     });
 
@@ -403,7 +403,7 @@ describe('TextAssessment Service', () => {
 
         resolver.resolve(snapshot);
 
-        expect(studentParticipationSpy).toHaveBeenCalledTimes(1);
+        expect(studentParticipationSpy).toHaveBeenCalledOnce();
         expect(studentParticipationSpy).toHaveBeenCalledWith(1, 2, undefined, 1);
     });
 
@@ -420,7 +420,7 @@ describe('TextAssessment Service', () => {
 
         resolver.resolve(snapshot);
 
-        expect(feedbackConflictSpy).toHaveBeenCalledTimes(1);
+        expect(feedbackConflictSpy).toHaveBeenCalledOnce();
         expect(feedbackConflictSpy).toHaveBeenCalledWith(1, 2, 3);
     });
 

--- a/src/test/javascript/spec/service/user-route-access.service.spec.ts
+++ b/src/test/javascript/spec/service/user-route-access.service.spec.ts
@@ -78,7 +78,7 @@ describe('UserRouteAccessService', () => {
     });
 
     it('should return true if authorities are omitted', async () => {
-        await expect(service.checkLogin([], url)).resolves.toBe(true);
+        await expect(service.checkLogin([], url)).resolves.toBeTrue();
     });
 
     it('should store url if identity is undefined', async () => {
@@ -87,7 +87,7 @@ describe('UserRouteAccessService', () => {
         const navigateMock = jest.spyOn(router, 'navigate').mockReturnValue(Promise.resolve(true));
 
         await expect(service.checkLogin([Authority.EDITOR], url)).resolves.toBe(false);
-        expect(storeSpy).toHaveBeenCalledTimes(1);
+        expect(storeSpy).toHaveBeenCalledOnce();
         expect(storeSpy).toHaveBeenCalledWith(url);
         expect(navigateMock).toHaveBeenCalledTimes(2);
         expect(navigateMock.mock.calls[0][0]).toEqual(['accessdenied']);

--- a/src/test/javascript/spec/service/user-route-access.service.spec.ts
+++ b/src/test/javascript/spec/service/user-route-access.service.spec.ts
@@ -86,7 +86,7 @@ describe('UserRouteAccessService', () => {
         const storeSpy = jest.spyOn(storageService, 'storeUrl');
         const navigateMock = jest.spyOn(router, 'navigate').mockReturnValue(Promise.resolve(true));
 
-        await expect(service.checkLogin([Authority.EDITOR], url)).resolves.toBe(false);
+        await expect(service.checkLogin([Authority.EDITOR], url)).resolves.toBeFalse();
         expect(storeSpy).toHaveBeenCalledOnce();
         expect(storeSpy).toHaveBeenCalledWith(url);
         expect(navigateMock).toHaveBeenCalledTimes(2);

--- a/src/test/javascript/spec/util/shared/sort-by.directive.spec.ts
+++ b/src/test/javascript/spec/util/shared/sort-by.directive.spec.ts
@@ -120,7 +120,7 @@ describe('Directive: SortByDirective', () => {
 
         // THEN
         expect(component.predicate).toBe('name');
-        expect(component.ascending).toBe(false);
+        expect(component.ascending).toBeFalse();
         expect(sortByDirective.iconComponent?.icon).toBe(faSortDown);
         expect(component.transition).toHaveBeenCalledOnce();
     });

--- a/src/test/javascript/spec/util/shared/sort-by.directive.spec.ts
+++ b/src/test/javascript/spec/util/shared/sort-by.directive.spec.ts
@@ -83,7 +83,7 @@ describe('Directive: SortByDirective', () => {
         // THEN
         expect(sortByDirective.jhiSortBy).toBe('name');
         expect(component.predicate).toBe('name');
-        expect(component.ascending).toBe(true);
+        expect(component.ascending).toBeTrue();
         expect(sortByDirective.iconComponent?.icon).toBe(faSortUp);
         expect(component.transition).toHaveBeenCalledTimes(0);
     });
@@ -102,9 +102,9 @@ describe('Directive: SortByDirective', () => {
         // THEN
         expect(sortByDirective.jhiSortBy).toBe('name');
         expect(component.predicate).toBe('name');
-        expect(component.ascending).toBe(true);
+        expect(component.ascending).toBeTrue();
         expect(sortByDirective.iconComponent?.icon).toBe(faSortUp);
-        expect(component.transition).toHaveBeenCalledTimes(1);
+        expect(component.transition).toHaveBeenCalledOnce();
     });
 
     it('should update component predicate, order, icon when user clicks on column header', () => {
@@ -122,7 +122,7 @@ describe('Directive: SortByDirective', () => {
         expect(component.predicate).toBe('name');
         expect(component.ascending).toBe(false);
         expect(sortByDirective.iconComponent?.icon).toBe(faSortDown);
-        expect(component.transition).toHaveBeenCalledTimes(1);
+        expect(component.transition).toHaveBeenCalledOnce();
     });
 
     it('should update component predicate, order, icon when user double clicks on column header', () => {
@@ -143,7 +143,7 @@ describe('Directive: SortByDirective', () => {
 
         // THEN
         expect(component.predicate).toBe('name');
-        expect(component.ascending).toBe(true);
+        expect(component.ascending).toBeTrue();
         expect(sortByDirective.iconComponent?.icon).toBe(faSortUp);
         expect(component.transition).toHaveBeenCalledTimes(2);
     });

--- a/src/test/javascript/spec/util/shared/sort.directive.spec.ts
+++ b/src/test/javascript/spec/util/shared/sort.directive.spec.ts
@@ -61,7 +61,7 @@ describe('Directive: SortDirective', () => {
 
         // THEN
         expect(component.predicate).toBe('ID');
-        expect(component.ascending).toBe(false);
+        expect(component.ascending).toBeFalse();
         expect(component.transition).toHaveBeenCalledTimes(2);
     });
 

--- a/src/test/javascript/spec/util/shared/sort.directive.spec.ts
+++ b/src/test/javascript/spec/util/shared/sort.directive.spec.ts
@@ -45,8 +45,8 @@ describe('Directive: SortDirective', () => {
 
         // THEN
         expect(component.predicate).toBe('ID');
-        expect(component.ascending).toBe(true);
-        expect(component.transition).toHaveBeenCalledTimes(1);
+        expect(component.ascending).toBeTrue();
+        expect(component.transition).toHaveBeenCalledOnce();
     });
 
     it('should change sort order to descending when same field is sorted again', () => {
@@ -77,7 +77,7 @@ describe('Directive: SortDirective', () => {
 
         // THEN
         expect(component.predicate).toBe('NAME');
-        expect(component.ascending).toBe(true);
+        expect(component.ascending).toBeTrue();
         expect(component.transition).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

A discussion sprung up in #5162 regarding the use of assertions. This PR makes the use of assertions consistent in our codebase.

### Description
<!-- Describe your changes in detail -->

I've changed `toBe(true)` → `.toBeTrue()`, `toBe(false)` → `.toBeFalse()` and also `.toHaveBeenCalledTimes(1)` → `.toHaveBeenCalledOnce()`.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
