### PR TITLE
`Development`: Align the service name to FileUploadExerciseImportService

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadExerciseImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadExerciseImportService.java
@@ -15,13 +15,13 @@ import de.tum.in.www1.artemis.repository.ResultRepository;
 import de.tum.in.www1.artemis.repository.SubmissionRepository;
 
 @Service
-public class FileUploadImportService extends ExerciseImportService {
+public class FileUploadExerciseImportService extends ExerciseImportService {
 
     private final Logger log = LoggerFactory.getLogger(TextExerciseImportService.class);
 
     private final FileUploadExerciseRepository fileUploadExerciseRepository;
 
-    public FileUploadImportService(ExampleSubmissionRepository exampleSubmissionRepository, SubmissionRepository submissionRepository, ResultRepository resultRepository,
+    public FileUploadExerciseImportService(ExampleSubmissionRepository exampleSubmissionRepository, SubmissionRepository submissionRepository, ResultRepository resultRepository,
             FileUploadExerciseRepository fileUploadExerciseRepository) {
         super(exampleSubmissionRepository, submissionRepository, resultRepository);
         this.fileUploadExerciseRepository = fileUploadExerciseRepository;

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamImportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamImportService.java
@@ -16,7 +16,7 @@ import de.tum.in.www1.artemis.domain.modeling.ModelingExercise;
 import de.tum.in.www1.artemis.domain.quiz.QuizExercise;
 import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.repository.hestia.ProgrammingExerciseTaskRepository;
-import de.tum.in.www1.artemis.service.FileUploadImportService;
+import de.tum.in.www1.artemis.service.FileUploadExerciseImportService;
 import de.tum.in.www1.artemis.service.ModelingExerciseImportService;
 import de.tum.in.www1.artemis.service.QuizExerciseImportService;
 import de.tum.in.www1.artemis.service.TextExerciseImportService;
@@ -53,7 +53,7 @@ public class ExamImportService {
 
     private final FileUploadExerciseRepository fileUploadExerciseRepository;
 
-    private final FileUploadImportService fileUploadImportService;
+    private final FileUploadExerciseImportService fileUploadExerciseImportService;
 
     private final GradingCriterionRepository gradingCriterionRepository;
 
@@ -64,7 +64,7 @@ public class ExamImportService {
             ExerciseGroupRepository exerciseGroupRepository, QuizExerciseRepository quizExerciseRepository, QuizExerciseImportService importQuizExercise,
             CourseRepository courseRepository, ProgrammingExerciseService programmingExerciseService1, ProgrammingExerciseRepository programmingExerciseRepository,
             ProgrammingExerciseImportService programmingExerciseImportService, FileUploadExerciseRepository fileUploadExerciseRepository,
-            FileUploadImportService fileUploadImportService, GradingCriterionRepository gradingCriterionRepository,
+            FileUploadExerciseImportService fileUploadExerciseImportService, GradingCriterionRepository gradingCriterionRepository,
             ProgrammingExerciseTaskRepository programmingExerciseTaskRepository) {
         this.textExerciseImportService = textExerciseImportService;
         this.textExerciseRepository = textExerciseRepository;
@@ -79,7 +79,7 @@ public class ExamImportService {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.programmingExerciseImportService = programmingExerciseImportService;
         this.fileUploadExerciseRepository = fileUploadExerciseRepository;
-        this.fileUploadImportService = fileUploadImportService;
+        this.fileUploadExerciseImportService = fileUploadExerciseImportService;
         this.gradingCriterionRepository = gradingCriterionRepository;
         this.programmingExerciseTaskRepository = programmingExerciseTaskRepository;
     }
@@ -254,7 +254,7 @@ public class ExamImportService {
                     if (optionalFileUploadExercise.isEmpty()) {
                         break;
                     }
-                    exerciseCopied = fileUploadImportService.importFileUploadExercise(optionalFileUploadExercise.get(), (FileUploadExercise) exerciseToCopy);
+                    exerciseCopied = fileUploadExerciseImportService.importFileUploadExercise(optionalFileUploadExercise.get(), (FileUploadExercise) exerciseToCopy);
                 }
 
                 case QUIZ -> {


### PR DESCRIPTION

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
With the Exam Import functionality #5330 a new service for the import of FileUpload Exercises was added.
The service is currently named `FileUploadImportService`. To allign the name to the other import services, the service is renamed to `FileUploadExerciseImportService`.

### Description
Renaming `FileUploadImportService` -> `FileUploadExerciseImportService`


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Exam with a file upload exercise

1. Verify, that all server-tests are passing
2. Take a look at the code 
3. Import an exam with a file upload exercise and verify the correct functionality

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2