### PR TITLE
Bugfix/make exercise editor read only

### DIFF
--- a/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.html
+++ b/src/main/webapp/app/exercises/file-upload/participate/file-upload-submission.component.html
@@ -4,6 +4,7 @@
     </span>
     <jhi-button
         submitbutton
+        *ngIf="isOwnerOfParticipation"
         [disabled]="(!isActive && !isLate) || !submission || !submissionFile || !!result"
         [title]="!isLate ? 'entity.action.submit' : 'entity.action.submitDeadlineMissed'"
         (onClick)="submitExercise()"
@@ -18,7 +19,7 @@
     <!--region Left Panel-->
     <div left-body class="px-2 pb-2 w-100">
         <div class="row">
-            <div class="col-12 col-md-6" *ngIf="(isActive || isLate) && !result && fileUploadExercise && submission">
+            <div class="col-12 col-md-6" *ngIf="(isActive || isLate) && !result && fileUploadExercise && submission && isOwnerOfParticipation">
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="artemisApp.fileUploadSubmission.selectFile">Please select </label>
                     <div class="input-group background-file">

--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.html
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.html
@@ -6,6 +6,7 @@
         submitbutton
         class="guided-tour submission-button"
         id="submit-modeling-submission"
+        *ngIf="isOwnerOfParticipation"
         [disabled]="(!isActive && !isLate) || !submission || !!result || (isLate && !!submission.submitted)"
         [title]="!isLate ? 'entity.action.submit' : 'entity.action.submitDeadlineMissed'"
         (onClick)="submit()"
@@ -33,6 +34,7 @@
             <div class="row flex-grow-1">
                 <div *ngIf="submission && (isActive || isLate) && !result && (!isLate || !submission.submitted)" class="col-12 editor-large">
                     <jhi-modeling-editor
+                        [readOnly]="!isOwnerOfParticipation"
                         [umlModel]="umlModel"
                         [diagramType]="modelingExercise.diagramType!"
                         [withExplanation]="true"

--- a/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
+++ b/src/main/webapp/app/exercises/modeling/participate/modeling-submission.component.ts
@@ -19,7 +19,7 @@ import { ApollonDiagramService } from 'app/exercises/quiz/manage/apollon-diagram
 import { hasExerciseDueDatePassed, participationStatus } from 'app/exercises/shared/exercise/exercise.utils';
 import { addParticipationToResult, getUnreferencedFeedback } from 'app/exercises/shared/result/result.utils';
 import { ResultService } from 'app/exercises/shared/result/result.service';
-import { TextEditorService } from 'app/exercises/text/participate/text-editor.service';
+import { AccountService } from 'app/core/auth/account.service';
 import { GuidedTourService } from 'app/guided-tour/guided-tour.service';
 import { modelingTour } from 'app/guided-tour/tours/modeling-tour';
 import { ParticipationWebsocketService } from 'app/overview/participation-websocket.service';
@@ -54,6 +54,8 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
     private resultUpdateListener: Subscription;
 
     participation: StudentParticipation;
+    isOwnerOfParticipation: boolean;
+
     modelingExercise: ModelingExercise;
     course?: Course;
     result?: Result;
@@ -112,7 +114,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
         private router: Router,
         private participationWebsocketService: ParticipationWebsocketService,
         private guidedTourService: GuidedTourService,
-        private textService: TextEditorService,
+        private accountService: AccountService,
     ) {
         this.isSaving = false;
         this.autoSaveTimer = 0;
@@ -155,6 +157,7 @@ export class ModelingSubmissionComponent implements OnInit, OnDestroy, Component
             modelingSubmission.participation!.results = [getLatestSubmissionResult(modelingSubmission)!];
         }
         this.participation = modelingSubmission.participation as StudentParticipation;
+        this.isOwnerOfParticipation = this.accountService.isOwnerOfParticipation(this.participation);
 
         // reconnect participation <--> submission
         this.participation.submissions = [<ModelingSubmission>omit(modelingSubmission, 'participation')];

--- a/src/main/webapp/app/exercises/text/participate/text-editor.component.html
+++ b/src/main/webapp/app/exercises/text/participate/text-editor.component.html
@@ -45,7 +45,7 @@
                     #textEditor
                     class="text-editor-textarea"
                     [(ngModel)]="answer"
-                    [readonly]="!isActive || !submission"
+                    [readonly]="!isActive || !submission || !isOwnerOfParticipation"
                     [disabled]="!isActive || !submission"
                     (keydown.tab)="onTextEditorTab(textEditor, $event)"
                     (input)="onTextEditorInput($event)"


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [ ] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [ ] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context

When tutors/instructors/admins access the route of an exercise (to which they have access), they would still see the `Submit` button enabled and the text-editor/modeling-editor wouldn't be read-only, as well as the `Upload file` button. This wasn't intented since the only the actual user who is participating in the exercise can edit/submit the participation.

### Description

Makes the editors read-only and hides the `Submit` for text, modeling and file-upload exercises. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor/Tutor/Admin
- 1 Student

1. Log in to Artemis as as student
2. Do steps 3 and 4 for Text, Modeling and File Upload exercises
3. Go to the exercise participation route
4. Verify that the editors can be used (aren't read-only) and that the Submit button is visible

1. Log in to Artemis as an instructor/tutor/admin
2. Do steps 3 and 4 for Text, Modeling and File Upload exercises
4. Go to the exercise participation route
5. Verify that the editors are read only and that the Submit button isn't visible

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
