### PR TITLE
`Exam mode`: Fix error state for teaching assistance and add absolute number of complaints

### DIFF
--- a/src/main/webapp/app/exam/manage/exam-status.component.html
+++ b/src/main/webapp/app/exam/manage/exam-status.component.html
@@ -162,6 +162,14 @@
                                 ? round((examChecklist.numberOfAllComplaintsDone * 100) / examChecklist.numberOfAllComplaints, 1)
                                 : 100
                         }}%
+                        {{
+                            'artemisApp.examStatus.correction.complaintsCount'
+                                | artemisTranslate
+                                    : {
+                                          done: examChecklist.numberOfAllComplaintsDone!,
+                                          total: examChecklist.numberOfAllComplaints!
+                                      }
+                        }}
                     </span>
                 </li>
             </ol>

--- a/src/main/webapp/app/exam/manage/exam-status.component.ts
+++ b/src/main/webapp/app/exam/manage/exam-status.component.ts
@@ -142,7 +142,8 @@ export class ExamStatusComponent implements OnChanges {
      */
     private setConductionState(): void {
         // In case the exercise configuration is wrong, but the (Test)Exam already started, students are not able to start a test eam or real exam
-        if (this.examAlreadyStarted() && !this.mandatoryPreparationFinished) {
+        // The ERROR-State should only be visible to Instructors, as editors & TAs have no access to the required data to determine if the preparation is finished
+        if (this.isAtLeastInstructor && this.examAlreadyStarted() && !this.mandatoryPreparationFinished) {
             this.examConductionState = ExamConductionState.ERROR;
         } else if (this.examAlreadyEnded() && (!this.isAtLeastInstructor || this.examPreparationFinished)) {
             this.examConductionState = ExamConductionState.FINISHED;

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -718,7 +718,8 @@
                 "planned": "Geplant",
                 "running": "Im Gange",
                 "finished": "Abgeschlossen",
-                "complaints": "Beschwerden"
+                "complaints": "Beschwerden",
+                "complaintsCount": "({{ done }} von {{ total}})"
             }
         }
     }

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -719,7 +719,8 @@
                 "planned": "Planned",
                 "running": "Running",
                 "finished": "Finished",
-                "complaints": "Complaints"
+                "complaints": "Complaints",
+                "complaintsCount": "({{ done }} out of {{ total}})"
             }
         }
     }

--- a/src/test/javascript/spec/component/exam/manage/student-exams/exam-status.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/exam-status.component.spec.ts
@@ -168,12 +168,12 @@ describe('ExamStatusComponent', () => {
         expect(component.examConductionState).toBe(ExamConductionState.RUNNING);
     });
 
-    it('should set examConductionState correctly if TestExam is started but not finished yet AND preparation is not finished', () => {
+    it('should set examConductionState correctly if TestExam is started but not finished yet AND preparation is not finished AND user is editor', () => {
         prepareForTestExamConductionStateTest(dayjs().add(-1, DateOffsetType.HOURS), 1, DateOffsetType.DAYS);
         component.mandatoryPreparationFinished = false;
         component.ngOnChanges();
-
-        expect(component.examConductionState).toBe(ExamConductionState.ERROR);
+        // Editors and TAs have no access to the required data to determine, if the preparation is not yet finished -> use RUNNING in this case
+        expect(component.examConductionState).toBe(ExamConductionState.RUNNING);
     });
 
     it('should set examConductionState correctly if TestExam not started yet', () => {


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
With #5204 a new exam status has been introduced. If the exam is not correctly configured (mismatch number of points / exercises OR mismatch number of exercise groups OR no generated student exams) AND the working time has already begun, students will not be able to start the exam. Instead, they will receive an error.
To visually warn the instructor, the ERROR-State has been introduced. However, as editors / teaching assistance do not have access to the required date to determine the ERROR-State, this state was displayed wrongly for all exams.

### Description
The ERROR-State is only displayed when an instructor accesses the list. Editors and tutors will no longer see the ERROR-Status, as they do not have access to the required data.
Furthermore, for complaints, the absolute number of processed complaints is displayed in addition to the percentual number.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Editor
- 1 Exam with at least one unsolved complaint

#### Instructor
1. Log in to Artemis
2. Navigate to Course Administration -> Exam
3. Create a new Exam and make a configuration error (mismatch number of points / exercises OR mismatch number of exercise groups OR no generated student exams)
4. Wait till the working time has started
5. Navigate to the Exam Management Page
6. Verify, that a warning is displayed in the exam conduction status, that students cannot start their Exam / Test Exam
7. Verify, that for a correctly configured exam during / after the working time, no warning is displayed
8. Verify, that the number of absolute complaints is displayed correctly (e.g. by using the exam with at least one unsolved complaint -> 4. Complaints 0& (0 out of 1)
#### Editor
7. Log in to Artemis
8. Navigate to Course Administration -> Exam
9. Verify, that no waring is displayed for the wrongly configured exam
10. Verify, that for a correctly configured exam during / after the working time, no warning is displayed

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
For Instructors (the error is displayed and the absolute number of complaints: 
![image](https://user-images.githubusercontent.com/94070506/182583767-df69c638-a316-4e4f-99c5-f6b6768adc39.png)
For Editors / TAs (the error state is not displayed):
![image](https://user-images.githubusercontent.com/94070506/182583876-ec25af92-b2de-464f-98e7-30004410787a.png)

Another example for the absolute number of complaints:
![image](https://user-images.githubusercontent.com/94070506/182584071-805e9d8e-6520-48a1-98cc-008672304806.png)
