### PR TITLE
`Exam mode`: Show exercise ids in live statistics to avoid confusion when identical exercise titles are used

### DIFF
--- a/src/main/webapp/app/exam/monitoring/charts/exercises/exercise-group-chart.component.ts
+++ b/src/main/webapp/app/exam/monitoring/charts/exercises/exercise-group-chart.component.ts
@@ -58,7 +58,7 @@ export class ExerciseGroupChartComponent extends ChartComponent implements OnIni
             group.exercises?.forEach((exercise) => {
                 amount += exerciseAmountMap.get(exercise.id!) ?? 0;
             });
-            this.ngxData.push({ name: group.title ?? '', value: amount });
+            this.ngxData.push({ name: `${group.title} (${group.id})`, value: amount });
             this.ngxColor.domain.push(getColor(index));
         });
         // Re-trigger change detection

--- a/src/main/webapp/app/exam/monitoring/charts/monitoring-chart.ts
+++ b/src/main/webapp/app/exam/monitoring/charts/monitoring-chart.ts
@@ -150,7 +150,7 @@ export function convertCurrentExercisePerStudentMapToNumberOfStudentsPerExercise
 export function insertNgxDataAndColorForExerciseMap(exam: Exam | undefined, exerciseAmountMap: Map<number, number>, ngxData: NgxChartsEntry[], ngxColor: Color) {
     exam?.exerciseGroups?.forEach((group, index) => {
         group.exercises?.forEach((exercise) => {
-            ngxData.push({ name: exercise.title ?? '', value: exerciseAmountMap.get(exercise.id!) ?? 0 });
+            ngxData.push({ name: `${exercise.title} (${exercise.id})`, value: exerciseAmountMap.get(exercise.id!) ?? 0 });
             ngxColor.domain.push(getColor(index));
         });
     });

--- a/src/test/javascript/spec/component/exam/monitoring/charts/exercise-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/monitoring/charts/exercise-chart.component.spec.ts
@@ -89,7 +89,7 @@ describe('Exercise Chart Component', () => {
         comp.ngOnInit();
 
         // THEN
-        expect(comp.ngxData).toEqual([{ name: exercises[0].title!, value: 1 }]);
+        expect(comp.ngxData).toEqual([{ name: `${exercises[0].title} (${exercises[0].id})`, value: 1 }]);
         expect(comp.ngxColor.domain).toEqual([getColor(0)]);
     });
 });

--- a/src/test/javascript/spec/component/exam/monitoring/charts/exercise-group-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/monitoring/charts/exercise-group-chart.component.spec.ts
@@ -108,8 +108,8 @@ describe('Exercise Group Chart Component', () => {
 
         // THEN
         expect(comp.ngxData).toEqual([
-            { name: exerciseGroup1.title!, value: param.expect[0] },
-            { name: exerciseGroup2.title!, value: param.expect[1] },
+            { name: `${exerciseGroup1.title} (${exerciseGroup1.id})`, value: param.expect[0] },
+            { name: `${exerciseGroup2.title} (${exerciseGroup2.id})`, value: param.expect[1] },
         ]);
         expect(comp.ngxColor.domain).toEqual([getColor(0), getColor(1)]);
     });

--- a/src/test/javascript/spec/component/exam/monitoring/charts/exercise-navigation-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/monitoring/charts/exercise-navigation-chart.component.spec.ts
@@ -111,8 +111,8 @@ describe('Exercise Navigation Chart Component', () => {
 
         // THEN
         expect(comp.ngxData).toEqual([
-            { name: exercises[0].title!, value: param.expect[0] },
-            { name: exercises[1].title!, value: param.expect[1] },
+            { name: `${exercises[0].title} (${exercises[0].id})`, value: param.expect[0] },
+            { name: `${exercises[1].title} (${exercises[1].id})`, value: param.expect[1] },
         ]);
         expect(comp.ngxColor.domain).toEqual(param.color);
     });

--- a/src/test/javascript/spec/component/exam/monitoring/charts/exercise-submission-chart.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/monitoring/charts/exercise-submission-chart.component.spec.ts
@@ -111,8 +111,8 @@ describe('Exercise Submission Chart Component', () => {
 
         // THEN
         expect(comp.ngxData).toEqual([
-            { name: exercises[0].title!, value: param.expect[0] },
-            { name: exercises[1].title!, value: param.expect[1] },
+            { name: `${exercises[0].title} (${exercises[0].id})`, value: param.expect[0] },
+            { name: `${exercises[1].title} (${exercises[1].id})`, value: param.expect[1] },
         ]);
         expect(comp.ngxColor.domain).toEqual(param.color);
     });

--- a/src/test/javascript/spec/component/exam/monitoring/charts/monitoring-chart.spec.ts
+++ b/src/test/javascript/spec/component/exam/monitoring/charts/monitoring-chart.spec.ts
@@ -166,8 +166,8 @@ describe('Monitoring charts helper methods', () => {
 
         insertNgxDataAndColorForExerciseMap(exam, exerciseAmountMap, ngxData, ngxColor);
         expect(ngxData).toEqual([
-            { name: exercise1.title, value: 1 },
-            { name: exercise2.title, value: 1 },
+            { name: `${exercise1.title} (${exercise1.id})`, value: 1 },
+            { name: `${exercise2.title} (${exercise2.id})`, value: 1 },
         ]);
         expect(ngxColor.domain).toEqual([getColor(0), getColor(0)]);
     });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Since instructors can create exercise groups and exercises with the same name, this could cause overlapping bars in the bar charts of the exam live statistics. In order to avoid this, we added the exercise (group) ids at the end of each entry.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- One/Multiple Students
- Exam

1. Log in to Artemis
2. Create an Exam with multiple exercise groups and exercises with the same name
3. Register multiple students
4. Navigate to the Exam Live Statistics dashboard
5. Enable the Exam Live Statistics
6. See for each exercise group and each exercise a single bar (no overlapping bars)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->


<details>
<summary>Exercise Groups</summary>

![image](https://user-images.githubusercontent.com/60005702/183128982-904efb56-ce6d-40a8-a825-288dab91cf4e.png)
This is how you dropdown.
</details>

<details>
<summary>Exercises</summary>

![image](https://user-images.githubusercontent.com/60005702/183129011-6412323b-08c6-4880-8624-828cdcb2460e.png)
This is how you dropdown.
</details>

