### PR TITLE
`Tutorial groups`: Fix an issue in an authentication check

### DIFF
--- a/docs/dev/guidelines/development-process.rst
+++ b/docs/dev/guidelines/development-process.rst
@@ -11,7 +11,7 @@ Naming Conventions for GitHub Pull Requests
 
 1. The first term is a main feature of Artemis and is using code highlighting, e.g.  “``Programming exercises``:”.
 
-    1. Possible feature tags are: ``Programming exercises``, ``Modeling exercises``, ``Text exercises``, ``Quiz exercises``, ``File upload exercises``, ``Lectures``, ``Exam mode``, ``Assessment``, ``Communication``, ``Notifications``. More tags are possible if they make sense.
+    1. Possible feature tags are: ``Programming exercises``, ``Modeling exercises``, ``Text exercises``, ``Quiz exercises``, ``File upload exercises``, ``Lectures``, ``Exam mode``, ``Assessment``, ``Communication``, ``Notifications``, ``Tutorial groups``. More tags are possible if they make sense.
     2. If no feature makes sense, and it is a pure development or test improvement, we use the term “``Development``:”. More tags are also possible if they make sense.
     3. Everything else belongs to the ``General`` category.
 

--- a/src/main/java/de/tum/in/www1/artemis/repository/tutorialgroups/TutorialGroupRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/tutorialgroups/TutorialGroupRepository.java
@@ -65,6 +65,15 @@ public interface TutorialGroupRepository extends JpaRepository<TutorialGroup, Lo
             SELECT tutorialGroup
             FROM TutorialGroup tutorialGroup
             LEFT JOIN FETCH tutorialGroup.teachingAssistant
+            LEFT JOIN FETCH tutorialGroup.course
+            WHERE tutorialGroup.id = :#{#tutorialGroupId}
+            """)
+    Optional<TutorialGroup> findByIdWithTeachingAssistantAndCourse(@Param("tutorialGroupId") long tutorialGroupId);
+
+    @Query("""
+            SELECT tutorialGroup
+            FROM TutorialGroup tutorialGroup
+            LEFT JOIN FETCH tutorialGroup.teachingAssistant
             LEFT JOIN FETCH tutorialGroup.registrations
             WHERE tutorialGroup.title = :#{#title}
             AND tutorialGroup.course.id = :#{#courseId}
@@ -79,6 +88,10 @@ public interface TutorialGroupRepository extends JpaRepository<TutorialGroup, Lo
     @Modifying
     // ok because of delete
     void deleteAllByCourse(Course course);
