### PR TITLE
`Plagiarism checks`: Allow students to compare their files against other student's files for programming exercise plagiarism cases

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/plagiarism/PlagiarismService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/plagiarism/PlagiarismService.java
@@ -57,7 +57,17 @@ public class PlagiarismService {
      * @return the anonymized submission for the given student
      */
     public Submission anonymizeSubmissionForStudent(Submission submission, String userLogin) {
-        var comparisonOptional = plagiarismComparisonRepository.findBySubmissionA_SubmissionIdOrSubmissionB_SubmissionId(submission.getId(), submission.getId());
+        if (!isUserNotifiedByInstructor(submission.getId(), userLogin)) {
+            throw new AccessForbiddenException("This plagiarism submission is not related to the requesting user or the user has not been notified yet.");
+        }
+        submission.setParticipation(null);
+        submission.setResults(null);
+        submission.setSubmissionDate(null);
+        return submission;
+    }
+
+    public boolean isUserNotifiedByInstructor(Long submissionId, String userLogin) {
+        var comparisonOptional = plagiarismComparisonRepository.findBySubmissionA_SubmissionIdOrSubmissionB_SubmissionId(submissionId, submissionId);
 
         // disallow requests from users who are not notified about this case:
         boolean isUserNotifiedByInstructor = false;
@@ -71,13 +81,7 @@ public class PlagiarismService {
                                     && (comparison.getSubmissionB().getPlagiarismCase().getPost() != null || comparison.getSubmissionB().getPlagiarismCase().getVerdict() != null)
                                     && (comparison.getSubmissionB().getStudentLogin().equals(userLogin))));
         }
-        if (!isUserNotifiedByInstructor) {
-            throw new AccessForbiddenException("This plagiarism submission is not related to the requesting user or the user has not been notified yet.");
-        }
-        submission.setParticipation(null);
-        submission.setResults(null);
-        submission.setSubmissionDate(null);
-        return submission;
+        return isUserNotifiedByInstructor;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/plagiarism/PlagiarismService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/plagiarism/PlagiarismService.java
@@ -66,14 +66,20 @@ public class PlagiarismService {
         return submission;
     }
 
+    /**
+     * Checks whether the student with the given userlogin is involved in a plagiarism case which contains the given submissionId and the student is notified by the instructor.
+     *
+     * @param submissionId the id of a submissions that will be checked in plagiarism cases
+     * @param userLogin the user login of the student
+     * @return true if the student with userlogin owns one of the submissions in a PlagiarismComparison which contains the given submissionId and is notified by the instructor, otherwise false
+     */
     public boolean isUserNotifiedByInstructor(Long submissionId, String userLogin) {
         var comparisonOptional = plagiarismComparisonRepository.findBySubmissionA_SubmissionIdOrSubmissionB_SubmissionId(submissionId, submissionId);
 
         // disallow requests from users who are not notified about this case:
-        boolean isUserNotifiedByInstructor = false;
         if (comparisonOptional.isPresent()) {
             var comparisons = comparisonOptional.get();
-            isUserNotifiedByInstructor = comparisons.stream()
+            return comparisons.stream()
                     .anyMatch(comparison -> (comparison.getSubmissionA().getPlagiarismCase() != null
                             && (comparison.getSubmissionA().getPlagiarismCase().getPost() != null || comparison.getSubmissionA().getPlagiarismCase().getVerdict() != null)
                             && (comparison.getSubmissionA().getStudentLogin().equals(userLogin)))
@@ -81,7 +87,7 @@ public class PlagiarismService {
                                     && (comparison.getSubmissionB().getPlagiarismCase().getPost() != null || comparison.getSubmissionB().getPlagiarismCase().getVerdict() != null)
                                     && (comparison.getSubmissionB().getStudentLogin().equals(userLogin))));
         }
-        return isUserNotifiedByInstructor;
+        return false;
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The students can only see their own submission, but cannot compare it to the submission of the other student even if they are notified about the plagiarism case.

### Description
<!-- Describe your changes in detail -->
Authorized the notified student in both `/api/repository/{participationId}/files` and `/repository/{participationId}/file?file={filename}` endpoints to allow the student to see the other student's files after the instructor notified the student about the plagiarism case.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Programming Exercise

1. Log in to Artemis
2. Make two similar submissions with both students.
3. As the instructor, set the due date of the exercise to now and run plagiarism check from Exercise Detail page > Check Plagiarism page.
4. Notify a student about the plagiarism.
5. With the notified student, check if the plagiarism split view shows files correctly (non-empty) for both "Your submission" and "Other submission" panels.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| PlagiarismService.java | 39% | 71% |
| RepositoryProgrammingExerciseParticipationResource.java | 69% | 76% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:
![image](https://user-images.githubusercontent.com/18427209/182037113-2a86deb5-f779-4e2e-8c1f-4dc6fbcc9372.png)


After:
![image](https://user-images.githubusercontent.com/18427209/182037129-349571ca-70ce-41dd-9cdc-e306e52c8914.png)
