### PR TITLE
`Quiz exercises`: Fix jump cursor when editing a multiple choice option correctness

### DIFF
--- a/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-validation.directive.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/quiz-exercise-validation.directive.ts
@@ -95,6 +95,7 @@ export abstract class QuizExerciseValidationDirective {
                         question.title.length < this.maxLengthThreshold &&
                         mcQuestion.answerOptions!.every(
                             (answerOption) =>
+                                answerOption.isCorrect !== undefined &&
                                 (!answerOption.explanation || answerOption.explanation.length <= this.explanationLengthThreshold) &&
                                 (!answerOption.hint || answerOption.hint.length <= this.hintLengthThreshold),
                         )

--- a/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.html
+++ b/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.html
@@ -94,7 +94,7 @@
                     <fa-icon [icon]="faArrowsAltV" size="2x"></fa-icon>
                 </span>
                 <jhi-markdown-editor
-                    [markdown]="generateAnswerMarkdown(answer)"
+                    [markdown]="markdownMap.get(answer.id!)"
                     [editorMode]="editorMode"
                     [metaCommands]="[]"
                     [defaultCommands]="[]"

--- a/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.ts
+++ b/src/main/webapp/app/exercises/quiz/manage/re-evaluate/multiple-choice-question/re-evaluate-multiple-choice-question.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { AnswerOption } from 'app/entities/quiz/answer-option.model';
 import { MultipleChoiceQuestion } from 'app/entities/quiz/multiple-choice-question.model';
 import { CorrectOptionCommand } from 'app/shared/markdown-editor/domainCommands/correctOptionCommand';
@@ -15,7 +15,7 @@ import { CdkDragDrop, moveItemInArray } from '@angular/cdk/drag-drop';
     templateUrl: './re-evaluate-multiple-choice-question.component.html',
     styleUrls: ['./re-evaluate-multiple-choice-question.component.scss', '../../../shared/quiz.scss'],
 })
