### PR TITLE
`Programming exercises`: Fix PMD version in Java Maven template

### DIFF
--- a/src/main/resources/templates/java/maven_maven/test/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/maven_maven/test/projectTemplate/pom.xml
@@ -151,7 +151,7 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>6.44</version>
+                        <version>6.44.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.

### Motivation and Context
PMD version 6.44 does not exist on Maven Central. Only 6.44.0 exists. Therefore, Maven fails to download the dependency and the build fails.
https://search.maven.org/artifact/net.sourceforge.pmd/pmd-core/6.44.0/jar

### Description
Changed the version to the correct one. In other `pom.xml` files including the one used to build the Docker image the version is correctly specified. No change is necessary there.
