### PR TITLE
`General`: Remove most update success alerts

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ApollonDiagramResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ApollonDiagramResource.java
@@ -101,7 +101,7 @@ public class ApollonDiagramResource {
         authCheckService.checkHasAtLeastRoleInCourseElseThrow(Role.TEACHING_ASSISTANT, course, null);
 
         ApollonDiagram result = apollonDiagramRepository.save(apollonDiagram);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, apollonDiagram.getId().toString())).body(result);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/AttachmentResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/AttachmentResource.java
@@ -106,7 +106,7 @@ public class AttachmentResource {
         if (notificationText != null) {
             groupNotificationService.notifyStudentGroupAboutAttachmentChange(result, notificationText);
         }
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, attachment.getId().toString())).body(result);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/CourseResource.java
@@ -269,7 +269,7 @@ public class CourseResource {
                 .ifPresent(userManagementService -> userManagementService.updateCoursePermissions(result, oldInstructorGroup, oldEditorGroup, oldTeachingAssistantGroup));
         optionalCiUserManagementService
                 .ifPresent(ciUserManagementService -> ciUserManagementService.updateCoursePermissions(result, oldInstructorGroup, oldEditorGroup, oldTeachingAssistantGroup));
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, Course.ENTITY_NAME, updatedCourse.getTitle())).body(result);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExamResource.java
@@ -215,7 +215,7 @@ public class ExamResource {
             examService.scheduleModelingExercises(examWithExercises);
         }
 
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, result.getTitle())).body(result);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseGroupResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ExerciseGroupResource.java
@@ -129,7 +129,7 @@ public class ExerciseGroupResource {
         examAccessService.checkCourseAndExamAndExerciseGroupAccessElseThrow(Role.EDITOR, courseId, examId, updatedExerciseGroup);
 
         ExerciseGroup result = exerciseGroupRepository.save(updatedExerciseGroup);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, result.getTitle())).body(result);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/FileUploadExerciseResource.java
@@ -184,7 +184,7 @@ public class FileUploadExerciseResource {
         groupNotificationService.checkAndCreateAppropriateNotificationsWhenUpdatingExercise(fileUploadExerciseBeforeUpdate, updatedExercise, notificationText,
                 instanceMessageSendService);
 
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, exerciseId.toString())).body(updatedExercise);
+        return ResponseEntity.ok(updatedExercise);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/LearningGoalResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/LearningGoalResource.java
@@ -221,8 +221,7 @@ public class LearningGoalResource {
 
         LearningGoal updatedLearningGoal = learningGoalRepository.save(learningGoalFromDb);
 
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, updatedLearningGoal.getId().toString()))
-                .body(updatedLearningGoal);
+        return ResponseEntity.ok(updatedLearningGoal);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ModelingExerciseResource.java
@@ -212,8 +212,7 @@ public class ModelingExerciseResource {
         groupNotificationService.checkAndCreateAppropriateNotificationsWhenUpdatingExercise(modelingExerciseBeforeUpdate, updatedModelingExercise, notificationText,
                 instanceMessageSendService);
 
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, modelingExercise.getId().toString()))
-                .body(updatedModelingExercise);
+        return ResponseEntity.ok(updatedModelingExercise);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/OrganizationResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/OrganizationResource.java
@@ -162,7 +162,7 @@ public class OrganizationResource {
         }
         organizationRepository.findByIdElseThrow(organization.getId());
         Organization updated = organizationService.update(organization);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, updated.getName())).body(updated);
+        return ResponseEntity.ok(updated);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingExerciseResource.java
@@ -350,8 +350,7 @@ public class ProgrammingExerciseResource {
         ProgrammingExercise savedProgrammingExercise = programmingExerciseService.updateProgrammingExercise(updatedProgrammingExercise, notificationText);
         exerciseService.logUpdate(updatedProgrammingExercise, updatedProgrammingExercise.getCourseViaExerciseGroupOrCourseMember(), user);
         exerciseService.updatePointsInRelatedParticipantScores(programmingExerciseBeforeUpdate, updatedProgrammingExercise);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, updatedProgrammingExercise.getTitle()))
