### PR TITLE
`Exam mode`: Allow editing individual working time during conduction 

### DIFF
--- a/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/exam/StudentExamService.java
@@ -48,6 +48,8 @@ public class StudentExamService {
 
     private static final String EXAM_EXERCISE_START_STATUS_TOPIC = "/topic/exams/%s/exercise-start-status";
 
+    private static final String WORKING_TIME_CHANGE_DURING_CONDUCTION_TOPIC = "/topic/studentExams/%s/working-time-change-during-conduction";
+
     private final Logger log = LoggerFactory.getLogger(StudentExamService.class);
 
     private final ParticipationService participationService;
@@ -653,5 +655,9 @@ public class StudentExamService {
         HashSet<User> userHashSet = new HashSet<>();
         userHashSet.add(student);
         return studentExamRepository.createRandomStudentExams(exam, userHashSet).get(0);
+    }
+
+    public void notifyStudentAboutWorkingTimeChangeDuringConduction(StudentExam studentExam) {
+        messagingTemplate.convertAndSend(WORKING_TIME_CHANGE_DURING_CONDUCTION_TOPIC.formatted(studentExam.getId()), studentExam.getWorkingTime());
     }
 }

--- a/src/main/java/de/tum/in/www1/artemis/service/messaging/DistributedInstanceMessageSendService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/messaging/DistributedInstanceMessageSendService.java
@@ -142,6 +142,12 @@ public class DistributedInstanceMessageSendService implements InstanceMessageSen
     }
 
     @Override
