### PR TITLE
`Assessment`: Fix an issue that prevented assessing empty modeling submissions

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/compass/CompassService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/compass/CompassService.java
@@ -89,6 +89,13 @@ public class CompassService {
             List<Feedback> feedbacksForSuggestion = new ArrayList<>();
             ModelClusterFactory clusterBuilder = new ModelClusterFactory();
             List<UMLElement> elements = clusterBuilder.getModelElements(modelingSubmission);
+
+            // elements can be null if the modeling submission does not contain a model
+            // this can happen for empty submissions in exams
+            if (elements == null) {
+                return null;
+            }
+
             List<ModelElement> modelElements = modelElementRepository.findByModelElementIdIn(elements.stream().map(UMLElement::getJSONElementID).collect(Collectors.toList()));
             List<Long> clusterIds = modelElements.stream().map(ModelElement::getCluster).map(ModelCluster::getId).collect(Collectors.toList());
             List<ModelCluster> modelClusters = modelClusterRepository.findAllByIdInWithEagerElements(clusterIds);

--- a/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
+++ b/src/main/webapp/app/exercises/modeling/assess/modeling-assessment-editor/modeling-assessment-editor.component.ts
@@ -187,7 +187,7 @@ export class ModelingAssessmentEditorComponent implements OnInit {
             this.model = JSON.parse(this.submission.model);
         } else {
             this.alertService.closeAll();
-            this.alertService.error('modelingAssessmentEditor.messages.noModel');
+            this.alertService.warning('modelingAssessmentEditor.messages.noModel');
         }
         if ((!this.result?.assessor || this.result.assessor.id === this.userId) && !this.result?.completionDate) {
             this.alertService.closeAll();

--- a/src/main/webapp/i18n/de/modelingAssessmentEditor.json
+++ b/src/main/webapp/i18n/de/modelingAssessmentEditor.json
@@ -10,7 +10,7 @@
         },
         "messages": {
             "lock": "Dieses Modell kann jetzt exklusiv nur noch von dir bearbeitet werden. Bitte bewerte dieses Modell bevor du ein neues öffnest.",
-            "noModel": "Kein Modell für Abgabe gefunden.",
+            "noModel": "Diese Abgabe enthält kein Modell.",
             "loadSubmissionFailed": "Laden der angefragten Abgabe ist fehlgeschlagen.",
             "saveSuccessful": "Deine Bewertung wurde erfolgreich gespeichert!",
             "saveFailed": "Das Speichern deiner Bewertung ist fehlgeschlagen!",

--- a/src/main/webapp/i18n/en/modelingAssessmentEditor.json
+++ b/src/main/webapp/i18n/en/modelingAssessmentEditor.json
@@ -10,7 +10,7 @@
         },
         "messages": {
             "lock": "You now have the lock on this submission. Only you can assess this model. Please assess this model before opening other submissions.",
-            "noModel": "No model could be found for this submission.",
+            "noModel": "This submission does not contain a model.",
             "loadSubmissionFailed": "Retrieving requested submission failed.",
             "saveSuccessful": "Your assessment was saved successfully!",
             "saveFailed": "Saving your assessment failed!",

--- a/src/test/java/de/tum/in/www1/artemis/ModelingAssessmentIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ModelingAssessmentIntegrationTest.java
@@ -481,6 +481,24 @@ public class ModelingAssessmentIntegrationTest extends AbstractSpringIntegration
         assertThat(automaticResult).as("automatic result is not created").isNull();
     }
 
+    /**
+     * Tests that a submission without model (can happen for exam submissions) does not throw an exception and does
+     * not create an automatic result.
+     * @throws Exception any exception in the test
+     */
+    @Test
+    @WithMockUser(username = "student2")
+    public void testAutomaticAssessmentUponModelSubmission_emptyModel() throws Exception {
+        database.createAndSaveParticipationForExercise(classExercise, "student2");
+
+        ModelingSubmission submission = ModelFactory.generateModelingSubmission(null, true);
+        ModelingSubmission storedSubmission = request.postWithResponseBody("/api/exercises/" + classExercise.getId() + "/modeling-submissions", submission,
+                ModelingSubmission.class, HttpStatus.OK);
+
+        Result automaticResult = compassService.getSuggestionResult(storedSubmission, classExercise);
+        assertThat(automaticResult).as("automatic result is not created").isNull();
+    }
+
     @Test
     @WithMockUser(username = "student2")
     public void testAutomaticAssessmentUponModelSubmission_activityDiagram_identicalModel() throws Exception {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

During the last [exam testing session](https://confluence.ase.in.tum.de/display/ArTEMiS/Testing+Session+11.07.2022) there was an issue when trying to assess empty modeling submissions. The server returned an internal error as it tried to suggest feedback items for a model that didn't exist.

![Screenshot 2022-07-14 at 14 09 05](https://user-images.githubusercontent.com/23171488/178981041-85e645e9-ec1f-4bdf-b0df-4695e1537179.png)

In general, this only happens if the Instructors do not use the button to set empty modeling exercises to zero points in advance, as they don't show up in open assessments then:

![Screenshot 2022-07-14 at 14 25 44](https://user-images.githubusercontent.com/23171488/178981927-06d9a009-9fbf-479b-af16-f0c644df7b5d.png)
![Screenshot 2022-07-14 at 14 25 20](https://user-images.githubusercontent.com/23171488/178981933-10eb0322-1a3d-482e-9c1b-1418ef0ae9d9.png)


### Description
<!-- Describe your changes in detail -->

- Added a null check to cancel the operation in ``CompassService#getSuggestionResult`` early when there is no model in the submission.
- Updated the wording of the alert about this and lowered the level from error to warning as this isn't necessarily an error - the student just didn't add a model

![Screenshot 2022-07-14 at 14 19 30](https://user-images.githubusercontent.com/23171488/178985498-2bc02871-514e-4c11-988f-21d4c8dd3188.png)


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 3 Students
- 1 Exam with a modeling exercise

1. Let the students participate:
Student 1: Start the exam, add a solution to the modeling exercise, save, hand in
Student 2: Start the exam, do not even open the modeling exercise, hand in
Student 3: Start the exam, do not hand in (let the time run out)

2. After the exam ended, try to assess the participatios as instructor.
3. On the submitted exam of student 2, you should get a warning that the submission is empty (no model), but not get an error and be able to add feedback as normal.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| CompassService.java | 57% | 93%% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
