### PR TITLE
`Lectures`: Move buttons of lecture units into header

### DIFF
--- a/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.html
@@ -1,7 +1,7 @@
 <div class="row align-items-center mb-2 mt-2">
     <div class="card unit-card">
         <div class="card-header unit-card-header row align-content-center justify-content-between" (click)="handleCollapse($event)">
-            <div class="col-auto row align-content-center">
+            <div class="col-auto row align-content-center flex-shrink-1">
                 <h5 class="m-0 fw-medium">
                     <fa-icon class="me-2" [icon]="getAttachmentIcon()" [ngbTooltip]="'artemisApp.attachmentUnit.tooltip' | artemisTranslate"> </fa-icon>
                     {{ attachmentUnit?.attachment?.name ? attachmentUnit?.attachment?.name : '' }}
@@ -14,24 +14,30 @@
                     </span>
                 </h5>
             </div>
-            <div class="col-auto" *ngIf="!isPresentationMode && attachmentUnit.visibleToStudents">
-                <fa-icon
-                    *ngIf="attachmentUnit.completed; else uncompleted"
-                    class="text-success"
-                    size="lg"
-                    [icon]="faSquareCheck"
-                    [ngbTooltip]="'artemisApp.lectureUnit.completedTooltip' | artemisTranslate"
-                    (click)="handleClick($event, false)"
-                ></fa-icon>
-                <ng-template #uncompleted>
+            <div class="col-auto d-flex align-items-center gap-3 pe-0">
+                <button id="downloadButton" class="btn btn-primary btn-sm" (click)="downloadAttachment()">
+                    <fa-icon [icon]="faDownload"></fa-icon>
+                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.attachmentUnit.download">Download</span>
+                </button>
+                <div class="col-auto" *ngIf="!isPresentationMode && attachmentUnit.visibleToStudents">
                     <fa-icon
-                        class="text-muted"
+                        *ngIf="attachmentUnit.completed; else uncompleted"
+                        class="text-success"
                         size="lg"
-                        [icon]="faSquare"
-                        [ngbTooltip]="'artemisApp.lectureUnit.uncompletedTooltip' | artemisTranslate"
-                        (click)="handleClick($event, true)"
+                        [icon]="faSquareCheck"
+                        [ngbTooltip]="'artemisApp.lectureUnit.completedTooltip' | artemisTranslate"
+                        (click)="handleClick($event, false)"
                     ></fa-icon>
-                </ng-template>
+                    <ng-template #uncompleted>
+                        <fa-icon
+                            class="text-muted"
+                            size="lg"
+                            [icon]="faSquare"
+                            [ngbTooltip]="'artemisApp.lectureUnit.uncompletedTooltip' | artemisTranslate"
+                            (click)="handleClick($event, true)"
+                        ></fa-icon>
+                    </ng-template>
+                </div>
             </div>
         </div>
         <div class="card-body unit-card-body" [ngbCollapse]="isCollapsed">
@@ -51,11 +57,6 @@
                 <hr />
                 {{ attachmentUnit?.description }}
             </div>
-            <hr />
-            <button id="downloadButton" class="btn btn-primary btn-sm rounded-pill" (click)="downloadAttachment()">
-                <fa-icon [icon]="faDownload"></fa-icon>
-                <span class="d-none d-md-inline" jhiTranslate="artemisApp.attachmentUnit.download">Download</span>
-            </button>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.html
@@ -15,7 +15,7 @@
                 </h5>
             </div>
             <div class="col-auto d-flex align-items-center gap-3 pe-0">
-                <button id="downloadButton" class="btn btn-primary btn-sm" (click)="downloadAttachment()">
+                <button id="downloadButton" class="btn btn-primary btn-sm" (click)="downloadAttachment($event)">
                     <fa-icon [icon]="faDownload"></fa-icon>
                     <span class="d-none d-md-inline" jhiTranslate="artemisApp.attachmentUnit.download">Download</span>
                 </button>

--- a/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.ts
+++ b/src/main/webapp/app/overview/course-lectures/attachment-unit/attachment-unit.component.ts
@@ -29,7 +29,8 @@ export class AttachmentUnitComponent {
         this.isCollapsed = !this.isCollapsed;
     }
 
