### PR TITLE
`Assessment`: Fix an issue if no more programming submissions are assessable

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/ProgrammingSubmissionResource.java
@@ -439,9 +439,7 @@ public class ProgrammingSubmissionResource {
 
         final User user = userRepository.getUserWithGroupsAndAuthorities();
 
-        if (!authCheckService.isAtLeastTeachingAssistantForExercise(programmingExercise, user)) {
-            throw new AccessForbiddenException();
-        }
+        authCheckService.checkHasAtLeastRoleForExerciseElseThrow(Role.TEACHING_ASSISTANT, programmingExercise, user);
 
         // Check if the limit of simultaneously locked submissions has been reached
         programmingSubmissionService.checkSubmissionLockLimit(programmingExercise.getCourseViaExerciseGroupOrCourseMember().getId());
@@ -460,12 +458,11 @@ public class ProgrammingSubmissionResource {
             programmingSubmissionService.checkIfExerciseDueDateIsReached(programmingExercise);
         }
 
-        if (lockSubmission) {
-            Result lockedResult = programmingSubmissionService.lockSubmission(submission, correctionRound);
-            submission = (ProgrammingSubmission) lockedResult.getSubmission();
-        }
-
         if (Objects.nonNull(submission)) {
+            if (lockSubmission) {
+                Result lockedResult = programmingSubmissionService.lockSubmission(submission, correctionRound);
+                submission = (ProgrammingSubmission) lockedResult.getSubmission();
+            }
             submission.getParticipation().setExercise(programmingExercise);
             programmingSubmissionService.hideDetails(submission, user);
             // remove automatic results before sending to client

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
@@ -768,7 +768,7 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     @WithMockUser(username = "tutor1", roles = "TA")
-    void getProgrammingSubmissionWithoutAssessmentNothingAvailable(boolean lock) throws Exception {
+    void test_getProgrammingSubmissionWithoutAssessmentNothingAvailable(boolean lock) throws Exception {
         exercise.setDueDate(ZonedDateTime.now().minusDays(2));
         exercise.setBuildAndTestStudentSubmissionsAfterDueDate(ZonedDateTime.now().minusDays(1));
         programmingExerciseRepository.saveAndFlush(exercise);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
@@ -768,7 +768,7 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     @WithMockUser(username = "tutor1", roles = "TA")
-    void test_getProgrammingSubmissionWithoutAssessmentNothingAvailable(boolean lock) throws Exception {
+    void testGetProgrammingSubmissionWithoutAssessmentNothingAvailable(boolean lock) throws Exception {
         exercise.setDueDate(ZonedDateTime.now().minusDays(2));
         exercise.setBuildAndTestStudentSubmissionsAfterDueDate(ZonedDateTime.now().minusDays(1));
         programmingExerciseRepository.saveAndFlush(exercise);

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionIntegrationTest.java
@@ -765,9 +765,10 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     @WithMockUser(username = "tutor1", roles = "TA")
-    void getProgrammingSubmissionWithoutAssessmentAlreadyAssessedNoFound() throws Exception {
+    void getProgrammingSubmissionWithoutAssessmentNothingAvailable(boolean lock) throws Exception {
         exercise.setDueDate(ZonedDateTime.now().minusDays(2));
         exercise.setBuildAndTestStudentSubmissionsAfterDueDate(ZonedDateTime.now().minusDays(1));
         programmingExerciseRepository.saveAndFlush(exercise);
@@ -776,7 +777,7 @@ class ProgrammingSubmissionIntegrationTest extends AbstractSpringIntegrationBamb
         final var tutor = database.getUserByLogin("tutor1");
         database.addResultToSubmission(submission, AssessmentType.SEMI_AUTOMATIC, tutor);
 
-        String url = "/api/exercises/" + exercise.getId() + "/programming-submission-without-assessment";
+        String url = "/api/exercises/" + exercise.getId() + "/programming-submission-without-assessment?lock=" + lock;
 
         var storedSubmission = request.get(url, HttpStatus.OK, ProgrammingSubmission.class);
         assertThat(storedSubmission).isNull();


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).

### Motivation and Context
When manually assessing programming exercises a bug happened after the last available submission was assessed: Pressing the "Assess next Submission" button leads to a NullPointerException in the Server:

![grafik](https://user-images.githubusercontent.com/26540346/197333605-7204b3dc-cf17-4d61-856a-e545ab4f7860.png)


### Description
#5670 changed the behavior of this endpoint. Instead of returning early with a 404 status code, the endpoint now just returns an empty body (null).

This led to an exception when no more submission was available for assessment since the server tried to set a lock to non-existing submission.

### Steps for Testing
Prerequisites:
- 1 Tutor
- 1 Student
- 1 Programming Exercise with manual correction enabled

1. Submit a solution to the exercise as a student
2. Assess the submission as a tutor and submit the assessment
3. Press the green "Assess next submission"-button
4. Check that just the message "We couldn't find any unassessed programming submissions, please go back." is shown, no Internal Server Error

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
<!--
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->
