### PR TITLE
`Quiz exercises`: Fix quiz preview and show overlay when quiz was never started

### DIFF
--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
@@ -5,7 +5,7 @@
         <span *ngSwitchCase="'preview'" class="in-parentheses" jhiTranslate="artemisApp.quizExercise.previewMode"></span>
         <span *ngSwitchCase="'solution'" class="in-parentheses" jhiTranslate="artemisApp.quizExercise.solution"></span>
     </h2>
-    <p *ngIf="!waitingForQuizStart && !submission.submitted && !showingResult" jhiTranslate="artemisApp.quizExercise.quizInstructions.live"></p>
+    <p *ngIf="!waitingForQuizStart && !submission.submitted && !showingResult && remainingTimeSeconds >= 0" jhiTranslate="artemisApp.quizExercise.quizInstructions.live"></p>
     <p *ngIf="!waitingForQuizStart && submission.submitted && !showingResult" jhiTranslate="artemisApp.quizExercise.quizInstructions.wait"></p>
     <p
         *ngIf="!waitingForQuizStart && showingResult && mode !== 'solution'"
@@ -201,10 +201,7 @@
         </div>
     </div>
 </div>
-<div
-    class="quiz-is-over-overlay alert alert-info"
-    *ngIf="!waitingForQuizStart && !showingResult && !submission.submitted && remainingTimeSeconds < 0 && quizExercise?.quizMode === QuizMode.SYNCHRONIZED"
->
+<div class="quiz-is-over-overlay alert alert-info" *ngIf="!waitingForQuizStart && !showingResult && !submission.submitted && remainingTimeSeconds < 0">
     <span *ngIf="submission.submissionDate" jhiTranslate="artemisApp.quizExercise.quizIsOverText"></span>
     <span *ngIf="!submission.submissionDate" jhiTranslate="artemisApp.quizExercise.notParticipatedText"></span>
 </div>

--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.ts
@@ -444,7 +444,7 @@ export class QuizParticipationComponent implements OnInit, OnDestroy {
     checkForQuizEnd() {
         const running = this.mode === 'live' && !!this.quizBatch && this.remainingTimeSeconds >= 0 && this.quizExercise?.quizMode !== QuizMode.SYNCHRONIZED;
         if (!running && this.previousRunning) {
-            if (!this.submission.submitted) {
+            if (!this.submission.submitted && this.submission.submissionDate) {
                 this.alertService.success('artemisApp.quizExercise.submitSuccess');
             }
         }
@@ -607,6 +607,7 @@ export class QuizParticipationComponent implements OnInit, OnDestroy {
             }
         } else {
             this.submission = new QuizSubmission();
+            this.initQuiz();
         }
     }
 
@@ -945,6 +946,10 @@ export class QuizParticipationComponent implements OnInit, OnDestroy {
             next: (res: HttpResponse<QuizExercise>) => {
                 const quizExercise = res.body!;
                 if (quizExercise.quizStarted) {
+                    if (quizExercise.quizEnded) {
+                        this.waitingForQuizStart = false;
+                        this.endDate = dayjs();
+                    }
                     this.quizExercise = quizExercise;
                     this.initLiveMode();
                 }

--- a/src/test/javascript/spec/component/exercises/quiz/quiz-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/quiz-participation.component.spec.ts
@@ -196,6 +196,37 @@ describe('QuizParticipationComponent', () => {
             expect(updateSpy).toHaveBeenCalled();
         }));
 
+        it('should check quiz end in intervals', fakeAsync(() => {
+            fixture.detectChanges();
+
+            const checkQuizEndSpy = jest.spyOn(component, 'checkForQuizEnd');
+            tick(5000);
+            fixture.detectChanges();
+            discardPeriodicTasks();
+
+            expect(checkQuizEndSpy).toHaveBeenCalled();
+        }));
+
+        it('should add alert on quiz end', fakeAsync(() => {
+            fixture.detectChanges();
+
+            component.endDate = dayjs().add(1, 'seconds');
+            component.quizExercise.quizMode = QuizMode.BATCHED;
+            component.submission.submissionDate = dayjs();
+
+            const alertService = fixture.debugElement.injector.get(AlertService);
+            const alertSpy = jest.spyOn(alertService, 'success');
+
+            const checkQuizEndSpy = jest.spyOn(component, 'checkForQuizEnd');
+
+            tick(2000);
+            fixture.detectChanges();
+            discardPeriodicTasks();
+
+            expect(checkQuizEndSpy).toHaveBeenCalled();
+            expect(alertSpy).toHaveBeenCalledOnce();
+        }));
+
         it('should refresh quiz', () => {
             exerciseService = fixture.debugElement.injector.get(QuizExerciseService);
             fixture.detectChanges();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context

Close #5160 

### Description

Slightly changed the logic around the `quiz-is-over-overlay` so that it also covers the scenario described by #5160, so that the user has an indication that the quiz has ended. The questions will be shown but the user can't select any answers since the quiz has ended. Fixed the logic in `checkForQuizEnd` so that the alert isn't shown when no submission has been made.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Students

(Follow the steps described in #5160, or the simplified ones below)

1. Log in to Artemis as the instructor
2. Navigate to a course
3. Create a Batched quiz with a due date and save the quiz
4. Add a batch for the quiz, **but don't start the batch**, and copy the batch code/password
5. Log in to Artemis as the student
6. Go to the live quiz, past the code and wait for the quiz to start
7. The quiz won't start, so wait for the due date to arrive
8. Press "Refresh", verify that the overlay "Quiz has ended and you did not participate.." is shown and that questions are displayed correctly (as shown in screenshot below)

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| quiz-participation.component.ts | 75% | 87% |

### Screenshots

Old (questions get cut, no indication that the quiz has ended):

![image](https://user-images.githubusercontent.com/11006274/174441908-b04d928c-807f-491e-b71b-06ccf707c00f.png)

New (questions are displayed correctly, answers can't be selected, overlay indicating quiz has ended):

![image](https://user-images.githubusercontent.com/11006274/174442281-1ad0fa94-c97b-45b3-85c2-07d003a81f2c.png)


