### PR TITLE
`Exam mode`: Enhance import

### DIFF
--- a/src/main/webapp/app/exam/manage/exam-management.component.html
+++ b/src/main/webapp/app/exam/manage/exam-management.component.html
@@ -1,14 +1,14 @@
 <div *ngIf="course">
-    <div class="d-flex">
+    <div class="d-flex flex-wrap">
         <h4 id="course-page-heading" jhiTranslate="artemisApp.examManagement.title">Exams</h4>
-        <div class="ms-auto d-flex" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
+        <div class="ms-auto text-truncate justify-content-end" *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_INSTRUCTOR']">
             <a class="btn btn-primary me-1" *ngIf="course.isAtLeastInstructor" (click)="openImportModal()">
                 <fa-icon [icon]="faPlus"></fa-icon>
-                <span class="hidden-sm-down">{{ 'artemisApp.examManagement.importExam' | artemisTranslate }}</span>
+                <span>{{ 'artemisApp.examManagement.importExam' | artemisTranslate }}</span>
             </a>
             <a class="btn btn-primary jh-create-entity create-exam" id="create-exam" *ngIf="course.isAtLeastInstructor" [routerLink]="['new']">
                 <fa-icon [icon]="faPlus"></fa-icon>
-                <span class="hidden-sm-down">{{ 'artemisApp.examManagement.createExam' | artemisTranslate }}</span>
+                <span>{{ 'artemisApp.examManagement.createExam' | artemisTranslate }}</span>
             </a>
         </div>
     </div>

--- a/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.html
@@ -103,21 +103,21 @@
                                 />
                                 <input
                                     *ngIf="exercise.type === exerciseType.PROGRAMMING"
-                                    [class]="{ 'form-control': true, 'is-invalid': !validateTitleInput(exercise) }"
+                                    [class]="{ 'form-control': true, 'is-invalid': !validateTitleOfProgrammingExercise(exercise) }"
                                     type="text"
                                     [id]="'exercise-' + exercise.id + '-title'"
                                     [name]="'exercise-' + exercise.id + '-title'"
-                                    [placeholder]="getPlaceholderTitleOfProgrammingExercise(exercise.id!)"
+                                    [placeholder]="getBlocklistTitleOfProgrammingExercise(exercise.id!)"
                                     [(ngModel)]="exercise.title"
                                 />
                             </td>
                             <td *ngIf="exercise.type! === exerciseType.PROGRAMMING">
                                 <input
-                                    [ngClass]="{ 'form-control': true, 'is-invalid': !validateShortNameInput(exercise) }"
+                                    [ngClass]="{ 'form-control': true, 'is-invalid': !validateShortNameOfProgrammingExercise(exercise) }"
                                     type="text"
                                     [id]="'programming-exercise-' + exercise.id + '-shortName'"
                                     [name]="'programming-exercise-' + exercise.id + '-shortName'"
-                                    [placeholder]="getPlaceholderShortNameOfProgrammingExercise(exercise.id!)"
+                                    [placeholder]="getBlocklistShortNameOfProgrammingExercise(exercise.id!)"
                                     [(ngModel)]="exercise.shortName"
                                 />
                             </td>

--- a/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.html
@@ -26,8 +26,7 @@
                             </td>
                             <td class="w-75">
                                 <input
-                                    class="form-control"
-                                    required
+                                    [ngClass]="{ 'form-control': true, 'is-invalid': exerciseGroup?.title?.length! === 0 }"
                                     type="text"
                                     [id]="'exerciseGroup-' + exerciseGroup.id + '-title'"
                                     [name]="'exerciseGroup-' + exerciseGroup.id + '-title'"
@@ -96,8 +95,7 @@
                             <td>
                                 <input
                                     *ngIf="exercise.type !== exerciseType.PROGRAMMING"
-                                    class="form-control"
-                                    required
+                                    [ngClass]="{ 'form-control': true, 'is-invalid': exercise?.title?.length! === 0 }"
                                     type="text"
                                     [id]="'exercise-' + exercise.id + '-title'"
                                     [name]="'exercise-' + exercise.id + '-title'"
@@ -105,26 +103,21 @@
                                 />
                                 <input
                                     *ngIf="exercise.type === exerciseType.PROGRAMMING"
-                                    class="form-control"
-                                    required
+                                    [class]="{ 'form-control': true, 'is-invalid': !validateTitleInput(exercise) }"
                                     type="text"
                                     [id]="'exercise-' + exercise.id + '-title'"
                                     [name]="'exercise-' + exercise.id + '-title'"
                                     [placeholder]="getPlaceholderTitleOfProgrammingExercise(exercise.id!)"
                                     [(ngModel)]="exercise.title"
