### PR TITLE
`Plagiarism checks`: Fix wrong file content showed in split view

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-domain-dependent-endpoint.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-domain-dependent-endpoint.service.ts
@@ -22,16 +22,18 @@ export abstract class DomainDependentEndpointService extends DomainDependentServ
      */
     setDomain(domain: DomainChange) {
         super.setDomain(domain);
-        const [domainType, domainValue] = this.domain;
+        this.restResourceUrl = this.calculateRestResourceURL(domain);
+    }
+
+    calculateRestResourceURL(domain: DomainChange): string | null {
+        const [domainType, domainValue] = domain;
         switch (domainType) {
             case DomainType.PARTICIPATION:
-                this.restResourceUrl = `${this.restResourceUrlBase}/repository/${domainValue.id}`;
-                break;
+                return `${this.restResourceUrlBase}/repository/${domainValue.id}`;
             case DomainType.TEST_REPOSITORY:
-                this.restResourceUrl = `${this.restResourceUrlBase}/test-repository/${domainValue.id}`;
-                break;
+                return `${this.restResourceUrlBase}/test-repository/${domainValue.id}`;
             default:
-                this.restResourceUrl = null;
+                return null;
         }
     }
 }

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/service/code-editor-repository.service.ts
@@ -168,34 +168,37 @@ export class CodeEditorRepositoryFileService extends DomainDependentEndpointServ
         this.fileUpdateUrl = `${this.restResourceUrl}/files`;
     }
 
