### PR TITLE
`Quiz exercises`: Fix visual mode selection

### DIFF
--- a/src/main/webapp/app/exercises/quiz/shared/short-answer-question-util.service.ts
+++ b/src/main/webapp/app/exercises/quiz/shared/short-answer-question-util.service.ts
@@ -307,7 +307,7 @@ export class ShortAnswerQuestionUtil {
 
         return questionText.split(/\n/g).map((line) => {
             const spots = line.match(spotRegExpo) || [];
-            const texts = line.split(spotRegExpo);
+            const texts = line.split(spotRegExpo).map((text) => text.trim());
             return interleave(texts, spots).filter((x) => x.length > 0);
         });
     }

--- a/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
+++ b/src/test/javascript/spec/service/short-answer-question-util.service.spec.ts
@@ -189,13 +189,23 @@ describe('ShortAnswerQuestionUtil', () => {
     it('should split the question text into text parts and transform to html', () => {
         const textPart1 = 'This is a short answer question';
         const textPart2 = '**with highlighted markdown**';
-        shortAnswerQuestion.text = textPart1 + '\n' + textPart2;
+        const textPart3 = '[-spot 1] test test2';
+        const textPart4 = '[-spot 2] test3';
+        shortAnswerQuestion.text = textPart1 + '\n' + textPart2 + '\n' + textPart3 + '\n' + textPart4;
         const textParts = service.divideQuestionTextIntoTextParts(shortAnswerQuestion.text!);
         expect(textParts[0][0]).toContain(textPart1);
         expect(textParts[1][0]).toContain(textPart2);
+        expect(textParts[2][0]).toBe('[-spot 1]');
+        expect(textParts[2][1]).toBe('test test2');
+        expect(textParts[3][0]).toBe('[-spot 2]');
+        expect(textParts[3][1]).toBe('test3');
 
         const textPartsInHTML = service.transformTextPartsIntoHTML(textParts);
         expect(textPartsInHTML[0][0]).toContain(`<p>${textPart1}</p>`);
         expect(textPartsInHTML[1][0]).toContain(`<p><strong>${textPart2.split('**').join('')}</strong></p>`);
+        expect(textPartsInHTML[2][0]).toContain(`<p>[-spot 1]</p>`);
+        expect(textPartsInHTML[2][1]).toContain(`<p>test test2</p>`);
+        expect(textPartsInHTML[3][0]).toContain(`<p>[-spot 2]</p>`);
+        expect(textPartsInHTML[3][1]).toContain(`<p>test3</p>`);
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Adding spot in visual mode of short answer question in quiz exercise does not work as expected when the text to be added is located exactly beside an existing spot.

https://user-images.githubusercontent.com/10885503/204464705-711ad243-ce3c-4a78-8aa2-6f60bfef5d63.mov

### Description
<!-- Describe your changes in detail -->
When replacing the highlighted text with the new spot, the space between the previous spot and the highlighted text causes the selection range calculation to be incorrect. Trimming the words solves the issue.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course
- 1 Quiz Exercise which has Short Answer Question

1. Log in to Artemis
2. Navigate to Course Administration
3. Select the Course
4. Click Exercises
5. Click Edit of the Quiz Exercise
6. Click the Visual Tab of the Short Answer Question
7. Highlight the text which is located exactly beside the spot
8. Click Add Spot
9. Verify that the highlighted text is added as a spot correctly

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| short-answer-question-util.service.ts | 80.18% | 95% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

https://user-images.githubusercontent.com/10885503/204468627-91fedffc-c64f-48dd-a334-bf7e74b18179.mov
