### PR TITLE
`Exam mode`: Fix saving exam when hand in early is clicked

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-navigation-bar/exam-navigation-bar.component.ts
@@ -206,7 +206,6 @@ export class ExamNavigationBarComponent implements OnInit {
      * Notify parent component when user wants to hand in early
      */
     handInEarly() {
-        this.saveExercise(false);
         this.onExamHandInEarly.emit();
     }
 }

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -452,6 +452,7 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         if (this.handInEarly) {
             // update local studentExam for later sync with server if the student wants to hand in early
             this.updateLocalStudentExam();
+            this.triggerSave(true, false);
             this.examMonitoringService.handleAndSaveActionEvent(this.exam, this.studentExam, new HandedInEarlyAction(), this.connected);
         } else if (this.studentExam?.exercises && this.activeExamPage) {
             const index = this.studentExam.exercises.findIndex((exercise) => !this.activeExamPage.isOverviewPage && exercise.id === this.activeExamPage.exercise!.id);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Simpler solution than https://github.com/ls1intum/Artemis/pull/5413: Closes [Findings #6](https://confluence.ase.in.tum.de/pages/viewpage.action?spaceKey=ArTEMiS&title=Testing+Session+11.07.2022)

Thanks to @akesfeden for the first version!

### Description
<!-- Describe your changes in detail -->

- Instead of switching again to the same page, we can just call the `triggerSave` method. No fixes are required.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student (For the exam below at TS1 test users from 6 to 14 (except 10 and 13) can be used)
- 1 Exam (You can use [All Exercises Exam](https://artemis-test1.artemis.in.tum.de/course-management/12/exams/76) at TS1 - Instructor: test user 1)

1. Log in to Artemis
2. Open and start the exam
3. Edit an exercise (e.g. write text in a text exercise)
4. Click "Hand in early" so quickly that it doesn't have time to save (I wrote some text beforehand and saved it; then I quickly deleted it and clicked "Hand in early")
5. Exit the appearing tab in any way that is not through the "Finish" or the "Continue" button
6. When you enter the exam again, you should have your last changes saved.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
