### PR TITLE
`Development`: Prevent duplicated REST calls in exam scores view

### DIFF
--- a/src/main/webapp/app/exam/exam-scores/exam-scores-average-scores-graph.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores-average-scores-graph.component.ts
@@ -8,7 +8,6 @@ import { roundValueSpecifiedByCourseSettings } from 'app/shared/util/utils';
 import { ActivatedRoute } from '@angular/router';
 import { ExerciseType } from 'app/entities/exercise.model';
 import { ArtemisNavigationUtilService, navigateToExamExercise } from 'app/utils/navigation.utils';
-import { CourseManagementService } from 'app/course/manage/course-management.service';
 import { Course } from 'app/entities/course.model';
 import { Color, ScaleType } from '@swimlane/ngx-charts';
 import { NgxChartsSingleSeriesDataEntry } from 'app/shared/chart/ngx-charts-datatypes';
@@ -46,7 +45,6 @@ export class ExamScoresAverageScoresGraphComponent implements OnInit {
         private service: StatisticsService,
         private translateService: TranslateService,
         private localeConversionService: LocaleConversionService,
-        private courseService: CourseManagementService,
     ) {}
 
     ngOnInit(): void {

--- a/src/main/webapp/app/exam/exam-scores/exam-scores-average-scores-graph.component.ts
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores-average-scores-graph.component.ts
@@ -22,9 +22,9 @@ type NameToValueMap = { [name: string]: any };
 })
 export class ExamScoresAverageScoresGraphComponent implements OnInit {
     @Input() averageScores: AggregatedExerciseGroupResult;
+    @Input() course: Course;
 
     courseId: number;
-    course?: Course;
     examId: number;
 
     readonly xAxisTickFormatting = axisTickFormattingWithPercentageSign;
@@ -54,7 +54,6 @@ export class ExamScoresAverageScoresGraphComponent implements OnInit {
             this.courseId = +params['courseId'];
             this.examId = +params['examId'];
         });
-        this.courseService.find(this.courseId).subscribe((courseResponse) => (this.course = courseResponse.body!));
         this.initializeChart();
     }
 

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
@@ -300,9 +300,9 @@
             <h4 class="mt-3">
                 <span jhiTranslate="artemisApp.examScores.ExerciseGroupsTitle">Exercise groups statistics</span>
             </h4>
-            <div class="col mb-3">
+            <div class="col mb-3" *ngIf="course">
                 <div *ngFor="let exerciseGroup of aggregatedExerciseGroupResults">
-                    <jhi-exam-scores-average-scores-graph [averageScores]="exerciseGroup"></jhi-exam-scores-average-scores-graph>
+                    <jhi-exam-scores-average-scores-graph [averageScores]="exerciseGroup" [course]="course"></jhi-exam-scores-average-scores-graph>
                 </div>
             </div>
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When opening the exam score page with a few scores and multiple exercise groups, the client dispatches one call for the course and then another, equal call for each of the exercise groups which is unnecessary:
![grafik](https://user-images.githubusercontent.com/23171488/183644875-cd0e99ad-03ac-4a51-9333-5089b9c39288.png)


### Description
<!-- Describe your changes in detail -->

Forward the course instance from the exam scores component to the ``ExamScoresAverageScoresGraphComponent`` which needs it and was previously fetching it itself, causing one repeated call per exercise group

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Exam with scores and multiple exercise groups

1. Go to the exam scores view with the network tab of your dev tools open
2. Verify that the repeated rest calls to fetch the course are not happening anymore (compare to image)
3. Verify that all graphs still works correctly

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| exam-scores-average-scores-graph.component.ts | 76% | 98% |
| exam-scores.component.ts | 83% | 96% |
