### PR TITLE
`General`: Fix an issue when hovering over tooltips

### DIFF
--- a/src/main/webapp/app/admin/user-management/user-management.component.html
+++ b/src/main/webapp/app/admin/user-management/user-management.component.html
@@ -226,7 +226,7 @@
             <div class="row user-management-border-bottom">
                 <div class="col d-flex flex-row pb-1">
                     <h5 class="my-0">{{ 'artemisApp.userManagement.filter.authority.title' | artemisTranslate: { num: this.filters.authorityFilter.size } }}</h5>
-                    <jhi-help-icon class="ps-1" placement="top" text="artemisApp.userManagement.filter.authority.tooltip"></jhi-help-icon>
+                    <jhi-help-icon class="ps-1" text="artemisApp.userManagement.filter.authority.tooltip"></jhi-help-icon>
                 </div>
             </div>
             <div class="row user-management-background-accent">
@@ -256,7 +256,7 @@
                                 <label for="emptyRoles" class="form-check-label ps-1">
                                     {{ 'artemisApp.userManagement.filter.authority.without' | artemisTranslate }}
                                 </label>
-                                <jhi-help-icon class="ps-1" placement="top" text="artemisApp.userManagement.filter.authority.withoutTooltip"></jhi-help-icon>
+                                <jhi-help-icon class="ps-1" text="artemisApp.userManagement.filter.authority.withoutTooltip"></jhi-help-icon>
                             </div>
                             <div class="form-check col-3 d-flex justify-content-center">
                                 <input
@@ -294,7 +294,7 @@
             <div class="row row user-management-border-bottom">
                 <div class="col d-flex flex-row pt-3 pb-1">
                     <h5 class="my-0">{{ 'artemisApp.userManagement.filter.origin.title' | artemisTranslate: { num: this.filters.originFilter.size } }}</h5>
-                    <jhi-help-icon class="ps-1" placement="top" text="artemisApp.userManagement.filter.origin.tooltip"></jhi-help-icon>
+                    <jhi-help-icon class="ps-1" text="artemisApp.userManagement.filter.origin.tooltip"></jhi-help-icon>
                 </div>
             </div>
             <div class="row user-management-background-accent">
@@ -318,7 +318,7 @@
             <div class="row row user-management-border-bottom">
                 <div class="col d-flex flex-row pt-3 pb-1">
                     <h5 class="my-0">{{ 'artemisApp.userManagement.filter.registrationNumber.title' | artemisTranslate: { num: this.filters.registrationNumberFilter.size } }}</h5>
-                    <jhi-help-icon class="ps-1" placement="top" text="artemisApp.userManagement.filter.registrationNumber.tooltip"></jhi-help-icon>
+                    <jhi-help-icon class="ps-1" text="artemisApp.userManagement.filter.registrationNumber.tooltip"></jhi-help-icon>
                 </div>
             </div>
             <div class="row user-management-background-accent">
@@ -355,7 +355,7 @@
             <div class="row user-management-border-bottom">
                 <div class="col d-flex flex-row pt-3 pb-1">
                     <h5 class="my-0">{{ 'artemisApp.userManagement.filter.status.title' | artemisTranslate: { num: this.filters.statusFilter.size } }}</h5>
-                    <jhi-help-icon class="ps-1" placement="top" text="artemisApp.userManagement.filter.status.tooltip"></jhi-help-icon>
+                    <jhi-help-icon class="ps-1" text="artemisApp.userManagement.filter.status.tooltip"></jhi-help-icon>
                 </div>
             </div>
             <div class="row user-management-background-accent">
@@ -379,7 +379,7 @@
             <div class="row user-management-border-bottom">
                 <div class="col d-flex flex-row pt-3 pb-1">
                     <h5 class="my-0">{{ 'artemisApp.userManagement.filter.course.title' | artemisTranslate: { num: this.filters.courseFilter.size } }}</h5>
-                    <jhi-help-icon class="ps-1" placement="top" text="artemisApp.userManagement.filter.course.tooltip"></jhi-help-icon>
+                    <jhi-help-icon class="ps-1" text="artemisApp.userManagement.filter.course.tooltip"></jhi-help-icon>
                 </div>
             </div>
             <div class="row user-management-background-accent">
@@ -409,7 +409,7 @@
                                 <label for="selectEmptyCourses" class="form-check-label ps-1">
                                     {{ 'artemisApp.userManagement.filter.course.without' | artemisTranslate }}
                                 </label>
-                                <jhi-help-icon class="ps-1" placement="top" text="artemisApp.userManagement.filter.course.withoutTooltip"></jhi-help-icon>
+                                <jhi-help-icon class="ps-1" text="artemisApp.userManagement.filter.course.withoutTooltip"></jhi-help-icon>
                             </div>
                             <div class="form-check col-3 d-flex justify-content-center">
                                 <input

--- a/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
+++ b/src/main/webapp/app/assessment/assessment-detail/assessment-detail.component.html
@@ -26,12 +26,7 @@
             <div class="col-4 assessment-label">
                 <label class="pe-0" style="float: left" jhiTranslate="artemisApp.assessment.detail.feedback"></label>
                 <div *ngIf="assessment.gradingInstruction">
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary ps-1"
-                        [ngbTooltip]="'artemisApp.assessment.feedbackHint' | artemisTranslate"
-                        container="body"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary ps-1" [ngbTooltip]="'artemisApp.assessment.feedbackHint' | artemisTranslate"></fa-icon>
                 </div>
             </div>
             <div class="col p-0">

--- a/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
+++ b/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
@@ -28,7 +28,7 @@
                     <td>
                         <fa-icon
                             [icon]="getIcon(submission.participation!.exercise!.type)"
-                            placement="right"
+                            placement="right auto"
                             [ngbTooltip]="getIconTooltip(submission.participation!.exercise!.type) | artemisTranslate"
                         ></fa-icon>
                     </td>

--- a/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
+++ b/src/main/webapp/app/assessment/assessment-locks/assessment-locks.component.html
@@ -30,7 +30,6 @@
                             [icon]="getIcon(submission.participation!.exercise!.type)"
                             placement="right"
                             [ngbTooltip]="getIconTooltip(submission.participation!.exercise!.type) | artemisTranslate"
-                            container="body"
                         ></fa-icon>
                     </td>
                     <td>{{ submission.participation!.exercise!.title || '' }}</td>

