### PR TITLE
`Development`: Update flaky test dependencies for security

### DIFF
--- a/src/test/cypress/cypress.config.ts
+++ b/src/test/cypress/cypress.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
     },
     e2e: {
         setupNodeEvents(on, config) {
-            process.env.CYPRESS_COLLECT_COVERAGE === 'true' && registerMultilanguageCoveragePlugin({ workingDirectory: path.join(__dirname), saveRawCoverage: true })(on, config);
             on('task', {
                 error(message: string) {
                     console.error('\x1b[31m', 'ERROR: ', message, '\x1b[0m');
@@ -38,6 +37,7 @@ export default defineConfig({
                 launchOptions.args.push('--lang=en');
                 return launchOptions;
             });
+            process.env.CYPRESS_COLLECT_COVERAGE === 'true' && registerMultilanguageCoveragePlugin({ workingDirectory: path.join(__dirname), saveRawCoverage: true })(on, config);
         },
         specPattern: ['init/ImportUsers.cy.ts', 'e2e/**/*.cy.{js,jsx,ts,tsx}'],
         supportFile: 'support/index.ts',

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -9,7 +9,7 @@
             "devDependencies": {
                 "@4tw/cypress-drag-drop": "2.2.3",
                 "@heddendorp/coverage-git-compare": "1.5.4",
-                "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.0",
+                "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.1",
                 "@types/node": "18.11.18",
                 "cypress": "12.2.0",
                 "cypress-file-upload": "5.0.8",
@@ -133,9 +133,9 @@
             }
         },
         "node_modules/@heddendorp/cypress-plugin-multilanguage-coverage": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.5.0.tgz",
-            "integrity": "sha512-zWuTVD8EEscVo/teg2T7L0jzWxPAdrpX0vI+OnW1o/F0sLgE3rOe3QNWbx2l0QdN3lKJBgyRQCz2Y3ZBvgeGbQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.5.1.tgz",
+            "integrity": "sha512-TYyDf1b4OBip3IsqduDAvQcnxoRSxGqHvrkWd753fYfleERqwpdmxFj2KFR9A2ONJkdLDuTWOkoNy4PD5NhrkQ==",
             "dev": true,
             "dependencies": {
                 "@heddendorp/jacoco-parse": "^2.1.0",

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -8,8 +8,8 @@
             "license": "MIT",
             "devDependencies": {
                 "@4tw/cypress-drag-drop": "2.2.3",
-                "@heddendorp/coverage-git-compare": "^1.5.4",
-                "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.5.0",
+                "@heddendorp/coverage-git-compare": "1.5.4",
+                "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.0",
                 "@types/node": "18.11.18",
                 "cypress": "12.2.0",
                 "cypress-file-upload": "5.0.8",

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -9,7 +9,7 @@
             "devDependencies": {
                 "@4tw/cypress-drag-drop": "2.2.3",
                 "@heddendorp/coverage-git-compare": "^1.5.4",
-                "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.4.13",
+                "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.5.0",
                 "@types/node": "18.11.18",
                 "cypress": "12.2.0",
                 "cypress-file-upload": "5.0.8",
@@ -133,19 +133,29 @@
             }
         },
         "node_modules/@heddendorp/cypress-plugin-multilanguage-coverage": {
-            "version": "1.4.13",
-            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.4.13.tgz",
-            "integrity": "sha512-RddlM4iptntvWTqURaOwsDpbyxnElLhL28pR5BOjxyOuXtkBMdmaJvqUrc2x5CQLrjX0sHihlzNoEAxhlrKtAA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.5.0.tgz",
+            "integrity": "sha512-zWuTVD8EEscVo/teg2T7L0jzWxPAdrpX0vI+OnW1o/F0sLgE3rOe3QNWbx2l0QdN3lKJBgyRQCz2Y3ZBvgeGbQ==",
             "dev": true,
             "dependencies": {
+                "@heddendorp/jacoco-parse": "^2.1.0",
                 "adm-zip": "^0.5.9",
                 "chrome-remote-interface": "^0.31.3",
                 "fs-jetpack": "^5.1.0",
-                "jacoco-parse": "^2.0.1",
                 "v8-to-istanbul": "^9.0.1"
             },
             "engines": {
                 "node": "^18.12.1"
+            }
+        },
+        "node_modules/@heddendorp/jacoco-parse": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@heddendorp/jacoco-parse/-/jacoco-parse-2.1.0.tgz",
+            "integrity": "sha512-MQJBWEjwxNcRtQw6tkJfakLevIj75jXM6Jy9+QY+1itTivyxFJVKWpzw4YGQ4gkuNewwQLjmUCTfgpectqqNYg==",
+            "dev": true,
+            "dependencies": {
+                "mocha": "^10.2.0",
+                "xml2js": "^0.4.9"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -365,6 +375,19 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/arch": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
@@ -384,6 +407,12 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true
         },
         "node_modules/asn1": {
             "version": "0.2.6",
@@ -521,6 +550,15 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "node_modules/binary-extensions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/blob-util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/blob-util/-/blob-util-2.0.2.tgz",
@@ -540,6 +578,18 @@
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/browser-stdout": {
@@ -602,6 +652,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -631,6 +693,33 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/chrome-remote-interface": {
@@ -720,6 +809,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
             }
         },
         "node_modules/color-convert": {
@@ -948,6 +1048,18 @@
                 }
             }
         },
+        "node_modules/decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -958,9 +1070,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+            "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
             "dev": true,
             "engines": {
                 "node": ">=0.3.1"
@@ -1001,6 +1113,15 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -1146,6 +1267,43 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true,
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
         "node_modules/follow-redirects": {
             "version": "1.15.2",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
@@ -1247,6 +1405,29 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true
         },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
         "node_modules/get-stream": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -1281,9 +1462,9 @@
             }
         },
         "node_modules/glob": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -1295,6 +1476,21 @@
             },
             "engines": {
                 "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
@@ -1340,15 +1536,6 @@
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
             "dev": true
         },
