### PR TITLE
`Development`: Enforce absence of JUnit 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ dependencies {
     testImplementation "org.apache.maven.surefire:surefire-report-parser:3.0.0-M7"
     testImplementation "com.opencsv:opencsv:5.7.1"
     testImplementation "io.zonky.test:embedded-database-spring-test:2.2.0"
-    testImplementation 'com.tngtech.archunit:archunit:1.0.1'
+    testImplementation "com.tngtech.archunit:archunit:1.0.1"
 
     // Lightweight JSON library needed for the internals of the MockRestServiceServer
     testImplementation "org.json:json:20220924"

--- a/build.gradle
+++ b/build.gradle
@@ -311,6 +311,7 @@ dependencies {
     testImplementation "org.apache.maven.surefire:surefire-report-parser:3.0.0-M7"
     testImplementation "com.opencsv:opencsv:5.7.1"
     testImplementation "io.zonky.test:embedded-database-spring-test:2.2.0"
+    testImplementation 'com.tngtech.archunit:archunit:1.0.1'
 
     // Lightweight JSON library needed for the internals of the MockRestServiceServer
     testImplementation "org.json:json:20220924"

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationBambooBitbucketJiraTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractSpringIntegrationBambooBitbucketJiraTest extends A
     protected PasswordService passwordService;
 
     @AfterEach
-    public void resetSpyBeans() {
+    protected void resetSpyBeans() {
         Mockito.reset(ldapUserService, continuousIntegrationUpdateService, continuousIntegrationService, versionControlService, bambooServer, textBlockService);
         super.resetSpyBeans();
     }

--- a/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationJenkinsGitlabTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/AbstractSpringIntegrationJenkinsGitlabTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractSpringIntegrationJenkinsGitlabTest extends Abstrac
     protected GitlabRequestMockProvider gitlabRequestMockProvider;
 
     @AfterEach
-    public void resetSpyBeans() {
+    protected void resetSpyBeans() {
         Mockito.reset(continuousIntegrationService, versionControlService, jenkinsServer);
         super.resetSpyBeans();
     }

--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -1,0 +1,26 @@
+package de.tum.in.www1.artemis;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+
+class ArchitectureTest {
+
+    @Test
+    void testNoJUnit4() {
+        JavaClasses testClasses = new ClassFileImporter().withImportOption(new ImportOption.OnlyIncludeTests()).importPackages("de.tum.in.www1.artemis");
+
+        ArchRule noJUnit4Imports = noClasses().should().dependOnClassesThat().resideInAPackage("org.junit");
+        ArchRule noPublicTests = noMethods().that().areAnnotatedWith(Test.class).or().areAnnotatedWith(ParameterizedTest.class).or().areAnnotatedWith(BeforeEach.class).or()
+                .areAnnotatedWith(BeforeAll.class).or().areAnnotatedWith(AfterEach.class).or().areAnnotatedWith(AfterAll.class).should().bePublic();
+
+        noJUnit4Imports.check(testClasses);
+        noPublicTests.check(testClasses);
+    }
+}

--- a/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/ArchitectureTest.java
@@ -1,5 +1,8 @@
 package de.tum.in.www1.artemis;
 
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.simpleNameContaining;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 
 import org.junit.jupiter.api.*;
@@ -19,8 +22,12 @@ class ArchitectureTest {
         ArchRule noJUnit4Imports = noClasses().should().dependOnClassesThat().resideInAPackage("org.junit");
         ArchRule noPublicTests = noMethods().that().areAnnotatedWith(Test.class).or().areAnnotatedWith(ParameterizedTest.class).or().areAnnotatedWith(BeforeEach.class).or()
                 .areAnnotatedWith(BeforeAll.class).or().areAnnotatedWith(AfterEach.class).or().areAnnotatedWith(AfterAll.class).should().bePublic();
+        ArchRule classNames = methods().that().areAnnotatedWith(Test.class).should().beDeclaredInClassesThat().haveNameMatching(".*Test");
+        ArchRule noPublicTestClasses = noClasses().that().haveNameMatching(".*Test").should().bePublic();
 
         noJUnit4Imports.check(testClasses);
         noPublicTests.check(testClasses);
+        classNames.check(testClasses);
+        noPublicTestClasses.check(testClasses.that(are(not(simpleNameContaining("Abstract")))));
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/ExamIntegrationTest.java
@@ -2861,32 +2861,32 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testGetExamForImportWithExercises_successful() throws Exception {
+    void testGetExamForImportWithExercises_successful() throws Exception {
         Exam received = request.get("/api/exams/" + exam2.getId(), HttpStatus.OK, Exam.class);
         assertEquals(exam2, received);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor6", roles = "INSTRUCTOR")
-    public void testGetExamForImportWithExercises_noInstructorAccess() throws Exception {
+    void testGetExamForImportWithExercises_noInstructorAccess() throws Exception {
         request.get("/api/exams/" + exam2.getId(), HttpStatus.FORBIDDEN, Exam.class);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TUTOR")
-    public void testGetExamForImportWithExercises_noTutorAccess() throws Exception {
+    void testGetExamForImportWithExercises_noTutorAccess() throws Exception {
         request.get("/api/exams/" + exam2.getId(), HttpStatus.FORBIDDEN, Exam.class);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "editor1", roles = "EDITOR")
-    public void testGetExamForImportWithExercises_noEditorAccess() throws Exception {
+    void testGetExamForImportWithExercises_noEditorAccess() throws Exception {
         request.get("/api/exams/" + exam2.getId(), HttpStatus.FORBIDDEN, Exam.class);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testGetAllExamsOnPage_WithoutExercises_instructor_successful() throws Exception {
+    void testGetAllExamsOnPage_WithoutExercises_instructor_successful() throws Exception {
         var title = "My fancy search title for the exam which is not used somewhere else";
         var exam = ModelFactory.generateExam(course1);
         exam.setTitle(title);
@@ -2898,7 +2898,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testGetAllExamsOnPage_WithExercises_instructor_successful() throws Exception {
+    void testGetAllExamsOnPage_WithExercises_instructor_successful() throws Exception {
         var newExam = database.addTestExamWithExerciseGroup(course1, true);
         var searchTerm = "A very distinct title that should only ever exist once in the database";
         newExam.setTitle(searchTerm);
@@ -2911,7 +2911,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testGetAllExamsOnPage_WithoutExercisesAndExamsNotLinkedToCourse_instructor_successful() throws Exception {
+    void testGetAllExamsOnPage_WithoutExercisesAndExamsNotLinkedToCourse_instructor_successful() throws Exception {
         var title = "Another fancy exam search title for the exam which is not used somewhere else";
         Course course3 = database.addEmptyCourse();
         course3.setInstructorGroupName("non-instructors");
@@ -2926,7 +2926,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = "admin", roles = "ADMIN")
-    public void testGetAllExamsOnPage_WithoutExercisesAndExamsNotLinkedToCourse_admin_successful() throws Exception {
+    void testGetAllExamsOnPage_WithoutExercisesAndExamsNotLinkedToCourse_admin_successful() throws Exception {
         var title = "Yet another 3rd exam search title for the exam which is not used somewhere else";
         Course course3 = database.addEmptyCourse();
         course3.setInstructorGroupName("non-instructors");
@@ -2942,33 +2942,33 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TUTOR")
-    public void testGetAllExamsOnPage_tutor() throws Exception {
+    void testGetAllExamsOnPage_tutor() throws Exception {
         final PageableSearchDTO<String> search = database.configureSearch("");
         request.getSearchResult("/api/exams", HttpStatus.FORBIDDEN, Exam.class, database.searchMapping(search));
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    public void testGetAllExamsOnPage_student() throws Exception {
+    void testGetAllExamsOnPage_student() throws Exception {
         final PageableSearchDTO<String> search = database.configureSearch("");
         request.getSearchResult("/api/exams", HttpStatus.FORBIDDEN, Exam.class, database.searchMapping(search));
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")
-    public void testImportExamWithExercises_student() throws Exception {
+    void testImportExamWithExercises_student() throws Exception {
         request.postWithoutLocation("/api/courses/" + course1.getId() + "/exam-import", exam1, HttpStatus.FORBIDDEN, null);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "tutor1", roles = "TUTOR")
-    public void testImportExamWithExercises_tutor() throws Exception {
+    void testImportExamWithExercises_tutor() throws Exception {
         request.postWithoutLocation("/api/courses/" + course1.getId() + "/exam-import", exam1, HttpStatus.FORBIDDEN, null);
     }
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_idExists() throws Exception {
+    void testImportExamWithExercises_idExists() throws Exception {
         final Exam exam = ModelFactory.generateExam(course1);
         exam.setId(2L);
         request.postWithoutLocation("/api/courses/" + course1.getId() + "/exam-import", exam, HttpStatus.BAD_REQUEST, null);
@@ -2976,7 +2976,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_courseMismatch() throws Exception {
+    void testImportExamWithExercises_courseMismatch() throws Exception {
         // No Course
         final Exam examA = ModelFactory.generateExam(course1);
         examA.setCourse(null);
@@ -2990,7 +2990,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_dateConflict() throws Exception {
+    void testImportExamWithExercises_dateConflict() throws Exception {
         // Visible Date after Started Date
         final Exam examA = ModelFactory.generateExam(course1);
         examA.setVisibleDate(ZonedDateTime.now().plusHours(2));
@@ -3014,7 +3014,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_dateConflictTestExam() throws Exception {
+    void testImportExamWithExercises_dateConflictTestExam() throws Exception {
         // Working Time larger than Working window
         final Exam examA = ModelFactory.generateTestExam(course1);
         examA.setWorkingTime(3 * 60 * 60);
@@ -3028,7 +3028,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_pointConflict() throws Exception {
+    void testImportExamWithExercises_pointConflict() throws Exception {
         final Exam examA = ModelFactory.generateExam(course1);
         examA.setExamMaxPoints(-5);
         request.postWithoutLocation("/api/courses/" + course1.getId() + "/exam-import", examA, HttpStatus.BAD_REQUEST, null);
@@ -3036,7 +3036,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_correctionRoundConflict() throws Exception {
+    void testImportExamWithExercises_correctionRoundConflict() throws Exception {
         // Correction round <= 0
         final Exam examA = ModelFactory.generateExam(course1);
         examA.setNumberOfCorrectionRoundsInExam(0);
@@ -3055,7 +3055,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_successfulWithoutExercises() throws Exception {
+    void testImportExamWithExercises_successfulWithoutExercises() throws Exception {
         Exam exam = database.addExam(course1);
         exam.setId(null);
 
@@ -3087,7 +3087,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_successfulWithExercises() throws Exception {
+    void testImportExamWithExercises_successfulWithExercises() throws Exception {
         Exam exam = database.addExamWithModellingAndTextAndFileUploadAndQuizAndEmptyGroup(course1);
         exam.setId(null);
 
@@ -3101,7 +3101,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_successfulWithImportToOtherCourse() throws Exception {
+    void testImportExamWithExercises_successfulWithImportToOtherCourse() throws Exception {
         Exam exam = database.addExamWithModellingAndTextAndFileUploadAndQuizAndEmptyGroup(course2);
         exam.setCourse(course1);
         exam.setId(null);
@@ -3120,7 +3120,7 @@ class ExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTe
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void testImportExamWithExercises_preCheckFailed() throws Exception {
+    void testImportExamWithExercises_preCheckFailed() throws Exception {
         Exam exam = ModelFactory.generateExam(course1);
         ExerciseGroup programmingGroup = ModelFactory.generateExerciseGroup(false, exam);
         exam = examRepository.save(exam);

--- a/src/test/java/de/tum/in/www1/artemis/lecture/LearningGoalIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/lecture/LearningGoalIntegrationTest.java
@@ -446,7 +446,7 @@ class LearningGoalIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void deleteLearningGoal_witRelatedGoals_shouldReturnBadRequest() throws Exception {
+    void deleteLearningGoal_witRelatedGoals_shouldReturnBadRequest() throws Exception {
         LearningGoal learningGoal = learningGoalRepository.findByIdElseThrow(idOfLearningGoal);
         Course course = courseRepository.findByIdElseThrow(idOfCourse);
         LearningGoal learningGoal1 = database.createLearningGoal(course);
@@ -476,7 +476,7 @@ class LearningGoalIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void createLearningGoalRelation() throws Exception {
+    void createLearningGoalRelation() throws Exception {
         Course course = courseRepository.findByIdElseThrow(idOfCourse);
         Long idOfOtherLearningGoal = database.createLearningGoal(course).getId();
 
@@ -491,7 +491,7 @@ class LearningGoalIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student42", roles = "USER")
-    public void createLearningGoalRelation_shouldReturnForbidden() throws Exception {
+    void createLearningGoalRelation_shouldReturnForbidden() throws Exception {
         Course course = courseRepository.findByIdElseThrow(idOfCourse);
         Long idOfOtherLearningGoal = database.createLearningGoal(course).getId();
 
@@ -502,7 +502,7 @@ class LearningGoalIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void getLearningGoalRelations() throws Exception {
+    void getLearningGoalRelations() throws Exception {
         LearningGoal learningGoal = learningGoalRepository.findByIdElseThrow(idOfLearningGoal);
         Course course = courseRepository.findByIdElseThrow(idOfCourse);
         LearningGoal otherLearningGoal = database.createLearningGoal(course);
@@ -521,7 +521,7 @@ class LearningGoalIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "instructor1", roles = "INSTRUCTOR")
-    public void deleteLearningGoalRelation() throws Exception {
+    void deleteLearningGoalRelation() throws Exception {
         LearningGoal learningGoal = learningGoalRepository.findByIdElseThrow(idOfLearningGoal);
         Course course = courseRepository.findByIdElseThrow(idOfCourse);
         LearningGoal otherLearningGoal = database.createLearningGoal(course);

--- a/src/test/java/de/tum/in/www1/artemis/management/SecurityMetersServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/management/SecurityMetersServiceTest.java
@@ -11,7 +11,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
-class SecurityMetersServiceTests {
+class SecurityMetersServiceTest {
 
     private static final String INVALID_TOKENS_METER_EXPECTED_NAME = "security.authentication.invalid-tokens";
 

--- a/src/test/java/de/tum/in/www1/artemis/metis/ConversationIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/metis/ConversationIntegrationTest.java
@@ -7,7 +7,6 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,18 +40,12 @@ class ConversationIntegrationTest extends AbstractSpringIntegrationBambooBitbuck
     private Course course;
 
     @BeforeEach
-    public void initTestCase() {
+    void initTestCase() {
         database.addUsers(TEST_PREFIX, 5, 5, 0, 1);
         course = database.createCourse(1L);
         existingConversation = database.createConversation(course, TEST_PREFIX);
         doNothing().when(messagingTemplate).convertAndSendToUser(any(), any(), any());
     }
-
-    @AfterEach
-    public void tearDown() {
-    }
-
-    // Conversation
 
     @Test
     @WithMockUser(username = TEST_PREFIX + "student1", roles = "USER")

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ConsistencyCheckBitbucketBambooIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ConsistencyCheckBitbucketBambooIntegrationTest.java
@@ -7,16 +7,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
-import de.tum.in.www1.artemis.service.ConsistencyCheckServiceTest;
+import de.tum.in.www1.artemis.service.ConsistencyCheckTestService;
 
 class ConsistencyCheckBitbucketBambooIntegrationTest extends AbstractSpringIntegrationBambooBitbucketJiraTest {
 
     @Autowired
-    private ConsistencyCheckServiceTest consistencyCheckServiceTest;
+    private ConsistencyCheckTestService consistencyCheckTestService;
 
     @BeforeEach
     void setup() throws Exception {
-        consistencyCheckServiceTest.setup(this);
+        consistencyCheckTestService.setup(this);
         bambooRequestMockProvider.enableMockingOfRequests();
         bitbucketRequestMockProvider.enableMockingOfRequests();
     }
@@ -35,36 +35,36 @@ class ConsistencyCheckBitbucketBambooIntegrationTest extends AbstractSpringInteg
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_noErrors() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_noErrors();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_noErrors();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_missingVCSProject() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_missingVCSProject();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_missingVCSProject();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_missingVCSRepos() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_missingVCSRepos();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_missingVCSRepos();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_buildPlansMissing() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_buildPlansMissing();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_buildPlansMissing();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_isLocalSimulation() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_isLocalSimulation();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_isLocalSimulation();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_forbidden() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_forbidden();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_forbidden();
     }
 }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ConsistencyCheckGitlabJenkinsIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ConsistencyCheckGitlabJenkinsIntegrationTest.java
@@ -7,16 +7,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import de.tum.in.www1.artemis.AbstractSpringIntegrationJenkinsGitlabTest;
-import de.tum.in.www1.artemis.service.ConsistencyCheckServiceTest;
+import de.tum.in.www1.artemis.service.ConsistencyCheckTestService;
 
 class ConsistencyCheckGitlabJenkinsIntegrationTest extends AbstractSpringIntegrationJenkinsGitlabTest {
 
     @Autowired
-    private ConsistencyCheckServiceTest consistencyCheckServiceTest;
+    private ConsistencyCheckTestService consistencyCheckTestService;
 
     @BeforeEach
     void setup() throws Exception {
-        consistencyCheckServiceTest.setup(this);
+        consistencyCheckTestService.setup(this);
         jenkinsRequestMockProvider.enableMockingOfRequests(jenkinsServer);
         gitlabRequestMockProvider.enableMockingOfRequests();
     }
@@ -35,37 +35,37 @@ class ConsistencyCheckGitlabJenkinsIntegrationTest extends AbstractSpringIntegra
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_noErrors() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_noErrors();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_noErrors();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_missingVCSProject() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_missingVCSProject();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_missingVCSProject();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_missingVCSRepos() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_missingVCSRepos();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_missingVCSRepos();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_buildPlansMissing() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_buildPlansMissing();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_buildPlansMissing();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_isLocalSimulation() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_isLocalSimulation();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_isLocalSimulation();
     }
 
     @Test
     @WithMockUser(username = "instructor1", roles = "INSTRUCTOR")
     void checkConsistencyOfProgrammingExercise_forbidden() throws Exception {
-        consistencyCheckServiceTest.testCheckConsistencyOfProgrammingExercise_forbidden();
+        consistencyCheckTestService.testCheckConsistencyOfProgrammingExercise_forbidden();
     }
 
 }

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseGradingServiceTest.java
@@ -122,7 +122,7 @@ abstract class ProgrammingExerciseGradingServiceTest extends AbstractSpringInteg
     /**
      * Test class for COURSE exercises
      */
-    public static class CourseProgrammingExerciseGradingServiceTest extends ProgrammingExerciseGradingServiceTest {
+    static class CourseProgrammingExerciseGradingServiceTest extends ProgrammingExerciseGradingServiceTest {
 
         @Override
         ProgrammingExercise generateDefaultProgrammingExercise() {
@@ -147,7 +147,7 @@ abstract class ProgrammingExerciseGradingServiceTest extends AbstractSpringInteg
     /**
      * Test class for EXAM exercises
      */
-    public static class ExamProgrammingExerciseGradingServiceTest extends ProgrammingExerciseGradingServiceTest {
+    static class ExamProgrammingExerciseGradingServiceTest extends ProgrammingExerciseGradingServiceTest {
 
         @Override
         ProgrammingExercise generateDefaultProgrammingExercise() {

--- a/src/test/java/de/tum/in/www1/artemis/security/jwt/TokenProviderSecurityMetersTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/security/jwt/TokenProviderSecurityMetersTest.java
@@ -26,7 +26,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import tech.jhipster.config.JHipsterProperties;
 
-class TokenProviderSecurityMetersTests {
+class TokenProviderSecurityMetersTest {
 
     private static final long ONE_MINUTE = 60000;
 

--- a/src/test/java/de/tum/in/www1/artemis/service/ConsistencyCheckTestService.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/ConsistencyCheckTestService.java
@@ -24,7 +24,7 @@ import de.tum.in.www1.artemis.util.RequestUtilService;
  * 2) Jenkins + Gitlab
  */
 @Service
-public class ConsistencyCheckServiceTest {
+public class ConsistencyCheckTestService {
 
     @Autowired
     private DatabaseUtilService database;

--- a/src/test/java/de/tum/in/www1/artemis/service/TextBlockServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/service/TextBlockServiceTest.java
@@ -17,7 +17,7 @@ class TextBlockServiceTest {
     private TextBlockService textBlockService;
 
     @BeforeEach
-    public void prepareFreshService() {
+    void prepareFreshService() {
         textBlockService = new TextBlockService(null);
     }
 

--- a/src/test/java/de/tum/in/www1/artemis/util/AbstractArtemisIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/util/AbstractArtemisIntegrationTest.java
@@ -144,7 +144,7 @@ public abstract class AbstractArtemisIntegrationTest implements MockDelegate {
         participantScoreSchedulerService.shutdown();
     }
 
-    public void resetSpyBeans() {
+    protected void resetSpyBeans() {
         Mockito.reset(lti10Service, gitService, groupNotificationService, tutorialGroupNotificationService, singleUserNotificationService, websocketMessagingService,
                 messagingTemplate, examAccessService, mailService, instanceMessageSendService, programmingExerciseScheduleService, programmingExerciseParticipationService,
                 urlService, scheduleService, participantScoreSchedulerService, javaMailSender, programmingTriggerService, zipFileService,


### PR DESCRIPTION
### Checklist
#### General
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
While working on #5661 I noticed that a few tests were still using JUnit 4 functionality, where JUnit 5 should be preferred. While fixing these instances in that PR, I could not find a way to unsure that no future PRs would re-introduce JUnit 4 testing. 

### Description
I considered the following options, which did not work out:

#### Excluding JUnit 4 as  a dependency

JUnit 4 is already excluded from dependencies like `spring-boot-starter-test`, a couple of other dependencies (~7) reintroduced JUnit 4 into Artemis. While I could explicitly remove JUnit 4 from all of them, any newly added dependency would bring the risk of unwantedly adding JUnit 4 to the classpath again. 

#### Universally excluding JUnit 4
In commit https://github.com/ls1intum/Artemis/pull/5661/commits/4ad9db56eb9d127b8d8106ab82d6bd14648e1a41 I added a line to the `build.gradle` which removed JUnit 4 from all added dependencies, This resolved the issue explained above, but did not work out in combination with the Postgres test containers. This library used JUnit 4 internally and would break with such a configuration. 

####  Using SCA
I could not find a configuration in any of our used SCA tools that would report the Usage of JUnit 4.

#### Solution in this PR: Using ArchUnit
The testing library ArchUnit allows writing unit tests against the code structure. We already use this library successfully in programming exercises about architectural patterns in the "Introduction to Software engineering" course.

In this PR, I added an architectural test case that disallows any test classes to depend on JUnit 4 classes. In case a developer adds test cases with JUnit 4, this test will fail.

In the future, we can extend this test class to also check if the server is actually following our architecture and is using the different layers correctly.

### Steps for Testing
Code review, check that the new test case is successful. 

### Review Progress

#### Code Review
- [x] Review 1
- [ ] Review 2