### PR TITLE
`General`: Remove exercise detail links for tutors

### DIFF
--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
@@ -45,10 +45,20 @@
             <tbody class="markdown-preview">
                 <tr *ngFor="let fileUploadExercise of filteredFileUploadExercises; trackBy: trackId">
                     <td>
-                        <a [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]">{{ fileUploadExercise.id }}</a>
+                        <a
+                            *ngIf="fileUploadExercise.isAtLeastEditor; else showId"
+                            [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]"
+                            >{{ fileUploadExercise.id }}</a
+                        >
+                        <ng-template #showId>{{ fileUploadExercise.id }}</ng-template>
                     </td>
                     <td>
-                        <a [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]">{{ fileUploadExercise.title }}</a>
+                        <a
+                            *ngIf="fileUploadExercise.isAtLeastEditor; else showTitle"
+                            [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]"
+                            >{{ fileUploadExercise.title }}</a
+                        >
+                        <ng-template #showTitle>{{ fileUploadExercise.title }}</ng-template>
                     </td>
                     <td>{{ fileUploadExercise.releaseDate | artemisDate }}</td>
                     <td>{{ fileUploadExercise.dueDate | artemisDate }}</td>

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise.component.html
@@ -45,19 +45,18 @@
             <tbody class="markdown-preview">
                 <tr *ngFor="let fileUploadExercise of filteredFileUploadExercises; trackBy: trackId">
                     <td>
-                        <a
-                            *ngIf="fileUploadExercise.isAtLeastEditor; else showId"
-                            [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]"
-                            >{{ fileUploadExercise.id }}</a
-                        >
+                        <a *ngIf="fileUploadExercise.isAtLeastEditor; else showId" [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]">
+                            {{ fileUploadExercise.id }}
+                        </a>
                         <ng-template #showId>{{ fileUploadExercise.id }}</ng-template>
                     </td>
                     <td>
                         <a
                             *ngIf="fileUploadExercise.isAtLeastEditor; else showTitle"
                             [routerLink]="['/course-management', courseId, 'file-upload-exercises', fileUploadExercise.id]"
-                            >{{ fileUploadExercise.title }}</a
                         >
+                            {{ fileUploadExercise.title }}
+                        </a>
                         <ng-template #showTitle>{{ fileUploadExercise.title }}</ng-template>
                     </td>
                     <td>{{ fileUploadExercise.releaseDate | artemisDate }}</td>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
@@ -57,16 +57,18 @@
                         <a
                             *ngIf="modelingExercise.isAtLeastEditor; else showId"
                             [routerLink]="['/course-management', modelingExercise.course?.id, 'modeling-exercises', modelingExercise.id]"
-                            >{{ modelingExercise.id }}</a
                         >
+                            {{ modelingExercise.id }}
+                        </a>
                         <ng-template #showId>{{ modelingExercise.id }}</ng-template>
                     </td>
                     <td id="modeling-exercise-{{ modelingExercise.id }}-title">
                         <a
                             *ngIf="modelingExercise.isAtLeastEditor; else showTitle"
                             [routerLink]="['/course-management', modelingExercise.course?.id, 'modeling-exercises', modelingExercise.id]"
-                            >{{ modelingExercise.title }}</a
                         >
+                            {{ modelingExercise.title }}
+                        </a>
                         <ng-template #showTitle>{{ modelingExercise.title }}</ng-template>
                     </td>
                     <td id="modeling-exercise-{{ modelingExercise.id }}-releaseDate">{{ modelingExercise.releaseDate | artemisDate }}</td>

--- a/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/modeling-exercise.component.html
@@ -54,10 +54,20 @@
             <tbody>
                 <tr *ngFor="let modelingExercise of filteredModelingExercises; trackBy: trackId" id="{{ 'exercise-card-' + modelingExercise.id }}">
                     <td>
-                        <a [routerLink]="['/course-management', modelingExercise.course?.id, 'modeling-exercises', modelingExercise.id]">{{ modelingExercise.id }}</a>
+                        <a
+                            *ngIf="modelingExercise.isAtLeastEditor; else showId"
+                            [routerLink]="['/course-management', modelingExercise.course?.id, 'modeling-exercises', modelingExercise.id]"
+                            >{{ modelingExercise.id }}</a
+                        >
+                        <ng-template #showId>{{ modelingExercise.id }}</ng-template>
                     </td>
                     <td id="modeling-exercise-{{ modelingExercise.id }}-title">
-                        <a [routerLink]="['/course-management', modelingExercise.course?.id, 'modeling-exercises', modelingExercise.id]">{{ modelingExercise.title }}</a>
+                        <a
+                            *ngIf="modelingExercise.isAtLeastEditor; else showTitle"
+                            [routerLink]="['/course-management', modelingExercise.course?.id, 'modeling-exercises', modelingExercise.id]"
+                            >{{ modelingExercise.title }}</a
+                        >
+                        <ng-template #showTitle>{{ modelingExercise.title }}</ng-template>
                     </td>
                     <td id="modeling-exercise-{{ modelingExercise.id }}-releaseDate">{{ modelingExercise.releaseDate | artemisDate }}</td>
                     <td id="modeling-exercise-{{ modelingExercise.id }}-dueDate">{{ modelingExercise.dueDate | artemisDate }}</td>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -77,10 +77,20 @@
                         />
                     </td>
                     <td class="d-md-table-cell">
