### PR TITLE
`Programming exercises:` Change color of save button for changing template

### DIFF
--- a/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/instructions-editor/programming-exercise-editable-instruction.component.html
@@ -24,7 +24,8 @@
         id="save-instructions-button"
         [disabled]="savingInstructions || !unsavedChangesValue"
         (click)="saveInstructions($event)"
-        class="btn btn-light editable-instruction-container__save"
+        class="btn editable-instruction-container__save"
+        [ngClass]="savingInstructions || !unsavedChangesValue ? 'btn-light' : 'btn-primary'"
     >
         <fa-icon *ngIf="!savingInstructions" [icon]="faSave" class="me-2"></fa-icon>
         <fa-icon *ngIf="savingInstructions" [icon]="faCircleNotch" [spin]="true" class="me-2"></fa-icon>


### PR DESCRIPTION
### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] Following the [theming guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-design/), I specified colors only in the theming variable files and checked that the changes look consistent in both the light and the dark theme.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
The save button in the problem statement of a programming exercise is almost not perceptive. Even when there are some changes.
https://github.com/ls1intum/Artemis/issues/5830

### Description
I changed the color to the same blue used for saving the entire exercise.

### Steps for Testing
1. Go to a programming exercise
2. Click on edit
3. Verify that the save button in the problem statement is unactivated (no changes yet)
4. Change the problem statement, the save button color changes to the same blue used for the entire exercise.

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2

### Screenshots
![Screenshot (56)](https://user-images.githubusercontent.com/64478731/201071484-78791249-6fe7-4abd-808e-c5908dba3e4b.png)
![Screenshot (57)](https://user-images.githubusercontent.com/64478731/201071487-5197c0ef-4459-4208-8216-ba2cfc8d5f89.png)
![Screenshot (58)](https://user-images.githubusercontent.com/64478731/201071490-f050bc5a-6427-4be9-9dfb-22155bba94ec.png)
![Screenshot (59)](https://user-images.githubusercontent.com/64478731/201071493-eb605091-02da-4b85-b137-93bd5e03b101.png)
