### PR TITLE
`Development`: Improve logging for scheduled score updates

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/scheduled/ParticipantScoreSchedulerService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/scheduled/ParticipantScoreSchedulerService.java
@@ -132,7 +132,7 @@ public class ParticipantScoreSchedulerService {
      */
     @Scheduled(cron = "0 * * * * *")
     protected void scheduleTasks() {
-        logger.info("Schedule tasks to process...");
+        logger.debug("Schedule tasks to process...");
         SecurityUtils.setAuthorizationObject();
         if (isRunning.get()) {
             executeScheduledTasks();
@@ -172,7 +172,7 @@ public class ParticipantScoreSchedulerService {
             }
         });
 
-        logger.info("Processing of {} results and {} participant scores.", resultsToProcess.size(), participantScoresToProcess.size());
+        logger.debug("Processing of {} results and {} participant scores.", resultsToProcess.size(), participantScoresToProcess.size());
     }
 
     /**


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
Closes #5744
The scheduler logs every minute that tasks will be scheduled and in most cases then also logs that no updates were scheduled as none were necessary. As there still exist additional logs in case an actual scheduled update has been performed, no information is lost by removing those log statements.
This reduces unnecessary noise in the logs and makes it easier to spot issues.

### Description
Set the two messages that are printed every minute to debug logging level.
In case actual score updates are performed, there still exist INFO-level logging messages that state for which exercise and participation a score update was performed, and how long it took. So no important information is lost.

### Steps for Testing
n/a, just code review


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2

### Test Coverage
unchanged