### PR TITLE
`Programming exercises`: Fix text overflow in git-diff modal

### DIFF
--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/full-git-diff-entry.component.html
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/full-git-diff-entry.component.html
@@ -1,12 +1,14 @@
 <div class="jhi-git-diff-report">
     <div class="row">
-        <div class="col-6">
-            <h6>{{ diffEntry.previousFilePath }}</h6>
+        <div class="col-8 col-md-10">
+            <div *ngIf="diffEntry.previousFilePath && diffEntry.filePath && diffEntry.previousFilePath !== diffEntry.filePath; else oneFileName">
+                <h6 class="text-wrap">{{ diffEntry.previousFilePath }} → {{ diffEntry.filePath }}</h6>
+            </div>
+            <ng-template #oneFileName>
+                <h6 class="text-break">{{ diffEntry.previousFilePath || diffEntry.filePath }}</h6>
+            </ng-template>
         </div>
-        <div class="col-4">
-            <h6>{{ diffEntry.filePath }}</h6>
-        </div>
-        <div class="col-2 text-end">
+        <div class="col-4 col-md-10 text-end">
             <jhi-git-diff-line-stat
                 [addedLineCount]="addedLineCount"
                 [removedLineCount]="removedLineCount"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The file path in the git-diff modal would overflow on small screen sizes.

### Description
<!-- Describe your changes in detail -->
Now, the file path will only be displayed once if the name does not change. If the file was renamed, the file paths are now displayed in a way that will make them wrap on small screens.

Please note that there is a limit on what can be done. Very long file paths will still overflow on very small screens, but this should be very rare, and the modal wouldn't even be very useable on such small screens, so it doesn't make sense to fix this at the moment.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Log in to Artemis
2. Navigate to the Programming exercise detail page
3. Open the git-diff (either the button at the top or if my other PR got merged the button at the bottom)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:
<img width="525" alt="Bildschirmfoto 2022-07-22 um 17 24 06" src="https://user-images.githubusercontent.com/18218285/180472449-aa054c2c-d081-4bc6-86ae-cbf78eee7a8b.png">
After (when the file name did change):
<img width="478" alt="Bildschirmfoto 2022-07-22 um 17 24 18" src="https://user-images.githubusercontent.com/18218285/180472456-4953a881-ffae-49b9-8630-e8591fd7153b.png">
After (when the file name didn't change):
<img width="477" alt="grafik" src="https://user-images.githubusercontent.com/18218285/180473421-1ae83015-13f4-4edc-9fba-81cdd339a3cd.png">


