### PR TITLE
`Programming exercises`: Add possibility to configure docker run arguments on bamboo via spring properties 

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/ProgrammingLanguageConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/ProgrammingLanguageConfiguration.java
@@ -2,6 +2,8 @@ package de.tum.in.www1.artemis.config;
 
 import java.util.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import de.tum.in.www1.artemis.domain.enumeration.ProgrammingLanguage;
@@ -13,6 +15,8 @@ import de.tum.in.www1.artemis.domain.enumeration.ProjectType;
 @ConfigurationProperties(prefix = "artemis.continuous-integration.build")
 public class ProgrammingLanguageConfiguration {
 
+    private final Logger log = LoggerFactory.getLogger(ProgrammingLanguageConfiguration.class);
+
     private static final ProjectType DEFAULT_PROJECT_TYPE = ProjectType.PLAIN;
 
     private static final ProjectType MAVEN_PROJECT_TYPE = ProjectType.MAVEN_MAVEN;
@@ -20,6 +24,8 @@ public class ProgrammingLanguageConfiguration {
     private static final ProjectType GRADLE_PROJECT_TYPE = ProjectType.GRADLE_GRADLE;
 
     private Map<ProgrammingLanguage, Map<ProjectType, String>> images = new EnumMap<>(ProgrammingLanguage.class);
+
+    private Map<String, String> defaultDockerFlags;
 
     /**
      * Set the map of languages to build images.
@@ -30,6 +36,16 @@ public class ProgrammingLanguageConfiguration {
         final var languageSpecificBuildImages = loadImages(buildImages);
         checkImageForAllProgrammingLanguagesDefined(languageSpecificBuildImages);
         images = languageSpecificBuildImages;
+        log.info("Load docker image configuration: " + images);
+    }
+
+    public Map<String, String> getDefaultDockerFlags() {
+        return defaultDockerFlags;
+    }
+
+    public void setDefaultDockerFlags(final Map<String, String> dockerFlags) {
+        log.info("Set Docker flags to " + dockerFlags);
+        this.defaultDockerFlags = dockerFlags;
     }
 
     /**

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooBuildPlanService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/bamboo/BambooBuildPlanService.java
@@ -58,7 +58,6 @@ import de.tum.in.www1.artemis.exception.ContinuousIntegrationBuildPlanException;
 import de.tum.in.www1.artemis.service.ResourceLoaderService;
 import de.tum.in.www1.artemis.service.connectors.ContinuousIntegrationService.RepositoryCheckoutPath;
 import de.tum.in.www1.artemis.service.connectors.VersionControlService;
-import tech.jhipster.config.JHipsterConstants;
 
 @Service
 @Profile("bamboo")
@@ -500,8 +499,21 @@ public class BambooBuildPlanService {
         }
     }
 
-    private DockerConfiguration dockerConfigurationImageNameFor(ProgrammingLanguage programmingLanguage, Optional<ProjectType> projectType) {
-        var dockerImage = programmingLanguageConfiguration.getImage(programmingLanguage, projectType);
-        return new DockerConfiguration().image(dockerImage);
+    private DockerConfiguration dockerConfigurationFor(ProgrammingLanguage programmingLanguage, Optional<ProjectType> projectType) {
+        var dockerConfiguration = new DockerConfiguration();
+
+        dockerConfiguration.dockerRunArguments(getDockerConfigurationRunArgumentsFor(programmingLanguage));
+        dockerConfiguration.image(programmingLanguageConfiguration.getImage(programmingLanguage, projectType));
+
+        return dockerConfiguration;
+    }
+
+    /**
+     * Returns the (default) docker run arguments for a given ProgrammingLanguage. Bamboo requires the arguments to be in separate lines!
+     * @param programmingLanguage
+     * @return the docker run arguments for a given ProgrammingLanguage
+     */
+    private String getDockerConfigurationRunArgumentsFor(ProgrammingLanguage programmingLanguage) {
+        return "--cpus\n4\n--memory\n4g\n--pids-limit\n 100";
     }
 }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -40,6 +40,10 @@ artemis:
         # This `default` option will be overridden by more specific project type
         # definitions.
         build:
+            default-docker-flags:
+                cpus: 2
+                memory: 2g
+                pid-limit: 1000
             images:
                 java:
                     # possible overrides: maven, gradle

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -26,6 +26,10 @@ artemis:
     continuous-integration:
     # Defines the used docker images for certain programming languages
         build:
+            default-docker-flags:
+                cpus: 2
+                memory: 2g
+                pid-limit: 1000
             images:
                 # java intentionally uppercase to make sure both variants are
                 # accepted


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/).
- [ ] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [ ] I added pre-authorization annotations according to the [guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/server/#rest-endpoint-best-practices-for-authorization) and checked the course groups for all new REST Calls (security).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [ ] I documented the Java code using JavaDoc style.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Programming Exercises may negatively influence the Build Infrastructure if not prevented explicitly. Especially C programming exercises can crash Build Agents with memory leaks or fork bombs. Since the exercises are executed within a docker container, we can limit the containers resources explicitly and kill the container before the agent crashes. 


### Description
<!-- Describe your changes in detail -->

In this PR we add a new configuration option for docker run arguments: `artemis.continuous-integration.build.default-docker-flags`. An Administrator may provide any docker run flag as a key-value pair to this config. Artemis will explicitly add those flags to all newly created Bamboo Build plans. 

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

__Steps in Artemis__

1. Log in to Artemis
2. Navigate to Course Administration
3. Select a Course 
4. Create a new Programming Exercise 
5. Open the base and solution build plans in bamboo (links can be found in the lower half of the exercise overview page)

__Steps in Bamboo__

6. Click on "Actions" and then on "Configure plan" in the top right corner or the build plan 
7. Select the "Default Job" 
8. Change to the "Docker" Tab 9. 10. 
9. Inspect the "Extra arguments". They should look like this: 

```
--cpus
2
--memory
2g
--pids-limit
1000
```


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test
