### PR TITLE
`General`: Fix page title service

### DIFF
--- a/src/main/webapp/app/core/language/language.helper.ts
+++ b/src/main/webapp/app/core/language/language.helper.ts
@@ -5,6 +5,7 @@ import { TranslateService } from '@ngx-translate/core';
 
 import { LANGUAGES } from './language.constants';
 import { BehaviorSubject, Observable } from 'rxjs';
+import { captureException } from '@sentry/browser';
 
 @Injectable({ providedIn: 'root' })
 export class JhiLanguageHelper {
@@ -29,11 +30,10 @@ export class JhiLanguageHelper {
     }
 
     /**
-     * Update the window title using params in the following
-     * order:
-     * 1. titleKey parameter
-     * 2. $state.$current.data.pageTitle (current state page title)
-     * 3. 'global.title'
+     * Update the window title using a value from the following order:
+     * 1. The function's titleKey parameter
+     * 2. The return value of {@link getPageTitle}, extracting it from the router state or a fallback value
+     * If the translation doesn't exist, a Sentry exception is thrown.
      */
     updateTitle(titleKey?: string) {
         if (!titleKey) {
@@ -41,7 +41,11 @@ export class JhiLanguageHelper {
         }
 
         this.translateService.get(titleKey).subscribe((title) => {
-            this.titleService.setTitle(title);
+            if (title) {
+                this.titleService.setTitle(title);
+            } else {
+                captureException(new Error(`Translation key '${titleKey}' for page title not found`));
+            }
         });
     }
 
@@ -53,8 +57,13 @@ export class JhiLanguageHelper {
         });
     }
 
-    private getPageTitle(routeSnapshot: ActivatedRouteSnapshot) {
-        let title: string = routeSnapshot.data && routeSnapshot.data['pageTitle'] ? routeSnapshot.data['pageTitle'] : 'artemisApp';
+    /**
+     * Get the current page's title key based on the router state.
+     * Fallback to 'global.title' when no key is found.
+     * @param routeSnapshot The snapshot of the current route
+     */
+    getPageTitle(routeSnapshot: ActivatedRouteSnapshot) {
+        let title: string = routeSnapshot.data && routeSnapshot.data['pageTitle'] ? routeSnapshot.data['pageTitle'] : 'global.title';
         if (routeSnapshot.firstChild) {
             title = this.getPageTitle(routeSnapshot.firstChild) || title;
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There was a long-existing error in Artemis, where the page title (e.g., the title displayed in your Browser's tab bar) sometimes flashed `[Object object]`. 
This often happened when refreshing the website or clicking on some deep links.

### Description
<!-- Describe your changes in detail -->

The core bug lived in the `language.helper.ts`, where the page title is extracted from the current route. If no title is found, a default value is used. This fallback was `artemisApp`, which is wrong as it does not exist. It should be `global.title`.
The translation service would return `[Object object]` for the key `artemisApp`, resulting in the described behavior.
To avoid this mistake in the future, I added Sentry to capture any missing translations for the page title.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student

1. Log in to Artemis
2. Browse different pages and verify the page title is displayed correctly.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
![recording2](https://user-images.githubusercontent.com/102237363/174961799-516979a6-9dd7-4620-b314-e3a9470eacb5.gif)