-    getRepositoryContent = () => {
-        return this.http.get<{ [fileName: string]: FileType }>(`${this.restResourceUrl}/files`).pipe(handleErrorResponse<{ [fileName: string]: FileType }>(this.conflictService));
+    getRepositoryContent = (domain?: DomainChange) => {
+        const restResourceUrl = domain ? this.calculateRestResourceURL(domain) : this.restResourceUrl;
+        return this.http.get<{ [fileName: string]: FileType }>(`${restResourceUrl}/files`).pipe(handleErrorResponse<{ [fileName: string]: FileType }>(this.conflictService));
     };
 
     /**
      * Gets the files of the repository and checks whether they were changed during a student participation.
      */
-    getFilesWithInformationAboutChange = () => {
-        return this.http
-            .get<{ [fileName: string]: boolean }>(`${this.restResourceUrl}/files-change`)
-            .pipe(handleErrorResponse<{ [fileName: string]: boolean }>(this.conflictService));
+    getFilesWithInformationAboutChange = (domain?: DomainChange) => {
+        const restResourceUrl = domain ? this.calculateRestResourceURL(domain) : this.restResourceUrl;
+        return this.http.get<{ [fileName: string]: boolean }>(`${restResourceUrl}/files-change`).pipe(handleErrorResponse<{ [fileName: string]: boolean }>(this.conflictService));
     };
 
-    getFile = (fileName: string) => {
-        return this.http.get(`${this.restResourceUrl}/file`, { params: new HttpParams().set('file', fileName), responseType: 'text' }).pipe(
+    getFile = (fileName: string, domain?: DomainChange) => {
+        const restResourceUrl = domain ? this.calculateRestResourceURL(domain) : this.restResourceUrl;
+        return this.http.get(`${restResourceUrl}/file`, { params: new HttpParams().set('file', fileName), responseType: 'text' }).pipe(
             map((data) => ({ fileContent: data })),
             handleErrorResponse<{ fileContent: string }>(this.conflictService),
         );
     };
 
-    getFileHeaders = (fileName: string) => {
+    getFileHeaders = (fileName: string, domain?: DomainChange) => {
+        const restResourceUrl = domain ? this.calculateRestResourceURL(domain) : this.restResourceUrl;
         return this.http
-            .head<Blob>(`${this.restResourceUrl}/file`, { observe: 'response', params: new HttpParams().set('file', fileName) })
+            .head<Blob>(`${restResourceUrl}/file`, { observe: 'response', params: new HttpParams().set('file', fileName) })
             .pipe(handleErrorResponse(this.conflictService));
     };
 
-    getFilesWithContent = () => {
-        return this.http.get(`${this.restResourceUrl}/files-content`).pipe(handleErrorResponse<{ [fileName: string]: string }>(this.conflictService));
+    getFilesWithContent = (domain?: DomainChange) => {
+        const restResourceUrl = domain ? this.calculateRestResourceURL(domain) : this.restResourceUrl;
+        return this.http.get(`${restResourceUrl}/files-content`).pipe(handleErrorResponse<{ [fileName: string]: string }>(this.conflictService));
     };
 
     createFile = (fileName: string) => {

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
@@ -6,7 +6,7 @@ import { TextSubmissionElement } from 'app/exercises/shared/plagiarism/types/tex
 import { TextExercise } from 'app/entities/text-exercise.model';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
 import { ExerciseType } from 'app/entities/exercise.model';
-import { DomainType, FileType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
+import { DomainChange, DomainType, FileType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
 import { CodeEditorRepositoryFileService } from 'app/exercises/programming/shared/code-editor/service/code-editor-repository.service';
 import { FileWithHasMatch } from 'app/exercises/shared/plagiarism/plagiarism-split-view/split-pane-header/split-pane-header.component';
 
@@ -88,8 +88,8 @@ export class TextSubmissionViewerComponent implements OnChanges {
     private loadProgrammingExercise(currentPlagiarismSubmission: PlagiarismSubmission<TextSubmissionElement>) {
         this.isProgrammingExercise = true;
 
-        this.repositoryService.setDomain([DomainType.PARTICIPATION, { id: currentPlagiarismSubmission.submissionId }]);
-        this.repositoryService.getRepositoryContent().subscribe({
+        const domain: DomainChange = [DomainType.PARTICIPATION, { id: currentPlagiarismSubmission.submissionId }];
+        this.repositoryService.getRepositoryContent(domain).subscribe({
             next: (files) => {
                 this.loading = false;
                 this.files = this.programmingExerciseFilesWithMatches(files);
@@ -162,16 +162,16 @@ export class TextSubmissionViewerComponent implements OnChanges {
         this.currentFile = file;
         this.loading = true;
 
-        this.repositoryService.setDomain([DomainType.PARTICIPATION, { id: this.plagiarismSubmission.submissionId }]);
+        const domain: DomainChange = [DomainType.PARTICIPATION, { id: this.plagiarismSubmission.submissionId }];
 
-        this.repositoryService.getFileHeaders(file).subscribe((response) => {
+        this.repositoryService.getFileHeaders(file, domain).subscribe((response) => {
             const contentType = response.headers.get('content-type');
             if (contentType && !contentType.startsWith('text')) {
                 this.binaryFile = true;
                 this.loading = false;
             } else {
                 this.binaryFile = false;
-                this.repositoryService.getFile(file).subscribe({
+                this.repositoryService.getFile(file, domain).subscribe({
                     next: ({ fileContent }) => {
                         this.loading = false;
                         this.fileContent = this.insertMatchTokens(fileContent);

--- a/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
@@ -10,7 +10,7 @@ import { ExerciseType } from 'app/entities/exercise.model';
 import { TextExercise } from 'app/entities/text-exercise.model';
 import { MockSyncStorage } from '../../helpers/mocks/service/mock-sync-storage.service';
 import { ProgrammingExercise } from 'app/entities/programming-exercise.model';
-import { FileType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
+import { DomainChange, DomainType, FileType } from 'app/exercises/programming/shared/code-editor/model/code-editor.model';
 import { PlagiarismSubmission } from 'app/exercises/shared/plagiarism/types/PlagiarismSubmission';
 import { TextSubmissionElement } from 'app/exercises/shared/plagiarism/types/text/TextSubmissionElement';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
@@ -118,7 +118,8 @@ describe('Text Submission Viewer Component', () => {
     });
 
     it('handles file selection', () => {
-        comp.plagiarismSubmission = { submissionId: 1 } as PlagiarismSubmission<TextSubmissionElement>;
+        const submissionId = 1;
+        comp.plagiarismSubmission = { submissionId } as PlagiarismSubmission<TextSubmissionElement>;
 
         const fileName = Object.keys(files)[1];
         const expectedHeaders = new HttpHeaders().append('content-type', 'text/plain');
@@ -127,7 +128,8 @@ describe('Text Submission Viewer Component', () => {
 
         comp.handleFileSelect(fileName);
 
-        expect(repositoryService.getFile).toHaveBeenCalledWith(fileName);
+        const expectedDomain: DomainChange = [DomainType.PARTICIPATION, { id: submissionId }];
+        expect(repositoryService.getFile).toHaveBeenCalledWith(fileName, expectedDomain);
         expect(comp.currentFile).toEqual(fileName);
     });
 


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
When viewing the plagiarism split view (either as an instructor or affected student) it can happen that both sides of the split view show the exact same content, even if the underlying repositories contain different files. 

### Description
The repository service in its current state is not meant to be used for multiple repositories at the same time. It currently saves it's own `restResourceUrl` that contains the repository id. This allows the code editor to easily support many actions in the same repository without having to specify this information again and again.

But for the split view this leads to concurrency problems. Both viewers set the repository settings and overwrite each other. Later calls (e.g. first retrieving the headers and later the file content) could use the wrong repository id in this case.

I decided to change this by adding the possibility to manually specify the domain used for the next call. If no domain gets specified the preconfigured option gets used.

### Steps for Testing
Prerequisites:
- 1 Programming Exercise with plagiarism cases (make sure that every submission contains slight differences so you can identify them)

1. Open the case overview as an instructor 
2. Click through the cases and check that in every case the split view shows two different files on both sides.
3. As a notified student, open your own plagiarism view. Check here that again both sides show different files.

Since it's a concurrency issue, reload the page a few times and check that the issue actually never shows up.

Additionaly, please test that the code editor stil works:

- Check that the code editor works for exams with multiple programming exercises
- Check that "edit in editor" works for programming exercises
- Check that the code editor works for course exercises

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

