### PR TITLE
`Development`: Improve code readability for custom course group names

### DIFF
--- a/src/main/webapp/app/course/manage/detail/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.html
@@ -162,7 +162,7 @@
                     >
                 </dd>
             </div>
-            <div *ngIf="!course.isAtLeastInstructor">
+            <div *ngIf="course.isAtLeastInstructor">
                 <dt><span jhiTranslate="artemisApp.course.studentGroupName">Student Group Name</span></dt>
                 <dd>
                     <span>{{ course.studentGroupName }}</span>

--- a/src/main/webapp/app/course/manage/detail/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.html
@@ -140,7 +140,7 @@
             <dd>
                 <span>{{ course.shortName }}</span>
             </dd>
-            <div *ngIf="course.isAtLeastInstructor">
+            <div *ngIf="course.isAtLeastInstructor; else groupsWithoutLink">
                 <dt><span jhiTranslate="artemisApp.course.studentGroupName">Student Group Name</span></dt>
                 <dd>
                     <a [routerLink]="['/course-management', course.id, 'groups', 'students']" id="add-students"> {{ course.studentGroupName }} ({{ course.numberOfStudents }})</a>
@@ -162,24 +162,26 @@
                     >
                 </dd>
             </div>
-            <div *ngIf="course.isAtLeastInstructor">
-                <dt><span jhiTranslate="artemisApp.course.studentGroupName">Student Group Name</span></dt>
-                <dd>
-                    <span>{{ course.studentGroupName }}</span>
-                </dd>
-                <dt><span jhiTranslate="artemisApp.course.teachingAssistantGroupName">Teaching Assistant Group Name</span></dt>
-                <dd>
-                    <span>{{ course.teachingAssistantGroupName }}</span>
-                </dd>
-                <dt><span jhiTranslate="artemisApp.course.editorGroupName">Editor Group Name</span></dt>
-                <dd>
-                    <span>{{ course.editorGroupName }}</span>
-                </dd>
-                <dt><span jhiTranslate="artemisApp.course.instructorGroupName">Instructor Group Name</span></dt>
-                <dd>
-                    <span>{{ course.instructorGroupName }}</span>
-                </dd>
-            </div>
+            <ng-template #groupsWithoutLink>
+                <div>
+                    <dt><span jhiTranslate="artemisApp.course.studentGroupName">Student Group Name</span></dt>
+                    <dd>
+                        <span>{{ course.studentGroupName }}</span>
+                    </dd>
+                    <dt><span jhiTranslate="artemisApp.course.teachingAssistantGroupName">Teaching Assistant Group Name</span></dt>
+                    <dd>
+                        <span>{{ course.teachingAssistantGroupName }}</span>
+                    </dd>
+                    <dt><span jhiTranslate="artemisApp.course.editorGroupName">Editor Group Name</span></dt>
+                    <dd>
+                        <span>{{ course.editorGroupName }}</span>
+                    </dd>
+                    <dt><span jhiTranslate="artemisApp.course.instructorGroupName">Instructor Group Name</span></dt>
+                    <dd>
+                        <span>{{ course.instructorGroupName }}</span>
+                    </dd>
+                </div>
+            </ng-template>
             <dt><span jhiTranslate="artemisApp.course.startDate">Start Date</span></dt>
             <dd>
                 <span>{{ course.startDate | artemisDate }}</span>

--- a/src/main/webapp/app/course/manage/detail/course-detail.component.html
+++ b/src/main/webapp/app/course/manage/detail/course-detail.component.html
@@ -140,6 +140,10 @@
             <dd>
                 <span>{{ course.shortName }}</span>
             </dd>
+            <!--
+                For users which are at least instructor we show the group name including a link to the course user group management,
+                where new users can be added to the group, since they have the permission to add/remove users to/from the group  
+            -->
             <div *ngIf="course.isAtLeastInstructor; else groupsWithoutLink">
                 <dt><span jhiTranslate="artemisApp.course.studentGroupName">Student Group Name</span></dt>
                 <dd>
@@ -162,6 +166,10 @@
                     >
                 </dd>
             </div>
+            <!-- 
+                For users which are not at least instructor we just show the group names without the link to the course user management page, 
+                since they don't have the permission to add/remove users to/from the group
+            -->
             <ng-template #groupsWithoutLink>
                 <div>
                     <dt><span jhiTranslate="artemisApp.course.studentGroupName">Student Group Name</span></dt>


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
~When writing some e2e tests I realised, that currently custom group names for courses are not shown, since they are guarded by a `!course.isAtLeastInstructor`. So users with alteast instructor permission are **NOT** allowed to see the custom groups. It seems this was done by mistake.~ 
Update: Seems that the logic did make sense. I enhanced the code according to @Strohgelaender suggestion.

### Description
<!-- Describe your changes in detail -->
~This PR changes `!course.isAtLeastInstructor` to `course.isAtLeastInstructor`, so users with at least instructor permission can see the custom group names.~ This PR enhances the display logic for the course group name.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor

1. Log in to Artemis
2. Navigate to Course Administration
3. Create a new course or use existing course
4. Look for this view:
![image](https://user-images.githubusercontent.com/1368405/211873051-4d2c2361-6875-422c-9f08-556d86c272d1.png)
5. You should be able to see the marked segment

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
#### Exam Mode Test
- [ ] Test
