### PR TITLE
`Programming exercises`: Remove redundant latest-due-date calls

### DIFF
--- a/src/main/webapp/app/exercises/shared/result/result.component.ts
+++ b/src/main/webapp/app/exercises/shared/result/result.component.ts
@@ -267,12 +267,12 @@ export class ResultComponent implements OnInit, OnChanges {
     private determineShowMissingAutomaticFeedbackInformation(componentInstance: FeedbackComponent) {
         if (!this.latestIndividualDueDate) {
             this.exerciseService.getLatestDueDate(this.exercise!.id!).subscribe((latestIndividualDueDate?: dayjs.Dayjs) => {
-                this.latestIndividualDueDate = latestIndividualDueDate;
-                this.initializeMissingAutomaticFeedbackAndLatestIndividualDueDate(componentInstance);
+                // If the server returns no value, a not-reachable date in the future is assumed
+                this.latestIndividualDueDate = latestIndividualDueDate ?? dayjs().add(999, 'years');
             });
-        } else {
-            this.initializeMissingAutomaticFeedbackAndLatestIndividualDueDate(componentInstance);
         }
+
+        this.initializeMissingAutomaticFeedbackAndLatestIndividualDueDate(componentInstance);
     }
 
     private initializeMissingAutomaticFeedbackAndLatestIndividualDueDate(componentInstance: FeedbackComponent) {


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [ ] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [ ] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [ ] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Reduces work on the server

### Description
<!-- Describe your changes in detail -->
The caching did not work correctly if no `exercise.dueDate` was set or no participation had an individual due date.

This was fixed by setting a date in the future in the client, so that those calls are not repeated. 

However this introduces an interesting edge-case where information could be displayed incorrectly if someone were to keep the same artemis client open for 999 years.


### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [ ] Review 1
- [ ] Review 2