### PR TITLE
`Development`: Fix Emojis not showing in documentation

### DIFF
--- a/docs/dev/guidelines/development-process.rst
+++ b/docs/dev/guidelines/development-process.rst
@@ -69,7 +69,7 @@ Reviewer
     * make sure you can easily understand the code.
     * make sure that (extensive) comments are present where deemed necessary.
     * performance is reasonable (e.g. number of database queries or HTTP calls).
-* Submit your comments and status ((thumbs up) Approve or (thumbs down) Request Changes) using GitHub.
+* Submit your comments and status (👍 Approve or 👎 Request Changes) using GitHub.
     * Explain what you did (test, review code) and on which test server in the review comment.
 
 4. Respond to review
@@ -89,7 +89,7 @@ Reviewer
 * Respond to questions raised by the reviewer.
 * Mark conversations as resolved if the change is sufficient.
 
-Iterate steps 3 & 4 until ready for merge (all reviewers approve (thumbs up))
+Iterate steps 3 & 4 until ready for merge (all reviewers approve 👍)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 5. Merge
@@ -102,11 +102,11 @@ Stale Bot
 =========
 
 If the pull request doesn't have any activity for at least 7 days, the stale bot will mark the PR as `stale`.
-The `stale` status can simply be removed by adding a comment or a commit to the PR. 
+The `stale` status can simply be removed by adding a comment or a commit to the PR.
 After the PR is marked as `stale`, the bot waits another 14 days until the PR will be closed (21 days in total).
-Adding activity to the PR will remove the `stale` label again and reset the stale timer. 
+Adding activity to the PR will remove the `stale` label again and reset the stale timer.
 To prevent the bot from adding the `stale` label to the PR in the first place, the `no-stale` label can be used.
-This label should only be utilized if the PR is blocked by another PR or the PR needs help from another developer. 
+This label should only be utilized if the PR is blocked by another PR or the PR needs help from another developer.
 
 A full documentation on this bit can be found here:
 https://github.com/actions/stale


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
I noticed that the documentation did not show emojis anymore: 
![grafik](https://user-images.githubusercontent.com/26540346/198260199-f8aff349-5f6a-4454-a8b8-2216ad642c70.png)


### Description
I directly integrated the emojis into the documentation.

### Steps for Testing

1. Open [the documentation](https://artemis-platform--5781.org.readthedocs.build/en/5781/dev/guidelines/development-process/#review)
2. Check that the emotes are showing

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Screenshots
![grafik](https://user-images.githubusercontent.com/26540346/198260512-7625bad6-1831-42d9-a891-43e1422e6b64.png)

