### PR TITLE
General: Fix potentially unsafe external link on "About Us" page

### DIFF
--- a/src/main/webapp/app/core/about-us/about-us.component.html
+++ b/src/main/webapp/app/core/about-us/about-us.component.html
@@ -21,7 +21,7 @@
                         <h5>{{ 'artemisApp.aboutUsOverview.' + pm.role | artemisTranslate }}</h5>
                         <span>
                             <i></i>
-                            <a href="{{ pm.website }}" target="_blank">{{ 'artemisApp.aboutUsOverview.website' | artemisTranslate }}</a>
+                            <a href="{{ pm.website }}" target="_blank" rel="noopener noreferrer">{{ 'artemisApp.aboutUsOverview.website' | artemisTranslate }}</a>
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
### Checklist
#### General
- [X] ~I tested **all** changes and their related features with **all** corresponding user types on a test server.~
- [X] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [X] ~Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).~
- [X] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [X] ~I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.~
- [X] ~Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.~
- [X] ~I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).~
- [X] ~I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).~
- [X] ~I documented the TypeScript code using JSDoc style.~
- [X] ~I added multiple screenshots/screencasts of my UI changes.~
- [X] ~I translated all newly inserted strings into English and German.~

### Motivation and Context
Code Scanning found a https://github.com/ls1intum/Artemis/security/code-scanning/272.

### Description
Fix https://github.com/ls1intum/Artemis/security/code-scanning/272. Introduce `noopener`/`noreferrer` attribute.

### Steps for Testing
1. Open About Us page (link in footer)
2. Inspect Project Manager Links to @krusche's and @jpbernius's websites (with developer tools)
3. Find `rel="noopener noreferrer"` attribute on link.
