### PR TITLE
`General`: Localize time ago pipe

### DIFF
--- a/src/main/webapp/app/shared/pipes/artemis-time-ago.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/artemis-time-ago.pipe.ts
@@ -1,6 +1,8 @@
 import { Pipe, ChangeDetectorRef, PipeTransform, OnDestroy, NgZone } from '@angular/core';
 import dayjs from 'dayjs/esm';
 import { isDate } from 'app/shared/util/utils';
+import 'dayjs/locale/de';
+import { TranslateService } from '@ngx-translate/core';
 
 @Pipe({
     name: 'artemisTimeAgo',
@@ -16,10 +18,10 @@ export class ArtemisTimeAgoPipe implements PipeTransform, OnDestroy {
     private lastText: string;
     private formatFn: (m: dayjs.Dayjs) => string;
 
-    constructor(private cdRef: ChangeDetectorRef, private ngZone: NgZone) {}
+    constructor(private cdRef: ChangeDetectorRef, private ngZone: NgZone, private translateService: TranslateService) {}
 
     format(date: dayjs.Dayjs) {
-        return date.from(dayjs(), this.lastOmitSuffix);
+        return date.locale(this.lastLocale).from(dayjs(), this.lastOmitSuffix);
     }
 
     transform(value: dayjs.ConfigType, omitSuffix?: boolean, formatFn?: (m: dayjs.Dayjs) => string): string {
@@ -27,7 +29,7 @@ export class ArtemisTimeAgoPipe implements PipeTransform, OnDestroy {
             this.lastTime = getTime(value);
             this.lastValue = value;
             this.lastOmitSuffix = omitSuffix;
-            this.lastLocale = getLocale(value);
+            this.lastLocale = this.translateService.currentLang;
             this.formatFn = formatFn || this.format.bind(this);
             this.removeTimer();
             this.createTimer();
@@ -73,7 +75,7 @@ export class ArtemisTimeAgoPipe implements PipeTransform, OnDestroy {
     }
 
     private hasChanged(value: dayjs.ConfigType, omitSuffix?: boolean): boolean {
-        return getTime(value) !== this.lastTime || getLocale(value) !== this.lastLocale || omitSuffix !== this.lastOmitSuffix;
+        return getTime(value) !== this.lastTime || this.translateService.currentLang !== this.lastLocale || omitSuffix !== this.lastOmitSuffix;
     }
 }
 
@@ -98,8 +100,4 @@ function getSecondsUntilUpdate(dayjsInstance: dayjs.Dayjs) {
     } else {
         return 3600;
     }
-}
-
-function getLocale(value: dayjs.ConfigType): string {
-    return dayjs.isDayjs(value) ? value.locale() : dayjs.locale();
 }

--- a/src/main/webapp/app/shared/pipes/artemis-time-ago.pipe.ts
+++ b/src/main/webapp/app/shared/pipes/artemis-time-ago.pipe.ts
@@ -1,7 +1,6 @@
 import { Pipe, ChangeDetectorRef, PipeTransform, OnDestroy, NgZone } from '@angular/core';
 import dayjs from 'dayjs/esm';
 import { isDate } from 'app/shared/util/utils';
-import 'dayjs/locale/de';
 import { TranslateService } from '@ngx-translate/core';
 
 @Pipe({

--- a/src/test/javascript/spec/pipe/artemis-time-ago.pipe.spec.ts
+++ b/src/test/javascript/spec/pipe/artemis-time-ago.pipe.spec.ts
@@ -30,9 +30,9 @@ describe('ArtemisTimeAgoPipe', () => {
         { value: dayjs().add(5, 'minutes'), expected: { en: 'in 5 minutes', de: 'in 5 Minuten' } },
         { value: dayjs().add(10, 'minutes'), expected: { en: 'in 10 minutes', de: 'in 10 Minuten' } },
         { value: dayjs().add(2, 'hours'), expected: { en: 'in 2 hours', de: 'in 2 Stunden' } },
-        { value: dayjs().add(-5, 'minutes'), expected: { en: '5 minutes ago', de: 'vor 5 Minuten' } },
-        { value: dayjs().add(-10, 'minutes'), expected: { en: '10 minutes ago', de: 'vor 10 Minuten' } },
-        { value: dayjs().add(-2, 'hours'), expected: { en: '2 hours ago', de: 'vor 2 Stunden' } },
+        { value: dayjs().subtract(5, 'minutes'), expected: { en: '5 minutes ago', de: 'vor 5 Minuten' } },
+        { value: dayjs().subtract(10, 'minutes'), expected: { en: '10 minutes ago', de: 'vor 10 Minuten' } },
+        { value: dayjs().subtract(2, 'hours'), expected: { en: '2 hours ago', de: 'vor 2 Stunden' } },
     ])('returns the correct time and switches the language correctly', ({ value, expected }) => {
         Object.entries(expected).forEach(([langKey, expectedOutput]) => {
             translateService.use(langKey);
@@ -41,7 +41,7 @@ describe('ArtemisTimeAgoPipe', () => {
     });
 
     it('updates the output automatically as time passes, but removes the timer after destroy', fakeAsync(() => {
-        const time = dayjs().add(-60, 'seconds');
+        const time = dayjs().subtract(60, 'seconds');
         expect(pipe.transform(time)).toBe('a minute ago');
         expect(cdRef.markForCheck).not.toHaveBeenCalled();
         tick(30000);

--- a/src/test/javascript/spec/pipe/artemis-time-ago.pipe.spec.ts
+++ b/src/test/javascript/spec/pipe/artemis-time-ago.pipe.spec.ts
@@ -1,0 +1,55 @@
+import { MockTranslateService } from '../helpers/mocks/service/mock-translate.service';
+import { ArtemisTimeAgoPipe } from 'app/shared/pipes/artemis-time-ago.pipe';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
+import { ChangeDetectorRef, NgZone } from '@angular/core';
+import dayjs from 'dayjs/esm';
+
+describe('ArtemisTimeAgoPipe', () => {
+    let pipe: ArtemisTimeAgoPipe;
+    let translateService: TranslateService;
+    let cdRef: ChangeDetectorRef;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [ArtemisTimeAgoPipe],
+            providers: [{ provide: TranslateService, useClass: MockTranslateService }],
+        })
+            .compileComponents()
+            .then(() => {
+                cdRef = { markForCheck: jest.fn() } as any as ChangeDetectorRef;
+
+                translateService = TestBed.inject(TranslateService);
+                translateService.use('en');
+                const ngZone = TestBed.inject(NgZone);
+                pipe = new ArtemisTimeAgoPipe(cdRef, ngZone, translateService);
+            });
+    });
+
+    it.each([
+        { value: dayjs().add(5, 'minutes'), expected: { en: 'in 5 minutes', de: 'in 5 Minuten' } },
+        { value: dayjs().add(10, 'minutes'), expected: { en: 'in 10 minutes', de: 'in 10 Minuten' } },
+        { value: dayjs().add(2, 'hours'), expected: { en: 'in 2 hours', de: 'in 2 Stunden' } },
+        { value: dayjs().add(-5, 'minutes'), expected: { en: '2 minutes ago', de: 'vor 2 Minuten' } },
+        { value: dayjs().add(-10, 'minutes'), expected: { en: '10 minutes ago', de: 'vor 10 Minuten' } },
+        { value: dayjs().add(-2, 'hours'), expected: { en: '2 hours ago', de: 'vor 2 Stunden' } },
+    ])('returns the correct time and switches the language correctly', ({ value, expected }) => {
+        Object.entries(expected).forEach(([langKey, expectedOutput]) => {
+            translateService.use(langKey);
+            expect(pipe.transform(value)).toBe(expectedOutput);
+        });
+    });
+
+    it('updates the output automatically as time passes, but removes the timer after destory', fakeAsync(() => {
+        const time = dayjs().add(-60, 'seconds');
+        expect(pipe.transform(time)).toBe('a minute ago');
+        expect(cdRef.markForCheck).not.toHaveBeenCalled();
+        tick(30000);
+        expect(cdRef.markForCheck).toHaveBeenCalledOnce();
+        expect(pipe.transform(time)).toBe('2 minutes ago');
+
+        pipe.ngOnDestroy();
+        tick(30000);
+        expect(cdRef.markForCheck).toHaveBeenCalledOnce(); // not a second time
+    }));
+});

--- a/src/test/javascript/spec/pipe/artemis-time-ago.pipe.spec.ts
+++ b/src/test/javascript/spec/pipe/artemis-time-ago.pipe.spec.ts
@@ -30,7 +30,7 @@ describe('ArtemisTimeAgoPipe', () => {
         { value: dayjs().add(5, 'minutes'), expected: { en: 'in 5 minutes', de: 'in 5 Minuten' } },
         { value: dayjs().add(10, 'minutes'), expected: { en: 'in 10 minutes', de: 'in 10 Minuten' } },
         { value: dayjs().add(2, 'hours'), expected: { en: 'in 2 hours', de: 'in 2 Stunden' } },
-        { value: dayjs().add(-5, 'minutes'), expected: { en: '2 minutes ago', de: 'vor 2 Minuten' } },
+        { value: dayjs().add(-5, 'minutes'), expected: { en: '5 minutes ago', de: 'vor 5 Minuten' } },
         { value: dayjs().add(-10, 'minutes'), expected: { en: '10 minutes ago', de: 'vor 10 Minuten' } },
         { value: dayjs().add(-2, 'hours'), expected: { en: '2 hours ago', de: 'vor 2 Stunden' } },
     ])('returns the correct time and switches the language correctly', ({ value, expected }) => {

--- a/src/test/javascript/spec/pipe/artemis-time-ago.pipe.spec.ts
+++ b/src/test/javascript/spec/pipe/artemis-time-ago.pipe.spec.ts
@@ -40,7 +40,7 @@ describe('ArtemisTimeAgoPipe', () => {
         });
     });
 
-    it('updates the output automatically as time passes, but removes the timer after destory', fakeAsync(() => {
+    it('updates the output automatically as time passes, but removes the timer after destroy', fakeAsync(() => {
         const time = dayjs().add(-60, 'seconds');
         expect(pipe.transform(time)).toBe('a minute ago');
         expect(cdRef.markForCheck).not.toHaveBeenCalled();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

As noted in #5029, the ``ArtemisTimeAgoPipe`` is not localized and display "time ago" strings in English even if the selected language is German.

### Description
<!-- Describe your changes in detail -->

- Make the pipe use the current language from the ``TranslateService``
- Added a test for the pipe as there was none so far

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2. Go to a course
3. Make sure that the "XX minutes ago" etc strings are localized correctly in the exercise list view, in the exercise detail view header and elsewhere you know the format is used

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| artemis-time-ago.pipe.ts | 72% | 87% |


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
![Screenshot 2022-06-15 at 16 39 15](https://user-images.githubusercontent.com/23171488/173867917-dd4ceb5a-dcdc-464d-bef6-6ab2a9f32187.png)

After:
![Screenshot 2022-06-15 at 16 39 34](https://user-images.githubusercontent.com/23171488/173867936-ed6f9c7d-972c-4db7-992b-ede97a973e81.png)
