### PR TITLE
`Development`: Fix modernizer warnings

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/service/notifications/TutorialGroupNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/notifications/TutorialGroupNotificationServiceTest.java
@@ -20,8 +20,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import com.google.common.collect.ImmutableSet;
-
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 import de.tum.in.www1.artemis.domain.*;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
@@ -71,7 +69,7 @@ class TutorialGroupNotificationServiceTest extends AbstractSpringIntegrationBamb
         student1 = userRepository.findOneByLogin("student1").get();
         tutor1 = userRepository.findOneByLogin("tutor1").get();
         tutorialGroup = createAndSaveTutorialGroup(course.getId(), "ExampleTitle1", "LoremIpsum1", 10, false, "LoremIpsum1", Language.ENGLISH,
-                userRepository.findOneByLogin("tutor1").get(), ImmutableSet.of(userRepository.findOneByLogin("student1").get(), userRepository.findOneByLogin("student2").get(),
+                userRepository.findOneByLogin("tutor1").get(), Set.of(userRepository.findOneByLogin("student1").get(), userRepository.findOneByLogin("student2").get(),
                         userRepository.findOneByLogin("student3").get(), userRepository.findOneByLogin("student4").get(), userRepository.findOneByLogin("student5").get()));
 
         doNothing().when(javaMailSender).send(any(MimeMessage.class));

--- a/src/test/java/de/tum/in/www1/artemis/tutorialgroups/AbstractTutorialGroupIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/tutorialgroups/AbstractTutorialGroupIntegrationTest.java
@@ -15,8 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import com.google.common.collect.ImmutableSet;
-
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.enumeration.Language;
@@ -128,15 +126,13 @@ abstract class AbstractTutorialGroupIntegrationTest extends AbstractSpringIntegr
 
         exampleConfigurationId = databaseUtilService.createTutorialGroupConfiguration(exampleCourseId, LocalDate.of(2022, 8, 1), LocalDate.of(2022, 9, 1)).getId();
 
-        exampleOneTutorialGroupId = databaseUtilService
-                .createTutorialGroup(exampleCourseId, "ExampleTitle1", "LoremIpsum1", 10, false, "LoremIpsum1", Language.ENGLISH, userRepository.findOneByLogin("tutor1").get(),
-                        ImmutableSet.of(userRepository.findOneByLogin("student1").get(), userRepository.findOneByLogin("student2").get(),
-                                userRepository.findOneByLogin("student3").get(), userRepository.findOneByLogin("student4").get(), userRepository.findOneByLogin("student5").get()))
+        exampleOneTutorialGroupId = databaseUtilService.createTutorialGroup(exampleCourseId, "ExampleTitle1", "LoremIpsum1", 10, false, "LoremIpsum1", Language.ENGLISH,
+                userRepository.findOneByLogin("tutor1").get(), Set.of(userRepository.findOneByLogin("student1").get(), userRepository.findOneByLogin("student2").get(),
+                        userRepository.findOneByLogin("student3").get(), userRepository.findOneByLogin("student4").get(), userRepository.findOneByLogin("student5").get()))
                 .getId();
 
         exampleTwoTutorialGroupId = databaseUtilService.createTutorialGroup(exampleCourseId, "ExampleTitle2", "LoremIpsum2", 10, true, "LoremIpsum2", Language.GERMAN,
-                userRepository.findOneByLogin("tutor2").get(), ImmutableSet.of(userRepository.findOneByLogin("student6").get(), userRepository.findOneByLogin("student7").get()))
-                .getId();
+                userRepository.findOneByLogin("tutor2").get(), Set.of(userRepository.findOneByLogin("student6").get(), userRepository.findOneByLogin("student7").get())).getId();
 
     }
 


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).

### Motivation and Context
The modernizer tool currently shows some warnings: 
![grafik](https://user-images.githubusercontent.com/26540346/204229193-00d3c971-cb7d-48d7-b51e-d1971f15a0a8.png)


### Description
This PR fixes the last 3 warnings. The other 2 are needed by the API of a dependency and therefore must stay.

Calling an explicitly `ImmuteableSet` from the Google Collections Library is not needed since the Set returned by `Set.of()` is already immuteable.

### Steps for Testing
Code review

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2