-                .body(savedProgrammingExercise);
+        return ResponseEntity.ok(savedProgrammingExercise);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/QuizExerciseResource.java
@@ -200,7 +200,7 @@ public class QuizExerciseResource {
         quizExercise = quizExerciseService.save(quizExercise);
         exerciseService.logUpdate(quizExercise, quizExercise.getCourseViaExerciseGroupOrCourseMember(), user);
 
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, quizExercise.getId().toString())).body(quizExercise);
+        return ResponseEntity.ok(quizExercise);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/TextExerciseResource.java
@@ -214,7 +214,7 @@ public class TextExerciseResource {
         groupNotificationService.checkAndCreateAppropriateNotificationsWhenUpdatingExercise(textExerciseBeforeUpdate, updatedTextExercise, notificationText,
                 instanceMessageSendService);
 
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, textExercise.getId().toString())).body(updatedTextExercise);
+        return ResponseEntity.ok(updatedTextExercise);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/AttachmentUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/AttachmentUnitResource.java
@@ -19,7 +19,6 @@ import de.tum.in.www1.artemis.repository.LectureRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.web.rest.errors.ConflictException;
-import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
 @RestController
 @RequestMapping("/api")
@@ -95,7 +94,7 @@ public class AttachmentUnitResource {
         attachmentUnit.setAttachment(originalAttachmentUnit.getAttachment());
 
         AttachmentUnit result = attachmentUnitRepository.save(attachmentUnit);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, attachmentUnit.getId().toString())).body(result);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/OnlineUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/OnlineUnitResource.java
@@ -27,7 +27,6 @@ import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.web.rest.dto.OnlineResourceDTO;
 import de.tum.in.www1.artemis.web.rest.errors.ConflictException;
 import de.tum.in.www1.artemis.web.rest.errors.InternalServerErrorException;
-import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
 @RestController
 @RequestMapping("/api")
@@ -102,7 +101,7 @@ public class OnlineUnitResource {
         }
 
         OnlineUnit result = onlineUnitRepository.save(onlineUnit);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, onlineUnit.getId().toString())).body(result);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/TextUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/TextUnitResource.java
@@ -20,7 +20,6 @@ import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.errors.ConflictException;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
-import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
 @RestController
 @RequestMapping("/api")
@@ -88,7 +87,7 @@ public class TextUnitResource {
         authorizationCheckService.checkHasAtLeastRoleForLectureElseThrow(Role.EDITOR, textUnit.getLecture(), null);
 
         TextUnit result = textUnitRepository.save(textUnit);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, textUnit.getId().toString())).body(result);
+        return ResponseEntity.ok(result);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/lecture/VideoUnitResource.java
@@ -21,7 +21,6 @@ import de.tum.in.www1.artemis.repository.VideoUnitRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.service.AuthorizationCheckService;
 import de.tum.in.www1.artemis.web.rest.errors.ConflictException;
-import de.tum.in.www1.artemis.web.rest.util.HeaderUtil;
 
 @RestController
 @RequestMapping("/api")
@@ -121,7 +120,7 @@ public class VideoUnitResource {
         }
 
         VideoUnit result = videoUnitRepository.save(videoUnit);
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityUpdateAlert(applicationName, true, ENTITY_NAME, videoUnit.getId().toString())).body(result);
+        return ResponseEntity.ok(result);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This is a followup to #5382 where we removed most alerts for creating entities as the success is obvious through navigation events or other indicators. We should do the same for update alerts.

### Description
<!-- Describe your changes in detail -->

Removed update alerts from most entity update response headers on the server.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor / Admin

Verify that you don't get a green alert in the top right if you update any of the following entities:
- Apollon Diagrams
- Attachments
- Courses
- Exams
- Exercise groups
- [File upload, Programming, Modeling, Text, Quiz]-exercises
- Learning goals
- [Attachment, Exercise, Online, Text, Video]-units
- Organizations

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
