### PR TITLE
`Exam mode`: Fix navbar exam detection and hide breadcrumbs appropriately

### DIFF
--- a/src/main/webapp/app/exam/participate/exam-participation.service.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.service.ts
@@ -4,7 +4,7 @@ import { StudentExam } from 'app/entities/student-exam.model';
 import { HttpClient, HttpErrorResponse, HttpResponse, HttpParams } from '@angular/common/http';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { QuizSubmission } from 'app/entities/quiz/quiz-submission.model';
-import { catchError, map } from 'rxjs/operators';
+import { catchError, map, tap } from 'rxjs/operators';
 import { ExerciseService } from 'app/exercises/shared/exercise/exercise.service';
 import { Exam } from 'app/entities/exam.model';
 import dayjs from 'dayjs/esm';
@@ -163,6 +163,7 @@ export class ExamParticipationService {
             map((submittedStudentExam: StudentExam) => {
                 return ExamParticipationService.convertStudentExamFromServer(submittedStudentExam);
             }),
+            tap((submittedStudentExam: StudentExam) => this.currentlyLoadedStudentExam.next(submittedStudentExam)),
             catchError((error: HttpErrorResponse) => {
                 if (error.status === 403 && error.headers.get('x-null-error') === 'error.submissionNotInTime') {
                     return throwError(() => new Error('artemisApp.studentExam.submissionNotInTime'));

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <ng-template #iconMenu>
     <div id="navbar-icon-menu" [ngClass]="{ evenly: isNavbarNavVertical, 'in-menu': iconsMovedToMenu }">
-        <jhi-notification-sidebar *ngIf="currAccount && !examModeActive()"></jhi-notification-sidebar>
+        <jhi-notification-sidebar *ngIf="currAccount && !isExamActive"></jhi-notification-sidebar>
         <jhi-theme-switch [popoverPlacement]="iconsMovedToMenu ? 'bottom' : 'bottom-right'"></jhi-theme-switch>
         <div
             *ngIf="isAuthenticated()"
@@ -101,7 +101,7 @@
     </div>
     <div class="navbar-collapse collapse" id="navbarResponsive" [ngbCollapse]="isNavbarCollapsed">
         <ul class="navbar-nav ms-auto" [class.vertical]="isNavbarNavVertical">
-            <li *ngIf="currAccount && !examModeActive()" class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
+            <li *ngIf="currAccount && !isExamActive" class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">
                 <a class="guided-tour-overview nav-link" routerLink="courses" (click)="collapseNavbar()" id="overview-menu">
                     <span>
                         <fa-icon [icon]="faThLarge"></fa-icon>
@@ -117,7 +117,7 @@
                 routerLinkActive="active"
                 [routerLinkActiveOptions]="{ exact: true }"
             >
-                <a *ngIf="!examModeActive()" class="guided-tour-course-admin nav-link" routerLink="course-management" (click)="collapseNavbar()" id="course-admin-menu">
+                <a *ngIf="!isExamActive" class="guided-tour-course-admin nav-link" routerLink="course-management" (click)="collapseNavbar()" id="course-admin-menu">
                     <span>
                         <fa-icon [icon]="faThList"></fa-icon>
                         <span jhiTranslate="global.menu.course">Course Management</span>
@@ -133,7 +133,7 @@
                 routerLinkActive="active"
                 [routerLinkActiveOptions]="{ exact: true }"
             >
-                <a *ngIf="!examModeActive()" class="guided-tour-admin nav-link dropdown-toggle" ngbDropdownToggle id="admin-menu">
+                <a *ngIf="!isExamActive" class="guided-tour-admin nav-link dropdown-toggle" ngbDropdownToggle id="admin-menu">
                     <span>
                         <fa-icon [icon]="faUserPlus"></fa-icon>
                         <span jhiTranslate="global.menu.admin.main">Server Administration</span>
@@ -236,7 +236,7 @@
     </div>
 </nav>
 <div class="breadcrumb-container">
-    <div *ngIf="breadcrumbs && breadcrumbs.length > 0">
+    <div *ngIf="!isExamActive && breadcrumbs && breadcrumbs.length > 0">
         <ol class="breadcrumb">
             <li *ngFor="let breadcrumb of breadcrumbs; let i = index" class="breadcrumb-item">
                 <a

--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -714,7 +714,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
     /**
      * Check if the student is currently working on an active exam.
      * If yes, hide some elements like notifications and breadcrumbs.
-     * Schedules a check for this at the next relevant timestamp (exam start or exam end, whichever comes next9)
+     * Schedules a check for this at the next relevant timestamp (exam start or exam end, whichever comes next)
      */
     checkExamActive() {
         if (this.examActiveCheckFuture) {
@@ -722,7 +722,15 @@ export class NavbarComponent implements OnInit, OnDestroy {
             this.examActiveCheckFuture = undefined;
         }
 
-        if (this.studentExam?.exam && this.studentExam.exam.id === this.examId && this.studentExam.exam.startDate && this.studentExam.exam.endDate && !this.studentExam.submitted) {
+        if (
+            this.studentExam?.exam &&
+            this.studentExam.exam.id === this.examId &&
+            !this.studentExam.exam.testExam &&
+            !this.studentExam.testRun &&
+            this.studentExam.exam.startDate &&
+            this.studentExam.exam.endDate &&
+            !this.studentExam.submitted
+        ) {
             const serverTime = this.serverDateService.now();
             // As end date, we use the working time of this student plus the grace period
             const workingTime = this.studentExam.workingTime ?? this.studentExam.exam.workingTime;

--- a/src/test/javascript/spec/component/admin/system-notification-management/system-notification-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/system-notification-management/system-notification-detail.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterEvent, RouterOutlet } from '@angular/router';
+import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
 import { SystemNotificationManagementDetailComponent } from 'app/admin/system-notification-management/system-notification-management-detail.component';
 import { SystemNotification } from 'app/entities/system-notification.model';
 import { FormDateTimePickerComponent } from 'app/shared/date-time-picker/date-time-picker.component';

--- a/src/test/javascript/spec/component/admin/system-notification-management/system-notification-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/system-notification-management/system-notification-detail.component.spec.ts
@@ -23,7 +23,7 @@ describe('SystemNotificationManagementDetailComponent', () => {
 
     beforeEach(() => {
         router = new MockRouter();
-        router.events = of({ id: 1, url: '' } as RouterEvent);
+        router.setUrl('');
 
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule, FormsModule],

--- a/src/test/javascript/spec/component/admin/system-notification-management/system-notification-management.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/system-notification-management/system-notification-management.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { ActivatedRoute, Router, RouterEvent, RouterOutlet } from '@angular/router';
+import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
 import { SystemNotificationManagementComponent } from 'app/admin/system-notification-management/system-notification-management.component';
 import { SystemNotification } from 'app/entities/system-notification.model';

--- a/src/test/javascript/spec/component/admin/system-notification-management/system-notification-management.component.spec.ts
+++ b/src/test/javascript/spec/component/admin/system-notification-management/system-notification-management.component.spec.ts
@@ -27,7 +27,7 @@ describe('SystemNotificationManagementComponent', () => {
 
     beforeEach(() => {
         router = new MockRouter();
-        router.events = of({ id: 1, url: '' } as RouterEvent);
+        router.setUrl('');
 
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],

--- a/src/test/javascript/spec/component/shared/navbar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/navbar.component.spec.ts
@@ -228,9 +228,6 @@ describe('NavbarComponent', () => {
     });
 
     it('should set the exam active state correctly', fakeAsync(() => {
-        // TODO inject exam part service, return fake exam
-        // Set examId through nav event
-        // Make sure that scheduled updates of the active state work
         const now = dayjs();
         const examParticipationService = TestBed.inject(ExamParticipationService);
         const activatedRoute = TestBed.inject(ActivatedRoute) as MockActivatedRoute;

--- a/src/test/javascript/spec/component/shared/navbar.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/navbar.component.spec.ts
@@ -237,10 +237,12 @@ describe('NavbarComponent', () => {
         router.setUrl('/course/2/exams/1');
 
         examParticipationService.currentlyLoadedStudentExam.next({
+            workingTime: 60,
             exam: {
                 id: 1,
                 startDate: now.add(1, 'minute'),
                 endDate: now.add(2, 'minutes'),
+                gracePeriod: 180,
             },
         } as StudentExam);
 
@@ -248,6 +250,8 @@ describe('NavbarComponent', () => {
         tick(61000);
         expect(component.isExamActive).toBeTrue();
         tick(61000);
+        expect(component.isExamActive).toBeTrue();
+        tick(180000);
         expect(component.isExamActive).toBeFalse();
     }));
 

--- a/src/test/javascript/spec/helpers/mocks/activated-route/mock-activated-route.ts
+++ b/src/test/javascript/spec/helpers/mocks/activated-route/mock-activated-route.ts
@@ -2,9 +2,9 @@ import { ActivatedRoute, Data, Params } from '@angular/router';
 import { ReplaySubject } from 'rxjs';
 
 export class MockActivatedRoute extends ActivatedRoute {
-    private queryParamsSubject = new ReplaySubject<Params>();
-    private paramSubject = new ReplaySubject<Params>();
-    private dataSubject = new ReplaySubject<Data>();
+    private queryParamsSubject = new ReplaySubject<Params>(1);
+    private paramSubject = new ReplaySubject<Params>(1);
+    private dataSubject = new ReplaySubject<Data>(1);
 
     constructor(parameters?: any) {
         super();
@@ -26,5 +26,13 @@ export class MockActivatedRoute extends ActivatedRoute {
                 predicate: 'id',
             },
         });
+    }
+
+    get root(): ActivatedRoute {
+        return this;
+    }
+
+    get firstChild(): ActivatedRoute {
+        return this;
     }
 }

--- a/src/test/javascript/spec/helpers/mocks/mock-router.ts
+++ b/src/test/javascript/spec/helpers/mocks/mock-router.ts
@@ -1,18 +1,27 @@
-import { EMPTY, Observable } from 'rxjs';
-import { RouterEvent, RouterState, UrlTree } from '@angular/router';
+import { EMPTY, Observable, Subject } from 'rxjs';
+import { NavigationEnd, RouterEvent, RouterState, UrlTree } from '@angular/router';
 
 // When using the spies, bear in mind jest.resetAllMocks does not affect them, they need to be reset manually
 export class MockRouter {
     url = '/';
-    setUrl = (url: string) => (this.url = url);
     navigateByUrl = jest.fn().mockReturnValue(true);
     navigate = jest.fn().mockReturnValue(true);
-    events: Observable<RouterEvent> = EMPTY;
     routerState: RouterState;
     createUrlTree = jest.fn().mockReturnValue({ path: 'testValue' } as unknown as UrlTree);
     serializeUrl = jest.fn().mockReturnValue('testValue');
 
+    eventSubject: Subject<RouterEvent> = new Subject<RouterEvent>();
+
     setRouterState(routerState: RouterState) {
         this.routerState = routerState;
+    }
+
+    get events(): Observable<RouterEvent> {
+        return this.eventSubject.asObservable();
+    }
+
+    setUrl(url: string) {
+        this.url = url;
+        this.eventSubject.next(new NavigationEnd(0, url, url));
     }
 }

--- a/src/test/javascript/spec/service/navigation-util.service.spec.ts
+++ b/src/test/javascript/spec/service/navigation-util.service.spec.ts
@@ -10,7 +10,7 @@ describe('Navigation Util Service', () => {
     let service: ArtemisNavigationUtilService;
 
     const router = new MockRouter();
-    router.events = of(new NavigationEnd(1, 'a', 'b'), new NavigationEnd(1, 'a', 'b'));
+    router.setUrl('a');
 
     beforeEach(() => {
         TestBed.configureTestingModule({

--- a/src/test/javascript/spec/service/navigation-util.service.spec.ts
+++ b/src/test/javascript/spec/service/navigation-util.service.spec.ts
@@ -1,9 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 import { ArtemisTestModule } from '../test.module';
-import { NavigationEnd, Router, UrlTree } from '@angular/router';
+import { Router, UrlTree } from '@angular/router';
 import { Location } from '@angular/common';
 import { ArtemisNavigationUtilService } from 'app/utils/navigation.utils';
-import { of } from 'rxjs';
 import { MockRouter } from '../helpers/mocks/mock-router';
 
 describe('Navigation Util Service', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The navbar should hide a few elements (notifications, breadcrumbs ..) when an exam is running. However, at the moment there are a few problems with the related implementation:
- The template calls a method to check if the exam is active at multiple locations. This is a bad practice as the function is called over and over again to check for different results, causing continuous load
- The breadcrumbs only check if an exam is running when they are generated; however, this is not sufficient as the state of the exam can change over time, and without an navigation event, the breadcrumbs are not regenerated
- The current implementation does not take individual working times into account

### Description
<!-- Describe your changes in detail -->

- Reimplemented the check for an exam active to only populate a component field that can be consumed by the template that is updated by timeouts
- Hide the entire breadcrumb row if an exam is active instead of checking this while generating them
- Only hide elements for real exams (as we want do avoid distraction there). Do not do it for test runs or test exams

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Course with an upcoming Exam
- 1 Student registered for the exam, with a generated student exam so they can participate

1. Open the exam page as student before it starts. Notification icon and breadcrumbs should be visible.
2. Enter your name and click start. The countdown for the exam should appear as normal.
3. As soon as the countdown for the start of the exam runs out, you should be forwarded to the exercise overview. At the same time, breadcrumbs and the notification icon in the navbar etc should disappear.
4. Let the time of the exam run out. The hidden stuff should still be hidden.
5. Submit the exam OR let the submission time run out. In both cases the hidden things should reappear.

See the video below for how it could look like.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| navbar.component.ts | 82% | 92% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


https://user-images.githubusercontent.com/23171488/180625119-87f6835c-783c-4b27-b807-e9d36170caae.mov