-        "node_modules/growl": {
-            "version": "1.10.5",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.x"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1359,9 +1546,9 @@
             }
         },
         "node_modules/he": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true,
             "bin": {
                 "he": "bin/he"
@@ -1444,6 +1631,18 @@
                 "node": ">=10"
             }
         },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-ci": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -1456,6 +1655,15 @@
                 "is-ci": "bin.js"
             }
         },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1463,6 +1671,18 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-installed-globally": {
@@ -1481,10 +1701,28 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
             "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
             "dev": true,
             "engines": {
                 "node": ">=8"
@@ -1532,16 +1770,6 @@
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "dev": true
         },
-        "node_modules/jacoco-parse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/jacoco-parse/-/jacoco-parse-2.0.1.tgz",
-            "integrity": "sha512-YGhIb2iXuQ4/zNh2zgHd6Z6dqlYwLYH1wfsxtTNQ+jnHH9PhhuMwqOFihXymSI41trxok48LdKkSeDIWs28tYg==",
-            "dev": true,
-            "dependencies": {
-                "mocha": "^5.2.0",
-                "xml2js": "^0.4.9"
-            }
-        },
         "node_modules/joi": {
             "version": "17.7.0",
             "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
@@ -1553,6 +1781,18 @@
                 "@sideway/address": "^4.1.3",
                 "@sideway/formula": "^3.0.0",
                 "@sideway/pinpoint": "^2.0.0"
+            }
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dev": true,
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/jsbn": {
@@ -1634,6 +1874,21 @@
                 "enquirer": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/lodash": {
@@ -1782,113 +2037,98 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
-            "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-            "dev": true,
-            "dependencies": {
-                "minimist": "0.0.8"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/mkdirp/node_modules/minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
-            "dev": true
-        },
         "node_modules/mocha": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+            "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
             "dev": true,
             "dependencies": {
+                "ansi-colors": "4.1.1",
                 "browser-stdout": "1.3.1",
-                "commander": "2.15.1",
-                "debug": "3.1.0",
-                "diff": "3.5.0",
-                "escape-string-regexp": "1.0.5",
-                "glob": "7.1.2",
-                "growl": "1.10.5",
-                "he": "1.1.1",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "supports-color": "5.4.0"
+                "chokidar": "3.5.3",
+                "debug": "4.3.4",
+                "diff": "5.0.0",
+                "escape-string-regexp": "4.0.0",
+                "find-up": "5.0.0",
+                "glob": "7.2.0",
+                "he": "1.2.0",
+                "js-yaml": "4.1.0",
+                "log-symbols": "4.1.0",
+                "minimatch": "5.0.1",
+                "ms": "2.1.3",
+                "nanoid": "3.3.3",
+                "serialize-javascript": "6.0.0",
+                "strip-json-comments": "3.1.1",
+                "supports-color": "8.1.1",
+                "workerpool": "6.2.1",
+                "yargs": "16.2.0",
+                "yargs-parser": "20.2.4",
+                "yargs-unparser": "2.0.0"
             },
             "bin": {
                 "_mocha": "bin/_mocha",
-                "mocha": "bin/mocha"
+                "mocha": "bin/mocha.js"
             },
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">= 14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/mochajs"
             }
         },
