### PR TITLE
`Development`: Add GitHub bot to mark pull requests as stale

### DIFF
--- a/.github/workflows/pullrequest-stale.yml
+++ b/.github/workflows/pullrequest-stale.yml
@@ -1,7 +1,7 @@
 name: Stale
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 12 * * *"
 
 jobs:
   stale:

--- a/.github/workflows/pullrequest-stale.yml
+++ b/.github/workflows/pullrequest-stale.yml
@@ -1,0 +1,25 @@
+name: Stale
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  stale:
+    if: github.repository_owner == 'ls1intum'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 7 days stale PRs
+        uses: actions/stale@v5
+        with:
+          days-before-stale: 7
+          days-before-close: 14
+          # Disable issue checking, only PR
+          days-before-issue-stale: -1
+          remove-stale-when-updated: true
+          stale-pr-label: "stale"
+          exempt-pr-labels: "no-stale"
+          stale-pr-message: >
+            There hasn't been any activity on this pull request recently. This
+            pull request has been automatically marked as stale because of that
+            and will be closed if no further activity occurs within 7 days.
+            Thank you for your contributions.

--- a/.github/workflows/pullrequest-stale.yml
+++ b/.github/workflows/pullrequest-stale.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.repository_owner == 'ls1intum'
     runs-on: ubuntu-latest
     steps:
-      - name: 7 days stale PRs
+      - name: Check for stale PRs
         uses: actions/stale@v5
         with:
           days-before-stale: 7
@@ -19,7 +19,7 @@ jobs:
           stale-pr-label: "stale"
           exempt-pr-labels: "no-stale"
           stale-pr-message: >
-            There hasn't been any activity on this pull request recently. This
-            pull request has been automatically marked as stale because of that
-            and will be closed if no further activity occurs within 7 days.
+            There hasn't been any activity on this pull request recently. 
+            Therefore, this pull request has been automatically marked as stale
+            and will be closed if no further activity occurs within **seven** days.
             Thank you for your contributions.

--- a/docs/dev/guidelines/development-process.rst
+++ b/docs/dev/guidelines/development-process.rst
@@ -101,13 +101,12 @@ A project maintainer merges your changes into the ``develop`` branch.
 Stale Bot
 =========
 
-If the pull request doesn't have any activity for at least 7 days, the stale bot will mark the PR as `stale``.
+If the pull request doesn't have any activity for at least 7 days, the stale bot will mark the PR as `stale`.
 The `stale` status can simply be removed by adding a comment or a commit to the PR. 
-After the PR is marked as `stale` the bot waits another 14 days until the PR will be closed (21 days in total).
+After the PR is marked as `stale`, the bot waits another 14 days until the PR will be closed (21 days in total).
 Adding activity to the PR will remove the `stale` label again and reset the stale timer. 
-To prevent the bot from adding the `stale` label to the PR in the first place, the `no-stale` label 
-can be used. This label should only be utilized, if the PR is blocked by another PR or the PR needs 
-help from another developer. 
+To prevent the bot from adding the `stale` label to the PR in the first place, the `no-stale` label can be used.
+This label should only be utilized if the PR is blocked by another PR or the PR needs help from another developer. 
 
 A full documentation on this bit can be found here:
 https://github.com/actions/stale

--- a/docs/dev/guidelines/development-process.rst
+++ b/docs/dev/guidelines/development-process.rst
@@ -96,3 +96,18 @@ Iterate steps 3 & 4 until ready for merge (all reviewers approve (thumbs up))
 --------
 A project maintainer merges your changes into the ``develop`` branch.
 
+
+
+Stale Bot
+=========
+
+If the pull request doesn't have any activity for at least 7 days, the stale bot will mark the PR as `stale``.
+The `stale` status can simply be removed by adding a comment or a commit to the PR. 
+After the PR is marked as `stale` the bot waits another 14 days until the PR will be closed (21 days in total).
+Adding activity to the PR will remove the `stale` label again and reset the stale timer. 
+To prevent the bot from adding the `stale` label to the PR in the first place, the `no-stale` label 
+can be used. This label should only be utilized, if the PR is blocked by another PR or the PR needs 
+help from another developer. 
+
+A full documentation on this bit can be found here:
+https://github.com/actions/stale


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Over the last weeks we had a lot of open PRs. Since this is bad practice, we decided to add a stale bot, that will mark the PRs stale after 7 days and close it after again 14 days.  After some time period we want to change the days until closed period to 7 days. 

### Description
<!-- Describe your changes in detail -->

This adds a stale bot, that marks PRs as stale when there is no activity for 7 days. The bot will add a message to the PR to tell the user, why this PR was marked as stale and what he could do to fix that. If there is no activity for another 14 days, the bot will close the PR. The PR can then be reopened at any time, since we do not lock the PR. 
The workflow runs once every hour (at :00).

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
