### PR TITLE
`Development`: Enforce consistent order of modifiers

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -19,5 +19,6 @@
             <property name="severity" value="error"/>
             <property name="allowedAnnotations" value="Override,Test,ParameterizedTest,BeforeEach,AfterEach,BeforeAll,AfterAll"/>
         </module>
+        <module name="ModifierOrder"/>
     </module>
 </module>

--- a/src/main/java/de/tum/in/www1/artemis/domain/notification/TutorialGroupNotification.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/notification/TutorialGroupNotification.java
@@ -23,7 +23,7 @@ import de.tum.in.www1.artemis.domain.tutorialgroups.TutorialGroup;
 public class TutorialGroupNotification extends Notification {
 
     @JsonIgnore
-    public final static Set<NotificationType> TUTORIAL_GROUP_NOTIFICATION_TYPES = Set.of(TUTORIAL_GROUP_DELETED, TUTORIAL_GROUP_UPDATED);
+    public static final Set<NotificationType> TUTORIAL_GROUP_NOTIFICATION_TYPES = Set.of(TUTORIAL_GROUP_DELETED, TUTORIAL_GROUP_UPDATED);
 
     // ToDo: Idea: Reuse jhi_type_column to allow tutorial group notifications to be sent to only for example officially registered students and not self registered students
     @ManyToOne

--- a/src/main/java/de/tum/in/www1/artemis/service/ldap/LdapUserDto.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/ldap/LdapUserDto.java
@@ -11,7 +11,7 @@ import org.springframework.ldap.odm.annotations.Id;
 
 @Entry(base = "ou=users", objectClasses = { "imdPerson" })
 @Profile("ldap")
-final public class LdapUserDto {
+public final class LdapUserDto {
 
     @Id
     private Name uid;

--- a/src/main/java/de/tum/in/www1/artemis/service/notifications/NotificationSettingsService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/notifications/NotificationSettingsService.java
@@ -23,54 +23,54 @@ public class NotificationSettingsService {
     // notification settings settingIds analogous to client side
 
     // weekly summary
-    public final static String NOTIFICATION__WEEKLY_SUMMARY__BASIC_WEEKLY_SUMMARY = "notification.weekly-summary.basic-weekly-summary";
+    public static final String NOTIFICATION__WEEKLY_SUMMARY__BASIC_WEEKLY_SUMMARY = "notification.weekly-summary.basic-weekly-summary";
 
     // course wide discussion notification setting group
-    public final static String NOTIFICATION__COURSE_WIDE_DISCUSSION__NEW_COURSE_POST = "notification.course-wide-discussion.new-course-post";
+    public static final String NOTIFICATION__COURSE_WIDE_DISCUSSION__NEW_COURSE_POST = "notification.course-wide-discussion.new-course-post";
 
-    public final static String NOTIFICATION__COURSE_WIDE_DISCUSSION__NEW_REPLY_FOR_COURSE_POST = "notification.course-wide-discussion.new-reply-for-course-post";
+    public static final String NOTIFICATION__COURSE_WIDE_DISCUSSION__NEW_REPLY_FOR_COURSE_POST = "notification.course-wide-discussion.new-reply-for-course-post";
 
-    public final static String NOTIFICATION__COURSE_WIDE_DISCUSSION__NEW_ANNOUNCEMENT_POST = "notification.course-wide-discussion.new-announcement-post";
+    public static final String NOTIFICATION__COURSE_WIDE_DISCUSSION__NEW_ANNOUNCEMENT_POST = "notification.course-wide-discussion.new-announcement-post";
 
     // exercise notification setting group
-    public final static String NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_SUBMISSION_ASSESSED = "notification.exercise-notification.exercise-submission-assessed";
+    public static final String NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_SUBMISSION_ASSESSED = "notification.exercise-notification.exercise-submission-assessed";
 
-    public final static String NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_RELEASED = "notification.exercise-notification.exercise-released";
+    public static final String NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_RELEASED = "notification.exercise-notification.exercise-released";
 
-    public final static String NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_OPEN_FOR_PRACTICE = "notification.exercise-notification.exercise-open-for-practice";
+    public static final String NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_OPEN_FOR_PRACTICE = "notification.exercise-notification.exercise-open-for-practice";
 
-    public final static String NOTIFICATION__EXERCISE_NOTIFICATION__NEW_EXERCISE_POST = "notification.exercise-notification.new-exercise-post";
+    public static final String NOTIFICATION__EXERCISE_NOTIFICATION__NEW_EXERCISE_POST = "notification.exercise-notification.new-exercise-post";
 
-    public final static String NOTIFICATION__EXERCISE_NOTIFICATION__NEW_REPLY_FOR_EXERCISE_POST = "notification.exercise-notification.new-reply-for-exercise-post";
+    public static final String NOTIFICATION__EXERCISE_NOTIFICATION__NEW_REPLY_FOR_EXERCISE_POST = "notification.exercise-notification.new-reply-for-exercise-post";
 
-    public final static String NOTIFICATION__EXERCISE_NOTIFICATION__FILE_SUBMISSION_SUCCESSFUL = "notification.exercise-notification.file-submission-successful";
+    public static final String NOTIFICATION__EXERCISE_NOTIFICATION__FILE_SUBMISSION_SUCCESSFUL = "notification.exercise-notification.file-submission-successful";
 
     // lecture notification settings group
-    public final static String NOTIFICATION__LECTURE_NOTIFICATION__ATTACHMENT_CHANGES = "notification.lecture-notification.attachment-changes";
+    public static final String NOTIFICATION__LECTURE_NOTIFICATION__ATTACHMENT_CHANGES = "notification.lecture-notification.attachment-changes";
 
-    public final static String NOTIFICATION__LECTURE_NOTIFICATION__NEW_LECTURE_POST = "notification.lecture-notification.new-lecture-post";
+    public static final String NOTIFICATION__LECTURE_NOTIFICATION__NEW_LECTURE_POST = "notification.lecture-notification.new-lecture-post";
 
-    public final static String NOTIFICATION__LECTURE_NOTIFICATION__NEW_REPLY_FOR_LECTURE_POST = "notification.lecture-notification.new-reply-for-lecture-post";
+    public static final String NOTIFICATION__LECTURE_NOTIFICATION__NEW_REPLY_FOR_LECTURE_POST = "notification.lecture-notification.new-reply-for-lecture-post";
 
     // tutorial group notification settings group
-    public final static String NOTIFICATION__TUTORIAL_GROUP_NOTIFICATION__TUTORIAL_GROUP_REGISTRATION = "notification.tutorial-group-notification.tutorial-group-registration";
+    public static final String NOTIFICATION__TUTORIAL_GROUP_NOTIFICATION__TUTORIAL_GROUP_REGISTRATION = "notification.tutorial-group-notification.tutorial-group-registration";
 
-    public final static String NOTIFICATION__TUTORIAL_GROUP_NOTIFICATION__TUTORIAL_GROUP_DELETE_UPDATE = "notification.tutorial-group-notification.tutorial-group-delete-update";
+    public static final String NOTIFICATION__TUTORIAL_GROUP_NOTIFICATION__TUTORIAL_GROUP_DELETE_UPDATE = "notification.tutorial-group-notification.tutorial-group-delete-update";
 
     // tutor notification setting group
-    public final static String NOTIFICATION__TUTOR_NOTIFICATION__TUTORIAL_GROUP_REGISTRATION = "notification.tutor-notification.tutorial-group-registration";
+    public static final String NOTIFICATION__TUTOR_NOTIFICATION__TUTORIAL_GROUP_REGISTRATION = "notification.tutor-notification.tutorial-group-registration";
 
-    public final static String NOTIFICATION__TUTOR_NOTIFICATION__TUTORIAL_GROUP_ASSIGN_UNASSIGN = "notification.tutor-notification.tutorial-group-assign-unassign";
+    public static final String NOTIFICATION__TUTOR_NOTIFICATION__TUTORIAL_GROUP_ASSIGN_UNASSIGN = "notification.tutor-notification.tutorial-group-assign-unassign";
 
     // editor notification setting group
-    public final static String NOTIFICATION__EDITOR_NOTIFICATION__PROGRAMMING_TEST_CASES_CHANGED = "notification.editor-notification.programming-test-cases-changed";
+    public static final String NOTIFICATION__EDITOR_NOTIFICATION__PROGRAMMING_TEST_CASES_CHANGED = "notification.editor-notification.programming-test-cases-changed";
 
     // instructor notification setting group
-    public final static String NOTIFICATION__INSTRUCTOR_NOTIFICATION__COURSE_AND_EXAM_ARCHIVING_STARTED = "notification.instructor-notification.course-and-exam-archiving-started";
+    public static final String NOTIFICATION__INSTRUCTOR_NOTIFICATION__COURSE_AND_EXAM_ARCHIVING_STARTED = "notification.instructor-notification.course-and-exam-archiving-started";
 
     // if webapp or email is not explicitly set for a specific setting -> no support for this communication channel for this setting
     // this has to match the properties in the notification settings structure file on the client that hides the related UI elements
-    public final static Set<NotificationSetting> DEFAULT_NOTIFICATION_SETTINGS = new HashSet<>(Arrays.asList(
+    public static final Set<NotificationSetting> DEFAULT_NOTIFICATION_SETTINGS = new HashSet<>(Arrays.asList(
             // weekly summary
             new NotificationSetting(false, false, NOTIFICATION__WEEKLY_SUMMARY__BASIC_WEEKLY_SUMMARY),
             // course wide discussion notification setting group
@@ -103,7 +103,7 @@ public class NotificationSettingsService {
      * This is the place where the mapping between SettingId and NotificationTypes happens on the server side
      * Each SettingId can be based on multiple different NotificationTypes
      */
-    private final static Map<String, NotificationType[]> NOTIFICATION_SETTING_ID_TO_NOTIFICATION_TYPES_MAP = Map.ofEntries(
+    private static final Map<String, NotificationType[]> NOTIFICATION_SETTING_ID_TO_NOTIFICATION_TYPES_MAP = Map.ofEntries(
             Map.entry(NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_SUBMISSION_ASSESSED, new NotificationType[] { EXERCISE_SUBMISSION_ASSESSED }),
             Map.entry(NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_RELEASED, new NotificationType[] { EXERCISE_RELEASED }),
             Map.entry(NOTIFICATION__EXERCISE_NOTIFICATION__EXERCISE_OPEN_FOR_PRACTICE, new NotificationType[] { EXERCISE_PRACTICE }),

--- a/src/main/java/de/tum/in/www1/artemis/service/team/TeamImportStrategy.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/team/TeamImportStrategy.java
@@ -14,9 +14,9 @@ public abstract class TeamImportStrategy {
         this.teamRepository = teamRepository;
     }
 
-    abstract public void importTeams(Exercise sourceExercise, Exercise destinationExercise);
+    public abstract void importTeams(Exercise sourceExercise, Exercise destinationExercise);
 
-    abstract public void importTeams(Exercise exercise, List<Team> teams);
+    public abstract void importTeams(Exercise exercise, List<Team> teams);
 
     /**
      * Clones the given original teams via copy constructor, assigns them to the given destination exercise and persists them

--- a/src/test/java/de/tum/in/www1/artemis/domain/notification/SingleUserNotificationFactoryTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/domain/notification/SingleUserNotificationFactoryTest.java
@@ -82,7 +82,7 @@ class SingleUserNotificationFactoryTest {
 
     private static User cheatingUser;
 
-    private final static String USER_LOGIN = "de27sms";
+    private static final String USER_LOGIN = "de27sms";
 
     private static PlagiarismComparison plagiarismComparison;
 

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -167,7 +167,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     private Exam testExam1;
 
-    private final static int numberOfStudents = 10;
+    private static final int numberOfStudents = 10;
 
     private User instructor;
 

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportIntegrationTest.java
@@ -24,7 +24,7 @@ class ProgrammingExerciseGitDiffReportIntegrationTest extends AbstractSpringInte
 
     private static final String TEST_PREFIX = "progexgitdiffreport";
 
-    private final static String FILE_NAME = "test.java";
+    private static final String FILE_NAME = "test.java";
 
     private final LocalRepository solutionRepo = new LocalRepository("main");
 

--- a/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/hestia/ProgrammingExerciseGitDiffReportServiceTest.java
@@ -28,7 +28,7 @@ class ProgrammingExerciseGitDiffReportServiceTest extends AbstractSpringIntegrat
 
     private static final String TEST_PREFIX = "progexgitdiffreportservice";
 
-    private final static String FILE_NAME = "test.java";
+    private static final String FILE_NAME = "test.java";
 
     private final LocalRepository solutionRepo = new LocalRepository("main");
 

--- a/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/notification/GroupNotificationServiceTest.java
@@ -87,19 +87,19 @@ class GroupNotificationServiceTest extends AbstractSpringIntegrationBambooBitbuc
 
     private List<String> archiveErrors;
 
-    private final static String NOTIFICATION_TEXT = "notificationText";
+    private static final String NOTIFICATION_TEXT = "notificationText";
 
-    private final static ZonedDateTime FUTURISTIC_TIME = ZonedDateTime.now().plusHours(2);
+    private static final ZonedDateTime FUTURISTIC_TIME = ZonedDateTime.now().plusHours(2);
 
-    private final static ZonedDateTime FUTURE_TIME = ZonedDateTime.now().plusHours(1);
+    private static final ZonedDateTime FUTURE_TIME = ZonedDateTime.now().plusHours(1);
 
-    private final static ZonedDateTime CURRENT_TIME = ZonedDateTime.now();
+    private static final ZonedDateTime CURRENT_TIME = ZonedDateTime.now();
 
-    private final static ZonedDateTime PAST_TIME = ZonedDateTime.now().minusHours(1);
+    private static final ZonedDateTime PAST_TIME = ZonedDateTime.now().minusHours(1);
 
-    private final static ZonedDateTime ANCIENT_TIME = ZonedDateTime.now().minusHours(2);
+    private static final ZonedDateTime ANCIENT_TIME = ZonedDateTime.now().minusHours(2);
 
-    private final static int NUMBER_OF_ALL_GROUPS = 4;
+    private static final int NUMBER_OF_ALL_GROUPS = 4;
 
     /**
      * Sets up all needed mocks and their wanted behavior.

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTemplateIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseTemplateIntegrationTest.java
@@ -63,9 +63,9 @@ class ProgrammingExerciseTemplateIntegrationTest extends AbstractSpringIntegrati
 
     private final LocalRepository auxRepo = new LocalRepository(defaultBranch);
 
-    private final static String MAVEN_TEST_RESULTS_PATH = "target/surefire-reports";
+    private static final String MAVEN_TEST_RESULTS_PATH = "target/surefire-reports";
 
-    private final static String GRADLE_TEST_RESULTS_PATH = "build/test-results/test";
+    private static final String GRADLE_TEST_RESULTS_PATH = "build/test-results/test";
 
     @BeforeAll
     static void detectMavenHome() {

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionConstants.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingSubmissionConstants.java
@@ -16,11 +16,11 @@ public final class ProgrammingSubmissionConstants {
 
     public static final String BAMBOO_BUILD_RESULT_REQUEST;
 
-    public final static String GITLAB_PUSH_EVENT_REQUEST;
+    public static final String GITLAB_PUSH_EVENT_REQUEST;
 
-    public final static String GITLAB_PUSH_EVENT_REQUEST_WITHOUT_COMMIT;
+    public static final String GITLAB_PUSH_EVENT_REQUEST_WITHOUT_COMMIT;
 
-    public final static String GITLAB_PUSH_EVENT_REQUEST_WRONG_COMMIT_ORDER;
+    public static final String GITLAB_PUSH_EVENT_REQUEST_WRONG_COMMIT_ORDER;
 
     static {
         try {

--- a/src/test/java/de/tum/in/www1/artemis/service/EmailSummaryServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/EmailSummaryServiceTest.java
@@ -42,9 +42,9 @@ class EmailSummaryServiceTest extends AbstractSpringIntegrationBambooBitbucketJi
 
     private Exercise exerciseReleasedYesterdayAndNotYetDue;
 
-    private final static String USER_WITH_DEACTIVATED_WEEKLY_SUMMARIES_LOGIN = TEST_PREFIX + "student1";
+    private static final String USER_WITH_DEACTIVATED_WEEKLY_SUMMARIES_LOGIN = TEST_PREFIX + "student1";
 
-    private final static String USER_WITH_ACTIVATED_WEEKLY_SUMMARIES_LOGIN = TEST_PREFIX + "student2";
+    private static final String USER_WITH_ACTIVATED_WEEKLY_SUMMARIES_LOGIN = TEST_PREFIX + "student2";
 
     /**
      * Prepares the needed values and objects for testing

--- a/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/CourseTestService.java
@@ -139,13 +139,13 @@ public class CourseTestService {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private final static int numberOfStudents = 8;
+    private static final int numberOfStudents = 8;
 
-    private final static int numberOfTutors = 5;
+    private static final int numberOfTutors = 5;
 
-    private final static int numberOfEditors = 1;
+    private static final int numberOfEditors = 1;
 
-    private final static int numberOfInstructors = 1;
+    private static final int numberOfInstructors = 1;
 
     private MockDelegate mockDelegate;
 

--- a/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/UserTestService.java
@@ -78,13 +78,13 @@ public class UserTestService {
 
     public User student;
 
-    private final static int numberOfStudents = 50;
+    private static final int numberOfStudents = 50;
 
-    private final static int numberOfTutors = 1;
+    private static final int numberOfTutors = 1;
 
-    private final static int numberOfEditors = 1;
+    private static final int numberOfEditors = 1;
 
-    private final static int numberOfInstructors = 1;
+    private static final int numberOfInstructors = 1;
 
     public void setup(String testPrefix, MockDelegate mockDelegate) throws Exception {
         this.TEST_PREFIX = testPrefix;


### PR DESCRIPTION
### Checklist
#### General
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
This PR fixes some modifiers used in an incorrect order. 

### Description
Added the checksytle `ModifierOrder` check and fixed all reported issues.

### Steps for Testing
Code review / double-check that there are no more inconsistent modifier orders

### Review Progress
#### Code Review
- [x] Review 1
- [x] Review 2
