### PR TITLE
`Development`: Refactor ExerciseDateService to reduce service dependencies

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/domain/participation/ProgrammingExerciseParticipation.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/participation/ProgrammingExerciseParticipation.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
 import de.tum.in.www1.artemis.domain.Result;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUrl;
+import de.tum.in.www1.artemis.service.ExerciseDateService;
 
 public interface ProgrammingExerciseParticipation extends ParticipationInterface {
 
@@ -80,8 +81,8 @@ public interface ProgrammingExerciseParticipation extends ParticipationInterface
      * This is the case when the participation is a ProgrammingExerciseStudentParticipation,
      * the buildAndTestAfterDueDate of the exercise is set and the due date has passed,
      * or if manual correction is involved and the due date has passed.
-     *
-     * Locked means that the student can't make any changes to their repository anymore.
+     * <p>
+     * Locked means that the student can't make any changes to their repository any more.
      * While we can control this easily in the remote VCS, we need to check this manually
      * for the local repository on the Artemis server.
      *
@@ -93,16 +94,8 @@ public interface ProgrammingExerciseParticipation extends ParticipationInterface
             return false;
         }
 
-        final ProgrammingExercise programmingExercise = getProgrammingExercise();
         final ZonedDateTime now = ZonedDateTime.now();
-
-        boolean isAfterDueDate = false;
-        if (getIndividualDueDate() != null) {
-            isAfterDueDate = now.isAfter(getIndividualDueDate());
-        }
-        else if (programmingExercise.getDueDate() != null) {
-            isAfterDueDate = now.isAfter(programmingExercise.getDueDate());
-        }
+        boolean isAfterDueDate = ExerciseDateService.getDueDate(studentParticipation).map(now::isAfter).orElse(false);
 
         return isAfterDueDate && !studentParticipation.isTestRun();
     }

--- a/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
+++ b/src/main/java/de/tum/in/www1/artemis/repository/StudentExamRepository.java
@@ -21,6 +21,7 @@ import de.tum.in.www1.artemis.domain.exam.Exam;
 import de.tum.in.www1.artemis.domain.exam.ExerciseGroup;
 import de.tum.in.www1.artemis.domain.exam.StudentExam;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
