### PR TITLE
`General`: Remove duplicate GET call in course management pages

### DIFF
--- a/src/main/webapp/app/course/manage/course-management-exercises.component.ts
+++ b/src/main/webapp/app/course/manage/course-management-exercises.component.ts
@@ -10,7 +10,6 @@ import { ExerciseFilter } from 'app/entities/exercise-filter.model';
 })
 export class CourseManagementExercisesComponent implements OnInit {
     course: Course;
-    courseId = 0;
     showSearch = false;
     quizExercisesCount = 0;
     textExercisesCount = 0;
@@ -31,11 +30,14 @@ export class CourseManagementExercisesComponent implements OnInit {
     constructor(private courseService: CourseManagementService, private route: ActivatedRoute) {}
 
     /**
-     * initializes courseId and course
+     * initializes course
      */
     ngOnInit(): void {
-        this.courseId = Number(this.route.parent!.snapshot.paramMap.get('courseId'));
-        this.courseService.find(this.courseId).subscribe((courseResponse) => (this.course = courseResponse.body!));
+        this.route.parent!.data.subscribe(({ course }) => {
+            if (course) {
+                this.course = course;
+            }
+        });
         this.exerciseFilter = new ExerciseFilter('');
     }
 

--- a/src/test/javascript/spec/component/course/course-management-exercises.component.spec.ts
+++ b/src/test/javascript/spec/component/course/course-management-exercises.component.spec.ts
@@ -1,6 +1,5 @@
-import { HttpResponse } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap';
 import { CourseExerciseCardComponent } from 'app/course/manage/course-exercise-card.component';
 import { CourseManagementExercisesComponent } from 'app/course/manage/course-management-exercises.component';
@@ -23,12 +22,12 @@ import { of } from 'rxjs';
 describe('Course Management Exercises Component', () => {
     let comp: CourseManagementExercisesComponent;
     let fixture: ComponentFixture<CourseManagementExercisesComponent>;
-    let courseService: CourseManagementService;
     const course = new Course();
     course.id = 123;
-    const parentRoute = { snapshot: { paramMap: convertToParamMap({ courseId: course.id }) } } as any as ActivatedRoute;
+    const parentRoute = {
+        data: of({ course }),
+    } as any as ActivatedRoute;
     const route = { parent: parentRoute } as any as ActivatedRoute;
-    let findStub: jest.SpyInstance;
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ArtemisTestModule],
@@ -57,19 +56,15 @@ describe('Course Management Exercises Component', () => {
         }).compileComponents();
         fixture = TestBed.createComponent(CourseManagementExercisesComponent);
         comp = fixture.componentInstance;
-        courseService = TestBed.inject(CourseManagementService);
-        findStub = jest.spyOn(courseService, 'find').mockReturnValue(of(new HttpResponse({ body: course })));
     });
 
     afterEach(() => {
         jest.restoreAllMocks();
     });
 
-    it('should find course on on init', () => {
+    it('should get course on onInit', () => {
         comp.ngOnInit();
-        expect(comp.courseId).toBe(course.id);
-        expect(findStub).toHaveBeenCalledWith(course.id);
-        expect(findStub).toHaveBeenCalledOnce();
+        expect(comp.course).toBe(course);
     });
 
     it('should open search bar on button click', () => {

--- a/src/test/javascript/spec/component/course/detail/course-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/course/detail/course-detail.component.spec.ts
@@ -1,5 +1,5 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Data } from '@angular/router';
 import { of } from 'rxjs';
 import { ArtemisTestModule } from '../../../test.module';
 import { CourseDetailComponent } from 'app/course/manage/detail/course-detail.component';
@@ -19,7 +19,6 @@ import { CourseDetailLineChartComponent } from 'app/course/manage/detail/course-
 import { CourseManagementDetailViewDto } from 'app/course/manage/course-management-detail-view-dto.model';
 import { UsersImportButtonComponent } from 'app/shared/import/users-import-button.component';
 import { EventManager } from 'app/core/util/event-manager.service';
-import { MockRouter } from '../../../helpers/mocks/mock-router';
 import { FullscreenComponent } from 'app/shared/fullscreen/fullscreen.component';
 import { Course } from 'app/entities/course.model';
 
@@ -29,7 +28,6 @@ describe('Course Management Detail Component', () => {
     let courseService: CourseManagementService;
     let eventManager: EventManager;
 
-    const route = { params: of({ courseId: 1 }) };
     const course: Course = {
         id: 123,
         title: 'Course Title',
@@ -79,7 +77,21 @@ describe('Course Management Detail Component', () => {
                 MockComponent(CourseDetailLineChartComponent),
                 MockComponent(FullscreenComponent),
             ],
-            providers: [{ provide: ActivatedRoute, useValue: route }, { provide: Router, useClass: MockRouter }, MockProvider(CourseManagementService)],
+            providers: [
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        data: {
+                            subscribe: (fn: (value: Data) => void) =>
+                                fn({
+                                    course,
+                                }),
+                        },
+                        params: of({ courseId: course.id }),
+                    },
+                },
+                MockProvider(CourseManagementService),
+            ],
         }).compileComponents();
         fixture = TestBed.createComponent(CourseDetailComponent);
         component = fixture.componentInstance;
@@ -90,11 +102,6 @@ describe('Course Management Detail Component', () => {
     beforeEach(fakeAsync(() => {
         const statsStub = jest.spyOn(courseService, 'getCourseStatisticsForDetailView');
         statsStub.mockReturnValue(of(new HttpResponse({ body: dtoMock })));
-        const infoStub = jest.spyOn(courseService, 'find');
-        infoStub.mockReturnValue(of(new HttpResponse({ body: course })));
-
-        component.ngOnInit();
-        tick();
     }));
 
     afterEach(() => {


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
Close #5701 

### Description
Removes the call to `courseManagementService.find()` in **course-detail** and **course-management-exercises** since the call is already done by the resolver **course-management-resolve**. Update the tests accordingly.

### Steps for Testing
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Management
3. Navigate to the detail page for a course
4. Verify in the browsers network tab that only one request is sent to "api/courses/{course.id}"
5. Verify that all the information is still visible in the page
6. Navigate to the exercises page for that course and you don't find any issues
7. Verify in the browsers network tab that only one request is sent to "api/courses/{course.id}"
8. Verify that all the information is still visible in the page and you don't find any issues

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
| Class/File | Branch | Line |
|------------|-------:|-----:|
| course-management-exercises.component.ts | 70% | 90% |
| course-detail.component.ts | 79% | 92% |
