### PR TITLE
`Programming exercises`: Make hint display threshold editable

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/hestia/ExerciseHint.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/hestia/ExerciseHint.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.persistence.*;
+import javax.validation.constraints.Min;
 
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -50,6 +51,10 @@ public class ExerciseHint extends DomainObject {
     @OneToMany(mappedBy = "exerciseHint", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonIgnore
     private Set<ExerciseHintActivation> exerciseHintActivations = new HashSet<>();
+
+    @Column(name = "display_threshold")
+    @Min(0)
+    private int displayThreshold = 3;
 
     @Transient
     private Integer currentUserRatingTransient;
@@ -138,12 +143,15 @@ public class ExerciseHint extends DomainObject {
     /**
      * Returns a threshold value that defines when this exercise hint is displayed to student participating in a programming exercise.
      * The algorithm defining if the hint is display is described in {@link de.tum.in.www1.artemis.service.hestia.ExerciseHintService#getAvailableExerciseHints}
-     * Note: This value is currently fixed but planned to be adjustable.
      *
      * @return the display threshold value
      */
     public int getDisplayThreshold() {
-        return 3;
+        return displayThreshold;
+    }
+
+    public void setDisplayThreshold(int displayThreshold) {
+        this.displayThreshold = displayThreshold;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/ExerciseHintService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/ExerciseHintService.java
@@ -163,6 +163,8 @@ public class ExerciseHintService {
         var subsequentNumberOfSuccessfulSubmissionsByTask = tasks.stream()
                 .collect(Collectors.toMap(task -> task, task -> subsequentNumberOfSubmissionsForTaskWithStatus(submissions, task, true)));
 
+        var availableHints = new HashSet<ExerciseHint>();
+
         for (int i = 0; i < tasks.size(); i++) {
             var task = tasks.get(i);
             int subsequentNumberOfUnsuccessfulSubmissionsForCurrentTask = subsequentNumberOfUnsuccessfulSubmissionsByTask.get(task);
@@ -196,10 +198,13 @@ public class ExerciseHintService {
             var availableHintsForCurrentTask = getAvailableExerciseHintsForTask(subsequentNumberSuccessfulSubmissionsForPreviousTask,
                     subsequentNumberOfUnsuccessfulSubmissionsForCurrentTask, hintsInTask);
             if (!availableHintsForCurrentTask.isEmpty()) {
-                return availableHintsForCurrentTask;
+                availableHints.addAll(availableHintsForCurrentTask);
+                break;
             }
         }
-        return new HashSet<>();
+        // Hints with a threshold of 0 will always be displayed
+        availableHints.addAll(exerciseHints.stream().filter(hint -> hint.getDisplayThreshold() == 0).toList());
+        return availableHints;
     }
 
     private boolean isTaskSuccessfulInSubmission(ProgrammingExerciseTask task, Submission submission) {

--- a/src/main/resources/config/liquibase/changelog/20220620150000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20220620150000_changelog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.4.xsd">
+    <!--
+    This changeset adds the display threshold to the exercise_hint table
+    -->
+    <changeSet author="timor-morrien" id="20220620150000">
+        <addColumn tableName="exercise_hint">
+            <column name="display_threshold" type="INTEGER" defaultValueNumeric="3">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -170,6 +170,7 @@
     <include file="classpath:config/liquibase/changelog/20220420081504_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20220519170000_changelog.xml" relativeToChangelogFile="false"/>
     <include file="classpath:config/liquibase/changelog/20220609095000_changelog.xml" relativeToChangelogFile="false"/>
+    <include file="classpath:config/liquibase/changelog/20220620150000_changelog.xml" relativeToChangelogFile="false"/>
 
     <!-- NOTE: please use the format "YYYYMMDDhhmmss_changelog.xml", i.e. year month day hour minutes seconds and not something else! -->
     <!-- we should also stay in a chronological order! -->

--- a/src/main/webapp/app/entities/hestia/exercise-hint.model.ts
+++ b/src/main/webapp/app/entities/hestia/exercise-hint.model.ts
@@ -15,5 +15,6 @@ export class ExerciseHint implements BaseEntity {
     public exercise?: ProgrammingExercise;
     public type?: HintType;
     public programmingExerciseTask?: ProgrammingExerciseServerSideTask;
+    public displayThreshold?: number;
     public currentUserRating?: number;
 }

--- a/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
+++ b/src/main/webapp/app/exercises/programming/participate/code-editor-student-container.component.ts
@@ -199,9 +199,10 @@ export class CodeEditorStudentContainerComponent implements OnInit, OnDestroy {
                 this.availableExerciseHints = availableRes!.body!.filter(
                     (availableHint) => !this.activatedExerciseHints?.some((activatedHint) => availableHint.id === activatedHint.id),
                 );
-                if (this.availableExerciseHints.length) {
+                const filteredAvailableExerciseHints = this.availableExerciseHints.filter((hint) => hint.displayThreshold !== 0);
+                if (filteredAvailableExerciseHints.length) {
                     this.alertService.info('artemisApp.exerciseHint.availableHintsAlertMessage', {
-                        taskName: this.availableExerciseHints.first()?.programmingExerciseTask?.taskName,
+                        taskName: filteredAvailableExerciseHints.first()?.programmingExerciseTask?.taskName,
                     });
                 }
             });

--- a/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.html
@@ -32,6 +32,15 @@
                         <option *ngFor="let task of tasks" [ngValue]="task">{{ task.taskName }}</option>
                     </select>
                 </div>
+
+                <div class="form-group">
+                    <div>
+                        <label class="label-narrow" jhiTranslate="artemisApp.exerciseHint.displayThreshold" for="field_description">Display Threshold</label>
+                        <jhi-help-icon placement="auto" text="artemisApp.exerciseHint.displayThresholdTooltip"></jhi-help-icon>
+                    </div>
+                    <input type="number" required min="0" class="form-control" name="displayThreshold" id="field_displayThreshold" [(ngModel)]="exerciseHint.displayThreshold" />
+                </div>
+
                 <div class="form-group hint-form__editor-wrapper">
                     <jhi-markdown-editor
                         [markdown]="exerciseHint.content"

--- a/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.ts
@@ -63,6 +63,7 @@ export class ExerciseHintUpdateComponent implements OnInit, OnDestroy {
         });
         this.route.data.subscribe(({ exerciseHint }) => {
             this.exerciseHint = exerciseHint;
+            this.exerciseHint.displayThreshold = this.exerciseHint.displayThreshold ?? 3;
 
             if (!this.exerciseHint.exercise) {
                 this.programmingExerciseService

--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.ts
@@ -388,9 +388,10 @@ export class CourseExerciseDetailsComponent implements OnInit, OnDestroy {
                             this.availableExerciseHints = availableRes!.body!.filter(
                                 (availableHint) => !this.activatedExerciseHints.some((activatedHint) => availableHint.id === activatedHint.id),
                             );
-                            if (this.availableExerciseHints.length) {
+                            const filteredAvailableExerciseHints = this.availableExerciseHints.filter((hint) => hint.displayThreshold !== 0);
+                            if (filteredAvailableExerciseHints.length) {
                                 this.alertService.info('artemisApp.exerciseHint.availableHintsAlertMessage', {
-                                    taskName: this.availableExerciseHints.first()?.programmingExerciseTask?.taskName,
+                                    taskName: filteredAvailableExerciseHints.first()?.programmingExerciseTask?.taskName,
                                 });
                             }
                         });

--- a/src/main/webapp/i18n/de/exerciseHint.json
+++ b/src/main/webapp/i18n/de/exerciseHint.json
@@ -20,6 +20,8 @@
             "title": "Titel",
             "task": "Task",
             "taskTooltip": "Es wird nicht empfohlen, Code-Hinweise anderen Tasks zuzuweisen, weil die Hinweise speziell für einen Task erstellt wurden.",
+            "displayThreshold": "Anzeige Schwellenwert",
+            "displayThresholdTooltip": "Die Anzahl der erfolglosen Einreichungen für eine Aufgabe, nach der dieser Hinweis verfügbar sein soll. Wird dieser Wert auf Null gesetzt, ist der Hinweis immer sichtbar.",
             "description": "Beschreibung",
             "descriptionTooltip": "Dieser Text wird Studierenden angezeigt, die diesen Hint angezeigt bekommen.",
             "content": "Inhalt",

--- a/src/main/webapp/i18n/en/exerciseHint.json
+++ b/src/main/webapp/i18n/en/exerciseHint.json
@@ -20,6 +20,8 @@
             "title": "Title",
             "task": "Task",
             "taskTooltip": "It is not recommended to assign code hints to other tasks since these are specifically generated for a task.",
+            "displayThreshold": "Display Threshold",
+            "displayThresholdTooltip": "The number of unsuccessful submissions for a task after which this hint should become available. Setting this to zero means that the hint is always visible.",
             "description": "Description",
             "descriptionTooltip": "This text is displayed to students who are shown this hint.",
             "content": "Content",


### PR DESCRIPTION
# Do not deploy this to a test server yet
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [ ] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [ ] I implemented the changes with a good performance and prevented too many database calls.
- [ ] I documented the Java code using JavaDoc style.
#### Client
- [ ] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [ ] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
These changes are part of the Bachelor Thesis from @Hialus and @ole-ve about the automatic generation of code hints for programming exercises (HESTIA) in Java.
In the previous PR #5136, where we made the hint displaying dynamic, we introduced a fixed display threshold of 3. 
This PR allows editors to edit this threshold.

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Programming exercise with 1 existing hint
- 1 Instructor
- 1 Student

1. Log in to Artemis
2. Navigate to the programming exercise management page
3. Navigate to the hint management page for this exercise
4. Edit the existing hint
    - The display threshold should be set to 3
6. Create a new hint
    - The display threshold is set to 3 as a default
    - Set it to any value >= 0
8. Start the exercise as a student
    - No hints should be shown just yet
9. Push a submission
10. Any hints with a threshold of 0 are available
11. Push more submissions
12. Hints should be available after their threshold was met 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
<img width="1089" alt="grafik" src="https://user-images.githubusercontent.com/18218285/174678956-f2222d14-75dc-4204-9e78-8f7cd16168c5.png">