-        "node_modules/mocha/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/mocha/node_modules/commander": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-            "dev": true
-        },
-        "node_modules/mocha/node_modules/debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.0.0"
-            }
-        },
-        "node_modules/mocha/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+        "node_modules/mocha/node_modules/ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true,
             "engines": {
-                "node": ">=4"
+                "node": ">=6"
+            }
+        },
+        "node_modules/mocha/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/mocha/node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+            "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
             "dev": true,
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": "*"
+                "node": ">=10"
             }
         },
         "node_modules/mocha/node_modules/ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
         "node_modules/mocha/node_modules/supports-color": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "dependencies": {
-                "has-flag": "^3.0.0"
+                "has-flag": "^4.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/ms": {
@@ -1896,6 +2136,18 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+            "dev": true,
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
         },
         "node_modules/node-domexception": {
             "version": "1.0.0",
@@ -1934,6 +2186,15 @@
                 "encoding": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/npm-run-path": {
@@ -1978,6 +2239,36 @@
             "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
             "dev": true
         },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/p-map": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -1991,6 +2282,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/path-is-absolute": {
@@ -2022,6 +2322,18 @@
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
             "dev": true
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/pify": {
             "version": "2.3.0",
@@ -2102,6 +2414,27 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
         "node_modules/request-progress": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
@@ -2109,6 +2442,15 @@
             "dev": true,
             "dependencies": {
                 "throttleit": "^1.0.0"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/restore-cursor": {
@@ -2243,6 +2585,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/serialize-javascript": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+            "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+            "dev": true,
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2353,6 +2704,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -2393,6 +2756,18 @@
             },
             "engines": {
                 "node": ">=8.17.0"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/tough-cookie": {
@@ -2611,6 +2986,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/workerpool": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+            "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+            "dev": true
+        },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -2677,11 +3058,62 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "20.2.4",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+            "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+            "dev": true,
+            "dependencies": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/yauzl": {
             "version": "2.10.0",
@@ -2691,6 +3123,18 @@
             "dependencies": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         }
     }

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -9,7 +9,7 @@
             "devDependencies": {
                 "@4tw/cypress-drag-drop": "2.2.3",
                 "@heddendorp/coverage-git-compare": "1.5.4",
-                "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.4",
+                "@heddendorp/cypress-plugin-multilanguage-coverage": "1.6.0",
                 "@types/node": "18.11.18",
                 "cypress": "12.3.0",
                 "cypress-file-upload": "5.0.8",
@@ -133,9 +133,9 @@
             }
         },
         "node_modules/@heddendorp/cypress-plugin-multilanguage-coverage": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.5.4.tgz",
-            "integrity": "sha512-kOMSiZ/ggMGLpy59FxDGGRfObn+PNFurSQ2OikvpN0ekCGm+hP/GtUEUoMaJcIJr8aYFZR1+s9lxjhypBt3odg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.6.0.tgz",
+            "integrity": "sha512-V3z6TQX+2vboVJTXl6urWodhj9X4Wl4Acu4n6t2Di8wvlYf482kADyNhaB23Q83AtkqzK504j9UJK1UK7uk4aA==",
             "dev": true,
             "dependencies": {
                 "@heddendorp/jacoco-parse": "^2.1.0",

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -8,8 +8,8 @@
             "license": "MIT",
             "devDependencies": {
                 "@4tw/cypress-drag-drop": "2.2.3",
-                "@heddendorp/coverage-git-compare": "^1.5.3",
-                "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.4.10",
+                "@heddendorp/coverage-git-compare": "^1.5.4",
+                "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.4.13",
                 "@types/node": "18.11.18",
                 "cypress": "12.2.0",
                 "cypress-file-upload": "5.0.8",
@@ -111,9 +111,9 @@
             }
         },
         "node_modules/@heddendorp/coverage-git-compare": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/@heddendorp/coverage-git-compare/-/coverage-git-compare-1.5.3.tgz",
