### PR TITLE
`Programming exercises`: Fix result creation for exercises using different default branches

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -167,10 +167,10 @@ public class ProgrammingExerciseGradingService {
      * @throws IllegalArgumentException Thrown if the result does not belong to the default branch of the exercise.
      */
     private void checkCorrectBranchElseThrow(final ProgrammingExercise exercise, final AbstractBuildResultNotificationDTO buildResult) throws IllegalArgumentException {
-        final String exerciseDefaultBranch = versionControlService.get().getOrRetrieveBranchOfExercise(exercise);
-
         // If the branch is not present, it might be because the assignment repo did not change because only the test repo was changed
         buildResult.getBranchNameFromAssignmentRepo().ifPresent(branchName -> {
+            final String exerciseDefaultBranch = versionControlService.get().getOrRetrieveBranchOfExercise(exercise);
+
             if (!branchName.equals(exerciseDefaultBranch)) {
                 throw new IllegalArgumentException("Result was produced for a different branch than the default branch");
             }

--- a/src/test/java/de/tum/in/www1/artemis/GitlabServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/GitlabServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -28,8 +29,12 @@ import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUrl;
 import de.tum.in.www1.artemis.exception.VersionControlException;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 
 class GitlabServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
+
+    @Autowired
+    private ProgrammingExerciseRepository programmingExerciseRepository;
 
     @Value("${artemis.version-control.url}")
     private URL gitlabServerUrl;
@@ -96,7 +101,11 @@ class GitlabServiceTest extends AbstractSpringIntegrationJenkinsGitlabTest {
     @Test
     void testGetOrRetrieveDefaultBranch() throws GitLabApiException {
         Course course = database.addCourseWithOneProgrammingExercise();
+
         ProgrammingExercise programmingExercise = (ProgrammingExercise) course.getExercises().stream().findAny().get();
+        programmingExercise.setBranch(null);
+        programmingExercise = programmingExerciseRepository.save(programmingExercise);
+
         database.addTemplateParticipationForProgrammingExercise(programmingExercise);
         database.addSolutionParticipationForProgrammingExercise(programmingExercise);
         gitlabRequestMockProvider.mockGetDefaultBranch(defaultBranch);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultJenkinsIntegrationTest.java
@@ -1,12 +1,12 @@
 package de.tum.in.www1.artemis.programmingexercise;
 
+import static de.tum.in.www1.artemis.util.ModelFactory.DEFAULT_BRANCH;
 import static org.mockito.Mockito.doReturn;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import org.eclipse.jgit.lib.ObjectId;
 import org.gitlab4j.api.GitLabApiException;
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -104,24 +103,22 @@ class ProgrammingExerciseResultJenkinsIntegrationTest extends AbstractSpringInte
         programmingExerciseResultTestService.shouldGenerateNewManualResultIfManualAssessmentExists(notification);
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
-    @MethodSource("branchNames")
+    @Test
     @WithMockUser(username = "student1", roles = "USER")
-    void shouldIgnoreResultOnOtherBranches(String defaultBranch) {
+    void shouldIgnoreResultOnOtherBranches() {
         var commit = new CommitDTO("abc123", "slug", "other");
         var notification = ModelFactory.generateTestResultDTO(null, Constants.SOLUTION_REPO_NAME, null, ProgrammingLanguage.JAVA, false, List.of(), List.of(), List.of(),
                 List.of(commit), null);
-        programmingExerciseResultTestService.shouldIgnoreResultIfNotOnDefaultBranch(defaultBranch, notification);
+        programmingExerciseResultTestService.shouldIgnoreResultIfNotOnDefaultBranch(notification);
     }
 
-    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
-    @MethodSource("branchNames")
+    @Test
     @WithMockUser(username = "student1", roles = "USER")
-    void shouldCreateResultOnDefaultBranch(String defaultBranch) {
-        var commit = new CommitDTO("abc123", "slug", "main");
+    void shouldCreateResultOnDefaultBranch() {
+        var commit = new CommitDTO("abc123", "slug", DEFAULT_BRANCH);
         var notification = ModelFactory.generateTestResultDTO(null, Constants.SOLUTION_REPO_NAME, null, ProgrammingLanguage.JAVA, false, List.of(), List.of(), List.of(),
                 List.of(commit), null);
-        programmingExerciseResultTestService.shouldCreateResultOnDefaultBranch(defaultBranch, notification);
+        programmingExerciseResultTestService.shouldCreateResultOnCustomDefaultBranch(defaultBranch, notification);
     }
 
     @Test
@@ -131,10 +128,6 @@ class ProgrammingExerciseResultJenkinsIntegrationTest extends AbstractSpringInte
         var commit = new CommitDTO("abc123", "slug", customDefaultBranch);
         var notification = ModelFactory.generateTestResultDTO(null, Constants.SOLUTION_REPO_NAME, null, ProgrammingLanguage.JAVA, false, List.of(), List.of(), List.of(),
                 List.of(commit), null);
-        programmingExerciseResultTestService.shouldCreateResultOnDefaultBranch(customDefaultBranch, notification);
-    }
-
-    private static Stream<String> branchNames() {
-        return Stream.of(null, "main");
+        programmingExerciseResultTestService.shouldCreateResultOnCustomDefaultBranch(customDefaultBranch, notification);
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
@@ -1,7 +1,6 @@
 package de.tum.in.www1.artemis.programmingexercise;
 
 import static de.tum.in.www1.artemis.config.Constants.NEW_RESULT_RESOURCE_PATH;
-import static de.tum.in.www1.artemis.util.ModelFactory.DEFAULT_BRANCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -105,13 +104,7 @@ public class ProgrammingExerciseResultTestService {
     public void setupForProgrammingLanguage(ProgrammingLanguage programmingLanguage) {
         Course course = database.addCourseWithOneProgrammingExercise(false, false, programmingLanguage);
         programmingExercise = programmingExerciseRepository.findAll().get(0);
-        programmingExercise.setBranch(DEFAULT_BRANCH);
-        programmingExercise = programmingExerciseRepository.save(programmingExercise);
-
         programmingExerciseWithStaticCodeAnalysis = database.addProgrammingExerciseToCourse(course, true, false, programmingLanguage);
-        programmingExerciseWithStaticCodeAnalysis.setBranch(DEFAULT_BRANCH);
-        programmingExerciseWithStaticCodeAnalysis = programmingExerciseRepository.save(programmingExerciseWithStaticCodeAnalysis);
-
         staticCodeAnalysisService.createDefaultCategories(programmingExerciseWithStaticCodeAnalysis);
         // This is done to avoid an unproxy issue in the processNewResult method of the ResultService.
         solutionParticipation = solutionProgrammingExerciseRepository.findWithEagerResultsAndSubmissionsByProgrammingExerciseId(programmingExercise.getId()).get();

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
@@ -2,6 +2,7 @@ package de.tum.in.www1.artemis.programmingexercise;
 
 import static de.tum.in.www1.artemis.config.Constants.NEW_RESULT_RESOURCE_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -305,7 +306,7 @@ public class ProgrammingExerciseResultTestService {
     }
 
     // Test
-    public void shouldGenerateTestwiseCoverageFileReports(Object resultNotification) throws GitAPIException, InterruptedException {
+    public void shouldGenerateTestwiseCoverageFileReports(Object resultNotification) throws GitAPIException {
         // set testwise coverage analysis for programming exercise
         programmingExercise.setTestwiseCoverageEnabled(true);
         programmingExerciseRepository.save(programmingExercise);
@@ -330,6 +331,25 @@ public class ProgrammingExerciseResultTestService {
         // the coverage result attribute is transient in the result and should not be saved to the database
         var resultFromDatabase = resultRepository.findByIdElseThrow(result.getId());
         assertThat(resultFromDatabase.getCoverageFileReportsByTestCaseName()).isNull();
+    }
+
+    // Test
+    public void shouldIgnoreResultIfNotOnDefaultBranch(String defaultBranch, Object resultNotification) {
+        programmingExercise.setBranch(defaultBranch);
+        programmingExercise = programmingExerciseRepository.save(programmingExercise);
+        solutionParticipation.setProgrammingExercise(programmingExercise);
+
+        assertThatThrownBy(() -> gradingService.processNewProgrammingExerciseResult(solutionParticipation, resultNotification)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // Test
+    public void shouldCreateResultOnDefaultBranch(String defaultBranch, Object resultNotification) {
+        programmingExercise.setBranch(defaultBranch);
+        programmingExercise = programmingExerciseRepository.save(programmingExercise);
+        solutionParticipation.setProgrammingExercise(programmingExercise);
+
+        final var result = gradingService.processNewProgrammingExerciseResult(solutionParticipation, resultNotification);
+        assertThat(result).isPresent();
     }
 
     private int getNumberOfBuildLogs(Object resultNotification) {

--- a/src/test/java/de/tum/in/www1/artemis/service/BitbucketServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/BitbucketServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -21,8 +22,12 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 import de.tum.in.www1.artemis.domain.Course;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUrl;
+import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
 
 class BitbucketServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
+
+    @Autowired
+    private ProgrammingExerciseRepository programmingExerciseRepository;
 
     @Value("${artemis.version-control.url}")
     private URL bitbucketServerUrl;
@@ -77,7 +82,11 @@ class BitbucketServiceTest extends AbstractSpringIntegrationBambooBitbucketJiraT
     @Test
     void testGetOrRetrieveDefaultBranch() throws IOException {
         Course course = database.addCourseWithOneProgrammingExercise();
+
         ProgrammingExercise programmingExercise = (ProgrammingExercise) course.getExercises().stream().findAny().get();
+        programmingExercise.setBranch(null);
+        programmingExercise = programmingExerciseRepository.save(programmingExercise);
+
         database.addTemplateParticipationForProgrammingExercise(programmingExercise);
         database.addSolutionParticipationForProgrammingExercise(programmingExercise);
         bitbucketRequestMockProvider.mockGetDefaultBranch(defaultBranch, programmingExercise.getProjectKey(), 1);

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -1,6 +1,7 @@
 package de.tum.in.www1.artemis.util;
 
 import static com.google.gson.JsonParser.parseString;
+import static de.tum.in.www1.artemis.util.ModelFactory.DEFAULT_BRANCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -2280,6 +2281,7 @@ public class DatabaseUtilService {
         programmingExercise.setCategories(new HashSet<>(Set.of("cat1", "cat2")));
         programmingExercise.setTestRepositoryUrl("http://nadnasidni.tum/scm/" + programmingExercise.getProjectKey() + "/" + programmingExercise.getProjectKey() + "-tests.git");
         programmingExercise.setShowTestNamesToStudents(false);
+        programmingExercise.setBranch(DEFAULT_BRANCH);
     }
 
     /**

--- a/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/ModelFactory.java
@@ -182,6 +182,7 @@ public class ModelFactory {
         final var repoName = programmingExercise.generateRepositoryName(RepositoryType.TESTS);
         String testRepoUrl = String.format("http://some.test.url/scm/%s/%s.git", programmingExercise.getProjectKey(), repoName);
         programmingExercise.setTestRepositoryUrl(testRepoUrl);
+        programmingExercise.setBranch(DEFAULT_BRANCH);
     }
 
     public static ModelingExercise generateModelingExercise(ZonedDateTime releaseDate, ZonedDateTime dueDate, ZonedDateTime assessmentDueDate, DiagramType diagramType,


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
Programming exercises can have different default branches than the global default set in the configuration. For those programming exercises at the moment no new results are created.

### Description
Checks for the *exercise specific* instead of the *global* default branch when checking if a new result should be accepted.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 Programming exercise created before the default branch was changed in the server configuration

Probably locally, as the test servers do not have old exercises (?)/do not allow config changes:
1. Create a new programming exercise.
2. Change the configuration option `artemis.version-control.default-branch` to something different and restart Artemis.
3. Submit to the programming exercise again.
4. The result should be created.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
2x 100% for new code