### PR TITLE
`Programming exercises`: Disable changing option to record coverage when editing programming exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -314,6 +314,9 @@ public class ProgrammingExerciseResource {
         if (programmingExerciseBeforeUpdate.isStaticCodeAnalysisEnabled() != updatedProgrammingExercise.isStaticCodeAnalysisEnabled()) {
             throw new BadRequestAlertException("Static code analysis enabled flag must not be changed", ENTITY_NAME, "staticCodeAnalysisCannotChange");
         }
+        if (programmingExerciseBeforeUpdate.isTestwiseCoverageEnabled() != updatedProgrammingExercise.isTestwiseCoverageEnabled()) {
+            throw new BadRequestAlertException("Testwise coverage enabled flag must not be changed", ENTITY_NAME, "testwiseCoverageCannotChange");
+        }
         if (!Boolean.TRUE.equals(updatedProgrammingExercise.isAllowOnlineEditor()) && !Boolean.TRUE.equals(updatedProgrammingExercise.isAllowOfflineIde())) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createAlert(applicationName,
                     "You need to allow at least one participation mode, the online editor or the offline IDE", "noParticipationModeAllowed")).body(null);

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -513,7 +513,7 @@
                         type="checkbox"
                         name="testwiseCoverageEnabled"
                         id="field_testwiseCoverageEnabled"
-                        [disabled]="!!programmingExercise.sequentialTestRuns"
+                        [disabled]="!!programmingExercise.sequentialTestRuns || programmingExercise.id"
                         [(ngModel)]="programmingExercise.testwiseCoverageEnabled"
                         checked
                     />

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -513,7 +513,7 @@
                         type="checkbox"
                         name="testwiseCoverageEnabled"
                         id="field_testwiseCoverageEnabled"
-                        [disabled]="!!programmingExercise.sequentialTestRuns || programmingExercise.id"
+                        [disabled]="!!programmingExercise.sequentialTestRuns || !!programmingExercise?.id"
                         [(ngModel)]="programmingExercise.testwiseCoverageEnabled"
                         checked
                     />

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -513,7 +513,7 @@
                         type="checkbox"
                         name="testwiseCoverageEnabled"
                         id="field_testwiseCoverageEnabled"
