### PR TITLE
`Programming Exercises`: Fix case for "Build failed" result string

### DIFF
--- a/src/main/webapp/i18n/en/editor.json
+++ b/src/main/webapp/i18n/en/editor.json
@@ -31,7 +31,7 @@
             "submitDescription": "Stage, commit, push, build and test your changes.",
             "buildOutput": "&nbsp; Build Output",
             "building": "Building and testing...",
-            "buildFailed": "Build Failed",
+            "buildFailed": "Build failed",
             "noBuildOutput": "No build results available",
             "selectFile": "Select a file to get started!",
             "downloadBuildResult": "Download Build Result",

--- a/src/main/webapp/i18n/en/result.json
+++ b/src/main/webapp/i18n/en/result.json
@@ -22,7 +22,7 @@
             },
             "noResult": "No graded result",
             "resultString": "Result Text",
-            "resultStringBuildFailed": "Build Failed",
+            "resultStringBuildFailed": "Build failed",
             "resultStringBuildSuccessfulNoTests": "Build successful, no tests executed",
             "resultStringBuildSuccessfulTests": "{{ numberOfTestsPassed }} of {{ numberOfTestsTotal }} passed",
             "resultStringNonProgramming": "Score {{ relativeScore }}%, {{ points }} of {{ maxPoints }} points",

--- a/src/test/cypress/integration/exercises/programming/ProgrammingExerciseParticipation.spec.ts
+++ b/src/test/cypress/integration/exercises/programming/ProgrammingExerciseParticipation.spec.ts
@@ -66,7 +66,7 @@ describe('Programming exercise participations', () => {
     function makeFailingSubmission() {
         const submission = { files: [{ name: 'BubbleSort.java', path: 'programming_exercise_submissions/build_error/BubbleSort.txt' }] };
         makeSubmissionAndVerifyResults(editorPage, exercise.packageName!, submission, () => {
-            editorPage.getResultScore().contains('Build Failed').should('be.visible');
+            editorPage.getResultScore().contains('Build failed').should('be.visible');
             editorPage.getResultScore().contains('0%').and('be.visible');
         });
     }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
@@ -804,7 +804,7 @@ abstract class ProgrammingExerciseGradingServiceTest extends AbstractSpringInteg
             assertThat(singleResult).isEqualTo(participation.findLatestLegalResult());
         }
         else if (student == 5) {
-            // student5 Build Failed
+            // student5 Build failed
             assertThat(results).hasSize(1);
             var singleResult = results.iterator().next();
             testParticipationResult(singleResult, 0D, false, 0, AssessmentType.AUTOMATIC);


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
During the refactoring of the result string, the showed result for failed build changed to "Build Failed" from "Build failed". This is inconsistant with other strings (see screenshots below).

### Description
Changed to "Build failed"

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Programming Exercise 

1. Submit Code to the PE that won't compile.
2. Check that the student sees "Build failed"

### Review Progress
#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Screenshots
Old Version: 
![grafik](https://user-images.githubusercontent.com/26540346/180758832-074d34a5-ee5c-4cf4-b5a9-14c6a734be27.png)

Current State:
![grafik](https://user-images.githubusercontent.com/26540346/180758952-ad8f3efe-1a2f-4ba7-9d12-b5ce97b7ac81.png)

Inconsistent with e.g.: 
![grafik](https://user-images.githubusercontent.com/26540346/180759038-26552dfa-7934-45cc-a4b5-f43e8e21cb21.png)
