### PR TITLE
`Programming Exercises`: Fix server-side parsing of parametrized test cases from problem statement

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ProgrammingExerciseTaskService.java
@@ -140,9 +140,6 @@ public class ProgrammingExerciseTaskService {
             task.setExercise(exercise);
             var testCaseNames = extractTestCaseNames(capturedTestCaseNames);
 
-            // parsing the test case names from the capture group with splitting by ',', if there are no unclosed rounded brackets
-            // This respects the fact that parametrized tests may contain commas (e.g. "testInsert(InsertMock, 1)").
-
             for (String testName : testCaseNames) {
                 testCases.stream().filter(tc -> tc.getTestName().equals(testName)).findFirst().ifPresent(task.getTestCases()::add);
             }
@@ -153,7 +150,7 @@ public class ProgrammingExerciseTaskService {
 
     /**
      * Get the test case names from the captured group by splitting by ',' if there are no unclosed rounded brackets for
-     * the current test case. This respects the fact that parametrized tests may contain commas.
+     * the current test case. This respects the fact that parameterized tests may contain commas.
      * Example: "testInsert(InsertMock, 1),testClass[SortStrategy],testWithBraces()" results in the following list
      * ["testInsert(InsertMock, 1)", "testClass[SortStrategy]", "testWithBraces()"]
      * @param capturedTestCaseNames the captured test case names matched from the problem statement

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseTaskServiceTest.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.hestia;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -16,6 +17,7 @@ import de.tum.in.www1.artemis.domain.ProgrammingExerciseTestCase;
 import de.tum.in.www1.artemis.domain.hestia.CodeHint;
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseTask;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
 import de.tum.in.www1.artemis.repository.hestia.CodeHintRepository;
 import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseTaskRepository;
 import de.tum.in.www1.artemis.service.hestia.ProgrammingExerciseTaskService;
@@ -30,6 +32,9 @@ public class ProgrammingExerciseTaskServiceTest extends AbstractSpringIntegratio
 
     @Autowired
     private ProgrammingExerciseRepository programmingExerciseRepository;
+
+    @Autowired
+    private ProgrammingExerciseTestCaseRepository programmingExerciseTestCaseRepository;
 
     @Autowired
     private CodeHintRepository codeHintRepository;
@@ -134,7 +139,7 @@ public class ProgrammingExerciseTaskServiceTest extends AbstractSpringIntegratio
     }
 
     /**
-     * Tests that not changing any tasks in the problem statment will not update any tasks
+     * Tests that not changing any tasks in the problem statement will not update any tasks
      */
     @Test
     public void testNoChanges() {
@@ -169,6 +174,27 @@ public class ProgrammingExerciseTaskServiceTest extends AbstractSpringIntegratio
         assertThat(programmingExerciseTaskRepository.findAll()).hasSize(1);
         assertThat(programmingExerciseTaskRepository.findById(task.getId())).isEmpty();
         assertThat(codeHintRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    public void testParseTestCaseNames() {
+        List<String> testCaseNames = List.of("testClass[BubbleSort]", "testWithBraces()", "testParametrized(Parameter1, 2)[1]");
+        for (var name : testCaseNames) {
+            var testCase = new ProgrammingExerciseTestCase();
+            testCase.setExercise(programmingExercise);
+            testCase.setTestName(name);
+            testCase.setActive(true);
+            programmingExerciseTestCaseRepository.save(testCase);
+        }
+        updateProblemStatement("""
+                [task][Task 1](testClass[BubbleSort],testWithBraces(),testParametrized(Parameter1, 2)[1])
+                """);
+        var actualTasks = programmingExerciseTaskRepository.findAll();
+        assertThat(actualTasks).hasSize(1);
+        var actualTaskWithTestCases = programmingExerciseTaskRepository.findByIdWithTestCaseAndSolutionEntriesElseThrow(actualTasks.get(0).getId());
+        assertThat(actualTaskWithTestCases.getTaskName()).isEqualTo("Task 1");
+        var actualTestCaseNames = actualTaskWithTestCases.getTestCases().stream().map(ProgrammingExerciseTestCase::getTestName).toList();
+        assertThat(actualTestCaseNames).isEqualTo(testCaseNames);
     }
 
     private boolean checkTaskEqual(ProgrammingExerciseTask task, String expectedName, String expectedTestName) {


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [X] I added multiple integration tests (Spring) related to the features (with a high test coverag
- [X] I implemented the changes with a good performance and prevented too many database calls.
- [X] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
@JohannesStoehr found the issue that parametrized test cases are not parsed correctly from the problem statement. These changes fix this issue.

### Description
Previously, the test case names were split by a comma. This works fine for regular test case (names), but not for parametrized test case (names).

Example of non-parameterized test cases in the problem statement:
`testClass[BubbleSort],testMethods[Context], testMethods[Policy]`

Example of parameterized test cases in the problem statement:
`testInsert(InsertMock, int)[1], testInsert(InsertMock, int)[2], testInsert(InsertMock, int)[3])`

This example shows that just splitting by a comma does not work here. With these changes, the test cases are only split, if every round bracket has been closed. Therefore, a comma between arguments of a parameterized test case is not considered a split between test case names.

### Steps for Testing
Testing these changes on a test server is not possible with additional steps since the task-test mapping on the server-side is not directly shown in the client but is only used for the hint system. Therefore, I suggest either testing this locally and checking the correct mapping in the database or executing the added method with manual examples. However, you can check that the task names are saved correctly:
1. Create a new programming exercise (Java Maven/Gradle)
2. Go to the programming exercise details page.
3. Click the button "Manage hints"
4. Click the blue-colored button to create a new text hint
5. Select the dropdown and verify that all tasks from the problem statement are listed as dropdown values.


### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

