### PR TITLE
`Development`: Remove title service call from available hints endpoint

### DIFF
--- a/src/main/webapp/app/exercises/shared/exercise-hint/shared/exercise-hint.service.ts
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/shared/exercise-hint.service.ts
@@ -138,9 +138,7 @@ export class ExerciseHintService implements IExerciseHintService {
      * @param exerciseId Id of the exercise of which to retrieve all available exercise hints
      */
     getAvailableExerciseHints(exerciseId: number): Observable<HttpResponse<ExerciseHint[]>> {
-        return this.http
-            .get<ExerciseHint[]>(`${this.resourceUrl}/${exerciseId}/exercise-hints/available`, { observe: 'response' })
-            .pipe(tap((res) => res?.body?.forEach((hint) => this.sendTitlesToEntityTitleService(hint, exerciseId))));
+        return this.http.get<ExerciseHint[]>(`${this.resourceUrl}/${exerciseId}/exercise-hints/available`, { observe: 'response' });
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The client tries to send titles for exercise hints received from the ``exercise-hints/available`` endpoint to the entity title service. However, the [content and titles are cleared from the hints in this endpoint](https://github.com/ls1intum/Artemis/blob/75baaebc28a5d2565edff1fc34f18d09afe6c0aa/src/main/java/de/tum/in/www1/artemis/web/rest/hestia/ExerciseHintResource.java#L260) before being sent, so there are no titles available.

https://sentry.ase.in.tum.de/share/issue/90ddcdb2919646d6ae5c6b70dc495b14/ (thanks to @ge65cer for sending me this)

### Description
<!-- Describe your changes in detail -->

Remove the step to send titles for received hints to the title service in this case.

### Steps for Testing

Not necessary. This is just a one-line fix with no observable effects other than a Sentry issue not being sent anymore in this case. The title service was designed to be very defensive so this is not causing observable problems whose absence could be verified by manual testing

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