+    public void sendExamWorkingTimeChangeDuringConduction(Long studentExamId) {
+        log.info("Sending schedule to reschedule student exam {} to broker.", studentExamId);
+        sendMessageDelayed(MessageTopic.STUDENT_EXAM_RESCHEDULE_DURING_CONDUCTION, studentExamId);
+    }
+
+    @Override
     public void sendParticipantScoreSchedule(Long exerciseId, Long participantId, Long resultId) {
         log.info("Sending schedule participant score update for exercise {} and participant {}.", exerciseId, participantId);
         sendMessageDelayed(MessageTopic.PARTICIPANT_SCORE_SCHEDULE, exerciseId, participantId, resultId);

--- a/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageReceiveService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageReceiveService.java
@@ -272,6 +272,11 @@ public class InstanceMessageReceiveService {
         examMonitoringScheduleService.cancelExamMonitoringTask(examId);
     }
 
+    public void processExamWorkingTimeChangeDuringConduction(Long studentExamId) {
+        log.info("Received reschedule of student exam during conduction {}", studentExamId);
+        programmingExerciseScheduleService.rescheduleStudentExamDuringConduction(studentExamId);
+    }
+
     public void processScheduleParticipantScore(Long exerciseId, Long participantId, Long resultIdToBeDeleted) {
         log.info("Received schedule participant score for exercise {} and participant {} (result to be deleted: {})", exerciseId, participantId, resultIdToBeDeleted);
         participantScoreSchedulerService.scheduleTask(exerciseId, participantId, resultIdToBeDeleted);

--- a/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageSendService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/messaging/InstanceMessageSendService.java
@@ -115,6 +115,12 @@ public interface InstanceMessageSendService {
     void sendExamMonitoringScheduleCancel(Long examId);
 
     /**
+     * Send a message to the main server that the working time of a student exam was changed during the conduction and rescheduling might be necessary
+     * @param studentExamId the id of the student exam that should be scheduled
+     */
+    void sendExamWorkingTimeChangeDuringConduction(Long studentExamId);
+
+    /**
      * Send a message to the main server that schedules to update the participant score for this exercise/participant
      * @param exerciseId the id of the exercise
      * @param participantId the id of the participant

--- a/src/main/java/de/tum/in/www1/artemis/service/messaging/MainInstanceMessageSendService.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/messaging/MainInstanceMessageSendService.java
@@ -113,6 +113,11 @@ public class MainInstanceMessageSendService implements InstanceMessageSendServic
     }
 
     @Override
+    public void sendExamWorkingTimeChangeDuringConduction(Long studentExamId) {
+        instanceMessageReceiveService.processExamWorkingTimeChangeDuringConduction(studentExamId);
+    }
+
+    @Override
     public void sendParticipantScoreSchedule(Long exerciseId, Long participantId, Long resultIdToBeDeleted) {
         instanceMessageReceiveService.processScheduleParticipantScore(exerciseId, participantId, resultIdToBeDeleted);
     }

--- a/src/main/java/de/tum/in/www1/artemis/service/messaging/MessageTopic.java
+++ b/src/main/java/de/tum/in/www1/artemis/service/messaging/MessageTopic.java
@@ -24,6 +24,7 @@ public enum MessageTopic {
     ASSESSED_EXERCISE_SUBMISSION_SCHEDULE("assessed-exercise-submission-schedule"),
     EXAM_MONITORING_SCHEDULE("exam-monitoring-schedule"),
     EXAM_MONITORING_SCHEDULE_CANCEL("exam-monitoring-schedule-cancel"),
+    STUDENT_EXAM_RESCHEDULE_DURING_CONDUCTION("student-exam-reschedule-during-conduction"),
     PARTICIPANT_SCORE_SCHEDULE("participant-score-schedule");
     // @formatter:on
 

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.html
@@ -33,9 +33,9 @@
     </div>
 
     <div class="mb-3" *ngIf="!isTestExam">
-        <h5><span jhiTranslate="artemisApp.studentExams.workingTime" [ngbTooltip]="getWorkingTimeToolTip()">Working time</span></h5>
+        <h5><span jhiTranslate="artemisApp.studentExams.workingTime">Working time</span></h5>
         <form #form="ngForm" (ngSubmit)="saveWorkingTime()">
-            <div class="mb-1 working-time-form" [ngbTooltip]="getWorkingTimeToolTip()">
+            <div class="mb-1 working-time-form">
                 <div class="input-group mb-1 d-flex justify-content-between align-items-center">
                     <label for="hours" class="me-4" jhiTranslate="artemisApp.studentExams.setWorkingTime">Absolute:</label>
                     <input
@@ -98,8 +98,8 @@
                 </div>
             </div>
             <button type="submit" class="btn btn-primary me-2" [disabled]="!form.valid || isFormDisabled()">
-                <fa-icon [icon]="faSave" [ngbTooltip]="getWorkingTimeToolTip()"></fa-icon>
-                <span jhiTranslate="entity.action.save" [ngbTooltip]="getWorkingTimeToolTip()">Save</span>
+                <fa-icon [icon]="faSave"></fa-icon>
+                <span jhiTranslate="entity.action.save">Save</span>
             </button>
         </form>
     </div>

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
@@ -119,7 +119,7 @@ export class StudentExamDetailComponent implements OnInit {
      * @param studentExamWithGrade
      */
     private setStudentExamWithGrade(studentExamWithGrade: StudentExamWithGradeDTO) {
-        if (studentExamWithGrade.studentExam == undefined) {
+        if (!studentExamWithGrade.studentExam) {
             // This should not happen, the server endpoint should return studentExamWithGrade.studentExam.
             throw new Error('studentExamWithGrade.studentExam is undefined');
         }
@@ -237,24 +237,7 @@ export class StudentExamDetailComponent implements OnInit {
      * Checks if the user should be able to edit the inputs.
      */
     isFormDisabled(): boolean {
-        return this.isSavingWorkingTime || !this.canChangeExamWorkingTime();
-    }
-
-    /**
-     * Checks if the working time of the exam can still be changed.
-     * @private
-     */
-    private canChangeExamWorkingTime(): boolean {
-        if (this.isTestRun) {
-            // for unsubmitted test runs we always want to be able to change the working time
-            return !this.studentExam.submitted;
-        } else if (this.studentExam.exam) {
-            // for student exams it can only be changed before the student is able to see it
-            return dayjs().isBefore(dayjs(this.studentExam.exam.visibleDate));
-        }
-
-        // if there is no exam, then it cannot be changed
-        return false;
+        return this.isSavingWorkingTime;
     }
 
     examIsOver(): boolean {
@@ -263,14 +246,6 @@ export class StudentExamDetailComponent implements OnInit {
             return dayjs(this.studentExam.exam.endDate).add(this.studentExam.exam.gracePeriod!, 'seconds').isBefore(dayjs());
         } else {
             return false;
-        }
-    }
-
-    getWorkingTimeToolTip(): string {
-        if (this.canChangeExamWorkingTime()) {
-            return 'You can change the individual working time of the student here.';
-        } else {
-            return 'You cannot change the individual working time after the exam has become visible.';
         }
     }
 

--- a/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
+++ b/src/main/webapp/app/exam/manage/student-exams/student-exam-detail.component.ts
@@ -237,7 +237,7 @@ export class StudentExamDetailComponent implements OnInit {
      * Checks if the user should be able to edit the inputs.
      */
     isFormDisabled(): boolean {
-        return this.isSavingWorkingTime;
+        return this.isSavingWorkingTime || (this.isTestRun && !!this.studentExam.submitted) || !this.studentExam.exam;
     }
 
     examIsOver(): boolean {

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -573,6 +573,10 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
         this.websocketService.unsubscribe(getWebSocketChannelForWorkingTimeChange(this.studentExamId));
     }
 
+    /**
+     * Initializes the individual end dates and sets up a subscription for potential changes during the conduction
+     * @param startDate the start date of the exam
+     */
     initIndividualEndDates(startDate: dayjs.Dayjs) {
         this.individualStudentEndDate = dayjs(startDate).add(this.studentExam.workingTime!, 'seconds');
         this.individualStudentEndDateWithGracePeriod = this.individualStudentEndDate.clone().add(this.exam.gracePeriod!, 'seconds');

--- a/src/main/webapp/app/exam/participate/exam-participation.component.ts
+++ b/src/main/webapp/app/exam/participate/exam-participation.component.ts
@@ -591,9 +591,9 @@ export class ExamParticipationComponent implements OnInit, OnDestroy, ComponentC
             const dateFormat = startDate.isSame(this.individualStudentEndDate, 'day') ? 'time' : 'short';
             const newIndividualStudentEndDateFormatted = this.artemisDatePipe.transform(this.individualStudentEndDate, dateFormat);
             if (decreased) {
-                this.alertService.error('artemisApp.exam.examParticipation.workingTimeDecreased', { date: newIndividualStudentEndDateFormatted });
+                this.alertService.error('artemisApp.examParticipation.workingTimeDecreased', { date: newIndividualStudentEndDateFormatted });
             } else {
-                this.alertService.success('artemisApp.exam.examParticipation.workingTimeIncreased', { date: newIndividualStudentEndDateFormatted });
+                this.alertService.success('artemisApp.examParticipation.workingTimeIncreased', { date: newIndividualStudentEndDateFormatted });
             }
         });
     }

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -237,7 +237,9 @@
             "continueAfterHandInEarlyDescription": "Du willst doch nicht vorzeitig abgeben?",
             "handInEarlyNoticeFirstSentence": "Du bist dabei die Klausur vorzeitig abzugeben.",
             "handInEarlyNoticeSecondSentence": "Du kannst danach nicht mehr an der Klausur teilnehmen.",
-            "namePlaceholder": "Trage deinen vollen Namen hier ein"
+            "namePlaceholder": "Trage deinen vollen Namen hier ein",
+            "workingTimeIncreased": "Deine Arbeitszeit wurde verlängert bis {{ date }}.",
+            "workingTimeDecreased": "Deine Arbeitszeit wurde verkürzt bis {{ date }}."
         },
         "exerciseGroup": {
             "created": "Neue Aufgabengruppe erstellt",

--- a/src/main/webapp/i18n/de/exam.json
+++ b/src/main/webapp/i18n/de/exam.json
@@ -238,8 +238,8 @@
             "handInEarlyNoticeFirstSentence": "Du bist dabei die Klausur vorzeitig abzugeben.",
             "handInEarlyNoticeSecondSentence": "Du kannst danach nicht mehr an der Klausur teilnehmen.",
             "namePlaceholder": "Trage deinen vollen Namen hier ein",
-            "workingTimeIncreased": "Deine Arbeitszeit wurde verlängert bis {{ date }}.",
-            "workingTimeDecreased": "Deine Arbeitszeit wurde verkürzt bis {{ date }}."
+            "workingTimeIncreased": "Das Ende der Arbeitszeit wurde verlängert bis {{ date }}.",
+            "workingTimeDecreased": "Das Ende der Arbeitszeit wurde verkürzt bis {{ date }}."
         },
         "exerciseGroup": {
             "created": "Neue Aufgabengruppe erstellt",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -241,8 +241,8 @@
             "handInEarlyNoticeFirstSentence": "You are about to hand in your submission before the end of the exam.",
             "handInEarlyNoticeSecondSentence": "After finishing the exam you cannot participate any longer.",
             "namePlaceholder": "Enter your full name here",
-            "workingTimeIncreased": "Your working time was extended until {{ date }}.",
-            "workingTimeDecreased": "Your working time was shortened until {{ date }}."
+            "workingTimeIncreased": "The end of working time was extended until {{ date }}.",
+            "workingTimeDecreased": "The end of working time was shortened until {{ date }}."
         },
         "exerciseGroup": {
             "created": "New exercise group created",

--- a/src/main/webapp/i18n/en/exam.json
+++ b/src/main/webapp/i18n/en/exam.json
@@ -240,7 +240,9 @@
             "handInEarlyNotice": "You are about to hand in your submission before the end of the exam.\nAfter finishing the exam you cannot participate any longer.",
             "handInEarlyNoticeFirstSentence": "You are about to hand in your submission before the end of the exam.",
             "handInEarlyNoticeSecondSentence": "After finishing the exam you cannot participate any longer.",
-            "namePlaceholder": "Enter your full name here"
+            "namePlaceholder": "Enter your full name here",
+            "workingTimeIncreased": "Your working time was extended until {{ date }}.",
+            "workingTimeDecreased": "Your working time was shortened until {{ date }}."
         },
         "exerciseGroup": {
             "created": "New exercise group created",

--- a/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/exam/StudentExamIntegrationTest.java
@@ -690,11 +690,12 @@ class StudentExamIntegrationTest extends AbstractSpringIntegrationBambooBitbucke
         int newWorkingTime = 180 * 60;
         exam1.setVisibleDate(ZonedDateTime.now().minusMinutes(1));
         exam1 = examRepository.save(exam1);
-        request.patchWithResponseBody("/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/" + studentExam1.getId() + "/working-time", newWorkingTime,
-                StudentExam.class, HttpStatus.BAD_REQUEST);
-        // working time did not change
-        var studentExamDB = studentExamRepository.findById(studentExam1.getId()).get();
-        assertThat(studentExamDB.getWorkingTime()).isEqualTo(studentExam1.getWorkingTime());
+        StudentExam result = request.patchWithResponseBody(
+                "/api/courses/" + course1.getId() + "/exams/" + exam1.getId() + "/student-exams/" + studentExam1.getId() + "/working-time", newWorkingTime, StudentExam.class,
+                HttpStatus.OK);
+        assertThat(result.getWorkingTime()).isEqualTo(newWorkingTime);
+        assertThat(studentExamRepository.findById(studentExam1.getId()).get().getWorkingTime()).isEqualTo(newWorkingTime);
+        verify(messagingTemplate, times(1)).convertAndSend("/topic/studentExams/" + studentExam1.getId() + "/working-time-change-during-conduction", 10800);
     }
 
     @Test

--- a/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseScheduleServiceTest.java
+++ b/src/test/java/de/tum/in/www1/artemis/programmingexercise/ProgrammingExerciseScheduleServiceTest.java
@@ -24,17 +24,18 @@ import de.tum.in.www1.artemis.AbstractSpringIntegrationBambooBitbucketJiraTest;
 import de.tum.in.www1.artemis.config.Constants;
 import de.tum.in.www1.artemis.connector.BitbucketRequestMockProvider;
 import de.tum.in.www1.artemis.domain.ProgrammingExercise;
+import de.tum.in.www1.artemis.domain.User;
 import de.tum.in.www1.artemis.domain.VcsRepositoryUrl;
 import de.tum.in.www1.artemis.domain.enumeration.AssessmentType;
 import de.tum.in.www1.artemis.domain.enumeration.ExerciseLifecycle;
 import de.tum.in.www1.artemis.domain.enumeration.ParticipationLifecycle;
 import de.tum.in.www1.artemis.domain.enumeration.Visibility;
+import de.tum.in.www1.artemis.domain.exam.Exam;
+import de.tum.in.www1.artemis.domain.exam.StudentExam;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseParticipation;
 import de.tum.in.www1.artemis.domain.participation.ProgrammingExerciseStudentParticipation;
 import de.tum.in.www1.artemis.domain.participation.StudentParticipation;
-import de.tum.in.www1.artemis.repository.ProgrammingExerciseRepository;
-import de.tum.in.www1.artemis.repository.ProgrammingExerciseStudentParticipationRepository;
-import de.tum.in.www1.artemis.repository.ProgrammingExerciseTestCaseRepository;
+import de.tum.in.www1.artemis.repository.*;
 import de.tum.in.www1.artemis.service.messaging.InstanceMessageReceiveService;
 import de.tum.in.www1.artemis.util.LocalRepository;
 
@@ -56,6 +57,12 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
 
     @Autowired
     private BitbucketRequestMockProvider bitbucketRequestMockProvider;
+
+    @Autowired
+    private ExamRepository examRepository;
+
+    @Autowired
+    private StudentExamRepository studentExamRepository;
 
     private ProgrammingExercise programmingExercise;
 
@@ -622,6 +629,27 @@ class ProgrammingExerciseScheduleServiceTest extends AbstractSpringIntegrationBa
         verify(scheduleService, timeout(5000).times(1)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.DUE);
         verify(scheduleService, timeout(5000).times(1)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.BUILD_AND_TEST_AFTER_DUE_DATE);
         verify(scheduleService, timeout(5000).times(1)).cancelScheduledTaskForLifecycle(programmingExercise.getId(), ExerciseLifecycle.ASSESSMENT_DUE);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", roles = "ADMIN")
+    void foo() {
+        ProgrammingExercise examExercise = database.addCourseExamExerciseGroupWithOneProgrammingExercise();
+        Exam exam = examExercise.getExamViaExerciseGroupOrCourseMember();
+        exam.setStartDate(ZonedDateTime.now().minusMinutes(1));
+        exam = examRepository.save(exam);
+        User user = database.getUserByLogin(TEST_PREFIX + "student1");
+        StudentExam studentExam = database.addStudentExamWithUser(exam, user);
+        ProgrammingExerciseStudentParticipation participation = (ProgrammingExerciseStudentParticipation) database
+                .addProgrammingParticipationWithResultForExercise(examExercise, TEST_PREFIX + "student1").getParticipation();
+        studentExam.setExercises(List.of(examExercise));
+        studentExam.setWorkingTime(1);
+        studentExamRepository.save(studentExam);
+
+        instanceMessageReceiveService.processExamWorkingTimeChangeDuringConduction(studentExam.getId());
+
+        verify(versionControlService, timeout(200).times(1)).setRepositoryPermissionsToReadOnly(participation.getVcsRepositoryUrl(), examExercise.getProjectKey(),
+                participation.getStudents());
     }
 
     /**

--- a/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/manage/student-exams/student-exam-detail.component.spec.ts
@@ -245,17 +245,6 @@ describe('StudentExamDetailComponent', () => {
         expect(studentExamDetailComponent.isFormDisabled()).toBeTrue();
     });
 
-    it('should disable the working time form after the exam is visible to a student', () => {
-        studentExamDetailComponent.isTestRun = false;
-        studentExamDetailComponent.studentExam = studentExam;
-
-        studentExamDetailComponent.studentExam.exam!.visibleDate = dayjs().add(1, 'hour');
-        expect(studentExamDetailComponent.isFormDisabled()).toBeFalse();
-
-        studentExamDetailComponent.studentExam.exam!.visibleDate = dayjs().subtract(1, 'hour');
-        expect(studentExamDetailComponent.isFormDisabled()).toBeTrue();
-    });
-
     it('should disable the working time form if there is no exam', () => {
         studentExamDetailComponent.isTestRun = false;
         studentExamDetailComponent.studentExam = studentExam;

--- a/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
@@ -460,7 +460,7 @@ describe('ExamParticipationComponent', () => {
             comp.studentExamId = comp.studentExam.id!;
             jest.spyOn(websocketService, 'receive').mockReturnValue(of(1337));
             comp.initIndividualEndDates(startDate);
-            expect(comp.studentExam.workingTime).toEqual(1337);
+            expect(comp.studentExam.workingTime).toBe(1337);
             expect(artemisDatePipeSpy).toHaveBeenCalledWith(startDate.add(1337, 'seconds'), 'time');
             expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.exam.examParticipation.workingTimeIncreased', { date: undefined });
         });
@@ -470,7 +470,7 @@ describe('ExamParticipationComponent', () => {
             comp.studentExamId = comp.studentExam.id!;
             jest.spyOn(websocketService, 'receive').mockReturnValue(of(9001));
             comp.initIndividualEndDates(startDate);
-            expect(comp.studentExam.workingTime).toEqual(9001);
+            expect(comp.studentExam.workingTime).toBe(9001);
             expect(artemisDatePipeSpy).toHaveBeenCalledWith(startDate.add(9001, 'seconds'), 'short');
             expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.exam.examParticipation.workingTimeIncreased', { date: undefined });
         });
@@ -480,7 +480,7 @@ describe('ExamParticipationComponent', () => {
             comp.studentExamId = comp.studentExam.id!;
             jest.spyOn(websocketService, 'receive').mockReturnValue(of(42));
             comp.initIndividualEndDates(startDate);
-            expect(comp.studentExam.workingTime).toEqual(42);
+            expect(comp.studentExam.workingTime).toBe(42);
             expect(artemisDatePipeSpy).toHaveBeenCalledWith(startDate.add(42, 'seconds'), 'time');
             expect(alertErrorSpy).toHaveBeenCalledWith('artemisApp.exam.examParticipation.workingTimeDecreased', { date: undefined });
         });

--- a/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
@@ -30,6 +30,7 @@ import { ModelingSubmissionService } from 'app/exercises/modeling/participate/mo
 import { ProgrammingSubmissionService, ProgrammingSubmissionState, ProgrammingSubmissionStateObj } from 'app/exercises/programming/participate/programming-submission.service';
 import { TextSubmissionService } from 'app/exercises/text/participate/text-submission.service';
 import { JhiConnectionStatusComponent } from 'app/shared/connection-status/connection-status.component';
+import { ArtemisDatePipe } from 'app/shared/pipes/artemis-date.pipe';
 import { ArtemisServerDateService } from 'app/shared/server-date.service';
 import dayjs from 'dayjs/esm';
 import { MockComponent, MockDirective, MockPipe, MockProvider } from 'ng-mocks';
@@ -57,6 +58,8 @@ describe('ExamParticipationComponent', () => {
     let modelingSubmissionService: ModelingSubmissionService;
     let alertService: AlertService;
     let artemisServerDateService: ArtemisServerDateService;
+    let websocketService: JhiWebsocketService;
+    let artemisDatePipe: ArtemisDatePipe;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -76,6 +79,7 @@ describe('ExamParticipationComponent', () => {
                 MockDirective(TranslateDirective),
                 MockComponent(TestRunRibbonComponent),
                 MockComponent(ExamParticipationSummaryComponent),
+                MockPipe(ArtemisDatePipe),
             ],
             providers: [
                 { provide: JhiWebsocketService, useClass: MockWebsocketService },
@@ -95,6 +99,7 @@ describe('ExamParticipationComponent', () => {
                 MockProvider(TranslateService),
                 MockProvider(AlertService),
                 MockProvider(CourseExerciseService),
+                MockProvider(ArtemisDatePipe),
             ],
         })
             .compileComponents()
@@ -108,6 +113,8 @@ describe('ExamParticipationComponent', () => {
                 modelingSubmissionService = TestBed.inject(ModelingSubmissionService);
                 alertService = TestBed.inject(AlertService);
                 artemisServerDateService = TestBed.inject(ArtemisServerDateService);
+                websocketService = TestBed.inject(JhiWebsocketService);
+                artemisDatePipe = TestBed.inject(ArtemisDatePipe);
                 fixture.detectChanges();
                 comp.exam = new Exam();
             });
@@ -434,6 +441,49 @@ describe('ExamParticipationComponent', () => {
         const exercise = new ProgrammingExercise(new Course(), undefined);
         comp.createParticipationForExercise(exercise);
         expect(courseExerciseServiceStub).toHaveBeenCalledOnce();
+    });
+
+    describe('websocket working time subscription', () => {
+        let alertSuccessSpy: jest.SpyInstance;
+        let alertErrorSpy: jest.SpyInstance;
+        let artemisDatePipeSpy: jest.SpyInstance;
+        const startDate = dayjs('2022-02-21T23:00:00+01:00');
+
+        beforeEach(() => {
+            alertSuccessSpy = jest.spyOn(alertService, 'success');
+            alertErrorSpy = jest.spyOn(alertService, 'error');
+            artemisDatePipeSpy = jest.spyOn(artemisDatePipe, 'transform');
+        });
+
+        it('should correctly increase working time', () => {
+            comp.studentExam = { id: 3, workingTime: 420 };
+            comp.studentExamId = comp.studentExam.id!;
+            jest.spyOn(websocketService, 'receive').mockReturnValue(of(1337));
+            comp.initIndividualEndDates(startDate);
+            expect(comp.studentExam.workingTime).toEqual(1337);
+            expect(artemisDatePipeSpy).toHaveBeenCalledWith(startDate.add(1337, 'seconds'), 'time');
+            expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.exam.examParticipation.workingTimeIncreased', { date: undefined });
+        });
+
+        it('should correctly increase working time to next day', () => {
+            comp.studentExam = { id: 3, workingTime: 420 };
+            comp.studentExamId = comp.studentExam.id!;
+            jest.spyOn(websocketService, 'receive').mockReturnValue(of(9001));
+            comp.initIndividualEndDates(startDate);
+            expect(comp.studentExam.workingTime).toEqual(9001);
+            expect(artemisDatePipeSpy).toHaveBeenCalledWith(startDate.add(9001, 'seconds'), 'short');
+            expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.exam.examParticipation.workingTimeIncreased', { date: undefined });
+        });
+
+        it('should correctly decrease working time', () => {
+            comp.studentExam = { id: 3, workingTime: 420 };
+            comp.studentExamId = comp.studentExam.id!;
+            jest.spyOn(websocketService, 'receive').mockReturnValue(of(42));
+            comp.initIndividualEndDates(startDate);
+            expect(comp.studentExam.workingTime).toEqual(42);
+            expect(artemisDatePipeSpy).toHaveBeenCalledWith(startDate.add(42, 'seconds'), 'time');
+            expect(alertErrorSpy).toHaveBeenCalledWith('artemisApp.exam.examParticipation.workingTimeDecreased', { date: undefined });
+        });
     });
 
     describe('trigger save', () => {

--- a/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
+++ b/src/test/javascript/spec/component/exam/participate/exam-participation.component.spec.ts
@@ -453,36 +453,32 @@ describe('ExamParticipationComponent', () => {
             alertSuccessSpy = jest.spyOn(alertService, 'success');
             alertErrorSpy = jest.spyOn(alertService, 'error');
             artemisDatePipeSpy = jest.spyOn(artemisDatePipe, 'transform');
+            comp.studentExam = { id: 3, workingTime: 420 };
+            comp.studentExamId = comp.studentExam.id!;
         });
 
         it('should correctly increase working time', () => {
-            comp.studentExam = { id: 3, workingTime: 420 };
-            comp.studentExamId = comp.studentExam.id!;
             jest.spyOn(websocketService, 'receive').mockReturnValue(of(1337));
             comp.initIndividualEndDates(startDate);
             expect(comp.studentExam.workingTime).toBe(1337);
             expect(artemisDatePipeSpy).toHaveBeenCalledWith(startDate.add(1337, 'seconds'), 'time');
-            expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.exam.examParticipation.workingTimeIncreased', { date: undefined });
+            expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.examParticipation.workingTimeIncreased', { date: undefined });
         });
 
         it('should correctly increase working time to next day', () => {
-            comp.studentExam = { id: 3, workingTime: 420 };
-            comp.studentExamId = comp.studentExam.id!;
             jest.spyOn(websocketService, 'receive').mockReturnValue(of(9001));
             comp.initIndividualEndDates(startDate);
             expect(comp.studentExam.workingTime).toBe(9001);
             expect(artemisDatePipeSpy).toHaveBeenCalledWith(startDate.add(9001, 'seconds'), 'short');
-            expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.exam.examParticipation.workingTimeIncreased', { date: undefined });
+            expect(alertSuccessSpy).toHaveBeenCalledWith('artemisApp.examParticipation.workingTimeIncreased', { date: undefined });
         });
 
         it('should correctly decrease working time', () => {
-            comp.studentExam = { id: 3, workingTime: 420 };
-            comp.studentExamId = comp.studentExam.id!;
             jest.spyOn(websocketService, 'receive').mockReturnValue(of(42));
             comp.initIndividualEndDates(startDate);
             expect(comp.studentExam.workingTime).toBe(42);
             expect(artemisDatePipeSpy).toHaveBeenCalledWith(startDate.add(42, 'seconds'), 'time');
-            expect(alertErrorSpy).toHaveBeenCalledWith('artemisApp.exam.examParticipation.workingTimeDecreased', { date: undefined });
+            expect(alertErrorSpy).toHaveBeenCalledWith('artemisApp.examParticipation.workingTimeDecreased', { date: undefined });
         });
     });
 


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).
- [x] I added multiple integration tests (Spring) related to the features (with a high test coverage).
- [x] I implemented the changes with a good performance and prevented too many database calls.
- [x] I documented the Java code using JavaDoc style.
#### Client
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client/) and ensured that the layout is responsive.
- [x] I added multiple integration tests (Jest) related to the features (with a high test coverage), while following the [test guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/client-tests/).
- [x] I documented the TypeScript code using JSDoc style.
- [x] I translated all newly inserted strings into English and German.
#### Changes affecting Programming Exercises
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 1 (Atlassian Suite).
- [x] I tested **all** changes and their related features with **all** corresponding user types on Test Server 2 (Jenkins and Gitlab).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix #5962

### Description
<!-- Describe your changes in detail -->
It is now possible to change the working time of individual student exams during their conduction. The change is also sent via web socket to the student and displayed as an alert at the top right of the screen.
Programming exercises should get locked at the new due date for the student.

### Steps for Testing
<!-- Please describe in detail how the reviewer can test your changes. -->
Prerequisites:
- 1 Instructor
- 2 Students
- 1 Exam with a programming exercise.

1. Log in to Artemis
2. Create the exam
3. Participate as both students (you can do this simultaneously)
4. Go to the student exam overview as instructor
5. Decrease the working time of one student and verify that the student gets a notification (e.g. use two browsers one for the student, one for the instructor)
6. Increase the working time of the other student and verify that the student gets a notification (e.g. use two browsers one for the student, one for the instructor)
7. Make surre that both repositories are locked at their respective due date and the student can no longer push

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [x] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2

### Test Coverage
<!-- Please add the test coverages for all changed files here. You can see this when executing the tests locally (see build.gradle and package.json) or when looking into the corresponding Bamboo build plan. -->
<!-- Lines are the main reference but a significantly lower branch percentage can indicate missing edge cases in the tests. -->
| Class/File | Branch | Line |
|------------|-------:|-----:|
| ProgrammingExerciseScheduleService.java | 75% | 87% |
| exam-participation.component.ts | 67% | 78% |

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. -->
<!-- Create a GIF file from a screen recording in a docker container https://toub.es/2017/09/11/high-quality-gif-with-ffmpeg-and-docker/ -->
Instructor view:
<img width="516" alt="Bildschirm­foto 2023-01-28 um 01 08 38" src="https://user-images.githubusercontent.com/38322605/215228594-2f145b0b-cf82-4cd7-b7c0-0d2b187a528a.png">
Student view when time was changed:
<img width="1680" alt="Bildschirm­foto 2023-01-28 um 01 09 36" src="https://user-images.githubusercontent.com/38322605/215228623-c5edda0b-9f63-4714-be51-64f783d01ed1.png">