### PR TITLE
`Exam mode`: Disable exam live statistics during the exam

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamMonitoringScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamMonitoringScheduleService.java
@@ -119,6 +119,16 @@ public class ExamMonitoringScheduleService {
     }
 
     /**
+     * Used to update monitoring during the exam.
+     *
+     * @param examId        identifies the cache
+     * @param monitoring    new exam action
+     */
+    public void notifyMonitoringUpdate(Long examId, boolean monitoring) {
+        messagingService.sendMessage("/topic/exam-monitoring/" + examId + "/update", monitoring);
+    }
+
+    /**
      * This method schedules all exam activity save tasks after a server (re-)start.
      */
     public void startSchedule() {

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -179,6 +179,11 @@ public class ExamResource {
 
         if (updatedExam.isMonitoring()) {
             examMonitoringScheduleService.scheduleExamActivitySave(result.getId());
+            examMonitoringScheduleService.notifyMonitoringUpdate(result.getId(), true);
+        }
+        else {
+            examMonitoringScheduleService.cancelExamActivitySave(result.getId());
+            examMonitoringScheduleService.notifyMonitoringUpdate(result.getId(), false);
         }
 
         // We can't test dates for equality as the dates retrieved from the database lose precision. Also use instant to take timezones into account

--- a/src/main/webapp/app/exam/monitoring/exam-monitoring-websocket.service.ts
+++ b/src/main/webapp/app/exam/monitoring/exam-monitoring-websocket.service.ts
@@ -7,6 +7,7 @@ import dayjs from 'dayjs/esm';
 import { ceilDayjsSeconds } from 'app/exam/monitoring/charts/monitoring-chart';
 
 const EXAM_MONITORING_TOPIC = (examId: number) => `/topic/exam-monitoring/${examId}/action`;
+const EXAM_MONITORING_STATUS_TOPIC = (examId: number) => `/topic/exam-monitoring/${examId}/update`;
 
 export interface IExamMonitoringWebsocketService {}
 
@@ -14,6 +15,8 @@ export interface IExamMonitoringWebsocketService {}
 export class ExamMonitoringWebsocketService implements IExamMonitoringWebsocketService {
     examActionObservables: Map<number, BehaviorSubject<ExamAction | undefined>> = new Map<number, BehaviorSubject<ExamAction | undefined>>();
     openExamMonitoringWebsocketSubscriptions: Map<number, string> = new Map<number, string>();
+    examMonitoringStatusObservables: Map<number, BehaviorSubject<boolean>> = new Map<number, BehaviorSubject<boolean>>();
+    openExamMonitoringStatusWebsocketSubscriptions: Map<number, string> = new Map<number, string>();
 
     constructor(private jhiWebsocketService: JhiWebsocketService) {}
 
@@ -70,6 +73,60 @@ export class ExamMonitoringWebsocketService implements IExamMonitoringWebsocketS
         const topic = EXAM_MONITORING_TOPIC(exam.id!);
         this.jhiWebsocketService.unsubscribe(topic);
         this.openExamMonitoringWebsocketSubscriptions.delete(exam.id!);
+    }
+
+    /**
+     * Notify all exam monitoring update subscribers with the newest exam monitoring status.
+     * @param exam received or updated exam
+     * @param status whether the monitoring is enabled or not
+     */
+    public notifyExamMonitoringUpdateSubscribers = (exam: Exam, status: boolean) => {
+        const examMonitoringStatusObservable = this.examMonitoringStatusObservables.get(exam.id!);
+        if (!examMonitoringStatusObservable) {
+            this.examMonitoringStatusObservables.set(exam.id!, new BehaviorSubject(status));
+        } else {
+            examMonitoringStatusObservable.next(status);
+        }
+    };
+
+    /**
+     * Checks if a websocket connection for the exam monitoring update to the server already exists.
+     * If not a new one will be opened.
+     *
+     */
+    private openExamMonitoringUpdateWebsocketSubscriptionIfNotExisting(exam: Exam) {
+        const topic = EXAM_MONITORING_STATUS_TOPIC(exam.id!);
+        this.openExamMonitoringStatusWebsocketSubscriptions.set(exam.id!, topic);
+
+        this.jhiWebsocketService.subscribe(topic);
+        this.jhiWebsocketService.receive(topic).subscribe((status: boolean) => this.notifyExamMonitoringUpdateSubscribers(exam, status));
+    }
+
+    /**
+     * Subscribing to the exam monitoring update.
+     *
+     * If there is no observable for the exam monitoring update a new one will be created.
+     *
+     * @param exam the exam to observe
+     */
+    public subscribeForExamMonitoringUpdate = (exam: Exam): BehaviorSubject<Boolean> => {
+        this.openExamMonitoringUpdateWebsocketSubscriptionIfNotExisting(exam);
+        let examMonitoringStatusObservable = this.examMonitoringStatusObservables.get(exam.id!)!;
+        if (!examMonitoringStatusObservable) {
+            examMonitoringStatusObservable = new BehaviorSubject<boolean>(exam.monitoring!);
+            this.examMonitoringStatusObservables.set(exam.id!, examMonitoringStatusObservable);
+        }
+        return examMonitoringStatusObservable;
+    };
+
+    /**
+     * Unsubscribe from the exam monitoring update.
+     * @param exam the exam to unsubscribe
+     * */
+    public unsubscribeForExamMonitoringUpdate(exam: Exam): void {
+        const topic = EXAM_MONITORING_STATUS_TOPIC(exam.id!);
+        this.jhiWebsocketService.unsubscribe(topic);
+        this.openExamMonitoringStatusWebsocketSubscriptions.delete(exam.id!);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Client
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

To disable the collection of exam statistics during the exam, the instructor can disable this feature again in the exam details configuration.

### Description
<!-- Describe your changes in detail -->

TODO

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Exam

1. Log in to Artemis
2. Create an Exam with exam live statistics enabled
3. Participate with the student
4. Verify that actions are collected (exam live statistics dashboard)
5. Disable exam live statistics in the exam configuration
6. Verify that the students client does not send any actions (view websocket connection)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
