### PR TITLE
`Plagiarism checks`: Remove tooltips due to broken alignment.

### DIFF
--- a/src/main/webapp/app/course/plagiarism-cases/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.html
+++ b/src/main/webapp/app/course/plagiarism-cases/instructor-view/detail-view/plagiarism-case-instructor-detail-view.component.html
@@ -56,10 +56,7 @@
                         <span class="input-group-text">%</span>
                     </div>
                 </div>
-                <div
-                    class="row justify-content-center mt-2"
-                    [ngbTooltip]="isStudentNotified() ? undefined : ('artemisApp.plagiarism.plagiarismCases.verdict.tooltipStudentNotNotified' | artemisTranslate)"
-                >
+                <div class="row justify-content-center mt-2">
                     <jhi-confirm-button
                         title="artemisApp.plagiarism.plagiarismCases.verdict.pointDeduction"
                         confirmationText="artemisApp.plagiarism.plagiarismCases.verdict.confirmationText"
@@ -76,10 +73,7 @@
                 <div class="row justify-content-center">
                     <textarea class="col" [(ngModel)]="verdictMessage" [disabled]="!!plagiarismCase.verdict" [readonly]="!!plagiarismCase.verdict"></textarea>
                 </div>
-                <div
-                    class="row justify-content-center mt-2"
-                    [ngbTooltip]="isStudentNotified() ? undefined : ('artemisApp.plagiarism.plagiarismCases.verdict.tooltipStudentNotNotified' | artemisTranslate)"
-                >
+                <div class="row justify-content-center mt-2">
                     <jhi-confirm-button
                         title="artemisApp.plagiarism.plagiarismCases.verdict.warning"
                         confirmationText="artemisApp.plagiarism.plagiarismCases.verdict.confirmationText"
@@ -92,10 +86,7 @@
                     ></jhi-confirm-button>
                 </div>
             </div>
-            <div
-                class="col-3 d-flex flex-column"
-                [ngbTooltip]="isStudentNotified() ? undefined : ('artemisApp.plagiarism.plagiarismCases.verdict.tooltipStudentNotNotified' | artemisTranslate)"
-            >
+            <div class="col-3 d-flex flex-column">
                 <div class="row justify-content-center">
                     <jhi-confirm-button
                         title="artemisApp.plagiarism.plagiarismCases.verdict.plagiarism"
@@ -109,10 +100,7 @@
                     ></jhi-confirm-button>
                 </div>
             </div>
-            <div
-                class="col-3 d-flex flex-column"
-                [ngbTooltip]="isStudentNotified() ? undefined : ('artemisApp.plagiarism.plagiarismCases.verdict.tooltipStudentNotNotified' | artemisTranslate)"
-            >
+            <div class="col-3 d-flex flex-column">
                 <div class="row justify-content-center">
                     <jhi-confirm-button
                         title="artemisApp.plagiarism.plagiarismCases.verdict.noPlagiarism"


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added ~multiple~ screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
As noticed by @Santia-go, the tooltip to warn users that students must be notified before setting a verdict on disabled verdict buttons in instructor plagiarism view is not aligned correctly for the last two buttons. Closes #5537.

### Description
<!-- Describe your changes in detail -->
Since we already have a wrning alert box with the same message, the tooltips are removed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Exercise with Plagiarism Case without a verdict

1. Log in to Artemis
2. Navigate to Course Administration
3. Navigate to the Plagiarism Case
4. Ensure student is not notified yet (delete notification post if it is already present)
5. Hover above verdict buttons (Point deduction, Warning, Plagiarism, No Plagiarism) and ensure there is _no_ tooltip with the message "You must notify the student before determining the verdict."
6. Notify the student.
7. Hover above verdict buttons and ensure there is a tooltip with the message "Set this verdict?"

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before the tooltips are removed (pay attention to the tooltips of the two rightmost buttons):

https://user-images.githubusercontent.com/18427209/183269623-c05e3b6c-d388-47bc-9fb6-6876752f52f4.mov


