### PR TITLE
`Development`: Add peer dependency overrides to avoid NPM resolve errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,14 @@
         "xlsx": "0.18.5",
         "zone.js": "0.11.5"
     },
+    "overrides": {
+        "showdown-katex": {
+            "showdown": "2.1.0"
+        },
+        "@swimlane/ngx-datatable": {
+            "rxjs": "7.5.5"
+        }
+    },
     "devDependencies": {
         "@angular-builders/custom-webpack": "13.1.0",
         "@angular-builders/jest": "13.0.4",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Some of you might have noticed that our CI Pipelines building the client on GitHub actions started to fail in all PRs randomly.

This is due to the release of Node.js v16.15.1 which GH Actions gradually started to use on their runners. Compared to 16.15.0, this included a bump of NPM from 8.5.5 to 8.11.0:
![Screenshot 2022-06-09 at 18 53 31](https://user-images.githubusercontent.com/23171488/172902309-acc58bda-5ac2-451a-9c87-d3680b9f8fb2.png)

Our dependency tree for the client has conflicts due to outdated or even ancient dependencies that are hard to replace. They depend on older versions of other dependencies, causing NPM to fail when installing without ``--force``:
- ``@swimlane/ngx-data-table``: Last update on ``2021-09-14`` - Depends on ``rxjs@6.6.3`` while we have ``rxjs@7.5.5``
- ``showdown-katex``: Last update on ``2020-03-12`` - Depends on ``showdown@1.9.1`` while we have ``showdown@2.1.0``.

Previously, NPM was fine with letting us install the broken dependencies once with ``--force``, generating a ``package-lock.json``, and live on from then on. This apparently [changed with NPM 8.6.0](https://github.com/npm/cli/issues/4664#issuecomment-1086096726): Now all builds are failing, even if the ``package-lock.json`` already exists, when not using the ``--force`` flag. I've always considered this to be a feature, but apparently it was a "bug" that just got fixed, defeating one of the biggest purposes of lock files (imho) and randomly breaking thousands of production CI pipelines in a minor Node.JS patch 👍 🚀 ✨


### Description
<!-- Describe your changes in detail -->

As it wouldn't be wise to always use ``--force`` in light of future dependency updates we do, this PR adds overrides to the conflicting packages to force them onto the versions of dependencies that we use. These version have worked up until now, but we now have to take special care and spoon-feed NPM that we really want that. 🙃 