-                        <a [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]">{{ programmingExercise.id }}</a>
+                        <a
+                            *ngIf="programmingExercise.isAtLeastEditor; else showId"
+                            [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]"
+                            >{{ programmingExercise.id }}</a
+                        >
+                        <ng-template #showId>{{ programmingExercise.id }}</ng-template>
                     </td>
                     <td>
-                        <a [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]">{{ programmingExercise.title }}</a>
+                        <a
+                            *ngIf="programmingExercise.isAtLeastEditor; else showTitle"
+                            [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]"
+                            >{{ programmingExercise.title }}</a
+                        >
+                        <ng-template #showTitle>{{ programmingExercise.title }}</ng-template>
                         <jhi-programming-exercise-grading-dirty-warning
                             class="ms-2"
                             [programmingExerciseId]="programmingExercise.id!"

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise.component.html
@@ -80,16 +80,18 @@
                         <a
                             *ngIf="programmingExercise.isAtLeastEditor; else showId"
                             [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]"
-                            >{{ programmingExercise.id }}</a
                         >
+                            {{ programmingExercise.id }}
+                        </a>
                         <ng-template #showId>{{ programmingExercise.id }}</ng-template>
                     </td>
                     <td>
                         <a
                             *ngIf="programmingExercise.isAtLeastEditor; else showTitle"
                             [routerLink]="['/course-management', courseId, 'programming-exercises', programmingExercise.id]"
-                            >{{ programmingExercise.title }}</a
                         >
+                            {{ programmingExercise.title }}
+                        </a>
                         <ng-template #showTitle>{{ programmingExercise.title }}</ng-template>
                         <jhi-programming-exercise-grading-dirty-warning
                             class="ms-2"

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise.component.html
@@ -64,10 +64,10 @@
                 <tr *ngFor="let quizExercise of filteredQuizExercises; trackBy: trackId" id="exercise-card-{{ quizExercise.id }}">
                     <td *ngIf="!quizIsOver(quizExercise) || !quizExercise.isAtLeastEditor">
                         <a
-                            *ngIf="quizExercise.status !== QuizStatus.ACTIVE; else readOnlyId"
+                            *ngIf="quizExercise.status !== QuizStatus.ACTIVE && quizExercise.isAtLeastEditor; else readOnlyId"
                             [routerLink]="['/course-management', quizExercise.course?.id, 'quiz-exercises', quizExercise.id, 'edit']"
-                            >{{ quizExercise.id }}</a
-                        >
+                            >{{ quizExercise.id }}
+                        </a>
                         <ng-template #readOnlyId>{{ quizExercise.id }}</ng-template>
                     </td>
                     <td *ngIf="quizIsOver(quizExercise) && quizExercise.isAtLeastEditor">

--- a/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.html
+++ b/src/main/webapp/app/exercises/text/manage/text-exercise/text-exercise.component.html
@@ -53,10 +53,16 @@
             <tbody class="markdown-preview">
                 <tr *ngFor="let textExercise of filteredTextExercises; trackBy: trackId" id="exercise-card-{{ textExercise.id }}">
                     <td>
-                        <a [routerLink]="['/course-management', course.id, 'text-exercises', textExercise.id]">{{ textExercise.id }}</a>
+                        <a *ngIf="textExercise.isAtLeastEditor; else showId" [routerLink]="['/course-management', course.id, 'text-exercises', textExercise.id]">{{
+                            textExercise.id
+                        }}</a>
+                        <ng-template #showId>{{ textExercise.id }}</ng-template>
                     </td>
                     <td>
-                        <a [routerLink]="['/course-management', course.id, 'text-exercises', textExercise.id]">{{ textExercise.title }}</a>
+                        <a *ngIf="textExercise.isAtLeastEditor; else showTitle" [routerLink]="['/course-management', course.id, 'text-exercises', textExercise.id]">{{
+                            textExercise.title
+                        }}</a>
+                        <ng-template #showTitle>{{ textExercise.title }}</ng-template>
                     </td>
                     <td>{{ textExercise.releaseDate | artemisDate }}</td>
                     <td>{{ textExercise.dueDate | artemisDate }}</td>


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
@julian-christl noticed that tutors see links to the exercise detail page and for quizzes even for the edit page. Both pages are not supposed to be accessible for tutors, if you click on the link an error gets shown:
![grafik](https://user-images.githubusercontent.com/26540346/177496467-af71f552-6900-4940-8476-0276e124e10d.png)


### Description
I removed the link for tutors, showing only the id and title in text.

### Steps for Testing
Prerequisites:
- 1 Editor / Instructor
- 1 Tutor
- 1 Exercise of each type

1. Navigate to the exercise overview
2. Check that tutors don't see a link to the detail page at the id and title.
3. Check that the editor / instructor sees the links and that they work.

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
old / unchanged for editors:
![grafik](https://user-images.githubusercontent.com/26540346/177497100-874601f8-8b8b-4f5d-9283-5865fc26fe4e.png)


new for tutors:
![grafik](https://user-images.githubusercontent.com/26540346/177497161-a797680a-a173-4d85-b0d1-e8ea726f6626.png)

