### PR TITLE
`Programming exercises`: Improve displaying the git-diff for large files

### DIFF
--- a/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-file.component.ts
+++ b/src/main/webapp/app/exercises/programming/hestia/git-diff-report/git-diff-file.component.ts
@@ -280,7 +280,7 @@ export class GitDiffFileComponent implements OnInit {
             getWidth(session2: any, lastLineNumber: number, config: any) {
                 return Math.max(
                     ...Array.from({ length: copyActualEndLine - copyActualStartLine }, (_, index) => index + 1).map((lineNumber) => {
-                        return this.getText(session, lineNumber + copyActualStartLine - 1).toString().length * config.characterWidth;
+                        return this.getText(session, lineNumber - 1).toString().length * config.characterWidth;
                     }),
                 );
             },
@@ -345,7 +345,7 @@ export class GitDiffFileComponent implements OnInit {
             getWidth(session2: any, lastLineNumber: number, config: any) {
                 return Math.max(
                     ...Array.from({ length: copyActualEndLine - copyActualStartLine }, (_, index) => index + 1).map((lineNumber) => {
-                        return this.getText(session, lineNumber + copyActualStartLine - 1).toString().length * config.characterWidth;
+                        return this.getText(session, lineNumber - 1).toString().length * config.characterWidth;
                     }),
                 );
             },


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
On the live server I noticed that the line counter for the git-diff view was sometimes completely wrong and only displayed a single number like "9" for every line. 

### Description
<!-- Describe your changes in detail -->
This was caused by the gutter being too narrow and therefore only displaying the first number of the line counter (e.g. 9 for 92 and 1 for 120).
This was in turn caused by an unnecessary addition, which I removed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Programming Exercise

1. Log in to Artemis
2. You need to create a long file in the programming exercise template and solution repos with the only changes between the two being in the double- or triple-digit range
3. Check that the git-diff view has the correct line numbers for this file.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
Unchanged
