### PR TITLE
`Assessment`: Fix undefined router param in grade key view

### DIFF
--- a/src/main/webapp/app/overview/courses-routing.module.ts
+++ b/src/main/webapp/app/overview/courses-routing.module.ts
@@ -82,15 +82,6 @@ const routes: Routes = [
             },
         ],
     },
-    {
-        path: 'courses/:courseId/statistics/grading-key',
-        component: GradingKeyOverviewComponent,
-        data: {
-            authorities: [Authority.USER],
-            pageTitle: 'artemisApp.gradingSystem.title',
-        },
-        canActivate: [UserRouteAccessService],
-    },
 ];
 
 @NgModule({

--- a/src/main/webapp/app/overview/courses-routing.module.ts
+++ b/src/main/webapp/app/overview/courses-routing.module.ts
@@ -7,7 +7,6 @@ import { CourseExamsComponent } from 'app/overview/course-exams/course-exams.com
 import { NgModule } from '@angular/core';
 import { Authority } from 'app/shared/constants/authority.constants';
 import { CourseExercisesComponent } from 'app/overview/course-exercises/course-exercises.component';
-import { GradingKeyOverviewComponent } from 'app/grading-system/grading-key-overview/grading-key-overview.component';
 
 const routes: Routes = [
     {

--- a/src/test/javascript/spec/component/grading-system/grading-key-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/grading-key-overview.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { ActivatedRoute, ActivatedRouteSnapshot, Router } from '@angular/router';
+import { ActivatedRoute, ActivatedRouteSnapshot, Params, Router } from '@angular/router';
 import { of } from 'rxjs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MockRouter } from '../../helpers/mocks/mock-router';
@@ -52,16 +52,16 @@ describe('GradeKeyOverviewComponent', () => {
 
     beforeEach(() => {
         route = {
-            snapshot: { params: {}, queryParams: { grade: studentGrade } },
+            snapshot: { params: {} as Params, queryParams: { grade: studentGrade } as Params },
             parent: {
                 snapshot: { params: {} },
                 parent: {
                     snapshot: {
-                        params: { courseId: 345, examId: 123 },
+                        params: { courseId: 345, examId: 123 } as Params,
                     },
                 },
             },
-        } as unknown as ActivatedRoute;
+        } as ActivatedRoute;
 
         return TestBed.configureTestingModule({
             imports: [MockModule(NgbModule)],

--- a/src/test/javascript/spec/component/grading-system/grading-key-overview.component.spec.ts
+++ b/src/test/javascript/spec/component/grading-system/grading-key-overview.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { ArtemisTranslatePipe } from 'app/shared/pipes/artemis-translate.pipe';
 import { MockComponent, MockDirective, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, ActivatedRouteSnapshot, Router } from '@angular/router';
 import { of } from 'rxjs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MockRouter } from '../../helpers/mocks/mock-router';
@@ -21,6 +21,7 @@ import { ThemeService } from 'app/core/theme/theme.service';
 describe('GradeKeyOverviewComponent', () => {
     let fixture: ComponentFixture<GradingKeyOverviewComponent>;
     let comp: GradingKeyOverviewComponent;
+    let route: ActivatedRoute;
 
     let gradingSystemService: GradingSystemService;
 
@@ -47,7 +48,21 @@ describe('GradeKeyOverviewComponent', () => {
         maxPoints: 100,
     };
 
+    const studentGrade = '2.0';
+
     beforeEach(() => {
+        route = {
+            snapshot: { params: {}, queryParams: { grade: studentGrade } },
+            parent: {
+                snapshot: { params: {} },
+                parent: {
+                    snapshot: {
+                        params: { courseId: 345, examId: 123 },
+                    },
+                },
+            },
+        } as unknown as ActivatedRoute;
+
         return TestBed.configureTestingModule({
             imports: [MockModule(NgbModule)],
             declarations: [
@@ -59,7 +74,7 @@ describe('GradeKeyOverviewComponent', () => {
                 MockPipe(GradeStepBoundsPipe),
             ],
             providers: [
-                { provide: ActivatedRoute, useValue: { parent: { parent: { params: of({ courseId: 345, examId: 123 }), queryParams: of({ grade: '2.0' }) } } } },
+                { provide: ActivatedRoute, useValue: route },
                 { provide: Router, useClass: MockRouter },
                 MockProvider(GradingSystemService),
                 MockProvider(ArtemisNavigationUtilService),
@@ -78,7 +93,7 @@ describe('GradeKeyOverviewComponent', () => {
         jest.restoreAllMocks();
     });
 
-    it('should initialize', () => {
+    function expectInitialState(grade?: string) {
         jest.spyOn(gradingSystemService, 'findGradeSteps').mockReturnValue(of(gradeStepsDto));
         jest.spyOn(gradingSystemService, 'sortGradeSteps').mockReturnValue([gradeStep1, gradeStep2]);
         const gradePointsSpy = jest.spyOn(gradingSystemService, 'setGradePoints').mockImplementation();
@@ -89,12 +104,36 @@ describe('GradeKeyOverviewComponent', () => {
         expect(comp).toBeTruthy();
         expect(comp.examId).toBe(123);
         expect(comp.courseId).toBe(345);
-        expect(comp.studentGrade).toBe('2.0');
+        expect(comp.studentGrade).toBe(grade);
         expect(comp.title).toBe('Title');
         expect(comp.isBonus).toBeTrue();
         expect(comp.isExam).toBeTrue();
         expect(comp.gradeSteps).toEqual([gradeStep1, gradeStep2]);
         expect(gradePointsSpy).toHaveBeenCalledWith([gradeStep1, gradeStep2], 100);
+    }
+
+    it('should initialize when grade queryParam is not given', () => {
+        route.snapshot.queryParams = {};
+
+        expectInitialState(undefined);
+    });
+
+    it('should initialize when params are in grandparent route', () => {
+        expectInitialState(studentGrade);
+    });
+
+    it('should initialize when params are in parent route', () => {
+        route.parent!.snapshot.params = route.parent?.parent?.snapshot.params!;
+        route.parent!.parent!.snapshot = { params: {} } as ActivatedRouteSnapshot;
+
+        expectInitialState(studentGrade);
+    });
+
+    it('should initialize when params are in current route', () => {
+        route.snapshot.params = route.parent?.parent?.snapshot.params!;
+        route.parent!.parent!.snapshot = { params: {} } as ActivatedRouteSnapshot;
+
+        expectInitialState(studentGrade);
     });
 
     it('should print PDF', fakeAsync(() => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Instructors cannot see the correct grading key when they navigate to the summary of a student exam. They see either the course grading key or no grading key at all if the course does not have one. We need to make sure that the correct grading key is loaded by all usages of `GradingKeyOverviewComponent` even if the params are placed in different url segments.

### Description
<!-- Describe your changes in detail -->
`GradingKeyOverviewComponent` is used in multiple routes, so it can be lazy loaded. Also, `courseId` and `examId` can be found on different levels of hierarchy tree (on the same level or a parent or a grandparent, etc.) so the component can be able to get the route params in every case to load the grading key correctly.

A similar issue was addressed in https://github.com/ls1intum/Artemis/pull/4858 by using `this.route.parent?.parent?.params` but it turns out the desired params are found at `this.route.params` in some router configurations.

Also, this PR removes the duplicate `grading-key` route that was already removed in https://github.com/ls1intum/Artemis/pull/4858 but re-introduced later possibly during a merge conflict resolution.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Course with a grading key
- 1 Exam with a grading key (submitted by student)

1. Log in to Artemis
2. Navigate to Course Administration
3. Check the routes below (by navigating through links/buttons and by typing the url directly) and make sure the correct grading key for the course or exam is visible and grade step corresponding to the queryParam `:grade` is highlighted. Note that before the fix exams were displaying their course's grade key instead of their own grade key so ensure this not the case anymore.
    1. With instructor : `/course-management/:courseId/exams/:examId/student-exams/:studentExamId/summary/overview/grading-key?grade=:grade`
    2. With instructor: `/courses/:courseId/statistics/grading-key?grade=:grade`
    3. With student: `/courses/:courseId/exams/:examId/overview/grading-key?grade=:grade`
    4. With student: `/courses/:courseId/statistics/grading-key?grade=:grade`

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| grading-key-overview.component.ts | 75% | 84.48% |
