### PR TITLE
`General`: Fix a bug that caused the first breadcrumb item to be two-lined in Safari

### DIFF
--- a/src/main/webapp/app/shared/layouts/navbar/navbar.scss
+++ b/src/main/webapp/app/shared/layouts/navbar/navbar.scss
@@ -205,13 +205,8 @@ a:not(.btn):hover {
         }
     }
 
-    .breadcrumb-item::before {
+    .breadcrumb-item:not(:first-of-type)::before {
         content: '>';
-    }
-
-    // Hide the first divider
-    .breadcrumb-item:first-of-type::before {
-        content: '';
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

For some reason, the empty pseudo-element before the first breadcrumb item caused Safari (only Safari) to break the first breadcrumb item into two lines.
![Screenshot 2022-09-25 at 20 23 30](https://user-images.githubusercontent.com/23171488/192159483-fd099a37-a5b3-464e-87af-cce5bde88fd8.png)


### Description
<!-- Describe your changes in detail -->

Removing the pseudo-element fixed the issue.
![Screenshot 2022-09-25 at 20 30 23](https://user-images.githubusercontent.com/23171488/192159512-bcd6a880-24e8-4d58-af7c-0907733d03a9.png)


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Navigate to some deeper page to have a few breadcrumb items
3. Verify that the first breadcrumb item is not two-lined in any browser, especially Safari

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