-            "integrity": "sha512-TgKHxlkY7++qfWsbuxyqN4w45xMJHHunVwlSpoOGXYrV8VlHWQX13oZEuOYDh66GGyP6sY8AfSCMXaBaw8/X7Q==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@heddendorp/coverage-git-compare/-/coverage-git-compare-1.5.4.tgz",
+            "integrity": "sha512-j+OY/jVLVuk0U1iGDZj4Vzn3pclHQg3KRI5HV68ALavkf5tvPnFoRqfGMXukuviH3zv24rT0l7tlGne+xl2g5Q==",
             "dev": true,
             "dependencies": {
                 "@whatwg-node/fetch": "^0.5.3",
@@ -133,9 +133,9 @@
             }
         },
         "node_modules/@heddendorp/cypress-plugin-multilanguage-coverage": {
-            "version": "1.4.10",
-            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.4.10.tgz",
-            "integrity": "sha512-caz1QhM6RnmIwgyX3juKRWIbAzg78AeoAdyGNAtAAnu+jr3ghYobdQke8d7u0gAERW5HNcZux8UtlOAgfRvXdw==",
+            "version": "1.4.13",
+            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.4.13.tgz",
+            "integrity": "sha512-RddlM4iptntvWTqURaOwsDpbyxnElLhL28pR5BOjxyOuXtkBMdmaJvqUrc2x5CQLrjX0sHihlzNoEAxhlrKtAA==",
             "dev": true,
             "dependencies": {
                 "adm-zip": "^0.5.9",
@@ -143,6 +143,9 @@
                 "fs-jetpack": "^5.1.0",
                 "jacoco-parse": "^2.0.1",
                 "v8-to-istanbul": "^9.0.1"
+            },
+            "engines": {
+                "node": "^18.12.1"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -8,8 +8,8 @@
             "license": "MIT",
             "devDependencies": {
                 "@4tw/cypress-drag-drop": "2.2.3",
-                "@heddendorp/coverage-git-compare": "1.3.3",
-                "@heddendorp/cypress-plugin-multilanguage-coverage": "1.3.0",
+                "@heddendorp/coverage-git-compare": "^1.5.3",
+                "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.4.10",
                 "@types/node": "18.11.18",
                 "cypress": "12.2.0",
                 "cypress-file-upload": "5.0.8",
@@ -111,9 +111,9 @@
             }
         },
         "node_modules/@heddendorp/coverage-git-compare": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@heddendorp/coverage-git-compare/-/coverage-git-compare-1.3.3.tgz",
-            "integrity": "sha512-aguBpFJppLCzOxB5bv3VkKqM0OnOoKpjUE3BgWF8lgXsrXPPJM/nNI1pudW5x+Z4pJIo9Brd+AN/6fucwVMfjQ==",
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/@heddendorp/coverage-git-compare/-/coverage-git-compare-1.5.3.tgz",
+            "integrity": "sha512-TgKHxlkY7++qfWsbuxyqN4w45xMJHHunVwlSpoOGXYrV8VlHWQX13oZEuOYDh66GGyP6sY8AfSCMXaBaw8/X7Q==",
             "dev": true,
             "dependencies": {
                 "@whatwg-node/fetch": "^0.5.3",
@@ -133,9 +133,9 @@
             }
         },
         "node_modules/@heddendorp/cypress-plugin-multilanguage-coverage": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.3.0.tgz",
-            "integrity": "sha512-qT0hM/uZBD/jugTCgoWXjPsXTBvNbS0/RSXOd8BLYgN4Z2r484IjMS0JnmXFOSQShVJ5t9jbSnyOKId9na6R+g==",
+            "version": "1.4.10",
+            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.4.10.tgz",
+            "integrity": "sha512-caz1QhM6RnmIwgyX3juKRWIbAzg78AeoAdyGNAtAAnu+jr3ghYobdQke8d7u0gAERW5HNcZux8UtlOAgfRvXdw==",
             "dev": true,
             "dependencies": {
                 "adm-zip": "^0.5.9",

--- a/src/test/cypress/package-lock.json
+++ b/src/test/cypress/package-lock.json
@@ -9,7 +9,7 @@
             "devDependencies": {
                 "@4tw/cypress-drag-drop": "2.2.3",
                 "@heddendorp/coverage-git-compare": "1.5.4",
-                "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.1",
+                "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.4",
                 "@types/node": "18.11.18",
                 "cypress": "12.3.0",
                 "cypress-file-upload": "5.0.8",
@@ -133,9 +133,9 @@
             }
         },
         "node_modules/@heddendorp/cypress-plugin-multilanguage-coverage": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.5.1.tgz",
