### PR TITLE
`Communication`: Enable save button when multi-line content is copied into new posts

### DIFF
--- a/src/main/webapp/app/shared/metis/metis.util.ts
+++ b/src/main/webapp/app/shared/metis/metis.util.ts
@@ -123,6 +123,12 @@ export type RouteComponents = (string | number)[];
 
 export const MetisWebsocketChannelPrefix = '/topic/metis/';
 
+/**
+ * whitespace accepted only together with a character excluding newline character
+ */
 export const PostTitleValidationPattern = Validators.pattern(/^(.)*\S+(.)*$/);
 
+/**
+ * whitespace accepted only together with a character including newline character
+ * */
 export const PostContentValidationPattern = Validators.pattern(/^(\n|\r|.)*\S+(\n|\r|.)*$/);

--- a/src/main/webapp/app/shared/metis/metis.util.ts
+++ b/src/main/webapp/app/shared/metis/metis.util.ts
@@ -123,6 +123,6 @@ export type RouteComponents = (string | number)[];
 
 export const MetisWebsocketChannelPrefix = '/topic/metis/';
 
-export const PostTitleValidationPattern = Validators.pattern(/^(\n|.)*\S+(\n|.)*$/);
+export const PostTitleValidationPattern = Validators.pattern(/^(.)*\S+(.)*$/);
 
 export const PostContentValidationPattern = Validators.pattern(/^(\n|\r|.)*\S+(\n|\r|.)*$/);