-export class ReEvaluateMultipleChoiceQuestionComponent {
+export class ReEvaluateMultipleChoiceQuestionComponent implements OnInit {
     @Input() question: MultipleChoiceQuestion;
     @Input() questionIndex: number;
 
@@ -25,6 +25,7 @@ export class ReEvaluateMultipleChoiceQuestionComponent {
     @Output() questionMoveDown = new EventEmitter<object>();
 
     editorMode = EditorMode.NONE;
+    markdownMap: Map<number, string>;
 
     // Create Backup Question for resets
     @Input() backupQuestion: MultipleChoiceQuestion;
@@ -35,6 +36,16 @@ export class ReEvaluateMultipleChoiceQuestionComponent {
     faChevronUp = faChevronUp;
     faChevronDown = faChevronDown;
     faArrowsAltV = faArrowsAltV;
+
+    ngOnInit(): void {
+        this.markdownMap = new Map<number, string>();
+        for (const answer of this.question.answerOptions!) {
+            this.markdownMap.set(
+                answer.id!,
+                (answer.isCorrect ? CorrectOptionCommand.identifier : IncorrectOptionCommand.identifier) + ' ' + generateExerciseHintExplanation(answer),
+            );
+        }
+    }
 
     /**
      * generate the question using the markdown service
@@ -69,21 +80,6 @@ export class ReEvaluateMultipleChoiceQuestionComponent {
     }
 
     /**
-     * Generate the Markdown text for this question
-     *
-     * The markdown is generated according to these rules:
-     *
-     * 1. First the answer text is inserted
-     * 2. If hint and/or explanation exist,
-     *      they are added after the text with a linebreak and tab in front of them
-     *
-     * @param answer {AnswerOption}  is the AnswerOption, which the Markdown-field presents
-     */
-    generateAnswerMarkdown(answer: AnswerOption): string {
-        return (answer.isCorrect ? CorrectOptionCommand.identifier : IncorrectOptionCommand.identifier) + ' ' + generateExerciseHintExplanation(answer);
-    }
-
-    /**
      * Parse the answer Markdown and apply the result to the question's data
      *
      * The markdown rules are as follows:
@@ -102,7 +98,13 @@ export class ReEvaluateMultipleChoiceQuestionComponent {
         const startOfThisPart = text.indexOf(answerOptionText);
         const box = text.substring(0, startOfThisPart);
         // Check if box says this answer option is correct or not
-        answer.isCorrect = box === CorrectOptionCommand.identifier;
+        if (box === CorrectOptionCommand.identifier) {
+            answer.isCorrect = true;
+        } else if (box === IncorrectOptionCommand.identifier) {
+            answer.isCorrect = false;
+        } else {
+            answer.isCorrect = undefined;
+        }
         parseExerciseHintExplanation(answerOptionText, answer);
     }
 

--- a/src/test/javascript/spec/component/exercises/quiz/manage/re-evaluate/re-evaluate-multiple-choice-question.component.spec.ts
+++ b/src/test/javascript/spec/component/exercises/quiz/manage/re-evaluate/re-evaluate-multiple-choice-question.component.spec.ts
@@ -145,22 +145,13 @@ describe('ReEvaluateMultipleChoiceQuestionComponent', () => {
     });
 
     it('should react to answer option changes', () => {
+        const answer = component.question.answerOptions![0];
         component.onAnswerOptionChange('solution[wrong]answer', answer1);
         fixture.detectChanges();
 
         expect(component.question.answerOptions).toHaveLength(1);
 
-        const answer = component.question.answerOptions![0];
-        expect(answer.isCorrect).toBeFalse();
-    });
-
-    it('should generate answer markdown', () => {
-        const generatedText = 'answer';
-
-        const result = component.generateAnswerMarkdown(answer1);
-        fixture.detectChanges();
-
-        expect(result).toBe(IncorrectOptionCommand.identifier + ' ' + generatedText);
+        expect(answer.isCorrect).toBeUndefined();
     });
 
     it('should react to question changes', () => {
@@ -179,5 +170,27 @@ describe('ReEvaluateMultipleChoiceQuestionComponent', () => {
         fixture.detectChanges();
 
         expect(text).toBe(fakeText);
+    });
+
+    it('should change answer isCorrect to true if text is set to correct', () => {
+        const answer = component.question.answerOptions![0];
+        component.onAnswerOptionChange('[correct] correct option', answer1);
+        fixture.detectChanges();
+        expect(answer.isCorrect).toBeTrue();
+    });
+
+    it('should change answer isCorrect to false if text is set to wrong', () => {
+        const answer = component.question.answerOptions![0];
+        component.onAnswerOptionChange('[wrong] wrong option', answer1);
+        fixture.detectChanges();
+        expect(answer.isCorrect).toBeFalse();
+    });
+
+    it('should not change answer isCorrect if text is not set to either correct or wrong', () => {
+        const answer = component.question.answerOptions![0];
+        component.onAnswerOptionChange('[some text] wrong option', answer1);
+        fixture.detectChanges();
+        expect(component.question.answerOptions).toHaveLength(1);
+        expect(answer.isCorrect).toBeUndefined();
     });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.ase.in.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.ase.in.tum.de/dev/guidelines/client-tests/).
- [ ] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Changing the correctness of multiple-choice options of the quiz exercises during re-evaluation caused the cursor to jump to other parts of the text editor. This complicated the process of re-evaluating quiz exercises.

### Description
<!-- Describe your changes in detail -->

If the answer option correctness was set to neither **[correct]** nor **[wrong]**, the isCorrect flag of the answer option would be set to false. After that, the text correctness would be replaced automatically with **[wrong]**. This behavior was intentional in order to prevent invalid answer options during reevaluation. Unfortunately, this behavior caused the cursor to jump after the text was changed.

Instead of setting the isCorrect flag to false, the flag will be set to undefined if the answer option correctness is neither **[correct]** nor **[wrong]**. Then, the isCorrect flag will be validated to ensure that undefined value cannot be saved. This means the instructor can only set the answer option correctness to either [correct]** nor **[wrong]**.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course

1. Log in to Artemis
2. Navigate to Course Administration
3. Select the Course
4. Create Quiz Exercise
5. Add 1 Multiple Choice Option
6. Set duration to 1 second
7. Click Save
8. Click Start Exercise
9. Wait for 6 seconds and refresh the page
10. Click Re-evaluate
11. Verify that when changing the answer option correctness, the cursor does not jump

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
<!--
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ExerciseService.java | 85% | 77% |
| programming-exercise.component.ts | 13% | 95% |
-->

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
