### PR TITLE
`Exam mode`: Fix breadcrumbs for exam import

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.component.ts
@@ -529,6 +529,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
                 } else if (this.lastRouteUrlSegment === 'exercise-groups') {
                     // - Don't display '<type>-exercises' because it has no associated route
                     break;
+                } else if (this.lastRouteUrlSegment === 'exams' && segment === 'import') {
+                    // This route is only used internally when opening the exam import modal and therefore shouldn't be displayed.
+                    // When opening the exam-update.component, the id of the to be imported exam is appended (-> case `import`).
+                    break;
                 }
 
                 this.addTranslationAsCrumb(currentPath, segment);


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
When opening the exam import, two `import` breadcrumbs were displayed, although there should be only one (see screenshot)

### Description
Another exception has been added to the `navbar.component.ts`.
The first import breadcrumb is only used internally to load those exams to which the user has access. From these exams, one is then selected for import, but this exam has to be loaded again from the server, then with exercises.
Therefore only the second `import`-breadcrumb is important for the user. With the exception, the first breadcrumb is no longer displayed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration -> Exams
3. Click on "Import an exam"
4. Select an exam from the List and click on "Import".
5. Verify, that only one import breadcrumb is displayed, which is linked to the displayed page.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Issue:
<img width="776" alt="image" src="https://user-images.githubusercontent.com/94070506/181793738-e8d012a7-188a-4fa0-a655-1c9e8f8b0df2.png">
Resolved with this PR:
![image](https://user-images.githubusercontent.com/94070506/181793806-2890752a-2b7b-4f6b-a97d-a340b3a8d762.png)


