### PR TITLE
`Quiz exercises`: Fix short answer spot sequence number

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/short-answer-question/short-answer-question-edit.component.html
@@ -154,7 +154,7 @@
                     [(text)]="questionEditorText"
                     [mode]="questionEditorMode"
                     [autoUpdateContent]="questionEditorAutoUpdate"
-                    (textChange)="questionUpdated.emit()"
+                    (textChange)="onTextChange($event)"
                     style="min-height: 200px; width: 100%; overflow: auto"
                     class="form-control"
                 >

--- a/src/test/javascript/spec/component/short-answer-question/short-answer-question-edit.component.spec.ts
+++ b/src/test/javascript/spec/component/short-answer-question/short-answer-question-edit.component.spec.ts
@@ -282,6 +282,7 @@ describe('ShortAnswerQuestionEditComponent', () => {
         fixture.detectChanges();
 
         component.setupQuestionEditor();
+        component.setQuestionEditorValue('[-spot 1] [-spot 2]');
         expect(component.numberOfSpot).toBe(3);
         expect(component.optionsWithID).toEqual(['[-option 0]', '[-option 1]']);
     });
@@ -498,5 +499,18 @@ describe('ShortAnswerQuestionEditComponent', () => {
 
         expect(component.shortAnswerQuestion.similarityValue).toBe(100);
         expect(questionUpdated).toHaveBeenCalledOnce();
+    });
+
+    it('should return highst spot number', () => {
+        expect(component.getHighestSpotNumbers(`[-spot 1]`)).toBe(1);
+        expect(component.getHighestSpotNumbers(`hello [-spot 1] [-spot 3] [-spot 2]`)).toBe(3);
+        expect(
+            component.getHighestSpotNumbers(`hello
+        [-spot 1] [-spot 3]
+        [-spot 2]`),
+        ).toBe(3);
+        expect(component.getHighestSpotNumbers(`hello`)).toBe(0);
+        expect(component.getHighestSpotNumbers(`[-spot ]]`)).toBe(0);
+        expect(component.getHighestSpotNumbers(`[-spot x]]`)).toBe(0);
     });
 });

--- a/src/test/javascript/spec/component/short-answer-question/short-answer-question-edit.component.spec.ts
+++ b/src/test/javascript/spec/component/short-answer-question/short-answer-question-edit.component.spec.ts
@@ -501,7 +501,7 @@ describe('ShortAnswerQuestionEditComponent', () => {
         expect(questionUpdated).toHaveBeenCalledOnce();
     });
 
-    it('should return highst spot number', () => {
+    it('should return highest spot number', () => {
         expect(component.getHighestSpotNumbers(`[-spot 1]`)).toBe(1);
         expect(component.getHighestSpotNumbers(`hello [-spot 1] [-spot 3] [-spot 2]`)).toBe(3);
         expect(


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added `authorities` to all new routes and checked the course groups for displaying navigation elements (links, buttons).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The sequence number of spots in short answer questions of the quiz exercise is not correctly assigned which can potentially create incorrect mappings. Furthermore, the sequence number is never decreased even though some spots are deleted.

https://user-images.githubusercontent.com/10885503/204467333-04536b7a-c00d-4971-adba-f09a02fb8938.mov

### Description
<!-- Describe your changes in detail -->

To prevent the issue, the next spot number is set to the highest spot number of current text in the editor.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course

1. Log in to Artemis
2. Navigate to Course Administration
3. Select the Course
4. Click Exercises
5. Create Quiz Exercise
6. Create Short Answer Question
7. Verify that the number sequence is assigned correctly when some spots are deleted.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| short-answer-question-edit.component.ts | 70.32% | 94.42% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

https://user-images.githubusercontent.com/10885503/204466456-eec70b4a-5516-49ea-8be7-717393c285b8.mov
