### PR TITLE
`Assessment`: Fix scheduler for participant scores

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ParticipantScoreRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ParticipantScoreRepository.java
@@ -49,10 +49,15 @@ public interface ParticipantScoreRepository extends JpaRepository<ParticipantSco
     // Do not update last modified date
     void clearLastRatedResultByResultId(@Param("lastResultId") Long lastResultId);
 
+    /**
+     * Find all outdated participant scores where the last result was deleted (and therefore set to null).
+     * Note: There are valid scores where the last *rated* result is null because of practice runs.
+     * @see {@link #clearAllByResultId(Long)}
+     * @return A list of outdated participant scores
+     */
     @Query("""
             SELECT p FROM ParticipantScore p
             WHERE p.lastResult IS NULL
-            OR p.lastRatedResult IS NULL
             """)
     List<ParticipantScore> findAllOutdated();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There was a small oversight in the participant score scheduler. It queried the database for all participant scores where the `last_result` **or** `last_rated_result` was null to find outdated scores.
However, there are cases where a participant score with no `last_rated_result` is still valid, for example in practice runs.
This resulted in the unnecessary processing of old and valid participant scores.

### Description
<!-- Describe your changes in detail -->

I modified the SQL query to only find participant scores where no `last_result` is set.
Those are definitely outdated and need to be scheduled.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
