### PR TITLE
`General`: Fix an issue when reloading the course statistics

### DIFF
--- a/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
+++ b/src/main/webapp/app/overview/course-statistics/course-statistics.component.ts
@@ -417,6 +417,7 @@ export class CourseStatisticsComponent implements OnInit, OnDestroy, AfterViewIn
         absoluteScores[ExerciseType.TEXT] = textExerciseTotalScore;
         absoluteScores[ExerciseType.FILE_UPLOAD] = fileUploadExerciseTotalScore;
         this.overallPointsPerExercise = absoluteScores;
+        this.ngxDoughnutData = [];
         scores.forEach((score, index) => {
             if (score > 0) {
                 this.ngxDoughnutData.push({


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.

### Motivation and Context
Closes #5784

When pressing the reload button on the course statistics, the chart got more and more data added to it:
![grafik](https://user-images.githubusercontent.com/26540346/198821901-029c57e5-b24d-4b5a-a613-d72d5003300f.png)

### Description
We now reset the chart data before recalculating

### Steps for Testing
1. Open a course as a student
2. Click on 'Statistics'.
3. Hit the refresh button (multiple times)
4. Check the the chart entrys are only displayed once.


### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2