-            "integrity": "sha512-TYyDf1b4OBip3IsqduDAvQcnxoRSxGqHvrkWd753fYfleERqwpdmxFj2KFR9A2ONJkdLDuTWOkoNy4PD5NhrkQ==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/@heddendorp/cypress-plugin-multilanguage-coverage/-/cypress-plugin-multilanguage-coverage-1.5.4.tgz",
+            "integrity": "sha512-kOMSiZ/ggMGLpy59FxDGGRfObn+PNFurSQ2OikvpN0ekCGm+hP/GtUEUoMaJcIJr8aYFZR1+s9lxjhypBt3odg==",
             "dev": true,
             "dependencies": {
                 "@heddendorp/jacoco-parse": "^2.1.0",

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -9,7 +9,7 @@
     "devDependencies": {
         "@4tw/cypress-drag-drop": "2.2.3",
         "@heddendorp/coverage-git-compare": "1.5.4",
-        "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.0",
+        "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.1",
         "@types/node": "18.11.18",
         "cypress": "12.2.0",
         "cypress-file-upload": "5.0.8",

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -8,8 +8,8 @@
     ],
     "devDependencies": {
         "@4tw/cypress-drag-drop": "2.2.3",
-        "@heddendorp/coverage-git-compare": "^1.5.3",
-        "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.4.10",
+        "@heddendorp/coverage-git-compare": "^1.5.4",
+        "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.4.13",
         "@types/node": "18.11.18",
         "cypress": "12.2.0",
         "cypress-file-upload": "5.0.8",

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -9,7 +9,7 @@
     "devDependencies": {
         "@4tw/cypress-drag-drop": "2.2.3",
         "@heddendorp/coverage-git-compare": "1.5.4",
-        "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.1",
+        "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.4",
         "@types/node": "18.11.18",
         "cypress": "12.3.0",
         "cypress-file-upload": "5.0.8",

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -8,8 +8,8 @@
     ],
     "devDependencies": {
         "@4tw/cypress-drag-drop": "2.2.3",
-        "@heddendorp/coverage-git-compare": "1.3.3",
-        "@heddendorp/cypress-plugin-multilanguage-coverage": "1.3.0",
+        "@heddendorp/coverage-git-compare": "^1.5.3",
+        "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.4.10",
         "@types/node": "18.11.18",
         "cypress": "12.2.0",
         "cypress-file-upload": "5.0.8",

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -9,7 +9,7 @@
     "devDependencies": {
         "@4tw/cypress-drag-drop": "2.2.3",
         "@heddendorp/coverage-git-compare": "1.5.4",
-        "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.4",
+        "@heddendorp/cypress-plugin-multilanguage-coverage": "1.6.0",
         "@types/node": "18.11.18",
         "cypress": "12.3.0",
         "cypress-file-upload": "5.0.8",

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -9,7 +9,7 @@
     "devDependencies": {
         "@4tw/cypress-drag-drop": "2.2.3",
         "@heddendorp/coverage-git-compare": "^1.5.4",
-        "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.4.13",
+        "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.5.0",
         "@types/node": "18.11.18",
         "cypress": "12.2.0",
         "cypress-file-upload": "5.0.8",

--- a/src/test/cypress/package.json
+++ b/src/test/cypress/package.json
@@ -8,8 +8,8 @@
     ],
     "devDependencies": {
         "@4tw/cypress-drag-drop": "2.2.3",
-        "@heddendorp/coverage-git-compare": "^1.5.4",
-        "@heddendorp/cypress-plugin-multilanguage-coverage": "^1.5.0",
+        "@heddendorp/coverage-git-compare": "1.5.4",
+        "@heddendorp/cypress-plugin-multilanguage-coverage": "1.5.0",
         "@types/node": "18.11.18",
         "cypress": "12.2.0",
         "cypress-file-upload": "5.0.8",


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Changes
Forked the jacoco npm module and updated the mocha dependency. Switched the cypress plugin over to the new version of jacoco-parse.
Ran security report without issues.

As #6059 broke the plugin integration I have made sure that the plugin get's added last to override any listeners and applied the arguments in the plugin to make sure the tests work as expected still.
Refer to https://github.com/cypress-io/cypress/issues/5240 for the discussion with this cypress limitation.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
![image](https://user-images.githubusercontent.com/3612748/212464390-bf7fb9ef-25b2-43c1-ab84-8f85d258f451.png)
