### PR TITLE
`Programming exercises`: Show result string when viewing result details of previous submissions

### DIFF
--- a/src/main/webapp/app/exercises/shared/result/result-detail.component.html
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.component.html
@@ -7,10 +7,10 @@
     <div *ngIf="messageKey" class="mb-3"><h6 [innerHTML]="messageKey | artemisTranslate"></h6></div>
     <!-- for missing results this view shows the details of the previews result.
     since you cannot see the result string in this case, we need to show it here -->
-    <ng-container *ngIf="resultString && resultIconClass && textColorClass && templateStatus === ResultTemplateStatus.MISSING && !filteredFeedbackList?.length">
+    <span [ngClass]="textColorClass" *ngIf="resultString && resultIconClass && textColorClass && templateStatus === ResultTemplateStatus.MISSING && !filteredFeedbackList?.length">
         <fa-icon [icon]="resultIconClass" size="lg"></fa-icon>
-        <span [ngClass]="textColorClass" class="result" container="body">{{ resultString }}</span>
-    </ng-container>
+        <span class="result" container="body">{{ resultString }}</span>
+    </span>
     <div *ngIf="showMissingAutomaticFeedbackInformation" class="mb-3">
         <h6 [innerHTML]="'artemisApp.result.afterDueDateFeedbackHidden' | artemisTranslate: { date: latestIndividualDueDate }"></h6>
     </div>

--- a/src/main/webapp/app/exercises/shared/result/result-detail.component.html
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.component.html
@@ -7,7 +7,7 @@
     <div *ngIf="messageKey" class="mb-3"><h6 [innerHTML]="messageKey | artemisTranslate"></h6></div>
     <!-- for missing results this view shows the details of the previews result.
     since you cannot see the result string in this case, we need to show it here -->
-    <ng-container *ngIf="resultString && resultIconClass && textColorClass && templateStatus === ResultTemplateStatus.MISSING">
+    <ng-container *ngIf="resultString && resultIconClass && textColorClass && templateStatus === ResultTemplateStatus.MISSING && !filteredFeedbackList?.length">
         <fa-icon [icon]="resultIconClass" size="lg"></fa-icon>
         <span [ngClass]="textColorClass" class="result" container="body">{{ resultString }}</span>
     </ng-container>

--- a/src/main/webapp/app/exercises/shared/result/result-detail.component.html
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.component.html
@@ -5,6 +5,12 @@
 <div class="modal-body position-relative" id="result-detail-body">
     <!-- Message, if defined -->
     <div *ngIf="messageKey" class="mb-3"><h6 [innerHTML]="messageKey | artemisTranslate"></h6></div>
+    <!-- for missing results this view shows the details of the previews result.
+    since you cannot see the result string in this case, we need to show it here -->
+    <ng-container *ngIf="resultString && resultIconClass && textColorClass && templateStatus === ResultTemplateStatus.MISSING">
+        <fa-icon [icon]="resultIconClass" size="lg"></fa-icon>
+        <span [ngClass]="textColorClass" class="result" container="body">{{ resultString }}</span>
+    </ng-container>
     <div *ngIf="showMissingAutomaticFeedbackInformation" class="mb-3">
         <h6 [innerHTML]="'artemisApp.result.afterDueDateFeedbackHidden' | artemisTranslate: { date: latestIndividualDueDate }"></h6>
     </div>

--- a/src/main/webapp/app/exercises/shared/result/result-detail.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.component.ts
@@ -36,6 +36,8 @@ import { NgxChartsMultiSeriesDataEntry } from 'app/shared/chart/ngx-charts-datat
 import { axisTickFormattingWithPercentageSign } from 'app/shared/statistics-graph/statistics-graph.utils';
 import { Course } from 'app/entities/course.model';
 import dayjs from 'dayjs/esm';