+import de.tum.in.www1.artemis.service.ExerciseDateService;
 import de.tum.in.www1.artemis.web.rest.errors.EntityNotFoundException;
 
 /**
@@ -242,11 +243,8 @@ public interface StudentExamRepository extends JpaRepository<StudentExam, Long> 
             }
             return studentExam.getExam().getStartDate().plusSeconds(studentExam.getWorkingTime());
         }
-        else if (participation.getIndividualDueDate() != null) {
-            return participation.getIndividualDueDate();
-        }
         else {
-            return exercise.getDueDate();
+            return ExerciseDateService.getDueDate(participation).orElse(null);
         }
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/AssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/AssessmentService.java
@@ -35,8 +35,6 @@ public class AssessmentService {
 
     private final ExamDateService examDateService;
 
-    private final ExerciseDateService exerciseDateService;
-
     protected final SubmissionRepository submissionRepository;
 
     protected final GradingCriterionRepository gradingCriterionRepository;
@@ -49,8 +47,8 @@ public class AssessmentService {
 
     public AssessmentService(ComplaintResponseService complaintResponseService, ComplaintRepository complaintRepository, FeedbackRepository feedbackRepository,
             ResultRepository resultRepository, StudentParticipationRepository studentParticipationRepository, ResultService resultService, SubmissionService submissionService,
-            SubmissionRepository submissionRepository, ExamDateService examDateService, ExerciseDateService exerciseDateService,
-            GradingCriterionRepository gradingCriterionRepository, UserRepository userRepository, LtiNewResultService ltiNewResultService) {
+            SubmissionRepository submissionRepository, ExamDateService examDateService, GradingCriterionRepository gradingCriterionRepository, UserRepository userRepository,
+            LtiNewResultService ltiNewResultService) {
         this.complaintResponseService = complaintResponseService;
         this.complaintRepository = complaintRepository;
         this.feedbackRepository = feedbackRepository;
@@ -60,7 +58,6 @@ public class AssessmentService {
         this.submissionService = submissionService;
         this.submissionRepository = submissionRepository;
         this.examDateService = examDateService;
-        this.exerciseDateService = exerciseDateService;
         this.gradingCriterionRepository = gradingCriterionRepository;
         this.userRepository = userRepository;
         this.ltiNewResultService = ltiNewResultService;
@@ -101,7 +98,7 @@ public class AssessmentService {
             return resultRepository.findByIdWithEagerAssessor(savedResult.getId()).orElseThrow(); // to eagerly load assessor
         }
         else {
-            return resultRepository.submitResult(newResult, exercise, exerciseDateService.getDueDate(newResult.getParticipation()));
+            return resultRepository.submitResult(newResult, exercise, ExerciseDateService.getDueDate(newResult.getParticipation()));
         }
     }
 
@@ -225,9 +222,9 @@ public class AssessmentService {
     public Result submitManualAssessment(long resultId, Exercise exercise, ZonedDateTime submissionDate) {
         Result result = resultRepository.findWithEagerSubmissionAndFeedbackAndAssessorById(resultId)
                 .orElseThrow(() -> new EntityNotFoundException("No result for the given resultId could be found"));
-        result.setRatedIfNotExceeded(exerciseDateService.getDueDate(result.getParticipation()).orElse(null), submissionDate);
+        result.setRatedIfNotExceeded(ExerciseDateService.getDueDate(result.getParticipation()).orElse(null), submissionDate);
         result.setCompletionDate(ZonedDateTime.now());
-        result = resultRepository.submitResult(result, exercise, exerciseDateService.getDueDate(result.getParticipation()));
+        result = resultRepository.submitResult(result, exercise, ExerciseDateService.getDueDate(result.getParticipation()));
         // Note: we always need to report the result (independent of the assessment due date) over LTI, otherwise it might never become visible in the external system
         ltiNewResultService.onNewResult((StudentParticipation) result.getParticipation());
         return result;

--- a/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ComplaintService.java
@@ -292,6 +292,16 @@ public class ComplaintService {
         }
     }
 
+    /**
+     * Obtains the time when the complaint period starts.
+     * <p>
+     * Assumes the {@link Result#getCompletionDate()} to be present.
+     *
+     * @param exercise The exercise for which complaints can be submitted.
+     * @param studentParticipation The participation for which a complaint should be submitted.
+     * @param result The result which the complaint is about.
+     * @return The time from which submitting a complaint is possible.
+     */
     private static ZonedDateTime getComplaintStartDate(final Exercise exercise, final StudentParticipation studentParticipation, final Result result) {
         final List<ZonedDateTime> possibleComplaintStartDates = new ArrayList<>();
         possibleComplaintStartDates.add(result.getCompletionDate());
@@ -303,8 +313,8 @@ public class ComplaintService {
             possibleComplaintStartDates.add(exercise.getAssessmentDueDate());
         }
 
-        // At least result.getCompletionDate is present, since it was checked earlier
-        return possibleComplaintStartDates.stream().max(Comparator.naturalOrder()).orElseThrow();
+        return possibleComplaintStartDates.stream().max(Comparator.naturalOrder())
+                .orElseThrow(() -> new NoSuchElementException("Expected at least the result completion date to be present."));
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseDateService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseDateService.java
@@ -54,7 +54,7 @@ public class ExerciseDateService {
 
     /**
      * Checks if submissions are no longer possible.
-     *
+     * <p>
      * Checks for exam or course exercise, and if an individual due date is set for the given
      * participation or only a course-wide due date applies.
      * @param participation in a course or exam exercise.
@@ -123,17 +123,14 @@ public class ExerciseDateService {
      * @param participation of a student in an exercise.
      * @return the individual due date, or the exercise due date, or nothing.
      */
-    public Optional<ZonedDateTime> getDueDate(ParticipationInterface participation) {
+    public static Optional<ZonedDateTime> getDueDate(ParticipationInterface participation) {
         final Exercise exercise = participation.getExercise();
 
         if (participation.getIndividualDueDate() != null) {
             return Optional.of(participation.getIndividualDueDate());
         }
-        else if (exercise.getDueDate() != null) {
-            return Optional.of(exercise.getDueDate());
-        }
         else {
-            return Optional.empty();
+            return Optional.ofNullable(exercise.getDueDate());
         }
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ExerciseService.java
@@ -686,7 +686,7 @@ public class ExerciseService {
                     dueDate = Optional.empty();
                 }
                 else {
-                    dueDate = exerciseDateService.getDueDate(result.getParticipation());
+                    dueDate = ExerciseDateService.getDueDate(result.getParticipation());
                 }
                 resultRepository.submitResult(result, exercise, dueDate);
             }

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionExportService.java
@@ -16,9 +16,8 @@ import de.tum.in.www1.artemis.repository.ExerciseRepository;
 @Service
 public class FileUploadSubmissionExportService extends SubmissionExportService {
 
-    public FileUploadSubmissionExportService(ExerciseRepository exerciseRepository, ExerciseDateService exerciseDateService, ZipFileService zipFileService,
-            FileService fileService) {
-        super(exerciseRepository, exerciseDateService, zipFileService, fileService);
+    public FileUploadSubmissionExportService(ExerciseRepository exerciseRepository, ZipFileService zipFileService, FileService fileService) {
+        super(exerciseRepository, zipFileService, fileService);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/FileUploadSubmissionService.java
@@ -67,7 +67,7 @@ public class FileUploadSubmissionService extends SubmissionService {
             throw new ResponseStatusException(HttpStatus.FAILED_DEPENDENCY, "No participation found for " + user.getLogin() + " in exercise " + exercise.getId());
         }
         final var participation = optionalParticipation.get();
-        final var dueDate = exerciseDateService.getDueDate(participation);
+        final var dueDate = ExerciseDateService.getDueDate(participation);
         // Important: for exam exercises, we should NOT check the exercise due date, we only check if for course exercises
         if (dueDate.isPresent() && exerciseDateService.isAfterDueDate(participation) && participation.getInitializationDate().isBefore(dueDate.get())) {
             throw new AccessForbiddenException();

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionExportService.java
@@ -13,8 +13,8 @@ import de.tum.in.www1.artemis.repository.ExerciseRepository;
 @Service
 public class ModelingSubmissionExportService extends SubmissionExportService {
 
-    public ModelingSubmissionExportService(ExerciseRepository exerciseRepository, ExerciseDateService exerciseDateService, ZipFileService zipFileService, FileService fileService) {
-        super(exerciseRepository, exerciseDateService, zipFileService, fileService);
+    public ModelingSubmissionExportService(ExerciseRepository exerciseRepository, ZipFileService zipFileService, FileService fileService) {
+        super(exerciseRepository, zipFileService, fileService);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ModelingSubmissionService.java
@@ -94,7 +94,7 @@ public class ModelingSubmissionService extends SubmissionService {
             throw new ResponseStatusException(HttpStatus.FAILED_DEPENDENCY, "No participation found for " + user.getLogin() + " in exercise " + exercise.getId());
         }
         final var participation = optionalParticipation.get();
-        final var dueDate = exerciseDateService.getDueDate(participation);
+        final var dueDate = ExerciseDateService.getDueDate(participation);
         // Important: for exam exercises, we should NOT check the exercise due date, we only check if for course exercises
         if (dueDate.isPresent() && exerciseDateService.isAfterDueDate(participation) && participation.getInitializationDate().isBefore(dueDate.get())) {
             throw new AccessForbiddenException();

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationLifecycleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationLifecycleService.java
@@ -21,11 +21,8 @@ public class ParticipationLifecycleService {
 
     private final TaskScheduler scheduler;
 
-    private final ExerciseDateService exerciseDateService;
-
-    public ParticipationLifecycleService(@Qualifier("taskScheduler") TaskScheduler scheduler, ExerciseDateService exerciseDateService) {
+    public ParticipationLifecycleService(@Qualifier("taskScheduler") TaskScheduler scheduler) {
         this.scheduler = scheduler;
-        this.exerciseDateService = exerciseDateService;
     }
 
     /**
@@ -63,7 +60,7 @@ public class ParticipationLifecycleService {
 
     private Optional<ZonedDateTime> getDateForLifecycle(Participation participation, ParticipationLifecycle lifecycle) {
         return switch (lifecycle) {
-            case DUE -> exerciseDateService.getDueDate(participation);
+            case DUE -> ExerciseDateService.getDueDate(participation);
             case BUILD_AND_TEST_AFTER_DUE_DATE -> getBuildAndTestAfterDueDate(participation);
         };
     }
@@ -81,7 +78,7 @@ public class ParticipationLifecycleService {
     private Optional<ZonedDateTime> getBuildAndTestAfterDueDate(Participation participation) {
         if (participation.getExercise() instanceof ProgrammingExercise programmingExercise && programmingExercise.getBuildAndTestStudentSubmissionsAfterDueDate() != null) {
             final ZonedDateTime exerciseBuildAndTestAfterDueDate = programmingExercise.getBuildAndTestStudentSubmissionsAfterDueDate();
-            final Optional<ZonedDateTime> dueDate = exerciseDateService.getDueDate(participation);
+            final Optional<ZonedDateTime> dueDate = ExerciseDateService.getDueDate(participation);
 
             if (dueDate.map(date -> date.isAfter(exerciseBuildAndTestAfterDueDate)).orElse(false)) {
                 return dueDate;

--- a/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ParticipationService.java
@@ -63,15 +63,12 @@ public class ParticipationService {
 
     private final TeamScoreRepository teamScoreRepository;
 
-    private final ExerciseDateService exerciseDateService;
-
     public ParticipationService(GitService gitService, Optional<ContinuousIntegrationService> continuousIntegrationService, Optional<VersionControlService> versionControlService,
             ParticipationRepository participationRepository, StudentParticipationRepository studentParticipationRepository,
             ProgrammingExerciseStudentParticipationRepository programmingExerciseStudentParticipationRepository, ProgrammingExerciseRepository programmingExerciseRepository,
             SubmissionRepository submissionRepository, TeamRepository teamRepository, UrlService urlService, ResultService resultService,
             CoverageReportRepository coverageReportRepository, BuildLogStatisticsEntryRepository buildLogStatisticsEntryRepository,
-            ParticipantScoreRepository participantScoreRepository, StudentScoreRepository studentScoreRepository, TeamScoreRepository teamScoreRepository,
-            ExerciseDateService exerciseDateService) {
+            ParticipantScoreRepository participantScoreRepository, StudentScoreRepository studentScoreRepository, TeamScoreRepository teamScoreRepository) {
         this.gitService = gitService;
         this.continuousIntegrationService = continuousIntegrationService;
         this.versionControlService = versionControlService;
@@ -88,7 +85,6 @@ public class ParticipationService {
         this.participantScoreRepository = participantScoreRepository;
         this.studentScoreRepository = studentScoreRepository;
         this.teamScoreRepository = teamScoreRepository;
-        this.exerciseDateService = exerciseDateService;
     }
 
     /**
@@ -397,7 +393,7 @@ public class ParticipationService {
         // and must be handled by the calling method in case it would be necessary
 
         // If a graded participation gets reset after the deadline set the state back to finished. Otherwise, the participation is initialized
-        var dueDate = exerciseDateService.getDueDate(participation);
+        var dueDate = ExerciseDateService.getDueDate(participation);
         if (!participation.isTestRun() && dueDate.isPresent() && ZonedDateTime.now().isAfter(dueDate.get())) {
             participation.setInitializationState(FINISHED);
         }

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionExportService.java
@@ -32,21 +32,18 @@ public abstract class SubmissionExportService {
     @Value("${artemis.submission-export-path}")
     private String submissionExportPath;
 
-    private final static int EXPORTED_SUBMISSIONS_DELETION_DELAY_IN_MINUTES = 30;
+    private static final int EXPORTED_SUBMISSIONS_DELETION_DELAY_IN_MINUTES = 30;
 
     private final Logger log = LoggerFactory.getLogger(SubmissionExportService.class);
 
     private final ExerciseRepository exerciseRepository;
 
-    private final ExerciseDateService exerciseDateService;
-
     private final ZipFileService zipFileService;
 
     private final FileService fileService;
 
-    public SubmissionExportService(ExerciseRepository exerciseRepository, ExerciseDateService exerciseDateService, ZipFileService zipFileService, FileService fileService) {
+    public SubmissionExportService(ExerciseRepository exerciseRepository, ZipFileService zipFileService, FileService fileService) {
         this.exerciseRepository = exerciseRepository;
-        this.exerciseDateService = exerciseDateService;
         this.zipFileService = zipFileService;
         this.fileService = fileService;
     }
@@ -246,7 +243,7 @@ public abstract class SubmissionExportService {
                 continue;
             }
             // filter late submissions
-            boolean isSubmittedBeforeDueDate = exerciseDateService.getDueDate(participation).map(dueDate -> submission.getSubmissionDate().isBefore(dueDate)).orElse(true);
+            boolean isSubmittedBeforeDueDate = ExerciseDateService.getDueDate(participation).map(dueDate -> submission.getSubmissionDate().isBefore(dueDate)).orElse(true);
             if ((enableFilterAfterDueDate && isSubmittedBeforeDueDate) || lateSubmissionFilter == null || submission.getSubmissionDate().isBefore(lateSubmissionFilter)) {
                 if (latestSubmission == null || submission.getSubmissionDate().isAfter(latestSubmission.getSubmissionDate())) {
                     latestSubmission = submission;

--- a/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/SubmissionService.java
@@ -550,7 +550,7 @@ public class SubmissionService {
      * @return true, if the submission date was before the due date or the exercise has no due date.
      */
     private boolean isBeforeDueDate(Submission submission) {
-        return exerciseDateService.getDueDate(submission.getParticipation())
+        return ExerciseDateService.getDueDate(submission.getParticipation())
                 .map(dueDate -> submission.getSubmissionDate() != null && submission.getSubmissionDate().isBefore(dueDate)).orElse(true);
     }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextAssessmentService.java
@@ -27,10 +27,10 @@ public class TextAssessmentService extends AssessmentService {
     public TextAssessmentService(UserRepository userRepository, ComplaintResponseService complaintResponseService, ComplaintRepository complaintRepository,
             FeedbackRepository feedbackRepository, ResultRepository resultRepository, StudentParticipationRepository studentParticipationRepository, ResultService resultService,
             SubmissionRepository submissionRepository, TextBlockService textBlockService, Optional<AutomaticTextFeedbackService> automaticTextFeedbackService,
-            ExamDateService examDateService, ExerciseDateService exerciseDateService, FeedbackConflictRepository feedbackConflictRepository,
-            GradingCriterionRepository gradingCriterionRepository, SubmissionService submissionService, LtiNewResultService ltiNewResultService) {
+            ExamDateService examDateService, FeedbackConflictRepository feedbackConflictRepository, GradingCriterionRepository gradingCriterionRepository,
+            SubmissionService submissionService, LtiNewResultService ltiNewResultService) {
         super(complaintResponseService, complaintRepository, feedbackRepository, resultRepository, studentParticipationRepository, resultService, submissionService,
-                submissionRepository, examDateService, exerciseDateService, gradingCriterionRepository, userRepository, ltiNewResultService);
+                submissionRepository, examDateService, gradingCriterionRepository, userRepository, ltiNewResultService);
         this.textBlockService = textBlockService;
         this.automaticTextFeedbackService = automaticTextFeedbackService;
         this.feedbackConflictRepository = feedbackConflictRepository;

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionExportService.java
@@ -13,8 +13,8 @@ import de.tum.in.www1.artemis.repository.ExerciseRepository;
 @Service
 public class TextSubmissionExportService extends SubmissionExportService {
 
-    public TextSubmissionExportService(ExerciseRepository exerciseRepository, ExerciseDateService exerciseDateService, ZipFileService zipFileService, FileService fileService) {
-        super(exerciseRepository, exerciseDateService, zipFileService, fileService);
+    public TextSubmissionExportService(ExerciseRepository exerciseRepository, ZipFileService zipFileService, FileService fileService) {
+        super(exerciseRepository, zipFileService, fileService);
     }
 
     @Override

--- a/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/TextSubmissionService.java
@@ -61,7 +61,7 @@ public class TextSubmissionService extends SubmissionService {
             throw new ResponseStatusException(HttpStatus.FAILED_DEPENDENCY, "No participation found for " + user.getLogin() + " in exercise " + exercise.getId());
         }
         final var participation = optionalParticipation.get();
-        final var dueDate = exerciseDateService.getDueDate(participation);
+        final var dueDate = ExerciseDateService.getDueDate(participation);
         // Important: for exam exercises, we should NOT check the exercise due date, we only check if for course exercises
         if (dueDate.isPresent() && exerciseDateService.isAfterDueDate(participation) && participation.getInitializationDate().isBefore(dueDate.get())) {
             throw new AccessForbiddenException();

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingAssessmentService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingAssessmentService.java
@@ -14,10 +14,10 @@ public class ProgrammingAssessmentService extends AssessmentService {
 
     public ProgrammingAssessmentService(ComplaintResponseService complaintResponseService, ComplaintRepository complaintRepository, FeedbackRepository feedbackRepository,
             ResultRepository resultRepository, StudentParticipationRepository studentParticipationRepository, ResultService resultService, SubmissionService submissionService,
-            SubmissionRepository submissionRepository, ExamDateService examDateService, ExerciseDateService exerciseDateService, UserRepository userRepository,
-            GradingCriterionRepository gradingCriterionRepository, LtiNewResultService ltiNewResultService) {
+            SubmissionRepository submissionRepository, ExamDateService examDateService, UserRepository userRepository, GradingCriterionRepository gradingCriterionRepository,
+            LtiNewResultService ltiNewResultService) {
         super(complaintResponseService, complaintRepository, feedbackRepository, resultRepository, studentParticipationRepository, resultService, submissionService,
-                submissionRepository, examDateService, exerciseDateService, gradingCriterionRepository, userRepository, ltiNewResultService);
+                submissionRepository, examDateService, gradingCriterionRepository, userRepository, ltiNewResultService);
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseExportService.java
@@ -72,8 +72,6 @@ public class ProgrammingExerciseExportService {
 
     private final AuxiliaryRepositoryRepository auxiliaryRepositoryRepository;
 
-    private final ExerciseDateService exerciseDateService;
-
     private final ObjectMapper objectMapper;
 
     private final FileService fileService;
@@ -87,12 +85,11 @@ public class ProgrammingExerciseExportService {
     public static final String EXPORTED_EXERCISE_PROBLEM_STATEMENT_FILE_PREFIX = "Problem-Statement";
 
     public ProgrammingExerciseExportService(ProgrammingExerciseRepository programmingExerciseRepository, StudentParticipationRepository studentParticipationRepository,
-            ExerciseDateService exerciseDateService, FileService fileService, GitService gitService, ZipFileService zipFileService,
-            MappingJackson2HttpMessageConverter springMvcJacksonConverter, AuxiliaryRepositoryRepository auxiliaryRepositoryRepository) {
+            FileService fileService, GitService gitService, ZipFileService zipFileService, MappingJackson2HttpMessageConverter springMvcJacksonConverter,
+            AuxiliaryRepositoryRepository auxiliaryRepositoryRepository) {
         this.programmingExerciseRepository = programmingExerciseRepository;
         this.studentParticipationRepository = studentParticipationRepository;
         this.objectMapper = springMvcJacksonConverter.getObjectMapper();
-        this.exerciseDateService = exerciseDateService;
         this.fileService = fileService;
         this.gitService = gitService;
         this.zipFileService = zipFileService;
@@ -601,7 +598,7 @@ public class ProgrammingExerciseExportService {
         log.debug("Filter late submissions for participation {}", participation.toString());
         final Optional<ZonedDateTime> latestAllowedDate;
         if (repositoryExportOptions.isFilterLateSubmissionsIndividualDueDate()) {
-            latestAllowedDate = exerciseDateService.getDueDate(participation);
+            latestAllowedDate = ExerciseDateService.getDueDate(participation);
         }
         else {
             latestAllowedDate = Optional.of(repositoryExportOptions.getFilterLateSubmissionsDate());

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseGradingService.java
@@ -157,7 +157,7 @@ public class ProgrammingExerciseGradingService {
 
             // Note: we only set one side of the relationship because we don't know yet whether the result will actually be saved
             newResult.setSubmission(latestSubmission);
-            newResult.setRatedIfNotExceeded(exerciseDateService.getDueDate(participation).orElse(null), latestSubmission, (Participation) participation);
+            newResult.setRatedIfNotExceeded(ExerciseDateService.getDueDate(participation).orElse(null), latestSubmission, (Participation) participation);
             // NOTE: the result is not saved yet, but is connected to the submission, the submission is not completely saved yet
         }
         catch (ContinuousIntegrationException ex) {

--- a/src/test/java/de/tum/in/www1/artemis/service/AssessmentServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/AssessmentServiceTest.java
@@ -47,9 +47,6 @@ class AssessmentServiceTest extends AbstractSpringIntegrationBambooBitbucketJira
     @Autowired
     private AssessmentService assessmentService;
 
-    @Autowired
-    private ExerciseDateService exerciseDateService;
-
     private final ZonedDateTime pastTimestamp = ZonedDateTime.now().minusDays(5);
 
     private final ZonedDateTime futureTimestamp = ZonedDateTime.now().plusDays(5);
@@ -163,7 +160,7 @@ class AssessmentServiceTest extends AbstractSpringIntegrationBambooBitbucketJira
         result.setParticipation(submissionWithoutResult.getParticipation());
         submissionWithoutResult.addResult(result);
 
-        resultRepository.submitResult(result, exercise, exerciseDateService.getDueDate(result.getParticipation()));
+        resultRepository.submitResult(result, exercise, ExerciseDateService.getDueDate(result.getParticipation()));
         resultRepository.save(result);
 
         assertThat(result.getScore()).isEqualTo(85.7); // 85.7 = 6/7 * 100
@@ -185,7 +182,7 @@ class AssessmentServiceTest extends AbstractSpringIntegrationBambooBitbucketJira
         result.setParticipation(submissionWithoutResult.getParticipation());
         submissionWithoutResult.addResult(result);
 
-        resultRepository.submitResult(result, exercise, exerciseDateService.getDueDate(result.getParticipation()));
+        resultRepository.submitResult(result, exercise, ExerciseDateService.getDueDate(result.getParticipation()));
         resultRepository.save(result);
 
         assertThat(result.getScore()).isEqualTo(85.7); // 85.7 = 6/7 * 100
@@ -207,7 +204,7 @@ class AssessmentServiceTest extends AbstractSpringIntegrationBambooBitbucketJira
         result.setParticipation(submissionWithoutResult.getParticipation());
         submissionWithoutResult.addResult(result);
 
-        resultRepository.submitResult(result, exercise, exerciseDateService.getDueDate(result.getParticipation()));
+        resultRepository.submitResult(result, exercise, ExerciseDateService.getDueDate(result.getParticipation()));
         resultRepository.save(result);
 
         assertThat(result.getScore()).isEqualTo(85.7); // 85.7 = 6/7 * 100
@@ -246,7 +243,7 @@ class AssessmentServiceTest extends AbstractSpringIntegrationBambooBitbucketJira
         }
         exercise = exerciseRepository.save(exercise);
 
-        resultRepository.submitResult(result, exercise, exerciseDateService.getDueDate(result.getParticipation()));
+        resultRepository.submitResult(result, exercise, ExerciseDateService.getDueDate(result.getParticipation()));
         resultRepository.save(result);
 
         assertThat(result.isRated()).isTrue();
@@ -268,7 +265,7 @@ class AssessmentServiceTest extends AbstractSpringIntegrationBambooBitbucketJira
         result.setParticipation(submissionWithoutResult.getParticipation());
         submissionWithoutResult.addResult(result);
 
-        resultRepository.submitResult(result, exercise, exerciseDateService.getDueDate(result.getParticipation()));
+        resultRepository.submitResult(result, exercise, ExerciseDateService.getDueDate(result.getParticipation()));
         resultRepository.save(result);
 
         assertThat(result.isRated()).isFalse();
@@ -290,7 +287,7 @@ class AssessmentServiceTest extends AbstractSpringIntegrationBambooBitbucketJira
         result.setParticipation(submissionWithoutResult.getParticipation());
         submissionWithoutResult.addResult(result);
 
-        resultRepository.submitResult(result, exercise, exerciseDateService.getDueDate(result.getParticipation()));
+        resultRepository.submitResult(result, exercise, ExerciseDateService.getDueDate(result.getParticipation()));
         resultRepository.save(result);
 
         assertThat(result.isRated()).isTrue();

--- a/src/test/java/de/tum/in/www1/artemis/service/ExerciseDateServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ExerciseDateServiceTest.java
@@ -95,7 +95,7 @@ class ExerciseDateServiceTest extends AbstractSpringIntegrationBambooBitbucketJi
         exercise = exerciseRepository.save(exercise);
 
         final var participation = exercise.getStudentParticipations().stream().findAny().get();
-        assertThat(exerciseDateService.getDueDate(participation).get()).isEqualToIgnoringNanos(now.plusHours(4));
+        assertThat(ExerciseDateService.getDueDate(participation).get()).isEqualToIgnoringNanos(now.plusHours(4));
     }
 
     @Test
@@ -108,7 +108,7 @@ class ExerciseDateServiceTest extends AbstractSpringIntegrationBambooBitbucketJi
         participation.setIndividualDueDate(now.plusHours(20));
         participation = participationRepository.save(participation);
 
-        assertThat(exerciseDateService.getDueDate(participation).get()).isEqualToIgnoringNanos(now.plusHours(20));
+        assertThat(ExerciseDateService.getDueDate(participation).get()).isEqualToIgnoringNanos(now.plusHours(20));
     }
 
     @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
#### Changes affecting Programming Exercises
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [ ] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
Makes the instance method `ExerciseDateService::getDueDate` static to reduce dependencies on that service and to make it usable from static contexts in other services. This reduces code duplication (as noticed in #5833).

### Steps for Testing

1. Code review should be enough, no logic has been changed.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
unchanged