-    downloadAttachment() {
+    downloadAttachment(event: Event) {
+        event.stopPropagation();
         if (this.attachmentUnit?.attachment?.link) {
             this.fileService.downloadFileWithAccessToken(this.attachmentUnit?.attachment?.link);
             this.onCompletion.emit({ lectureUnit: this.attachmentUnit, completed: true });

--- a/src/main/webapp/app/overview/course-lectures/lecture-unit.component.scss
+++ b/src/main/webapp/app/overview/course-lectures/lecture-unit.component.scss
@@ -21,6 +21,7 @@
     border-radius: 3px 3px 0 0;
     background-color: var(--overview-light-background-color);
     cursor: pointer;
+    flex-wrap: nowrap !important;
 
     > div:first-child {
         padding-left: 0.5rem;

--- a/src/main/webapp/app/overview/course-lectures/online-unit/online-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/online-unit/online-unit.component.html
@@ -1,7 +1,7 @@
 <div class="row align-items-center mb-2 mt-2">
     <div class="card unit-card">
         <div class="card-header unit-card-header row align-content-center justify-content-between" (click)="handleCollapse($event)">
-            <div class="col-auto row align-content-center">
+            <div class="col-auto row align-content-center flex-shrink-1">
                 <h5 class="m-0 fw-medium">
                     <fa-icon class="me-2 col-auto" [icon]="faLink" [ngbTooltip]="'artemisApp.onlineUnit.tooltip' | artemisTranslate"></fa-icon>
                     {{ onlineUnit?.name }}
@@ -14,32 +14,34 @@
                     </span>
                 </h5>
             </div>
-            <div class="col-auto my-auto" *ngIf="!isPresentationMode && onlineUnit.visibleToStudents">
-                <fa-icon
-                    *ngIf="onlineUnit.completed; else uncompleted"
-                    class="text-success"
-                    size="lg"
-                    [icon]="faSquareCheck"
-                    [ngbTooltip]="'artemisApp.lectureUnit.completedTooltip' | artemisTranslate"
-                    (click)="handleClick($event, false)"
-                ></fa-icon>
-                <ng-template #uncompleted>
+            <div class="col-auto d-flex align-items-center gap-3 pe-0">
+                <button class="btn btn-sm btn-primary" (click)="openLink($event)" [ngbTooltip]="domainName">
+                    <fa-icon [icon]="faUpRightFromSquare"></fa-icon>
+                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.onlineUnit.doOpen">Open link</span>
+                </button>
+                <div class="col-auto my-auto" *ngIf="!isPresentationMode && onlineUnit.visibleToStudents">
                     <fa-icon
-                        class="text-muted"
+                        *ngIf="onlineUnit.completed; else uncompleted"
+                        class="text-success"
                         size="lg"
-                        [icon]="faSquare"
-                        [ngbTooltip]="'artemisApp.lectureUnit.uncompletedTooltip' | artemisTranslate"
-                        (click)="handleClick($event, true)"
+                        [icon]="faSquareCheck"
+                        [ngbTooltip]="'artemisApp.lectureUnit.completedTooltip' | artemisTranslate"
+                        (click)="handleClick($event, false)"
                     ></fa-icon>
-                </ng-template>
+                    <ng-template #uncompleted>
+                        <fa-icon
+                            class="text-muted"
+                            size="lg"
+                            [icon]="faSquare"
+                            [ngbTooltip]="'artemisApp.lectureUnit.uncompletedTooltip' | artemisTranslate"
+                            (click)="handleClick($event, true)"
+                        ></fa-icon>
+                    </ng-template>
+                </div>
             </div>
         </div>
         <div class="card-body unit-card-body" [ngbCollapse]="isCollapsed">
-            <p>{{ onlineUnit?.description }}</p>
-
-            <button class="btn btn-sm btn-primary rounded-pill" (click)="openLink($event)" [ngbTooltip]="domainName">
-                <fa-icon [icon]="faUpRightFromSquare"></fa-icon> <span jhiTranslate="artemisApp.onlineUnit.doOpen">Open link</span>
-            </button>
+            <p class="mb-0">{{ onlineUnit?.description }}</p>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/overview/course-lectures/text-unit/text-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/text-unit/text-unit.component.html
@@ -1,7 +1,7 @@
 <div class="row align-items-center mb-2 mt-2">
     <div class="card unit-card">
         <div class="card-header unit-card-header row align-content-center justify-content-between" (click)="handleCollapse($event)">
-            <div class="col-auto row align-content-center">
+            <div class="col-auto row align-content-center flex-shrink-1">
                 <h5 class="m-0 fw-medium">
                     <fa-icon class="me-2" [icon]="faScroll" [ngbTooltip]="'artemisApp.textUnit.tooltip' | artemisTranslate"></fa-icon>
                     {{ textUnit?.name ? textUnit.name : '' }}
@@ -14,35 +14,36 @@
                     </span>
                 </h5>
             </div>
-            <div class="col-auto" *ngIf="!isPresentationMode && textUnit.visibleToStudents">
-                <fa-icon
-                    *ngIf="textUnit.completed; else uncompleted"
-                    class="text-success"
-                    size="lg"
-                    [icon]="faSquareCheck"
-                    [ngbTooltip]="'artemisApp.lectureUnit.completedTooltip' | artemisTranslate"
-                    (click)="handleClick($event, false)"
-                ></fa-icon>
-                <ng-template #uncompleted>
+            <div class="col-auto d-flex align-items-center gap-3 pe-0">
+                <button id="popupButton" class="btn btn-sm btn-primary" (click)="openPopup($event)">
+                    <fa-icon [icon]="faExternalLinkAlt"></fa-icon>
+                    <span class="d-none d-md-inline" jhiTranslate="artemisApp.textUnit.isolated">View Isolated</span>
+                </button>
+                <div class="col-auto" *ngIf="!isPresentationMode && textUnit.visibleToStudents">
                     <fa-icon
-                        class="text-muted"
+                        *ngIf="textUnit.completed; else uncompleted"
+                        class="text-success"
                         size="lg"
-                        [icon]="faSquare"
-                        [ngbTooltip]="'artemisApp.lectureUnit.uncompletedTooltip' | artemisTranslate"
-                        (click)="handleClick($event, true)"
+                        [icon]="faSquareCheck"
+                        [ngbTooltip]="'artemisApp.lectureUnit.completedTooltip' | artemisTranslate"
+                        (click)="handleClick($event, false)"
                     ></fa-icon>
-                </ng-template>
+                    <ng-template #uncompleted>
+                        <fa-icon
+                            class="text-muted"
+                            size="lg"
+                            [icon]="faSquare"
+                            [ngbTooltip]="'artemisApp.lectureUnit.uncompletedTooltip' | artemisTranslate"
+                            (click)="handleClick($event, true)"
+                        ></fa-icon>
+                    </ng-template>
+                </div>
             </div>
         </div>
         <div class="card-body unit-card-body" [ngbCollapse]="isCollapsed">
             <div *ngIf="formattedContent">
                 <div class="markdown-preview" id="printContent" [innerHtml]="formattedContent"></div>
-                <hr />
             </div>
-            <button id="popupButton" class="btn btn-sm btn-primary rounded-pill" (click)="openPopup($event)">
-                <fa-icon [icon]="faExternalLinkAlt"></fa-icon>
-                <span class="d-none d-md-inline" jhiTranslate="artemisApp.textUnit.isolated">View Isolated</span>
-            </button>
         </div>
     </div>
 </div>

--- a/src/main/webapp/app/overview/course-lectures/video-unit/video-unit.component.html
+++ b/src/main/webapp/app/overview/course-lectures/video-unit/video-unit.component.html
@@ -1,7 +1,7 @@
 <div class="row align-items-center mb-2 mt-2">
     <div class="card unit-card">
         <div class="card-header unit-card-header row align-content-center justify-content-between" (click)="handleCollapse($event)">
-            <div class="col-auto row align-content-center">
+            <div class="col-auto row align-content-center flex-shrink-1">
                 <h5 class="m-0 fw-medium">
                     <fa-icon class="me-2" [icon]="faVideo" [ngbTooltip]="'artemisApp.videoUnit.tooltip' | artemisTranslate"> </fa-icon>
                     {{ videoUnit?.name ? videoUnit.name : '' }}
@@ -14,7 +14,7 @@
                     </span>
                 </h5>
             </div>
-            <div class="col-auto" *ngIf="!isPresentationMode && videoUnit.visibleToStudents">
+            <div class="col-auto d-flex align-items-center gap-3 pe-0" *ngIf="!isPresentationMode && videoUnit.visibleToStudents">
                 <fa-icon
                     *ngIf="videoUnit.completed; else uncompleted"
                     class="text-success"

--- a/src/test/javascript/spec/component/lecture-unit/attachment-unit/attachment-unit.component.spec.ts
+++ b/src/test/javascript/spec/component/lecture-unit/attachment-unit/attachment-unit.component.spec.ts
@@ -93,7 +93,9 @@ describe('AttachmentUnitComponent', () => {
                 expect(event.completed).toBeTrue();
                 done();
             });
-            attachmentUnitComponent.downloadAttachment();
+            const stopPropagation = jest.fn();
+            attachmentUnitComponent.downloadAttachment({ stopPropagation } as any as Event);
+            expect(stopPropagation).toHaveBeenCalledOnce();
         });
     }, 1000);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The buttons of lecture units that allow students to download an attachment or open an URL are currently located in the lecture unit cards that need to be expanded first. Moreover, they still have that "rounded pill" look that doesn't fit out usual styling. Additionally, the checkbox to mark the unit as completed moves in to the next line on smaller viewports which looks weird.

### Description
<!-- Describe your changes in detail -->

We decided to move these buttons into the header to make them easily accessible, and convert their design to match all other buttons. Also fixed the responsiveness issue

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course with a lecture with one or multiple units of each type

1. Go the lecture page of the course in the student view
2. Open the lecture
3. Verify that all units are visible and that the buttons in the header work correctly
4. Verify that you can still expand the units
5. Verify that the page is responsive enough
6. Go to the course management view
7. Navigate to the page where you can edit the lecture units
8. Verify the same as in steps 3-5
9. Verify that you can still reorder them by dragging and dropping

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
Unchanged

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

Before:

https://user-images.githubusercontent.com/23171488/185752990-f4e56f7d-9e94-4094-9039-f3d1bc9eaff8.mov


After:

https://user-images.githubusercontent.com/23171488/185752866-3bfd1e72-b70f-4791-9dfe-355bf505ca62.mov


