### PR TITLE
`General`: Improve email validation when communication with external user management systems

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/jira/JiraAuthenticationProvider.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/jira/JiraAuthenticationProvider.java
@@ -8,7 +8,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -347,7 +346,7 @@ public class JiraAuthenticationProvider extends ArtemisAuthenticationProviderImp
             }
 
             for (JiraUserDTO jiraUserDTO : results) {
-                if (Objects.equals(jiraUserDTO.getEmailAddress(), email)) {
+                if (email.equalsIgnoreCase(jiraUserDTO.getEmailAddress())) {
                     return Optional.of(jiraUserDTO.getName());
                 }
             }

--- a/src/test/java/de/tum/in/www1/artemis/LtiIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/LtiIntegrationTest.java
@@ -138,7 +138,7 @@ class LtiIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTes
         }
 
         if (existingUser) {
-            jiraRequestMockProvider.mockGetUsernameForEmail(email, "existingUser");
+            jiraRequestMockProvider.mockGetUsernameForEmail(email, email, "existingUser");
         }
         else {
             jiraRequestMockProvider.mockGetUsernameForEmailEmptyResponse(email);

--- a/src/test/java/de/tum/in/www1/artemis/authentication/AuthenticationIntegrationTestHelper.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/AuthenticationIntegrationTestHelper.java
@@ -4,6 +4,10 @@ import de.tum.in.www1.artemis.web.rest.dto.LtiLaunchRequestDTO;
 
 public class AuthenticationIntegrationTestHelper {
 
+    public static final String LTI_USER_EMAIL = "tester@tum.invalid";
+
+    public static final String LTI_USER_EMAIL_UPPER_CASE = "Tester@Tum.Invalid";
+
     public static LtiLaunchRequestDTO setupDefaultLtiLaunchRequest() {
         LtiLaunchRequestDTO ltiLaunchRequest = new LtiLaunchRequestDTO();
         ltiLaunchRequest.setContext_id("contextId123");
@@ -14,7 +18,7 @@ public class AuthenticationIntegrationTestHelper {
         ltiLaunchRequest.setLaunch_presentation_locale("EN");
         ltiLaunchRequest.setLaunch_presentation_return_url("some.return.url.com");
         ltiLaunchRequest.setLis_outcome_service_url("some.outcome.service.url.com");
-        ltiLaunchRequest.setLis_person_contact_email_primary("tester@tum.invalid");
+        ltiLaunchRequest.setLis_person_contact_email_primary(LTI_USER_EMAIL);
         ltiLaunchRequest.setLis_person_sourcedid("somePersonSourceId");
         ltiLaunchRequest.setLis_result_sourcedid("someResultSourceId");
         ltiLaunchRequest.setLti_message_type("someMessageType");

--- a/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/authentication/JiraAuthenticationIntegrationTest.java
@@ -1,5 +1,7 @@
 package de.tum.in.www1.artemis.authentication;
 
+import static de.tum.in.www1.artemis.authentication.AuthenticationIntegrationTestHelper.LTI_USER_EMAIL;
+import static de.tum.in.www1.artemis.authentication.AuthenticationIntegrationTestHelper.LTI_USER_EMAIL_UPPER_CASE;
 import static de.tum.in.www1.artemis.util.ModelFactory.USER_PASSWORD;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,6 +14,8 @@ import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -108,14 +112,16 @@ class JiraAuthenticationIntegrationTest extends AbstractSpringIntegrationBambooB
                 .isThrownBy(() -> applicationContext.getBean(ArtemisInternalAuthenticationProvider.class));
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = { LTI_USER_EMAIL, LTI_USER_EMAIL_UPPER_CASE })
     @WithAnonymousUser
-    void launchLtiRequest_authViaEmail_success() throws Exception {
+    void launchLtiRequest_authViaEmail_success(String launchEmail) throws Exception {
         final var username = "mrrobot";
-        final var email = ltiLaunchRequest.getLis_person_contact_email_primary();
         final var firstName = "Elliot";
         final var groups = Set.of("allsec", "security", ADMIN_GROUP_NAME, course.getInstructorGroupName(), course.getTeachingAssistantGroupName());
-        jiraRequestMockProvider.mockGetUsernameForEmail(email, username);
+        final var email = LTI_USER_EMAIL;
+        ltiLaunchRequest.setLis_person_contact_email_primary(launchEmail);
+        jiraRequestMockProvider.mockGetUsernameForEmail(launchEmail, email, username);
         jiraRequestMockProvider.mockGetOrCreateUserLti(JIRA_USER, JIRA_PASSWORD, username, email, firstName, groups);
         jiraRequestMockProvider.mockAddUserToGroupForMultipleGroups(Set.of(course.getStudentGroupName()));
         jiraRequestMockProvider.mockGetOrCreateUserLti(username, "", username, email, firstName, groups);

--- a/src/test/java/de/tum/in/www1/artemis/connector/JiraRequestMockProvider.java
+++ b/src/test/java/de/tum/in/www1/artemis/connector/JiraRequestMockProvider.java
@@ -86,10 +86,10 @@ public class JiraRequestMockProvider {
         mockServer.expect(ExpectedCount.twice(), requestTo(MatchesPattern.matchesPattern(uriPattern))).andExpect(method(HttpMethod.DELETE)).andRespond(withStatus(status));
     }
 
-    public void mockGetUsernameForEmail(String email, String usernameToBeReturned) throws IOException {
+    public void mockGetUsernameForEmail(String email, String emailToReturn, String usernameToBeReturned) throws IOException {
         final var uriPattern = Pattern.compile(JIRA_URL + "/rest/api/2/user/search\\?username=" + URLEncoder.encode(email, StandardCharsets.UTF_8));
         JiraUserDTO userDTO = new JiraUserDTO(usernameToBeReturned);
-        userDTO.setEmailAddress(email);
+        userDTO.setEmailAddress(emailToReturn);
         final var response = List.of(userDTO);
         mockServer.expect(requestTo(MatchesPattern.matchesPattern(uriPattern))).andExpect(method(HttpMethod.GET))
                 .andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(mapper.writeValueAsString(response)));


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I added `@PreAuthorize` and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
Artemis is treating emails as case-sensitive when looking for existing emails in Jira in the context of an LTI launch. Although emails can be case-sensitive, they are pretty much always treated as case-insensitive [(see here)](https://stackoverflow.com/questions/9807909/are-email-addresses-case-sensitive).

### Description
Use `str.equalsIgnoreCase()` when matching emails in Jira to the launch request email.

### Steps for Testing
Prerequisites:
- 1 Instructor
- 1 student
- access to https://moodle.ase.in.tum.de/

1. Log in to Artemis as the instructor
2. Create an online course with an exercise
3. Configure an LTI launch for the exercise in moodle
4. Create a user in moodle with the same email as an existing user in Artemis but with a different case
5. Launch the exercise as the user
6. Verify that you were matched with the existing user in Artemis

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
| Class/File | Branch | Line |
|------------|-------:|-----:|
| JiraAuthenticationProvider.java | 64% | 38% |
