### PR TITLE
`Exam mode`: Fix tooltip for test exams

### DIFF
--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -377,7 +377,7 @@
                 "realExam": "Klausur",
                 "testExam": "Testklausur",
                 "examMode": "Exammodus",
-                "examModeTooltip": "Testklausuren können von Studierenden einmal frei innerhalb des Bearbeitungsfensters begonnen werden, zur Durchführung steht die gewählte Arbeitszeit zur Verfügung. Nach dem Durchlauf erhalten die Studierenden automatisiertes Feedback. HINWEIS: Der Modus kann nach der Erstellung nicht mehr geändert werden!",
+                "examModeTooltip": "Testklausuren können von Studierenden an einem frei wählbaren Zeitpunkt innerhalb des Bearbeitungsfensters begonnen werden, zur Durchführung steht die gewählte Arbeitszeit zur Verfügung. Nach dem Durchlauf erhalten die Studierenden automatisiertes Feedback. HINWEIS: Der Modus kann nach der Erstellung nicht mehr geändert werden!",
                 "startDate": "Beginn Bearbeitungsfenster",
                 "endDate": "Ende Bearbeitungsfenster",
                 "workingTimeTooltip": "Die erlaubte Bearbeitungszeit je Durchlauf"

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -377,7 +377,7 @@
                 "realExam": "Klausur",
                 "testExam": "Testklausur",
                 "examMode": "Exammodus",
-                "examModeTooltip": "Testklausuren können von Studierenden mehrmals innerhalb des Bearbeitungsfensters durchgeführt werden und erhalten nach jedem Durchlauf automatisiertes Feedback. HINWEIS: Der Modus kann nach der Erstellung nicht mehr geändert werden!",
+                "examModeTooltip": "Testklausuren können von Studierenden einmal frei innerhalb des Bearbeitungsfensters begonnen werden, zur Durchführung steht die gewählte Arbeitszeit zur Verfügung. Nach dem Durchlauf erhalten die Studierenden automatisiertes Feedback. HINWEIS: Der Modus kann nach der Erstellung nicht mehr geändert werden!",
                 "startDate": "Beginn Bearbeitungsfenster",
                 "endDate": "Ende Bearbeitungsfenster",
                 "workingTimeTooltip": "Die erlaubte Bearbeitungszeit je Durchlauf"

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -378,7 +378,7 @@
                 "realExam": "Exam",
                 "testExam": "Test Exam",
                 "examMode": "Exam Mode",
-                "examModeTooltip": "Test Exams can be conducted multiple times within the working window. Students recieve automated feedback after every run. NOTE: This cannot be changed later on!",
+                "examModeTooltip": "Students can start working on a Test Exam once within the working window, the selected working time will be available during the conduction. Students recieve automated feedback after submitting. NOTE: This cannot be changed later on!",
                 "startDate": "Start of working window",
                 "endDate": "End of working window",
                 "workingTimeTooltip": "The working time allowed to the students per run"


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple screenshots/screencasts of my UI changes.
- [x] I translated all newly inserted strings into English and German.

### Motivation and Context
The tooltip for the exam mode within the exam update component currently descripes, that test exams could be conducted multiple times by the students.
As this feature is not yet implemented, the tooltip has to be updated.

### Description
The textual description for the tooltip has been updated to highlight, that students can start the test exam at any time within the working window, but are not able to conduct a test exam multiple times

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create an Exam
4. Hover over the tooltip for the Exam Mode Selection and make shure, that the text for the tooltip is displayed accordingly. 

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2


### Screenshots
![image](https://user-images.githubusercontent.com/94070506/203637776-77293ab2-fce6-4f0c-b4a7-625713a97109.png)
