### PR TITLE
`Exam mode`: Display correct working time within the exam details and course exam details

### DIFF
--- a/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
@@ -130,7 +130,7 @@
                     <span *ngIf="exam.examStudentReviewEnd; else examStudentReviewEndNotSet">{{ exam.examStudentReviewEnd | artemisDate }}</span>
                     <ng-template #examStudentReviewEndNotSet><span jhiTranslate="artemisApp.exercise.dateNotSet"></span></ng-template>
                 </dd>
-                <dt><span jhiTranslate="artemisApp.exam.overview.workingTime">Working Time</span></dt>
+                <dt><span jhiTranslate="artemisApp.examManagement.workingTime">Working Time</span></dt>
                 <dd>
                     <span>{{ exam.workingTime! | artemisDurationFromSeconds: true }}</span>
                 </dd>

--- a/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
@@ -130,9 +130,9 @@
                     <span *ngIf="exam.examStudentReviewEnd; else examStudentReviewEndNotSet">{{ exam.examStudentReviewEnd | artemisDate }}</span>
                     <ng-template #examStudentReviewEndNotSet><span jhiTranslate="artemisApp.exercise.dateNotSet"></span></ng-template>
                 </dd>
-                <dt><span jhiTranslate="artemisApp.examManagement.workingTime">Working time (minutes)</span></dt>
+                <dt><span jhiTranslate="artemisApp.exam.overview.workingTime">Working time</span></dt>
                 <dd>
-                    <span>{{ exam.workingTime }}</span>
+                    <span>{{ exam.workingTime! | artemisDurationFromSeconds: true }}</span>
                 </dd>
                 <dt><span jhiTranslate="artemisApp.examManagement.gracePeriod">Grace period (seconds)</span></dt>
                 <dd>

--- a/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
@@ -130,7 +130,7 @@
                     <span *ngIf="exam.examStudentReviewEnd; else examStudentReviewEndNotSet">{{ exam.examStudentReviewEnd | artemisDate }}</span>
                     <ng-template #examStudentReviewEndNotSet><span jhiTranslate="artemisApp.exercise.dateNotSet"></span></ng-template>
                 </dd>
-                <dt><span jhiTranslate="artemisApp.examManagement.workingTime">Working Time</span></dt>
+                <dt><span jhiTranslate="artemisApp.exam.workingTime">Working Time</span></dt>
                 <dd>
                     <span>{{ exam.workingTime! | artemisDurationFromSeconds: true }}</span>
                 </dd>

--- a/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-detail.component.html
@@ -130,7 +130,7 @@
                     <span *ngIf="exam.examStudentReviewEnd; else examStudentReviewEndNotSet">{{ exam.examStudentReviewEnd | artemisDate }}</span>
                     <ng-template #examStudentReviewEndNotSet><span jhiTranslate="artemisApp.exercise.dateNotSet"></span></ng-template>
                 </dd>
-                <dt><span jhiTranslate="artemisApp.exam.overview.workingTime">Working time</span></dt>
+                <dt><span jhiTranslate="artemisApp.exam.overview.workingTime">Working Time</span></dt>
                 <dd>
                     <span>{{ exam.workingTime! | artemisDurationFromSeconds: true }}</span>
                 </dd>

--- a/src/main/webapp/app/overview/course-exams/course-exam-detail/course-exam-detail.component.html
+++ b/src/main/webapp/app/overview/course-exams/course-exam-detail/course-exam-detail.component.html
@@ -86,7 +86,8 @@
             }}
         </div>
         <div *ngIf="exam.startDate && exam.endDate" class="col-12">
-            {{ 'artemisApp.exam.overview.duration' | artemisTranslate }} {{ exam.workingTime! | artemisDurationFromSeconds }}
+            {{ 'artemisApp.exam.overview.duration' | artemisTranslate }} {{ exam.workingTime! |
+            artemisDurationFromSeconds: true }}
         </div>
         <div *ngIf="exam.maxPoints" class="col-sm">{{ 'artemisApp.exam.overview.maxPoints' | artemisTranslate: { points: exam.maxPoints } }}</div>
     </div>

