### PR TITLE
`Lectures`: Fix attachment edit row overlay

### DIFF
--- a/src/main/webapp/app/lecture/lecture-attachments.component.html
+++ b/src/main/webapp/app/lecture/lecture-attachments.component.html
@@ -48,11 +48,11 @@
                             </thead>
                             <tbody>
                                 <tr *ngFor="let attachment of attachments; trackBy: trackId" class="position-relative">
-                                    <td [ngClass]="{ 'edit-overlay': attachmentToBeCreated && attachmentToBeCreated.id === attachment.id }">
-                                        <span *ngIf="attachmentToBeCreated && attachmentToBeCreated.id === attachment.id">{{
-                                            'artemisApp.lecture.attachments.isBeingEdited' | artemisTranslate
-                                        }}</span>
-                                        <span *ngIf="!attachmentToBeCreated || attachmentToBeCreated.id !== attachment.id">{{ attachment.id }}</span>
+                                    <td>
+                                        {{ attachment.id }}
+                                        <div *ngIf="attachmentToBeCreated?.id === attachment?.id" class="edit-overlay">
+                                            {{ 'artemisApp.lecture.attachments.isBeingEdited' | artemisTranslate }}
+                                        </div>
                                     </td>
                                     <td>{{ attachment.name }}</td>
                                     <td>{{ attachment.attachmentType }}</td>

--- a/src/main/webapp/app/lecture/lecture-attachments.component.scss
+++ b/src/main/webapp/app/lecture/lecture-attachments.component.scss
@@ -1,0 +1,14 @@
+.edit-overlay {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: -1px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--lecture-attachment-edit-overlay-color);
+    z-index: 9;
+    font-size: 18px;
+    height: calc(100% + 1px);
+    border: none;
+}

--- a/src/main/webapp/app/lecture/lecture-attachments.component.ts
+++ b/src/main/webapp/app/lecture/lecture-attachments.component.ts
@@ -13,20 +13,7 @@ import { faPaperclip, faPencilAlt, faSpinner, faTimes } from '@fortawesome/free-
 @Component({
     selector: 'jhi-lecture-attachments',
     templateUrl: './lecture-attachments.component.html',
-    styles: [
-        `
-            .edit-overlay {
-                position: absolute;
-                left: 0;
-                right: 0;
-                display: flex;
-                justify-content: center;
-                background-color: rgba(255, 255, 255, 0.9);
-                z-index: 9;
-                font-size: 18px;
-            }
-        `,
-    ],
+    styleUrls: ['./lecture-attachments.component.scss'],
 })
 export class LectureAttachmentsComponent implements OnInit, OnDestroy {
     @ViewChild('fileInput', { static: false }) fileInput: ElementRef;

--- a/src/main/webapp/content/scss/themes/_dark-variables.scss
+++ b/src/main/webapp/content/scss/themes/_dark-variables.scss
@@ -395,6 +395,9 @@ $lecture-unit-card-header-background: $neutral-dark-l-5;
 $lecture-unit-card-shadow: rgba(0, 0, 0, 0.25);
 $lecture-unit-card-hover-shadow: $primary;
 
+// Lecture Attachments
+$lecture-attachment-edit-overlay-color: rgba(0, 0, 0, 0.9);
+
 // Notification sidebar
 $notification-sb-background: $body-bg;
 $notification-sb-overlay-bg: rgba(0, 0, 0, 0.2);

--- a/src/main/webapp/content/scss/themes/_default-variables.scss
+++ b/src/main/webapp/content/scss/themes/_default-variables.scss
@@ -308,6 +308,9 @@ $lecture-unit-card-header-background: rgba($overview-light-border-color, 0.3);
 $lecture-unit-card-shadow: rgba(0, 0, 0, 0.25);
 $lecture-unit-card-hover-shadow: $primary;
 
+// Lecture Attachments
+$lecture-attachment-edit-overlay-color: rgba($gray-300, 0.9);
+
 // Notification sidebar
 $notification-sb-background: $brighter-body-bg;
 $notification-sb-overlay-bg: rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When editing a lecture attachment, the line of that attachment has a colored overlay to indicate that it is currently edited. It does not look well in dark mode:

![attachment_before](https://user-images.githubusercontent.com/23171488/179548587-7e9aac68-bc4b-430b-9c79-a95cbf9f0076.gif)


Additionally, the ID disappears when the overlay is active.
Lastly, the css for that overlay is specified in the component ts file rather than a dedicated scss file.

### Description
<!-- Describe your changes in detail -->

- Fixed styling of the overlay for both themes:

![attachment_after](https://user-images.githubusercontent.com/23171488/179548621-10854fb7-2beb-4979-8816-726caf0e8884.gif)


- Fixed ID disappearing when overlay is active
- Moved CSS into a dedicated file

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to a Lecture
3. Open Attachments view
4. Click the "Edit" button on an attachment
5. Check that the overlay saying "Is being edited..." or similar looks good in both themes

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2