### PR TITLE
`Programming exercises`: Fix test case names unintentionally visible to students

### DIFF
--- a/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
+++ b/src/main/webapp/app/overview/exercise-details/course-exercise-details.component.html
@@ -149,7 +149,14 @@
                             >
                                 {{ result.submission.submissionDate | artemisDate : 'long-date' }}
                             </h4>
-                            <jhi-result [result]="result" [showUngradedResults]="true" [showBadge]="true" [showTestDetails]="true" [exercise]="exercise"> </jhi-result>
+                            <jhi-result
+                                [result]="result"
+                                [showUngradedResults]="true"
+                                [showBadge]="true"
+                                [showTestDetails]="programmingExercise?.showTestNamesToStudents ?? false"
+                                [exercise]="exercise"
+                            >
+                            </jhi-result>
                         </div>
                         <div class="no-results" *ngIf="!sortedHistoryResults">
                             {{ 'artemisApp.courseOverview.exerciseDetails.noResults' | artemisTranslate }}


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.

### Motivation and Context
Students are able to see test case names using the "show more results" functionality. This should not be the case, this should only be able if activated by the instructor for this exercise.

### Description
Passing the PE-Setting to the component (with false als fallback) instead of simply true. 

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Programming Exercise

1. Participate in the PE mutliple times
2. Press on "Show all results"
3. Look at the detail of the result
4. Make sure test names are not visible.

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

