### PR TITLE
`Plagiarism checks`: Fix submission view for submissions with unescaped characters

### DIFF
--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
@@ -175,7 +175,7 @@ export class TextSubmissionViewerComponent implements OnChanges {
                 this.repositoryService.getFile(file, domain).subscribe({
                     next: ({ fileContent }) => {
                         this.loading = false;
-                        this.fileContent = this.insertMatchTokens(fileContent);
+                        this.fileContent = this.insertMatchTokens(this.sanitize(fileContent));
                     },
                     error: () => {
                         this.loading = false;
@@ -242,5 +242,16 @@ export class TextSubmissionViewerComponent implements OnChanges {
         });
 
         return rows.join('\n');
+    }
+
+    /**
+     * Replace characters in text so that the text can be displayed in html
+     *
+     * @param text Text containing characters to be replaced
+     * @return Text which characters are replaced
+     * @private
+     */
+    private sanitize(text: string): string {
+        return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
 }

--- a/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
+++ b/src/main/webapp/app/exercises/shared/plagiarism/plagiarism-split-view/text-submission-viewer/text-submission-viewer.component.ts
@@ -10,6 +10,7 @@ import { DomainChange, DomainType, FileType } from 'app/exercises/programming/sh
 import { CodeEditorRepositoryFileService } from 'app/exercises/programming/shared/code-editor/service/code-editor-repository.service';
 import { FileWithHasMatch } from 'app/exercises/shared/plagiarism/plagiarism-split-view/split-pane-header/split-pane-header.component';
 import { captureException } from '@sentry/angular';
+import { escape } from 'lodash-es';
 
 type FilesWithType = { [p: string]: FileType };
 
@@ -175,7 +176,7 @@ export class TextSubmissionViewerComponent implements OnChanges {
                 this.repositoryService.getFile(file, domain).subscribe({
                     next: ({ fileContent }) => {
                         this.loading = false;
-                        this.fileContent = this.insertMatchTokens(this.sanitize(fileContent));
+                        this.fileContent = this.insertMatchTokens(escape(fileContent));
                     },
                     error: () => {
                         this.loading = false;
@@ -242,16 +243,5 @@ export class TextSubmissionViewerComponent implements OnChanges {
         });
 
         return rows.join('\n');
-    }
-
-    /**
-     * Replace characters in text so that the text can be displayed in html
-     *
-     * @param text Text containing characters to be replaced
-     * @return Text which characters are replaced
-     * @private
-     */
-    private sanitize(text: string): string {
-        return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
 }

--- a/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
@@ -122,15 +122,17 @@ describe('Text Submission Viewer Component', () => {
         comp.plagiarismSubmission = { submissionId } as PlagiarismSubmission<TextSubmissionElement>;
 
         const fileName = Object.keys(files)[1];
+        comp.matches = new Map();
         const expectedHeaders = new HttpHeaders().append('content-type', 'text/plain');
         jest.spyOn(repositoryService, 'getFileHeaders').mockReturnValue(of(new HttpResponse<Blob>({ headers: expectedHeaders })));
-        jest.spyOn(repositoryService, 'getFile').mockReturnValue(of({ fileContent: 'Test' }));
+        jest.spyOn(repositoryService, 'getFile').mockReturnValue(of({ fileContent: 'if(current>max)' }));
 
         comp.handleFileSelect(fileName);
 
         const expectedDomain: DomainChange = [DomainType.PARTICIPATION, { id: submissionId }];
         expect(repositoryService.getFile).toHaveBeenCalledWith(fileName, expectedDomain);
         expect(comp.currentFile).toEqual(fileName);
+        expect(comp.fileContent).toEqual('if(current&gt;max)');
     });
 
     it('handles binary file selection', () => {

--- a/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
+++ b/src/test/javascript/spec/component/plagiarism/text-submission-viewer.component.spec.ts
@@ -132,7 +132,7 @@ describe('Text Submission Viewer Component', () => {
         const expectedDomain: DomainChange = [DomainType.PARTICIPATION, { id: submissionId }];
         expect(repositoryService.getFile).toHaveBeenCalledWith(fileName, expectedDomain);
         expect(comp.currentFile).toEqual(fileName);
-        expect(comp.fileContent).toEqual('if(current&gt;max)');
+        expect(comp.fileContent).toBe('if(current&gt;max)');
     });
 
     it('handles binary file selection', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I added multiple screenshots/screencasts of my UI changes.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Codes that were submitted by students for programming exercises were truncated in the plagiarism submission view. This causes the student to not be able to view the submission comparison.

![before](https://user-images.githubusercontent.com/10885503/209134374-a6b1adb9-9cb2-4c65-a50b-f70216980ac1.png)

### Description
<!-- Describe your changes in detail -->
The codes were truncated in the view because the code contains an HTML tag that was unescaped. Escaping the HTML tag solves the issue.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 1 Course with a plagiarism case (e.g. [https://artemis-test1.artemis.in.tum.de/course-management/104](https://artemis-test1.artemis.in.tum.de/course-management/104))

1. Log in to Artemis
2. Navigate to Course Administration
3. Select the Course
4. Navigate to Plagiarism Cases
5. Click 1 of the cases (e.g. [https://artemis-test1.artemis.in.tum.de/course-management/104/plagiarism-cases/74](https://artemis-test1.artemis.in.tum.de/course-management/104/plagiarism-cases/74))
6. Verify that the codes that are displayed on the page are the same as the codes in bitbucket. (e.g. [code](https://bitbucket-prelive.ase.in.tum.de/projects/RTC11PBVT/repos/rtc11pbvt-artemis_test_user_4/browse/src/de/tum/in/ase/Shopping.java) of artemis_test_user_4 and [code](https://bitbucket-prelive.ase.in.tum.de/projects/RTC11PBVT/repos/rtc11pbvt-artemis_test_user_5/browse/src/de/tum/in/ase/Shopping.java) of artemis_test_user_5)

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [ ] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
<!-- Note: You may use the table below or copy the file coverage from the Codecov bot's comment. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| text-submission-viewer.component.ts | 83.33% | 93.75% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->

![after](https://user-images.githubusercontent.com/10885503/209134175-f4a35eea-b7f2-4f4b-922d-2714831c099a.png)
