### PR TITLE
`Programming exercises`: Fix an issue that caused tasks to get duplicated during import

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ProgrammingExerciseRepository.java
@@ -241,19 +241,16 @@ public interface ProgrammingExerciseRepository extends JpaRepository<Programming
 
     @Query("""
             SELECT p FROM ProgrammingExercise p
-            LEFT JOIN FETCH p.testCases
+            LEFT JOIN FETCH p.testCases tc
             LEFT JOIN FETCH p.staticCodeAnalysisCategories
             LEFT JOIN FETCH p.exerciseHints
             LEFT JOIN FETCH p.templateParticipation
             LEFT JOIN FETCH p.solutionParticipation
             LEFT JOIN FETCH p.auxiliaryRepositories
-            LEFT JOIN FETCH p.tasks t
-            LEFT JOIN FETCH t.testCases tc
             LEFT JOIN FETCH tc.solutionEntries
             WHERE p.id = :#{#exerciseId}
             """)
-    Optional<ProgrammingExercise> findByIdWithEagerTestCasesStaticCodeAnalysisCategoriesHintsAndTemplateAndSolutionParticipationsAndAuxReposAndTasksWithTestCases(
-            @Param("exerciseId") Long exerciseId);
+    Optional<ProgrammingExercise> findByIdWithEagerTestCasesStaticCodeAnalysisCategoriesHintsAndTemplateAndSolutionParticipationsAndAuxRepos(@Param("exerciseId") Long exerciseId);
 
     /**
      * Returns the programming exercises that have a buildAndTestStudentSubmissionsAfterDueDate higher than the provided date.

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseExportImportResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseExportImportResource.java
@@ -34,6 +34,7 @@ import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
 import de.tum.in.www1.artemis.repository.AuxiliaryRepositoryRepository;
 import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
+import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseTaskRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.service.CourseService;
@@ -78,11 +79,13 @@ public class ProgrammingExerciseExportImportResource {
 
     private final SubmissionPolicyService submissionPolicyService;
 
+    private final ProgrammingExerciseTaskRepository programmingExerciseTaskRepository;
+
     public ProgrammingExerciseExportImportResource(ProgrammingExerciseRepository programmingExerciseRepository, UserRepository userRepository,
-            AuthorizationCheckService authCheckService, CourseService courseService, ProgrammingExerciseService programmingExerciseService,
-            ProgrammingExerciseImportService programmingExerciseImportService, ProgrammingExerciseExportService programmingExerciseExportService,
-            Optional<ProgrammingLanguageFeatureService> programmingLanguageFeatureService, TemplateUpgradePolicy templateUpgradePolicy,
-            AuxiliaryRepositoryRepository auxiliaryRepositoryRepository, SubmissionPolicyService submissionPolicyService) {
+            AuthorizationCheckService authCheckService, CourseService courseService, ProgrammingExerciseImportService programmingExerciseImportService,
+            ProgrammingExerciseExportService programmingExerciseExportService, Optional<ProgrammingLanguageFeatureService> programmingLanguageFeatureService,
+            AuxiliaryRepositoryRepository auxiliaryRepositoryRepository, SubmissionPolicyService submissionPolicyService,
+            ProgrammingExerciseTaskRepository programmingExerciseTaskRepository) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.userRepository = userRepository;
         this.courseService = courseService;
@@ -92,6 +95,7 @@ public class ProgrammingExerciseExportImportResource {
         this.programmingLanguageFeatureService = programmingLanguageFeatureService;
         this.auxiliaryRepositoryRepository = auxiliaryRepositoryRepository;
         this.submissionPolicyService = submissionPolicyService;
+        this.programmingExerciseTaskRepository = programmingExerciseTaskRepository;
     }
 
     /**
@@ -146,8 +150,12 @@ public class ProgrammingExerciseExportImportResource {
         programmingExerciseRepository.validateCourseSettings(newExercise, course);
 
         final var originalProgrammingExercise = programmingExerciseRepository
-                .findByIdWithEagerTestCasesStaticCodeAnalysisCategoriesHintsAndTemplateAndSolutionParticipationsAndAuxReposAndTasksWithTestCases(sourceExerciseId)
+                .findByIdWithEagerTestCasesStaticCodeAnalysisCategoriesHintsAndTemplateAndSolutionParticipationsAndAuxRepos(sourceExerciseId)
                 .orElseThrow(() -> new EntityNotFoundException("ProgrammingExercise", sourceExerciseId));
+
+        // Fetching the tasks separately, as putting it in the query above leads to Hibernate duplicating the tasks.
+        var templateTasks = programmingExerciseTaskRepository.findByExerciseIdWithTestCases(originalProgrammingExercise.getId());
+        originalProgrammingExercise.setTasks(new ArrayList<>(templateTasks));
 
         // The static code analysis flag can only change, if the build plans are recreated and the template is upgraded
         if (newExercise.isStaticCodeAnalysisEnabled() != originalProgrammingExercise.isStaticCodeAnalysisEnabled() && !(recreateBuildPlans && updateTemplate)) {

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -505,7 +505,7 @@ public class ProgrammingExerciseTestService {
         importedExercise = database.loadProgrammingExerciseWithEagerReferences(importedExercise);
 
         // Check that the tasks were imported correctly (see #5474)
-        assertThat(programmingExerciseTaskRepository.findByExerciseId(importedExercise.getId())).hasSize(sourceExercise.getTasks().size());
+        assertThat(programmingExerciseTaskRepository.findByExerciseId(importedExercise.getId())).hasSameSizeAs(sourceExercise.getTasks());
 
         // TODO: check why the assertions do not work correctly
         // Assert correct creation of test cases

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTestService.java
@@ -46,11 +46,13 @@ import de.tum.in.www1.artemis.domain.enumeration.*;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.hestia.ExerciseHint;
+import de.tum.in.www1.artemis.domain.hestia.ProgrammingExerciseTask;
 import de.tum.in.www1.artemis.domain.participation.Participant;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.exception.GitException;
 import de.tum.in.www1.artemis.exception.VersionControlException;
 import de.tum.in.www1.artemis.repository.*;
+import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseTaskRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.CourseExamExportService;
 import de.tum.in.www1.artemis.service.ParticipationService;
@@ -146,6 +148,12 @@ public class ProgrammingExerciseTestService {
 
     @Autowired
     private JavaTemplateUpgradeService javaTemplateUpgradeService;
+
+    @Autowired
+    private ProgrammingExerciseTaskRepository programmingExerciseTaskRepository;
+
+    @Autowired
+    private ProgrammingExerciseTestCaseRepository programmingExerciseTestCaseRepository;
 
     @Autowired
     private UrlService urlService;
@@ -457,6 +465,15 @@ public class ProgrammingExerciseTestService {
 
         // Setup exercises for import
         database.addTestCasesToProgrammingExercise(sourceExercise);
+        database.addTasksToProgrammingExercise(sourceExercise);
+        // Manually add task
+        var task = new ProgrammingExerciseTask();
+        task.setTaskName("Task 1");
+        task.setExercise(sourceExercise);
+        task.setTestCases(programmingExerciseTestCaseRepository.findByExerciseId(sourceExercise.getId()));
+        sourceExercise.setTasks(Collections.singletonList(task));
+        programmingExerciseTaskRepository.save(task);
+        programmingExerciseRepository.save(sourceExercise);
         database.addHintsToExercise(sourceExercise);
 
         // Reset because we will add mocks for new requests
@@ -486,6 +503,9 @@ public class ProgrammingExerciseTestService {
         var importedExercise = request.postWithResponseBody(ROOT + IMPORT.replace("{sourceExerciseId}", sourceExercise.getId().toString()), exerciseToBeImported,
                 ProgrammingExercise.class, params, HttpStatus.OK);
         importedExercise = database.loadProgrammingExerciseWithEagerReferences(importedExercise);
+
+        // Check that the tasks were imported correctly (see #5474)
+        assertThat(programmingExerciseTaskRepository.findByExerciseId(importedExercise.getId())).hasSize(sourceExercise.getTasks().size());
 
         // TODO: check why the assertions do not work correctly
         // Assert correct creation of test cases


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
<!-- Describe your changes in detail -->

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1/2 Course(s)

1. Log in to Artemis
2. Check that the existing programming exercise has the correct number of tasks
3. Import the existing programming exercise into the other course
4. Check that the imported programming exercise has the correct number of tasks

To check the number of tasks do one of these steps:
- Check the entries in your local database
- Call the endpoint `/api/programming-exercises/{exerciseId}/tasks` manually
- Apply this patch locally and you will get a button on the PE detail page
```diff
Index: src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html	(revision a01031dd57e0d0257ed6219cd78a9b96ff9f11ff)
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html	(date 1658825544410)
@@ -148,6 +148,16 @@
                             <span jhiTranslate="artemisApp.programmingExercise.structureTestOracle">Update Structure Test Oracle</span>
                         </button>
                     </span>
+                    <span *ngIf="programmingExercise.isAtLeastTutor" class="me-1">
+                        <button
+                            [jhiFeatureToggle]="FeatureToggle.ProgrammingExercises"
+                            type="button"
+                            (click)="getTasks()"
+                            class="btn btn-success btn-sm"
+                        >
+                            <span>Show tasks</span>
+                        </button>
+                    </span>
                 </div>
                 <div *ngIf="programmingExercise.isAtLeastEditor">
                     <span
Index: src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts
--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts	(revision a01031dd57e0d0257ed6219cd78a9b96ff9f11ff)
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.ts	(date 1658825718656)
@@ -453,6 +453,14 @@
         });
     }
 
+    getTasks(): void {
+        if (this.programmingExercise?.id) {
+            this.programmingExerciseService.getTasksAndTestsExtractedFromProblemStatement(this.programmingExercise.id).subscribe((tasks) => {
+                this.alertService.success(`There are ${tasks.length} tasks for this exercise.`);
+            });
+        }
+    }
+
     createBehavioralSolutionEntries() {
         this.programmingExerciseService.createBehavioralSolutionEntries(this.programmingExercise.id!).subscribe({
             next: () => {

```

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
