### PR TITLE
`Exam mode`: Improve the appearance of 'Review is Open' in the exam summary

### DIFF
--- a/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
+++ b/src/main/webapp/app/exam/participate/summary/exam-participation-summary.component.html
@@ -13,10 +13,12 @@
     </h2>
 </div>
 <jhi-exam-information *ngIf="studentExam?.exam" [exam]="studentExam.exam!" [studentExam]="studentExam"></jhi-exam-information>
-<div class="mb-4 text-center" *ngIf="studentExam?.exam && isBeforeStudentReviewEnd() && isAfterStudentReviewStart()">
-    <a class="btn btn-success" style="cursor: default; pointer-events: none">
-        {{ 'artemisApp.exam.studentReviewEnabled' | artemisTranslate }}
-    </a>
+<div class="mb-4 container text-center" *ngIf="studentExam?.exam && isBeforeStudentReviewEnd() && isAfterStudentReviewStart()">
+    <div class="row justify-content-center">
+        <div class="alert alert-success col-12 col-lg-6" role="alert">
+            {{ 'artemisApp.exam.studentReviewEnabled' | artemisTranslate }}
+        </div>
+    </div>
 </div>
 <div class="mb-4 container exam-points-summary-container" *ngIf="studentExam && studentExam.exercises && studentExam.exam?.course && studentExamGradeInfoDTO">
     <jhi-exam-points-summary [studentExamWithGrade]="studentExamGradeInfoDTO"></jhi-exam-points-summary>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [X] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guiXelines/).
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.

### Motivation and Context
A user in the exam testing session was confused that the "Review is open" text is in a button, that is not clickable.

### Description
- Changed the button to an alert

### Steps for Testing
Nothing really. The before and after screenshots are enough in my opinion

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2

### Screenshots
Before:
![before](https://user-images.githubusercontent.com/29718932/180610512-f3bf523c-d169-4c68-bb49-38cfb172130e.png)
After:
![after](https://user-images.githubusercontent.com/29718932/180610515-a6e28b0c-66b0-4b2d-9e9d-1e303c77408e.png)
 