### PR TITLE
`Exam mode`: Fix working time for test exams within the student exam management page

### DIFF
--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
@@ -32,7 +32,7 @@
         </ol>
     </div>
 
-    <div class="mb-3">
+    <div class="mb-3" *ngIf="!isTestExam">
         <h5><span jhiTranslate="artemisApp.studentExams.workingTime" [ngbTooltip]="getWorkingTimeToolTip()">Working time</span></h5>
         <form #form="ngForm" (ngSubmit)="saveWorkingTime()">
             <div class="mb-1 working-time-form" [ngbTooltip]="getWorkingTimeToolTip()">
@@ -102,6 +102,12 @@
                 <span jhiTranslate="entity.action.save" [ngbTooltip]="getWorkingTimeToolTip()">Save</span>
             </button>
         </form>
+    </div>
+
+    <div class="mb-3" *ngIf="isTestExam">
+        <h5 jhiTranslate="artemisApp.studentExams.workingTime">Working time</h5>
+        <span jhiTranslate="artemisApp.studentExams.usedWorkingTime">Used working time:</span>
+        <jhi-testexam-working-time [studentExam]="studentExam"></jhi-testexam-working-time>
     </div>
 
     <div class="mb-3">

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
@@ -106,7 +106,7 @@
 
     <div class="mb-3" *ngIf="isTestExam">
         <h5 jhiTranslate="artemisApp.studentExams.workingTime">Working time</h5>
