### PR TITLE
`Programming exercises`: Fix synchronization issue when opening feedback modal for the first time

### DIFF
--- a/src/main/webapp/app/exercises/shared/feedback/feedback.component.ts
+++ b/src/main/webapp/app/exercises/shared/feedback/feedback.component.ts
@@ -126,13 +126,7 @@ export class FeedbackComponent implements OnInit {
         this.initializeExerciseInformation();
 
         this.feedbackItemService = this.exerciseType === ExerciseType.PROGRAMMING ? this.injector.get(ProgrammingFeedbackItemService) : this.injector.get(FeedbackItemServiceImpl);
-        this.fetchAdditionalInformation();
-
-        if (this.showScoreChart) {
-            this.updateChart(this.feedbackItemNodes);
-        }
-
-        this.badge = ResultService.evaluateBadge(this.result.participation!, this.result);
+        this.initFeedbackInformation();
 
         this.commitHash = this.getCommitHash().slice(0, 11);
 
@@ -166,7 +160,7 @@ export class FeedbackComponent implements OnInit {
      * Fetches additional information about feedbacks and build logs if required.
      * @private
      */
-    private fetchAdditionalInformation() {
+    private initFeedbackInformation() {
         of(this.result.feedbacks)
             .pipe(
                 switchMap((feedbacks: Feedback[] | undefined | null) => {
@@ -195,6 +189,12 @@ export class FeedbackComponent implements OnInit {
                     ) {
                         return this.fetchAndSetBuildLogs(this.result.participation.id!, this.result.id);
                     }
+
+                    if (this.showScoreChart) {
+                        this.updateChart(this.feedbackItemNodes);
+                    }
+
+                    this.badge = ResultService.evaluateBadge(this.result.participation!, this.result);
 
                     return of(null);
                 }),

--- a/src/test/javascript/spec/component/shared/feedback/feedback.component.spec.ts
+++ b/src/test/javascript/spec/component/shared/feedback/feedback.component.spec.ts
@@ -355,13 +355,4 @@ describe('FeedbackComponent', () => {
         expect(comp.loadingFailed).toBeTrue();
         expect(comp.isLoading).toBeFalse();
     });
-
-    it('should hide chart if no exercise available', () => {
-        comp.showScoreChart = true;
-        comp.exercise = undefined;
-
-        comp.ngOnInit();
-
-        expect(comp.showScoreChart).toBeFalse();
-    });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Artemis! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Checklist
#### General
<!-- You only need to choose one of the first two check items: Generally, test on the test servers. -->
<!-- If it's only a small change, testing it locally is acceptable and you may remove the first checkmark. If you are unsure, please test on the test servers. -->
- [x] This is a small issue that I tested locally and was confirmed by another developer on a test server.
- [x] Language: I followed the [guidelines for inclusive, diversity-sensitive, and appreciative language](https://docs.artemis.cit.tum.de/dev/guidelines/language-guidelines/).
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes missing chart information when opening the feedback modal for the first time

### Description
<!-- Describe your changes in detail -->
Moves methods depending on `feedback` to exist into rxjs `pipe` function, leading to it being called sequentially.

### Review Progress
<!-- Each Pull Request should be reviewed by at least two other developers. The code, the functionality (= manual test) and the exam mode need to be reviewed. -->
<!-- The reviewer or author check the following boxes depending on what was reviewed or tested. All boxes should be checked before merge. -->
<!-- You can add additional checkboxes if it makes sense to only review parts of the code or functionality. -->
<!-- When changes are pushed, uncheck the affected boxes. (Not all changes require full re-reviews.) -->
<!-- All PRs that might affect the exam mode (e.g. change a client component that is also used in the exam mode) need an additional verification that the exam mode still works. -->

#### Code Review
- [x] Review 1
- [ ] Review 2