### PR TITLE
`Plagiarism checks`: Fix plagiarism split view for exam exercises

### DIFF
--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-details/plagiarism-details.component.html
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-details/plagiarism-details.component.html
@@ -1,5 +1,5 @@
 <div class="plagiarism-details" *ngIf="comparison">
-    <jhi-plagiarism-header [splitControlSubject]="splitControlSubject" [course]="exercise.course!" [comparison]="comparison"></jhi-plagiarism-header>
+    <jhi-plagiarism-header [splitControlSubject]="splitControlSubject" [exercise]="exercise" [comparison]="comparison"></jhi-plagiarism-header>
 
     <jhi-plagiarism-split-view [comparison]="comparison" [exercise]="exercise" [splitControlSubject]="splitControlSubject"></jhi-plagiarism-split-view>
 </div>

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.html
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.html
@@ -7,11 +7,22 @@
     </div>
 
     <div class="plagiarism-header-right">
-        <button [disabled]="comparison.status === plagiarismStatus.CONFIRMED" class="btn btn-success btn-sm" (click)="confirmPlagiarism()" data-qa="confirm-plagiarism-button">
+        <!-- Disable buttons for exam exercises since they are currently not supported -->
+        <button
+            [disabled]="comparison.status === plagiarismStatus.CONFIRMED || exercise.exerciseGroup"
+            class="btn btn-success btn-sm"
+            (click)="confirmPlagiarism()"
+            data-qa="confirm-plagiarism-button"
+        >
             {{ 'artemisApp.plagiarism.confirm' | artemisTranslate }}
         </button>
 
-        <button [disabled]="comparison.status === plagiarismStatus.DENIED" class="btn btn-danger btn-sm" (click)="denyPlagiarism()" data-qa="deny-plagiarism-button">
+        <button
+            [disabled]="comparison.status === plagiarismStatus.DENIED || exercise.exerciseGroup"
+            class="btn btn-danger btn-sm"
+            (click)="denyPlagiarism()"
+            data-qa="deny-plagiarism-button"
+        >
             {{ 'artemisApp.plagiarism.deny' | artemisTranslate }}
         </button>
 

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-header/plagiarism-header.component.ts
@@ -9,9 +9,9 @@ import { TextSubmissionElement } from 'app/exercises/shared/plagiarism/types/tex
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ModelingSubmissionElement } from 'app/exercises/shared/plagiarism/types/modeling/ModelingSubmissionElement';
 import { PlagiarismCasesService } from 'app/course/plagiarism-cases/shared/plagiarism-cases.service';
-import { Course } from 'app/entities/course.model';
 import { ConfirmAutofocusModalComponent } from 'app/shared/components/confirm-autofocus-button.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { Exercise, getCourseId } from 'app/entities/exercise.model';
 
 @Component({
     selector: 'jhi-plagiarism-header',
@@ -20,7 +20,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 })
 export class PlagiarismHeaderComponent {
     @Input() comparison: PlagiarismComparison<TextSubmissionElement | ModelingSubmissionElement>;
-    @Input() course: Course;
+    @Input() exercise: Exercise;
     @Input() splitControlSubject: Subject<string>;
 
     readonly plagiarismStatus = PlagiarismStatus;
@@ -60,7 +60,7 @@ export class PlagiarismHeaderComponent {
     updatePlagiarismStatus(status: PlagiarismStatus) {
         // store comparison in variable in case comparison changes while request is made
         const comparison = this.comparison;
-        this.plagiarismCasesService.updatePlagiarismComparisonStatus(this.course.id!, comparison.id, status).subscribe(() => {
+        this.plagiarismCasesService.updatePlagiarismComparisonStatus(getCourseId(this.exercise)!, comparison.id, status).subscribe(() => {
             comparison.status = status;
         });
     }

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/plagiarism-split-view.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/plagiarism-split-view.component.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
 import { PlagiarismComparison } from 'app/exercises/shared/plagiarism/types/PlagiarismComparison';
 import { TextSubmissionElement } from 'app/exercises/shared/plagiarism/types/text/TextSubmissionElement';
 import { ModelingSubmissionElement } from 'app/exercises/shared/plagiarism/types/modeling/ModelingSubmissionElement';
-import { Exercise, ExerciseType } from 'app/entities/exercise.model';
+import { Exercise, ExerciseType, getCourseId } from 'app/entities/exercise.model';
 import { PlagiarismSubmission } from 'app/exercises/shared/plagiarism/types/PlagiarismSubmission';
 import { PlagiarismCasesService } from 'app/course/plagiarism-cases/shared/plagiarism-cases.service';
 import { HttpResponse } from '@angular/common/http';
@@ -67,7 +67,7 @@ export class PlagiarismSplitViewComponent implements AfterViewInit, OnChanges, O
 
         if (changes.comparison) {
             this.plagiarismCasesService
-                .getPlagiarismComparisonForSplitView(this.exercise.course?.id!, changes.comparison.currentValue.id)
+                .getPlagiarismComparisonForSplitView(getCourseId(this.exercise)!, changes.comparison.currentValue.id)
                 .subscribe((resp: HttpResponse<PlagiarismComparison<TextSubmissionElement | ModelingSubmissionElement>>) => {
                     this.plagiarismComparison = resp.body!;
                     if (this.sortByStudentLogin && this.sortByStudentLogin === this.plagiarismComparison.submissionB.studentLogin) {

--- a/src/test/javascript/spec/component/plagiarism/plagiarism-header.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/plagiarism-header.component.spec.ts
@@ -7,7 +7,7 @@ import { MockTranslateService, TranslateTestingModule } from '../../helpers/mock
 import { PlagiarismComparison } from 'app/exercises/shared/plagiarism/types/PlagiarismComparison';
 import { ModelingSubmissionElement } from 'app/exercises/shared/plagiarism/types/modeling/ModelingSubmissionElement';
 import { PlagiarismStatus } from 'app/exercises/shared/plagiarism/types/PlagiarismStatus';
-import { Course } from 'app/entities/course.model';
+import { Exercise } from 'app/entities/exercise.model';
 import { PlagiarismCasesService } from 'app/course/plagiarism-cases/shared/plagiarism-cases.service';
 import { HttpResponse } from '@angular/common/http';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
@@ -37,7 +37,7 @@ describe('Plagiarism Header Component', () => {
             submissionB: { studentLogin: 'studentB' },
             status: PlagiarismStatus.NONE,
         } as PlagiarismComparison<ModelingSubmissionElement>;
-        comp.course = { id: 1 } as Course;
+        comp.exercise = { course: { id: 1 } } as Exercise;
         comp.splitControlSubject = new Subject<string>();
     });
 


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [ ] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
Currently, it's not possible to access the plagiarism split view for exam exercises. A Bad Request Error is shown becuase the request contains undefined as courseId.
![grafik](https://user-images.githubusercontent.com/26540346/184097875-ae774eca-0c67-4984-81f1-e89ab6b20c18.png)

### Description
For exam exercises, the course has to be retrieved using the exercise group. This PR solves this by calling a helper method.

Note: Artemis does not support the whole plagiarism process for exam exercises right now. This PR only fixes viewing the findings, more changes have to be done in a followup.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Exam programming exercise

1. Run Plagiarism checks for the exercise
2. Check that the split view works.
3. Make sure that the Accept / Deny buttons are disabled.

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2