-                        [disabled]="!!programmingExercise.sequentialTestRuns || !!programmingExercise?.id"
+                        [disabled]="!!programmingExercise.sequentialTestRuns || !!programmingExercise.id"
                         [(ngModel)]="programmingExercise.testwiseCoverageEnabled"
                         checked
                     />

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationBambooBitbucketJiraTest.java
@@ -260,6 +260,18 @@ class ProgrammingExerciseIntegrationBambooBitbucketJiraTest extends AbstractSpri
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void updateProgrammingExercise_updatingSCAEnabledOption_badRequest() throws Exception {
+        programmingExerciseIntegrationTestService.updateProgrammingExerciseShouldFailWithBadRequestWhenUpdatingSCAOption();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void updateProgrammingExercise_updatingCoverageOption_badRequest() throws Exception {
+        programmingExerciseIntegrationTestService.updateProgrammingExerciseShouldFailWithBadRequestWhenUpdatingCoverageOption();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateExerciseDueDateWithIndividualDueDateUpdate() throws Exception {
         programmingExerciseIntegrationTestService.updateExerciseDueDateWithIndividualDueDateUpdate();
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationJenkinsGitlabTest.java
@@ -313,6 +313,18 @@ public class ProgrammingExerciseIntegrationJenkinsGitlabTest extends AbstractSpr
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void updateProgrammingExercise_updatingSCAEnabledOption_badRequest() throws Exception {
+        programmingExerciseIntegrationTestService.updateProgrammingExerciseShouldFailWithBadRequestWhenUpdatingSCAOption();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
+    public void updateProgrammingExercise_updatingCoverageOption_badRequest() throws Exception {
+        programmingExerciseIntegrationTestService.updateProgrammingExerciseShouldFailWithBadRequestWhenUpdatingCoverageOption();
+    }
+
+    @Test
+    @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     public void updateExerciseDueDateWithIndividualDueDateUpdate() throws Exception {
         programmingExerciseIntegrationTestService.updateExerciseDueDateWithIndividualDueDateUpdate();
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseIntegrationTestService.java
@@ -770,6 +770,30 @@ public class ProgrammingExerciseIntegrationTestService {
         request.put(ROOT + PROGRAMMING_EXERCISES, newProgrammingExercise, HttpStatus.CONFLICT);
     }
 
+    /**
+     * This test checks that it is not allowed to change SCA enabled option
+     */
+    public void updateProgrammingExerciseShouldFailWithBadRequestWhenUpdatingSCAOption() throws Exception {
+        mockBuildPlanAndRepositoryCheck(programmingExercise);
+
+        ProgrammingExercise updatedExercise = programmingExercise;
+        updatedExercise.setStaticCodeAnalysisEnabled(true);
+
+        request.put(ROOT + PROGRAMMING_EXERCISES, updatedExercise, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * This test checks that it is not allowed to change coverage enabled option
+     */
+    public void updateProgrammingExerciseShouldFailWithBadRequestWhenUpdatingCoverageOption() throws Exception {
+        mockBuildPlanAndRepositoryCheck(programmingExercise);
+
+        ProgrammingExercise updatedExercise = programmingExercise;
+        updatedExercise.setTestwiseCoverageEnabled(true);
+
+        request.put(ROOT + PROGRAMMING_EXERCISES, updatedExercise, HttpStatus.BAD_REQUEST);
+    }
+
     public void updateExerciseDueDateWithIndividualDueDateUpdate() throws Exception {
         mockBuildPlanAndRepositoryCheck(programmingExercise);
 

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-update.component.spec.ts
@@ -50,6 +50,7 @@ import { LockRepositoryPolicy, SubmissionPenaltyPolicy } from 'app/entities/subm
 import { OwlDateTimeModule } from '@danielmoncada/angular-datetime-picker';
 import '@angular/localize/init';
 import { ModePickerComponent } from 'app/exercises/shared/mode-picker/mode-picker.component';
+import { By } from '@angular/platform-browser';
 
 describe('ProgrammingExercise Management Update Component', () => {
     const courseId = 1;
@@ -683,8 +684,37 @@ describe('ProgrammingExercise Management Update Component', () => {
             }
         });
     });
-});
 
+    it('should disable checkboxes for certain options of existing exercise', fakeAsync(() => {
+        // can be removed after https://github.com/ls1intum/Artemis/pull/5238 has been merged
+        comp.isBamboo = true;
+
+        const entity = new ProgrammingExercise(new Course(), undefined);
+        entity.id = 123;
+        comp.programmingExercise = entity;
+        comp.programmingExercise.course = course;
+        comp.programmingExercise.programmingLanguage = ProgrammingLanguage.JAVA;
+
+        const route = TestBed.inject(ActivatedRoute);
+        route.params = of({ courseId });
+        route.url = of([{ path: 'edit' } as UrlSegment]);
+        route.data = of({ programmingExercise: entity });
+
+        const getFeaturesStub = jest.spyOn(programmingExerciseFeatureService, 'getProgrammingLanguageFeature');
+        getFeaturesStub.mockImplementation((language: ProgrammingLanguage) => getProgrammingLanguageFeature(language));
+
+        fixture.detectChanges();
+        tick();
+
+        const scaCheckbox = debugElement.query(By.css('#field_staticCodeAnalysisEnabled'));
+        expect(scaCheckbox).toBeTruthy();
+        expect(scaCheckbox.nativeElement.disabled).toBeTrue();
+
+        const coverageCheckbox = debugElement.query(By.css('#field_testwiseCoverageEnabled'));
+        expect(coverageCheckbox).toBeTruthy();
+        expect(coverageCheckbox.nativeElement.disabled).toBeTrue();
+    }));
+});
 const getProgrammingLanguageFeature = (programmingLanguage: ProgrammingLanguage) => {
     switch (programmingLanguage) {
         case ProgrammingLanguage.SWIFT:


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.

### Motivation and Context
The option to record the coverage could be selected/unselected for existing programming exercises. Since this option requires additional options/dependencies in the build configuration file, this should not be changeable for existing exercises.

### Description
With these changes, the option is not changeable for already existing exercises (that have an id).

### Steps for Testing
Prerequisites:
- 1 Instructor on TS with Atlassian Stack (TS0, TS1, TS3, TS5)

1. Create a new Java programming exercise with the option to "Record testwise coverage" (right at the bottom)
2. Wait until the exercise has been created
3. Edit the exercise and make sure that you cannot change the selection of the option to "Record testwise coverage"

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
_no changes_