-                                    [pattern]="titleNamePattern"
                                 />
                             </td>
                             <td *ngIf="exercise.type! === exerciseType.PROGRAMMING">
                                 <input
-                                    class="form-control"
-                                    required
+                                    [ngClass]="{ 'form-control': true, 'is-invalid': !validateShortNameInput(exercise) }"
                                     type="text"
-                                    minlength="3"
                                     [id]="'programming-exercise-' + exercise.id + '-shortName'"
                                     [name]="'programming-exercise-' + exercise.id + '-shortName'"
                                     [placeholder]="getPlaceholderShortNameOfProgrammingExercise(exercise.id!)"
-                                    [pattern]="shortNamePattern"
                                     [(ngModel)]="exercise.shortName"
                                 />
                             </td>

--- a/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.ts
@@ -16,7 +16,7 @@ export class ExamExerciseImportComponent implements OnInit {
     @Input() importInSameCourse = false;
     // Map to determine, which exercises the user has selected and therefore should be imported alongside an exam
     selectedExercises = new Map<ExerciseGroup, Set<Exercise>>();
-    // Map with the title and shortName of the programming exercises to be displayed as a placeholder in case of a rejected import
+    // Map / Blocklist with the title and shortName of the programming exercises, that have been either rejected by the server or must be changed because the exam is imported into the same course
     titleAndShortNameOfProgrammingExercises = new Map<number, String[]>();
     // Expose enums to the template
     exerciseType = ExerciseType;
@@ -80,7 +80,7 @@ export class ExamExerciseImportComponent implements OnInit {
     }
 
     /**
-     * Method to update the Map titleAndShortNameOfProgrammingExercises for the import in the same course
+     * Method to initialize the Map titleAndShortNameOfProgrammingExercises for the import
      * Case rejected Import: In the selected exercises, all the (previously) selected exercises are stored. All programming exercises are added to the Map,
      * which functions as a blocklist.
      * Case import in same course: The selected exercises are already initialized and all programming exercises are added to the
@@ -144,7 +144,7 @@ export class ExamExerciseImportComponent implements OnInit {
      * Returns the placeholder title (i.e. the one rejected by the server) for the programming exercise
      * @param exerciseId the corresponding exercise
      */
-    getPlaceholderTitleOfProgrammingExercise(exerciseId: number): String {
+    getBlocklistTitleOfProgrammingExercise(exerciseId: number): String {
         const title = this.titleAndShortNameOfProgrammingExercises.get(exerciseId)?.first();
         return title ? title! : ``;
     }
@@ -153,7 +153,7 @@ export class ExamExerciseImportComponent implements OnInit {
      * Returns the placeholder shortName (i.e. the one rejected by the server) for the programming exercise
      * @param exerciseId the corresponding exercise
      */
-    getPlaceholderShortNameOfProgrammingExercise(exerciseId: number): String {
+    getBlocklistShortNameOfProgrammingExercise(exerciseId: number): String {
         const shortName = this.titleAndShortNameOfProgrammingExercises.get(exerciseId)?.last();
         return shortName ? shortName! : ``;
     }
@@ -177,19 +177,19 @@ export class ExamExerciseImportComponent implements OnInit {
      * Validates the Title for Programming Exercises based on the user's input
      * @param exercise the exercise to be checked
      */
-    validateTitleInput(exercise: Exercise): boolean {
-        return exercise.title?.length! > 0 && this.titleNamePattern.test(exercise.title!) && exercise.title !== this.getPlaceholderTitleOfProgrammingExercise(exercise.id!);
+    validateTitleOfProgrammingExercise(exercise: Exercise): boolean {
+        return exercise.title?.length! > 0 && this.titleNamePattern.test(exercise.title!) && exercise.title !== this.getBlocklistTitleOfProgrammingExercise(exercise.id!);
     }
 
     /**
      * Validates the Title for Programming Exercises based on the user's input
      * @param exercise the exercise to be checked
      */
-    validateShortNameInput(exercise: Exercise): boolean {
+    validateShortNameOfProgrammingExercise(exercise: Exercise): boolean {
         return (
             exercise.shortName?.length! > 2 &&
             this.shortNamePattern.test(exercise.shortName!) &&
-            exercise.shortName !== this.getPlaceholderShortNameOfProgrammingExercise(exercise.id!)
+            exercise.shortName !== this.getBlocklistShortNameOfProgrammingExercise(exercise.id!)
         );
     }
 
@@ -208,7 +208,7 @@ export class ExamExerciseImportComponent implements OnInit {
                         return false;
                     }
                     if (exercise.type === ExerciseType.PROGRAMMING) {
-                        validConfiguration = this.validateTitleInput(exercise) && this.validateShortNameInput(exercise);
+                        validConfiguration = this.validateTitleOfProgrammingExercise(exercise) && this.validateShortNameOfProgrammingExercise(exercise);
                     } else {
                         validConfiguration = exercise.title?.length! > 0;
                     }

--- a/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.ts
@@ -16,7 +16,8 @@ export class ExamExerciseImportComponent implements OnInit {
     @Input() importInSameCourse = false;
     // Map to determine, which exercises the user has selected and therefore should be imported alongside an exam
     selectedExercises = new Map<ExerciseGroup, Set<Exercise>>();
-    // Map / Blocklist with the title and shortName of the programming exercises, that have been either rejected by the server or must be changed because the exam is imported into the same course
+    // Map / Blocklist with the title and shortName of the programming exercises, that have been either rejected by the server
+    // or must be changed because the exam is imported into the same course
     titleAndShortNameOfProgrammingExercises = new Map<number, String[]>();
     // Expose enums to the template
     exerciseType = ExerciseType;

--- a/src/main/webapp/app/exam/manage/exams/exam-import/exam-import.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-import/exam-import.component.html
@@ -80,7 +80,7 @@
                     The import of the exercise groups and the exercises is currently done on the server. This may take some time
                 </p>
             </div>
-            <jhi-exam-exercise-import [exam]="exam!"></jhi-exam-exercise-import>
+            <jhi-exam-exercise-import [exam]="exam!" [importInSameCourse]="isImportInSameCourse"></jhi-exam-exercise-import>
         </div>
         <div class="modal-footer">
             <jhi-button

--- a/src/main/webapp/app/exam/manage/exams/exam-import/exam-import.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-import/exam-import.component.ts
@@ -43,6 +43,7 @@ export class ExamImportComponent implements OnInit {
     exam?: Exam;
     loading = false;
     isImportingExercises = false;
+    isImportInSameCourse = false;
 
     content: SearchResult<Exam>;
     total = 0;
@@ -80,6 +81,7 @@ export class ExamImportComponent implements OnInit {
         this.examManagementService.findWithExercisesAndWithoutCourseId(exam.id!).subscribe({
             next: (examRes: HttpResponse<Exam>) => {
                 this.exam = examRes.body!;
+                this.isImportInSameCourse = this.exam.course?.id === this.targetCourseId;
             },
             error: (res: HttpErrorResponse) => onError(this.alertService, res),
         });

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.html
@@ -145,7 +145,7 @@
                 <p jhiTranslate="artemisApp.examManagement.exerciseGroup.importModal.explanation">
                     Select the individual exercises, which should be imported alongside the exam, by clicking on it
                 </p>
-                <jhi-exam-exercise-import [exam]="exam"></jhi-exam-exercise-import>
+                <jhi-exam-exercise-import [exam]="exam" [importInSameCourse]="isImportInSameCourse"></jhi-exam-exercise-import>
             </div>
 
             <!-- Section exam assessment and student review

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.ts
@@ -28,6 +28,7 @@ export class ExamUpdateComponent implements OnInit {
     // The maximum working time in Minutes (used as a dynamic max-value for the working time Input)
     maxWorkingTimeInMinutes: number;
     isImport = false;
+    isImportInSameCourse = false;
     // Expose enums to the template
     exerciseType = ExerciseType;
     // Link to the component enabling the selection of exercise groups and exercises for import
@@ -57,6 +58,7 @@ export class ExamUpdateComponent implements OnInit {
 
             if (this.isImport) {
                 this.resetIdAndDatesForImport();
+                this.isImportInSameCourse = this.exam.course?.id === Number(this.route.snapshot.paramMap.get('courseId'));
             }
 
             this.courseManagementService.find(Number(this.route.snapshot.paramMap.get('courseId'))).subscribe({

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -437,7 +437,7 @@
                     "invalidKey": "The chosen short name and title of {{ number }} programming exercise(s) already exists. Please insert a new short name and title for the corresponding programming exercise(s)",
                     "invalidExerciseConfiguration": "One or more of the values specified are invalid. Please change them before importing",
                     "isImporting": "The import of the exercise groups and the exercises is currently done on the server. This may take some time",
-                    "infoProgrammingExercises": "Programming exercises are imported using their initial configuration. This import functionality cannot be used for changing the submission policy, for activating / deactivating the static code analysis or for creating new build plans. In this case, please import the tasks individually into the exercise groups."
+                    "infoProgrammingExercises": "Programming exercises are imported using their initial configuration. This import functionality cannot be used for changing the submission policy, for activating / deactivating the static code analysis or for creating new build plans. In this case, please import the exercises individually into the exercise groups."
                 },
                 "importSuccessful": "Exercise Groups successfully imported!"
             },

--- a/src/test/javascript/spec/component/exam/manage/exam-exercise-import.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exam-exercise-import.component.spec.ts
@@ -121,8 +121,8 @@ describe('Exam Exercise Import Component', () => {
         // For importInSameCourse = true, this should be initialized
         expect(component.titleAndShortNameOfProgrammingExercises.size).toEqual(1);
         expect(component.titleAndShortNameOfProgrammingExercises.get(programmingExercise.id!)).toEqual([programmingExercise.title, programmingExercise.shortName]);
-        expect(component.getPlaceholderTitleOfProgrammingExercise(programmingExercise.id!)).toEqual(programmingExercise.title);
-        expect(component.getPlaceholderShortNameOfProgrammingExercise(programmingExercise.id!)).toEqual(programmingExercise.shortName);
+        expect(component.getBlocklistTitleOfProgrammingExercise(programmingExercise.id!)).toEqual(programmingExercise.title);
+        expect(component.getBlocklistShortNameOfProgrammingExercise(programmingExercise.id!)).toEqual(programmingExercise.shortName);
     });
 
     it('should initialize maps when updateMapsAfterRejectedImport is called', () => {
@@ -152,7 +152,7 @@ describe('Exam Exercise Import Component', () => {
 
         // Check if titleAndShortNameOfProgrammingExercises contains the rejected title + shortName
         expect(component.titleAndShortNameOfProgrammingExercises.size).toEqual(1);
-        expect(component.getPlaceholderTitleOfProgrammingExercise(programmingExercise.id!)).toEqual(formerProgrammingExerciseTitle);
+        expect(component.getBlocklistTitleOfProgrammingExercise(programmingExercise.id!)).toEqual(formerProgrammingExerciseTitle);
         expect(component.titleAndShortNameOfProgrammingExercises.get(programmingExercise.id!)).toEqual([formerProgrammingExerciseTitle, formerProgrammingExerciseShortName]);
 
         expect(component.selectedExercises.size).toEqual(5);
@@ -216,8 +216,8 @@ describe('Exam Exercise Import Component', () => {
     });
 
     it('should correctly return an empty string when titleAndShortNameOfProgrammingExercises do not contain exercise ', () => {
-        expect(component.getPlaceholderTitleOfProgrammingExercise(55)).toEqual('');
-        expect(component.getPlaceholderShortNameOfProgrammingExercise(55)).toEqual('');
+        expect(component.getBlocklistTitleOfProgrammingExercise(55)).toEqual('');
+        expect(component.getBlocklistShortNameOfProgrammingExercise(55)).toEqual('');
     });
 
     it('should correctly map selected Exercises To Exercise Groups', () => {


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
This Pr fixes some minor issues regarding the intruced Exam Import

### Description
**Enhance appearance of exam management page on mobile devices**
On mobile devices, the buttons for importing / creating an exam are now displayed properly

**Display warning when importing into same course**
When importing programming exercises into the same course, the old title + short name are placed on a blocklist in the client, so the user has to change them before importing.

**Fix translation string**
When opening the exercise import dialoge, the string within the blue box cointained "tasks" instead of "exercises"

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Exam with one exercise group with one programming exercise

1. Log in to Artemis
2. Navigate to Course Administration -> Exam
3. Resize the Site and make sure, the buttons are displayed properly
4. Try to import the exam with programming exercises into the same course. The title + short name should be displayed as invalid
5. Navigtate into Exam -> Exercise Group
6. Try to import the exercise group with the programming exercise into the same course. The title + short name should be displayed as invalid
7. Verify, that the string within the blue container in the exercise dialoge doesn't cointain "tasks", but "exercises"

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| exam-import.component.ts | 80 % | 96 % |
| exam-exercise-import.component.ts | 100 % | 100 % |
| exam-update.component.ts | 89 % | 96 % |

### Screenshots
Resizing exam management (regarding the two buttons on the top)
![2022-07-21-15-02-10](https://user-images.githubusercontent.com/94070506/180221028-6e89c310-b0e3-4dc9-923f-2f69b2b8841d.gif)

Fixed string in the blue box and warning, when importing into the same course
![image](https://user-images.githubusercontent.com/94070506/180220278-7af13912-c102-4414-9fb8-917325582b08.png)
