### PR TITLE
`Development`: Increase heap size for client-style Github action to 3GB

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,8 @@ jobs:
   client-style:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+        NODE_OPTIONS: '--max_old_space_size=3072'
     steps:
     - uses: actions/checkout@v3
     - name: Setup Node.js


### PR DESCRIPTION
### Motivation and Context
The client-style GitHub action is flaky as can be seen by the latest commit history on `develop`. The issue seems to be related to the too small heap size.

### Description
This PR increases the heap size from the standard 1.7GB to 3GB.