### PR TITLE
`General`: Fix resizing of markdown editors if multiple are rendered at the same time

### DIFF
--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.html
@@ -4,7 +4,7 @@
         <ng-container ngbNavItem="editor_edit">
             <a ngbNavLink class="btn-sm text-normal" *ngIf="showEditButton">{{ 'entity.action.edit' | artemisTranslate }}</a>
             <ng-template ngbNavContent>
-                <div class="height-100 border-0 markdown-editor d-flex flex-column">
+                <div class="height-100 border-0 markdown-editor d-flex flex-column" [id]="uniqueMarkdownEditorId">
                     <jhi-ace-editor
                         #aceEditor
                         [mode]="aceEditorOptions.mode"

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -34,6 +34,7 @@ import { HeadingThreeCommand } from 'app/shared/markdown-editor/commands/heading
 import { CodeBlockCommand } from 'app/shared/markdown-editor/commands/codeblock.command';
 import { faAngleRight, faGripLines, faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import { MultiOptionCommand } from 'app/shared/markdown-editor/commands/multiOptionCommand';
+import { v4 as uuid } from 'uuid';
 
 export enum MarkdownEditorHeight {
     INLINE = 100,
@@ -164,7 +165,11 @@ export class MarkdownEditorComponent implements AfterViewInit {
     faGripLines = faGripLines;
     faAngleRight = faAngleRight;
 
-    constructor(private artemisMarkdown: ArtemisMarkdownService, private fileUploaderService: FileUploaderService, private alertService: AlertService) {}
+    uniqueMarkdownEditorId: string;
+
+    constructor(private artemisMarkdown: ArtemisMarkdownService, private fileUploaderService: FileUploaderService, private alertService: AlertService) {
+        this.uniqueMarkdownEditorId = 'markdown-editor-' + uuid();
+    }
 
     /** {boolean} true when the plane html view is needed, false when the preview content is needed from the parent */
     get showDefaultPreview(): boolean {
@@ -253,9 +258,10 @@ export class MarkdownEditorComponent implements AfterViewInit {
      */
     setupResizable(): void {
         // unregister previously set event listeners for class elements
-        interact('.markdown-editor').unset();
+        const selector = '#' + this.uniqueMarkdownEditorId;
+        interact(selector).unset();
 
-        this.interactResizable = interact('.markdown-editor')
+        this.interactResizable = interact(selector)
             .resizable({
                 // Enable resize from top edge; triggered by class rg-top
                 edges: { left: false, right: false, bottom: '.rg-bottom', top: false },
@@ -273,12 +279,12 @@ export class MarkdownEditorComponent implements AfterViewInit {
             })
             .on('resizeend', (event: any) => {
                 event.target.classList.remove('card-resizable');
-                this.aceEditorContainer.getEditor().resize();
             })
-            .on('resizemove', function (event: any) {
+            .on('resizemove', (event: any) => {
                 const target = event.target;
                 // Update element height
                 target.style.height = event.rect.height + 'px';
+                this.aceEditorContainer.getEditor().resize();
             });
     }
 

--- a/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
+++ b/src/main/webapp/app/shared/markdown-editor/markdown-editor.component.ts
@@ -257,8 +257,11 @@ export class MarkdownEditorComponent implements AfterViewInit {
      * @desc Sets up resizable to enable resizing for the user
      */
     setupResizable(): void {
-        // unregister previously set event listeners for class elements
+        // Use a unique, random ID to select the editor
+        // This is required to select the correct one in case multiple editors are used at the same time
         const selector = '#' + this.uniqueMarkdownEditorId;
+
+        // unregister previously set event listeners for class elements
         interact(selector).unset();
 
         this.interactResizable = interact(selector)


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Markdown editors do currently have an issue where the inner content isn't resized with their container.

Closes #5397. See the issue for an example of the problem.

### Description
<!-- Describe your changes in detail -->

After a long debugging process I found that this happens if you have multiple editors rendered at the same time. The InteractJS configuration selects the editor by class name. However, all editors on the page have the same class name, and thus, the wrong one is selected for all InteractJS configurations besides the last one on the page.

To solve this, I've added a UUID as ID to each markdown editor so InteractJS can select the correct one for each editor.
Additionally, I call ``resize`` on the underlying ace editor on each height update as that looks better (otherwise you don't see text appearing while dragging the resize bar) and does not have notable performance impacts.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

The issue appears on the edit page of an exam or on the edit page of a text exercise, for example, but generally every time multiple markdown editors are used. You can test any of them.

1. Log in to Artemis
2. Navigate to Course Administration
3. Open an exam edit view
4. Add long texts to the different markdown inputs (like exam end text etc)
5. Resize the editors and make sure the inner content is resized appropriately.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![ezgif-3-3bb1011d4f](https://user-images.githubusercontent.com/23171488/182656531-a711e38f-0599-4dd2-b9d0-360a7abeb27c.gif)
