### PR TITLE
`Exam mode`: Update near cache configuration

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spring.context.SpringManagedContext;
 
+import de.tum.in.www1.artemis.service.scheduled.cache.monitoring.ExamMonitoringScheduleService;
 import de.tum.in.www1.artemis.service.scheduled.cache.quiz.QuizScheduleService;
 import tech.jhipster.config.JHipsterProperties;
 import tech.jhipster.config.cache.PrefixedKeyGenerator;
@@ -157,7 +158,7 @@ public class CacheConfiguration {
         config.getMapConfigs().put("de.tum.in.www1.artemis.domain.*", initializeDomainMapConfig(jHipsterProperties));
 
         QuizScheduleService.configureHazelcast(config);
-
+        ExamMonitoringScheduleService.configureHazelcast(config);
         return Hazelcast.newHazelcastInstance(config);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/CacheConfiguration.java
@@ -26,7 +26,6 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spring.context.SpringManagedContext;
 
-import de.tum.in.www1.artemis.service.scheduled.cache.monitoring.ExamMonitoringScheduleService;
 import de.tum.in.www1.artemis.service.scheduled.cache.quiz.QuizScheduleService;
 import tech.jhipster.config.JHipsterProperties;
 import tech.jhipster.config.cache.PrefixedKeyGenerator;
@@ -158,7 +157,6 @@ public class CacheConfiguration {
         config.getMapConfigs().put("de.tum.in.www1.artemis.domain.*", initializeDomainMapConfig(jHipsterProperties));
 
         QuizScheduleService.configureHazelcast(config);
-        ExamMonitoringScheduleService.configureHazelcast(config);
 
         return Hazelcast.newHazelcastInstance(config);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamCache.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamCache.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.service.scheduled.cache.monitoring;
 
 import java.util.function.UnaryOperator;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 
 import de.tum.in.www1.artemis.config.Constants;
@@ -31,6 +32,15 @@ final class ExamCache extends CacheHandler<Long> {
     @Override
     protected Cache emptyCacheValue() {
         return ExamMonitoringCache.empty();
+    }
+
+    /**
+     * Configures Hazelcast for the ExamCache before the HazelcastInstance is created.
+     *
+     * @param config the {@link Config} the ExamCache-specific configuration should be added to
+     */
+    static void configureHazelcast(Config config) {
+        ExamMonitoringCache.registerSerializers(config);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamCache.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamCache.java
@@ -2,7 +2,6 @@ package de.tum.in.www1.artemis.service.scheduled.cache.monitoring;
 
 import java.util.function.UnaryOperator;
 
-import com.hazelcast.config.*;
 import com.hazelcast.core.HazelcastInstance;
 
 import de.tum.in.www1.artemis.config.Constants;
@@ -20,34 +19,13 @@ import de.tum.in.www1.artemis.service.scheduled.cache.CacheHandler;
  * {@linkplain #getTransientWriteCacheFor(Long) write operations on transient properties} easier and less error-prone;
  * and that allow for {@linkplain #performCacheWrite(Long, UnaryOperator) atomic writes} (including an
  * {@linkplain #performCacheWriteIfPresent(Long, UnaryOperator) if-present variant}).
+ * <p>
+ * Additionally, we don't need any near ache configuration since reloading all actions from the cache is a very rare case.
  */
 final class ExamCache extends CacheHandler<Long> {
 
     public ExamCache(HazelcastInstance hazelcastInstance) {
         super(hazelcastInstance, Constants.HAZELCAST_MONITORING_CACHE);
-    }
-
-    /**
-     * Configures Hazelcast for the ExamCache before the HazelcastInstance is created.
-     *
-     * @param config the {@link Config} the ExamCache-specific configuration should be added to
-     */
-    static void configureHazelcast(Config config) {
-        ExamMonitoringCache.registerSerializers(config);
-        // Important to avoid continuous serialization and de-serialization and the implications on transient fields
-        // of ExamMonitoringCache
-        // @formatter:off
-        EvictionConfig evictionConfig = new EvictionConfig().setEvictionPolicy(EvictionPolicy.NONE);
-        NearCacheConfig nearCacheConfig = new NearCacheConfig()
-                .setName(Constants.HAZELCAST_MONITORING_CACHE + "-local")
-                .setInMemoryFormat(InMemoryFormat.OBJECT).setSerializeKeys(true)
-                .setInvalidateOnChange(true)
-                .setTimeToLiveSeconds(0)
-                .setMaxIdleSeconds(0)
-                .setEvictionConfig(evictionConfig)
-                .setCacheLocalEntries(true);
-        config.getMapConfig(Constants.HAZELCAST_MONITORING_CACHE).setNearCacheConfig(nearCacheConfig);
-        // @formatter:on
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamMonitoringScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamMonitoringScheduleService.java
@@ -13,7 +13,6 @@ import org.springframework.core.env.Environment;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.scheduledexecutor.DuplicateTaskException;
 
@@ -61,15 +60,6 @@ public class ExamMonitoringScheduleService {
         this.examRepository = examRepository;
         this.studentExamRepository = studentExamRepository;
         this.messagingService = messagingService;
-    }
-
-    /**
-     * Configures Hazelcast for the ExamActivityService before the HazelcastInstance is created.
-     *
-     * @param config the {@link Config} the ExamActivityService-specific configuration should be added to
-     */
-    public static void configureHazelcast(Config config) {
-        ExamCache.configureHazelcast(config);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamMonitoringScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/monitoring/ExamMonitoringScheduleService.java
@@ -13,6 +13,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.scheduledexecutor.DuplicateTaskException;
 
@@ -60,6 +61,15 @@ public class ExamMonitoringScheduleService {
         this.examRepository = examRepository;
         this.studentExamRepository = studentExamRepository;
         this.messagingService = messagingService;
+    }
+
+    /**
+     * Configures Hazelcast for the ExamActivityService before the HazelcastInstance is created.
+     *
+     * @param config the {@link Config} the ExamActivityService-specific configuration should be added to
+     */
+    public static void configureHazelcast(Config config) {
+        ExamCache.configureHazelcast(config);
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Since collecting all actions from the cache is a really rare case, we decided to remove the near cache configuration since this is not needed.

### Description
<!-- Describe your changes in detail -->

- Removed the near cache configuration of the exam live statistics

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- One/Multiple Students
- Exam

1. Log in to Artemis
2. Create an Exam
3. Register multiple students
4. Navigate to the Exam Live Statistics dashboard
5. Enable the Exam Live Statistics
6. Participate with the students in the exam
7. Verify that actions are collected
8. Disable the exam live statistics via the feature toggle
9. Verify that the exam live statistics is disabled and cannot be enabled
10. Verify that the students client does not send any actions via websocket 
12. Enable the exam live statistics
13. Verify that the old actions are deleted (reload the exam live statistics dashboard)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
