### PR TITLE
`Programming exercises`: Fix missing value in static code analysis issue location

### DIFF
--- a/src/main/webapp/app/exercises/shared/feedback/item/programming-feedback-item.service.ts
+++ b/src/main/webapp/app/exercises/shared/feedback/item/programming-feedback-item.service.ts
@@ -158,7 +158,7 @@ export class ProgrammingFeedbackItemService implements FeedbackItemService {
         if (issue.startColumn) {
             const columnText =
                 !issue.endColumn || issue.startColumn === issue.endColumn
-                    ? this.translateService.instant('artemisApp.result.detail.codeIssue.column', { line: issue.startColumn })
+                    ? this.translateService.instant('artemisApp.result.detail.codeIssue.column', { column: issue.startColumn })
                     : this.translateService.instant('artemisApp.result.detail.codeIssue.columns', { from: issue.startColumn, to: issue.endColumn });
             return `${issue.filePath} ${lineText} ${columnText}`;
         }


### PR DESCRIPTION
### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.

### Motivation and Context
#5949 fixed a bug where the column of a code style issue was not shown. Merging #5923 re-introduced this bug since the old implementation was moved at a new location, not reflecting the changed code.

![grafik](https://user-images.githubusercontent.com/26540346/211195693-d8c8cfa6-3c44-4627-b2d5-48e60325e71f.png)


### Description
The translation expected a parameter called `column`, but the code passed this information as `line`.

### Steps for Testing
Prerequisites:
- 1 Student
- 1 Programming Exercise with SCA enabled

1. Submitt a solution with SCA issues as student (i.e. unused imports)
2. Check that the column-information always shows a value

### Review Progress

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [ ] Test 1
- [ ] Test 2

### Screenshots
