### PR TITLE
`Quiz exercises`: Fix text overflow in short answer quiz questions

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.scss
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.scss
@@ -6,6 +6,7 @@
     padding: 20px;
     position: relative;
     width: 100%;
+    word-break: break-word;
 
     .short-answer-question-display {
         display: flex;


### PR DESCRIPTION
### Checklist
#### General
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context

Credit to https://github.com/ls1intum/Artemis/pull/5049

Close #4721 

### Description

Add break-word to short answer question

### Steps for Testing

- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration and to course page
3. Create quiz exercise with a short answer question
4. Add for example the string "hsakjdflahsdfjhasdhadfsahsakjdflahsdfjhasdhadfsahsakjdflahsdfjhasdhadfsahsakjdflahsdfjhasdhadfsahsakjdflahsdfjhasdhadfsahsakjdflahsdfjhasdhadfasdfasdfsahsakjdflahsdfjhasdhadfsahsakjdflahsdfjhasdhadfsa" to the content of the short answer question
5. Save the quiz
6. Go to the "Preview Quiz"
7. Check that the content of the question doesn't overflow 

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/11006274/179287660-0b0de0f9-1712-48e8-8ec6-c32325f9d6de.png)


#### After

![image](https://user-images.githubusercontent.com/11006274/179287743-36bf9ed2-d585-4085-acd4-0adf9e56adca.png)
