### PR TITLE
`General`: Fix notification line breaks

### DIFF
--- a/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.component.html
+++ b/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.component.html
@@ -47,11 +47,11 @@
             </div>
             <div class="notification-item p-3" *ngFor="let notification of sortedNotifications" (click)="startNotification(notification)">
                 <div>
-                    <h5 class="fw-medium">
+                    <h5 class="fw-medium notification-title">
                         {{ notification.title }}
                         <span class="badge ms-1 bg-primary" *ngIf="lastNotificationRead && notification.notificationDate?.isAfter(lastNotificationRead)"> new </span>
                     </h5>
-                    <div class="mb-1 text-break" [innerHTML]="notification.text"></div>
+                    <div class="mb-1 text-break notification-text" [innerHTML]="notification.text"></div>
                     <div class="info text-muted text-end">
                         {{ notification.notificationDate?.toDate() | date: 'dd.MM.yy HH:mm' }}
                         {{ 'artemisApp.notification.by' | artemisTranslate }}

--- a/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.scss
+++ b/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.scss
@@ -50,7 +50,7 @@
             &:hover {
                 background-color: var(--notification-sb-hover-child-bg);
             }
-            h5 {
+            .notification-title {
                 font-size: 1rem;
             }
             .info {

--- a/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.scss
+++ b/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.scss
@@ -56,6 +56,10 @@
             .info {
                 font-size: 0.8rem;
             }
+            .notification-title,
+            .notification-text {
+                white-space: normal;
+            }
         }
     }
     .no-notifications {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

A change in the past accidentally prevented line-breaks in notification title and content.
Closes #5262.

### Description
<!-- Describe your changes in detail -->

Added CSS to re-enable line breaks in notification title and content.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 User with some long notifications (or use dev tools to edit the text of a short notification to something long)

1. Check that long notification titles or texts wrap correctly and do not break out of their parent container.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:

![grafik](https://user-images.githubusercontent.com/23171488/177523439-04e62de7-be33-4cc3-a8d8-5e40fcbf7031.png)

After:

![Screenshot 2022-07-06 at 11 48 33](https://user-images.githubusercontent.com/23171488/177523808-e6d29164-cf91-4c78-82f1-6cc2ef2d3129.png)
