### PR TITLE
`Programming exercises`: Fix race condition on exercise detail page for instructors

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
@@ -120,10 +120,14 @@ export class ProgrammingExerciseDetailComponent implements OnInit, OnDestroy {
             this.courseId = this.isExamExercise ? this.programmingExercise.exerciseGroup!.exam!.course!.id! : this.programmingExercise.course!.id!;
             this.isAdmin = this.accountService.isAdmin();
 
-            const auxiliaryRepositories = this.programmingExercise.auxiliaryRepositories;
             this.programmingExerciseService.findWithTemplateAndSolutionParticipation(programmingExercise.id!, true).subscribe((updatedProgrammingExercise) => {
+                // Copy over previous information
+                const previousExercise = this.programmingExercise;
                 this.programmingExercise = updatedProgrammingExercise.body!;
-                this.programmingExercise.auxiliaryRepositories = auxiliaryRepositories;
+                this.programmingExercise.gitDiffReport = previousExercise.gitDiffReport;
+                this.programmingExercise.auxiliaryRepositories = previousExercise.auxiliaryRepositories;
+                this.programmingExercise.submissionPolicy = previousExercise.submissionPolicy;
+
                 // get the latest results for further processing
                 if (this.programmingExercise.templateParticipation) {
                     const latestTemplateResult = this.getLatestResult(this.programmingExercise.templateParticipation.submissions);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
While using Artemis I noticed that the git-diff statistics were not displayed at random times (for the same exercise).
Here it is not displayed:
<img width="401" alt="grafik" src="https://user-images.githubusercontent.com/18218285/175825692-e190823c-31a0-479a-b450-7c5842c27be5.png">

And here it is displayed:
<img width="403" alt="grafik" src="https://user-images.githubusercontent.com/18218285/175825701-07cf570a-ab2f-40fc-9e6e-1124940b38ff.png">


### Description
<!-- Describe your changes in detail -->
This was caused by the fact that the programming exercise got overridden by another REST request and the git-diff report was therefore deleted. 
This issue was previously fixed for auxiliary repositories by copying them from the old to the new programming exercise.
I applied this same mechanism to the git-diff report and also the submission policy, as the same problem can happen there as well.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Log in to Artemis
2. Navigate to the programming exercise detail page (for instructors)
3. The git-diff statistics are always visible even after refreshing the page multiple times

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| programming-exercise-detail.component.ts | 53% | 53% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
