### PR TITLE
`Development`: Disable onDrop functionality for the complaint response text area

### DIFF
--- a/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
+++ b/src/main/webapp/app/complaints/complaints-for-tutor/complaints-for-tutor.component.html
@@ -67,6 +67,7 @@
                     [(ngModel)]="complaintResponse.responseText"
                     [readonly]="handled || isLockedForLoggedInUser"
                     [disabled]="handled || isLockedForLoggedInUser"
+                    ondrop="return false;"
                 >
                 </textarea>
                 <jhi-textarea-counter [maxLength]="this.course!.maxComplaintResponseTextLimit!" [content]="complaintResponse.responseText" [visible]="!handled">


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.

### Motivation and Context

Fixes issue 13 found in the exam testing sessions: https://confluence.ase.in.tum.de/pages/viewpage.action?spaceKey=ArTEMiS&title=Testing+Session+11.07.2022

### Description
Disables the drag and drop functionality into the complaint response box.

### Steps for Testing

We need to create a complaint as a student so that the instructor will then need to respond to the complaint, which is a somewhat long process:

Prerequisites:
- 1 Instructor
- 1 Student

1. Log in to Artemis as the instructor
2. Create an exam with 1 Text Exercise with an assessment criterion
3. Configure the exam and add the student to the exam
4. Start the exam
5. Log in to Artemis as the student
6. Take part in the exam and hand it in
7. Log in to Artemis as the instructor
8. Assess the text submission of the student
9. Log in to Artemis as the student
10. Create a complaint for the text exercise
11. Log in to Artemis as the instructor
12. Go back to the Asssessment Dashboard of the exam to respond to the complaint
13. Verify that dragging and dropping the assessment criterion in the 'Complaint's Response' text area is now disabled
14. Verify that writing in the text area still works and submit the complaint's response works

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/11006274/181032582-249862fb-6a83-4a09-ad66-421f04df3045.png)

Now:

Drag and drop of assessment criterion is disabled for the "Complaint's response" text area