--- a/src/main/webapp/app/assessment/assessment-warning/assessment-warning.component.ts
+++ b/src/main/webapp/app/assessment/assessment-warning/assessment-warning.component.ts
@@ -14,7 +14,7 @@ import { Submission } from 'app/entities/submission.model';
     template: `
         <h6>
             <div class="card-header" *ngIf="showWarning">
-                <fa-icon [icon]="faExclamationTriangle" size="2x" class="text-warning" placement="bottom"></fa-icon>
+                <fa-icon [icon]="faExclamationTriangle" size="2x" class="text-warning" placement="bottom auto"></fa-icon>
                 <span *ngIf="isBeforeExerciseDueDate">{{ 'artemisApp.assessment.dashboard.warning' | artemisTranslate }}</span>
                 <span *ngIf="!isBeforeExerciseDueDate">{{ 'artemisApp.assessment.dashboard.warningIndividual' | artemisTranslate }}</span>
             </div>

--- a/src/main/webapp/app/assessment/structured-grading-instructions-assessment-layout/structured-grading-instructions-assessment-layout.component.html
+++ b/src/main/webapp/app/assessment/structured-grading-instructions-assessment-layout/structured-grading-instructions-assessment-layout.component.html
@@ -32,7 +32,7 @@
                         <td class="td-usage-count">
                             <span *ngIf="instruction!.usageCount && instruction!.usageCount !== 0; else usageCountInfinity">{{ instruction.usageCount }}</span>
                             <ng-template #usageCountInfinity>&#8734;</ng-template>
-                            <jhi-help-icon placement="top" text="artemisApp.exercise.usageCountHint"></jhi-help-icon>
+                            <jhi-help-icon text="artemisApp.exercise.usageCountHint"></jhi-help-icon>
                         </td>
                     </tr>
                 </tbody>

--- a/src/main/webapp/app/core/core.module.ts
+++ b/src/main/webapp/app/core/core.module.ts
@@ -6,7 +6,7 @@ import { AuthInterceptor } from 'app/core/interceptor/auth.interceptor';
 import { AuthExpiredInterceptor } from 'app/core/interceptor/auth-expired.interceptor';
 import { ErrorHandlerInterceptor } from 'app/core/interceptor/errorhandler.interceptor';
 import { NotificationInterceptor } from 'app/core/interceptor/notification.interceptor';
-import { NgbDateAdapter, NgbDatepickerConfig } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDateAdapter, NgbDatepickerConfig, NgbTooltipConfig } from '@ng-bootstrap/ng-bootstrap';
 import { NgxWebstorageModule, SessionStorageService } from 'ngx-webstorage';
 import locale from '@angular/common/locales/en';
 import { MissingTranslationHandler, TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -108,11 +108,18 @@ import { Router } from '@angular/router';
     ],
 })
 export class ArtemisCoreModule {
-    constructor(dpConfig: NgbDatepickerConfig, translateService: TranslateService, languageHelper: JhiLanguageHelper, sessionStorageService: SessionStorageService) {
+    constructor(
+        dpConfig: NgbDatepickerConfig,
+        tooltipConfig: NgbTooltipConfig,
+        translateService: TranslateService,
+        languageHelper: JhiLanguageHelper,
+        sessionStorageService: SessionStorageService,
+    ) {
         registerLocaleData(locale);
         dpConfig.minDate = { year: dayjs().subtract(100, 'year').year(), month: 1, day: 1 };
         translateService.setDefaultLang('en');
         const languageKey = sessionStorageService.retrieve('locale') || languageHelper.determinePreferredLanguage();
         translateService.use(languageKey);
+        tooltipConfig.container = 'body';
     }
 }

--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
@@ -114,7 +114,7 @@
                 <tbody>
                     <tr *ngFor="let exercise of currentlyShownExercises">
                         <td>
-                            <fa-icon [icon]="getIcon(exercise.type)" placement="right" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate"></fa-icon>
+                            <fa-icon [icon]="getIcon(exercise.type)" placement="right auto" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate"></fa-icon>
                         </td>
                         <td>
                             <span>{{ exercise.title }}</span>
@@ -141,12 +141,12 @@
                             <span *ngIf="exercise.averageRating === undefined"> n.a. </span>
                         </td>
                         <td *ngIf="!isExamMode">
-                            <span placement="right" [hidden]="!exercise.dueDate" ngbTooltip="{{ exercise.dueDate | artemisDate }}">
+                            <span placement="right auto" [hidden]="!exercise.dueDate" ngbTooltip="{{ exercise.dueDate | artemisDate }}">
                                 {{ exercise.dueDate | artemisTimeAgo }}
                             </span>
                         </td>
                         <td *ngIf="!isExamMode">
-                            <span placement="right" [hidden]="!exercise.assessmentDueDate" ngbTooltip="{{ exercise.assessmentDueDate | artemisDate }}">
+                            <span placement="right auto" [hidden]="!exercise.assessmentDueDate" ngbTooltip="{{ exercise.assessmentDueDate | artemisDate }}">
                                 {{ exercise.assessmentDueDate | artemisTimeAgo }}
                             </span>
                         </td>

--- a/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
+++ b/src/main/webapp/app/course/dashboards/assessment-dashboard/assessment-dashboard.component.html
@@ -114,7 +114,7 @@
                 <tbody>
                     <tr *ngFor="let exercise of currentlyShownExercises">
                         <td>
-                            <fa-icon [icon]="getIcon(exercise.type)" placement="right" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate" container="body"></fa-icon>
+                            <fa-icon [icon]="getIcon(exercise.type)" placement="right" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate"></fa-icon>
                         </td>
                         <td>
                             <span>{{ exercise.title }}</span>

--- a/src/main/webapp/app/course/learning-goals/learning-goals-popover/learning-goals-popover.component.html
+++ b/src/main/webapp/app/course/learning-goals/learning-goals-popover/learning-goals-popover.component.html
@@ -14,6 +14,6 @@
         <a [routerLink]="navigationArray">{{ 'artemisApp.learningGoal.learningGoalPopover.noLearningGoals' | artemisTranslate }}</a>
     </ng-template>
 </ng-template>
-<button type="button" class="btn btn-sm btn-primary learning-goal-button" [ngbPopover]="popContent" [popoverTitle]="popTitle" container="body" popoverClass="learning-goal-popover">
+<button type="button" class="btn btn-sm btn-primary learning-goal-button" [ngbPopover]="popContent" [popoverTitle]="popTitle" popoverClass="learning-goal-popover">
     <fa-icon [icon]="faFlag" [fixedWidth]="true"></fa-icon>
 </button>

--- a/src/main/webapp/app/course/manage/course-update.component.html
+++ b/src/main/webapp/app/course/manage/course-update.component.html
@@ -131,12 +131,7 @@
                         (change)="changeTestCourseEnabled()"
                     />
                     <label class="form-control-label" jhiTranslate="artemisApp.course.testCourse.title" for="field_testCourse"></label>
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.testCourse.description' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.course.testCourse.description' | artemisTranslate }}"></fa-icon>
                 </div>
                 <div class="form-group">
                     <label for="semester" jhiTranslate="artemisApp.course.semester"></label>
@@ -146,12 +141,7 @@
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" for="field_maxPoints" jhiTranslate="artemisApp.course.maxPoints.title"> Maximum number of points for course </label>
-                    <fa-icon
-                        [icon]="faExclamationTriangle"
-                        class="text-warning"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.maxPoints.warning' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faExclamationTriangle" class="text-warning" ngbTooltip="{{ 'artemisApp.course.maxPoints.warning' | artemisTranslate }}"></fa-icon>
                     <input type="number" class="form-control" name="maxPoints" id="field_maxPoints" min="1" formControlName="maxPoints" />
                 </div>
                 <div class="form-group">
@@ -184,7 +174,6 @@
                         <fa-icon
                             [icon]="faQuestionCircle"
                             class="text-secondary"
-                            placement="top"
                             ngbTooltip="{{ 'artemisApp.course.customizeGroupNames.description' | artemisTranslate }}"
                         ></fa-icon>
                     </div>
@@ -227,59 +216,34 @@
                         formControlName="complaintsEnabled"
                     />
                     <label class="form-control-label" jhiTranslate="artemisApp.course.complaintsEnabled.title" for="field_maxComplaintSettingEnabled">Enable Complaints</label>
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.complaintsEnabled.description' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.course.complaintsEnabled.description' | artemisTranslate }}"></fa-icon>
                 </div>
                 <div class="form-group" *ngIf="complaintsEnabled">
                     <label class="form-control-label" jhiTranslate="artemisApp.course.maxComplaints.title" for="field_maxComplaints">
                         Maximum amount of complaints per student
                     </label>
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.maxComplaints.description' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.course.maxComplaints.description' | artemisTranslate }}"></fa-icon>
                     <input required type="number" class="form-control" name="maxComplaints" id="field_maxComplaints" formControlName="maxComplaints" />
                 </div>
                 <div class="form-group" *ngIf="complaintsEnabled">
                     <label class="form-control-label" jhiTranslate="artemisApp.course.maxTeamComplaints.title" for="field_maxTeamComplaints"
                         >Maximum amount of complaints per team</label
                     >
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.maxTeamComplaints.description' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.course.maxTeamComplaints.description' | artemisTranslate }}"></fa-icon>
                     <input required type="number" class="form-control" name="maxTeamComplaints" id="field_maxTeamComplaints" formControlName="maxTeamComplaints" />
                 </div>
                 <div class="form-group" *ngIf="complaintsEnabled">
                     <label class="form-control-label" jhiTranslate="artemisApp.course.maxComplaintTimeDays.title" for="field_maxComplaintTimeDays">
                         Deadline for complaints in days after result date
                     </label>
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.maxComplaintTimeDays.description' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.course.maxComplaintTimeDays.description' | artemisTranslate }}"></fa-icon>
                     <input required type="number" class="form-control" name="maxComplaintTimeDays" id="field_maxComplaintTimeDays" formControlName="maxComplaintTimeDays" />
                 </div>
                 <div class="form-group" *ngIf="complaintsEnabled">
                     <label class="form-control-label" jhiTranslate="artemisApp.course.maxComplaintTextLimit.title" for="field_maxComplaintTextLimit">
                         Maximum complaint text limit
                     </label>
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.maxComplaintTextLimit.description' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.course.maxComplaintTextLimit.description' | artemisTranslate }}"></fa-icon>
                     <input required type="number" class="form-control" name="maxComplaintTextLimit" id="field_maxComplaintTextLimit" formControlName="maxComplaintTextLimit" />
                 </div>
                 <div class="form-group" *ngIf="complaintsEnabled">
@@ -289,7 +253,6 @@
                     <fa-icon
                         [icon]="faQuestionCircle"
                         class="text-secondary"
-                        placement="top"
                         ngbTooltip="{{ 'artemisApp.course.maxComplaintResponseTextLimit.description' | artemisTranslate }}"
                     ></fa-icon>
                     <input
@@ -317,7 +280,6 @@
                     <fa-icon
                         [icon]="faQuestionCircle"
                         class="text-secondary"
-                        placement="top"
                         ngbTooltip="{{ 'artemisApp.course.requestMoreFeedbackEnabled.description' | artemisTranslate }}"
                     ></fa-icon>
                 </div>
@@ -328,7 +290,6 @@
                     <fa-icon
                         [icon]="faQuestionCircle"
                         class="text-secondary"
-                        placement="top"
                         ngbTooltip="{{ 'artemisApp.course.maxRequestMoreFeedbackTimeDays.description' | artemisTranslate }}"
                     ></fa-icon>
                     <input
@@ -343,12 +304,7 @@
                 <div class="form-check">
                     <input type="checkbox" class="form-check-input" name="postsEnabled" id="field_postsEnabled" formControlName="postsEnabled" />
                     <label class="form-control-label" jhiTranslate="artemisApp.course.postsEnabled.title" for="field_postsEnabled">Enable Questions and Answers</label>
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.postsEnabled.description' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.course.postsEnabled.description' | artemisTranslate }}"></fa-icon>
                 </div>
                 <div class="form-check" *ngIf="!this.course.registrationEnabled">
                     <input
@@ -361,12 +317,7 @@
                         (change)="this.changeOnlineCourse()"
                     />
                     <label class="form-control-label" jhiTranslate="artemisApp.course.onlineCourse.title" for="field_onlineCourse">Online Course</label>
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.onlineCourse.description' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.course.onlineCourse.description' | artemisTranslate }}"></fa-icon>
                 </div>
 
                 <div *ngIf="isOnlineCourse()">
@@ -430,12 +381,7 @@
                         (change)="this.changeRegistrationEnabled()"
                     />
                     <label class="form-control-label" jhiTranslate="artemisApp.course.registrationEnabled.title" for="field_registrationEnabled">Registration Enabled</label>
-                    <fa-icon
-                        [icon]="faQuestionCircle"
-                        class="text-secondary"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.course.registrationEnabled.description' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.course.registrationEnabled.description' | artemisTranslate }}"></fa-icon>
                 </div>
                 <div class="form-group" id="field_registrationConfirmationMessage" *ngIf="course.registrationEnabled">
                     <label class="form-control-label" jhiTranslate="artemisApp.course.registrationConfirmationMessage" for="field_registrationConfirmationMessage"
@@ -462,7 +408,6 @@
                     <fa-icon
                         [icon]="faQuestionCircle"
                         class="text-secondary"
-                        placement="top"
                         ngbTooltip="{{ 'artemisApp.course.presentationScoreEnabled.description' | artemisTranslate }}"
                     ></fa-icon>
                 </div>
@@ -475,7 +420,7 @@
                 <button type="button" id="cancel-save" class="btn btn-secondary" (click)="previousState()">
                     <fa-icon [icon]="faBan"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
                 </button>
-                <span *ngIf="courseForm.invalid; else saveButtonTpl" data-toggle="tooltip" title="Please fill in all required fields." placement="top">
+                <span *ngIf="courseForm.invalid; else saveButtonTpl" data-toggle="tooltip" title="Please fill in all required fields.">
                     <ng-container *ngTemplateOutlet="saveButtonTpl"></ng-container>
                 </span>
                 <ng-template #saveButtonTpl>

--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
@@ -5,13 +5,13 @@
                 <a class="stretched-link" [routerLink]="['/course-management', course.id, details.type + '-exercises', details.id]"></a>
                 <div class="row-flex exercise-details-container">
                     <div class="ms-2 me-1 exercise-details-item" *ngIf="hasLeftoverAssessments">
-                        <fa-icon [icon]="faExclamationTriangle" class="text-warning" placement="right" [ngbTooltip]="iconTooltip | artemisTranslate"></fa-icon>
+                        <fa-icon [icon]="faExclamationTriangle" class="text-warning" placement="right auto" [ngbTooltip]="iconTooltip | artemisTranslate"></fa-icon>
                     </div>
                     <div class="ms-2 exercise-details-item" *ngIf="details.teamMode">
-                        <fa-icon [icon]="faUsers" placement="right" [ngbTooltip]="'artemisApp.exercise.isTeamExercise' | artemisTranslate"></fa-icon>
+                        <fa-icon [icon]="faUsers" placement="right auto" [ngbTooltip]="'artemisApp.exercise.isTeamExercise' | artemisTranslate"></fa-icon>
                     </div>
                     <div class="ms-2 exercise-details-item">
-                        <fa-icon [icon]="icon" placement="right" [ngbTooltip]="iconTooltip | artemisTranslate"></fa-icon>
+                        <fa-icon [icon]="icon" placement="right auto" [ngbTooltip]="iconTooltip | artemisTranslate"></fa-icon>
                     </div>
                     <div class="item-title-container">
                         <span class="item-title">{{ details.title }}</span>

--- a/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
+++ b/src/main/webapp/app/course/manage/overview/course-management-exercise-row.component.html
@@ -5,13 +5,13 @@
                 <a class="stretched-link" [routerLink]="['/course-management', course.id, details.type + '-exercises', details.id]"></a>
                 <div class="row-flex exercise-details-container">
                     <div class="ms-2 me-1 exercise-details-item" *ngIf="hasLeftoverAssessments">
-                        <fa-icon [icon]="faExclamationTriangle" class="text-warning" placement="right" [ngbTooltip]="iconTooltip | artemisTranslate" container="body"></fa-icon>
+                        <fa-icon [icon]="faExclamationTriangle" class="text-warning" placement="right" [ngbTooltip]="iconTooltip | artemisTranslate"></fa-icon>
                     </div>
                     <div class="ms-2 exercise-details-item" *ngIf="details.teamMode">
-                        <fa-icon [icon]="faUsers" placement="right" [ngbTooltip]="'artemisApp.exercise.isTeamExercise' | artemisTranslate" container="body"></fa-icon>
+                        <fa-icon [icon]="faUsers" placement="right" [ngbTooltip]="'artemisApp.exercise.isTeamExercise' | artemisTranslate"></fa-icon>
                     </div>
                     <div class="ms-2 exercise-details-item">
-                        <fa-icon [icon]="icon" placement="right" [ngbTooltip]="iconTooltip | artemisTranslate" container="body"></fa-icon>
+                        <fa-icon [icon]="icon" placement="right" [ngbTooltip]="iconTooltip | artemisTranslate"></fa-icon>
                     </div>
                     <div class="item-title-container">
                         <span class="item-title">{{ details.title }}</span>

--- a/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
+++ b/src/main/webapp/app/exam/exam-scores/exam-scores.component.html
@@ -342,11 +342,11 @@
                             </th>
                             <th>
                                 {{ 'artemisApp.examScores.participantsColumn' | artemisTranslate }}
-                                <jhi-help-icon placement="top" text="artemisApp.examScores.participantsExerciseGroupTooltip"></jhi-help-icon>
+                                <jhi-help-icon text="artemisApp.examScores.participantsExerciseGroupTooltip"></jhi-help-icon>
                             </th>
                             <th>
                                 {{ 'artemisApp.examScores.averagePointsColumn' | artemisTranslate }}
-                                <jhi-help-icon placement="top" text="artemisApp.examScores.averageExerciseGroupTooltip"></jhi-help-icon>
+                                <jhi-help-icon text="artemisApp.examScores.averageExerciseGroupTooltip"></jhi-help-icon>
                             </th>
                             <th *ngIf="gradingScaleExists">
                                 {{ isBonus ? ('artemisApp.examScores.averageBonusColumn' | artemisTranslate) : ('artemisApp.examScores.averageGradeColumn' | artemisTranslate) }}
@@ -356,11 +356,11 @@
                             </th>
                             <th>
                                 {{ 'artemisApp.examScores.participantsColumn' | artemisTranslate }}
-                                <jhi-help-icon placement="top" text="artemisApp.examScores.participantsExerciseTooltip"></jhi-help-icon>
+                                <jhi-help-icon text="artemisApp.examScores.participantsExerciseTooltip"></jhi-help-icon>
                             </th>
                             <th>
                                 {{ 'artemisApp.examScores.averagePointsColumn' | artemisTranslate }}
-                                <jhi-help-icon placement="top" text="artemisApp.examScores.averageExerciseTooltip"></jhi-help-icon>
+                                <jhi-help-icon text="artemisApp.examScores.averageExerciseTooltip"></jhi-help-icon>
                             </th>
                         </tr>
                     </thead>

--- a/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist-exercisegroup-table/exam-checklist-exercisegroup-table.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-checklist-component/exam-checklist-exercisegroup-table/exam-checklist-exercisegroup-table.component.html
@@ -60,7 +60,7 @@
             <td>
                 <div class="d-flex" *ngIf="column.exerciseTitle">
                     <div style="padding-right: 10px; max-width: min-content" [ngbTooltip]="getIconTooltip(column!.exerciseType) | artemisTranslate">
-                        <fa-icon [icon]="getIcon(column!.exerciseType)" placement="right"></fa-icon>
+                        <fa-icon [icon]="getIcon(column!.exerciseType)" placement="right auto"></fa-icon>
                     </div>
                     <span>{{ column.exerciseTitle }}</span>
                 </div>

--- a/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.html
@@ -6,7 +6,7 @@
         <tr>
             <th class="w-25">
                 <label jhiTranslate="artemisApp.examScores.titleExerciseGroupColumn">Exercise Group</label>
-                <jhi-help-icon placement="top" text="artemisApp.examManagement.exerciseGroup.importModal.exerciseGroupTooltip"></jhi-help-icon>
+                <jhi-help-icon placement="top auto" text="artemisApp.examManagement.exerciseGroup.importModal.exerciseGroupTooltip"></jhi-help-icon>
             </th>
             <th class="w-75" jhiTranslate="artemisApp.examScores.titleExerciseColumn">Exercise</th>
         </tr>

--- a/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-exercise-import/exam-exercise-import.component.html
@@ -6,7 +6,7 @@
         <tr>
             <th class="w-25">
                 <label jhiTranslate="artemisApp.examScores.titleExerciseGroupColumn">Exercise Group</label>
-                <jhi-help-icon placement="top auto" text="artemisApp.examManagement.exerciseGroup.importModal.exerciseGroupTooltip"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.examManagement.exerciseGroup.importModal.exerciseGroupTooltip"></jhi-help-icon>
             </th>
             <th class="w-75" jhiTranslate="artemisApp.examScores.titleExerciseColumn">Exercise</th>
         </tr>
@@ -67,11 +67,11 @@
                             <th class="smallbox" jhiTranslate="artemisApp.exercise.type">Type</th>
                             <th [class]="exerciseGroupContainsProgrammingExercises(exerciseGroup) ? 'mediumbox' : 'largebox'">
                                 <label jhiTranslate="artemisApp.exercise.title">Title</label>
-                                <jhi-help-icon placement="top" text="artemisApp.examManagement.exerciseGroup.importModal.exerciseTitleTooltip"></jhi-help-icon>
+                                <jhi-help-icon text="artemisApp.examManagement.exerciseGroup.importModal.exerciseTitleTooltip"></jhi-help-icon>
                             </th>
                             <th *ngIf="exerciseGroupContainsProgrammingExercises(exerciseGroup)" class="mediumbox">
                                 <label class="label-narrow" jhiTranslate="artemisApp.exercise.shortName">Short Name</label>
-                                <jhi-help-icon placement="auto" text="artemisApp.examManagement.exerciseGroup.importModal.shortNameTooltip"></jhi-help-icon>
+                                <jhi-help-icon text="artemisApp.examManagement.exerciseGroup.importModal.shortNameTooltip"></jhi-help-icon>
                             </th>
                             <th class="smallbox" jhiTranslate="artemisApp.exercise.difficulty">Difficulty Level</th>
                         </tr>

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.html
@@ -28,7 +28,7 @@
             <div class="form-group">
                 <div>
                     <label class="form-check-label" jhiTranslate="artemisApp.examManagement.testExam.examMode">Exam Mode</label>
-                    <jhi-help-icon placement="top auto" text="artemisApp.examManagement.testExam.examModeTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.examManagement.testExam.examModeTooltip"></jhi-help-icon>
                 </div>
                 <jhi-exam-mode-picker [exam]="exam" [disableInput]="exam.id !== undefined"></jhi-exam-mode-picker>
             </div>
@@ -43,7 +43,7 @@
                         [jhiFeatureToggle]="FeatureToggle.ExamLiveStatistics"
                     />
                     <label for="examMonitoring" class="form-control-label" jhiTranslate="artemisApp.examManagement.monitoring.enable.title">Exam Monitoring Enabled</label>
-                    <jhi-help-icon placement="top auto" text="artemisApp.examManagement.monitoring.enable.description"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.examManagement.monitoring.enable.description"></jhi-help-icon>
                 </div>
             </div>
             <div class="row mb-3">
@@ -100,7 +100,7 @@
             <div class="row mb-3">
                 <div class="col-sm-6">
                     <label class="form-check-label" for="workingTimeInMinutes" jhiTranslate="artemisApp.examManagement.workingTime">Working Time</label>
-                    <jhi-help-icon placement="top" [text]="'artemisApp.examManagement' + (exam.testExam ? '.testExam' : '') + '.workingTimeTooltip'"></jhi-help-icon>
+                    <jhi-help-icon [text]="'artemisApp.examManagement' + (exam.testExam ? '.testExam' : '') + '.workingTimeTooltip'"></jhi-help-icon>
                     <input *ngIf="!exam.testExam" readonly type="text" class="form-control" [value]="calculateWorkingTime" />
                     <input
                         *ngIf="exam.testExam"
@@ -116,7 +116,7 @@
                 </div>
                 <div class="col-sm-6">
                     <label class="form-check-label" for="gracePeriod" jhiTranslate="artemisApp.examManagement.gracePeriod">Grace period (seconds)</label>
-                    <jhi-help-icon placement="top" text="artemisApp.examManagement.gracePeriodTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.examManagement.gracePeriodTooltip"></jhi-help-icon>
                     <input id="gracePeriod" name="gracePeriod" class="form-control" type="number" min="0" [(ngModel)]="exam.gracePeriod" />
                 </div>
             </div>
@@ -126,12 +126,7 @@
             <div class="row mb-3">
                 <div class="col-sm-6">
                     <label class="form-check-label" for="maxPoints" jhiTranslate="artemisApp.examManagement.maxPoints.title">Maximum Number of Points in Exam</label>
-                    <fa-icon
-                        [icon]="faExclamationTriangle"
-                        class="text-warning"
-                        placement="top"
-                        ngbTooltip="{{ 'artemisApp.examManagement.maxPoints.warning' | artemisTranslate }}"
-                    ></fa-icon>
+                    <fa-icon [icon]="faExclamationTriangle" class="text-warning" ngbTooltip="{{ 'artemisApp.examManagement.maxPoints.warning' | artemisTranslate }}"></fa-icon>
                     <input id="maxPoints" name="maxPoints" class="form-control" type="number" min="1" [(ngModel)]="exam.maxPoints" />
                 </div>
                 <div class="col-sm-6">
@@ -236,7 +231,7 @@
                 <ng-template #renderedWarning>
                     <div>{{ 'artemisApp.examManagement.reviewDatesInvalidExplanation' | artemisTranslate }}</div>
                 </ng-template>
-                <span *ngIf="!isValidExamStudentReviewEnd" class="badge bg-warning" [ngbTooltip]="renderedWarning" tooltip-placement="right">
+                <span *ngIf="!isValidExamStudentReviewEnd" class="badge bg-warning" [ngbTooltip]="renderedWarning" tooltip-placement="right auto">
                     <span jhiTranslate="artemisApp.quizExercise.edit.warning"></span>
                 </span>
             </div>

--- a/src/main/webapp/app/exam/manage/exams/exam-update.component.html
+++ b/src/main/webapp/app/exam/manage/exams/exam-update.component.html
@@ -28,7 +28,7 @@
             <div class="form-group">
                 <div>
                     <label class="form-check-label" jhiTranslate="artemisApp.examManagement.testExam.examMode">Exam Mode</label>
-                    <jhi-help-icon placement="top" text="artemisApp.examManagement.testExam.examModeTooltip"></jhi-help-icon>
+                    <jhi-help-icon placement="top auto" text="artemisApp.examManagement.testExam.examModeTooltip"></jhi-help-icon>
                 </div>
                 <jhi-exam-mode-picker [exam]="exam" [disableInput]="exam.id !== undefined"></jhi-exam-mode-picker>
             </div>
@@ -43,7 +43,7 @@
                         [jhiFeatureToggle]="FeatureToggle.ExamLiveStatistics"
                     />
                     <label for="examMonitoring" class="form-control-label" jhiTranslate="artemisApp.examManagement.monitoring.enable.title">Exam Monitoring Enabled</label>
-                    <jhi-help-icon placement="top" text="artemisApp.examManagement.monitoring.enable.description"></jhi-help-icon>
+                    <jhi-help-icon placement="top auto" text="artemisApp.examManagement.monitoring.enable.description"></jhi-help-icon>
                 </div>
             </div>
             <div class="row mb-3">

--- a/src/main/webapp/app/exam/monitoring/subpages/exercise/monitoring-exercises.component.html
+++ b/src/main/webapp/app/exam/monitoring/subpages/exercise/monitoring-exercises.component.html
@@ -92,5 +92,5 @@
 </div>
 
 <ng-template #typeRef let-type="type">
-    <fa-icon [icon]="getIcon(type)" placement="right" [ngbTooltip]="getIconTooltip(type) | artemisTranslate" container="body"></fa-icon>
+    <fa-icon [icon]="getIcon(type)" placement="right" [ngbTooltip]="getIconTooltip(type) | artemisTranslate"></fa-icon>
 </ng-template>

--- a/src/main/webapp/app/exam/monitoring/subpages/exercise/monitoring-exercises.component.html
+++ b/src/main/webapp/app/exam/monitoring/subpages/exercise/monitoring-exercises.component.html
@@ -92,5 +92,5 @@
 </div>
 
 <ng-template #typeRef let-type="type">
-    <fa-icon [icon]="getIcon(type)" placement="right" [ngbTooltip]="getIconTooltip(type) | artemisTranslate"></fa-icon>
+    <fa-icon [icon]="getIcon(type)" placement="right auto" [ngbTooltip]="getIconTooltip(type) | artemisTranslate"></fa-icon>
 </ng-template>

--- a/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
@@ -42,7 +42,7 @@
                 </td>
                 <td style="max-width: 30px">
                     <div [ngbTooltip]="getIconTooltip(item.exercise.type) | artemisTranslate">
-                        <fa-icon [icon]="getIcon(item.exercise.type)" placement="right" container="body"></fa-icon>
+                        <fa-icon [icon]="getIcon(item.exercise.type)" placement="right"></fa-icon>
                     </div>
                 </td>
                 <td style="max-width: 100px; font-weight: bold">

--- a/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
+++ b/src/main/webapp/app/exam/participate/exercises/exercise-overview-page/exam-exercise-overview-page.component.html
@@ -42,7 +42,7 @@
                 </td>
                 <td style="max-width: 30px">
                     <div [ngbTooltip]="getIconTooltip(item.exercise.type) | artemisTranslate">
-                        <fa-icon [icon]="getIcon(item.exercise.type)" placement="right"></fa-icon>
+                        <fa-icon [icon]="getIcon(item.exercise.type)" placement="right auto"></fa-icon>
                     </div>
                 </td>
                 <td style="max-width: 100px; font-weight: bold">

--- a/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/file-upload/manage/file-upload-exercise-update.component.html
@@ -119,12 +119,7 @@
         </div>
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="artemisApp.fileUploadExercise.filePattern" for="field_filePattern">File Pattern </label>
-            <fa-icon
-                [icon]="faQuestionCircle"
-                class="text-secondary"
-                placement="top"
-                ngbTooltip="{{ 'artemisApp.fileUploadExercise.filePatternInfo' | artemisTranslate }}"
-            ></fa-icon>
+            <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.fileUploadExercise.filePatternInfo' | artemisTranslate }}"></fa-icon>
             <input required minlength="2" type="text" class="form-control" name="filePattern" id="field_filePattern" [(ngModel)]="fileUploadExercise.filePattern" />
         </div>
         <jhi-presentation-score-checkbox [exercise]="fileUploadExercise"></jhi-presentation-score-checkbox>

--- a/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
+++ b/src/main/webapp/app/exercises/modeling/manage/example-modeling/example-modeling-submission.component.html
@@ -12,7 +12,7 @@
             <div>
                 <div class="text-start">
                     <span>{{ 'artemisApp.exampleSubmission.assessmentTraining' | artemisTranslate }}</span>
-                    <jhi-help-icon placement="auto" [text]="'artemisApp.exampleSubmission.selectModelExplanation'"></jhi-help-icon>
+                    <jhi-help-icon [text]="'artemisApp.exampleSubmission.selectModelExplanation'"></jhi-help-icon>
                 </div>
                 <div class="btn-group" role="group">
                     <input

--- a/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
+++ b/src/main/webapp/app/exercises/programming/assess/code-editor-tutor-assessment-inline-feedback.component.html
@@ -12,7 +12,7 @@
             <div class="form-group col-8 m-0">
                 <label class="d-inline" jhiTranslate="artemisApp.assessment.detail.feedback"></label>
                 <div class="d-inline" *ngIf="feedback.gradingInstruction!">
-                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" [ngbTooltip]="'artemisApp.assessment.feedbackHint' | artemisTranslate" container="body"></fa-icon>
+                    <fa-icon [icon]="faQuestionCircle" class="text-secondary" [ngbTooltip]="'artemisApp.assessment.feedbackHint' | artemisTranslate"></fa-icon>
                     <span>{{ feedback.gradingInstruction!.feedback }}</span>
                 </div>
             </div>

--- a/src/main/webapp/app/exercises/programming/hestia/generation-overview/code-hint-generation-overview/code-hint-generation-overview.component.html
+++ b/src/main/webapp/app/exercises/programming/hestia/generation-overview/code-hint-generation-overview/code-hint-generation-overview.component.html
@@ -23,7 +23,7 @@
             ></jhi-code-hint-generation-status>
         </div>
         <div class="col text-end">
-            <jhi-help-icon *ngIf="!isNextStepAvailable()" placement="auto" text="artemisApp.codeHint.management.nextButton.tooltip"></jhi-help-icon>
+            <jhi-help-icon *ngIf="!isNextStepAvailable()" text="artemisApp.codeHint.management.nextButton.tooltip"></jhi-help-icon>
             <button
                 *ngIf="currentStep !== 3"
                 type="button"

--- a/src/main/webapp/app/exercises/programming/hestia/generation-overview/code-hint-generation-status/code-hint-generation-status-step.component.html
+++ b/src/main/webapp/app/exercises/programming/hestia/generation-overview/code-hint-generation-status/code-hint-generation-status-step.component.html
@@ -5,6 +5,6 @@
     </div>
     <div class="col status-step-content">
         <span class="row text-center" [class.selected-label]="currentlySelected" [jhiTranslate]="labelTranslationKey">Current step</span>
-        <jhi-help-icon placement="auto" [text]="descriptionTranslationKey"></jhi-help-icon>
+        <jhi-help-icon [text]="descriptionTranslationKey"></jhi-help-icon>
     </div>
 </div>

--- a/src/main/webapp/app/exercises/programming/hestia/generation-overview/manual-solution-entry-creation-modal/manual-solution-entry-creation-modal.component.html
+++ b/src/main/webapp/app/exercises/programming/hestia/generation-overview/manual-solution-entry-creation-modal/manual-solution-entry-creation-modal.component.html
@@ -6,7 +6,7 @@
     <div class="modal-body">
         <div class="form-group">
             <label class="label-narrow" for="field_test" jhiTranslate="artemisApp.programmingExerciseSolutionEntry.test">Test Name</label>
-            <jhi-help-icon *ngIf="codeHint" placement="top" text="artemisApp.programmingExerciseSolutionEntry.testOnlyForCurrentTask"></jhi-help-icon>
+            <jhi-help-icon *ngIf="codeHint" text="artemisApp.programmingExerciseSolutionEntry.testOnlyForCurrentTask"></jhi-help-icon>
             <select *ngIf="testCases?.length" class="form-select" required name="test" [(ngModel)]="this.solutionEntry.testCase" id="field_test">
                 <option *ngFor="let testCase of testCases" [ngValue]="testCase">{{ testCase?.testName }}</option>
             </select>

--- a/src/main/webapp/app/exercises/programming/hestia/generation-overview/steps/solution-entry-generation-step/solution-entry-generation-step.component.html
+++ b/src/main/webapp/app/exercises/programming/hestia/generation-overview/steps/solution-entry-generation-step/solution-entry-generation-step.component.html
@@ -56,7 +56,7 @@
                 <th scope="col" class="text-left">{{ 'artemisApp.exerciseHint.content' | artemisTranslate }}</th>
                 <th scope="col" class="text-left">
                     <span jhiTranslate="artemisApp.codeHint.entryType">Type (S/B)</span>
-                    <jhi-help-icon placement="auto" text="artemisApp.codeHint.entryTypeTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.codeHint.entryTypeTooltip"></jhi-help-icon>
                 </th>
             </tr>
         </thead>

--- a/src/main/webapp/app/exercises/programming/manage/grading/charts/category-issues-chart.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/grading/charts/category-issues-chart.component.ts
@@ -19,8 +19,7 @@ export class IssueColumn {
                     class="d-flex align-items-end"
                     [style]="{ width: column.w, height: '30px' }"
                     [ngbTooltip]="column.tooltip"
-                    placement="bottom"
-                    container="body"
+                    placement="bottom auto"
                 >
                     <div [style]="{ width: '100%', height: column.h, background: column.color }"></div>
                 </div>

--- a/src/main/webapp/app/exercises/programming/manage/grading/charts/test-case-passed-builds-chart.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/grading/charts/test-case-passed-builds-chart.component.ts
@@ -5,7 +5,7 @@ import { round } from 'app/shared/util/utils';
 @Component({
     selector: 'jhi-test-case-passed-builds-chart',
     template: `