--- a/src/main/webapp/app/overview/course-exams/course-exam-detail/course-exam-detail.component.html
+++ b/src/main/webapp/app/overview/course-exams/course-exam-detail/course-exam-detail.component.html
@@ -86,8 +86,7 @@
             }}
         </div>
         <div *ngIf="exam.startDate && exam.endDate" class="col-12">
-            {{ 'artemisApp.exam.overview.duration' | artemisTranslate }} {{ exam.workingTime! |
-            artemisDurationFromSeconds: true }}
+            {{ 'artemisApp.exam.overview.duration' | artemisTranslate }} {{ exam.workingTime! | artemisDurationFromSeconds: true }}
         </div>
         <div *ngIf="exam.maxPoints" class="col-sm">{{ 'artemisApp.exam.overview.maxPoints' | artemisTranslate: { points: exam.maxPoints } }}</div>
     </div>

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
@@ -28,6 +28,7 @@ import { of } from 'rxjs';
 import { DeleteButtonDirective } from 'app/shared/delete-dialog/delete-button.directive';
 import { MockAccountService } from '../../../../helpers/mocks/service/mock-account.service';
 import { AlertService } from 'app/core/util/alert.service';
+import {ArtemisDurationFromSecondsPipe} from "app/shared/pipes/artemis-duration-from-seconds.pipe";
 
 @Component({
     template: '',
@@ -72,6 +73,7 @@ describe('ExamDetailComponent', () => {
                 MockDirective(NgbTooltip),
                 MockComponent(CourseExamArchiveButtonComponent),
                 MockDirective(DeleteButtonDirective),
+                MockPipe(ArtemisDurationFromSecondsPipe),
             ],
             providers: [
                 {

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
@@ -28,7 +28,7 @@ import { of } from 'rxjs';
 import { DeleteButtonDirective } from 'app/shared/delete-dialog/delete-button.directive';
 import { MockAccountService } from '../../../../helpers/mocks/service/mock-account.service';
 import { AlertService } from 'app/core/util/alert.service';
-import {ArtemisDurationFromSecondsPipe} from "app/shared/pipes/artemis-duration-from-seconds.pipe";
+import {ArtemisDurationFromSecondsPipe} from 'app/shared/pipes/artemis-duration-from-seconds.pipe';
 
 @Component({
     template: '',

--- a/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/exams/exam-detail.component.spec.ts
@@ -28,7 +28,7 @@ import { of } from 'rxjs';
 import { DeleteButtonDirective } from 'app/shared/delete-dialog/delete-button.directive';
 import { MockAccountService } from '../../../../helpers/mocks/service/mock-account.service';
 import { AlertService } from 'app/core/util/alert.service';
-import {ArtemisDurationFromSecondsPipe} from 'app/shared/pipes/artemis-duration-from-seconds.pipe';
+import { ArtemisDurationFromSecondsPipe } from 'app/shared/pipes/artemis-duration-from-seconds.pipe';
 
 @Component({
     template: '',


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
In the `exam-detail` component, the working time was displayed in secounds, while the header claimed that the working time is in minutes

### Description
To display the working time, the `artemisDurationFromSecounds` Pipe is now used, which automatically converts the working time into the correct format.
Additionally, the `short` pipe is now used for the `course-exam-detail` component (the tiles representing the individual exam), as the short one doesn't display seconds. As the working time is based on minutes, the seconds do not need to be displayed to the student.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 visible Real Exam
- 1 visible Test Exam

1. Log in to Artemis
2. Navigate to Course Administration -> Exam
3. For both exams, open the exam checklist (e.g. by clicking on the ID or Title) and navigate down to till the working time is displayed
4. Verify, that the working time is displayed correctly
5. Navigate to Course -> Exams
6. Verify, that the working time on the tiles is correctly displayed without secounds.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
Issue:
![image](https://user-images.githubusercontent.com/94070506/182809603-15a7cc3f-1b23-47e4-bcbb-0e20ed34b3f6.png)
Solved: 
![image](https://user-images.githubusercontent.com/94070506/182811196-3b0e7d92-9ea8-456e-ab8f-0bd44d229193.png)

exam detail without seconds:
![image](https://user-images.githubusercontent.com/94070506/182810481-43ab32b8-2ccc-49e0-a204-742bd05a2a29.png)

