### PR TITLE
`Development`: Fix issue in changelog for e2e tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_ROOT_PASSWORD=
       - MYSQL_DATABASE=Artemis
-    image: mysql:8.0.27
+    image: mysql:8.0.30
     networks:
       - artemis
     ports:

--- a/src/main/docker/cypress/docker-compose.yml
+++ b/src/main/docker/cypress/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
     artemis-cypress:
         # Cypress image with node and chrome browser installed (Cypress installation needs to be done separately because we require additional dependencies)
-        image: cypress/browsers:node16.14.0-chrome99-ff97
+        image: cypress/browsers:node18.6.0-chrome105-ff104
         depends_on:
             - artemis-app
             - artemis-mysql

--- a/src/main/docker/gitlab-jenkins-mysql.yml
+++ b/src/main/docker/gitlab-jenkins-mysql.yml
@@ -41,7 +41,7 @@ services:
         environment:
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=Artemis
-        image: mysql:8.0.27
+        image: mysql:8.0.30
         ports:
             - 3306:3306
         volumes:

--- a/src/main/docker/mysql.yml
+++ b/src/main/docker/mysql.yml
@@ -3,7 +3,7 @@ services:
     artemis-mysql:
         # Use this for arm64 processors (and remove the platform: linux/x86_64
         # image: ubuntu/mysql:8.0-21.10_beta
-        image: mysql:8.0.27
+        image: mysql:8.0.30
         platform: linux/x86_64
         # volumes:
         #     - ~/volumes/jhipster/Artemis/mysql/:/var/lib/mysql/

--- a/src/main/kubernetes/artemis/statefulsets/artemis-mysql.yml
+++ b/src/main/kubernetes/artemis/statefulsets/artemis-mysql.yml
@@ -31,7 +31,7 @@ spec:
         envFrom:
         - configMapRef:
             name: artemis-mysql
-        image: mysql:8.0.27
+        image: mysql:8.0.30
         imagePullPolicy: IfNotPresent
         name: artemis-mysql
         ports:

--- a/src/main/resources/config/liquibase/changelog/20210930113000_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20210930113000_changelog.xml
@@ -8,7 +8,7 @@
         </sql>
         <addNotNullConstraint tableName="answer_post" columnName="tutor_approved" columnDataType="BIT(1)"/>
         <addColumn tableName="answer_post">
-            <column name="resolves_post" type="BIT(1)" valueComputed="tutor_approved" defaultValue="0">
+            <column name="resolves_post" type="BIT(1)" valueComputed="tutor_approved" defaultValueBoolean="false">
                 <constraints nullable="false"/>
             </column>
         </addColumn>

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -7,23 +7,23 @@
             "name": "artemis_cypress",
             "license": "MIT",
             "devDependencies": {
-                "@4tw/cypress-drag-drop": "2.1.0",
-                "@types/node": "17.0.24",
+                "@4tw/cypress-drag-drop": "2.2.1",
+                "@types/node": "18.7.16",
                 "cypress": "9.5.4",
                 "cypress-file-upload": "5.0.8",
                 "cypress-wait-until": "1.7.2",
-                "typescript": "4.6.3",
-                "uuid": "8.3.2",
+                "typescript": "4.8.3",
+                "uuid": "9.0.0",
                 "wait-on": "6.0.1"
             }
         },
         "node_modules/@4tw/cypress-drag-drop": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.1.0.tgz",
-            "integrity": "sha512-HbPBcx2KBdxL3hhyTlZYsF7XSkHkEKAcmDGfvzXp0sBs2sA/NkHE9CMqHz52liLnnVgKEkVkzcoVnyatCc9J5w==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.2.1.tgz",
+            "integrity": "sha512-+ioJSnEwx70IiMyb4pLEjOS5u6AMWRIVCV20toCY7lb0YcvA0ipbjQBa9DdxEI7Zg2E2jtcIj7Rx0e3WNUbk/w==",
             "dev": true,
             "peerDependencies": {
-                "cypress": "^2.1.0 || ^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
+                "cypress": "^2.1.0 || ^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
             }
         },
         "node_modules/@cypress/request": {
@@ -53,6 +53,15 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/@cypress/request/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@cypress/xvfb": {
@@ -114,9 +123,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "17.0.24",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
-            "integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g==",
+            "version": "18.7.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
+            "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
             "dev": true
         },
         "node_modules/@types/sinonjs__fake-timers": {
@@ -1728,9 +1737,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+            "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -1757,8 +1766,9 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
             "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
@@ -1865,9 +1875,9 @@
     },
     "dependencies": {
         "@4tw/cypress-drag-drop": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.1.0.tgz",
-            "integrity": "sha512-HbPBcx2KBdxL3hhyTlZYsF7XSkHkEKAcmDGfvzXp0sBs2sA/NkHE9CMqHz52liLnnVgKEkVkzcoVnyatCc9J5w==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.2.1.tgz",
+            "integrity": "sha512-+ioJSnEwx70IiMyb4pLEjOS5u6AMWRIVCV20toCY7lb0YcvA0ipbjQBa9DdxEI7Zg2E2jtcIj7Rx0e3WNUbk/w==",
             "dev": true,
             "requires": {}
         },
