### PR TITLE
`Development`: Fix string concatenations in logger calls

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/config/LiquibaseConfiguration.java
+++ b/src/main/java/de/tum/in/www1/artemis/config/LiquibaseConfiguration.java
@@ -106,7 +106,7 @@ public class LiquibaseConfiguration {
         }
         if (currentVersion.isGreaterThanOrEqualTo(version600) && currentVersion.isLowerThan(version700)) {
             previousVersionString = getPreviousVersionElseThrow();
-            log.info("The previous version was " + previousVersionString);
+            log.info("The previous version was {}", previousVersionString);
             if (previousVersionString == null) {
                 // this means Artemis was never started before and no DATABASECHANGELOG exists, we can simply proceed
                 return;
@@ -177,11 +177,11 @@ public class LiquibaseConfiguration {
         }
         try (var statement = createStatement()) {
             if (previousVersionString == null) {
-                log.info("Insert latest version " + currentVersionString + " into database");
+                log.info("Insert latest version {} into database", currentVersionString);
                 statement.executeUpdate("INSERT INTO artemis_version (latest_version) VALUES('" + currentVersionString + "');");
             }
             else {
-                log.info("Update latest version to " + currentVersionString + " in database");
+                log.info("Update latest version to {} in database", currentVersionString);
                 statement.executeUpdate("UPDATE artemis_version SET latest_version = '" + currentVersionString + "';");
             }
             statement.getConnection().commit();

--- a/src/main/java/de/tum/in/www1/artemis/domain/GradeStep.java
+++ b/src/main/java/de/tum/in/www1/artemis/domain/GradeStep.java
@@ -165,7 +165,7 @@ public class GradeStep extends DomainObject {
             }
         }
         catch (Exception e) {
-            log.debug("getNumericValue failed for: " + this.gradeName, e);
+            log.debug("getNumericValue failed for: {}", this.gradeName, e);
         }
         return null;
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/connectors/Lti13Service.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/connectors/Lti13Service.java
@@ -169,7 +169,7 @@ public class Lti13Service {
             Optional<Result> result = resultRepository.findFirstWithSubmissionAndFeedbacksByParticipationIdOrderByCompletionDateDesc(participation.getId());
 
             if (result.isEmpty()) {
-                log.error("onNewResult triggered for participation " + participation.getId() + " but no result could be found");
+                log.error("onNewResult triggered for participation {} but no result could be found", participation.getId());
                 return;
             }
 
@@ -188,7 +188,7 @@ public class Lti13Service {
         String token = tokenRetriever.getToken(clientRegistration, Scopes.AGS_SCORE);
 
         if (token == null) {
-            log.error("Could not transmit score to " + clientRegistration.getClientId() + ": missing token");
+            log.error("Could not transmit score to {}: missing token", clientRegistration.getClientId());
             return;
         }
 
@@ -199,7 +199,7 @@ public class Lti13Service {
         HttpEntity<String> httpRequest = new HttpEntity<>(body, headers);
         try {
             restTemplate.postForEntity(scoreLineItemUrl, httpRequest, Object.class);
-            log.info("Submitted score for " + launch.getUser().getLogin() + " to client" + clientRegistration.getClientId());
+            log.info("Submitted score for {} to client {}", launch.getUser().getLogin(), clientRegistration.getClientId());
         }
         catch (HttpClientErrorException e) {
             String message = "Could not submit score for " + launch.getUser().getLogin() + " to client " + clientRegistration.getClientId() + ": " + e.getMessage();
@@ -245,12 +245,12 @@ public class Lti13Service {
             targetLinkPath = (new URL(targetLinkUrl)).getPath();
         }
         catch (MalformedURLException ex) {
-            log.info("Malformed target link url: " + targetLinkUrl);
+            log.info("Malformed target link url: {}", targetLinkUrl);
             return Optional.empty();
         }
 
         if (!matcher.match(EXERCISE_PATH_PATTERN, targetLinkPath)) {
-            log.info("Could not extract exerciseId and courseId from target link: " + targetLinkUrl);
+            log.info("Could not extract exerciseId and courseId from target link: {}", targetLinkUrl);
             return Optional.empty();
         }
         Map<String, String> pathVariables = matcher.extractUriTemplateVariables(EXERCISE_PATH_PATTERN, targetLinkPath);
@@ -260,7 +260,7 @@ public class Lti13Service {
         Optional<Exercise> exerciseOpt = exerciseRepository.findById(Long.valueOf(exerciseId));
 
         if (exerciseOpt.isEmpty()) {
-            log.info("Could not find exercise or course for target link url: " + targetLinkUrl);
+            log.info("Could not find exercise or course for target link url: {}", targetLinkUrl);
             return Optional.empty();
         }
 

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/ExamService.java
@@ -288,7 +288,7 @@ public class ExamService {
         List<StudentParticipation> studentParticipations = studentParticipationRepository.findByExamIdWithSubmissionRelevantResult(examId); // without test run participations
         log.info("Try to find quiz submitted answer counts");
         List<QuizSubmittedAnswerCount> submittedAnswerCounts = studentParticipationRepository.findSubmittedAnswerCountForQuizzesInExam(examId);
-        log.info("Found " + submittedAnswerCounts.size() + " quiz submitted answer counts");
+        log.info("Found {} quiz submitted answer counts", submittedAnswerCounts.size());
 
         // Counts how many participants each exercise has
         Map<Long, Long> exerciseIdToNumberParticipations = studentParticipations.stream()

--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -513,7 +513,7 @@ public class StudentExamService {
                         .thenRun(() -> sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.incrementAndGet(), failedExamsCounter.get(), studentExams.size(),
                                 generatedParticipations.size(), startedAt, lock))
                         .exceptionally(throwable -> {
-                            log.error("Exception while preparing exercises for student exam " + studentExam.getId(), throwable);
+                            log.error("Exception while preparing exercises for student exam {}", studentExam.getId(), throwable);
                             sendAndCacheExercisePreparationStatus(examId, finishedExamsCounter.get(), failedExamsCounter.incrementAndGet(), studentExams.size(),
                                     generatedParticipations.size(), startedAt, lock);
                             return null;

--- a/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/programming/ProgrammingExerciseService.java
@@ -1055,8 +1055,8 @@ public class ProgrammingExerciseService {
     public boolean preCheckProjectExistsOnVCSOrCI(ProgrammingExercise programmingExercise, String courseShortName) {
         String projectKey = courseShortName + programmingExercise.getShortName().toUpperCase().replaceAll("\\s+", "");
         String projectName = courseShortName + " " + programmingExercise.getTitle();
-        log.debug("Project Key: " + projectKey);
-        log.debug("Project Name: " + projectName);
+        log.debug("Project Key: {}", projectKey);
+        log.debug("Project Name: {}", projectName);
         boolean projectExists = versionControlService.get().checkIfProjectExists(projectKey, projectName);
         if (projectExists) {
             return true;

--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/cache/quiz/QuizScheduleService.java
@@ -616,7 +616,7 @@ public class QuizScheduleService {
                 participation.setInitializationDate(quizSubmission.getSubmissionDate());
                 Optional<User> user = userRepository.findOneByLogin(username);
                 if (user.isEmpty()) {
-                    log.error("Cannot find the user for username " + username);
+                    log.error("Cannot find the user for username {}", username);
                 } else {
                     participation.setParticipant(user.get());
                 }

--- a/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/DatabaseUtilService.java
@@ -559,19 +559,19 @@ public class DatabaseUtilService {
         if (authorityRepository.count() == 0) {
             authorityRepository.saveAll(adminAuthorities);
         }
-        log.debug("Generate " + numberOfStudents + " students...");
+        log.debug("Generate {} students...", numberOfStudents);
         var students = generateActivatedUsers(prefix + "student", passwordService.hashPassword(USER_PASSWORD), new String[] { "tumuser", "testgroup", prefix + "tumuser" },
                 studentAuthorities, numberOfStudents);
-        log.debug(numberOfStudents + " students generated. Generate " + numberOfTutors + " tutors...");
+        log.debug("{} students generated. Generate {} tutors...", numberOfStudents, numberOfTutors);
         var tutors = generateActivatedUsers(prefix + "tutor", passwordService.hashPassword(USER_PASSWORD), new String[] { "tutor", "testgroup", prefix + "tutor" },
                 tutorAuthorities, numberOfTutors);
-        log.debug(numberOfTutors + " tutors generated. Generate " + numberOfEditors + " editors...");
+        log.debug("{} tutors generated. Generate {} editors...", numberOfTutors, numberOfEditors);
         var editors = generateActivatedUsers(prefix + "editor", passwordService.hashPassword(USER_PASSWORD), new String[] { "editor", "testgroup", prefix + "editor" },
                 editorAuthorities, numberOfEditors);
-        log.debug(numberOfEditors + " editors generated. Generate " + numberOfInstructors + " instructors...");
+        log.debug("{} editors generated. Generate {} instructors...", numberOfEditors, numberOfInstructors);
         var instructors = generateActivatedUsers(prefix + "instructor", passwordService.hashPassword(USER_PASSWORD),
                 new String[] { "instructor", "testgroup", prefix + "instructor" }, instructorAuthorities, numberOfInstructors);
-        log.debug(numberOfInstructors + " instructors generated");
+        log.debug("{} instructors generated", numberOfInstructors);
 
         List<User> usersToAdd = new ArrayList<>();
         usersToAdd.addAll(students);
@@ -589,9 +589,9 @@ public class DatabaseUtilService {
         }
 
         if (usersToAdd.size() > 0) {
-            log.debug("Save " + usersToAdd.size() + " users to database...");
+            log.debug("Save {} users to database...", usersToAdd.size());
             usersToAdd = userRepo.saveAll(usersToAdd);
-            log.debug("Save " + usersToAdd.size() + " users to database. Done");
+            log.debug("Save {} users to database. Done", usersToAdd.size());
         }
 
         return usersToAdd;


### PR DESCRIPTION
### Checklist
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
Logger calls should not contain string concatenation, instead, the arguments should be passed as parameters.

### Description
There have been multiple PRs like this before, e.g. #5377 and #3122. I still don't know of any tools to detect this automatically and warn the developer / fail the server style check, so for now we need to detect this in code review or regularly open PRs like this.

### Steps for Testing
Code Review

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
