### PR TITLE
`Programming exercises`: Fix access denied error when accessing result details of the template participation

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/programming-exercise-instruction.component.ts
@@ -234,7 +234,7 @@ export class ProgrammingExerciseInstructionComponent implements OnChanges, OnDes
      * If there is no result, return undefined.
      */
     loadLatestResult(): Observable<Result | undefined> {
-        return this.programmingExerciseParticipationService.getLatestResultWithFeedback(this.participation.id!).pipe(
+        return this.programmingExerciseParticipationService.getLatestResultWithFeedback(this.participation.id!, true).pipe(
             catchError(() => of(undefined)),
             mergeMap((latestResult: Result) => (latestResult && !latestResult.feedbacks ? this.loadAndAttachResultDetails(latestResult) : of(latestResult))),
         );

--- a/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
+++ b/src/test/javascript/spec/component/programming-exercise/programming-exercise-instruction.component.spec.ts
@@ -304,7 +304,8 @@ describe('ProgrammingExerciseInstructionComponent', () => {
 
         expect(comp.markdownExtensions).toHaveLength(2);
         expect(getLatestResultWithFeedbacks).toHaveBeenCalledOnce();
-        expect(getLatestResultWithFeedbacks).toHaveBeenCalledWith(participation.id);
+        // result should have been fetched with the submission as this is required to show details for it
+        expect(getLatestResultWithFeedbacks).toHaveBeenCalledWith(participation.id, true);
         expect(updateMarkdownStub).toHaveBeenCalledOnce();
         expect(comp.isInitial).toBeFalse();
         expect(comp.isLoading).toBeFalse();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).

### Motivation and Context
Closes #5027 

### Description
The result detail pop-up requires the submission to check if the build logs should be fetched
https://github.com/ls1intum/Artemis/blob/7e3291e65d6e970f8ea0128c6dc337b97dc6bc5f/src/main/webapp/app/exercises/shared/result/result-detail.component.ts#L212

However, only the result was fetched from the server without the submission.


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Go to an existing programming exercise details page.
   <details>

    ![Screenshot 2022-10-24 at 20-35-59 Programming Exercises](https://user-images.githubusercontent.com/64250573/197600321-9b42aa80-ec36-4b6d-be4d-1a625357c9c4.png)
   </details>
2. On this page you can see the problem statement for this exercise.
3. Click on one of the failing tasks.
4. Only the message should be shown, no alert that you are not authorized should show up.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
unchanged

### Screenshots
Issue before:
![Screenshot 2022-10-24 at 20-34-02 Programming Exercises](https://user-images.githubusercontent.com/64250573/197599966-9aa381ff-6301-4335-802b-f4da591c7ff5.png)

