### PR TITLE
`Development`: Fix an issue in the migration for conversations

### DIFF
--- a/src/main/resources/config/liquibase/changelog/20230102203648_changelog.xml
+++ b/src/main/resources/config/liquibase/changelog/20230102203648_changelog.xml
@@ -41,7 +41,7 @@
         <addForeignKeyConstraint baseColumnNames="creator_id" baseTableName="conversation" constraintName="fk_conversation_creator" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="jhi_user"/>
         <addUniqueConstraint columnNames="conversation_id, user_id" constraintName="conversation_participant_uq" tableName="conversation_participant"/>
         <sql>update conversation SET discriminator = 'O' WHERE discriminator IS NULL;</sql>
-        <sql>update conversation c SET creator_id = (select cp.user_id from conversation_participant cp where cp.conversation_id = c.id)
+        <sql>update conversation c SET creator_id = (select cp.user_id from conversation_participant cp where cp.conversation_id = c.id LIMIT 1)
              where creator_id IS NULL AND discriminator = 'O';</sql>
         <!-- Reset unread message properties for all users to prevent edge cases -->
         <sql>update conversation_participant SET unread_messages_count = 0</sql>

--- a/src/main/webapp/app/overview/course-conversations/layout/conversation-selection-sidebar/conversation-selection-sidebar.component.html
+++ b/src/main/webapp/app/overview/course-conversations/layout/conversation-selection-sidebar/conversation-selection-sidebar.component.html
@@ -68,13 +68,7 @@
                                         <button id="channelOverview" ngbDropdownItem (click)="openChannelOverviewDialog($event)">
                                             {{ 'artemisApp.conversationsLayout.conversationSelectionSideBar.browseChannels' | artemisTranslate }}
                                         </button>
-                                        <button
-                                            id="createChannel"
-                                            ngbDropdownItem
-                                            [hidden]="!course.isAtLeastInstructor"
-                                            (click)="openCreateChannelDialog($event)"
-                                            *ngIf="canCreateChannel(course)"
-                                        >
+                                        <button id="createChannel" ngbDropdownItem (click)="openCreateChannelDialog($event)" *ngIf="canCreateChannel(course)">
                                             {{ 'artemisApp.conversationsLayout.conversationSelectionSideBar.createChannel' | artemisTranslate }}
                                         </button>
                                     </div>


### PR DESCRIPTION

#### General
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Description
- Added LIMIT 1 to the changelog to prevent error in migration
- Made sure that not only instructors see the create channel button
### Steps for Testing
- Migration of existing conversations should work.
- Tutors should see the create channel button.

#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2
#### Exam Mode Test
- [ ] Test

### Test Coverage
- No Changes

### Screenshots
- No Changes
