### PR TITLE
`General`: Fix an issue where tooltips were not displayed

### DIFF
--- a/src/main/webapp/app/shared/components/help-icon.component.ts
+++ b/src/main/webapp/app/shared/components/help-icon.component.ts
@@ -3,7 +3,7 @@ import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
     selector: 'jhi-help-icon',
-    template: ` <fa-icon [icon]="faQuestionCircle" class="text-secondary" [placement]="placement" ngbTooltip="{{ text | artemisTranslate }}"></fa-icon> `,
+    template: ` <fa-icon [icon]="faQuestionCircle" class="text-secondary" [placement]="placement ? placement : 'auto'" ngbTooltip="{{ text | artemisTranslate }}"></fa-icon> `,
 })
 export class HelpIconComponent {
     @Input() placement: string;

--- a/src/main/webapp/app/shared/components/help-icon.component.ts
+++ b/src/main/webapp/app/shared/components/help-icon.component.ts
@@ -3,10 +3,10 @@ import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
     selector: 'jhi-help-icon',
-    template: ` <fa-icon [icon]="faQuestionCircle" class="text-secondary" [placement]="placement ? placement : 'auto'" ngbTooltip="{{ text | artemisTranslate }}"></fa-icon> `,
+    template: ` <fa-icon [icon]="faQuestionCircle" class="text-secondary" [placement]="placement" ngbTooltip="{{ text | artemisTranslate }}"></fa-icon> `,
 })
 export class HelpIconComponent {
-    @Input() placement: string;
+    @Input() placement = 'auto';
     @Input() text: string;
 
     // Icons


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
With PR [#5846](https://github.com/ls1intum/Artemis/pull/5846) I introduced a bug, that lead to tooltips not being displayed if they got created by the HelpIconComponent. 

### Description
<!-- Describe your changes in detail -->
The reason for this error was, that the placement attribute was set to "undefined" instead of "auto" if you didn't explicitly set it through the HelpIconComponent.
I changed the code to set it to "auto" if no value is provided.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->

1. Log in to Artemis
2. Hover over any help icon (e.g. on exercise creation)
3. Verify, that tooltip gets displayed

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Before:

https://user-images.githubusercontent.com/44734881/202664525-5d325462-21f4-4b42-84a8-bc78a0420892.mov

After:

https://user-images.githubusercontent.com/44734881/202664583-6a7f36e3-f2a4-4edc-9592-b7fdf56842e6.mov
