### PR TITLE
`Development`: Fix source code block highlighting in server guideline documentation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,4 +14,4 @@ database:
 - src/main/resources/config/liquibase/master.xml
 
 documentation:
-- docs/*
+- docs/**/*

--- a/docs/dev/guidelines/server.rst
+++ b/docs/dev/guidelines/server.rst
@@ -431,11 +431,11 @@ add any other assertions to the test, as shown below.
 
 .. code-block:: java
 
-    public class TestClass {
+    class TestClass {
 
         @Test
         @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-        public void testQueryCount() throws Exception {
+        void testQueryCount() throws Exception {
             Course course = assertThatDb(() -> request.get("/api/courses/" + courses.get(0).getId() + "/for-dashboard", HttpStatus.OK, Course.class)).hasBeenCalledTimes(3);
             assertThat(course).isNotNull();
         }

--- a/docs/dev/guidelines/server.rst
+++ b/docs/dev/guidelines/server.rst
@@ -428,6 +428,7 @@ However, we should consider carefully before adding such assertions to a test as
 An example on how to track how many database calls are performed during a REST call is shown below. It uses the ``HibernateQueryInterceptor`` which counts the number of queries.
 For ease of use, a custom assert ``assertThatDb`` was added that allows to do the check in one line. It also returns the original result of the REST call and so allows you to
 add any other assertions to the test, as shown below.
+
 .. code-block:: java
 
     public class TestClass {

--- a/docs/dev/guidelines/server.rst
+++ b/docs/dev/guidelines/server.rst
@@ -418,7 +418,7 @@ https://www.baeldung.com/spring-tests
 
 If you want to write tests for Programming Exercises to test student's submissions check out `this <https://confluence.ase.in.tum.de/display/ArTEMiS/Best+Practices+for+writing+Java+Programming+Exercise+Tests+in+Artemis>`__.
 
-23. Counting database query calls within tests
+24. Counting database query calls within tests
 ==============================================
 
 It's possible to write tests that check how many database calls are performed during a REST call. This is useful to ensure that code changes don't lead to more database calls,
@@ -441,7 +441,7 @@ add any other assertions to the test, as shown below.
         }
     }
 
-24. Avoid using @MockBean
+25. Avoid using @MockBean
 =========================
 
 Do not use the ``@SpyBean`` or ``@MockBean`` annotation unless absolutely necessary, or possibly in an abstract Superclass. If you want to see why in more detail, take a look `here <https://www.baeldung.com/spring-tests>`__.


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
See screenshots.

### Steps for Testing
n/a

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2

### Screenshots
Before:
![grafik](https://user-images.githubusercontent.com/64250573/188167062-e5cd371e-1132-4542-a2b9-839288f4c9d4.png)

After:
![grafik](https://user-images.githubusercontent.com/64250573/188168226-44325052-5330-4bd0-9e97-d380b1f46e63.png)

