### PR TITLE
`Programming exercises`: Fix re-rendering of collapsed instructions component

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
@@ -24,4 +24,5 @@
         <ng-content></ng-content>
     </div>
     <!-- Required for resizing; don't remove empty span -->
+    <div class="rg-left"><span></span></div>
 </div>

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/instructions/code-editor-instructions.component.html
@@ -20,7 +20,8 @@
         </h3>
         <fa-icon *ngIf="!collapsed" class="ms-auto clickable" [icon]="faChevronRight"></fa-icon>
     </div>
-    <ng-content *ngIf="!collapsed"></ng-content>
+    <div style="display: contents" [hidden]="collapsed">
+        <ng-content></ng-content>
+    </div>
     <!-- Required for resizing; don't remove empty span -->
-    <div class="rg-left"><span></span></div>
 </div>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It has been noticed that by collapsing and re-expanding the problem statement card in the online editor view, this re-renders differently and moves all testcases to the bottom of the card. (see recording below)

This has been experienced with Chrome and Edge based browsers.

### Description
<!-- Describe your changes in detail -->
The reason why this happens seems to be related to the `*ngIf` directive, re-rendering the problem statement when expanded. By replacing this with the `[hidden]` attribute, this isn't re-rendered anymore as it remains in the DOM.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Students
- 1 Programming Exercise

1. Log in to Artemis
2. Participate to a programming exercise and open it in the online **code editor**
3. Collapse and expand the problem statement on the right
4. Check that the problem statement rendering is showed properly

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![issue_ps](https://user-images.githubusercontent.com/45761921/189099245-c45f391a-632d-4338-908a-cb038e9a0a76.gif)