-        <span jhiTranslate="artemisApp.studentExams.usedWorkingTime">Used working time:</span>
+        <span jhiTranslate="artemisApp.studentExams.usedWorkingTime">Used working time</span>:
         <jhi-testexam-working-time [studentExam]="studentExam"></jhi-testexam-working-time>
     </div>
 

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
@@ -30,6 +30,7 @@ export class StudentExamDetailComponent implements OnInit {
     student: User;
     isSavingWorkingTime = false;
     isTestRun = false;
+    isTestExam: boolean;
     maxTotalPoints = 0;
     achievedTotalPoints = 0;
     bonusTotalPoints = 0;
@@ -75,6 +76,7 @@ export class StudentExamDetailComponent implements OnInit {
         this.courseId = Number(this.route.snapshot.paramMap.get('courseId'));
         this.examId = Number(this.route.snapshot.paramMap.get('examId'));
         this.route.data.subscribe(({ studentExam }) => this.setStudentExamWithGrade(studentExam));
+        this.isTestExam = this.studentExam.exam!.testExam!;
     }
 
     /**

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
@@ -155,7 +155,10 @@
                         <fa-icon [icon]="controls.iconForSortPropField('workingTime')"></fa-icon>
                     </span>
                 </ng-template>
-                <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                <ng-template *ngIf="isTestExam; else realExam" ngx-datatable-cell-template let-value="value" let-row="row">
+                    <jhi-testexam-working-time [studentExam]="row"></jhi-testexam-working-time>
+                </ng-template>
+                <ng-template #realExam ngx-datatable-cell-template let-value="value" let-row="row">
                     <jhi-student-exam-working-time [studentExam]="row"></jhi-student-exam-working-time>
                 </ng-template>
             </ngx-datatable-column>

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
@@ -155,11 +155,9 @@
                         <fa-icon [icon]="controls.iconForSortPropField('workingTime')"></fa-icon>
                     </span>
                 </ng-template>
-                <ng-template *ngIf="isTestExam; else realExam" ngx-datatable-cell-template let-value="value" let-row="row">
-                    <jhi-testexam-working-time [studentExam]="row"></jhi-testexam-working-time>
-                </ng-template>
-                <ng-template #realExam ngx-datatable-cell-template let-value="value" let-row="row">
-                    <jhi-student-exam-working-time [studentExam]="row"></jhi-student-exam-working-time>
+                <ng-template ngx-datatable-cell-template let-value="value" let-row="row">
+                    <jhi-testexam-working-time *ngIf="isTestExam" [studentExam]="row"></jhi-testexam-working-time>
+                    <jhi-student-exam-working-time *ngIf="!isTestExam" [studentExam]="row"></jhi-student-exam-working-time>
                 </ng-template>
             </ngx-datatable-column>
 

--- a/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exams.component.html
@@ -151,7 +151,8 @@
             <ngx-datatable-column prop="workingTime" [minWidth]="170" [width]="170">
                 <ng-template ngx-datatable-header-template>
                     <span class="datatable-header-cell-wrapper" (click)="controls.onSort('workingTime')">
-                        <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.studentExams.workingTime"> Working time </span>
+                        <span *ngIf="!isTestExam" class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.studentExams.workingTime"> Working time </span>
+                        <span *ngIf="isTestExam" class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.studentExams.usedWorkingTime"> Used Working time </span>
                         <fa-icon [icon]="controls.iconForSortPropField('workingTime')"></fa-icon>
                     </span>
                 </ng-template>

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -274,7 +274,7 @@
             "lockAllRepositoriesSuccess": "Repositories von {{number}} Programmieraufgaben wurden gesperrt.",
             "lockAllRepositoriesFailure": "Es gab einen Fehler beim Sperren der Repositories:\n {{message}}",
             "setWorkingTime": "Absolut:",
-            "usedWorkingTime": "Genutzte Arbeitszeit:",
+            "usedWorkingTime": "Genutzte Bearbeitungszeit",
             "setWorkingTimeRelative": "Verlängerung relativ zur normalen Bearbeitungszeit:",
             "removeAllStudents": {
                 "title": "Entferne alle Studierenden",

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -274,6 +274,7 @@
             "lockAllRepositoriesSuccess": "Repositories von {{number}} Programmieraufgaben wurden gesperrt.",
             "lockAllRepositoriesFailure": "Es gab einen Fehler beim Sperren der Repositories:\n {{message}}",
             "setWorkingTime": "Absolut:",
+            "usedWorkingTime": "Genutzte Arbeitszeit:",
             "setWorkingTimeRelative": "Verlängerung relativ zur normalen Bearbeitungszeit:",
             "removeAllStudents": {
                 "title": "Entferne alle Studierenden",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -276,7 +276,7 @@
             "lockAllRepositoriesSuccess": "Repositories of {{number}} programming exercises were locked.",
             "lockAllRepositoriesFailure": "There was an error during the locking of the programming exercises:\n {{message}}",
             "setWorkingTime": "Absolute:",
-            "usedWorkingTime": "Used working time:",
+            "usedWorkingTime": "Used working time",
             "setWorkingTimeRelative": "Addition relative to regular working time:",
             "removeAllStudents": {
                 "title": "Remove all students",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -276,6 +276,7 @@
             "lockAllRepositoriesSuccess": "Repositories of {{number}} programming exercises were locked.",
             "lockAllRepositoriesFailure": "There was an error during the locking of the programming exercises:\n {{message}}",
             "setWorkingTime": "Absolute:",
+            "usedWorkingTime": "Used working time:",
             "setWorkingTimeRelative": "Addition relative to regular working time:",
             "removeAllStudents": {
                 "title": "Remove all students",


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.

### Motivation and Context
When opening the `Student Exams` subpage within the Exam Management, the percentual working time was displayed wrongly for test exams.

### Description
For real exams, the percentage representation represents how much more / less working time a student has compared to the standard processing time (keyword: time extension).
However, there are no time extensions for test exams. Instead, we use the `testexam-working-time` component, which represents the working time used by students in an absolute way as well as the time used relative to the available working time.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Test Exam with one submitted student exam (submit prior to the end of the working time) and one started, but not submitted student exam
- 1 Real Exam with at least one student exam 

1. Log in to Artemis
2. Navigate to Course Administration -> Exams
3. Select the real exam -> Student Exams
4. Verify, that in the column working time the default working time of the exam as well as the percentual deviation is displayed (no change within this PR)
5. Open any student exam by clicking on "View". Verify, that the input field for changing the working time is still shown (disabled after the start of the exam) (no change within this PR)
6. Select the test exam -> Student Exams
7. Verify, that in the column working time for a not yet submitted student exam shows 0min of working time 
8. Open the student exam by clicking on "View". Verify, that for the working time, no input field, but just a plain text with the same information is displayed
9. Navigate back to the list of student exams
10. Verify, that in the column working time for a submitted student exam, the used working time (absolute) as well as the percentage share of the working time is shown
11. Open the student exam by clicking on "View". Verify, that for the working time, no input field, but just a plain text with the same information is displayed.
 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
#### For real exams:
The first one has a time extension of 1 Minute (+100 %)
The second one uses the default working time of 1 Minute
![image](https://user-images.githubusercontent.com/94070506/182587543-67990e71-6d33-4cce-b035-cb652e641588.png)
The current implementation of the `student-exam-details` component:
![image](https://user-images.githubusercontent.com/94070506/182602154-ea463445-8d4a-4e98-95d0-3f1e40741037.png)


#### For test exams
For the first one, the default working time is 2min
The second one is not submitted -> 0min working time 
![image](https://user-images.githubusercontent.com/94070506/182586844-80c57512-5c0b-4c43-aaaf-0361ed11ae86.png)
Change in the `student-exam-details` component:
![image](https://user-images.githubusercontent.com/94070506/182602017-85fc9850-1066-443f-ba40-73b4c440c61a.png)
