### PR TITLE
`Programming exercises`: Always include user in clone URL

### DIFF
--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.ts
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.ts
@@ -152,12 +152,8 @@ export class CloneRepoButtonComponent implements OnInit, OnChanges {
     /**
      * Transforms the repository url to an ssh clone url
      */
-    private getSshCloneUrl(url: string) {
-        url = url?.replace(/^\w*:\/\/[^/]*?\/(scm\/)?(.*)$/, this.sshTemplateUrl + '$2');
-        if (this.user.login) {
-            url = url.replace('git', this.user.login);
-        }
-        return url;
+    private getSshCloneUrl(url?: string) {
+        return url?.replace(/^\w*:\/\/[^/]*?\/(scm\/)?(.*)$/, this.sshTemplateUrl + '$2');
     }
 
     /**

--- a/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.ts
+++ b/src/main/webapp/app/shared/components/clone-repo-button/clone-repo-button.component.ts
@@ -99,37 +99,31 @@ export class CloneRepoButtonComponent implements OnInit, OnChanges {
         }
 
         if (this.isTeamParticipation) {
-            return this.addAccessTokenToHttpUrl(this.repositoryUrlForTeam(this.getRepositoryUrl()), insertPlaceholder);
+            return this.addCredentialsToHttpUrl(this.repositoryUrlForTeam(this.getRepositoryUrl()), insertPlaceholder);
         }
 
-        return this.addAccessTokenToHttpUrl(this.getRepositoryUrl(), insertPlaceholder);
+        return this.addCredentialsToHttpUrl(this.getRepositoryUrl(), insertPlaceholder);
     }
 
     /**
-     * Add the access token to the http url, if possible.
+     * Add the credentials to the http url, if possible.
      * The token will be added if
      * - the token is required (based on the profile information), and
      * - the token is present (based on the user model).
      *
-     * It will only be added if a username is present in the given url and will be added after the username and before the host name.
-     * @param url the url to which the token should be added
+     * @param url the url to which the credentials should be added
      * @param insertPlaceholder if true, instead of the actual token, '**********' is used (e.g. to prevent leaking the token during a screen-share)
      */
-    private addAccessTokenToHttpUrl(url: string, insertPlaceholder = false): string {
-        const vcsAccessToken = this.user.vcsAccessToken;
-        // If the token is not present or not required, don't include it
-        if (!this.versionControlAccessTokenRequired || !vcsAccessToken || !url) {
-            return url;
-        }
-
-        const token = insertPlaceholder ? '**********' : vcsAccessToken;
-        const urlUserInfoPart = `://${this.user.login}:${token}@`;
+    private addCredentialsToHttpUrl(url: string, insertPlaceholder = false): string {
+        const includeToken = this.versionControlAccessTokenRequired && this.user.vcsAccessToken;
+        const token = insertPlaceholder ? '**********' : this.user.vcsAccessToken;
+        const credentials = `://${this.user.login}${includeToken ? `:${token}` : ''}@`;
         if (!url.includes('@')) {
             // the url has the format https://vcs-server.com
-            return url.replace('://', urlUserInfoPart);
+            return url.replace('://', credentials);
         } else {
             // the url has the format https://username@vcs-server.com -> replace ://username@
-            return url.replace(/:\/\/.*@/, urlUserInfoPart);
+            return url.replace(/:\/\/.*@/, credentials);
         }
     }
 
@@ -158,8 +152,12 @@ export class CloneRepoButtonComponent implements OnInit, OnChanges {
     /**
      * Transforms the repository url to an ssh clone url
      */
-    private getSshCloneUrl(url?: string) {
-        return url?.replace(/^\w*:\/\/[^/]*?\/(scm\/)?(.*)$/, this.sshTemplateUrl + '$2');
+    private getSshCloneUrl(url: string) {
+        url = url?.replace(/^\w*:\/\/[^/]*?\/(scm\/)?(.*)$/, this.sshTemplateUrl + '$2');
+        if (this.user.login) {
+            url = url.replace('git', this.user.login);
+        }
+        return url;
     }
 
     /**

--- a/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
@@ -127,11 +127,11 @@ describe('JhiCloneRepoButtonComponent', () => {
 
         component.useSsh = true;
 
-        expect(component.getHttpOrSshRepositoryUrl()).toBe('ssh://git@bitbucket.ase.in.tum.de:7999/ITCPLEASE1/itcplease1-exercise.git');
+        expect(component.getHttpOrSshRepositoryUrl()).toBe('ssh://user1@bitbucket.ase.in.tum.de:7999/ITCPLEASE1/itcplease1-exercise.git');
 
         participation.team = undefined;
         component.isTeamParticipation = false;
-        expect(component.getHttpOrSshRepositoryUrl()).toBe('ssh://git@bitbucket.ase.in.tum.de:7999/ITCPLEASE1/itcplease1-exercise.git');
+        expect(component.getHttpOrSshRepositoryUrl()).toBe('ssh://user1@bitbucket.ase.in.tum.de:7999/ITCPLEASE1/itcplease1-exercise.git');
     });
 
     it('should get html url (not the same url for team and individual participation)', () => {
@@ -150,7 +150,7 @@ describe('JhiCloneRepoButtonComponent', () => {
         participation.team = undefined;
         component.isTeamParticipation = false;
         url = component.getHttpOrSshRepositoryUrl();
-        expect(url).toBe(info.versionControlUrl!);
+        expect(url).toBe(`https://${component.user.login}@bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise-team1.git`);
     });
 
     it('should get copy the repository url', () => {
@@ -168,7 +168,7 @@ describe('JhiCloneRepoButtonComponent', () => {
         participation.team = undefined;
         component.isTeamParticipation = false;
         url = component.getHttpOrSshRepositoryUrl();
-        expect(url).toBe(info.versionControlUrl!);
+        expect(url).toBe(`https://${component.user.login}@bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise-team1.git`);
     });
 
     it('should insert the correct token in the repository url', () => {
@@ -227,12 +227,12 @@ describe('JhiCloneRepoButtonComponent', () => {
         component.ngOnChanges();
 
         expect(component.isTeamParticipation).toBeFalse();
-        expect(component.getHttpOrSshRepositoryUrl()).toBe('https://bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise-practice.git');
+        expect(component.getHttpOrSshRepositoryUrl()).toBe('https://user1@bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise-practice.git');
         expect(component.cloneHeadline).toBe('artemisApp.exerciseActions.clonePracticeRepository');
 
         component.switchPracticeMode();
 
-        expect(component.getHttpOrSshRepositoryUrl()).toBe('https://bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise.git');
+        expect(component.getHttpOrSshRepositoryUrl()).toBe('https://user1@bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise.git');
         expect(component.cloneHeadline).toBe('artemisApp.exerciseActions.cloneRatedRepository');
     });
 
@@ -243,7 +243,7 @@ describe('JhiCloneRepoButtonComponent', () => {
         component.ngOnInit();
 
         expect(component.isTeamParticipation).toBeFalsy();
-        expect(component.getHttpOrSshRepositoryUrl()).toBe('https://bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise.solution.git');
+        expect(component.getHttpOrSshRepositoryUrl()).toBe('https://user1@bitbucket.ase.in.tum.de/scm/ITCPLEASE1/itcplease1-exercise.solution.git');
     });
 
     it('should fetch and store ssh preference', fakeAsync(() => {

--- a/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/clone-repo-button.component.spec.ts
@@ -127,11 +127,11 @@ describe('JhiCloneRepoButtonComponent', () => {
 
         component.useSsh = true;
 
-        expect(component.getHttpOrSshRepositoryUrl()).toBe('ssh://user1@bitbucket.ase.in.tum.de:7999/ITCPLEASE1/itcplease1-exercise.git');
+        expect(component.getHttpOrSshRepositoryUrl()).toBe('ssh://git@bitbucket.ase.in.tum.de:7999/ITCPLEASE1/itcplease1-exercise.git');
 
         participation.team = undefined;
         component.isTeamParticipation = false;
-        expect(component.getHttpOrSshRepositoryUrl()).toBe('ssh://user1@bitbucket.ase.in.tum.de:7999/ITCPLEASE1/itcplease1-exercise.git');
+        expect(component.getHttpOrSshRepositoryUrl()).toBe('ssh://git@bitbucket.ase.in.tum.de:7999/ITCPLEASE1/itcplease1-exercise.git');
     });
 
     it('should get html url (not the same url for team and individual participation)', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Some students and lecturers have multiple git users on their machine and/or configured in their git client. This can lead to problems when the git user is not specified in the clone url for https.

### Description
<!-- Describe your changes in detail -->
This PR always adds the git user name to the clone url before the host of the repository for https urls.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Programming Exercise

1. Log in to Artemis
2. Try to clone the repository as a student (using https and ssh)
3. Try to clone the solution as instructor (using https and ssh)
4. Make sure that the https link always includes the current user and the SSH link still has the `git` user.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| clone-repo-button.component.ts | 80% | 86% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
HTTPS with user:
<img width="1177" alt="Bildschirm­foto 2022-11-22 um 14 11 52" src="https://user-images.githubusercontent.com/38322605/203322584-dcf93c06-d27c-4d61-964e-c2f1d2b088a4.png">
SSH without user:
<img width="968" alt="Bildschirm­foto 2022-11-22 um 14 11 39" src="https://user-images.githubusercontent.com/38322605/203322512-91a1cb5c-6c7d-478f-bed3-efa5a1ce3557.png">