### PR TITLE
`Exam mode`: Improve performance when saving submissions for modeling, text and file upload exercises

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -144,7 +144,7 @@ public class FileUploadSubmissionService extends SubmissionService {
         }
         fileUploadSubmission.setSubmissionDate(ZonedDateTime.now());
         fileUploadSubmission.setType(SubmissionType.MANUAL);
-        fileUploadSubmission.setParticipation(participation);
+        participation.addSubmission(fileUploadSubmission);
 
         // remove result from submission (in the unlikely case it is passed here), so that students cannot inject a result
         fileUploadSubmission.setResults(new ArrayList<>());
@@ -155,14 +155,10 @@ public class FileUploadSubmissionService extends SubmissionService {
         // Note: we save again so that the new file is stored on the file system
         fileUploadSubmission = fileUploadSubmissionRepository.save(fileUploadSubmission);
 
-        participation.addSubmission(fileUploadSubmission);
-        participation.setInitializationState(InitializationState.FINISHED);
-        StudentParticipation savedParticipation = studentParticipationRepository.save(participation);
-        if (fileUploadSubmission.getId() == null) {
-            Optional<Submission> optionalSubmission = savedParticipation.findLatestSubmission();
-            if (optionalSubmission.isPresent()) {
-                fileUploadSubmission = (FileUploadSubmission) optionalSubmission.get();
-            }
+        if (!exercise.isExamExercise() && participation.getInitializationState() != InitializationState.FINISHED) {
+            // not for exam exercises
+            participation.setInitializationState(InitializationState.FINISHED);
+            studentParticipationRepository.save(participation);
         }
 
         return fileUploadSubmission;

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -155,8 +155,7 @@ public class FileUploadSubmissionService extends SubmissionService {
         // Note: we save again so that the new file is stored on the file system
         fileUploadSubmission = fileUploadSubmissionRepository.save(fileUploadSubmission);
 
-        if (!exercise.isExamExercise() && participation.getInitializationState() != InitializationState.FINISHED) {
-            // not for exam exercises
+        if (participation.getInitializationState() != InitializationState.FINISHED) {
             participation.setInitializationState(InitializationState.FINISHED);
             studentParticipationRepository.save(participation);
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -125,8 +125,7 @@ public class ModelingSubmissionService extends SubmissionService {
             log.error("Modeling submission version could not be saved", ex);
         }
 
-        if (!modelingExercise.isExamExercise() && participation.getInitializationState() != InitializationState.FINISHED) {
-            // not for exam exercises
+        if (participation.getInitializationState() != InitializationState.FINISHED) {
             participation.setInitializationState(InitializationState.FINISHED);
             studentParticipationRepository.save(participation);
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -108,8 +108,7 @@ public class TextSubmissionService extends SubmissionService {
             log.error("Text submission version could not be saved", ex);
         }
 
-        if (!textExercise.isExamExercise() && participation.getInitializationState() != InitializationState.FINISHED) {
-            // not for exam exercises
+        if (participation.getInitializationState() != InitializationState.FINISHED) {
             participation.setInitializationState(InitializationState.FINISHED);
             studentParticipationRepository.save(participation);
         }


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When an exercise is saved and the initialization state is already finished, an unnecessary save of the participation was made.

### Description
<!-- Describe your changes in detail -->
The participation is now only saved if the initialization state was explicitly set.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Test the exam mode in general. Try to hand in exams with all sorts of things.
In general, this should be tested in the exam testing session with the practical course so we can be sure that nothing broke

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
