### PR TITLE
`General`: Use number instead of amount for countable elements in translations

### DIFF
--- a/src/main/webapp/i18n/en/course.json
+++ b/src/main/webapp/i18n/en/course.json
@@ -34,11 +34,11 @@
             },
             "maxComplaintTextLimit": {
                 "title": "Maximum number of characters per complaint",
-                "description": "This number indicates the maximum number of characters a student may use per complaint."
+                "description": "This value indicates the maximum number of characters a student may use per complaint."
             },
             "maxComplaintResponseTextLimit": {
                 "title": "Maximum number of characters per complaint response",
-                "description": "This number indicates the maximum number of characters that may be used for the response per complaint."
+                "description": "This value indicates the maximum number of characters that may be used for the response per complaint."
             },
             "postsEnabled": {
                 "title": "Enable communication features",

--- a/src/main/webapp/i18n/en/exampleSubmission.json
+++ b/src/main/webapp/i18n/en/exampleSubmission.json
@@ -58,8 +58,8 @@
             "useAsExampleSubmissionLabel": "Use as an Example Submission",
             "searchSubmission": "Search for Submission",
             "submissionSize": "Submission Size",
-            "textSubmissionSizeHint": "This number shows the number of words in the text.",
-            "modelingSubmissionSizeHint": "This number shows the number of elements used in the model.",
+            "textSubmissionSizeHint": "This value shows the number of words in the text.",
+            "modelingSubmissionSizeHint": "This value shows the number of elements used in the model.",
             "exampleAssessmentCreated": "Example Assessment Created",
             "exampleAssessmentWarning": "You need to complete the assessment to use this submission in the assessment training."
         },

--- a/src/main/webapp/i18n/en/global.json
+++ b/src/main/webapp/i18n/en/global.json
@@ -313,7 +313,7 @@
         "invalid.auxiliary.repository.checkout.directory": "At least one Auxiliary Repository checkout directory is invalid or duplicated. Please make sure all checkout directories are appropriate and do not contain duplications.",
         "invalid.auxiliary.repository.description": "The description of at least one Auxiliary Repository is too long!",
         "invalid.testcases.weights": "Before deactivating manual feedback, please give at least one test case a weight greater than zero.",
-        "invalid.page.request": "The page request seems to be invalid. Please make sure that enough number of {{entityName}} entities exist, so that the request page can be created.",
+        "invalid.page.request": "The page request seems to be invalid. Please make sure that enough {{entityName}} entities exist, so that the request page can be created.",
         "unexpectedError": "An unexpected error occurred: {{error}}",
         "manualCodeHintOperation": "This endpoint does not allow to change code hints manually.",
         "exerciseNotDefined": "The exercise is not defined.",

--- a/src/main/webapp/i18n/en/programmingAssessment.json
+++ b/src/main/webapp/i18n/en/programmingAssessment.json
@@ -12,7 +12,7 @@
             "penaltyTooltip": "Penalty: {{ percentage }}% of all penalties.",
             "issuesTooltip": "Issues: {{ percentage }}% of all detected issues.",
             "deductionsTooltip": "Deductions: {{ percentage }}% of all deducted points.",
-            "codeIssueNotApplied": "This issue does not deduct the maximum amount of possible points, since similar code issues already deduct enough points. If this was the only issue, it would deduct {{points}} points."
+            "codeIssueNotApplied": "This issue does not deduct the maximum number of possible points, since similar code issues already deduct enough points. If this was the only issue, it would deduct {{points}} points."
         }
     }
 }

--- a/src/main/webapp/i18n/en/programmingExercise.json
+++ b/src/main/webapp/i18n/en/programmingExercise.json
@@ -203,7 +203,7 @@
                     "state": "Determines whether issues in this category should be shown to the students and used for grading.",
                     "penalty": "Penalty points given on each detected issue of this category.",
                     "maxPenalty": "Maximum applied penalty for one student across all issues of this category.",
-                    "detectedIssues": "Shows the number of students grouped by amount of detected issues in a category, starting at 1 issue. The bars turn red when surpassing the threshold defined by the maxPenalty of the respective category.",
+                    "detectedIssues": "Shows the number of students grouped by number of detected issues in a category, starting at 1 issue. The bars turn red when surpassing the threshold defined by the maxPenalty of the respective category.",
                     "weight": "The weighting of a test case determines the points a student receives for passing the test case. The number of points a test case awards is proportional to its weight and calculated as a fraction of the total exercise points.",
                     "bonusMultiplier": "This multiplies the points given for passing a test case without affecting the fractions of other test cases. Multipliers greater than 1 can result in student scores greater than 100%.",
                     "bonusPoints": "Bonus points added on top of the regular points for passing a test case. Setting bonus points can result in student scores greater than 100%.",
@@ -361,7 +361,7 @@
                 "submissionPenalty": {
                     "optionLabel": "Submission Penalty",
                     "penaltyInputFieldTitle": "Exceeding Submission Limit Penalty",
-                    "exceedingLimitDescription": "The amount of points that is deducted from the result score for each submission exceeding the submission limit. Enter any amount of points greater than 0.",
+                    "exceedingLimitDescription": "The number of points that is deducted from the result score for each submission exceeding the submission limit. Enter any number of points greater than 0.",
                     "penaltyInputFieldValidationWarning": {
                         "pattern": "The penalty must be a number greater than 0.",
                         "required": "The penalty must be set."
@@ -384,7 +384,7 @@
                     }
                 },
                 "submissionLimitTitle": "Submission limit",
-                "submissionLimitDescription": "The amount of submissions a participant can make before the system enforces the selected policy.",
+                "submissionLimitDescription": "The number of submissions a participant can make before the system enforces the selected policy.",
                 "editInGradingInformation": "The submission policy can only be edited and toggled on the grading page of the programming exercise!",
                 "submissionLimitWarning": {
                     "pattern": "The submission limit must be and integer between 1 and 500!",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
Amount is used for uncountable quantities, number for countable ones.

### Description
Replaced amount with number in the translation strings where it made sense to do so.

Additionally, in a few places where ‘number […] number’ was repeated I replaced one of them with value. This occurs mostly for tooltips explaining what some number shown in the UI means. Therefore, changing it to ‘value’ retains identical semantics.

### Steps for Testing
Just code review is enough.

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
n/a

### Screenshots
n/a
