### PR TITLE
`Programming exercises`: Fix an issue with ordered tasks in problem statements on Safari

### DIFF
--- a/src/main/webapp/app/exercises/programming/shared/instructions-render/extensions/programming-exercise-task.extension.ts
+++ b/src/main/webapp/app/exercises/programming/shared/instructions-render/extensions/programming-exercise-task.extension.ts
@@ -80,8 +80,7 @@ export class ProgrammingExerciseTaskExtensionWrapper implements ArtemisShowdownE
 
                 const domElem = (componentRef.hostView as EmbeddedViewRef<any>).rootNodes[0] as HTMLElement;
                 const taskHtmlContainer = taskHtmlContainers[i];
-                taskHtmlContainer.innerHTML = '';
-                taskHtmlContainer.append(domElem);
+                taskHtmlContainer.replaceChildren(domElem);
             }
         });
     };
@@ -96,13 +95,10 @@ export class ProgrammingExerciseTaskExtensionWrapper implements ArtemisShowdownE
         const extension: ShowdownExtension = {
             type: 'lang',
             filter: (text: string) => {
-                const idPlaceholder = '%idPlaceholder%';
                 // E.g. [task][Implement BubbleSort](testBubbleSort)
                 const taskRegex = /\[task\]\[.*\]\(.*\)({.*})?/g;
                 // E.g. Implement BubbleSort, testBubbleSort
                 const innerTaskRegex = /\[task\]\[(.*)\]\((.*)\)({(.*)})?/;
-                // Without class="d-flex" the injected components height would be 0.
-                const taskContainer = `<div class="pe-task-${idPlaceholder} d-flex"></div>`;
                 const tasks = text.match(taskRegex) || [];
                 const testsForTask: TaskArray = tasks
                     .map((task) => {
@@ -132,7 +128,9 @@ export class ProgrammingExerciseTaskExtensionWrapper implements ArtemisShowdownE
                 return testsForTask.reduce(
                     (acc: string, { completeString: task, id }): string =>
                         // Insert anchor divs into the text so that injectable elements can be inserted into them.
-                        acc.replace(new RegExp(escapeStringForUseInRegex(task), 'g'), taskContainer.replace(idPlaceholder, id.toString())),
+                        // Without class="d-flex" the injected components height would be 0.
+                        // Added zero-width space as content so the div actually consumes a line to prevent a <ol> display bug in Safari
+                        acc.replace(new RegExp(escapeStringForUseInRegex(task), 'g'), `<div class="pe-task-${id.toString()} d-flex">&#8203;</div>`),
                     text,
                 );
             },


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There seems to be a bug in Safari that displays the marker of an ordered list in the wrong position if an element is injected into the list item. I created a minimal reproduction example: https://jsfiddle.net/L7ug9hkt/
This does not happen in Chrome or Firefox.

This affects programming exercise task lists as the status indicators are injected later:
![grafik](https://user-images.githubusercontent.com/23171488/201677971-b7be6d14-6987-4a98-ac91-1cd71dc1ba1c.png)


### Description
<!-- Describe your changes in detail -->

Added a zero-width space as initial content to the ``div`` anchor where the status gets injected so it actually consumes a line of space. Then, we only replace that space with the actual status indicator, preventing the incorrect placement of the marker.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Programming Exercise with a Task List (Default Bubble Sort)
- 1 User on Safari (macOS)

1. Log in to Artemis
2. Navigate to the exercise as a student
3. Ensure that Safari displays the ordered list numbers in the correct location (unlike the image above)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2