### PR TITLE
`Quiz exercises`: Fix an issue when setting a multiple choice option to invalid during re-evaluate

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-validation.directive.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-validation.directive.ts
@@ -139,7 +139,6 @@ export abstract class QuizExerciseValidationDirective {
         return (
             isGenerallyValid &&
             areAllQuestionsValid === true &&
-            this.isEmpty(this.invalidFlaggedQuestions) &&
             maxPointsReachableInQuiz !== undefined &&
             maxPointsReachableInQuiz > 0 &&
             !this.testRunExistsAndShouldNotBeIgnored()

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-re-evaluate.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-re-evaluate.component.spec.ts
@@ -275,4 +275,27 @@ describe('QuizExercise Re-evaluate Component', () => {
         comp.includedInOverallScoreChange(IncludedInOverallScore.INCLUDED_AS_BONUS);
         expect(comp.quizExercise.includedInOverallScore).toEqual(IncludedInOverallScore.INCLUDED_AS_BONUS);
     });
+
+    it('should be valid when mc option is marked as invalid', () => {
+        const course = new Course();
+        const quizExercise = new QuizExercise(course, undefined);
+        quizExercise.title = 'Test';
+        quizExercise.duration = 100;
+        const question = new MultipleChoiceQuestion();
+        question.title = 'Test Question';
+        question.singleChoice = false;
+        const answerOption1 = new AnswerOption();
+        answerOption1.isCorrect = true;
+        const answerOption2 = new AnswerOption();
+        answerOption2.isCorrect = true;
+        const answerOption3 = new AnswerOption();
+        answerOption3.isCorrect = false;
+        question.answerOptions = [answerOption1, answerOption2, answerOption3];
+        question.points = 100;
+        quizExercise.quizQuestions = [question];
+        comp.quizExercise = quizExercise;
+        // @ts-ignore
+        comp.invalidFlaggedQuestions = [question];
+        expect(comp.isValidQuiz()).toBeTrue();
+    });
 });

--- a/src/test/javascript/spec/component/quiz-exercise/quiz-re-evaluate.component.spec.ts
+++ b/src/test/javascript/spec/component/quiz-exercise/quiz-re-evaluate.component.spec.ts
@@ -277,8 +277,6 @@ describe('QuizExercise Re-evaluate Component', () => {
     });
 
     it('should be valid when mc option is marked as invalid', () => {
-        const course = new Course();
-        const quizExercise = new QuizExercise(course, undefined);
         quizExercise.title = 'Test';
         quizExercise.duration = 100;
         const question = new MultipleChoiceQuestion();


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).buttons).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

When marking one of the options of multiple choice questions to be invalid, the save button is disabled. Hence, it is not possible to mark options to be invalid when re-evaluating quiz exercises.

https://user-images.githubusercontent.com/10885503/205958043-6ceb31b2-c1c9-41d6-ba4d-7744ed496242.mov


### Description
<!-- Describe your changes in detail -->

Having invalidFlaggedQuestions should not prevent re-evaluating quiz exercises. Therefore, the validation is removed.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Student
- 1 Course
- 1 Quiz Exercise with 1 Multiple Choice Question with 2 correct options. (Set the duration to 1 or 2 minutes)

1. Log In to Artemis as the Instructor
2. Navigate to Course Administration
3. Select the Course
4. Click Exercises
5. Start the Quiz Exercise
6. Log Out and Log In as the Student
7. Answer the Quiz Exercise by ticking the **first correct option.**
8. Submit the Answer
9. Wait for the quiz to end
10. Verify that the result is 0%
11. Log Out and Log In as the Instructor
12. Navigate to Course Administration
13. Select the Course
14. Click Exercises
15. Re-evaluate the Quiz Exercise
16. Click **Set answer invalid** to the **second correct option.**
17. Click Save. (Verify that the Save button can be clicked).
18. Log Out and Log In as the Student
19. View the result of the Quiz Exercise.
20. Verify that the result is now 100%.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| quiz-exercise-validation.directive.ts | 91.42% | 98.11% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

https://user-images.githubusercontent.com/10885503/205957908-0d9f03d3-a29d-4ed8-9523-bca5d8bb65ac.mov
