### PR TITLE
`Documentation`: Add Publication List

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,8 @@ master_doc = "index"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx_rtd_theme"
+    "sphinx_rtd_theme",
+    "sphinxcontrib.bibtex"
 ]
 
 # List of patterns, relative to source directory, that match files and
@@ -40,6 +41,10 @@ extensions = [
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# -- Publications ------------------------------------------------------------
+bibtex_bibfiles = ['research/publications.bib']
+bibtex_default_style = 'unsrtalpha'
+bibtex_reference_style = 'label'
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,3 +64,10 @@ All these exercises are supposed to be run either live in the lecture with insta
    admin/accessRights
    admin/troubleshooting
    admin/knownIssues
+
+.. toctree::
+   :caption: Research
+   :includehidden:
+   :maxdepth: 3
+
+   research/publications

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==5.0.2
 sphinx-rtd-theme==1.0.0
 sphinx-autobuild==2021.3.14
 docutils==0.17
+sphinxcontrib-bibtex==2.5.0

--- a/docs/research/publications.bib
+++ b/docs/research/publications.bib
@@ -1,0 +1,236 @@
+%%%
+% All entries in this file should be sorted chronologically.
+% Use BibTeX Tidy to keep this file sorted, formated, and organized.
+%
+% https://flamingtempura.github.io/bibtex-tidy/index.html?opt=%7B%22curly%22%3Atrue%2C%22numeric%22%3Atrue%2C%22sort%22%3A%5B%22-year%22%2C%22-month%22%2C%22author%22%5D%2C%22omit%22%3A%5B%22timestamp%22%2C%22biburl%22%2C%22bibsource%22%2C%22editor%22%2C%22copyright%22%2C%22category%22%2C%22note%22%2C%22metadata%22%5D%2C%22space%22%3A2%2C%22tab%22%3Afalse%2C%22align%22%3A13%2C%22wrap%22%3A80%2C%22blankLines%22%3Afalse%2C%22duplicates%22%3A%5B%22key%22%2C%22doi%22%2C%22citation%22%5D%2C%22merge%22%3Afalse%2C%22enclosingBraces%22%3Afalse%2C%22stripEnclosingBraces%22%3Atrue%2C%22dropAllCaps%22%3Afalse%2C%22sortFields%22%3A%5B%22title%22%2C%22shorttitle%22%2C%22author%22%2C%22year%22%2C%22month%22%2C%22day%22%2C%22journal%22%2C%22booktitle%22%2C%22location%22%2C%22on%22%2C%22publisher%22%2C%22address%22%2C%22series%22%2C%22volume%22%2C%22number%22%2C%22pages%22%2C%22doi%22%2C%22isbn%22%2C%22issn%22%2C%22url%22%2C%22urldate%22%5D%2C%22stripComments%22%3Afalse%2C%22tidyComments%22%3Atrue%2C%22encodeUrls%22%3Afalse%2C%22escape%22%3Afalse%2C%22trailingCommas%22%3Atrue%2C%22removeEmptyFields%22%3Afalse%2C%22removeDuplicateFields%22%3Afalse%2C%22lowercase%22%3Atrue%2C%22generateKeys%22%3Atrue%7D
+%%%
+
+@article{bernius2022machine,
+  title        = {
+    Machine Learning Based Feedback on Textual Student Answers in Large Courses
+  },
+  author       = {Bernius, Jan Philip and Krusche, Stephan and Bruegge, Bernd},
+  year         = 2022,
+  month        = jun,
+  journal      = {Computers and Education: Artificial Intelligence},
+  publisher    = {Elsevier {BV}},
+  volume       = 3,
+  doi          = {10.1016/j.caeai.2022.100081},
+  issn         = {2666-920X},
+}
+@inproceedings{krusche2022semi,
+  title        = {
+    Semi-Automatic Assessment of Modeling Exercises using Supervised Machine
+    Learning
+  },
+  author       = {Stephan Krusche},
+  year         = 2022,
+  month        = jan,
+  booktitle    = {55th Hawaii International Conference on System Sciences},
+  location     = {Virtual Event / Maui, Hawaii, USA},
+  publisher    = {ScholarSpace},
+  series       = {{HICSS} '22},
+  pages        = {1--10},
+  url          = {http://hdl.handle.net/10125/79439},
+}
+@inproceedings{hagerer2021analysis,
+  title        = {
+    An Analysis of Programming Course Evaluations Before and After the
+    Introduction of an Autograder
+  },
+  author       = {
+    Gerhard Hagerer and Laura Lahesoo and Miriam Ansch{\"{u}}tz and Stephan
+    Krusche and Georg Groh
+  },
+  year         = 2021,
+  month        = nov,
+  booktitle    = {
+    19th International Conference on Information Technology Based Higher
+    Education and Training
+  },
+  location     = {Sydney, Australia},
+  publisher    = {IEEE},
+  series       = {{ITHET} '21},
+  pages        = {1--9},
+  doi          = {10.1109/ITHET50392.2021.9759809},
+}
+@inproceedings{bernius2021machine,
+  title        = {
+    A Machine Learning Approach for Suggesting Feedback in Textual Exercises in
+    Large Courses
+  },
+  author       = {Bernius, Jan Philip and Krusche, Stephan and Bruegge, Bernd},
+  year         = 2021,
+  month        = jun,
+  booktitle    = {8th ACM Conference on Learning @ Scale},
+  location     = {Potsdam, Germany},
+  publisher    = {Association for Computing Machinery {(ACM)}},
+  series       = {{L@S} '21},
+  pages        = {173--182},
+  doi          = {10.1145/3430895.3460135},
+  isbn         = 9781450382151,
+}
+@inproceedings{m_unzner2021can,
+  title        = {
+    Can I Code? User Experience of an Assessment Platform for Programming
+    Assignments
+  },
+  author       = {M\"{u}nzner, Anne and Bruckmoser, Nadja and Meschtscherjakov, Alexander},
+  year         = 2021,
+  month        = may,
+  booktitle    = {2nd International Computer Programming Education Conference},
+  location     = {Braga, Portugal},
+  publisher    = {Schloss Dagstuhl -- Leibniz-Zentrum f{\"u}r Informatik},
+  series       = {{ICPEC} '21},
+  volume       = 91,
+  pages        = {18:1--18:12},
+  doi          = {10.4230/OASIcs.ICPEC.2021.18},
+}
+@inproceedings{bernius2021computer,
+  title        = {
+    Toward Computer-Aided Assessment of Textual Exercises in Very Large Courses
+  },
+  author       = {Bernius, Jan Philip},
+  year         = 2021,
+  month        = mar,
+  booktitle    = {52nd ACM Technical Symposium on Computer Science Education},
+  location     = {Toronto, ON, Canada},
+  publisher    = {Association for Computing Machinery {(ACM)}},
+  series       = {{SIGCSE} '21},
+  pages        = 1386,
+  doi          = {10.1145/3408877.3439703},
+}
+@inproceedings{bernius2020towards,
+  title        = {
+    Towards the Automation of Grading Textual Student Submissions to Open-ended
+    Questions
+  },
+  author       = {
+    Bernius, Jan Philip and Kovaleva, Anna and Krusche, Stephan and Bruegge,
+    Bernd
+  },
+  year         = 2020,
+  month        = jun,
+  booktitle    = {4th European Conference of Software Engineering Education},
+  location     = {Seeon, Germany},
+  publisher    = {Association for Computing Machinery {(ACM)}},
+  series       = {{ECSEE} '20},
+  pages        = {61--70},
+  doi          = {10.1145/3396802.3396805},
+  isbn         = 9781450377522,
+}
+@inproceedings{krusche2020interactive,
+  title        = {An interactive learning method to engage students in modeling},
+  author       = {
+    Stephan Krusche and Nadine von Frankenberg and Lara Marie Reimer and Bernd
+    Bruegge
+  },
+  year         = 2020,
+  month        = jun,
+  booktitle    = {
+    42nd International Conference on Software Engineering, Software Engineering
+    Education and Training
+  },
+  location     = {Seoul, South Korea},
+  publisher    = {ACM},
+  series       = {{ICSE-SEET} '20},
+  pages        = {12--22},
+  doi          = {10.1145/3377814.3381701},
+}
+@inproceedings{bernius2020segmenting,
+  title        = {Segmenting Student Answers to Textual Exercises Based on Topic Modeling},
+  author       = {Bernius, Jan Philip and Kovaleva, Anna and Bruegge, Bernd},
+  year         = 2020,
+  month        = feb,
+  booktitle    = {17th Workshop on Software Engineering im Unterricht der Hochschulen},
+  location     = {Innsbruck, Austria},
+  publisher    = {CEUR-WS.org},
+  series       = {{SEUH} '20},
+  pages        = {72--73},
+  url          = {http://ceur-ws.org/Vol-2531/poster03.pdf},
+}
+@inproceedings{la_ss2019stager,
+  title        = {Stager: Simplifying the Manual Assessment of Programming Exercises},
+  author       = {
+    Christopher La{\ss} and Stephan Krusche and Nadine von Frankenberg and
+    Bernd Bruegge
+  },
+  year         = 2019,
+  month        = feb,
+  booktitle    = {16th Workshop on Software Engineering im Unterricht der Hochschulen},
+  location     = {Bremerhaven, Deutschland},
+  publisher    = {CEUR-WS.org},
+  series       = {{SEUH} '19},
+  pages        = {34--43},
+  url          = {http://ceur-ws.org/Vol-2358/paper-03.pdf},
+}
+@inproceedings{bernius2019automatic,
+  title        = {Toward the Automatic Assessment of Text Exercises},
+  author       = {Bernius, Jan Philip and Bruegge, Bernd},
+  year         = 2019,
+  month        = feb,
+  booktitle    = {2nd Workshop on Innovative Software Engineering Education},
+  location     = {Stuttgart, Germany},
+  publisher    = {CEUR-WS.org},
+  series       = {{ISEE} '19},
+  pages        = {19--22},
+  url          = {http://ceur-ws.org/Vol-2308/isee2019paper04.pdf},
+}
+@inproceedings{krusche2019increasing,
+  title        = {
+    Increasing the Interactivity in Software Engineering MOOCs - {A} Case Study
+  },
+  author       = {Stephan Krusche and Andreas Seitz},
+  year         = 2019,
+  month        = jan,
+  booktitle    = {52nd Hawaii International Conference on System Sciences},
+  location     = {Grand Wailea, Maui, Hawaii, USA},
+  publisher    = {ScholarSpace},
+  series       = {{HICSS} '19},
+  pages        = {1--10},
+  url          = {https://hdl.handle.net/10125/60197},
+}
+@inproceedings{krusche2018artemis,
+  title        = {
+    ArTEMiS: An Automatic Assessment Management System for Interactive Learning
+  },
+  author       = {Stephan Krusche and Andreas Seitz},
+  year         = 2018,
+  month        = feb,
+  booktitle    = {49th {ACM} Technical Symposium on Computer Science Education},
+  location     = {Baltimore, MD, USA},
+  publisher    = {ACM},
+  series       = {{SIGCSE} '18},
+  pages        = {284--289},
+  doi          = {10.1145/3159450.3159602},
+}
+@inproceedings{krusche2017experiences,
+  title        = {Experiences of a Software Engineering Course based on Interactive Learning},
+  author       = {Stephan Krusche and Nadine von Frankenberg and Sami Afifi},
+  year         = 2017,
+  month        = feb,
+  booktitle    = {15th Workshop on Software Engineering im Unterricht der Hochschulen},
+  location     = {Hannover, Deutschland},
+  publisher    = {CEUR-WS.org},
+  series       = {{SEUH} '17},
+  pages        = {32--40},
+  url          = {http://ceur-ws.org/Vol-1790/paper04.pdf},
+}
+@inproceedings{krusche2017interactive,
+  title        = {
+    Interactive Learning: Increasing Student Participation through Shorter
+    Exercise Cycles
+  },
+  author       = {
+    Stephan Krusche and Andreas Seitz and J{\"{u}}rgen B{\"{o}}rstler and Bernd
+    Br{\"{u}}gge
+  },
+  year         = 2017,
+  month        = jan,
+  booktitle    = {19th Australasian Computing Education Conference},
+  location     = {Geelong, VIC, Australia},
+  publisher    = {ACM},
+  series       = {{ACE} '17},
+  pages        = {17--26},
+  doi          = {10.1145/3013499.3013513},
+}

--- a/docs/research/publications.rst
+++ b/docs/research/publications.rst
@@ -1,0 +1,14 @@
+.. _research_publications:
+
+Publications
+============
+
+.. bibliography::
+   :list: bullet
+   :all:
+
+
+..
+   Add publication entries into the publications.bib file.
+   Use the BibTeX Tidy to format and sort the file:
+   https://flamingtempura.github.io/bibtex-tidy/index.html?opt=%7B%22curly%22%3Atrue%2C%22numeric%22%3Atrue%2C%22sort%22%3A%5B%22-year%22%2C%22-month%22%2C%22author%22%5D%2C%22omit%22%3A%5B%22timestamp%22%2C%22biburl%22%2C%22bibsource%22%2C%22editor%22%2C%22copyright%22%2C%22category%22%2C%22note%22%2C%22metadata%22%5D%2C%22space%22%3A2%2C%22tab%22%3Afalse%2C%22align%22%3A13%2C%22wrap%22%3A80%2C%22blankLines%22%3Afalse%2C%22duplicates%22%3A%5B%22key%22%2C%22doi%22%2C%22citation%22%5D%2C%22merge%22%3Afalse%2C%22enclosingBraces%22%3Afalse%2C%22stripEnclosingBraces%22%3Atrue%2C%22dropAllCaps%22%3Afalse%2C%22sortFields%22%3A%5B%22title%22%2C%22shorttitle%22%2C%22author%22%2C%22year%22%2C%22month%22%2C%22day%22%2C%22journal%22%2C%22booktitle%22%2C%22location%22%2C%22on%22%2C%22publisher%22%2C%22address%22%2C%22series%22%2C%22volume%22%2C%22number%22%2C%22pages%22%2C%22doi%22%2C%22isbn%22%2C%22issn%22%2C%22url%22%2C%22urldate%22%5D%2C%22stripComments%22%3Afalse%2C%22tidyComments%22%3Atrue%2C%22encodeUrls%22%3Afalse%2C%22escape%22%3Afalse%2C%22trailingCommas%22%3Atrue%2C%22removeEmptyFields%22%3Afalse%2C%22removeDuplicateFields%22%3Afalse%2C%22lowercase%22%3Atrue%2C%22generateKeys%22%3Atrue%7D


### PR DESCRIPTION
This adds a list of Artemis-related publications to a new section in the documentation.
The list is generated from a `BibTeX` file using the [`sphinxcontrib-bibtex`](https://sphinxcontrib-bibtex.readthedocs.io/en/2.5.0/) package.

View the new page here: https://artemis-platform--5827.org.readthedocs.build/en/5827/research/publications/