+import { ResultTemplateStatus } from 'app/exercises/shared/result/result.component';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
 export enum FeedbackItemType {
     Issue,
@@ -69,6 +71,7 @@ export class ResultDetailComponent implements OnInit {
     readonly AssessmentType = AssessmentType;
     readonly ExerciseType = ExerciseType;
     readonly FeedbackItemType = FeedbackItemType;
+    readonly ResultTemplateStatus = ResultTemplateStatus;
     readonly roundScoreSpecifiedByCourseSettings = roundValueSpecifiedByCourseSettings;
 
     @Input() exercise?: Exercise;
@@ -78,6 +81,10 @@ export class ResultDetailComponent implements OnInit {
     @Input() showTestDetails = false;
     @Input() showScoreChart = false;
     @Input() exerciseType: ExerciseType;
+    @Input() resultString: string;
+    @Input() textColorClass: string;
+    @Input() resultIconClass: IconProp;
+    @Input() templateStatus: ResultTemplateStatus;
     /**
      * Translate key for an HTML message that is displayed at the top of the result details, if defined.
      */

--- a/src/main/webapp/app/exercises/shared/result/result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.component.ts
@@ -352,6 +352,10 @@ export class ResultComponent implements OnInit, OnChanges {
         const componentInstance: ResultDetailComponent = modalRef.componentInstance;
         componentInstance.exercise = this.exercise;
         componentInstance.result = result;
+        componentInstance.resultString = this.resultString;
+        componentInstance.textColorClass = this.textColorClass;
+        componentInstance.resultIconClass = this.resultIconClass;
+        componentInstance.templateStatus = this.templateStatus;
         componentInstance.showTestDetails =
             (this.exercise?.type === ExerciseType.PROGRAMMING && (this.exercise as ProgrammingExercise).showTestNamesToStudents) || this.showTestDetails;
         if (this.exercise) {

--- a/src/main/webapp/app/exercises/shared/result/result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.component.ts
@@ -353,8 +353,8 @@ export class ResultComponent implements OnInit, OnChanges {
         componentInstance.exercise = this.exercise;
         componentInstance.result = result;
         componentInstance.resultString = this.resultString;
-        componentInstance.textColorClass = this.textColorClass;
-        componentInstance.resultIconClass = this.resultIconClass;
+        componentInstance.textColorClass = this.getTextColorClass();
+        componentInstance.resultIconClass = this.getResultIconClass();
         componentInstance.templateStatus = this.templateStatus;
         componentInstance.showTestDetails =
             (this.exercise?.type === ExerciseType.PROGRAMMING && (this.exercise as ProgrammingExercise).showTestNamesToStudents) || this.showTestDetails;

--- a/src/main/webapp/i18n/de/result.json
+++ b/src/main/webapp/i18n/de/result.json
@@ -78,7 +78,7 @@
                     "tooltipOnlineIde": "Für deine letzte Einreichung konnte kein Ergebnis gefunden / nicht rechtzeitig generiert werden. Bitte überprüfe deinen Code soweit möglich manuell."
                 }
             },
-            "notLatestSubmission": "Hinweis: Dieses Ergebnis und Feedback bezieht sich <strong>nicht</strong> auf die letzte Einreichung.",
+            "notLatestSubmission": "Hinweis: Dieses Ergebnis und Feedback bezieht sich <strong>nicht</strong> auf die letzte Einreichung. Pushe einen neuen Commit, um einen weiteren Build zu starten.",
             "seeMore": "Mehr anzeigen",
             "noFeedback": "Kein Feedback verfügbar",
             "afterDueDateFeedbackHidden": "Auch nach der Abgabefrist werden Detailfeedbacks nicht zu allen Testfällen angezeigt. Dies ist etwa der Fall wenn für andere Studierende eine spätere Abgabefrist gesetzt ist (z.B. zum Ausgleich von Krankheitstagen). Alle Feedbacks werden automatisch am {{date}} sichtbar sein."

--- a/src/main/webapp/i18n/en/result.json
+++ b/src/main/webapp/i18n/en/result.json
@@ -78,7 +78,7 @@
                     "tooltipOnlineIde": "No result was found / could be generated in time for your most recent submission. Please check your code manually as far as possible."
                 }
             },
-            "notLatestSubmission": "Note: This result and feedback is <strong>not</strong> based on the latest submission.",
+            "notLatestSubmission": "Note: This result and feedback is <strong>not</strong> based on the latest submission. Commit and push again to start a new build.",
             "seeMore": "See more",
             "noFeedback": "No feedback available",
             "afterDueDateFeedbackHidden": "Even after the due date not for all test cases a detailed feedback is shown. This could be the case if other students are still working on the exercise (e.g. to allow for the compensation of sick days). Those feedbacks will automatically become visible after {{date}}."


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [ ] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
When participating in programming exercises, it can happen that for some submissions Artemis does not receive a build result from the CI system. In this case, Artemis shows a message and allows to show the result details of the previous result. But this view does not show the result string, a information that is normally shown by the result component itself, but in this case there is no way to see the result string (since the result component shows the information about not receiving build information). Therefore for this special case, we want to display the result string in the details view.

For course exercises this is not a huge problem, since the current score is stil shown in a diagram. But for exam exercises where no test feedback is provided, the result string is needed.

### Description
The result string and all necessary information are passed forward to the result details component.

### Steps for Testing
Prerequisites:
- 1 Students
- 1 Programming Exercise with no feedback before the deadline (e.g. change the visibility of all test cases in the grading tab)
- Access to the CI server

1. Submit a solution as a student
2. Stop the new build on the CI server so that it never completes.
3. Wait 2 minutes
4. Click on "View previous result"
5. Check that the result string of the previous result is shown correctly.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
