### PR TITLE
`Programming exercises`: Update Ares to 1.11.1

### DIFF
--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -43,12 +43,12 @@ artemis:
             images:
                 java:
                     # possible overrides: maven, gradle
-                    default: "ls1tum/artemis-maven-template:java17-11"
+                    default: "ls1tum/artemis-maven-template:java17-12"
                 kotlin:
                     # possible overrides: maven, gradle
-                    default: "ls1tum/artemis-maven-template:java17-11"
+                    default: "ls1tum/artemis-maven-template:java17-12"
                 empty:
-                    default: "ls1tum/artemis-maven-template:java17-11"
+                    default: "ls1tum/artemis-maven-template:java17-12"
                 python:
                     default: "ls1tum/artemis-python-docker:latest"
                 c:

--- a/src/main/resources/templates/java/maven_maven/test/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/maven_maven/test/projectTemplate/pom.xml
@@ -19,7 +19,7 @@
             <!-- Comes with JUnit 5, AssertJ and Hamcrest. JUnit 4 (JUnit 5 Vintage) or jqwik need to be added explicitly -->
             <groupId>de.tum.in.ase</groupId>
             <artifactId>artemis-java-test-sandbox</artifactId>
-            <version>1.11.0</version>
+            <version>1.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -104,7 +104,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.7.2.0</version>
+                <version>4.7.3.0</version>
                 <configuration>
                     <!-- Do not analyze the files in the test directory -->
                     <includeTests>${analyzeTests}</includeTests>
@@ -129,7 +129,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.1</version>
+                        <version>10.5.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>
@@ -151,12 +151,12 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>6.49.0</version>
+                        <version>6.52.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>6.49.0</version>
+                        <version>6.52.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/main/resources/templates/java/test/gradle/projectTemplate/build.gradle
+++ b/src/main/resources/templates/java/test/gradle/projectTemplate/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'com.github.spotbugs' version '5.0.13'
     // %static-code-analysis-stop%
     // %record-testwise-coverage-start%
-    id "com.teamscale" version "26.0.1"
+    id 'com.teamscale' version '27.0.1'
     // %record-testwise-coverage-stop%
 }
 
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'de.tum.in.ase:artemis-java-test-sandbox:1.11.0'
+    testImplementation 'de.tum.in.ase:artemis-java-test-sandbox:1.11.1'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
 
     // testImplementation(':${exerciseNamePomXml}')

--- a/src/main/resources/templates/java/test/maven/projectTemplate/pom.xml
+++ b/src/main/resources/templates/java/test/maven/projectTemplate/pom.xml
@@ -19,7 +19,7 @@
             <!-- Comes with JUnit 5, AssertJ and Hamcrest. JUnit 4 (JUnit 5 Vintage) or jqwik need to be added explicitly -->
             <groupId>de.tum.in.ase</groupId>
             <artifactId>artemis-java-test-sandbox</artifactId>
-            <version>1.11.0</version>
+            <version>1.11.1</version>
         </dependency>
     </dependencies>
     <build>
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.7.2.0</version>
+                <version>4.7.3.0</version>
                 <configuration>
                     <!-- Do not analyze the files in the test directory -->
                     <includeTests>${analyzeTests}</includeTests>
@@ -124,7 +124,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.1</version>
+                        <version>10.5.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>
@@ -146,12 +146,12 @@
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>6.49.0</version>
+                        <version>6.52.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>6.49.0</version>
+                        <version>6.52.0</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/src/main/resources/templates/kotlin/test/maven/projectTemplate/pom.xml
+++ b/src/main/resources/templates/kotlin/test/maven/projectTemplate/pom.xml
@@ -21,7 +21,7 @@
             <!-- Comes with JUnit 5, AssertJ and Hamcrest. JUnit 4 (JUnit 5 Vintage) or jqwik need to be added explicitly -->
             <groupId>de.tum.in.ase</groupId>
             <artifactId>artemis-java-test-sandbox</artifactId>
-            <version>1.11.0</version>
+            <version>1.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
A [new Ares version](https://github.com/ls1intum/Ares/releases/tag/1.11.1) got released. The templates should contain this new version.

### Description
This PR updates Ares to 1.11.1 and the different SCA tools to their latest versions

Related Docker-PR: https://github.com/ls1intum/artemis-maven-docker/pull/114

### Steps for Testing
Prerequisites:
- 1 Instructor

1. Create a new PE with SCA enabled
2. Check that running test cases / viewing SCA feedback is still possible

### Review Progress
#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