-        <div class="chart-body" placement="left" container="body" [ngbTooltip]="tooltip">
+        <div class="chart-body" placement="left" [ngbTooltip]="tooltip">
             <div class="passed-bar" [style]="{ width: passedPercent + '%' }"></div>
             <div class="failed-bar" [style]="{ left: passedPercent + '%', width: failedPercent + '%' }"></div>
         </div>

--- a/src/main/webapp/app/exercises/programming/manage/grading/charts/test-case-passed-builds-chart.component.ts
+++ b/src/main/webapp/app/exercises/programming/manage/grading/charts/test-case-passed-builds-chart.component.ts
@@ -5,7 +5,7 @@ import { round } from 'app/shared/util/utils';
 @Component({
     selector: 'jhi-test-case-passed-builds-chart',
     template: `
-        <div class="chart-body" placement="left" [ngbTooltip]="tooltip">
+        <div class="chart-body" placement="left auto" [ngbTooltip]="tooltip">
             <div class="passed-bar" [style]="{ width: passedPercent + '%' }"></div>
             <div class="failed-bar" [style]="{ left: passedPercent + '%', width: failedPercent + '%' }"></div>
         </div>

--- a/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
@@ -127,7 +127,6 @@
                                             class="text-secondary ms-2"
                                             placement="bottom"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.weight' | artemisTranslate"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -151,7 +150,6 @@
                                             class="text-secondary ms-2"
                                             placement="bottom"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.bonusMultiplier' | artemisTranslate"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -175,7 +173,6 @@
                                             class="text-secondary ms-2"
                                             placement="bottom"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.bonusPoints' | artemisTranslate"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -199,7 +196,6 @@
                                             class="text-secondary ms-2"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.visibility' | artemisTranslate"
                                             placement="bottom"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -223,7 +219,6 @@
                                             class="text-secondary ms-2"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.points' | artemisTranslate"
                                             placement="bottom"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -243,7 +238,6 @@
                                             class="text-secondary ms-2"
                                             placement="bottom"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.type' | artemisTranslate"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -337,7 +331,6 @@
                                             class="text-secondary ms-2"
                                             placement="bottom"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.state' | artemisTranslate"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -362,7 +355,6 @@
                                             class="text-secondary ms-2"
                                             placement="bottom"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.penalty' | artemisTranslate"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -387,7 +379,6 @@
                                             class="text-secondary ms-2"
                                             placement="bottom"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.maxPenalty' | artemisTranslate"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -412,7 +403,6 @@
                                             class="text-secondary ms-2"
                                             placement="bottom"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.detectedIssues' | artemisTranslate"
-                                            container="body"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>

--- a/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/grading/programming-exercise-configure-grading.component.html
@@ -125,7 +125,7 @@
                                         ><fa-icon
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.weight' | artemisTranslate"
                                         ></fa-icon>
                                     </span>
@@ -148,7 +148,7 @@
                                         ><fa-icon
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.bonusMultiplier' | artemisTranslate"
                                         ></fa-icon>
                                     </span>
@@ -171,7 +171,7 @@
                                         <fa-icon
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.bonusPoints' | artemisTranslate"
                                         ></fa-icon>
                                     </span>
@@ -195,7 +195,7 @@
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.visibility' | artemisTranslate"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -218,7 +218,7 @@
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.points' | artemisTranslate"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                         ></fa-icon>
                                     </span>
                                 </ng-template>
@@ -236,7 +236,7 @@
                                         ><fa-icon
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.type' | artemisTranslate"
                                         ></fa-icon>
                                     </span>
@@ -329,7 +329,7 @@
                                         <fa-icon
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.state' | artemisTranslate"
                                         ></fa-icon>
                                     </span>
@@ -353,7 +353,7 @@
                                         <fa-icon
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.penalty' | artemisTranslate"
                                         ></fa-icon>
                                     </span>
@@ -377,7 +377,7 @@
                                         <fa-icon
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.maxPenalty' | artemisTranslate"
                                         ></fa-icon>
                                     </span>
@@ -401,7 +401,7 @@
                                         <fa-icon
                                             [icon]="faQuestionCircle"
                                             class="text-secondary ms-2"
-                                            placement="bottom"
+                                            placement="bottom auto"
                                             [ngbTooltip]="'artemisApp.programmingExercise.configureGrading.help.detectedIssues' | artemisTranslate"
                                         ></fa-icon>
                                     </span>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -538,7 +538,7 @@
                 <div *ngIf="programmingExercise.isAtLeastEditor && programmingExercise.buildLogStatistics">
                     <dt>
                         <span jhiTranslate="artemisApp.programmingExercise.buildLogStatistics.title">Build Log Statistics</span>
-                        <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.buildLogStatistics.tooltip"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.programmingExercise.buildLogStatistics.tooltip"></jhi-help-icon>
                     </dt>
                     <dd>
                         <table class="table table-striped">

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-detail.component.html
@@ -132,7 +132,6 @@
                             type="button"
                             (click)="combineTemplateCommits()"
                             class="btn btn-secondary btn-sm"
-                            container="body"
                             ngbTooltip="{{ 'artemisApp.programmingExercise.combineTemplateCommitsWarning' | artemisTranslate }}"
                         >
                             <span jhiTranslate="artemisApp.programmingExercise.combineTemplateCommits">Combine Template Commits</span>
@@ -144,7 +143,6 @@
                             type="button"
                             (click)="generateStructureOracle()"
                             class="btn btn-secondary btn-sm"
-                            container="body"
                             ngbTooltip="{{ 'artemisApp.programmingExercise.structureTestOracleWarning' | artemisTranslate }}"
                         >
                             <span jhiTranslate="artemisApp.programmingExercise.structureTestOracle">Update Structure Test Oracle</span>
@@ -164,7 +162,6 @@
                             type="button"
                             (click)="getAndShowTestwiseCoverage()"
                             class="btn btn-secondary btn-sm"
-                            container="body"
                             ngbTooltip="{{ 'artemisApp.programmingExercise.testwiseCoverageReport.tooltip' | artemisTranslate }}"
                         >
                             <span jhiTranslate="artemisApp.programmingExercise.testwiseCoverageReport.button">Show Testwise Coverage</span>

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-edit-selected.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-edit-selected.component.html
@@ -39,7 +39,7 @@
                             <label class="label-narrow label-timeline" jhiTranslate="artemisApp.programmingExercise.timeline.timelineLabel" for="timeline">
                                 Timeline for the whole programming exercise
                             </label>
-                            <jhi-help-icon placement="top auto" text="artemisApp.programmingExercise.timeline.timelineTooltip"></jhi-help-icon>
+                            <jhi-help-icon text="artemisApp.programmingExercise.timeline.timelineTooltip"></jhi-help-icon>
                         </div>
                         <jhi-programming-exercise-lifecycle id="timeline" [exercise]="newProgrammingExercise" [isExamMode]="false"></jhi-programming-exercise-lifecycle>
                         <jhi-button class="text-center" id="save-entity" [icon]="faSave" [title]="'entity.action.save'" [isLoading]="isSaving">

--- a/src/main/webapp/app/exercises/programming/manage/programming-exercise-edit-selected.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/programming-exercise-edit-selected.component.html
@@ -39,7 +39,7 @@
                             <label class="label-narrow label-timeline" jhiTranslate="artemisApp.programmingExercise.timeline.timelineLabel" for="timeline">
                                 Timeline for the whole programming exercise
                             </label>
-                            <jhi-help-icon placement="top" text="artemisApp.programmingExercise.timeline.timelineTooltip"></jhi-help-icon>
+                            <jhi-help-icon placement="top auto" text="artemisApp.programmingExercise.timeline.timelineTooltip"></jhi-help-icon>
                         </div>
                         <jhi-programming-exercise-lifecycle id="timeline" [exercise]="newProgrammingExercise" [isExamMode]="false"></jhi-programming-exercise-lifecycle>
                         <jhi-button class="text-center" id="save-entity" [icon]="faSave" [title]="'entity.action.save'" [isLoading]="isSaving">

--- a/src/main/webapp/app/exercises/programming/manage/status/programming-exercise-instructor-exercise-status.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/status/programming-exercise-instructor-exercise-status.component.html
@@ -1,4 +1,4 @@
-<fa-icon *ngIf="issues.length; else noIssues" [icon]="faExclamationTriangle" size="2x" class="text-warning" placement="bottom" [ngbTooltip]="tooltipContent"></fa-icon>
+<fa-icon *ngIf="issues.length; else noIssues" [icon]="faExclamationTriangle" size="2x" class="text-warning" placement="bottom auto" [ngbTooltip]="tooltipContent"></fa-icon>
 
 <ng-template #noIssues>
     <fa-icon [icon]="faCheckCircle" size="2x" class="text-success"></fa-icon>

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-plans-and-repositories-preview.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-plans-and-repositories-preview.component.html
@@ -11,19 +11,19 @@
                         <code class="text-white badge bg-primary label-preview">
                             {{ getCourseShortName()?.toLowerCase() }}{{ programmingExercise.shortName.toLowerCase() }}-exercise
                         </code>
-                        <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.preview.templateRepoTooltip"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.programmingExercise.preview.templateRepoTooltip"></jhi-help-icon>
                     </li>
                     <li>
                         <code class="text-white badge bg-primary label-preview">
                             {{ getCourseShortName()?.toLowerCase() }}{{ programmingExercise.shortName.toLowerCase() }}-solution
                         </code>
-                        <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.preview.solutionRepoTooltip"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.programmingExercise.preview.solutionRepoTooltip"></jhi-help-icon>
                     </li>
                     <li>
                         <code class="text-white badge bg-primary label-preview">
                             {{ getCourseShortName()?.toLowerCase() }}{{ programmingExercise.shortName.toLowerCase() }}-tests
                         </code>
-                        <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.preview.testRepoTooltip"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.programmingExercise.preview.testRepoTooltip"></jhi-help-icon>
                     </li>
                     <div *ngIf="programmingExercise.auxiliaryRepositories && programmingExercise.auxiliaryRepositories.length > 0">
                         <div *ngFor="let auxiliaryRepository of programmingExercise.auxiliaryRepositories">
@@ -31,10 +31,7 @@
                                 <code class="text-white badge bg-success label-preview">
                                     {{ getCourseShortName()?.toLowerCase() }}{{ programmingExercise.shortName.toLowerCase() }}-{{ auxiliaryRepository.name?.toLowerCase() }}
                                 </code>
-                                <jhi-help-icon-without-translation
-                                    placement="auto"
-                                    text="{{ auxiliaryRepository.description || 'Auxiliary Repository' }}"
-                                ></jhi-help-icon-without-translation>
+                                <jhi-help-icon-without-translation text="{{ auxiliaryRepository.description || 'Auxiliary Repository' }}"></jhi-help-icon-without-translation>
                             </li>
                         </div>
                     </div>
@@ -49,13 +46,13 @@
             <ul>
                 <li>
                     <code class="text-white badge bg-primary label-preview">{{ getCourseShortName()?.toUpperCase() }}{{ programmingExercise.shortName.toUpperCase() }}-BASE</code>
-                    <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.preview.templateBuildPlanTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.programmingExercise.preview.templateBuildPlanTooltip"></jhi-help-icon>
                 </li>
                 <li>
                     <code class="text-white badge bg-primary label-preview"
                         >{{ getCourseShortName()?.toUpperCase() }}{{ programmingExercise.shortName.toUpperCase() }}-SOLUTION</code
                     >
-                    <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.preview.solutionBuildPlanTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.programmingExercise.preview.solutionBuildPlanTooltip"></jhi-help-icon>
                 </li>
             </ul>
         </div>

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -14,7 +14,7 @@
         <div class="form-group">
             <div>
                 <label class="label-narrow" jhiTranslate="artemisApp.exercise.title" for="field_title">Title</label>
-                <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.titleTooltip"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.programmingExercise.titleTooltip"></jhi-help-icon>
             </div>
             <input required type="text" class="form-control" name="title" id="field_title" [pattern]="titleNamePattern" [(ngModel)]="programmingExercise.title" #title="ngModel" />
             <ng-container *ngFor="let e of title.errors! | keyvalue | removekeys: ['required']">
@@ -26,7 +26,7 @@
         <div class="form-group">
             <div>
                 <label class="label-narrow" jhiTranslate="artemisApp.exercise.shortName" for="field_shortName">Short Name</label>
-                <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.shortNameTooltip"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.programmingExercise.shortNameTooltip"></jhi-help-icon>
             </div>
             <input
                 required
@@ -48,7 +48,7 @@
         </div>
         <div class="form-group mt-2 mb-0">
             <label class="label-narrow" jhiTranslate="artemisApp.programmingExercise.preview.label" for="preview"></label>
-            <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.preview.tooltip"></jhi-help-icon>
+            <jhi-help-icon text="artemisApp.programmingExercise.preview.tooltip"></jhi-help-icon>
         </div>
         <jhi-programming-exercise-plans-and-repositories-preview [programmingExercise]="programmingExercise"></jhi-programming-exercise-plans-and-repositories-preview>
         <div *ngIf="!isImport" class="form-group">
@@ -121,7 +121,7 @@
         <div *ngIf="!isExamMode" class="form-group position-relative">
             <div>
                 <label class="label-narrow" jhiTranslate="artemisApp.exercise.categories">Categories</label>
-                <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.categoriesTooltip"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.programmingExercise.categoriesTooltip"></jhi-help-icon>
             </div>
             <jhi-category-selector
                 [categories]="exerciseCategories"
@@ -175,7 +175,7 @@
             <div class="form-check mt-2" *ngIf="!isImport && !programmingExercise.id && programmingExercise.programmingLanguage === ProgrammingLanguage.JAVA">
                 <input class="form-check-input" type="checkbox" name="withDependencies" id="field_with_dependencies" [(ngModel)]="withDependencies" checked />
                 <span jhiTranslate="artemisApp.programmingExercise.withDependencies">With Dependencies</span>
-                <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.withDependenciesTooltip"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.programmingExercise.withDependenciesTooltip"></jhi-help-icon>
             </div>
         </div>
 
@@ -224,7 +224,7 @@
         <div class="form-group mt-2">
             <div>
                 <label jhiTranslate="artemisApp.programmingExercise.timeline.timelineLabel" for="timeline"> Timeline for the whole programming exercise </label>
-                <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.timeline.timelineTooltip"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.programmingExercise.timeline.timelineTooltip"></jhi-help-icon>
             </div>
             <jhi-programming-exercise-lifecycle id="timeline" [exercise]="programmingExercise" [isExamMode]="isExamMode" [readOnly]="false"></jhi-programming-exercise-lifecycle>
         </div>
@@ -312,7 +312,6 @@
                 <fa-icon
                     [icon]="faQuestionCircle"
                     class="text-secondary"
-                    placement="auto"
                     ngbTooltip="{{ 'artemisApp.programmingExercise.enableStaticCodeAnalysis.description' | artemisTranslate }}"
                 ></fa-icon>
             </div>
@@ -323,7 +322,6 @@
                 <fa-icon
                     [icon]="faQuestionCircle"
                     class="text-secondary"
-                    placement="auto"
                     ngbTooltip="{{ 'artemisApp.programmingExercise.maxStaticCodeAnalysisPenalty.description' | artemisTranslate }}"
                 ></fa-icon>
                 <div class="input-group">
@@ -391,7 +389,7 @@
                         checked
                     />
                     <span jhiTranslate="artemisApp.programmingExercise.sequentialTestRuns.title">Differentiate Test Case Execution</span>
-                    <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.sequentialTestRuns.description"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.programmingExercise.sequentialTestRuns.description"></jhi-help-icon>
                 </label>
             </div>
         </div>
@@ -407,7 +405,7 @@
                         [(ngModel)]="programmingExercise.checkoutSolutionRepository"
                     />
                     <span jhiTranslate="artemisApp.programmingExercise.checkoutSolutionRepository.title">Checkout Solution repository</span>
-                    <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.checkoutSolutionRepository.description"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.programmingExercise.checkoutSolutionRepository.description"></jhi-help-icon>
                 </label>
             </div>
         </div>
@@ -463,7 +461,6 @@
                     <fa-icon
                         [icon]="faQuestionCircle"
                         class="text-secondary"
-                        placement="auto"
                         ngbTooltip="{{ 'artemisApp.programmingExercise.showTestNamesToStudentsTooltip' | artemisTranslate }}"
                     ></fa-icon>
                 </label>
@@ -521,7 +518,6 @@
                     <fa-icon
                         [icon]="faQuestionCircle"
                         class="text-secondary"
-                        placement="auto"
                         ngbTooltip="{{ 'artemisApp.programmingExercise.recordTestwiseCoverageTooltip' | artemisTranslate }}"
                     ></fa-icon>
                 </label>
@@ -539,7 +535,7 @@
                         (change)="onRecreateBuildPlanOrUpdateTemplateChange()"
                     />
                     <span jhiTranslate="artemisApp.programmingExercise.recreateBuildPlans.title">Recreate Build Plans</span>
-                    <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.recreateBuildPlans.description"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.programmingExercise.recreateBuildPlans.description"></jhi-help-icon>
                 </label>
             </div>
         </div>
@@ -558,7 +554,7 @@
                         (change)="onRecreateBuildPlanOrUpdateTemplateChange()"
                     />
                     <span jhiTranslate="artemisApp.programmingExercise.updateTemplate.title">Update template</span>
-                    <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.updateTemplate.description"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.programmingExercise.updateTemplate.description"></jhi-help-icon>
                 </label>
             </div>
         </div>

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -96,7 +96,7 @@
                 <ngx-datatable-column name="" prop="removeButton">
                     <ng-template ngx-datatable-cell-template let-row="row">
                         <jhi-remove-auxiliary-repository-button
-                            placement="right"
+                            placement="right auto"
                             [programmingExercise]="programmingExercise"
                             (onRefresh)="refreshAuxiliaryRepositoryChecks()"
                             [row]="row"

--- a/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
+++ b/src/main/webapp/app/exercises/programming/manage/update/programming-exercise-update.component.html
@@ -420,7 +420,7 @@
                         *ngIf="!validIdeSelection()"
                         [icon]="faQuestionCircle"
                         class="text-danger"
-                        [placement]="'top'"
+                        [placement]="'top auto'"
                         ngbTooltip="{{ 'artemisApp.programmingExercise.allowOfflineIde.alert' | artemisTranslate }}"
                     ></fa-icon>
                 </label>
@@ -442,7 +442,7 @@
                         *ngIf="!validIdeSelection()"
                         [icon]="faQuestionCircle"
                         class="text-danger"
-                        [placement]="'top'"
+                        [placement]="'top auto'"
                         ngbTooltip="{{ 'artemisApp.programmingExercise.allowOnlineEditor.alert' | artemisTranslate }}"
                     ></fa-icon>
                 </label>
@@ -570,7 +570,7 @@
                         <p jhiTranslate="{{ reason.translateKey }}"></p>
                     </div>
                 </ng-template>
-                <span *ngIf="getInvalidReasons().length > 0" class="badge bg-danger" [ngbTooltip]="tooltipTranslate" tooltip-placement="top-right">
+                <span *ngIf="getInvalidReasons().length > 0" class="badge bg-danger" [ngbTooltip]="tooltipTranslate" tooltip-placement="top-right auto">
                     <fa-icon [icon]="faExclamationCircle"></fa-icon>
                     <span jhiTranslate="artemisApp.quizExercise.edit.invalidInput"></span>
                     <span>({{ getInvalidReasons().length }})</span>

--- a/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/code-editor/ace/code-editor-ace.component.html
@@ -5,7 +5,7 @@
             <span> &nbsp;{{ selectedFile }}</span>
             <fa-icon *ngIf="isLoading" [icon]="faCircleNotch" [spin]="true" class="ms-2" title="{{ 'artemisApp.editor.loadingFile' | artemisTranslate }}"></fa-icon>
         </h3>
-        <div ngbDropdown class="ms-2" placement="bottom-end" [autoClose]="'outside'" aria-label="Code Editor Settings">
+        <div ngbDropdown class="ms-2" placement="bottom-end auto" [autoClose]="'outside'" aria-label="Code Editor Settings">
             <button ngbDropdownToggle class="btn btn-sm btn-primary" type="button" id="dropdownCodeEditorSettings" aria-expanded="false">
                 <fa-icon [icon]="faGear"></fa-icon>
             </button>

--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-lifecycle.component.html
@@ -13,7 +13,7 @@
             <div class="test-schedule-date px-1">
                 <div class="mb-2 text-nowrap">
                     <span class="fw-bold" jhiTranslate="artemisApp.programmingExercise.timeline.automaticTests"> Automatic Tests </span>
-                    <jhi-help-icon placement="auto" text="artemisApp.programmingExercise.timeline.automaticTestsMandatoryTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.programmingExercise.timeline.automaticTestsMandatoryTooltip"></jhi-help-icon>
                 </div>
                 <div class="btn btn-light scheduled-test btn-lifecycle" [class.btn-lifecycle--disabled]="readOnly">
                     <fa-icon [icon]="faCogs" size="lg"></fa-icon>
@@ -49,7 +49,6 @@
                     <div class="mb-2 text-nowrap">
                         <span class="fw-bold" jhiTranslate="artemisApp.programmingExercise.timeline.assessmentType"> Assessment Type </span>
                         <jhi-help-icon
-                            placement="auto"
                             [text]="
                                 'artemisApp.programmingExercise.timeline.' +
                                 (exercise.assessmentType === assessmentType.SEMI_AUTOMATIC ? 'assessmentTypeTooltipManualAssessment' : 'assessmentTypeTooltipAutomaticAssessment')
@@ -76,7 +75,6 @@
                     <div class="mb-2 text-nowrap">
                         <span class="fw-bold" jhiTranslate="artemisApp.programmingExercise.timeline.allowFeedbackRequests">requests</span>
                         <jhi-help-icon
-                            placement="auto"
                             [text]="
                                 'artemisApp.programmingExercise.timeline.' +
                                 (exercise.allowManualFeedbackRequests ? 'feedbackRequestsEnabledTooltip' : 'feedbackRequestsDisabledTooltip')
@@ -113,7 +111,6 @@
                     <div class="mb-2 text-nowrap">
                         <span class="fw-bold" jhiTranslate="artemisApp.programmingExercise.timeline.complaintOnAutomaticAssessment"> Complaints </span>
                         <jhi-help-icon
-                            placement="auto"
                             [text]="
                                 'artemisApp.programmingExercise.timeline.' +
                                 (exercise.allowComplaintsForAutomaticAssessments ? 'allowComplaintOnAutomaticAssessmentTooltip' : 'disallowComplaintOnAutomaticAssessmentTooltip')

--- a/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-test-schedule-date-picker.component.html
+++ b/src/main/webapp/app/exercises/programming/shared/lifecycle/programming-exercise-test-schedule-date-picker.component.html
@@ -1,7 +1,7 @@
 <div class="test-schedule-date-content">
     <div class="mb-2 text-nowrap">
         <span class="fw-bold" [jhiTranslate]="label"></span>
-        <jhi-help-icon *ngIf="tooltipText" placement="auto" [text]="tooltipText"></jhi-help-icon>
+        <jhi-help-icon *ngIf="tooltipText" [text]="tooltipText"></jhi-help-icon>
     </div>
     <div class="invisible-date-time-picker">
         <input class="form-control" [ngModel]="selectedDate" [min]="min" [max]="max" (ngModelChange)="writeValue($event)" [owlDateTime]="dt" />

--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-detail.component.html
@@ -99,7 +99,7 @@
                         </div>
                         <ng-container *ngIf="!isExamMode">
                             <label for="quizMode" jhiTranslate="artemisApp.quizExercise.quizMode.title" class="colon-suffix no-flex-shrink"></label>
-                            <jhi-help-icon placement="auto" text="artemisApp.quizExercise.quizMode.explanation"></jhi-help-icon>
+                            <jhi-help-icon text="artemisApp.quizExercise.quizMode.explanation"></jhi-help-icon>
                             <select id="quizMode" class="form-select" [(ngModel)]="quizExercise.quizMode" (ngModelChange)="cacheValidation()">
                                 <option [value]="QuizMode.SYNCHRONIZED">{{ 'artemisApp.quizExercise.quizMode.synchronized' | artemisTranslate }}</option>
                                 <option [value]="QuizMode.BATCHED">{{ 'artemisApp.quizExercise.quizMode.batched' | artemisTranslate }}</option>
@@ -139,7 +139,7 @@
                                     (ngModelChange)="cacheValidation()"
                                 />
                                 <label class="form-check-label custom-control-label" for="cbScheduleQuizStart" jhiTranslate="artemisApp.quizExercise.setStartTime"> </label>
-                                <jhi-help-icon placement="auto" text="artemisApp.quizExercise.startTimeExplanation"></jhi-help-icon>
+                                <jhi-help-icon text="artemisApp.quizExercise.startTimeExplanation"></jhi-help-icon>
                             </div>
                             <div class="form-check custom-control custom-checkbox" *ngIf="quizExercise.quizMode === QuizMode.BATCHED && false">
                                 <!-- no scheduled batched mode yet -->
@@ -309,12 +309,12 @@
                                     <p *ngIf="(warning.translateValues | json) == '{}'" jhiTranslate="{{ warning.translateKey }}"></p>
                                 </div>
                             </ng-template>
-                            <span *ngIf="!quizIsValid" class="badge bg-danger" [ngbTooltip]="tooltipTranslate" tooltip-placement="top-right">
+                            <span *ngIf="!quizIsValid" class="badge bg-danger" [ngbTooltip]="tooltipTranslate" tooltip-placement="top-right auto">
                                 <fa-icon [icon]="faExclamationCircle"></fa-icon>
                                 <span jhiTranslate="artemisApp.quizExercise.edit.invalidInput"></span>
                                 <span>({{ computeInvalidReasons().length }})</span>
                             </span>
-                            <span *ngIf="warningQuizCache" class="badge bg-warning" [ngbTooltip]="warningTranslate" tooltip-placement="top-right">
+                            <span *ngIf="warningQuizCache" class="badge bg-warning" [ngbTooltip]="warningTranslate" tooltip-placement="top-right auto">
                                 <span jhiTranslate="artemisApp.quizExercise.edit.warning"></span>
                                 <span>({{ computeInvalidWarnings().length }})</span>
                             </span>
@@ -333,7 +333,7 @@
                                 [disabled]="isSaveDisabled()"
                                 jhiTranslate="entity.action.save"
                                 [ngbTooltip]="quizIsValid ? '' : tooltipTranslate"
-                                tooltip-placement="top-right"
+                                tooltip-placement="top-right auto"
                                 tooltip-class="invalid-reasons-tooltip"
                             ></button>
                         </div>

--- a/src/main/webapp/app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/re-evaluate/quiz-re-evaluate.component.html
@@ -116,12 +116,12 @@
                             <p *ngIf="(warning.translateValues | json) == '{}'" jhiTranslate="{{ warning.translateKey }}"></p>
                         </div>
                     </ng-template>
-                    <span *ngIf="!quizIsValid" class="badge bg-danger" [ngbTooltip]="tooltipTranslate" tooltip-placement="top-right">
+                    <span *ngIf="!quizIsValid" class="badge bg-danger" [ngbTooltip]="tooltipTranslate" tooltip-placement="top-right auto">
                         <fa-icon [icon]="faExclamationCircle"></fa-icon>
                         <span jhiTranslate="artemisApp.quizExercise.edit.invalidInput"></span>
                         <span>({{ invalidReasons.length }})</span>
                     </span>
-                    <span *ngIf="warningQuizCache" class="badge bg-warning" [ngbTooltip]="warningTranslate" tooltip-placement="top-right">
+                    <span *ngIf="warningQuizCache" class="badge bg-warning" [ngbTooltip]="warningTranslate" tooltip-placement="top-right auto">
                         <span jhiTranslate="artemisApp.quizExercise.edit.warning"></span>
                         <span>({{ invalidWarnings.length }})</span>
                     </span>

--- a/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/statistics/quiz-statistics-footer/quiz-statistics-footer.component.html
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="edit-quiz-footer-content row">
             <div class="form-group col-sm">
-                <div class="d-inline-block" ngbDropdown placement="top-right">
+                <div class="d-inline-block" ngbDropdown placement="top-right auto">
                     <button class="btn btn-primary btn-sm" ngbDropdownToggle>
                         <fa-icon [icon]="farListAlt"></fa-icon>
                         <span class="hidden-xs hidden-sm" jhiTranslate="artemisApp.showStatistic.chooseStatistic"></span>

--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
@@ -131,7 +131,7 @@
                     <span jhiTranslate="artemisApp.quizExercise.waitingForStart"></span>
                 </div>
                 <div *ngIf="mode === 'live' && !waitingForQuizStart">
-                    <span *ngIf="!isMobile" ngbTooltip="{{ submission.submissionDate | artemisDate: 'long':true }}" placement="right">
+                    <span *ngIf="!isMobile" ngbTooltip="{{ submission.submissionDate | artemisDate: 'long':true }}" placement="right auto">
                         <span *ngIf="!submission.submitted" jhiTranslate="artemisApp.quizExercise.lastSaved" class="colon-suffix"></span>
                         <span *ngIf="submission.submitted" jhiTranslate="artemisApp.quizExercise.submitted" class="colon-suffix"></span>
                         <span *ngIf="justSaved" jhiTranslate="justNow"></span>
@@ -139,7 +139,7 @@
                         <span *ngIf="!justSaved && lastSavedTimeText === ''" jhiTranslate="artemisApp.quizExercise.lastSavedTimeNever"></span>
                     </span>
                     <!-- Only display save and submission hint without time stamps for mobile -->
-                    <span *ngIf="isMobile" ngbTooltip="{{ submission.submissionDate | artemisDate: 'long':true }}" placement="right">
+                    <span *ngIf="isMobile" ngbTooltip="{{ submission.submissionDate | artemisDate: 'long':true }}" placement="right auto">
                         <span *ngIf="!submission.submitted" jhiTranslate="artemisApp.quizExercise.lastSaved"></span>
                         <span *ngIf="submission.submitted" jhiTranslate="artemisApp.quizExercise.submitted"></span>
                     </span>

--- a/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
+++ b/src/main/webapp/app/exercises/quiz/participate/quiz-participation.component.html
@@ -77,7 +77,6 @@
                             (click)="navigateToQuestion(i)"
                             [ngbTooltip]="mode !== 'solution' ? (dragAndDropMappings.get(question.id!)?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate) : ''"
                             [ngClass]="!!dragAndDropMappings.get(question.id!)?.length ? 'changed-question' : ''"
-                            container="body"
                         >
                             <b class="fa">DD</b>
                         </span>
@@ -89,7 +88,6 @@
                                 mode !== 'solution' ? (selectedAnswerOptions.get(question.id!)?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate) : ''
                             "
                             [ngClass]="!!selectedAnswerOptions.get(question.id!)?.length ? 'changed-question' : ''"
-                            container="body"
                         >
                             <b class="fa">MC</b>
                         </span>
@@ -101,7 +99,6 @@
                                 mode !== 'solution' ? (shortAnswerSubmittedTexts.get(question.id!)?.length ? tooltipExplanationTranslate : tooltipNotExplanationTranslate) : ''
                             "
                             [ngClass]="!!shortAnswerSubmittedTexts.get(question.id!)?.length ? 'changed-question' : ''"
-                            container="body"
                         >
                             <b class="fa">SA</b>
                         </span>

--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
@@ -28,7 +28,7 @@
         <p [innerHTML]="renderedQuestion.text"></p>
         <span style="color: red" *ngIf="question.invalid" jhiTranslate="artemisApp.quizQuestion.invalidText"></span>
         <div class="hint" *ngIf="question.hint || (question.explanation && showResult)">
-            <span class="label label-info" [ngbPopover]="renderedHint" placement="auto" triggers="mouseenter:mouseleave" *ngIf="question.hint">
+            <span class="label label-info" [ngbPopover]="renderedHint" triggers="mouseenter:mouseleave" *ngIf="question.hint">
                 <fa-icon [icon]="faQuestionCircle"></fa-icon>
                 <span jhiTranslate="artemisApp.quizQuestion.hint"></span>
             </span>

--- a/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/drag-and-drop-question/drag-and-drop-question.component.html
@@ -36,7 +36,7 @@
                 <div [innerHTML]="renderedQuestion.hint"></div>
             </ng-template>
             <br />
-            <span class="label label-primary" [ngbPopover]="renderedExplanation" placement="auto" triggers="mouseenter:mouseleave" *ngIf="question.explanation && showResult">
+            <span class="label label-primary" [ngbPopover]="renderedExplanation" triggers="mouseenter:mouseleave" *ngIf="question.explanation && showResult">
                 <fa-icon [icon]="faExclamationCircle"></fa-icon>
                 <span jhiTranslate="artemisApp.quizQuestion.explanation"></span>
             </span>
@@ -151,7 +151,6 @@
                                     ></span>
                                     <fa-icon
                                         ngbTooltip="Invalid Drop Locations and invalid Drag Items will be assessed as correct."
-                                        placement="top"
                                         style="color: black"
                                         [icon]="faQuestionCircle"
                                         *ngIf="dropLocation.invalid || question.invalid || invalidDragItemForDropLocation(dropLocation)"
@@ -211,7 +210,6 @@
                                     ></span>
                                     <fa-icon
                                         ngbTooltip="Invalid Drop Locations and invalid Drag Items will be assessed as correct."
-                                        placement="top"
                                         style="color: black"
                                         [icon]="faQuestionCircle"
                                         *ngIf="dropLocation.invalid || question.invalid"

--- a/src/main/webapp/app/exercises/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/multiple-choice-question/multiple-choice-question.component.html
@@ -13,7 +13,7 @@
         <ng-template #renderedHint>
             <div [innerHTML]="renderedQuestion.hint"></div>
         </ng-template>
-        <span class="label label-info" [ngbPopover]="renderedHint" placement="auto" triggers="mouseenter:mouseleave" *ngIf="question.hint">
+        <span class="label label-info" [ngbPopover]="renderedHint" triggers="mouseenter:mouseleave" *ngIf="question.hint">
             <fa-icon [icon]="faQuestionCircle"></fa-icon>
             <span jhiTranslate="artemisApp.quizQuestion.hint"></span>
         </span>
@@ -21,7 +21,7 @@
         <ng-template #renderedExplanation>
             <div [innerHTML]="renderedQuestion.explanation"></div>
         </ng-template>
-        <span class="label label-primary" [ngbPopover]="renderedExplanation" placement="right" triggers="mouseenter:mouseleave" *ngIf="question.explanation && showResult">
+        <span class="label label-primary" [ngbPopover]="renderedExplanation" placement="right auto" triggers="mouseenter:mouseleave" *ngIf="question.explanation && showResult">
             <fa-icon [icon]="faExclamationCircle"></fa-icon>
             <span jhiTranslate="artemisApp.quizQuestion.explanation"></span>
         </span>
@@ -58,7 +58,7 @@
                     <ng-template #renderedAnswerOptionsHint>
                         <div [innerHTML]="renderedQuestion.renderedSubElements[i].hint"></div>
                     </ng-template>
-                    <span class="label label-info" [ngbPopover]="renderedAnswerOptionsHint" placement="auto" triggers="mouseenter:mouseleave" *ngIf="answerOption.hint">
+                    <span class="label label-info" [ngbPopover]="renderedAnswerOptionsHint" triggers="mouseenter:mouseleave" *ngIf="answerOption.hint">
                         <fa-icon [icon]="faQuestionCircle"></fa-icon>
                         <span jhiTranslate="artemisApp.quizQuestion.hint"></span>
                     </span>
@@ -84,20 +84,14 @@
                     <ng-template #renderedAnswerOptionsHint2>
                         <div [innerHTML]="renderedQuestion.renderedSubElements![i].hint"></div>
                     </ng-template>
-                    <span class="label label-info" [ngbPopover]="renderedAnswerOptionsHint2" placement="top" triggers="mouseenter:mouseleave" *ngIf="answerOption.hint">
+                    <span class="label label-info" [ngbPopover]="renderedAnswerOptionsHint2" triggers="mouseenter:mouseleave" *ngIf="answerOption.hint">
                         <fa-icon [icon]="faQuestionCircle"></fa-icon>
                         <span jhiTranslate="artemisApp.quizQuestion.hint"></span>
                     </span>
                     <ng-template #renderedAnswerOptionsExplanation>
                         <div [innerHTML]="renderedQuestion.renderedSubElements![i].explanation"></div>
                     </ng-template>
-                    <span
-                        class="label label-primary"
-                        [ngbPopover]="renderedAnswerOptionsExplanation"
-                        placement="top"
-                        triggers="mouseenter:mouseleave"
-                        *ngIf="answerOption.explanation"
-                    >
+                    <span class="label label-primary" [ngbPopover]="renderedAnswerOptionsExplanation" triggers="mouseenter:mouseleave" *ngIf="answerOption.explanation">
                         <fa-icon [icon]="faExclamationCircle"></fa-icon>
                         <span jhiTranslate="artemisApp.quizQuestion.explanation"></span>
                     </span>
@@ -113,7 +107,6 @@
                 <span id="answer-option-{{ i }}-invalid" *ngIf="answerOption.invalid || question.invalid" class="wrong" jhiTranslate="artemisApp.quizQuestion.invalid"></span>
                 <fa-icon
                     ngbTooltip="{{ 'artemisApp.multipleChoiceQuestion.invalid' | artemisTranslate }}"
-                    placement="top"
                     style="color: black"
                     [icon]="faQuestionCircle"
                     *ngIf="answerOption.invalid || question.invalid"

--- a/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/shared/questions/short-answer-question/short-answer-question.component.html
@@ -56,7 +56,7 @@
         <ng-template #renderedHint>
             <div [innerHTML]="renderedQuestion.hint"></div>
         </ng-template>
-        <span class="label label-info" [ngbPopover]="renderedHint" placement="right" triggers="mouseenter:mouseleave" *ngIf="shortAnswerQuestion.hint">
+        <span class="label label-info" [ngbPopover]="renderedHint" placement="right auto" triggers="mouseenter:mouseleave" *ngIf="shortAnswerQuestion.hint">
             <fa-icon [icon]="farQuestionCircle"></fa-icon>
             <span jhiTranslate="artemisApp.quizQuestion.hint"></span>
         </span>
@@ -67,7 +67,7 @@
         <span
             class="label label-primary"
             [ngbPopover]="renderedExplanation"
-            placement="right"
+            placement="right auto"
             triggers="mouseenter:mouseleave"
             *ngIf="shortAnswerQuestion.explanation && showResult"
         >

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -118,7 +118,6 @@
                 class="text-warning"
                 *ngIf="exercise.testRunParticipationsExist"
                 [ngbTooltip]="'artemisApp.quizExercise.edit.testRunSubmissionsExist' | artemisTranslate"
-                placement="auto"
             >
             </fa-icon>
             <a

--- a/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
+++ b/src/main/webapp/app/exercises/shared/exam-exercise-row-buttons/exam-exercise-row-buttons.component.html
@@ -119,7 +119,6 @@
                 *ngIf="exercise.testRunParticipationsExist"
                 [ngbTooltip]="'artemisApp.quizExercise.edit.testRunSubmissionsExist' | artemisTranslate"
                 placement="auto"
-                container="body"
             >
             </fa-icon>
             <a

--- a/src/main/webapp/app/exercises/shared/example-submission/example-submission-import/example-submission-import.component.html
+++ b/src/main/webapp/app/exercises/shared/example-submission/example-submission-import/example-submission-import.component.html
@@ -40,14 +40,12 @@
                                 [icon]="faQuestionCircle"
                                 class="text-secondary ps-1"
                                 [ngbTooltip]="'artemisApp.exampleSubmission.textSubmissionSizeHint' | artemisTranslate"
-                                container="body"
                             ></fa-icon>
                             <fa-icon
                                 *ngIf="exercise && exercise.type === exerciseType.MODELING"
                                 [icon]="faQuestionCircle"
                                 class="text-secondary ps-1"
                                 [ngbTooltip]="'artemisApp.exampleSubmission.modelingSubmissionSizeHint' | artemisTranslate"
-                                container="body"
                             ></fa-icon>
                         </th>
                         <th></th>

--- a/src/main/webapp/app/exercises/shared/example-submission/example-submissions.component.html
+++ b/src/main/webapp/app/exercises/shared/example-submission/example-submissions.component.html
@@ -33,14 +33,12 @@
                             [icon]="faQuestionCircle"
                             class="text-secondary ps-1"
                             [ngbTooltip]="'artemisApp.exampleSubmission.textSubmissionSizeHint' | artemisTranslate"
-                            container="body"
                         ></fa-icon>
                         <fa-icon
                             *ngIf="exercise.type === exerciseType.MODELING"
                             [icon]="faQuestionCircle"
                             class="text-secondary ps-1"
                             [ngbTooltip]="'artemisApp.exampleSubmission.modelingSubmissionSizeHint' | artemisTranslate"
-                            container="body"
                         ></fa-icon>
                     </th>
                     <th><span jhiTranslate="artemisApp.exampleSubmission.assessmentTraining"></span></th>
@@ -82,7 +80,6 @@
                             [icon]="faExclamationTriangle"
                             class="text-warning"
                             [ngbTooltip]="'artemisApp.exampleSubmission.exampleAssessmentWarning' | artemisTranslate"
-                            container="body"
                         ></fa-icon>
                     </td>
                     <td *ngIf="exercise.course.isAtLeastEditor">

--- a/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/header-exercise-page-with-details.component.html
@@ -2,7 +2,7 @@
     <div class="left-col">
         <div class="title-row">
             <div class="inner-row">
-                <fa-icon *ngIf="exercise.type" [icon]="getIcon(exercise.type)" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate" container="body"></fa-icon>
+                <fa-icon *ngIf="exercise.type" [icon]="getIcon(exercise.type)" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate"></fa-icon>
                 &nbsp;
                 <ng-content select="[pagetitle]"></ng-content>
             </div>

--- a/src/main/webapp/app/exercises/shared/exercise-headers/included-in-score-badge.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-headers/included-in-score-badge.component.html
@@ -1,1 +1,1 @@
-<span class="badge included-score-badge" [ngClass]="badgeClass" [ngbTooltip]="translatedTooltip" container="body">{{ translatedEnum }}</span>
+<span class="badge included-score-badge" [ngClass]="badgeClass" [ngbTooltip]="translatedTooltip">{{ translatedEnum }}</span>

--- a/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise-hint/manage/exercise-hint-update.component.html
@@ -17,7 +17,7 @@
                 <div class="form-group">
                     <div>
                         <label class="label-narrow" jhiTranslate="artemisApp.exerciseHint.description" for="field_description">Description</label>
-                        <jhi-help-icon placement="auto" text="artemisApp.exerciseHint.descriptionTooltip"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.exerciseHint.descriptionTooltip"></jhi-help-icon>
                     </div>
                     <input type="text" required minlength="3" class="form-control" name="description" id="field_description" [(ngModel)]="exerciseHint.description" />
                 </div>
@@ -25,7 +25,7 @@
                     <div>
                         <label class="label-narrow" jhiTranslate="artemisApp.exerciseHint.task" for="field_task">Task</label>
                         <ng-container *ngIf="exerciseHint.type === 'code'">
-                            <jhi-help-icon placement="auto" text="artemisApp.exerciseHint.taskTooltip"></jhi-help-icon>
+                            <jhi-help-icon text="artemisApp.exerciseHint.taskTooltip"></jhi-help-icon>
                         </ng-container>
                     </div>
                     <select class="form-select" required name="task" [(ngModel)]="this.exerciseHint.programmingExerciseTask" id="field_task">
@@ -36,7 +36,7 @@
                 <div class="form-group">
                     <div>
                         <label class="label-narrow" jhiTranslate="artemisApp.exerciseHint.displayThreshold" for="field_description">Display Threshold</label>
-                        <jhi-help-icon placement="auto" text="artemisApp.exerciseHint.displayThresholdTooltip"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.exerciseHint.displayThresholdTooltip"></jhi-help-icon>
                     </div>
                     <input
                         type="number"

--- a/src/main/webapp/app/exercises/shared/exercise/exercise-lti-configuration.component.html
+++ b/src/main/webapp/app/exercises/shared/exercise/exercise-lti-configuration.component.html
@@ -30,7 +30,7 @@
 
         <dt>
             <span>{{ 'artemisApp.lti.ltiLaunchTarget' | artemisTranslate }}</span>
-            <fa-icon [icon]="faQuestionCircle" class="text-secondary" placement="top" ngbTooltip="{{ 'artemisApp.lti.launchTargetTooltip' | artemisTranslate }}"></fa-icon>
+            <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.lti.launchTargetTooltip' | artemisTranslate }}"></fa-icon>
         </dt>
         <dd>
             <span>New Window</span>
@@ -52,7 +52,7 @@
 
         <dt>
             <span>{{ 'artemisApp.lti.requestEmail' | artemisTranslate }}</span>
-            <fa-icon [icon]="faQuestionCircle" class="text-secondary" placement="top" ngbTooltip="{{ 'artemisApp.lti.requestUserEmailTooltip' | artemisTranslate }}"></fa-icon>
+            <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.lti.requestUserEmailTooltip' | artemisTranslate }}"></fa-icon>
         </dt>
         <dd>
             <span>True</span>
@@ -63,12 +63,7 @@
 
             <dt>
                 <span>{{ 'artemisApp.lti.requireExistingUser' | artemisTranslate }}</span>
-                <fa-icon
-                    [icon]="faQuestionCircle"
-                    class="text-secondary"
-                    placement="top"
-                    ngbTooltip="{{ 'artemisApp.lti.requireExistingUserTooltip' | artemisTranslate }}"
-                ></fa-icon>
+                <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.lti.requireExistingUserTooltip' | artemisTranslate }}"></fa-icon>
             </dt>
             <dd>
                 <input type="checkbox" class="form-check-input" (change)="requireExistingUser = !requireExistingUser" [checked]="requireExistingUser" />
@@ -76,7 +71,7 @@
 
             <dt>
                 <span>{{ 'artemisApp.lti.lookupByEmail' | artemisTranslate }}</span>
-                <fa-icon [icon]="faQuestionCircle" class="text-secondary" placement="top" ngbTooltip="{{ 'artemisApp.lti.lookupUserByEmailTooltip' | artemisTranslate }}"></fa-icon>
+                <fa-icon [icon]="faQuestionCircle" class="text-secondary" ngbTooltip="{{ 'artemisApp.lti.lookupUserByEmailTooltip' | artemisTranslate }}"></fa-icon>
             </dt>
             <dd>
                 <input type="checkbox" class="form-check-input" (change)="lookupUserByEmail = !lookupUserByEmail" [checked]="lookupUserByEmail" />

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
@@ -78,12 +78,7 @@
         <div class="plagiarism-header-options" [hidden]="!showOptions">
             <div class="plagiarism-option">
                 <div class="plagiarism-option-label" jhiTranslate="artemisApp.plagiarism.similarityThreshold">Similarity Threshold</div>
-                <fa-icon
-                    [icon]="faQuestionCircle"
-                    placement="bottom"
-                    [ngbTooltip]="'artemisApp.plagiarism.similarityThresholdTooltip' | artemisTranslate"
-                    container="body"
-                ></fa-icon>
+                <fa-icon [icon]="faQuestionCircle" placement="bottom" [ngbTooltip]="'artemisApp.plagiarism.similarityThresholdTooltip' | artemisTranslate"></fa-icon>
                 <input type="number" required class="form-control" min="0" max="100" step="5" id="plagiarism-similarity-threshold" [(ngModel)]="similarityThreshold" />
             </div>
 
@@ -92,7 +87,7 @@
                     <input type="checkbox" id="enableMinimumScore" class="plagiarism-option-checkbox form-check-input" [(ngModel)]="enableMinimumScore" checked />
                     <div class="plagiarism-option-label form-check-label" jhiTranslate="artemisApp.plagiarism.minimumScore">Minimum Score</div>
                 </div>
-                <fa-icon [icon]="faQuestionCircle" placement="bottom" [ngbTooltip]="'artemisApp.plagiarism.minimumScoreTooltip' | artemisTranslate" container="body"></fa-icon>
+                <fa-icon [icon]="faQuestionCircle" placement="bottom" [ngbTooltip]="'artemisApp.plagiarism.minimumScoreTooltip' | artemisTranslate"></fa-icon>
                 <input required type="number" [disabled]="!enableMinimumScore" class="form-control" min="0" max="100" id="plagiarism-minimum-score" [(ngModel)]="minimumScore" />
             </div>
 
@@ -101,7 +96,7 @@
                     <input type="checkbox" id="enableMinimumSize" class="plagiarism-option-checkbox form-check-input" [(ngModel)]="enableMinimumSize" checked />
                     <label for="enableMinimumSize" class="plagiarism-option-label form-check-label" jhiTranslate="artemisApp.plagiarism.minimumSize">Minimum Size</label>
                 </div>
-                <fa-icon [icon]="faQuestionCircle" placement="bottom" [ngbTooltip]="getMinimumSizeTooltip() | artemisTranslate" container="body"></fa-icon>
+                <fa-icon [icon]="faQuestionCircle" placement="bottom" [ngbTooltip]="getMinimumSizeTooltip() | artemisTranslate"></fa-icon>
                 <input required type="number" [disabled]="!enableMinimumSize" class="form-control" min="0" max="100" id="plagiarism-minimum-size" [(ngModel)]="minimumSize" />
             </div>
 

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-inspector/plagiarism-inspector.component.html
@@ -78,7 +78,7 @@
         <div class="plagiarism-header-options" [hidden]="!showOptions">
             <div class="plagiarism-option">
                 <div class="plagiarism-option-label" jhiTranslate="artemisApp.plagiarism.similarityThreshold">Similarity Threshold</div>
-                <fa-icon [icon]="faQuestionCircle" placement="bottom" [ngbTooltip]="'artemisApp.plagiarism.similarityThresholdTooltip' | artemisTranslate"></fa-icon>
+                <fa-icon [icon]="faQuestionCircle" placement="bottom auto" [ngbTooltip]="'artemisApp.plagiarism.similarityThresholdTooltip' | artemisTranslate"></fa-icon>
                 <input type="number" required class="form-control" min="0" max="100" step="5" id="plagiarism-similarity-threshold" [(ngModel)]="similarityThreshold" />
             </div>
 
@@ -87,7 +87,7 @@
                     <input type="checkbox" id="enableMinimumScore" class="plagiarism-option-checkbox form-check-input" [(ngModel)]="enableMinimumScore" checked />
                     <div class="plagiarism-option-label form-check-label" jhiTranslate="artemisApp.plagiarism.minimumScore">Minimum Score</div>
                 </div>
-                <fa-icon [icon]="faQuestionCircle" placement="bottom" [ngbTooltip]="'artemisApp.plagiarism.minimumScoreTooltip' | artemisTranslate"></fa-icon>
+                <fa-icon [icon]="faQuestionCircle" placement="bottom auto" [ngbTooltip]="'artemisApp.plagiarism.minimumScoreTooltip' | artemisTranslate"></fa-icon>
                 <input required type="number" [disabled]="!enableMinimumScore" class="form-control" min="0" max="100" id="plagiarism-minimum-score" [(ngModel)]="minimumScore" />
             </div>
 
@@ -96,7 +96,7 @@
                     <input type="checkbox" id="enableMinimumSize" class="plagiarism-option-checkbox form-check-input" [(ngModel)]="enableMinimumSize" checked />
                     <label for="enableMinimumSize" class="plagiarism-option-label form-check-label" jhiTranslate="artemisApp.plagiarism.minimumSize">Minimum Size</label>
                 </div>
-                <fa-icon [icon]="faQuestionCircle" placement="bottom" [ngbTooltip]="getMinimumSizeTooltip() | artemisTranslate"></fa-icon>
+                <fa-icon [icon]="faQuestionCircle" placement="bottom auto" [ngbTooltip]="getMinimumSizeTooltip() | artemisTranslate"></fa-icon>
                 <input required type="number" [disabled]="!enableMinimumSize" class="form-control" min="0" max="100" id="plagiarism-minimum-size" [(ngModel)]="minimumSize" />
             </div>
 

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-run-details/plagiarism-run-details.component.html
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-run-details/plagiarism-run-details.component.html
@@ -11,7 +11,7 @@
     <div class="plagiarism-run-details-item">
         <div class="plagiarism-run-details-label text-center">
             {{ 'artemisApp.plagiarism.similarityDistribution' | artemisTranslate }}
-            <jhi-help-icon placement="right" text="artemisApp.plagiarism.similarityDistributionExplanationTooltip"></jhi-help-icon>
+            <jhi-help-icon placement="right auto" text="artemisApp.plagiarism.similarityDistributionExplanationTooltip"></jhi-help-icon>
         </div>
         <div #containerRef class="plagiarism-run-details-info">
             <ngx-charts-bar-vertical

--- a/src/main/webapp/app/exercises/shared/presentation-score/presentation-score.component.ts
+++ b/src/main/webapp/app/exercises/shared/presentation-score/presentation-score.component.ts
@@ -23,7 +23,6 @@ import { Authority } from 'app/shared/constants/authority.constants';
                     <fa-icon
                         [icon]="faQuestionCircle"
                         class="text-secondary"
-                        placement="top"
                         ngbTooltip="{{ 'artemisApp.exercise.presentationScoreEnabled.description' | artemisTranslate }}"
                     ></fa-icon>
                 </div>

--- a/src/main/webapp/app/exercises/shared/result/result-detail.component.html
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.component.html
@@ -60,7 +60,7 @@
                     </ngx-charts-bar-horizontal-stacked>
                 </div>
                 <div *ngIf="showScoreChartTooltip" class="chart-tooltip-space d-flex justify-content-center position-relative">
-                    <div class="chart-tooltip-space-content" [ngbTooltip]="'artemisApp.result.chart.tooltip' | artemisTranslate" placement="bottom"></div>
+                    <div class="chart-tooltip-space-content" [ngbTooltip]="'artemisApp.result.chart.tooltip' | artemisTranslate" placement="bottom auto"></div>
                 </div>
                 <hr />
             </div>

--- a/src/main/webapp/app/exercises/shared/result/result.component.html
+++ b/src/main/webapp/app/exercises/shared/result/result.component.html
@@ -19,7 +19,7 @@
                 id="result-score"
                 (click)="showDetails(result)"
             >
-                <span class="guided-tour result" [ngbTooltip]="resultTooltip | artemisTranslate" container="body">
+                <span class="guided-tour result" [ngbTooltip]="resultTooltip | artemisTranslate">
                     {{ resultString }}
                 </span>
                 <span class="result" [ngbTooltip]="result.submission?.submissionDate ?? result.completionDate | artemisDate">
@@ -28,10 +28,10 @@
             </span>
             <ng-template #notPreliminaryAndNoFeedback>
                 <span [ngClass]="textColorClass" class="guided-tour result" id="result-score">
-                    <span class="result" [ngbTooltip]="resultTooltip | artemisTranslate" container="body">
+                    <span class="result" [ngbTooltip]="resultTooltip | artemisTranslate">
                         {{ resultString }}
                     </span>
-                    <span class="result" [ngbTooltip]="result.submission?.submissionDate ?? result.completionDate | artemisDate" container="body">
+                    <span class="result" [ngbTooltip]="result.submission?.submissionDate ?? result.completionDate | artemisDate">
                         ({{ result.submission?.submissionDate ?? result.completionDate! | artemisTimeAgo }})
                     </span>
                 </span>
@@ -42,7 +42,7 @@
                     <span jhiTranslate="artemisApp.editor.downloadBuildResult">Download Build Result</span>
                 </a>
             </span>
-            <span *ngIf="showBadge" class="badge" [ngClass]="badgeClass" id="result-score-badge" ngbTooltip="{{ badgeTooltip | artemisTranslate }}" container="body">
+            <span *ngIf="showBadge" class="badge" [ngClass]="badgeClass" id="result-score-badge" ngbTooltip="{{ badgeTooltip | artemisTranslate }}">
                 {{ badgeText | artemisTranslate | uppercase }}
             </span>
         </ng-container>

--- a/src/main/webapp/app/exercises/shared/structured-grading-criterion/grading-instructions-details/grading-instructions-details.component.html
+++ b/src/main/webapp/app/exercises/shared/structured-grading-criterion/grading-instructions-details/grading-instructions-details.component.html
@@ -42,23 +42,23 @@
                             <tr>
                                 <th width="10%">
                                     <span>{{ 'artemisApp.exercise.credits' | artemisTranslate }}</span>
-                                    <jhi-help-icon placement="top" text="artemisApp.exercise.creditsHint" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon text="artemisApp.exercise.creditsHint" class="me-1"></jhi-help-icon>
                                 </th>
                                 <th width="10%">
                                     <span>{{ 'artemisApp.exercise.gradingScale' | artemisTranslate }}</span>
-                                    <jhi-help-icon placement="top" text="artemisApp.exercise.gradingScaleHint" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon text="artemisApp.exercise.gradingScaleHint" class="me-1"></jhi-help-icon>
                                 </th>
                                 <th width="30%">
                                     <span>{{ 'artemisApp.exercise.instructionDescription' | artemisTranslate }}</span>
-                                    <jhi-help-icon placement="top" text="artemisApp.exercise.descriptionHint" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon text="artemisApp.exercise.descriptionHint" class="me-1"></jhi-help-icon>
                                 </th>
                                 <th width="30%">
                                     <span>{{ 'artemisApp.exercise.feedback' | artemisTranslate }}</span>
-                                    <jhi-help-icon placement="top" text="artemisApp.exercise.feedbackHint" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon text="artemisApp.exercise.feedbackHint" class="me-1"></jhi-help-icon>
                                 </th>
                                 <th width="10%">
                                     <span>{{ 'artemisApp.exercise.limit' | artemisTranslate }}</span>
-                                    <jhi-help-icon placement="top" text="artemisApp.exercise.usageCountHint" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon text="artemisApp.exercise.usageCountHint" class="me-1"></jhi-help-icon>
                                 </th>
                                 <th width="5%">
                                     <span>{{ 'artemisApp.exercise.action' | artemisTranslate }}</span>

--- a/src/main/webapp/app/exercises/shared/submission-policy/submission-policy-update.component.ts
+++ b/src/main/webapp/app/exercises/shared/submission-policy/submission-policy-update.component.ts
@@ -30,7 +30,7 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
                         <label class="label-narrow" jhiTranslate="artemisApp.programmingExercise.submissionPolicy.submissionLimitTitle" for="field_submissionLimitExceededPenalty"
                             >Submission limit</label
                         >
-                        <jhi-help-icon placement="top" text="artemisApp.programmingExercise.submissionPolicy.submissionLimitDescription"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.programmingExercise.submissionPolicy.submissionLimitDescription"></jhi-help-icon>
                         <div class="input-group">
                             <input
                                 required
@@ -58,7 +58,7 @@ import { FormControl, FormGroup, Validators } from '@angular/forms';
                             for="field_submissionLimitExceededPenalty"
                             >Penalty after Exceeding Submission limit</label
                         >
-                        <jhi-help-icon placement="top" text="artemisApp.programmingExercise.submissionPolicy.submissionPenalty.exceedingLimitDescription"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.programmingExercise.submissionPolicy.submissionPenalty.exceedingLimitDescription"></jhi-help-icon>
                         <div class="input-group">
                             <input
                                 required

--- a/src/main/webapp/app/exercises/shared/team-config-form-group/team-config-form-group.component.html
+++ b/src/main/webapp/app/exercises/shared/team-config-form-group/team-config-form-group.component.html
@@ -3,7 +3,7 @@
         <div class="col-auto">
             <div>
                 <label class="label-narrow" jhiTranslate="artemisApp.exercise.mode">Mode</label>
-                <jhi-help-icon placement="top auto" text="artemisApp.exercise.modeTooltip"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.exercise.modeTooltip"></jhi-help-icon>
             </div>
             <div>
                 <jhi-mode-picker
@@ -17,7 +17,7 @@
         <div class="col-auto" *ngIf="exercise.mode === TEAM">
             <div>
                 <label class="label-narrow" jhiTranslate="artemisApp.exercise.teamAssignmentConfig.teamSize">Team size</label>
-                <jhi-help-icon placement="top" text="artemisApp.exercise.teamAssignmentConfig.teamSizeTooltip"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.exercise.teamAssignmentConfig.teamSizeTooltip"></jhi-help-icon>
             </div>
             <div>
                 <div class="input-group">

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
@@ -119,7 +119,6 @@
                             ngbTooltip="{{ 'artemisApp.team.detail.participationsTable.columns.assessment.tooltip' | artemisTranslate }}"
                             [disableTooltip]="!isAssessmentButtonDisabled(value, value.submission)"
                             placement="left"
-                            container="body"
                         >
                             <a
                                 [class.disabled]="isAssessmentButtonDisabled(value, value.submission)"

--- a/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-participation-table/team-participation-table.component.html
@@ -118,7 +118,7 @@
                         <div
                             ngbTooltip="{{ 'artemisApp.team.detail.participationsTable.columns.assessment.tooltip' | artemisTranslate }}"
                             [disableTooltip]="!isAssessmentButtonDisabled(value, value.submission)"
-                            placement="left"
+                            placement="left auto"
                         >
                             <a
                                 [class.disabled]="isAssessmentButtonDisabled(value, value.submission)"

--- a/src/main/webapp/app/exercises/shared/team/team-update-dialog/team-update-dialog.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team-update-dialog/team-update-dialog.component.html
@@ -31,7 +31,7 @@
         <div class="form-group">
             <div>
                 <label class="label-narrow" jhiTranslate="artemisApp.team.shortName.label" for="teamShortName">Short Name</label>
-                <jhi-help-icon placement="auto" text="artemisApp.team.shortName.tooltip"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.team.shortName.tooltip"></jhi-help-icon>
             </div>
             <input
                 type="text"
@@ -56,7 +56,7 @@
             <div class="d-flex align-items-end">
                 <div>
                     <label class="label-narrow" jhiTranslate="artemisApp.team.owner.label">Tutor</label>
-                    <jhi-help-icon placement="auto" text="artemisApp.team.owner.tooltip" class="me-1"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.team.owner.tooltip" class="me-1"></jhi-help-icon>
                 </div>
                 <fa-icon class="search-searching" [icon]="faSpinner" [spin]="true" *ngIf="searchingOwner"></fa-icon>
                 <span *ngIf="searchingOwnerQueryTooShort" class="label-inline-message text-danger" jhiTranslate="artemisApp.team.ownerSearch.queryTooShort">

--- a/src/main/webapp/app/exercises/shared/team/team.component.html
+++ b/src/main/webapp/app/exercises/shared/team/team.component.html
@@ -14,7 +14,7 @@
                 </span>
                 <span class="d-inline-block ms-2">
                     <span class="text-muted font-weight-bolder">Created:</span>
-                    <span ngbTooltip="{{ team.createdDate | artemisDate }}" placement="top" tooltipClass="date-tooltip">
+                    <span ngbTooltip="{{ team.createdDate | artemisDate }}" tooltipClass="date-tooltip">
                         {{ team.createdDate!.fromNow() }}
                     </span>
                     <a *ngIf="isAdmin" [routerLink]="['/admin', 'user-management', team.createdBy]">({{ team.createdBy }})</a>

--- a/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-dialog.component.html
+++ b/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-dialog.component.html
@@ -34,7 +34,7 @@
             <div class="d-flex align-items-end">
                 <div>
                     <label class="label-narrow" jhiTranslate="artemisApp.team.sourceExercise.label">Source exercise</label>
-                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceExercise.tooltip" class="me-1"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.team.sourceExercise.tooltip" class="me-1"></jhi-help-icon>
                 </div>
                 <fa-icon class="loading-spinner" [icon]="faSpinner" [spin]="true" *ngIf="searchingExercises"></fa-icon>
                 <span *ngIf="searchingExercisesNoResultsForQuery === ''" class="error-message text-danger">
@@ -63,7 +63,7 @@
             <div class="d-flex align-items-end">
                 <div>
                     <label class="label-narrow" jhiTranslate="artemisApp.team.sourceTeams.label">Source teams</label>
-                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.tooltip" class="me-1"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.team.sourceTeams.tooltip" class="me-1"></jhi-help-icon>
                 </div>
                 <fa-icon class="loading-spinner" [icon]="faSpinner" [spin]="true" *ngIf="loadingSourceTeams"></fa-icon>
                 <span *ngIf="loadingSourceTeamsFailed" class="error-message text-danger" jhiTranslate="artemisApp.team.loadSourceTeams.failed">
@@ -106,7 +106,7 @@
                     <hr class="mt-3 mb-2" />
                     <div>
                         <label jhiTranslate="artemisApp.team.sourceTeams.legend.label">Legend</label>
-                        <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.legend.tooltip" class="me-1"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.team.sourceTeams.legend.tooltip" class="me-1"></jhi-help-icon>
                     </div>
                     <div class="source-teams-legend-box">
                         <div class="source-teams-legend d-flex justify-content-between">
@@ -117,7 +117,7 @@
                                 </div>
                                 <div class="label-with-tooltip">
                                     <label jhiTranslate="artemisApp.team.sourceTeams.legend.items.conflictFreeTeam.label">Conflict-free team</label>
-                                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.legend.items.conflictFreeTeam.tooltip" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon text="artemisApp.team.sourceTeams.legend.items.conflictFreeTeam.tooltip" class="me-1"></jhi-help-icon>
                                 </div>
                             </div>
                             <div>
@@ -127,7 +127,7 @@
                                 </div>
                                 <div class="label-with-tooltip">
                                     <label jhiTranslate="artemisApp.team.sourceTeams.legend.items.teamShortNameConflict.label">Team short name conflict</label>
-                                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.legend.items.teamShortNameConflict.tooltip" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon text="artemisApp.team.sourceTeams.legend.items.teamShortNameConflict.tooltip" class="me-1"></jhi-help-icon>
                                 </div>
                             </div>
                             <div>
@@ -142,7 +142,7 @@
                                 </div>
                                 <div class="label-with-tooltip">
                                     <label jhiTranslate="artemisApp.team.sourceTeams.legend.items.studentConflict.label">Student conflict</label>
-                                    <jhi-help-icon placement="auto" text="artemisApp.team.sourceTeams.legend.items.studentConflict.tooltip" class="me-1"></jhi-help-icon>
+                                    <jhi-help-icon text="artemisApp.team.sourceTeams.legend.items.studentConflict.tooltip" class="me-1"></jhi-help-icon>
                                 </div>
                             </div>
                         </div>
@@ -155,7 +155,7 @@
             <div class="form-group mb-0">
                 <div>
                     <label class="label-narrow" jhiTranslate="artemisApp.team.importStrategy.label">Import conflict strategy</label>
-                    <jhi-help-icon placement="auto" text="artemisApp.team.importStrategy.tooltip" class="me-1"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.team.importStrategy.tooltip" class="me-1"></jhi-help-icon>
                 </div>
                 <div class="d-flex flex-column mt-2 ps-2">
                     <label class="d-flex align-items-start">

--- a/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-from-file-form.component.html
+++ b/src/main/webapp/app/exercises/shared/team/teams-import-dialog/teams-import-from-file-form.component.html
@@ -1,6 +1,6 @@
 <div>
     <label class="label-narrow" jhiTranslate="artemisApp.team.sourceFile.label">Source file</label>
-    <jhi-help-icon placement="auto" text="artemisApp.team.sourceFile.tooltip" class="me-1"></jhi-help-icon>
+    <jhi-help-icon text="artemisApp.team.sourceFile.tooltip" class="me-1"></jhi-help-icon>
     <fa-icon class="loading-spinner" [icon]="faSpinner" [spin]="true" *ngIf="loading"></fa-icon>
 </div>
 <div class="custom-file">

--- a/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/dropdown/textblock-feedback-dropdown.component.html
+++ b/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/dropdown/textblock-feedback-dropdown.component.html
@@ -11,7 +11,7 @@
                         <span *ngIf="instruction!.usageCount; else usageCountInfinity">{{ instruction!.usageCount }}</span>
                         <!-- if the usage count has no limit, the infinity symbol is displayed (= &#8734) -->
                         <ng-template #usageCountInfinity>&#8734;</ng-template>
-                        <jhi-help-icon placement="top" text="artemisApp.exercise.usageCountHint"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.exercise.usageCountHint"></jhi-help-icon>
                     </td>
                 </tr>
             </tbody>

--- a/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.html
+++ b/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.html
@@ -9,7 +9,6 @@
         *ngIf="feedback.type === FeedbackType.AUTOMATIC"
         (click)="openOriginOfFeedbackModal(toggleMore)"
         [ngbTooltip]="'artemisApp.textAssessment.feedbackEditor.automaticFeedbackInformationModal.trace' | artemisTranslate"
-        placement="top"
     >
         <fa-icon [icon]="faSearch"></fa-icon>
     </span>
@@ -105,11 +104,11 @@
                     (ngModelChange)="didChange()"
                 ></textarea>
                 <div class="card-header" *ngIf="!conflictMode && feedback.credits !== 0 && textBlock?.numberOfAffectedSubmissions && feedback.type === FeedbackType.MANUAL">
-                    <fa-icon [icon]="faInfoCircle" size="1x" class="text-info" placement="left"></fa-icon>
+                    <fa-icon [icon]="faInfoCircle" size="1x" class="text-info" placement="left auto"></fa-icon>
                     <span
                         jhiTranslate="artemisApp.textAssessment.feedbackEditor.impactWarning"
                         [ngbTooltip]="'artemisApp.textAssessment.feedbackEditor.impactWarningTooltip' | artemisTranslate"
-                        placement="bottom"
+                        placement="bottom auto"
                         class="impactWarningLabel"
                         (mouseenter)="mouseEnteredWarningLabel()"
                         [translateValues]="{ affectedSubmissionsCount: textBlock.numberOfAffectedSubmissions }"

--- a/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.html
+++ b/src/main/webapp/app/exercises/text/assess/textblock-feedback-editor/textblock-feedback-editor.component.html
@@ -49,7 +49,7 @@
             <label class="d-inline" jhiTranslate="artemisApp.assessment.detail.feedbackWithColon" for="detailText-{{ textBlock.id }}"></label>
             <div class="d-inline" *ngIf="feedback.gradingInstruction!">
                 <span class="fw-bold">{{ feedback.gradingInstruction!.feedback }}</span>
-                <fa-icon [icon]="faQuestionCircle" class="text-secondary" [ngbTooltip]="'artemisApp.assessment.feedbackHint' | artemisTranslate" container="body"></fa-icon>
+                <fa-icon [icon]="faQuestionCircle" class="text-secondary" [ngbTooltip]="'artemisApp.assessment.feedbackHint' | artemisTranslate"></fa-icon>
             </div>
         </div>
         <div class="form-group col-md-1 text-end m-0">

--- a/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
+++ b/src/main/webapp/app/exercises/text/manage/example-text-submission/example-text-submission.component.html
@@ -17,7 +17,7 @@
             <div>
                 <div class="text-start">
                     <span>{{ 'artemisApp.exampleSubmission.assessmentTraining' | artemisTranslate }}</span>
-                    <jhi-help-icon placement="auto" [text]="'artemisApp.exampleSubmission.selectModelExplanation'"></jhi-help-icon>
+                    <jhi-help-icon [text]="'artemisApp.exampleSubmission.selectModelExplanation'"></jhi-help-icon>
                 </div>
                 <div class="btn-group" role="group">
                     <input

--- a/src/main/webapp/app/exercises/text/manage/tutor-effort/tutor-effort-statistics.component.html
+++ b/src/main/webapp/app/exercises/text/manage/tutor-effort/tutor-effort-statistics.component.html
@@ -30,7 +30,7 @@
             <div #containerRef class="col-10">
                 <div class="d-flex flex-row justify-content-center align-items-center">
                     <h3 jhiTranslate="artemisApp.textExercise.tutorEffortStatistics.title">Tutor Effort Statistics</h3>
-                    <jhi-help-icon [text]="'artemisApp.textExercise.tutorEffortStatistics.titleDescription'" [placement]="'right'"></jhi-help-icon>
+                    <jhi-help-icon [text]="'artemisApp.textExercise.tutorEffortStatistics.titleDescription'" [placement]="'right auto'"></jhi-help-icon>
                 </div>
                 <ngx-charts-bar-vertical
                     [roundEdges]="false"

--- a/src/main/webapp/app/grading-system/bonus/bonus.component.html
+++ b/src/main/webapp/app/grading-system/bonus/bonus.component.html
@@ -1,6 +1,6 @@
 <ng-template #helpTextTemplate let-translationKey="translationKey">
     <ng-template #tipContent><span [innerHTML]="translationKey | artemisTranslate | safeHtml"></span></ng-template>
-    <fa-icon *ngIf="bonus.id" [icon]="faQuestionCircle" class="text-secondary" placement="right" [ngbTooltip]="tipContent"></fa-icon>
+    <fa-icon *ngIf="bonus.id" [icon]="faQuestionCircle" class="text-secondary" placement="right auto" [ngbTooltip]="tipContent"></fa-icon>
     <label *ngIf="!bonus.id" [innerHTML]="translationKey | artemisTranslate | safeHtml" class="d-block py-1"></label>
 </ng-template>
 <h2>{{ 'artemisApp.bonus.title' | artemisTranslate }}</h2>
@@ -113,7 +113,6 @@
                             *ngIf="example.exceedsMax"
                             [icon]="faExclamationTriangle"
                             class="text-warning"
-                            placement="top"
                             [ngbTooltip]="'artemisApp.bonus.examples.exceedsMax' | artemisTranslate"
                         ></fa-icon>
                     </td>
@@ -126,7 +125,6 @@
                             *ngIf="bonus.bonusStrategy !== BonusStrategy.POINTS && example.exceedsMax"
                             [icon]="faExclamationTriangle"
                             class="text-warning"
-                            placement="top"
                             [ngbTooltip]="'artemisApp.bonus.examples.exceedsMax' | artemisTranslate"
                         ></fa-icon>
                     </td>
@@ -143,7 +141,6 @@
                                 *ngIf="dynamicExample.exceedsMax"
                                 [icon]="faExclamationTriangle"
                                 class="text-warning"
-                                placement="top"
                                 [ngbTooltip]="'artemisApp.bonus.examples.exceedsMax' | artemisTranslate"
                             ></fa-icon>
                         </ng-container>
@@ -157,7 +154,6 @@
                             *ngIf="bonus.bonusStrategy !== BonusStrategy.POINTS && dynamicExample.exceedsMax"
                             [icon]="faExclamationTriangle"
                             class="text-warning"
-                            placement="top"
                             [ngbTooltip]="'artemisApp.bonus.examples.exceedsMax' | artemisTranslate"
                         ></fa-icon>
                     </td>

--- a/src/main/webapp/app/grading-system/interval-grading-system/interval-grading-system.component.html
+++ b/src/main/webapp/app/grading-system/interval-grading-system/interval-grading-system.component.html
@@ -87,7 +87,7 @@
             <tbody>
                 <tr *ngFor="let gradeStep of gradingScale.gradeSteps; let i = index; let last = last" class="grading-scale-table-row">
                     <td *ngIf="last; else intervalInputs">
-                        <jhi-help-icon placement="auto" text="artemisApp.gradingSystem.stickyGradeStep"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.gradingSystem.stickyGradeStep"></jhi-help-icon>
                     </td>
                     <ng-template #intervalInputs>
                         <td *ngIf="gradeEditMode === GradeEditMode.PERCENTAGE">

--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -69,7 +69,7 @@
                     <h6 jhiTranslate="artemisApp.studentDashboard.cardExerciseLabel">Next exercises:</h6>
                 </div>
                 <div class="col-6 next-exercise-col">
-                    <fa-icon class="next-exercise-icon" [icon]="nextExerciseIcon" placement="right" [ngbTooltip]="nextExerciseTooltip | artemisTranslate"></fa-icon>
+                    <fa-icon class="next-exercise-icon" [icon]="nextExerciseIcon" placement="right auto" [ngbTooltip]="nextExerciseTooltip | artemisTranslate"></fa-icon>
                     <span class="next-exercise-title">{{ nextRelevantExercise.title }}</span>
                 </div>
                 <div class="col-3 next-exercise-col text-nowrap">

--- a/src/main/webapp/app/overview/course-card.component.html
+++ b/src/main/webapp/app/overview/course-card.component.html
@@ -69,13 +69,7 @@
                     <h6 jhiTranslate="artemisApp.studentDashboard.cardExerciseLabel">Next exercises:</h6>
                 </div>
                 <div class="col-6 next-exercise-col">
-                    <fa-icon
-                        class="next-exercise-icon"
-                        [icon]="nextExerciseIcon"
-                        placement="right"
-                        [ngbTooltip]="nextExerciseTooltip | artemisTranslate"
-                        container="body"
-                    ></fa-icon>
+                    <fa-icon class="next-exercise-icon" [icon]="nextExerciseIcon" placement="right" [ngbTooltip]="nextExerciseTooltip | artemisTranslate"></fa-icon>
                     <span class="next-exercise-title">{{ nextRelevantExercise.title }}</span>
                 </div>
                 <div class="col-3 next-exercise-col text-nowrap">

--- a/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
+++ b/src/main/webapp/app/overview/course-exercises/course-exercise-row.component.html
@@ -2,7 +2,7 @@
     <a class="stretched-link" [routerLink]="['/courses', course.id!, 'exercises', exercise.id!]"></a>
     <div class="col-auto d-none d-sm-block">
         <a class="exercise-row-icon" [routerLink]="['/courses', course.id!, 'exercises', exercise.id!]">
-            <fa-icon *ngIf="exercise.type" [icon]="getIcon(exercise.type)" size="2x" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate" container="body"></fa-icon>
+            <fa-icon *ngIf="exercise.type" [icon]="getIcon(exercise.type)" size="2x" [ngbTooltip]="getIconTooltip(exercise.type) | artemisTranslate"></fa-icon>
         </a>
     </div>
     <div class="col">

--- a/src/main/webapp/app/overview/course-lectures/course-lecture-row.component.html
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-row.component.html
@@ -2,13 +2,7 @@
     <a *ngIf="course && lecture" class="stretched-link" [routerLink]="['/courses', course.id!, 'lectures', lecture.id!]"></a>
     <div class="col-auto d-none d-sm-block">
         <div class="exercise-row-icon">
-            <fa-icon
-                [icon]="faChalkboardTeacher"
-                size="2x"
-                placement="right"
-                [ngbTooltip]="'artemisApp.courseOverview.lectureList.isLecture' | artemisTranslate"
-                container="body"
-            ></fa-icon>
+            <fa-icon [icon]="faChalkboardTeacher" size="2x" placement="right" [ngbTooltip]="'artemisApp.courseOverview.lectureList.isLecture' | artemisTranslate"></fa-icon>
         </div>
     </div>
     <div class="col">

--- a/src/main/webapp/app/overview/course-lectures/course-lecture-row.component.html
+++ b/src/main/webapp/app/overview/course-lectures/course-lecture-row.component.html
@@ -2,7 +2,7 @@
     <a *ngIf="course && lecture" class="stretched-link" [routerLink]="['/courses', course.id!, 'lectures', lecture.id!]"></a>
     <div class="col-auto d-none d-sm-block">
         <div class="exercise-row-icon">
-            <fa-icon [icon]="faChalkboardTeacher" size="2x" placement="right" [ngbTooltip]="'artemisApp.courseOverview.lectureList.isLecture' | artemisTranslate"></fa-icon>
+            <fa-icon [icon]="faChalkboardTeacher" size="2x" placement="right auto" [ngbTooltip]="'artemisApp.courseOverview.lectureList.isLecture' | artemisTranslate"></fa-icon>
         </div>
     </div>
     <div class="col">

--- a/src/main/webapp/app/overview/course-lectures/course-lectures.component.html
+++ b/src/main/webapp/app/overview/course-lectures/course-lectures.component.html
@@ -1,6 +1,6 @@
 <ng-template #controls>
     <div class="course-overview-controls d-none d-sm-block" *ngIf="course?.lectures && course!.lectures!.length > 0">
-        <div ngbDropdown placement="bottom-right" class="d-inline-block">
+        <div ngbDropdown placement="bottom-right auto" class="d-inline-block">
             <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>
                 {{ 'artemisApp.courseOverview.lectureList.sortLectures' | artemisTranslate }}
             </button>

--- a/src/main/webapp/app/shared/components/button.component.html
+++ b/src/main/webapp/app/shared/components/button.component.html
@@ -2,7 +2,6 @@
     [ngClass]="['jhi-btn', 'btn', btnType, btnSize]"
     [type]="shouldSubmit ? 'submit' : 'button'"
     ngbTooltip="{{ tooltip | artemisTranslate }}"
-    container="body"
     (click)="onClick.emit($event)"
     [jhiFeatureToggle]="featureToggle"
     [overwriteDisabled]="disabled || isLoading"

--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
@@ -10,7 +10,7 @@
         [hideLabelMobile]="false"
         [ngbPopover]="popContent"
         [autoClose]="'outside'"
-        placement="right"
+        placement="right auto"
     ></button>
     <ng-template #popContent>
         <div *ngIf="useSsh" class="alert alert-warning" [innerHTML]="getSshKeyTip()"></div>

--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.html
@@ -11,7 +11,6 @@
         [ngbPopover]="popContent"
         [autoClose]="'outside'"
         placement="right"
-        container="body"
     ></button>
     <ng-template #popContent>
         <div *ngIf="useSsh" class="alert alert-warning" [innerHTML]="getSshKeyTip()"></div>

--- a/src/main/webapp/app/shared/components/help-icon.component.ts
+++ b/src/main/webapp/app/shared/components/help-icon.component.ts
@@ -3,7 +3,7 @@ import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
     selector: 'jhi-help-icon',
-    template: ` <fa-icon [icon]="faQuestionCircle" class="text-secondary" [placement]="placement" container="body" ngbTooltip="{{ text | artemisTranslate }}"></fa-icon> `,
+    template: ` <fa-icon [icon]="faQuestionCircle" class="text-secondary" [placement]="placement" ngbTooltip="{{ text | artemisTranslate }}"></fa-icon> `,
 })
 export class HelpIconComponent {
     @Input() placement: string;

--- a/src/main/webapp/app/shared/components/open-code-editor-button/open-code-editor-button.component.html
+++ b/src/main/webapp/app/shared/components/open-code-editor-button/open-code-editor-button.component.html
@@ -25,7 +25,6 @@
         [ngbPopover]="popContent"
         [autoClose]="'outside'"
         placement="right"
-        container="body"
         *ngIf="participations?.length && participations.length! > 1"
     ></button>
     <ng-template #popContent style="max-width: 660px">

--- a/src/main/webapp/app/shared/components/open-code-editor-button/open-code-editor-button.component.html
+++ b/src/main/webapp/app/shared/components/open-code-editor-button/open-code-editor-button.component.html
@@ -24,7 +24,7 @@
         [hideLabelMobile]="false"
         [ngbPopover]="popContent"
         [autoClose]="'outside'"
-        placement="right"
+        placement="right auto"
         *ngIf="participations?.length && participations.length! > 1"
     ></button>
     <ng-template #popContent style="max-width: 660px">

--- a/src/main/webapp/app/shared/components/start-practice-mode-button/start-practice-mode-button.component.html
+++ b/src/main/webapp/app/shared/components/start-practice-mode-button/start-practice-mode-button.component.html
@@ -9,7 +9,7 @@
         [hideLabelMobile]="false"
         [ngbPopover]="popContent"
         [autoClose]="'outside'"
-        placement="right"
+        placement="right auto"
     ></button>
     <ng-template #popContent>
         <div style="max-width: 660px">

--- a/src/main/webapp/app/shared/components/start-practice-mode-button/start-practice-mode-button.component.html
+++ b/src/main/webapp/app/shared/components/start-practice-mode-button/start-practice-mode-button.component.html
@@ -10,7 +10,6 @@
         [ngbPopover]="popContent"
         [autoClose]="'outside'"
         placement="right"
-        container="body"
     ></button>
     <ng-template #popContent>
         <div style="max-width: 660px">

--- a/src/main/webapp/app/shared/confirm-icon/confirm-icon.component.html
+++ b/src/main/webapp/app/shared/confirm-icon/confirm-icon.component.html
@@ -1,11 +1,10 @@
-<fa-icon *ngIf="!showConfirm" [icon]="initialIcon" [ngbTooltip]="initialTooltip" [size]="iconSize" container="body" (click)="toggle()"></fa-icon>
+<fa-icon *ngIf="!showConfirm" [icon]="initialIcon" [ngbTooltip]="initialTooltip" [size]="iconSize" (click)="toggle()"></fa-icon>
 <fa-icon
     *ngIf="showConfirm"
     [ngClass]="'text-danger'"
     [icon]="confirmIcon"
     [ngbTooltip]="confirmTooltip"
     [size]="iconSize"
-    container="body"
     (mouseleave)="toggle()"
     (click)="confirmAction()"
 ></fa-icon>

--- a/src/main/webapp/app/shared/dashboards/tutor-participation-graph/progress-bar/progress-bar.component.html
+++ b/src/main/webapp/app/shared/dashboards/tutor-participation-graph/progress-bar/progress-bar.component.html
@@ -1,4 +1,4 @@
-<div class="progress position-relative" [ngbTooltip]="tooltip" container="body">
+<div class="progress position-relative" [ngbTooltip]="tooltip">
     <div
         class="progress-bar"
         role="progressbar"

--- a/src/main/webapp/app/shared/dashboards/tutor-participation-graph/tutor-participation-graph.component.html
+++ b/src/main/webapp/app/shared/dashboards/tutor-participation-graph/tutor-participation-graph.component.html
@@ -6,7 +6,6 @@
             [ngClass]="calculateClasses(REVIEWED_INSTRUCTIONS)"
             (click)="navigate()"
             [ngbTooltip]="'artemisApp.assessmentDashboard.readGradingInstructions' | artemisTranslate"
-            container="body"
         >
             <fa-icon [icon]="faBook"></fa-icon>
         </li>
@@ -15,7 +14,6 @@
             [ngClass]="calculateClasses(TRAINED)"
             (click)="navigate()"
             [ngbTooltip]="'artemisApp.assessmentDashboard.trainOnExampleSubmissions' | artemisTranslate"
-            container="body"
         >
             <fa-icon [icon]="faChalkboardTeacher"></fa-icon>
         </li>

--- a/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.html
+++ b/src/main/webapp/app/shared/date-time-picker/date-time-picker.component.html
@@ -1,10 +1,10 @@
 <label for="date-input-field" class="form-control-label col" *ngIf="labelName">
     {{ labelName }}
 </label>
-<fa-stack *ngIf="labelTooltip" class="text-secondary icon-full-size" placement="top" [ngbTooltip]="labelTooltip">
+<fa-stack *ngIf="labelTooltip" class="text-secondary icon-full-size" [ngbTooltip]="labelTooltip">
     <fa-icon [icon]="faQuestionCircle" stackItemSize="1x"></fa-icon>
 </fa-stack>
-<fa-stack *ngIf="shouldDisplayTimeZoneWarning" placement="top" ngbTooltip="{{ 'entity.timeZoneWarning' | artemisTranslate: { timeZone: currentTimeZone } }}" class="icon-full-size">
+<fa-stack *ngIf="shouldDisplayTimeZoneWarning" ngbTooltip="{{ 'entity.timeZoneWarning' | artemisTranslate: { timeZone: currentTimeZone } }}" class="icon-full-size">
     <fa-icon [icon]="faGlobe" stackItemSize="1x" class="text-lightgrey"></fa-icon>
     <fa-icon [icon]="faClock" stackItemSize="1x" transform="shrink-6 down-5 right-5" class="text-secondary"></fa-icon>
 </fa-stack>

--- a/src/main/webapp/app/shared/grading-instruction-link-icon/grading-instruction-link-icon.component.html
+++ b/src/main/webapp/app/shared/grading-instruction-link-icon/grading-instruction-link-icon.component.html
@@ -1,10 +1,9 @@
-<fa-icon *ngIf="!showConfirm" [icon]="linkIcon" [ngbTooltip]="setTooltip(instruction!)" container="body" (click)="toggle()"></fa-icon>
+<fa-icon *ngIf="!showConfirm" [icon]="linkIcon" [ngbTooltip]="setTooltip(instruction!)" (click)="toggle()"></fa-icon>
 <fa-icon
     *ngIf="showConfirm"
     [ngClass]="'text-danger'"
     [icon]="confirmIcon"
     [ngbTooltip]="'artemisApp.assessment.messages.removeAssessmentInstructionLink' | artemisTranslate"
-    container="body"
     (mouseleave)="toggle()"
     (click)="removeLink()"
 ></fa-icon>

--- a/src/main/webapp/app/shared/import/users-import-dialog.component.html
+++ b/src/main/webapp/app/shared/import/users-import-dialog.component.html
@@ -14,7 +14,7 @@
             <div class="d-flex align-items-end">
                 <div>
                     <label for="importCSV" class="label-narrow font-weight-bold" jhiTranslate="artemisApp.importUsers.csvFile.label">Select .csv file</label>
-                    <jhi-help-icon placement="top" text="artemisApp.importUsers.csvFile.tooltip" class="me-1"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.importUsers.csvFile.tooltip" class="me-1"></jhi-help-icon>
                 </div>
                 <fa-icon class="loading-spinner ms-1" [icon]="faSpinner" [spin]="true" *ngIf="isParsing"></fa-icon>
             </div>
@@ -34,7 +34,7 @@
         <div *ngIf="usersToImport && usersToImport.length > 0" class="form-group mt-4">
             <div>
                 <label class="label-narrow font-weight-bold" jhiTranslate="artemisApp.importUsers.usersForImport.label"> Users for import</label>
-                <jhi-help-icon placement="top" text="artemisApp.importUsers.usersForImport.tooltip" class="me-1"></jhi-help-icon>
+                <jhi-help-icon text="artemisApp.importUsers.usersForImport.tooltip" class="me-1"></jhi-help-icon>
             </div>
             <table class="table table-striped table-sm header-fixed mt-2">
                 <thead>

--- a/src/main/webapp/app/shared/metis/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.html
+++ b/src/main/webapp/app/shared/metis/posting-create-edit-modal/post-create-edit-modal/post-create-edit-modal.component.html
@@ -9,7 +9,7 @@
                 <!-- context -> only tutors can select from all possibles contexts in update mode, no matter if they open the post at course overview or page section level -->
                 <div *ngIf="isAtLeastTutorInCourse && editType === EditType.UPDATE; else restrictedContextSelect" class="position-relative mb-3">
                     <label class="mb-1" jhiTranslate="artemisApp.metis.post.context"></label>
-                    <jhi-help-icon placement="top auto" text="artemisApp.metis.post.contextTutorTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.metis.post.contextTutorTooltip"></jhi-help-icon>
                     <select formControlName="context" class="form-select" [compareWith]="compareContextSelectorOptionFn" name="context">
                         <optgroup [label]="'artemisApp.metis.post.courseWideContext' | artemisTranslate">
                             <!-- only tutors can select the announcement mode on post update -->
@@ -35,7 +35,7 @@
                 <ng-template #restrictedContextSelect>
                     <div *ngIf="pageType === PageType.OVERVIEW && editType === EditType.CREATE" class="position-relative mb-3">
                         <label class="mb-1" jhiTranslate="artemisApp.metis.post.context"></label>
-                        <jhi-help-icon placement="top auto" text="artemisApp.metis.post.courseWideTopicTooltip"></jhi-help-icon>
+                        <jhi-help-icon text="artemisApp.metis.post.courseWideTopicTooltip"></jhi-help-icon>
                         <select formControlName="context" class="form-select" [compareWith]="compareContextSelectorOptionFn" name="context">
                             <optgroup [label]="'artemisApp.metis.post.courseWideContext' | artemisTranslate">
                                 <ng-container *ngFor="let context of CourseWideContext | keyvalue">
@@ -60,7 +60,7 @@
             <div class="position-relative mb-3" *ngIf="!isCourseMessagesPage">
                 <div>
                     <label for="title" class="mb-1" jhiTranslate="artemisApp.metis.post.title">Title</label>
-                    <jhi-help-icon placement="top auto" text="artemisApp.metis.post.titleTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.metis.post.titleTooltip"></jhi-help-icon>
                 </div>
                 <div>
                     <input id="title" formControlName="title" type="text" class="form-control" name="title" />
@@ -70,7 +70,7 @@
             <div *ngIf="pageType !== PageType.PLAGIARISM_CASE && !isCourseMessagesPage" class="position-relative mb-3">
                 <div>
                     <label jhiTranslate="artemisApp.metis.post.tags">Tags</label>
-                    <jhi-help-icon placement="top auto" text="artemisApp.metis.post.tagsTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.metis.post.tagsTooltip"></jhi-help-icon>
                 </div>
                 <div>
                     <jhi-post-tag-selector [(postTags)]="tags"></jhi-post-tag-selector>
@@ -84,7 +84,7 @@
                             <div class="d-flex align-items-center justify-content-between">
                                 <p class="my-2 ps-1">
                                     {{ 'artemisApp.metis.post.similarPosts' | artemisTranslate }}
-                                    <jhi-help-icon placement="top auto" text="artemisApp.metis.post.similarPostsTooltip"></jhi-help-icon>
+                                    <jhi-help-icon text="artemisApp.metis.post.similarPostsTooltip"></jhi-help-icon>
                                 </p>
                                 <button ngbPanelToggle class="btn pe-3">
                                     <fa-icon [icon]="opened ? faAngleUp : faAngleDown"></fa-icon>
@@ -104,7 +104,7 @@
             <div class="position-relative mb-1">
                 <div>
                     <label class="mb-1" jhiTranslate="artemisApp.metis.post.content">Content</label>
-                    <jhi-help-icon placement="top auto" text="artemisApp.metis.post.contentTooltip"></jhi-help-icon>
+                    <jhi-help-icon text="artemisApp.metis.post.contentTooltip"></jhi-help-icon>
                 </div>
                 <div class="row mb-2">
                     <jhi-posting-markdown-editor formControlName="content" [editorHeight]="editorHeight" [maxContentLength]="maxContentLength"> </jhi-posting-markdown-editor>

--- a/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.html
+++ b/src/main/webapp/app/shared/metis/posting-header/answer-post-header/answer-post-header.component.html
@@ -1,14 +1,14 @@
 <div class="row justify-content-between my-1">
     <div class="col-auto pe-0">
         <span class="posting-header header-author-date">
-            <span class="posting-author-role" container="body" ngbTooltip="{{ userAuthorityTooltip | artemisTranslate }}">
+            <span class="posting-author-role" ngbTooltip="{{ userAuthorityTooltip | artemisTranslate }}">
                 <fa-icon [icon]="userAuthorityIcon"></fa-icon>
             </span>
             <span class="posting-author">
                 {{ posting.author!.name }}
             </span>
             <span class="today-flag" *ngIf="postingIsOfToday">{{ todayFlag | artemisTranslate }}</span>
-            <span container="body" [disableTooltip]="postingIsOfToday" [ngbTooltip]="posting.creationDate | artemisDate: 'time'">
+            <span [disableTooltip]="postingIsOfToday" [ngbTooltip]="posting.creationDate | artemisDate: 'time'">
                 {{ postingIsOfToday ? (posting.creationDate | artemisDate: 'time') : (posting.creationDate | artemisDate: 'short-date') }}
             </span>
         </span>
@@ -17,7 +17,6 @@
             size="xs"
             class="ms-1 editIcon clickable icon"
             [ngbTooltip]="'artemisApp.metis.editPosting' | artemisTranslate"
-            container="body"
             [icon]="faPencilAlt"
             (click)="openPostingCreateEditModal.emit()"
         ></fa-icon>

--- a/src/main/webapp/app/shared/metis/posting-header/post-header/post-header.component.html
+++ b/src/main/webapp/app/shared/metis/posting-header/post-header/post-header.component.html
@@ -1,14 +1,14 @@
 <div class="row justify-content-between my-1">
     <div class="col-auto pe-0">
         <span class="posting-header header-author-date">
-            <span class="posting-author-role" container="body" ngbTooltip="{{ userAuthorityTooltip | artemisTranslate }}">
+            <span class="posting-author-role" ngbTooltip="{{ userAuthorityTooltip | artemisTranslate }}">
                 <fa-icon [icon]="userAuthorityIcon"></fa-icon>
             </span>
             <span class="posting-author">
                 {{ posting.author!.name }}
             </span>
             <span class="today-flag" *ngIf="postingIsOfToday">{{ todayFlag | artemisTranslate }}</span>
-            <span container="body" [disableTooltip]="postingIsOfToday" ngbTooltip="{{ posting.creationDate | artemisDate: 'time' }}">
+            <span [disableTooltip]="postingIsOfToday" ngbTooltip="{{ posting.creationDate | artemisDate: 'time' }}">
                 {{ postingIsOfToday ? (posting.creationDate | artemisDate: 'time') : (posting.creationDate | artemisDate: 'short-date') }}
             </span>
         </span>
@@ -21,7 +21,6 @@
             size="xs"
             class="ms-1 editIcon clickable icon"
             [ngbTooltip]="'artemisApp.metis.editPosting' | artemisTranslate"
-            container="body"
             [icon]="faPencilAlt"
             (click)="!isCourseMessagesPage ? createEditModal.open() : isModalOpen.emit()"
         ></fa-icon>

--- a/src/main/webapp/app/shared/participant-scores/participant-scores-average-table/participant-scores-average-table.component.html
+++ b/src/main/webapp/app/shared/participant-scores/participant-scores-average-table/participant-scores-average-table.component.html
@@ -38,7 +38,7 @@
             <ngx-datatable-column prop="averageScore" [minWidth]="500">
                 <ng-template ngx-datatable-header-template>
                     <ng-template #tipContent>{{ 'artemisApp.participantScores.notIncluded' | artemisTranslate }}</ng-template>
-                    <span [ngbTooltip]="tipContent" container="body" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageScore')">
+                    <span [ngbTooltip]="tipContent" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageScore')">
                         <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.participantScores.participantScoreAverageDTO.averageScore">
                             AverageScore
                         </span>
@@ -54,7 +54,7 @@
             <ngx-datatable-column prop="averagePoints" [minWidth]="500">
                 <ng-template ngx-datatable-header-template>
                     <ng-template #tipContent>{{ 'artemisApp.participantScores.notIncluded' | artemisTranslate }}</ng-template>
-                    <span [ngbTooltip]="tipContent" container="body" class="datatable-header-cell-wrapper" (click)="controls.onSort('averagePoints')">
+                    <span [ngbTooltip]="tipContent" class="datatable-header-cell-wrapper" (click)="controls.onSort('averagePoints')">
                         <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.participantScores.participantScoreAverageDTO.averagePoints">
                             AveragePoints
                         </span>
@@ -70,7 +70,7 @@
             <ngx-datatable-column prop="averageRatedScore" [minWidth]="500">
                 <ng-template ngx-datatable-header-template>
                     <ng-template #tipContent>{{ 'artemisApp.participantScores.notIncluded' | artemisTranslate }}</ng-template>
-                    <span [ngbTooltip]="tipContent" container="body" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageRatedScore')">
+                    <span [ngbTooltip]="tipContent" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageRatedScore')">
                         <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.participantScores.participantScoreAverageDTO.averageRatedScore">
                             AverageRatedScore
                         </span>
@@ -86,7 +86,7 @@
             <ngx-datatable-column prop="averageRatedPoints" [minWidth]="500">
                 <ng-template ngx-datatable-header-template>
                     <ng-template #tipContent>{{ 'artemisApp.participantScores.notIncluded' | artemisTranslate }}</ng-template>
-                    <span [ngbTooltip]="tipContent" container="body" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageRatedPoints')">
+                    <span [ngbTooltip]="tipContent" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageRatedPoints')">
                         <span class="datatable-header-cell-label bold sortable" jhiTranslate="artemisApp.participantScores.participantScoreAverageDTO.averageRatedPoints">
                             AverageRatedPoints
                         </span>
@@ -102,7 +102,7 @@
             <ngx-datatable-column prop="averageGrade" [minWidth]="500">
                 <ng-template ngx-datatable-header-template>
                     <ng-template #tipContent>{{ 'artemisApp.participantScores.notIncluded' | artemisTranslate }}</ng-template>
-                    <span [ngbTooltip]="tipContent" container="body" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageGrade')">
+                    <span [ngbTooltip]="tipContent" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageGrade')">
                         <span class="datatable-header-cell-label bold sortable">
                             {{ isBonus ? ('artemisApp.participantScores.averageBonus' | artemisTranslate) : ('artemisApp.participantScores.averageGrade' | artemisTranslate) }}
                         </span>
@@ -118,7 +118,7 @@
             <ngx-datatable-column prop="averageRatedGrade" [minWidth]="500">
                 <ng-template ngx-datatable-header-template>
                     <ng-template #tipContent>{{ 'artemisApp.participantScores.notIncluded' | artemisTranslate }}</ng-template>
-                    <span [ngbTooltip]="tipContent" container="body" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageRatedGrade')">
+                    <span [ngbTooltip]="tipContent" class="datatable-header-cell-wrapper" (click)="controls.onSort('averageRatedGrade')">
                         <span class="datatable-header-cell-label bold sortable">
                             {{
                                 isBonus


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When creating a tooltip by hovering over an element, the tooltip is put in the same container as the anchor element. If the tooltip now overflows the previous container size, the container gets resized, which leads to a shifting of other elements on the page when a tooltip appears or vanishes.

### Description
<!-- Describe your changes in detail -->
I changed the default value for tooltips, so they get attached to the 'body' element. This way we do not have to change every existing tooltip and it also makes it easier for tooltips created in the future, as the developer does not have to know this possibly unwanted behavior.

NOTE: Even when we attach the tooltips to the 'body' element, overflows can still happen by bad use of the `placement `attribute. For example, if an element is placed on the right side of the screen and we define `placement='right'`. Then we get some overflow to the right, when the popup appears and ugly horizontal scrolling.
We can prevent this by defining fallback options, as bootstrap uses the first value, that doesn't cause overflow. There is also an `auto` option, that tries to put the element to the top, bottom, left, and right. In that order. So `placement='right auto'` will do the same as `placement='right'` in case there is enough space, but otherwise will put the tooltip to the top, bottom or left instead of forcing an overflow.
I already added the fallback option `auto` to every use of `placement`, but we have to keep that in mind for future use.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

<!-- If this PR changes some components that are also used in the exam mode, the PR needs additional testing that the exam mode is still working as expected. -->
<!-- If the testing steps above already describe the exam mode or the exam mode cannot be affected by this PR in any way, you can leave this out. -->

Prerequisites:
- none

1. Log in to Artemis
2. Hover over an element, that will spawn a tooltip and verify, that other elements on the page do not get shifted

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before Change:

https://user-images.githubusercontent.com/44734881/201890596-e048a7bc-e46c-4dfb-af87-baa285df362f.mov

After Change:

https://user-images.githubusercontent.com/44734881/201891607-fead39e6-045a-49b2-85f3-576c5cd50446.mov


