### PR TITLE
`Development`: Fix a flaky e2e test

### DIFF
--- a/src/test/cypress/e2e/exercises/modeling/ModelingExerciseParticipation.cy.ts
+++ b/src/test/cypress/e2e/exercises/modeling/ModelingExerciseParticipation.cy.ts
@@ -4,7 +4,6 @@ import { artemis } from '../../../support/ArtemisTesting';
 import { convertCourseAfterMultiPart } from '../../../support/requests/CourseManagementRequests';
 
 // pageobjects
-const courseManagement = artemis.pageobjects.course.management;
 const modelingEditor = artemis.pageobjects.exercise.modeling.editor;
 const courseOverview = artemis.pageobjects.course.overview;
 // requests
@@ -21,8 +20,7 @@ describe('Modeling Exercise Participation Spec', () => {
         cy.login(admin);
         courseManagementRequests.createCourse().then((response: Cypress.Response<Course>) => {
             course = convertCourseAfterMultiPart(response);
-            cy.visit(`/course-management/${course.id}`);
-            courseManagement.addStudentToCourse(student);
+            courseManagementRequests.addStudentToCourse(course, student);
             courseManagementRequests.createModelingExercise({ course }).then((resp: Cypress.Response<ModelingExercise>) => {
                 modelingExercise = resp.body;
             });
@@ -36,6 +34,7 @@ describe('Modeling Exercise Participation Spec', () => {
 
     it('Student can start and submit their model', () => {
         cy.login(student, `/courses/${course.id}`);
+        cy.reloadUntilFound('#start-exercise-' + modelingExercise.id);
         courseOverview.startExercise(modelingExercise.id!);
         cy.get('#open-exercise-' + modelingExercise.id).click();
         modelingEditor.addComponentToModel(1);


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After many debugging attempts I finally found the issue. The test used the wrong type of `addStudentToCourse` function, which for some reasons in this case lead to failing tests. 

### Description
<!-- Describe your changes in detail -->
This PR replaces the `addStudentToCourse` function with the correct call and now the tests pass again. 

To verify the fix works, I run the test 100 times on bamboo:

![image](https://user-images.githubusercontent.com/1368405/210524445-dc1e27eb-121a-4ca5-aa75-f39f32a95024.png)


### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- Bamboo access
- Or local cypress/artemis instance

1. Run cypress tests locally or on bamboo to see, if the tests fails or not

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test
