### PR TITLE
`Exam mode`: Fix test runs assessment dashboard for test exams

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/ResultRepository.java
@@ -364,6 +364,12 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
     default DueDateStat[] countNumberOfLockedAssessmentsByOtherTutorsForExamExerciseForCorrectionRounds(Exercise exercise, int numberOfCorrectionRounds, User tutor) {
         if (exercise.isExamExercise()) {
             DueDateStat[] correctionRoundsDataStats = new DueDateStat[numberOfCorrectionRounds];
+
+            // numberOfCorrectionRounds can be 0 for test exams
+            if (numberOfCorrectionRounds == 0) {
+                return correctionRoundsDataStats;
+            }
+
             var resultsLockedByOtherTutors = countNumberOfLockedAssessmentsByOtherTutorsForExamExerciseForCorrectionRoundsIgnoreTestRuns(exercise.getId(), tutor.getId());
 
             correctionRoundsDataStats[0] = new DueDateStat(resultsLockedByOtherTutors.stream().filter(result -> result.isRated() == null).count(), 0L);
@@ -402,13 +408,18 @@ public interface ResultRepository extends JpaRepository<Result, Long> {
     default DueDateStat[] convertDatabaseResponseToDueDateStats(List<Long> countList, int numberOfCorrectionRounds) {
         DueDateStat[] correctionRoundsDataStats = new DueDateStat[numberOfCorrectionRounds];
 
+        // numberOfCorrectionRounds can be 0 for test exams
+        if (numberOfCorrectionRounds == 0) {
+            return correctionRoundsDataStats;
+        }
+
         // depending on the number of correctionRounds we create 1 or 2 DueDateStats that contain the sum of all participations:
         // with either 1 or more manual results, OR 2 or more manual results
         correctionRoundsDataStats[0] = new DueDateStat(countList.stream().filter(x -> x >= 1L).count(), 0L);
-        // so far the number of correctionRounds is limited to 2
         if (numberOfCorrectionRounds == 2) {
             correctionRoundsDataStats[1] = new DueDateStat(countList.stream().filter(x -> x >= 2L).count(), 0L);
         }
+        // so far the number of correctionRounds is limited to 2
         return correctionRoundsDataStats;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/AssessmentDashboardService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AssessmentDashboardService.java
@@ -104,7 +104,11 @@ public class AssessmentDashboardService {
             }
 
             exercise.setNumberOfAssessmentsOfCorrectionRounds(numberOfAssessmentsOfCorrectionRounds);
-            exercise.setTotalNumberOfAssessments(numberOfAssessmentsOfCorrectionRounds[0]);
+            // numberOfAssessmentsOfCorrectionRounds can be length 0 for test exams
+            if (numberOfAssessmentsOfCorrectionRounds.length > 0) {
+                exercise.setTotalNumberOfAssessments(numberOfAssessmentsOfCorrectionRounds[0]);
+            }
+
             start = System.nanoTime();
             Set<ExampleSubmission> exampleSubmissions = exampleSubmissionRepository.findAllWithResultByExerciseId(exercise.getId());
 

--- a/src/main/webapp/app/exam/manage/test-runs/test-run-management.component.html
+++ b/src/main/webapp/app/exam/manage/test-runs/test-run-management.component.html
@@ -19,7 +19,7 @@
                     </button>
                 </div>
 
-                <div [ngbTooltip]="'artemisApp.examManagement.testRun.assessTestRunDisabled' | artemisTranslate" [disableTooltip]="testRunCanBeAssessed">
+                <div *ngIf="!exam.testExam" [ngbTooltip]="'artemisApp.examManagement.testRun.assessTestRunDisabled' | artemisTranslate" [disableTooltip]="testRunCanBeAssessed">
                     <a
                         class="btn btn-primary btn-sm me-1 mb-1"
                         style="height: 40px; display: inline-flex; align-items: center"

--- a/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ExamIntegrationTest.java
@@ -1626,14 +1626,20 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         verify(programmingExerciseScheduleService, times(1)).unlockAllStudentRepositories(programmingExercise2);
     }
 
-    @Test
+    @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
     @WithMockUser(username = "tutor1", roles = "TA")
-    void testGetExamForExamAssessmentDashboard() throws Exception {
+    @ValueSource(ints = { 0, 1, 2 })
+    void testGetExamForExamAssessmentDashboard(int numberOfCorrectionRounds) throws Exception {
         User user = userRepo.findOneByLogin("student1").get();
         // we need an exam from the past, otherwise the tutor won't have access
         Course course = database.createCourseWithExamAndExerciseGroupAndExercises(user, now().minusHours(3), now().minusHours(2), now().minusHours(1));
-        Exam receivedExam = request.get("/api/courses/" + course.getId() + "/exams/" + course.getExams().iterator().next().getId() + "/exam-for-assessment-dashboard",
-                HttpStatus.OK, Exam.class);
+        Exam exam = course.getExams().iterator().next();
+
+        // Ensure the API endpoint works for all number of correctionRounds
+        exam.setNumberOfCorrectionRoundsInExam(numberOfCorrectionRounds);
+        examRepository.save(exam);
+
+        Exam receivedExam = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/exam-for-assessment-dashboard", HttpStatus.OK, Exam.class);
 
         // Test that the received exam has two text exercises
         assertThat(receivedExam.getExerciseGroups().get(0).getExercises()).as("Two exercises are returned").hasSize(2);
@@ -2409,7 +2415,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
     }
 
     @ParameterizedTest(name = "{displayName} [{index}] {argumentsWithNames}")
-    @ValueSource(ints = { 1, 2 })
+    @ValueSource(ints = { 0, 1, 2 })
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void testGetStatsForExamAssessmentDashboard(int numberOfCorrectionRounds) throws Exception {
         doNothing().when(gitService).combineAllCommitsOfRepositoryIntoOne(any());
@@ -2429,11 +2435,21 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
         var stats = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/stats-for-exam-assessment-dashboard", HttpStatus.OK, StatsForDashboardDTO.class);
         assertThat(stats.getNumberOfSubmissions()).isInstanceOf(DueDateStat.class);
         assertThat(stats.getTutorLeaderboardEntries()).isInstanceOf(List.class);
-        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()).isInstanceOf(DueDateStat[].class);
+        if (numberOfCorrectionRounds != 0) {
+            assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()).isInstanceOf(DueDateStat[].class);
+            assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isZero();
+        }
+        else {
+            assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()).isNull();
+        }
         assertThat(stats.getNumberOfAssessmentLocks()).isZero();
         assertThat(stats.getNumberOfSubmissions().inTime()).isZero();
-        assertThat(stats.getNumberOfAssessmentsOfCorrectionRounds()[0].inTime()).isZero();
         assertThat(stats.getTotalNumberOfAssessmentLocks()).isZero();
+
+        if (numberOfCorrectionRounds == 0) {
+            // We do not need any more assertions, as numberOfCorrectionRounds is only 0 for test exams (no manual assessment)
+            return;
+        }
 
         var lockedSubmissions = request.get("/api/courses/" + course.getId() + "/exams/" + exam.getId() + "/lockedSubmissions", HttpStatus.OK, List.class);
         assertThat(lockedSubmissions).isEmpty();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I documented the TypeScript code using JSDoc style.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The method `convertDatabaseResponseToDueDateStats` expected `numberOfCorrectionRounds` to always be 1 or 2, but this is not the case for _test exams_ where the correction rounds are set to 0.
Fixes issue no. 2 found during [exam mode testing](https://confluence.ase.in.tum.de/pages/viewpage.action?pageId=138610767).

### Description
<!-- Describe your changes in detail -->

Bug was fixed by removing the assessment button for _test exams_ also from the test run dashboard (already hidden on the exam management page).

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 _Test Exam_ with different exercises

1. Log in to Artemis
2. Navigate to the Exam, then Test Runs
3. Create and participate in the test run
4. Ensure no errors occur
5. Make sure the "Assess Your Test Runs" button is _not_ shown
7. Repeat the steps with a _Real Test_, but instead of step 5 ensure assessment still works unaffected

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
Adapted server tests to also check with assessment rounds set to 0.