### PR TITLE
`Notifications`: Prevent notification badge from reappearing on resize

### DIFF
--- a/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.component.ts
+++ b/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.component.ts
@@ -14,8 +14,10 @@ import { NotificationSettingsService } from 'app/shared/user-settings/notificati
 import { UserSettingsCategory } from 'app/shared/constants/user-settings.constants';
 import { Setting } from 'app/shared/user-settings/user-settings.model';
 import { faArchive, faBell, faCircleNotch, faCog, faEye, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { SessionStorageService } from 'ngx-webstorage';
 
 export const reloadNotificationSideBarMessage = 'reloadNotificationsInNotificationSideBar';
+const LAST_READ_STORAGE_KEY = 'lastNotificationRead';
 
 @Component({
     selector: 'jhi-notification-sidebar',
@@ -57,6 +59,7 @@ export class NotificationSidebarComponent implements OnInit {
         private accountService: AccountService,
         private userSettingsService: UserSettingsService,
         private notificationSettingsService: NotificationSettingsService,
+        private sessionStorageService: SessionStorageService,
         private changeDetector: ChangeDetectorRef,
     ) {}
 
@@ -66,13 +69,27 @@ export class NotificationSidebarComponent implements OnInit {
     ngOnInit(): void {
         this.accountService.getAuthenticationState().subscribe((user: User | undefined) => {
             if (user) {
-                if (user.lastNotificationRead) {
+                const sessionLastNotificationReadRaw = this.sessionStorageService.retrieve(LAST_READ_STORAGE_KEY);
+                const sessionLastNotificationReadDayJs = sessionLastNotificationReadRaw ? dayjs(sessionLastNotificationReadRaw) : undefined;
+
+                if (user.lastNotificationRead && !sessionLastNotificationReadDayJs) {
                     this.lastNotificationRead = user.lastNotificationRead;
+                } else if (!user.lastNotificationRead && sessionLastNotificationReadDayJs) {
+                    this.lastNotificationRead = sessionLastNotificationReadDayJs;
+                } else if (user.lastNotificationRead && sessionLastNotificationReadDayJs) {
+                    if (sessionLastNotificationReadDayJs.isBefore(user.lastNotificationRead)) {
+                        this.lastNotificationRead = user.lastNotificationRead;
+                    } else {
+                        this.lastNotificationRead = sessionLastNotificationReadDayJs;
+                    }
                 }
+
                 this.loadNotificationSettings();
                 this.listenForNotificationSettingsChanges();
                 this.loadNotifications();
                 this.subscribeToNotificationUpdates();
+            } else {
+                this.sessionStorageService.clear(LAST_READ_STORAGE_KEY);
             }
         });
     }
@@ -132,6 +149,7 @@ export class NotificationSidebarComponent implements OnInit {
             const lastNotificationReadNow = dayjs();
             setTimeout(() => {
                 this.lastNotificationRead = lastNotificationReadNow;
+                this.sessionStorageService.store(LAST_READ_STORAGE_KEY, lastNotificationReadNow);
                 this.updateRecentNotificationCount();
             }, 2000);
         });

--- a/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.component.ts
+++ b/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.component.ts
@@ -17,7 +17,7 @@ import { faArchive, faBell, faCircleNotch, faCog, faEye, faTimes } from '@fortaw
 import { SessionStorageService } from 'ngx-webstorage';
 
 export const reloadNotificationSideBarMessage = 'reloadNotificationsInNotificationSideBar';
-const LAST_READ_STORAGE_KEY = 'lastNotificationRead';
+export const LAST_READ_STORAGE_KEY = 'lastNotificationRead';
 
 @Component({
     selector: 'jhi-notification-sidebar',

--- a/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.component.ts
+++ b/src/main/webapp/app/shared/notification/notification-sidebar/notification-sidebar.component.ts
@@ -69,6 +69,9 @@ export class NotificationSidebarComponent implements OnInit {
     ngOnInit(): void {
         this.accountService.getAuthenticationState().subscribe((user: User | undefined) => {
             if (user) {
+                // Check if we have a newer notification read date in session storage to prevent marking old notifications as new on a rerender
+                // If we have it, use the latest of both dates
+
                 const sessionLastNotificationReadRaw = this.sessionStorageService.retrieve(LAST_READ_STORAGE_KEY);
                 const sessionLastNotificationReadDayJs = sessionLastNotificationReadRaw ? dayjs(sessionLastNotificationReadRaw) : undefined;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

After we changed the navbar responsiveness in #5366, the notification icon shows unread notifications if we first read / dismiss them, and then resize. This happens as the notification component needs to be rerendered in a different location when the size changes.

![notifi_before](https://user-images.githubusercontent.com/23171488/179564432-956b60e7-5fc5-441c-a9f4-4faa8248de42.gif)


### Description
<!-- Describe your changes in detail -->

To solve this, we store the timestamp of the last notification read additionally in session storage so we can retrieve it after a rerender. The timestamp is also stored in the user profile, but it is only loaded once on app startup and not later. There's no need to refetch it as we can solve this locally.

A caveat is the fact that the notification sidebar component still re-fetches the list of notifications after a change in the responsive layout. However, this event won't occurr very often - window resizes that cause changes in the navbar layout are not happening frequently (if at all), so we can confidently say that this will not cause any remotely noteworthy server load. Nevertheless, the issue is now solved for the user if they ever happen to resize a window.

![notifi_after](https://user-images.githubusercontent.com/23171488/179564850-25b2df81-b5c5-4167-ab43-ce2e653dad09.gif)

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 User with unread notifications

1. Open the notifications bar to read the notifications, close it again after a few seconds
2. The red badge in the navbar should disappear
3. Resize your window so the navbar layout changes
4. Verify that the red badge does not reappear
5. Verify that notifications in the sidebar do not have the "new" badge again

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| notification-sidebar.component.ts | 79% | 89% |