### PR TITLE
`Programming exercises`: Fix an issue with mixed branch configurations

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -19,6 +19,8 @@ import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
+import com.google.common.base.Strings;
+
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.CategoryState;
@@ -127,7 +129,7 @@ public class ProgrammingExerciseGradingService {
         Result newResult = null;
         try {
             var buildResult = continuousIntegrationService.get().convertBuildResult(requestBody);
-            checkCorrectBranchElseThrow(participation.getProgrammingExercise(), buildResult);
+            checkCorrectBranchElseThrow(participation, buildResult);
 
             newResult = continuousIntegrationService.get().createResultFromBuildResult(buildResult, participation);
 
@@ -166,18 +168,30 @@ public class ProgrammingExerciseGradingService {
     }
 
     /**
-     * Checks that the build result belongs to the default branch of the exercise.
+     * Checks that the build result belongs to the default branch of the student participation (in case it has a branch).
+     * For all other cases (template/solution or student participation without a branch) it falls back to check the default branch of the programming exercise.
      *
-     * @param exercise The exercise in which the submission was made.
+     * @param participation The programming exercise participation in which the submission was made (including a reference to the programming exercise)
      * @param buildResult The build result received from the CI system.
      * @throws IllegalArgumentException Thrown if the result does not belong to the default branch of the exercise.
      */
-    private void checkCorrectBranchElseThrow(final ProgrammingExercise exercise, final AbstractBuildResultNotificationDTO buildResult) throws IllegalArgumentException {
+    private void checkCorrectBranchElseThrow(final ProgrammingExerciseParticipation participation, final AbstractBuildResultNotificationDTO buildResult)
+            throws IllegalArgumentException {
         // If the branch is not present, it might be because the assignment repo did not change because only the test repo was changed
         buildResult.getBranchNameFromAssignmentRepo().ifPresent(branchName -> {
-            final String exerciseDefaultBranch = versionControlService.get().getOrRetrieveBranchOfExercise(exercise);
+            if (participation instanceof ProgrammingExerciseStudentParticipation programmingExerciseStudentParticipation) {
+                final String participationDefaultBranch = programmingExerciseStudentParticipation.getBranch();
+                // only check it, in case the branch is defined in the student participation
+                if (!Strings.isNullOrEmpty(participationDefaultBranch)) {
+                    if (!Objects.equals(branchName, participationDefaultBranch)) {
+                        throw new IllegalArgumentException("Result was produced for a different branch than the default branch");
+                    }
+                    return;
+                }
+            }
+            final String exerciseDefaultBranch = versionControlService.get().getOrRetrieveBranchOfExercise(participation.getProgrammingExercise());
 
-            if (!branchName.equals(exerciseDefaultBranch)) {
+            if (!Objects.equals(branchName, exerciseDefaultBranch)) {
                 throw new IllegalArgumentException("Result was produced for a different branch than the default branch");
             }
         });

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -172,26 +172,22 @@ public class ProgrammingExerciseGradingService {
      * For all other cases (template/solution or student participation without a branch) it falls back to check the default branch of the programming exercise.
      *
      * @param participation The programming exercise participation in which the submission was made (including a reference to the programming exercise)
-     * @param buildResult The build result received from the CI system.
+     * @param buildResult   The build result received from the CI system.
      * @throws IllegalArgumentException Thrown if the result does not belong to the default branch of the exercise.
      */
     private void checkCorrectBranchElseThrow(final ProgrammingExerciseParticipation participation, final AbstractBuildResultNotificationDTO buildResult)
             throws IllegalArgumentException {
         // If the branch is not present, it might be because the assignment repo did not change because only the test repo was changed
         buildResult.getBranchNameFromAssignmentRepo().ifPresent(branchName -> {
-            if (participation instanceof ProgrammingExerciseStudentParticipation programmingExerciseStudentParticipation) {
-                final String participationDefaultBranch = programmingExerciseStudentParticipation.getBranch();
-                // only check it, in case the branch is defined in the student participation
-                if (!Strings.isNullOrEmpty(participationDefaultBranch)) {
-                    if (!Objects.equals(branchName, participationDefaultBranch)) {
-                        throw new IllegalArgumentException("Result was produced for a different branch than the default branch");
-                    }
-                    return;
-                }
+            String participationDefaultBranch = null;
+            if (participation instanceof ProgrammingExerciseStudentParticipation studentParticipation) {
+                participationDefaultBranch = studentParticipation.getBranch();
             }
-            final String exerciseDefaultBranch = versionControlService.get().getOrRetrieveBranchOfExercise(participation.getProgrammingExercise());
+            if (Strings.isNullOrEmpty(participationDefaultBranch)) {
+                participationDefaultBranch = versionControlService.get().getOrRetrieveBranchOfExercise(participation.getProgrammingExercise());
+            }
 
-            if (!Objects.equals(branchName, exerciseDefaultBranch)) {
+            if (!Objects.equals(branchName, participationDefaultBranch)) {
                 throw new IllegalArgumentException("Result was produced for a different branch than the default branch");
             }
         });

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultJenkinsIntegrationTest.java
@@ -114,6 +114,22 @@ class ProgrammingExerciseResultJenkinsIntegrationTest extends AbstractSpringInte
 
     @Test
     @WithMockUser(username = "student1", roles = "USER")
+    void shouldCreateResultOnParticipationDefaultBranch() {
+        var commit = new CommitDTO("abc123", "slug", "branch");
+        var notification = ModelFactory.generateTestResultDTO(null, "student1", null, ProgrammingLanguage.JAVA, false, List.of(), List.of(), List.of(), List.of(commit), null);
+        programmingExerciseResultTestService.shouldCreateResultOnParticipationDefaultBranch(notification);
+    }
+
+    @Test
+    @WithMockUser(username = "student1", roles = "USER")
+    void shouldIgnoreResultNotOnParticipationDefaultBranch() {
+        var commit = new CommitDTO("abc123", "slug", "other");
+        var notification = ModelFactory.generateTestResultDTO(null, "student1", null, ProgrammingLanguage.JAVA, false, List.of(), List.of(), List.of(), List.of(commit), null);
+        programmingExerciseResultTestService.shouldIgnoreResultIfNotOnParticipationBranch(notification);
+    }
+
+    @Test
+    @WithMockUser(username = "student1", roles = "USER")
     void shouldCreateResultOnDefaultBranch() {
         var commit = new CommitDTO("abc123", "slug", DEFAULT_BRANCH);
         var notification = ModelFactory.generateTestResultDTO(null, Constants.SOLUTION_REPO_NAME, null, ProgrammingLanguage.JAVA, false, List.of(), List.of(), List.of(),

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
@@ -383,8 +383,8 @@ public class ProgrammingExerciseResultTestService {
         programmingExerciseStudentParticipation.setBranch("default");
         programmingExerciseStudentParticipation.setProgrammingExercise(programmingExercise);
 
-        assertThatThrownBy(() -> gradingService.processNewProgrammingExerciseResult(programmingExerciseStudentParticipation, resultNotification)).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("different branch");
+        assertThatThrownBy(() -> gradingService.processNewProgrammingExerciseResult(programmingExerciseStudentParticipation, resultNotification))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("different branch");
     }
 
     // Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
@@ -364,7 +364,27 @@ public class ProgrammingExerciseResultTestService {
     public void shouldIgnoreResultIfNotOnDefaultBranch(Object resultNotification) {
         solutionParticipation.setProgrammingExercise(programmingExercise);
 
-        assertThatThrownBy(() -> gradingService.processNewProgrammingExerciseResult(solutionParticipation, resultNotification)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> gradingService.processNewProgrammingExerciseResult(solutionParticipation, resultNotification)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("different branch");
+    }
+
+    // Test
+    public void shouldCreateResultOnParticipationDefaultBranch(Object resultNotification) {
+        programmingExerciseStudentParticipation.setProgrammingExercise(programmingExercise);
+        programmingExerciseStudentParticipation.setBranch("branch");
+
+        var result = gradingService.processNewProgrammingExerciseResult(programmingExerciseStudentParticipation, resultNotification);
+
+        assertThat(result).isPresent();
+    }
+
+    // Test
+    public void shouldIgnoreResultIfNotOnParticipationBranch(Object resultNotification) {
+        programmingExerciseStudentParticipation.setBranch("default");
+        programmingExerciseStudentParticipation.setProgrammingExercise(programmingExercise);
+
+        assertThatThrownBy(() -> gradingService.processNewProgrammingExerciseResult(solutionParticipation, resultNotification)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("different branch");
     }
 
     // Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseResultTestService.java
@@ -383,7 +383,7 @@ public class ProgrammingExerciseResultTestService {
         programmingExerciseStudentParticipation.setBranch("default");
         programmingExerciseStudentParticipation.setProgrammingExercise(programmingExercise);
 
-        assertThatThrownBy(() -> gradingService.processNewProgrammingExerciseResult(solutionParticipation, resultNotification)).isInstanceOf(IllegalArgumentException.class)
+        assertThatThrownBy(() -> gradingService.processNewProgrammingExerciseResult(programmingExerciseStudentParticipation, resultNotification)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("different branch");
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [x] I documented the Java code using JavaDoc style.

### Motivation and Context
If an (old) exercise uses a different branch than the default one, the results are not stored at all. The reason is that new participations will use the default branch. However, when Artemis receives the build result, it only checks against the exercise (with the wrong branch) and not against the participation and therefore throws an IllegalArgumentException. 

### Description
This PR changes this behavior and now checks against the branch stored in the studentParticipation. If no branch is present there, the branch of the template repository gets used as a fallback.

### Steps for Testing
A bit tricky to test (you might need admin access): 
1. Create a programming exercise with a different default branch (potentially manipulating the database) as an instructor
2. Start the exercise and participate normally as a student
3. Make sure the result is correctly received, displayed, and stored

### Review Progress


#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2