### PR TITLE
`Communication`: Display spinner while loading posts on communication page

### DIFF
--- a/src/main/webapp/app/overview/course-discussion/course-discussion.component.html
+++ b/src/main/webapp/app/overview/course-discussion/course-discussion.component.html
@@ -145,9 +145,9 @@
         <div class="col-12" infinite-scroll (scrolled)="fetchNextPage()">
             <jhi-posting-thread *ngFor="let post of posts; trackBy: postsTrackByFn" [post]="post" [showAnswers]="posts.length === 1"></jhi-posting-thread>
         </div>
-        <!-- loading posts -->
-        <div *ngIf="isLoading" class="loading-notch">
-            <fa-icon size="3x" [icon]="faCircleNotch" [spin]="true"></fa-icon>
+        <!-- spinner while loading posts -->
+        <div class="text-center">
+            <div *ngIf="isLoading" class="spinner-border mt-3" role="status"></div>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/overview/course-discussion/course-discussion.component.html
+++ b/src/main/webapp/app/overview/course-discussion/course-discussion.component.html
@@ -145,5 +145,9 @@
         <div class="col-12" infinite-scroll (scrolled)="fetchNextPage()">
             <jhi-posting-thread *ngFor="let post of posts; trackBy: postsTrackByFn" [post]="post" [showAnswers]="posts.length === 1"></jhi-posting-thread>
         </div>
+        <!-- loading posts -->
+        <div *ngIf="isLoading" class="loading-notch">
+            <fa-icon size="3x" [icon]="faCircleNotch" [spin]="true"></fa-icon>
+        </div>
     </div>
 </div>

--- a/src/main/webapp/app/overview/course-discussion/course-discussion.component.scss
+++ b/src/main/webapp/app/overview/course-discussion/course-discussion.component.scss
@@ -12,11 +12,3 @@
 .course-discussion-select {
     background-color: var(--metis-course-discussion-select-bg);
 }
-
-.loading-notch {
-    text-align: center;
-    opacity: 0.75;
-    height: 350px;
-    padding-top: 100px;
-    padding-bottom: 100px;
-}

--- a/src/main/webapp/app/overview/course-discussion/course-discussion.component.scss
+++ b/src/main/webapp/app/overview/course-discussion/course-discussion.component.scss
@@ -12,3 +12,11 @@
 .course-discussion-select {
     background-color: var(--metis-course-discussion-select-bg);
 }
+
+.loading-notch {
+    text-align: center;
+    opacity: 0.75;
+    height: 350px;
+    padding-top: 100px;
+    padding-bottom: 100px;
+}

--- a/src/main/webapp/app/overview/course-discussion/course-discussion.component.ts
+++ b/src/main/webapp/app/overview/course-discussion/course-discussion.component.ts
@@ -12,7 +12,6 @@ import { HttpResponse } from '@angular/common/http';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
 import { CourseDiscussionDirective } from 'app/shared/metis/course-discussion.directive';
-import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
     selector: 'jhi-course-discussion',
@@ -36,9 +35,6 @@ export class CourseDiscussionComponent extends CourseDiscussionDirective impleme
     readonly pageType = PageType.OVERVIEW;
 
     private totalItemsSubscription: Subscription;
-
-    // Icons
-    faCircleNotch = faCircleNotch;
 
     constructor(
         protected metisService: MetisService,

--- a/src/main/webapp/app/overview/course-discussion/course-discussion.component.ts
+++ b/src/main/webapp/app/overview/course-discussion/course-discussion.component.ts
@@ -12,6 +12,7 @@ import { HttpResponse } from '@angular/common/http';
 import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
 import { CourseDiscussionDirective } from 'app/shared/metis/course-discussion.directive';
+import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
     selector: 'jhi-course-discussion',
@@ -35,6 +36,9 @@ export class CourseDiscussionComponent extends CourseDiscussionDirective impleme
     readonly pageType = PageType.OVERVIEW;
 
     private totalItemsSubscription: Subscription;
+
+    // Icons
+    faCircleNotch = faCircleNotch;
 
     constructor(
         protected metisService: MetisService,
@@ -240,6 +244,7 @@ export class CourseDiscussionComponent extends CourseDiscussionDirective impleme
      */
     fetchNextPage() {
         if (this.posts.length < this.totalItems) {
+            this.isLoading = true;
             this.page += 1;
             this.onSelectPage();
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
While the users scroll to the end of of posts on the course communication page, the next batch of posts are fetched and are then displayed in a short manner. However, during the short time when the data acquisition from the server happens, users cannot distinguish if there are more posts to fetch or not. This might lead to users thinking that no more posts exist besides the displayed ones.

### Description
To sensitize the user about the existence of more incoming posts, we display a spinner after the last post currently displayed. To increase the user experience, this spinner is displayed during the initial page load.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
-1 Students
-1 course with postings enabled and where exists more than 50 posts

1. Log in to Artemis
2. Navigate to Course Communication
3. Scroll to the end of the page and see the spinner.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
Not changed

### Screenshots
https://user-images.githubusercontent.com/67344158/177131164-3b829d7d-2034-44d5-9f73-46d2b4750732.mp4