@@ -1895,6 +1905,14 @@
                 "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^8.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true
+                }
             }
         },
         "@cypress/xvfb": {
@@ -1958,9 +1976,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "17.0.24",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.24.tgz",
-            "integrity": "sha512-aveCYRQbgTH9Pssp1voEP7HiuWlD2jW2BO56w+bVrJn04i61yh6mRfoKO6hEYQD9vF+W8Chkwc6j1M36uPkx4g==",
+            "version": "18.7.16",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.16.tgz",
+            "integrity": "sha512-EQHhixfu+mkqHMZl1R2Ovuvn47PUw18azMJOTwSZr9/fhzHNGXAJ0ma0dayRVchprpCj0Kc1K1xKoWaATWF1qg==",
             "dev": true
         },
         "@types/sinonjs__fake-timers": {
@@ -3130,9 +3148,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-            "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+            "version": "4.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+            "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
             "dev": true
         },
         "universalify": {
@@ -3146,8 +3164,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "8.3.2",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+            "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
             "dev": true
         },
         "verror": {

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -7,7 +7,7 @@
             "name": "artemis_cypress",
             "license": "MIT",
             "devDependencies": {
-                "@4tw/cypress-drag-drop": "2.2.1",
+                "@4tw/cypress-drag-drop": "2.1.0",
                 "@types/node": "18.7.16",
                 "cypress": "9.5.4",
                 "cypress-file-upload": "5.0.8",
@@ -18,12 +18,12 @@
             }
         },
         "node_modules/@4tw/cypress-drag-drop": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.2.1.tgz",
-            "integrity": "sha512-+ioJSnEwx70IiMyb4pLEjOS5u6AMWRIVCV20toCY7lb0YcvA0ipbjQBa9DdxEI7Zg2E2jtcIj7Rx0e3WNUbk/w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.1.0.tgz",
+            "integrity": "sha512-HbPBcx2KBdxL3hhyTlZYsF7XSkHkEKAcmDGfvzXp0sBs2sA/NkHE9CMqHz52liLnnVgKEkVkzcoVnyatCc9J5w==",
             "dev": true,
             "peerDependencies": {
-                "cypress": "^2.1.0 || ^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+                "cypress": "^2.1.0 || ^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
             }
         },
         "node_modules/@cypress/request": {
@@ -1875,9 +1875,9 @@
     },
     "dependencies": {
         "@4tw/cypress-drag-drop": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.2.1.tgz",
-            "integrity": "sha512-+ioJSnEwx70IiMyb4pLEjOS5u6AMWRIVCV20toCY7lb0YcvA0ipbjQBa9DdxEI7Zg2E2jtcIj7Rx0e3WNUbk/w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@4tw/cypress-drag-drop/-/cypress-drag-drop-2.1.0.tgz",
+            "integrity": "sha512-HbPBcx2KBdxL3hhyTlZYsF7XSkHkEKAcmDGfvzXp0sBs2sA/NkHE9CMqHz52liLnnVgKEkVkzcoVnyatCc9J5w==",
             "dev": true,
             "requires": {}
         },

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -7,13 +7,13 @@
         "node_modules"
     ],
     "devDependencies": {
-        "@4tw/cypress-drag-drop": "2.1.0",
-        "@types/node": "17.0.24",
+        "@4tw/cypress-drag-drop": "2.2.1",
+        "@types/node": "18.7.16",
         "cypress": "9.5.4",
         "cypress-file-upload": "5.0.8",
         "cypress-wait-until": "1.7.2",
-        "typescript": "4.6.3",
-        "uuid": "8.3.2",
+        "typescript": "4.8.3",
+        "uuid": "9.0.0",
         "wait-on": "6.0.1"
     },
     "scripts": {

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -7,7 +7,7 @@
         "node_modules"
     ],
     "devDependencies": {
-        "@4tw/cypress-drag-drop": "2.2.1",
+        "@4tw/cypress-drag-drop": "2.1.0",
         "@types/node": "18.7.16",
         "cypress": "9.5.4",
         "cypress-file-upload": "5.0.8",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

The e2e tests are currently failing with an old changelog that cannot be performed:


```
build	11-Sep-2022 09:07:20	[36martemis-app_1      |[0m Caused by: liquibase.exception.MigrationFailedException: Migration failed for changeset config/liquibase/changelog/20210930113000_changelog.xml::20210930113000::schlesinger:
build	11-Sep-2022 09:07:20	[36martemis-app_1      |[0m    Reason: liquibase.exception.DatabaseException: Invalid default value for 'resolves_post' [Failed SQL: (1067) ALTER TABLE Artemis.answer_post ALTER resolves_post SET DEFAULT '0']
```

Probably some validation was SQL or Liquibase was improved and therefore the changelog fails. This PR fixes the issue.

### Review Progress
not needed, we just need to check if the e2e tests succeed again