### PR TITLE
`Development`: Add TU Dresden & HS Heilbronn to list of universities

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The following universities are actively using Artemis or are currently evaluatin
 
 ##### TU Dresden
 
-* Main contact person: [Martin Morgenstern](martin.morgenstern1@tu-dresden.de)
+* Main contact person: [Martin Morgenstern](mailto:martin.morgenstern1@tu-dresden.de)
 
 ##### Hochschule Heilbronn
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,14 @@ The following universities are actively using Artemis or are currently evaluatin
 * https://artemis.cs.hm.edu
 * Main contact person: [Michael Eggers](mailto:michael.eggers@hm.edu)
 
+##### TU Dresden
+
+* Main contact person: [Martin Morgenstern](martin.morgenstern1@tu-dresden.de)
+
+##### Hochschule Heilbronn
+
+* Main contact person: [Jörg Winckler](mailto:joerg.winckler@hs-heilbronn.de)
+
 ##### Interested universities
 
-* TU Dresden
 * HU Berlin


### PR DESCRIPTION
### Motivation and Context
Add TU Dresden & Hochschule Heilbronn to list of universities with corresponding contact persons.

![image](https://user-images.githubusercontent.com/5084100/193469762-a5b2286f-b5f4-4ffd-8e43-5fb812008014.png)

