### PR TITLE
`Programming exercises`: Fix missing value in static code analysis issue location

### DIFF
--- a/src/main/webapp/app/exercises/shared/result/result-detail.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result-detail.component.ts
@@ -376,7 +376,7 @@ export class ResultDetailComponent implements OnInit {
         if (issue.startColumn) {
             const columnText =
                 !issue.endColumn || issue.startColumn === issue.endColumn
-                    ? this.translateService.instant('artemisApp.result.detail.codeIssue.column', { line: issue.startColumn })
+                    ? this.translateService.instant('artemisApp.result.detail.codeIssue.column', { column: issue.startColumn })
                     : this.translateService.instant('artemisApp.result.detail.codeIssue.columns', { from: issue.startColumn, to: issue.endColumn });
             return `${issue.filePath} ${lineText} ${columnText}`;
         }


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.

### Motivation and Context
Currently, Artemis sometimes shows SCA feedback with the missing column-information like this:
![grafik](https://user-images.githubusercontent.com/26540346/206866948-a014c478-17af-465e-9015-ca0904b14f88.png)
This PR fixes this bug.

### Description
The translation expected a parameter called `column`, but the code passed this information as `line`.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Programming Exercise with SCA enabled

1. Submitt a solution with SCA issues as student (i.e. unused imports)
2. Check that the column-information always shows a value

### Review Progress

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
