### PR TITLE
`General`: Only position footer absolute on desktop

### DIFF
--- a/src/main/webapp/app/shared/layouts/footer/footer.component.html
+++ b/src/main/webapp/app/shared/layouts/footer/footer.component.html
@@ -1,4 +1,4 @@
-<footer class="d-none d-md-flex row" id="footer">
+<footer class="fixed d-none d-md-flex row" id="footer">
     <div class="guided-tour-footer-about col-sm-6">
         <a [routerLink]="['/about']" id="about" jhiTranslate="aboutUs" class="footer-text"></a>
     </div>

--- a/src/main/webapp/app/shared/layouts/footer/footer.scss
+++ b/src/main/webapp/app/shared/layouts/footer/footer.scss
@@ -1,11 +1,16 @@
 :host {
-    display: block;
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    background-color: var(--footer-bg);
-    padding: 0.5rem 1rem;
-    width: 100%;
+    footer {
+        display: block;
+        left: 0;
+        bottom: 0;
+        background-color: var(--footer-bg);
+        padding: 0.5rem 1rem;
+        width: 100%;
+
+        &.fixed {
+            position: absolute;
+        }
+    }
 
     .footer-text {
         font-weight: normal;

--- a/src/main/webapp/content/scss/global.scss
+++ b/src/main/webapp/content/scss/global.scss
@@ -265,10 +265,13 @@ Generic styles
 }
 
 .page-wrapper {
-    //Space reserved at bottom for footer
-    padding-bottom: 5rem;
     min-height: 100vh;
     position: relative;
+
+    //Space reserved at bottom for footer
+    @media (min-width: 768px) {
+        padding-bottom: 5rem;
+    }
 }
 
 .main-container {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

[This PR](https://github.com/ls1intum/Artemis/pull/5869) changed the footer style and moved the main footer css to the root element. It also removed the `fixed` class, that was only applied on desktop screen sizes. This lead to the issue, that the footer on mobile devices also got a `position: absolute` css property:
<img src="https://user-images.githubusercontent.com/1368405/208243693-668029fa-692d-4a85-8baa-0a3210d72f35.png" width="300"/>


### Description
<!-- Describe your changes in detail -->
This PR moves the main css back into the child `<footer>` element and applies the fixed class only for the desktop footer element. That way the mobile footer does not get the `position: absolute` property and should work fine again.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 User

1. Log in to Artemis
2. Open any page with a longer content (e.g. a course in the course management page) on a mobile device
3. The footerbar should not be hanging in the middle of the screen after scrolling a bit down

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