+
+    default TutorialGroup findByIdWithTeachingAssistantAndCourseElseThrow(long tutorialGroupId) {
+        return this.findByIdWithTeachingAssistantAndCourse(tutorialGroupId).orElseThrow(() -> new EntityNotFoundException("TutorialGroup", tutorialGroupId));
+    }
 
     default TutorialGroup findByIdElseThrow(long tutorialGroupId) {
         return this.findById(tutorialGroupId).orElseThrow(() -> new EntityNotFoundException("TutorialGroup", tutorialGroupId));

--- a/src/main/java/de/tum/in/www1/artemis/service/AuthorizationCheckService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AuthorizationCheckService.java
@@ -15,9 +15,7 @@ import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.lecture.LectureUnit;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
-import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroup;
 import de.tum.in.www1.artemis.repository.UserRepository;
-import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRepository;
 import de.tum.in.www1.artemis.security.Role;
 import de.tum.in.www1.artemis.security.SecurityUtils;
 import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
@@ -30,11 +28,8 @@ public class AuthorizationCheckService {
 
     private final UserRepository userRepository;
 
-    private final TutorialGroupRepository tutorialGroupRepository;
-
-    public AuthorizationCheckService(UserRepository userRepository, TutorialGroupRepository tutorialGroupRepository) {
+    public AuthorizationCheckService(UserRepository userRepository) {
         this.userRepository = userRepository;
-        this.tutorialGroupRepository = tutorialGroupRepository;
     }
 
     /**
@@ -486,43 +481,6 @@ public class AuthorizationCheckService {
         }
         Course course = lectureUnit.getLecture().getCourse();
         return isAtLeastTeachingAssistantInCourse(course, user) || (isStudentInCourse(course, user) && lectureUnit.isVisibleToStudents());
-    }
-
-    /**
-     * Determines if a user is allowed to see private information about a tutorial group such as the list of registered students
-     *
-     * @param tutorialGroup the tutorial group for which to check permission
-     * @param user          the user for which to check permission
-     * @return true if the user is allowed, false otherwise
-     */
-    public boolean isAllowedToSeePrivateTutorialGroupInformation(@NotNull TutorialGroup tutorialGroup, @Nullable User user) {
-        if (user == null || user.getGroups() == null) {
-            user = userRepository.getUserWithGroupsAndAuthorities();
-        }
-        if (isAdmin(user)) {
-            return true;
-        }
-        // load from db to make sure that course and teachingAssistant is loaded
-        var tutorialGroupFromDatabase = tutorialGroupRepository.findByIdWithTeachingAssistantAndCourseElseThrow(tutorialGroup.getId());
-
-        Course course = tutorialGroupFromDatabase.getCourse();
-        if (isAtLeastInstructorInCourse(course, user)) {
-            return true;
-        }
-        return (tutorialGroupFromDatabase.getTeachingAssistant() != null && tutorialGroupFromDatabase.getTeachingAssistant().equals(user));
-    }
-
-    /**
-     * Checks if a user is allowed to change the registrations of a tutorial group
-     *
-     * @param tutorialGroup the tutorial group for which to check permission
-     * @param user          the user for which to check permission
-     */
-    public void isAllowedToChangeRegistrationsOfTutorialGroup(@NotNull TutorialGroup tutorialGroup, @Nullable User user) {
-        // ToDo: Clarify if this is the correct permission check
-        if (!isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
-            throw new AccessForbiddenException("The user is not allowed to change the registrations of tutorial group: " + tutorialGroup.getId());
-        }
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -229,7 +229,7 @@ public class CourseService {
             course.setExams(examRepository.filterVisibleExams(course.getExams()));
         }
         course.getTutorialGroups().forEach(tutorialGroup -> {
-            if (!authCheckService.isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
+            if (!tutorialGroupService.isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
                 tutorialGroup.hidePrivacySensitiveInformation();
             }
         });

--- a/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/CourseService.java
@@ -228,11 +228,6 @@ public class CourseService {
         if (authCheckService.isOnlyStudentInCourse(course, user)) {
             course.setExams(examRepository.filterVisibleExams(course.getExams()));
         }
-        course.getTutorialGroups().forEach(tutorialGroup -> {
-            if (!tutorialGroupService.isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
-                tutorialGroup.hidePrivacySensitiveInformation();
-            }
-        });
         return course;
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/TutorialGroupService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TutorialGroupService.java
@@ -400,7 +400,6 @@ public class TutorialGroupService {
         var courseInitialized = persistenceUtil.isLoaded(tutorialGroup, "course");
         var teachingAssistantInitialized = persistenceUtil.isLoaded(tutorialGroup, "teachingAssistant");
 
-        // load fresh from db to prevent NPEs nad lazy loading issues
         if (!courseInitialized || !teachingAssistantInitialized || tutorialGroup.getCourse() == null || tutorialGroup.getTeachingAssistant() == null) {
             tutorialGroup = tutorialGroupRepository.findByIdWithTeachingAssistantAndCourseElseThrow(tutorialGroup.getId());
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/TutorialGroupService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TutorialGroupService.java
@@ -7,6 +7,8 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+import javax.persistence.Persistence;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.stereotype.Service;
@@ -23,6 +25,7 @@ import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRegistratio
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRepository;
 import de.tum.in.www1.artemis.service.dto.StudentDTO;
 import de.tum.in.www1.artemis.service.notifications.SingleUserNotificationService;
+import de.tum.in.www1.artemis.web.rest.errors.AccessForbiddenException;
 import de.tum.in.www1.artemis.web.rest.errors.BadRequestAlertException;
 import de.tum.in.www1.artemis.web.rest.tutorialgroups.TutorialGroupResource.TutorialGroupImportErrors;
 import de.tum.in.www1.artemis.web.rest.tutorialgroups.TutorialGroupResource.TutorialGroupRegistrationImportDTO;
@@ -350,7 +353,7 @@ public class TutorialGroupService {
         Set<TutorialGroup> tutorialGroups = tutorialGroupRepository.findAllByCourseIdWithTeachingAssistantAndRegistrations(course.getId());
         tutorialGroups.forEach(tutorialGroup -> tutorialGroup.setTransientPropertiesForUser(user));
         tutorialGroups.forEach(tutorialGroup -> {
-            if (!authorizationCheckService.isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
+            if (!this.isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
                 tutorialGroup.hidePrivacySensitiveInformation();
             }
         });
@@ -371,10 +374,54 @@ public class TutorialGroupService {
             throw new BadRequestAlertException("The courseId in the path does not match the courseId in the tutorial group", "tutorialGroup", "courseIdMismatch");
         }
         tutorialGroup.setTransientPropertiesForUser(user);
-        if (!authorizationCheckService.isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
+        if (!this.isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
             tutorialGroup.hidePrivacySensitiveInformation();
         }
         return tutorialGroup;
+    }
+
+    /**
+     * Determines if a user is allowed to see private information about a tutorial group such as the list of registered students
+     *
+     * @param tutorialGroup the tutorial group for which to check permission
+     * @param user          the user for which to check permission
+     * @return true if the user is allowed, false otherwise
+     */
+    public boolean isAllowedToSeePrivateTutorialGroupInformation(@NotNull TutorialGroup tutorialGroup, @Nullable User user) {
+        if (user == null || user.getGroups() == null) {
+            user = userRepository.getUserWithGroupsAndAuthorities();
+        }
+        if (authorizationCheckService.isAdmin(user)) {
+            return true;
+        }
+
+        var persistenceUtil = Persistence.getPersistenceUtil();
+        var courseInitialized = persistenceUtil.isLoaded(tutorialGroup, "course");
+        var teachingAssistantInitialized = persistenceUtil.isLoaded(tutorialGroup, "teachingAssistant");
+
+        // load fresh from db to prevent NPEs nad lazy loading issues
+        if (!courseInitialized || !teachingAssistantInitialized || tutorialGroup.getCourse() == null || tutorialGroup.getTeachingAssistant() == null) {
+            tutorialGroup = tutorialGroupRepository.findByIdWithTeachingAssistantAndCourseElseThrow(tutorialGroup.getId());
+        }
+
+        Course course = tutorialGroup.getCourse();
+        if (authorizationCheckService.isAtLeastInstructorInCourse(course, user)) {
+            return true;
+        }
+        return (tutorialGroup.getTeachingAssistant() != null && tutorialGroup.getTeachingAssistant().equals(user));
+    }
+
+    /**
+     * Checks if a user is allowed to change the registrations of a tutorial group
+     *
+     * @param tutorialGroup the tutorial group for which to check permission
+     * @param user          the user for which to check permission
+     */
+    public void isAllowedToChangeRegistrationsOfTutorialGroup(@NotNull TutorialGroup tutorialGroup, @Nullable User user) {
+        // ToDo: Clarify if this is the correct permission check
+        if (!isAllowedToSeePrivateTutorialGroupInformation(tutorialGroup, user)) {
+            throw new AccessForbiddenException("The user is not allowed to change the registrations of tutorial group: " + tutorialGroup.getId());
+        }
     }
 
     private Optional<User> findStudent(StudentDTO studentDto, String studentCourseGroupName) {
@@ -382,4 +429,5 @@ public class TutorialGroupService {
                 .or(() -> userRepository.findUserWithGroupsAndAuthoritiesByLogin(studentDto.getLogin()));
         return userOptional.isPresent() && userOptional.get().getGroups().contains(studentCourseGroupName) ? userOptional : Optional.empty();
     }
+
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/TutorialGroupService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TutorialGroupService.java
@@ -388,14 +388,15 @@ public class TutorialGroupService {
      * @return true if the user is allowed, false otherwise
      */
     public boolean isAllowedToSeePrivateTutorialGroupInformation(@NotNull TutorialGroup tutorialGroup, @Nullable User user) {
-        if (user == null || user.getGroups() == null) {
+        var persistenceUtil = Persistence.getPersistenceUtil();
+        if (user == null || !persistenceUtil.isLoaded(user, "authorities") || !persistenceUtil.isLoaded(user, "groups") || user.getGroups() == null
+                || user.getAuthorities() == null) {
             user = userRepository.getUserWithGroupsAndAuthorities();
         }
         if (authorizationCheckService.isAdmin(user)) {
             return true;
         }
 
-        var persistenceUtil = Persistence.getPersistenceUtil();
         var courseInitialized = persistenceUtil.isLoaded(tutorialGroup, "course");
         var teachingAssistantInitialized = persistenceUtil.isLoaded(tutorialGroup, "teachingAssistant");
 

--- a/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupResource.java
+++ b/src/main/java/de/tum/in/www1/artemis/web/rest/tutorialgroups/TutorialGroupResource.java
@@ -291,7 +291,7 @@ public class TutorialGroupResource {
         log.debug("REST request to deregister {} student from tutorial group : {}", studentLogin, tutorialGroupId);
         var tutorialGroupFromDatabase = this.tutorialGroupRepository.findByIdElseThrow(tutorialGroupId);
         var responsibleUser = userRepository.getUserWithGroupsAndAuthorities();
-        authorizationCheckService.isAllowedToChangeRegistrationsOfTutorialGroup(tutorialGroupFromDatabase, responsibleUser);
+        tutorialGroupService.isAllowedToChangeRegistrationsOfTutorialGroup(tutorialGroupFromDatabase, responsibleUser);
         checkEntityIdMatchesPathIds(tutorialGroupFromDatabase, Optional.of(courseId), Optional.of(tutorialGroupId));
         User studentToDeregister = userRepository.getUserWithGroupsAndAuthorities(studentLogin);
         tutorialGroupService.deregisterStudent(studentToDeregister, tutorialGroupFromDatabase, TutorialGroupRegistrationType.INSTRUCTOR_REGISTRATION, responsibleUser);
@@ -313,7 +313,7 @@ public class TutorialGroupResource {
         log.debug("REST request to register {} student to tutorial group : {}", studentLogin, tutorialGroupId);
         var tutorialGroupFromDatabase = this.tutorialGroupRepository.findByIdElseThrow(tutorialGroupId);
         var responsibleUser = userRepository.getUserWithGroupsAndAuthorities();
-        authorizationCheckService.isAllowedToChangeRegistrationsOfTutorialGroup(tutorialGroupFromDatabase, responsibleUser);
+        tutorialGroupService.isAllowedToChangeRegistrationsOfTutorialGroup(tutorialGroupFromDatabase, responsibleUser);
         checkEntityIdMatchesPathIds(tutorialGroupFromDatabase, Optional.of(courseId), Optional.of(tutorialGroupId));
         User userToRegister = userRepository.getUserWithGroupsAndAuthorities(studentLogin);
         if (!userToRegister.getGroups().contains(tutorialGroupFromDatabase.getCourse().getStudentGroupName())) {

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
@@ -682,16 +682,14 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     private List<TutorialGroup> getTutorialGroupsOfExampleCourse(boolean loadFromService, String userLogin) throws Exception {
-        List<TutorialGroup> tutorialGroupsOfCourse;
         if (loadFromService) {
             var user = userRepository.findOneByLogin(userLogin).get();
             var course = courseRepository.findById(exampleCourseId).get();
-            tutorialGroupsOfCourse = tutorialGroupService.findAllForCourse(course, user).stream().toList();
+            return tutorialGroupService.findAllForCourse(course, user).stream().toList();
         }
         else {
-            tutorialGroupsOfCourse = request.getList("/api/courses/" + exampleCourseId + "/tutorial-groups", HttpStatus.OK, TutorialGroup.class);
+            return request.getList("/api/courses/" + exampleCourseId + "/tutorial-groups", HttpStatus.OK, TutorialGroup.class);
         }
-        return tutorialGroupsOfCourse;
     }
 
     private void registerStudentAllowedTest() throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
@@ -671,16 +671,14 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     private TutorialGroup getTutorialGroupOfExampleCourse(boolean loadFromService, String userLogin) throws Exception {
-        TutorialGroup tutorialGroupsOfCourse;
         if (loadFromService) {
             var user = userRepository.findOneByLogin(userLogin).get();
             var course = courseRepository.findById(exampleCourseId).get();
-            tutorialGroupsOfCourse = tutorialGroupService.getOneOfCourse(course, user, exampleOneTutorialGroupId);
+            return tutorialGroupService.getOneOfCourse(course, user, exampleOneTutorialGroupId);
         }
         else {
-            tutorialGroupsOfCourse = request.get("/api/courses/" + exampleCourseId + "/tutorial-groups/" + exampleOneTutorialGroupId, HttpStatus.OK, TutorialGroup.class);
+            return request.get("/api/courses/" + exampleCourseId + "/tutorial-groups/" + exampleOneTutorialGroupId, HttpStatus.OK, TutorialGroup.class);
         }
-        return tutorialGroupsOfCourse;
     }
 
     private List<TutorialGroup> getTutorialGroupsOfExampleCourse(boolean loadFromService, String userLogin) throws Exception {

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/TutorialGroupIntegrationTest.java
@@ -9,6 +9,8 @@ import java.util.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -26,6 +28,7 @@ import de.tum.in.www1.artemis.repository.CourseRepository;
 import de.tum.in.www1.artemis.repository.UserRepository;
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRegistrationRepository;
 import de.tum.in.www1.artemis.repository.tutorialgroups.TutorialGroupRepository;
+import de.tum.in.www1.artemis.service.TutorialGroupService;
 import de.tum.in.www1.artemis.service.dto.StudentDTO;
 import de.tum.in.www1.artemis.util.ModelFactory;
 import de.tum.in.www1.artemis.web.rest.tutorialgroups.TutorialGroupResource;
@@ -41,6 +44,9 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
 
     @Autowired
     TutorialGroupRepository tutorialGroupRepository;
+
+    @Autowired
+    TutorialGroupService tutorialGroupService;
 
     @Autowired
     TutorialGroupRegistrationRepository tutorialGroupRegistrationRepository;
@@ -154,10 +160,11 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         assertThat(tutorialGroupTitle).isEqualTo("ExampleTitle1");
     }
 
-    @Test
+    @ParameterizedTest
     @WithMockUser(username = "student1", roles = "USER")
-    void getAllForCourse_asStudent_shouldHidePrivateInformation() throws Exception {
-        var tutorialGroupsOfCourse = request.getList("/api/courses/" + exampleCourseId + "/tutorial-groups", HttpStatus.OK, TutorialGroup.class);
+    @ValueSource(booleans = { true, false })
+    void getAllForCourse_asStudent_shouldHidePrivateInformation(boolean loadFromService) throws Exception {
+        var tutorialGroupsOfCourse = getTutorialGroupsOfExampleCourse(loadFromService, "student1");
         assertThat(tutorialGroupsOfCourse).hasSize(2);
         assertThat(tutorialGroupsOfCourse.stream().map(TutorialGroup::getId).collect(ImmutableSet.toImmutableSet())).containsExactlyInAnyOrder(exampleOneTutorialGroupId,
                 exampleTwoTutorialGroupId);
@@ -166,10 +173,11 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         }
     }
 
-    @Test
+    @ParameterizedTest
     @WithMockUser(username = "editor1", roles = "EDITOR")
-    void getAllForCourse_asEditor_shouldHidePrivateInformation() throws Exception {
-        var tutorialGroupsOfCourse = request.getList("/api/courses/" + exampleCourseId + "/tutorial-groups", HttpStatus.OK, TutorialGroup.class);
+    @ValueSource(booleans = { true, false })
+    void getAllForCourse_asEditor_shouldHidePrivateInformation(boolean loadFromService) throws Exception {
+        var tutorialGroupsOfCourse = getTutorialGroupsOfExampleCourse(loadFromService, "editor1");
         assertThat(tutorialGroupsOfCourse).hasSize(2);
         assertThat(tutorialGroupsOfCourse.stream().map(TutorialGroup::getId).collect(ImmutableSet.toImmutableSet())).containsExactlyInAnyOrder(exampleOneTutorialGroupId,
                 exampleTwoTutorialGroupId);
@@ -178,10 +186,11 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     @WithMockUser(username = "tutor1", roles = "TA")
-    void getAllForCourse_asTutorOfOneGroup_shouldShowPrivateInformationForOwnGroup() throws Exception {
-        var tutorialGroupsOfCourse = request.getList("/api/courses/" + exampleCourseId + "/tutorial-groups", HttpStatus.OK, TutorialGroup.class);
+    void getAllForCourse_asTutorOfOneGroup_shouldShowPrivateInformationForOwnGroup(boolean loadFromService) throws Exception {
+        var tutorialGroupsOfCourse = getTutorialGroupsOfExampleCourse(loadFromService, "tutor1");
         assertThat(tutorialGroupsOfCourse).hasSize(2);
         assertThat(tutorialGroupsOfCourse.stream().map(TutorialGroup::getId).collect(ImmutableSet.toImmutableSet())).containsExactlyInAnyOrder(exampleOneTutorialGroupId,
                 exampleTwoTutorialGroupId);
@@ -191,10 +200,11 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         verifyPrivateInformationIsHidden(groupWhereNotTutor);
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void getAllForCourse_asInstructorOfCourse_shouldShowPrivateInformation() throws Exception {
-        var tutorialGroupsOfCourse = request.getList("/api/courses/" + exampleCourseId + "/tutorial-groups", HttpStatus.OK, TutorialGroup.class);
+    void getAllForCourse_asInstructorOfCourse_shouldShowPrivateInformation(boolean loadFromService) throws Exception {
+        var tutorialGroupsOfCourse = getTutorialGroupsOfExampleCourse(loadFromService, "instructor1");
         assertThat(tutorialGroupsOfCourse).hasSize(2);
         assertThat(tutorialGroupsOfCourse.stream().map(TutorialGroup::getId).collect(ImmutableSet.toImmutableSet())).containsExactlyInAnyOrder(exampleOneTutorialGroupId,
                 exampleTwoTutorialGroupId);
@@ -204,34 +214,39 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         verifyPrivateInformationIsShown(group2, 2);
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     @WithMockUser(username = "student1", roles = "USER")
-    void getOneOfCourse_asStudent_shouldHidePrivateInformation() throws Exception {
-        oneOfCoursePrivateInfoHiddenTest();
+    void getOneOfCourse_asStudent_shouldHidePrivateInformation(boolean loadFromService) throws Exception {
+        oneOfCoursePrivateInfoHiddenTest(loadFromService, "student1");
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     @WithMockUser(username = "editor1", roles = "EDITOR")
-    void getOneOfCourse_asEditor_shouldHidePrivateInformation() throws Exception {
-        oneOfCoursePrivateInfoHiddenTest();
+    void getOneOfCourse_asEditor_shouldHidePrivateInformation(boolean loadFromService) throws Exception {
+        oneOfCoursePrivateInfoHiddenTest(loadFromService, "editor1");
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     @WithMockUser(username = "tutor1", roles = "TA")
-    void getOneOfCourse_asTutorOfGroup_shouldShowPrivateInformation() throws Exception {
-        oneOfCoursePrivateInfoShownTest();
+    void getOneOfCourse_asTutorOfGroup_shouldShowPrivateInformation(boolean loadFromService) throws Exception {
+        oneOfCoursePrivateInfoShownTest(loadFromService, "tutor1");
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
-    void getOneOfCourse_asInstructor_shouldShowPrivateInformation() throws Exception {
-        oneOfCoursePrivateInfoShownTest();
+    void getOneOfCourse_asInstructor_shouldShowPrivateInformation(boolean loadFromService) throws Exception {
+        oneOfCoursePrivateInfoShownTest(loadFromService, "instructor1");
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
     @WithMockUser(username = "tutor2", roles = "TA")
-    void getOneOfCourse_asNotTutorOfGroup_shouldHidePrivateInformation() throws Exception {
-        oneOfCoursePrivateInfoHiddenTest();
+    void getOneOfCourse_asNotTutorOfGroup_shouldHidePrivateInformation(boolean loadFromService) throws Exception {
+        oneOfCoursePrivateInfoHiddenTest(loadFromService, "tutor2");
     }
 
     @Test
@@ -632,7 +647,7 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
     }
 
     private void verifyPrivateInformationIsHidden(TutorialGroup tutorialGroup) {
-        assertThat(tutorialGroup.getRegistrations()).isEqualTo(Set.of());
+        assertThat(tutorialGroup.getRegistrations()).isNullOrEmpty();
         assertThat(tutorialGroup.getTeachingAssistant()).isEqualTo(null);
         assertThat(tutorialGroup.getCourse()).isEqualTo(null);
     }
@@ -643,16 +658,42 @@ class TutorialGroupIntegrationTest extends AbstractSpringIntegrationBambooBitbuc
         assertThat(tutorialGroup.getCourse()).isNotNull();
     }
 
-    private void oneOfCoursePrivateInfoHiddenTest() throws Exception {
-        var tutorialGroup = request.get("/api/courses/" + exampleCourseId + "/tutorial-groups/" + exampleOneTutorialGroupId, HttpStatus.OK, TutorialGroup.class);
+    private void oneOfCoursePrivateInfoHiddenTest(boolean loadFromService, String userLogin) throws Exception {
+        var tutorialGroup = getTutorialGroupOfExampleCourse(loadFromService, userLogin);
         assertThat(tutorialGroup.getId()).isEqualTo(exampleOneTutorialGroupId);
         verifyPrivateInformationIsHidden(tutorialGroup);
     }
 
-    private void oneOfCoursePrivateInfoShownTest() throws Exception {
-        var tutorialGroup = request.get("/api/courses/" + exampleCourseId + "/tutorial-groups/" + exampleOneTutorialGroupId, HttpStatus.OK, TutorialGroup.class);
+    private void oneOfCoursePrivateInfoShownTest(boolean loadFromService, String userLogin) throws Exception {
+        var tutorialGroup = getTutorialGroupOfExampleCourse(loadFromService, userLogin);
         assertThat(tutorialGroup.getId()).isEqualTo(exampleOneTutorialGroupId);
         verifyPrivateInformationIsShown(tutorialGroup, 5);
+    }
+
+    private TutorialGroup getTutorialGroupOfExampleCourse(boolean loadFromService, String userLogin) throws Exception {
+        TutorialGroup tutorialGroupsOfCourse;
+        if (loadFromService) {
+            var user = userRepository.findOneByLogin(userLogin).get();
+            var course = courseRepository.findById(exampleCourseId).get();
+            tutorialGroupsOfCourse = tutorialGroupService.getOneOfCourse(course, user, exampleOneTutorialGroupId);
+        }
+        else {
+            tutorialGroupsOfCourse = request.get("/api/courses/" + exampleCourseId + "/tutorial-groups/" + exampleOneTutorialGroupId, HttpStatus.OK, TutorialGroup.class);
+        }
+        return tutorialGroupsOfCourse;
+    }
+
+    private List<TutorialGroup> getTutorialGroupsOfExampleCourse(boolean loadFromService, String userLogin) throws Exception {
+        List<TutorialGroup> tutorialGroupsOfCourse;
+        if (loadFromService) {
+            var user = userRepository.findOneByLogin(userLogin).get();
+            var course = courseRepository.findById(exampleCourseId).get();
+            tutorialGroupsOfCourse = tutorialGroupService.findAllForCourse(course, user).stream().toList();
+        }
+        else {
+            tutorialGroupsOfCourse = request.getList("/api/courses/" + exampleCourseId + "/tutorial-groups", HttpStatus.OK, TutorialGroup.class);
+        }
+        return tutorialGroupsOfCourse;
     }
 
     private void registerStudentAllowedTest() throws Exception {


### PR DESCRIPTION

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.

### Motivation and Context
- There was a bug in the AuthenticationCheckService when course or teaching assistant were null for a tutorial group because of hiding these properties for privacy reasons

### Description
<!-- Describe your changes in detail -->
- Always load the tutorial group from database in the authentication check service to prevent this error.

### Steps for Testing
Nothing to test really. Bug and bugfix is clear from the code

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
No changes
