### PR TITLE
`Development`: Add exam management modeling/programming/quiz exercise creation e2e tests

### DIFF
--- a/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
+++ b/src/main/webapp/app/exam/manage/exercise-groups/exercise-groups.component.html
@@ -59,7 +59,13 @@
                             <fa-icon class="d-xl-none" [icon]="faCheckDouble"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.quizExercise.home.importLabel' | artemisTranslate }}</span>
                         </a>
-                        <a *ngIf="course?.isAtLeastEditor" [routerLink]="[exerciseGroup.id, 'quiz-exercises', 'new']" class="btn btn-info btn-sm me-1 mb-1" style="max-height: 44%">
+                        <a
+                            *ngIf="course?.isAtLeastEditor"
+                            [routerLink]="[exerciseGroup.id, 'quiz-exercises', 'new']"
+                            class="btn btn-info btn-sm me-1 mb-1"
+                            [id]="'add-quiz-exercise-group-' + i"
+                            style="max-height: 44%"
+                        >
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <fa-icon class="d-xl-none" [icon]="faCheckDouble"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.examManagement.exerciseGroup.addQuizExercise' | artemisTranslate }}</span>
@@ -71,7 +77,12 @@
                             <fa-icon class="d-xl-none" [icon]="faFont"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.textExercise.home.importLabel' | artemisTranslate }}</span>
                         </a>
-                        <a *ngIf="course?.isAtLeastEditor" [routerLink]="[exerciseGroup.id, 'text-exercises', 'new']" class="btn btn-info btn-sm me-1 mb-1" id="add-text-exercise">
+                        <a
+                            *ngIf="course?.isAtLeastEditor"
+                            [routerLink]="[exerciseGroup.id, 'text-exercises', 'new']"
+                            class="btn btn-info btn-sm me-1 mb-1"
+                            [id]="'add-text-exercise-group-' + i"
+                        >
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <fa-icon class="d-xl-none" [icon]="faFont"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.examManagement.exerciseGroup.addTextExercise' | artemisTranslate }}</span>
@@ -83,7 +94,12 @@
                             <fa-icon class="d-xl-none" [icon]="faProjectDiagram"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.modelingExercise.home.importLabel' | artemisTranslate }}</span>
                         </a>
-                        <a *ngIf="course?.isAtLeastEditor" [routerLink]="[exerciseGroup.id, 'modeling-exercises', 'new']" class="btn btn-info btn-sm me-1 mb-1">
+                        <a
+                            *ngIf="course?.isAtLeastEditor"
+                            [routerLink]="[exerciseGroup.id, 'modeling-exercises', 'new']"
+                            class="btn btn-info btn-sm me-1 mb-1"
+                            [id]="'add-modeling-exercise-group-' + i"
+                        >
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <fa-icon class="d-xl-none" [icon]="faProjectDiagram"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.examManagement.exerciseGroup.addModelingExercise' | artemisTranslate }}</span>
@@ -95,7 +111,12 @@
                             <fa-icon class="d-xl-none" [icon]="faKeyboard"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.programmingExercise.home.importLabel' | artemisTranslate }}</span>
                         </a>
-                        <a *ngIf="course?.isAtLeastEditor" [routerLink]="[exerciseGroup.id, 'programming-exercises', 'new']" class="btn btn-info btn-sm me-1 mb-1">
+                        <a
+                            *ngIf="course?.isAtLeastEditor"
+                            [routerLink]="[exerciseGroup.id, 'programming-exercises', 'new']"
+                            class="btn btn-info btn-sm me-1 mb-1"
+                            [id]="'add-programming-exercise-group-' + i"
+                        >
                             <fa-icon [icon]="faPlus"></fa-icon>
                             <fa-icon class="d-xl-none" [icon]="faKeyboard"></fa-icon>
                             <span class="d-none d-xl-inline">{{ 'artemisApp.examManagement.exerciseGroup.addProgrammingExercise' | artemisTranslate }}</span>

--- a/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/multiple-choice-question/multiple-choice-question-edit.component.html
@@ -20,7 +20,7 @@
         <div class="question-card-header-inputs">
             <div class="form-group question-score">
                 <span jhiTranslate="artemisApp.quizQuestion.score" class="colon-suffix"></span>
-                <input class="form-control" title="score" type="number" min="1" max="9999" [(ngModel)]="question.points" (ngModelChange)="questionUpdated.emit()" />
+                <input id="score" class="form-control" title="score" type="number" min="1" max="9999" [(ngModel)]="question.points" (ngModelChange)="questionUpdated.emit()" />
             </div>
             <div class="question-type">
                 <h3 class="mb-0"><span class="badge bg-info align-text-top">MC</span></h3>

--- a/src/test/cypress/support/pageobjects/exam/ExamExerciseGroupsPage.ts
+++ b/src/test/cypress/support/pageobjects/exam/ExamExerciseGroupsPage.ts
@@ -29,8 +29,20 @@ export class ExamExerciseGroupsPage {
         cy.get('#create-new-group').click();
     }
 
-    clickAddTextExercise() {
-        cy.get('#add-text-exercise').click();
+    clickAddTextExercise(groupIndex = 0) {
+        cy.get('#add-text-exercise-group-' + groupIndex).click();
+    }
+
+    clickAddModelingExercise(groupIndex = 0) {
+        cy.get('#add-modeling-exercise-group-' + groupIndex).click();
+    }
+
+    clickAddQuizExercise(groupIndex = 0) {
+        cy.get('#add-quiz-exercise-group-' + groupIndex).click();
+    }
+
+    clickAddProgrammingExercise(groupIndex = 0) {
+        cy.get('#add-programming-exercise-group-' + groupIndex).click();
     }
 
     visitPageViaUrl(courseId: number, examId: number) {

--- a/src/test/cypress/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
+++ b/src/test/cypress/support/pageobjects/exercises/quiz/QuizExerciseCreationPage.ts
@@ -5,9 +5,10 @@ export class QuizExerciseCreationPage {
         cy.get('#quiz-title').type(title);
     }
 
-    addMultipleChoiceQuestion(title: string) {
+    addMultipleChoiceQuestion(title: string, points = 1) {
         cy.get('#quiz-add-mc-question').click();
         cy.get('#mc-question-title').type(title);
+        cy.get('#score').clear().type(points.toString());
         cy.fixture('quiz_exercise_fixtures/MultipleChoiceQuiz.txt').then((fileContent) => {
             cy.get('.ace_text-input').focus().clear().type(fileContent);
         });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] Tested on my local Artemis instance
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The current exam management test only test the creation of a text exercises. Since those are not the only types of exercises that are available, the missing types should be added.  

### Description
<!-- Describe your changes in detail -->

This PR adds the missing exercise types modeling, programming and quiz to the exam management e2e tests. In order for the new tests to work, some minor element id changes where necessary. 

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code as well as the functionality (= manual test) needs to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
