### PR TITLE
`Programming exercises`: Fix the creation of behavioral solution entries for git-diff entries representing removed content

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/BehavioralTestCaseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/BehavioralTestCaseService.java
@@ -75,6 +75,7 @@ public class BehavioralTestCaseService {
         if (gitDiffReport == null) {
             throw new BehavioralSolutionEntryGenerationException("Git-Diff Report has not been generated");
         }
+
         var coverageReport = testwiseCoverageService.getFullCoverageReportForLatestSolutionSubmissionFromProgrammingExercise(programmingExercise).orElse(null);
         if (coverageReport == null) {
             throw new BehavioralSolutionEntryGenerationException("Testwise coverage report has not been generated");
@@ -121,6 +122,7 @@ public class BehavioralTestCaseService {
         // Create knowledge sources (Turning the formatter off to make the code more readable)
         // @formatter:off
         List<BehavioralKnowledgeSource> behavioralKnowledgeSources = Arrays.asList(
+            new DropRemovedGitDiffEntries(blackboard),
             new GroupGitDiffAndCoverageEntriesByFilePathAndTestCase(blackboard),
             new ExtractCoveredLines(blackboard),
             new ExtractChangedLines(blackboard),

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/knowledgesource/DropRemovedGitDiffEntries.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/knowledgesource/DropRemovedGitDiffEntries.java
@@ -20,7 +20,7 @@ public class DropRemovedGitDiffEntries extends BehavioralKnowledgeSource {
 
     @Override
     public boolean executeCondition() {
-        return blackboard.getGitDiffReport() != null;
+        return blackboard.getGitDiffReport().getEntries().stream().anyMatch(entry -> entry.getStartLine() == null || entry.getLineCount() == null);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/knowledgesource/DropRemovedGitDiffEntries.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/knowledgesource/DropRemovedGitDiffEntries.java
@@ -1,0 +1,33 @@
+package de.tum.in.www1.artemis.service.hestia.behavioral.knowledgesource;
+
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+import de.tum.in.www1.artemis.service.hestia.behavioral.BehavioralBlackboard;
+import de.tum.in.www1.artemis.service.hestia.behavioral.BehavioralSolutionEntryGenerationException;
+
+/**
+ * Remove all {@link de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffEntry} from the
+ * {@link de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffReport} of the {@link BehavioralBlackboard}
+ * that represents removed consecutive blocks of code.
+ * Entries cannot be generated for removed code, therefore we have to drop them from the git diff report of the blackboard.
+ */
+public class DropRemovedGitDiffEntries extends BehavioralKnowledgeSource {
+
+    public DropRemovedGitDiffEntries(BehavioralBlackboard blackboard) {
+        super(blackboard);
+    }
+
+    @Override
+    public boolean executeCondition() {
+        return blackboard.getGitDiffReport() != null;
+    }
+
+    @Override
+    public boolean executeAction() throws BehavioralSolutionEntryGenerationException {
+        var nonRemovedEntries = blackboard.getGitDiffReport().getEntries().stream().filter(entry -> entry.getStartLine() != null && entry.getLineCount() != null)
+                .collect(Collectors.toCollection(HashSet::new));
+        blackboard.getGitDiffReport().setEntries(nonRemovedEntries);
+        return !nonRemovedEntries.isEmpty();
+    }
+}

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/knowledgesource/DropRemovedGitDiffEntries.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/knowledgesource/DropRemovedGitDiffEntries.java
@@ -9,7 +9,7 @@ import de.tum.in.www1.artemis.service.hestia.behavioral.BehavioralSolutionEntryG
 /**
  * Remove all {@link de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffEntry} from the
  * {@link de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffReport} of the {@link BehavioralBlackboard}
- * that represents removed consecutive blocks of code.
+ * that represents consecutive blocks of removed code.
  * Entries cannot be generated for removed code, therefore we have to drop them from the git diff report of the blackboard.
  */
 public class DropRemovedGitDiffEntries extends BehavioralKnowledgeSource {

--- a/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/knowledgesource/DropRemovedGitDiffEntries.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/hestia/behavioral/knowledgesource/DropRemovedGitDiffEntries.java
@@ -20,7 +20,8 @@ public class DropRemovedGitDiffEntries extends BehavioralKnowledgeSource {
 
     @Override
     public boolean executeCondition() {
-        return blackboard.getGitDiffReport().getEntries().stream().anyMatch(entry -> entry.getStartLine() == null || entry.getLineCount() == null);
+        return blackboard.getGitDiffReport() != null && blackboard.getGitDiffReport().getEntries() != null
+                && blackboard.getGitDiffReport().getEntries().stream().anyMatch(entry -> entry.getStartLine() == null || entry.getLineCount() == null);
     }
 
     @Override

--- a/src/test/java/de/tum/in/www1/artemis/hestia/behavioral/DropRemovedGitDiffEntriesTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/behavioral/DropRemovedGitDiffEntriesTest.java
@@ -1,0 +1,49 @@
+package de.tum.in.www1.artemis.hestia.behavioral;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffEntry;
+import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffReport;
+import de.tum.in.www1.artemis.service.hestia.behavioral.BehavioralBlackboard;
+import de.tum.in.www1.artemis.service.hestia.behavioral.BehavioralSolutionEntryGenerationException;
+import de.tum.in.www1.artemis.service.hestia.behavioral.knowledgesource.DropRemovedGitDiffEntries;
+
+public class DropRemovedGitDiffEntriesTest {
+
+    private BehavioralBlackboard blackboard;
+
+    private DropRemovedGitDiffEntries dropRemovedGitDiffEntries;
+
+    @Test
+    public void testNoAction() {
+        var gitDiffReport = new ProgrammingExerciseGitDiffReport();
+        gitDiffReport.setEntries(new HashSet<>());
+        blackboard = new BehavioralBlackboard(gitDiffReport, null, null);
+        dropRemovedGitDiffEntries = new DropRemovedGitDiffEntries(blackboard);
+        assertThat(dropRemovedGitDiffEntries.executeCondition()).isFalse();
+    }
+
+    @Test
+    public void testExecuteCondition() throws BehavioralSolutionEntryGenerationException {
+        var gitDiffReport = new ProgrammingExerciseGitDiffReport();
+        var removedEntry = new ProgrammingExerciseGitDiffEntry();
+        var addedEntry = new ProgrammingExerciseGitDiffEntry();
+        addedEntry.setStartLine(1);
+        addedEntry.setLineCount(2);
+        gitDiffReport.setEntries(Set.of(removedEntry, addedEntry));
+
+        blackboard = new BehavioralBlackboard(gitDiffReport, null, null);
+        dropRemovedGitDiffEntries = new DropRemovedGitDiffEntries(blackboard);
+
+        assertThat(dropRemovedGitDiffEntries.executeCondition()).isTrue();
+        assertThat(dropRemovedGitDiffEntries.executeAction()).isTrue();
+        var remainingEntries = blackboard.getGitDiffReport().getEntries();
+        assertThat(dropRemovedGitDiffEntries.executeCondition()).isFalse();
+        assertThat(remainingEntries).containsExactly(addedEntry);
+    }
+}

--- a/src/test/java/de/tum/in/www1/artemis/hestia/behavioral/DropRemovedGitDiffEntriesTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/behavioral/DropRemovedGitDiffEntriesTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseGitDiffEntry;
@@ -17,28 +18,32 @@ public class DropRemovedGitDiffEntriesTest {
 
     private BehavioralBlackboard blackboard;
 
+    private ProgrammingExerciseGitDiffReport gitDiffReport;
+
     private DropRemovedGitDiffEntries dropRemovedGitDiffEntries;
+
+    @BeforeEach
+    public void setup() {
+        gitDiffReport = new ProgrammingExerciseGitDiffReport();
+        gitDiffReport.setEntries(new HashSet<>());
+
+        blackboard = new BehavioralBlackboard(gitDiffReport, null, null);
+        dropRemovedGitDiffEntries = new DropRemovedGitDiffEntries(blackboard);
+
+    }
 
     @Test
     public void testNoAction() {
-        var gitDiffReport = new ProgrammingExerciseGitDiffReport();
-        gitDiffReport.setEntries(new HashSet<>());
-        blackboard = new BehavioralBlackboard(gitDiffReport, null, null);
-        dropRemovedGitDiffEntries = new DropRemovedGitDiffEntries(blackboard);
         assertThat(dropRemovedGitDiffEntries.executeCondition()).isFalse();
     }
 
     @Test
     public void testExecuteCondition() throws BehavioralSolutionEntryGenerationException {
-        var gitDiffReport = new ProgrammingExerciseGitDiffReport();
         var removedEntry = new ProgrammingExerciseGitDiffEntry();
         var addedEntry = new ProgrammingExerciseGitDiffEntry();
         addedEntry.setStartLine(1);
         addedEntry.setLineCount(2);
         gitDiffReport.setEntries(Set.of(removedEntry, addedEntry));
-
-        blackboard = new BehavioralBlackboard(gitDiffReport, null, null);
-        dropRemovedGitDiffEntries = new DropRemovedGitDiffEntries(blackboard);
 
         assertThat(dropRemovedGitDiffEntries.executeCondition()).isTrue();
         assertThat(dropRemovedGitDiffEntries.executeAction()).isTrue();


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
Hestia creates solution entries for behavioral test cases by using a git-diff report between template and solution repository. This report consists of multiple entries, each representing a consecutive block of changed/added/removed lines of code.

The current implementation of the algorithm that generates the behavioral solution entries cannot consider diff entries that represent removed lines of code by the nature of the general idea of the entry-generation. Therefore, those entries have to be dropped to be not considered.

### Description
The BehavioralBlackboard stores the GitDiffReport. These changes introduce a new BehavioralKnowledgeSource that removes the entries that represent a consecutive block of removed code as a first step.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Create a new Java-Gradle programming exercise with the option "Record testwise coverage" enabled
2. Edit the same file in both template and solution in a way, that a consecutive block of removed lines of code exists (you may have to experiment a little bit here).
3. Wait for both build plans to finish
4. Click the "Generate behavioral entries"-button on the programming exercise details page
5. Verify that no error alert occurs
6. Press the button "Generate code hints"
7. Go to "Manage hints"
8. Verify that the hints exist in the list and have some content

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2