### PR TITLE
`Programming exercises`: Remove extra left margin from clone repository button

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -187,7 +187,7 @@
                     </span>
                 </div>
                 <div *ngIf="programmingExercise.isAtLeastEditor">
-                    <span class="mr-1">
+                    <span class="me-1">
                         <button
                             [jhiFeatureToggle]="FeatureToggle.ProgrammingExercises"
                             type="button"
@@ -198,7 +198,7 @@
                             <span jhiTranslate="artemisApp.programmingExercise.diffReport.button">Update Diff-Report</span>
                         </button>
                     </span>
-                    <span class="mr-1" *ngIf="programmingExercise.programmingLanguage === ProgrammingLanguage.JAVA && programmingExercise.testwiseCoverageEnabled">
+                    <span class="me-1" *ngIf="programmingExercise.programmingLanguage === ProgrammingLanguage.JAVA && programmingExercise.testwiseCoverageEnabled">
                         <button
                             [jhiFeatureToggle]="FeatureToggle.ProgrammingExercises"
                             type="button"
@@ -340,13 +340,13 @@
                     <span jhiTranslate="artemisApp.programmingExercise.templateRepositoryUrl">Template Repository Url</span>
                     <div class="clone-buttons" *ngIf="programmingExercise.templateParticipation && programmingExercise.templateParticipation.repositoryUrl">
                         <jhi-clone-repo-button
-                            class="ml-2"
+                            class="ms-2"
                             [smallButtons]="true"
                             [repositoryUrl]="programmingExercise?.templateParticipation?.repositoryUrl! || ''"
                             [isTeamParticipation]="false"
                         ></jhi-clone-repo-button>
                         <jhi-programming-exercise-instructor-repo-download
-                            class="ml-2"
+                            class="ms-2"
                             [exerciseId]="programmingExercise.id!"
                             [repositoryType]="'TEMPLATE'"
                         ></jhi-programming-exercise-instructor-repo-download>
@@ -417,13 +417,13 @@
                             <dt>
                                 <span>{{ auxiliaryRepository.name }} Repository</span>
                                 <jhi-clone-repo-button
-                                    class="ml-2"
+                                    class="ms-2"
                                     [smallButtons]="true"
                                     [repositoryUrl]="auxiliaryRepository.repositoryUrl!"
                                     [isTeamParticipation]="false"
                                 ></jhi-clone-repo-button>
                                 <jhi-programming-exercise-instructor-repo-download
-                                    class="ml-2"
+                                    class="ms-2"
                                     [exerciseId]="programmingExercise.id!"
                                     [repositoryType]="'AUXILIARY'"
                                     [auxiliaryRepositoryId]="auxiliaryRepository.id!"
@@ -433,7 +433,7 @@
                                         >Checkout Directory: {{ auxiliaryRepository.checkoutDirectory }}
                                     </span>
                                     <ng-template #noCheckoutDirectorySet>
-                                        <fa-icon [icon]="faExclamationTriangle" class="text-warning mr-1" [ngbTooltip]="noCheckoutDirectorySetTooltip"></fa-icon>
+                                        <fa-icon [icon]="faExclamationTriangle" class="text-warning me-1" [ngbTooltip]="noCheckoutDirectorySetTooltip"></fa-icon>
                                         <span jhiTranslate="artemisApp.programmingExercise.noCheckoutDirectorySet">Checkout Directory was not set</span>
                                     </ng-template>
                                     <ng-template #noCheckoutDirectorySetTooltip>

--- a/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
+++ b/src/main/webapp/app/overview/exercise-details/exercise-details-student-actions.component.html
@@ -203,6 +203,7 @@
                 <button
                     [id]="'open-exercise-' + exercise.id"
                     jhi-exercise-action-button
+                    class="me-2"
                     [buttonIcon]="faFolderOpen"
                     [jhiFeatureToggle]="FeatureToggle.ProgrammingExercises"
                     [buttonLabel]="'artemisApp.exerciseActions.openCodeEditor' | artemisTranslate"

--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
@@ -2,7 +2,7 @@
     <button
         jhi-exercise-action-button
         [buttonIcon]="faDownload"
-        class="ms-2 clone-repository"
+        class="clone-repository"
         [jhiFeatureToggle]="FeatureToggle.ProgrammingExercises"
         [buttonLabel]="'artemisApp.exerciseActions.cloneRepository' | artemisTranslate"
         [buttonLoading]="loading"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The left alignment of the `Start exercise` and the `Clone Repository` buttons were not correct (see screenshots below). This PR fixes it and also replaces the `ml-*` (margin-left) and `mr-*` (margin-right) Bootstrap classes with `ms-*` (margin-start) and `me-*` (margin-end) classes to be more generic, which can be helpful if RTL support is desired in the future.

### Description
<!-- Describe your changes in detail -->
There was an extra margin before the `Clone Repository` button (caused by `ms-2` class) which looks fine when the `Open code editor` button is also active. But it breaks the alignment if `Open code editor` button is not visible and `Clone Repository` button is the first one in the row. Instead of having `ms-2 `class at the `Clone Repository` button, having `me-2` class at the `Open code editor` button solves the issue. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course with 2 Programming Exercises without `Allow Online Editor` selected

1. Log in to Artemis
3. Select a course with 2 programming exercises in Course Overview
4. Click `Start exercise` for one of the programming exercises.
5. Ensure `Clone Repository` button is aligned with the `Start exercise` button of the other exercise
6. Go to Course Management > (Current Course) > Exercises, select the previously started programming exercise
7. Ensure the extra margin before `Clone Repository` button next to Template, Solution, Test and Auxiliary Repositories are removed (There should still be a margin but smaller, see screenshots below).
8. Click Edit button at the top, check `Allow Online Editor` and save
9. Return to Course Overview > (Current Course) > Exercises
10. Ensure `Open code editor` button is aligned with the `Start exercise` button of the other exercise
11. Ensure there is a proper margin between `Open code editor` and `Clone Repository` buttons

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
![image](https://user-images.githubusercontent.com/18427209/173562527-ab336672-7656-43f7-86bd-bd7f4837f33c.png)

After:
![image](https://user-images.githubusercontent.com/18427209/173562027-1b191a02-60d2-4fc9-9045-f1fdd8a3c2fe.png)


Before:
![image](https://user-images.githubusercontent.com/18427209/173562626-747c4213-7218-450f-bf0c-4a46f0e60710.png)

After:
![image](https://user-images.githubusercontent.com/18427209/173562115-e3fbc840-a92e-4b32-aa71-4bdff242c31c.png)