--- a/src/main/webapp/app/shared/metis/metis.util.ts
+++ b/src/main/webapp/app/shared/metis/metis.util.ts
@@ -1,3 +1,4 @@
+import { Validators } from '@angular/forms';
 import { Params } from '@angular/router';
 
 export enum PostingEditType {
@@ -33,8 +34,6 @@ export enum SortDirection {
 
 export enum PostSortCriterion {
     CREATION_DATE = 'CREATION_DATE',
-    VOTES = 'VOTES',
-    ANSWER_COUNT = 'ANSWER_COUNT',
 }
 
 export enum MetisPostAction {
@@ -123,3 +122,7 @@ export interface ContextInformation {
 export type RouteComponents = (string | number)[];
 
 export const MetisWebsocketChannelPrefix = '/topic/metis/';
+
+export const PostTitleValidationPattern = Validators.pattern(/^(\n|.)*\S+(\n|.)*$/);
+
+export const PostContentValidationPattern = Validators.pattern(/^(\n|\r|.)*\S+(\n|\r|.)*$/);

--- a/src/main/webapp/app/shared/metis/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.ts
@@ -42,7 +42,7 @@ export class AnswerPostCreateEditModalComponent extends PostingCreateEditModalDi
     resetFormGroup(): void {
         this.formGroup = this.formBuilder.group({
             // the pattern ensures that the content must include at least one non-whitespace character
-            content: [this.posting.content, [Validators.required, Validators.maxLength(this.maxContentLength), Validators.pattern(/^(\n|.)*\S+(\n|.)*$/)]],
+            content: [this.posting.content, [Validators.required, Validators.maxLength(this.maxContentLength), Validators.pattern(/^(\n|\r|.)*\S+(\n|\r|.)*$/)]],
         });
     }
 

--- a/src/main/webapp/app/shared/metis/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-create-edit-modal/answer-post-create-edit-modal/answer-post-create-edit-modal.component.ts
@@ -5,6 +5,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { MetisService } from 'app/shared/metis/metis.service';
 import { FormBuilder, Validators } from '@angular/forms';
 import { MarkdownEditorHeight } from 'app/shared/markdown-editor/markdown-editor.component';
+import { PostContentValidationPattern } from 'app/shared/metis/metis.util';
 
 @Component({
     selector: 'jhi-answer-post-create-edit-modal',
@@ -42,7 +43,7 @@ export class AnswerPostCreateEditModalComponent extends PostingCreateEditModalDi
     resetFormGroup(): void {
         this.formGroup = this.formBuilder.group({
             // the pattern ensures that the content must include at least one non-whitespace character
-            content: [this.posting.content, [Validators.required, Validators.maxLength(this.maxContentLength), Validators.pattern(/^(\n|\r|.)*\S+(\n|\r|.)*$/)]],
+            content: [this.posting.content, [Validators.required, Validators.maxLength(this.maxContentLength), PostContentValidationPattern]],
         });
     }
 

--- a/src/main/webapp/app/shared/metis/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.ts
@@ -7,10 +7,10 @@ import { FormBuilder, Validators } from '@angular/forms';
 import { Lecture } from 'app/entities/lecture.model';
 import { Exercise } from 'app/entities/exercise.model';
 import { Course } from 'app/entities/course.model';
-import { CourseWideContext, PageType, PostingEditType } from 'app/shared/metis/metis.util';
 import { debounceTime, distinctUntilChanged } from 'rxjs';
 import { Router } from '@angular/router';
 import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
+import { CourseWideContext, PageType, PostContentValidationPattern, PostingEditType, PostTitleValidationPattern } from 'app/shared/metis/metis.util';
 
 const TITLE_MAX_LENGTH = 200;
 const DEBOUNCE_TIME_BEFORE_SIMILARITY_CHECK = 800;
@@ -98,8 +98,8 @@ export class PostCreateEditModalComponent extends PostingCreateEditModalDirectiv
         this.resetCurrentContextSelectorOption();
         this.formGroup = this.formBuilder.group({
             // the pattern ensures that the title and content must include at least one non-whitespace character
-            title: [this.posting.title, [Validators.required, Validators.maxLength(TITLE_MAX_LENGTH), Validators.pattern(/^(\n|.)*\S+(\n|.)*$/)]],
-            content: [this.posting.content, [Validators.required, Validators.maxLength(this.maxContentLength), Validators.pattern(/^(\n|\r|.)*\S+(\n|\r|.)*$/)]],
+            title: [this.posting.title, [Validators.required, Validators.maxLength(TITLE_MAX_LENGTH), PostTitleValidationPattern]],
+            content: [this.posting.content, [Validators.required, Validators.maxLength(this.maxContentLength), PostContentValidationPattern]],
             context: [this.currentContextSelectorOption, [Validators.required]],
         });
         this.formGroup.controls['context'].valueChanges.subscribe((context: ContextSelectorOption) => {

--- a/src/main/webapp/app/shared/metis/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.ts
+++ b/src/main/webapp/app/shared/metis/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.ts
@@ -99,7 +99,7 @@ export class PostCreateEditModalComponent extends PostingCreateEditModalDirectiv
         this.formGroup = this.formBuilder.group({
             // the pattern ensures that the title and content must include at least one non-whitespace character
             title: [this.posting.title, [Validators.required, Validators.maxLength(TITLE_MAX_LENGTH), Validators.pattern(/^(\n|.)*\S+(\n|.)*$/)]],
-            content: [this.posting.content, [Validators.required, Validators.maxLength(this.maxContentLength), Validators.pattern(/^(\n|.)*\S+(\n|.)*$/)]],
+            content: [this.posting.content, [Validators.required, Validators.maxLength(this.maxContentLength), Validators.pattern(/^(\n|\r|.)*\S+(\n|\r|.)*$/)]],
             context: [this.currentContextSelectorOption, [Validators.required]],
         });
         this.formGroup.controls['context'].valueChanges.subscribe((context: ContextSelectorOption) => {


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Previously while using the Discussion page, users were not able to save posts when they pasted the content part instead of typing, due to the 'Save' button not being enabled. Fixes #5244.

### Description
<!-- Describe your changes in detail --> After some debugging, we realized that the issue is present because the Regex pattern that verifies the validity of posting contents was not handling the edge case when the pasted text included the 'Carriage Return Character (\r)'. With this PR, we make sure that content with this escape character is also accepted by the posting content validator.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Student
- 1 Course with Postings enabled

1. Log in to Artemis
2. Navigate to Course Discussion page
3. Create or edit a Posting
4. Copy multiple lines 
5. Paste into the context of the Posting
6. Make sure that the "Save" button is enabled and postings can be saved.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
Not changed.

### Screenshots
https://user-images.githubusercontent.com/67344158/175520057-ab06f6be-699e-4da8-91dc-6b32e208534d.mp4


