### PR TITLE
`Development´: Fix and improve server tests for PostgreSQL

### DIFF
--- a/src/test/java/de/tum/in/www1/artemis/connectors/LtiServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/connectors/LtiServiceTest.java
@@ -144,7 +144,7 @@ class LtiServiceTest {
 
         assertThat(user.getGroups()).contains(courseStudentGroupName);
         assertThat(user.getGroups()).contains(LtiService.LTI_GROUP_NAME);
-        assertEquals(ltiUserId.getLtiUserId(), "ltiUserId");
+        assertEquals("ltiUserId", ltiUserId.getLtiUserId());
 
         verify(userCreationService, times(1)).saveUser(user);
         verify(artemisAuthenticationProvider, times(1)).addUserToGroup(user, courseStudentGroupName);
@@ -159,7 +159,7 @@ class LtiServiceTest {
 
         ltiService.authenticateLtiUser("useremail@tum.de", "userid", "username", "firstname", "lastname", onlineCourseConfiguration.isRequireExistingUser());
 
-        assertEquals(auth, SecurityContextHolder.getContext().getAuthentication());
+        assertEquals(SecurityContextHolder.getContext().getAuthentication(), auth);
     }
 
     @Test


### PR DESCRIPTION
### Motivation and Context
This is a follow-up PR to #6002. PostgreSQL is now supported, but executing the tests with PostgeSQL takes a long time and also produces some test failures. This PR aims to speedup the test execution and fixes the failing tests.

### Description
The following tests currently fail for Postgres:

- [x] NotificationScheduleServiceTest > shouldCreateNotificationAndEmailAtReleaseDate()
- [ ] StructuralTestCaseServiceTest > testGenerationForComplexConstructor()
- [ ] ExerciseGroupIntegrationTest  > importExerciseGroup_successfulWithImportToOtherCourse()
- [ ] ProgrammingExerciseBitbucketBambooIntegrationTest > resumeProgrammingExerciseByTriggeringInstructorBuild_correctInitializationState(ExerciseMode)
- [ ] ProgrammingExerciseGitlabJenkinsIntegrationTest > resumeProgrammingExerciseByTriggeringInstructorBuild_correctInitializationState(ExerciseMode)
- [ ] ProgrammingExerciseIntegrationBambooBitbucketJiraTest > unlockAllRepositories()
- [ ] ProgrammingExerciseScheduleServiceTest > cancelAllSchedulesOnRemovingExerciseDueDate()
- [ ] ProgrammingExerciseScheduleServiceTest > shouldScheduleExercisesWithBuildAndTestDateInFuture()
- [ ] ProgrammingExerciseScheduleServiceTest > keepIndividualScheduleOnExerciseDueDateChange()
- [ ] ProgrammingExerciseScheduleServiceTest > scheduleIndividualDueDateTestsAfterDueDateNoBuildAndTestDate()
- [ ] ProgrammingExerciseIntegrationBambooBitbucketJiraTest > unlockAllRepositories()
- [ ] QuizSubmissionIntegrationTest > testQuizSubmitPractice_forbidden()
- [x] AutomaticFeedbackConflictServiceTest > changedFeedbackConflictsType()
- [x] TextAssessmentQueueServiceTest > calculateSmallerClusterPercentageTest() 

The following tests seem to be flaky and should get improved:
- [ ] LearningGoalIntegrationTest > getLearningGoalCourseProgressIndividualTest_asInstructorOne_usingParticipantScoreTable()
- [ ] ExamIntegrationTest > testGetExamScore(boolean)
- [ ] FileUploadSubmissionIntegrationTest > submitExercise_beforeDueDate_allowed()
- [ ] AtheneIntegrationTest > testProcessingClusterAddedDistances()
- [ ] ProgrammingExerciseScheduleServiceTest > updateIndividualScheduleOnIndividualDueDateChange()
- [ ] ResultListenerIntegrationTest (all tests deleting results)

We should fix and re-enable the following disabled tests: 
- [x] ProgrammingExerciseScheduleServiceTest > shouldUpdateScoresIfHasTestsAfterDueDateAndNoBuildAfterDueDate
- [x] ProgrammingExerciseScheduleServiceTest  > shouldNotUpdateScoresIfHasNoTestsAfterDueDate
- [x] ProgrammingExerciseScheduleServiceTest > scheduleIndividualDueDateBetweenDueDateAndBuildAndTestDate
- [x] ProgrammingExerciseScheduleServiceTest > cancelIndividualSchedulesOnRemovingIndividualDueDate
- [x] ExampleSubmissionIntegrationTest > createExampleTextAssessment
- [x] StructuralTestCaseServiceTest > testGenerationForSimpleAttributeWithoutSource [enabled without changes, flaky?]
- [x] ProgrammingExerciseGitIntegrationTest > testCombineTemplateRepositoryCommits_invalidId_notFound
- [x] QuizExerciseIntegrationTest > testCreateQuizExerciseForExam
- [ ] DatabaseQueryCountTest

The following tests take way too long to execute:
- [x] CourseBitbucketBambooJiraIntegrationTest (11 min)
- [ ] ProgrammingExerciseBitbucketBambooIntegrationTest (7 min)
- [ ] QuizExerciseIntegrationTest (7 min)
- [ ] StudentExamIntegrationTest (5 min)
- [ ] ProgrammingExerciseIntegrationBambooBitbucketJiraTest (5 min)
- [ ] ExamIntegrationTest (5 min)
- [ ] ProgrammingExerciseIntegrationJenkinsGitlabTest (5 min)
- [x] CourseGitlabJenkinsIntegrationTest (4 min)
- [ ] ProgrammingExerciseGitlabJenkinsIntegrationTest (3 min)



### Steps for Testing
By default, the tests are executed using `H2` with an improved mode (taking liquibase changes into account) and a bit faster than previously.
If you want to use PostgreSQL, you have to set the `postgres` profile, e.g. by running:

`SPRING_PROFILES_INCLUDE=postgres ./gradlew executeTests -x webapp`

If you want to use MySQL, you have to set the `mysql` profile, e.g. by running 

`SPRING_PROFILES_INCLUDE=mysql ./gradlew executeTests -x webapp`

### Review Progress

#### Code Review
- [ ] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2