### PR TITLE
`Exam mode`: Fix saving exam when hand in early is clicked

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -13,6 +13,7 @@ import { map } from 'rxjs/operators';
 import { CodeEditorConflictStateService } from 'app/exercises/programming/shared/code-editor/service/code-editor-conflict-state.service';
 import { ExamSession } from 'app/entities/exam-session.model';
 import { faBars, faCheck, faEdit } from '@fortawesome/free-solid-svg-icons';
+import { ArtemisServerDateService } from 'app/shared/server-date.service';
 
 @Component({
     selector: 'jhi-exam-navigation-bar',
@@ -25,7 +26,7 @@ export class ExamNavigationBarComponent implements OnInit {
     @Input() endDate: dayjs.Dayjs;
     @Input() overviewPageOpen: boolean;
     @Input() examSessions?: ExamSession[] = [];
-    @Output() onPageChanged = new EventEmitter<{ overViewChange: boolean; exercise?: Exercise; forceSave: boolean }>();
+    @Output() onPageChanged = new EventEmitter<{ overViewChange: boolean; exercise?: Exercise; forceSave: boolean; timestamp?: dayjs.Dayjs }>();
     @Output() examAboutToEnd = new EventEmitter<void>();
     @Output() onExamHandInEarly = new EventEmitter<void>();
 
@@ -48,6 +49,7 @@ export class ExamNavigationBarComponent implements OnInit {
         private examExerciseUpdateService: ExamExerciseUpdateService,
         private repositoryService: CodeEditorRepositoryService,
         private conflictService: CodeEditorConflictStateService,
+        private serverDateService: ArtemisServerDateService,
     ) {}
 
     ngOnInit(): void {
@@ -106,6 +108,7 @@ export class ExamNavigationBarComponent implements OnInit {
      * @param forceSave: true if forceSave shall be used.
      */
     changePage(overviewPage: boolean, exerciseIndex: number, forceSave?: boolean): void {
+        const timestamp = this.serverDateService.now();
         if (!overviewPage) {
             // out of index -> do nothing
             if (exerciseIndex > this.exercises.length - 1 || exerciseIndex < 0) {
@@ -113,12 +116,12 @@ export class ExamNavigationBarComponent implements OnInit {
             }
             // set index and emit event
             this.exerciseIndex = exerciseIndex;
-            this.onPageChanged.emit({ overViewChange: false, exercise: this.exercises[this.exerciseIndex], forceSave: !!forceSave });
+            this.onPageChanged.emit({ overViewChange: false, exercise: this.exercises[this.exerciseIndex], forceSave: !!forceSave, timestamp });
         } else if (overviewPage) {
             // set index and emit event
             this.exerciseIndex = -1;
             // save current exercise
-            this.onPageChanged.emit({ overViewChange: true, exercise: undefined, forceSave: false });
+            this.onPageChanged.emit({ overViewChange: true, exercise: undefined, forceSave: false, timestamp });
         }
         this.setExerciseButtonStatus(this.exerciseIndex);
     }

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -137,18 +137,19 @@ export class ExamNavigationBarComponent implements OnInit {
      * @param changeExercise whether to go to the next exercise {boolean}
      */
     saveExercise(changeExercise = true) {
-        const newIndex = this.exerciseIndex + 1;
         const submission = ExamParticipationService.getSubmissionForExercise(this.exercises[this.exerciseIndex]);
         // we do not submit programming exercises on a save
         if (submission && this.exercises[this.exerciseIndex].type !== ExerciseType.PROGRAMMING) {
             submission.submitted = true;
         }
-        if (!changeExercise || newIndex > this.exercises.length - 1) {
-            // we are either in the last exercise or we do not want to change exercise, so "change" active exercise to current in order to trigger a save
-            this.changePage(false, this.exerciseIndex, true);
-        } else {
-            this.changePage(false, newIndex, true);
+
+        // If changeExercise is false, set newIndex to the current index to trigger a save without navigating to a new exercise.
+        let newIndex = changeExercise ? this.exerciseIndex + 1 : this.exerciseIndex;
+        if (newIndex > this.exercises.length - 1) {
+            // we are in the last exercise, if out of range "change" active exercise to current in order to trigger a save
+            newIndex = this.exerciseIndex;
         }
+        this.changePage(false, newIndex, true);
     }
 
     isProgrammingExercise() {
@@ -204,6 +205,8 @@ export class ExamNavigationBarComponent implements OnInit {
      * Notify parent component when user wants to hand in early
      */
     handInEarly() {
+        // Save the current exercise without navigating to a new exercise so that the student does not lose data
+        // even if they do not confirm handing in early and re-open the exam page.
         this.saveExercise(false);
         this.onExamHandInEarly.emit();
     }

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -143,13 +143,11 @@ export class ExamNavigationBarComponent implements OnInit {
         if (submission && this.exercises[this.exerciseIndex].type !== ExerciseType.PROGRAMMING) {
             submission.submitted = true;
         }
-        if (changeExercise) {
-            if (newIndex > this.exercises.length - 1) {
-                // we are in the last exercise, if out of range "change" active exercise to current in order to trigger a save
-                this.changePage(false, this.exerciseIndex, true);
-            } else {
-                this.changePage(false, newIndex, true);
-            }
+        if (!changeExercise || newIndex > this.exercises.length - 1) {
+            // we are either in the last exercise or we do not want to change exercise, so "change" active exercise to current in order to trigger a save
+            this.changePage(false, this.exerciseIndex, true);
+        } else {
+            this.changePage(false, newIndex, true);
         }
     }
 

--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -134,6 +134,8 @@ export class ExamNavigationBarComponent implements OnInit {
 
     /**
      * Save the currently active exercise and go to the next exercise.
+     * If it is already in the last exercise or if changeExercise is false,
+     * this method does not go to the next exercise but still saves the current one.
      * @param changeExercise whether to go to the next exercise {boolean}
      */
     saveExercise(changeExercise = true) {

--- a/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
@@ -60,7 +60,15 @@ describe('Exam Navigation Bar Component', () => {
                     } as StudentParticipation,
                 ],
             } as Exercise,
-            { id: 1, type: ExerciseType.TEXT } as Exercise,
+            {
+                id: 1,
+                type: ExerciseType.TEXT,
+                studentParticipations: [
+                    {
+                        submissions: [{ id: 4, isSynced: true, submitted: false } as Submission],
+                    } as StudentParticipation,
+                ],
+            } as Exercise,
             { id: 2, type: ExerciseType.MODELING } as Exercise,
         ];
     });
@@ -145,16 +153,45 @@ describe('Exam Navigation Bar Component', () => {
         expect(comp.isProgrammingExercise()).toBeFalse();
     });
 
-    it('save the exercise with changeExercise', () => {
+    it('should save the exercise with changeExercise', () => {
         jest.spyOn(comp, 'changePage');
         const changeExercise = true;
 
+        const oldExerciseIndex = comp.exerciseIndex;
         comp.saveExercise(changeExercise);
 
-        expect(comp.changePage).toHaveBeenCalled();
+        expect(comp.changePage).toHaveBeenCalledOnce();
+        expect(comp.changePage).toHaveBeenCalledWith(false, oldExerciseIndex + 1, true);
     });
 
-    it('save the exercise without changeExercise', () => {
+    it('should save the exercise with changeExercise for last exercise', () => {
+        jest.spyOn(comp, 'changePage');
+        const changeExercise = true;
+
+        comp.exerciseIndex = comp.exercises.length - 1;
+        const oldExerciseIndex = comp.exerciseIndex;
+        comp.saveExercise(changeExercise);
+
+        expect(comp.changePage).toHaveBeenCalledOnce();
+        expect(comp.changePage).toHaveBeenCalledWith(false, oldExerciseIndex, true);
+    });
+
+    it('should mark submission as submitted when saving the exercise', () => {
+        jest.spyOn(comp, 'changePage');
+        const changeExercise = true;
+
+        comp.exerciseIndex = 1;
+        const oldExerciseIndex = comp.exerciseIndex;
+
+        expect(comp.exercises[oldExerciseIndex]!.studentParticipations![0].submissions!.last()?.submitted).toBeFalse();
+        comp.saveExercise(changeExercise);
+        expect(comp.exercises[oldExerciseIndex]!.studentParticipations![0].submissions!.last()?.submitted).toBeTrue();
+
+        expect(comp.changePage).toHaveBeenCalledOnce();
+        expect(comp.changePage).toHaveBeenCalledWith(false, oldExerciseIndex + 1, true);
+    });
+
+    it('should save the exercise without changeExercise', () => {
         jest.spyOn(comp, 'changePage');
         const changeExercise = false;
 

--- a/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
@@ -20,11 +20,13 @@ import { MockSyncStorage } from '../../../helpers/mocks/service/mock-sync-storag
 import { CommitState } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
 import { TranslateService } from '@ngx-translate/core';
 import { faEdit } from '@fortawesome/free-solid-svg-icons';
+import { ArtemisServerDateService } from 'app/shared/server-date.service';
 
 describe('Exam Navigation Bar Component', () => {
     let fixture: ComponentFixture<ExamNavigationBarComponent>;
     let comp: ExamNavigationBarComponent;
     let repositoryService: CodeEditorRepositoryService;
+    let artemisServerDateService: ArtemisServerDateService;
 
     const examExerciseIdForNavigationSourceMock = new BehaviorSubject<number>(-1);
     const mockExamExerciseUpdateService = {
@@ -37,6 +39,7 @@ describe('Exam Navigation Bar Component', () => {
             declarations: [ExamNavigationBarComponent, MockComponent(ExamTimerComponent), MockDirective(NgbTooltip)],
             providers: [
                 ExamParticipationService,
+                ArtemisServerDateService,
                 { provide: ExamExerciseUpdateService, useValue: mockExamExerciseUpdateService },
                 { provide: LocalStorageService, useClass: MockSyncStorage },
                 { provide: SessionStorageService, useClass: MockSyncStorage },
@@ -48,6 +51,7 @@ describe('Exam Navigation Bar Component', () => {
         comp = fixture.componentInstance;
         repositoryService = fixture.debugElement.injector.get(CodeEditorRepositoryService);
         TestBed.inject(ExamParticipationService);
+        artemisServerDateService = TestBed.inject(ArtemisServerDateService);
 
         comp.endDate = dayjs();
         comp.exercises = [
@@ -122,7 +126,8 @@ describe('Exam Navigation Bar Component', () => {
     it('should change to overview page', () => {
         jest.spyOn(comp.onPageChanged, 'emit');
         jest.spyOn(comp, 'setExerciseButtonStatus');
-
+        const timestamp = dayjs();
+        jest.spyOn(artemisServerDateService, 'now').mockReturnValue(timestamp);
         expect(comp.exerciseIndex).toEqual(0);
 
         const expectedExerciseIndex = -1;
@@ -136,6 +141,7 @@ describe('Exam Navigation Bar Component', () => {
             overViewChange: true,
             exercise: undefined,
             forceSave: force,
+            timestamp,
         });
         expect(comp.setExerciseButtonStatus).toHaveBeenCalledWith(expectedExerciseIndex);
     });

--- a/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
@@ -119,6 +119,27 @@ describe('Exam Navigation Bar Component', () => {
         expect(comp.setExerciseButtonStatus).toHaveBeenCalledWith(exerciseIndex);
     });
 
+    it('should change to overview page', () => {
+        jest.spyOn(comp.onPageChanged, 'emit');
+        jest.spyOn(comp, 'setExerciseButtonStatus');
+
+        expect(comp.exerciseIndex).toEqual(0);
+
+        const expectedExerciseIndex = -1;
+        const force = false;
+
+        comp.changePage(true, 2, force);
+
+        expect(comp.exerciseIndex).toBe(expectedExerciseIndex);
+        expect(comp.onPageChanged.emit).toHaveBeenCalledOnce();
+        expect(comp.onPageChanged.emit).toHaveBeenCalledWith({
+            overViewChange: true,
+            exercise: undefined,
+            forceSave: force,
+        });
+        expect(comp.setExerciseButtonStatus).toHaveBeenCalledWith(expectedExerciseIndex);
+    });
+
     it('should not change the exercise with invalid index', () => {
         jest.spyOn(comp.onPageChanged, 'emit');
         jest.spyOn(comp, 'setExerciseButtonStatus');

--- a/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
@@ -160,7 +160,8 @@ describe('Exam Navigation Bar Component', () => {
 
         comp.saveExercise(changeExercise);
 
-        expect(comp.changePage).not.toHaveBeenCalled();
+        expect(comp.changePage).toHaveBeenCalledOnce();
+        expect(comp.changePage).toHaveBeenCalledWith(false, comp.exerciseIndex, true);
     });
 
     it('should hand in the exam early', () => {

--- a/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
@@ -169,10 +169,9 @@ describe('Exam Navigation Bar Component', () => {
         jest.spyOn(comp.onExamHandInEarly, 'emit');
 
         comp.handInEarly();
-        jest.spyOn(comp, 'saveExercise');
 
         expect(comp.saveExercise).toHaveBeenCalled();
-        expect(comp.onPageChanged.emit).toHaveBeenCalled();
+        expect(comp.onPageChanged.emit).toHaveBeenCalledOnce();
         expect(comp.onPageChanged.emit).toHaveBeenCalledWith(
             expect.objectContaining({
                 overViewChange: false,

--- a/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-navigation-bar.component.spec.ts
@@ -164,12 +164,22 @@ describe('Exam Navigation Bar Component', () => {
     });
 
     it('should hand in the exam early', () => {
+        jest.spyOn(comp.onPageChanged, 'emit');
         jest.spyOn(comp, 'saveExercise');
         jest.spyOn(comp.onExamHandInEarly, 'emit');
 
         comp.handInEarly();
+        jest.spyOn(comp, 'saveExercise');
 
         expect(comp.saveExercise).toHaveBeenCalled();
+        expect(comp.onPageChanged.emit).toHaveBeenCalled();
+        expect(comp.onPageChanged.emit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                overViewChange: false,
+                exercise: comp.exercises[comp.exerciseIndex],
+                forceSave: true,
+            }),
+        );
         expect(comp.onExamHandInEarly.emit).toHaveBeenCalled();
     });
 

--- a/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
@@ -551,7 +551,7 @@ describe('ExamParticipationComponent', () => {
         const createParticipationForExerciseSpy = jest.spyOn(comp, 'createParticipationForExercise').mockReturnValue(of(new StudentParticipation()));
         comp.exam = new Exam();
         comp.onPageChange(exerciseChange);
-        expect(triggerSpy).toHaveBeenCalledWith(true, false);
+        expect(triggerSpy).toHaveBeenCalledWith(true, false, undefined);
         expect(comp.exerciseIndex).toEqual(1);
         expect(createParticipationForExerciseSpy).toHaveBeenCalledWith(exercise2);
     });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] ~This is a small issue that I tested locally and was confirmed by another developer on a test server.~
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes [Findings #6](https://confluence.ase.in.tum.de/pages/viewpage.action?spaceKey=ArTEMiS&title=Testing+Session+11.07.2022) where using Hand in Early does not save the exam when the user leaves confirmation page without clicking `Continue` or `Finish`.
### Description
<!-- Describe your changes in detail -->
Always save the exercise in `saveExercise` method which is called by `handInEarly` method. `saveExercise` did not save the exercise when `changeExercise` is false, this PR fixes it.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student (For the exam below at TS1 test users from 6 to 14 (except 10 and 13) can be used)
- 1 Exam (You can use [All Exercises Exam](https://artemis-test1.artemis.in.tum.de/course-management/12/exams/76) at TS1 - Instructor: test user 1)

1. Log in to Artemis
2. Open and start the exam
3. Edit an exercise (e.g. write text in a text exercise)
4. Click "Hand in early" so quickly that it doesn't have time to save (I wrote some text beforehand and saved it; then I quickly deleted it and clicked "Hand in early")
5. Exit the appearing tab in any way that is not through the "Finish" or the "Continue" button
6. When you enter the exam again, you should have your last changes saved.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| exam-navigation-bar.component.ts | 81.66% | 94.44% |

