### PR TITLE
`Development`: Enforce consistent Jackson version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,8 @@ repositories {
     }
 }
 
+ext['jackson.version'] = fasterxml_version
+
 dependencies {
     implementation "com.offbytwo.jenkins:jenkins-client:0.3.8"
     implementation "org.gitlab4j:gitlab4j-api:5.0.1"


### PR DESCRIPTION
### Checklist
#### General
- [x] I tested **all** changes and their related features with **all** corresponding user types on a test server.
- [x] This is a small issue that I tested locally
- [x] I chose a title conforming to the [naming conventions for pull requests](https://artemis-platform.readthedocs.io/en/latest/dev/guidelines/development-process.html#naming-conventions-for-github-pull-requests).
#### Server
- [x] I followed the [coding and design guidelines](https://docs.artemis.cit.tum.de/dev/guidelines/server/).

### Motivation and Context
In the 6.0.0-rc1 Testing seesion, we found out that it's not possible to create or edit exercises with structured grading instructions: 
![grafik](https://user-images.githubusercontent.com/26540346/213280084-3c74450f-95f5-44e5-a93b-19caf475b731.png)



### Description

The error was caused by two different versions of jackson in the runtime, which were not compatible with each other: 
![grafik](https://user-images.githubusercontent.com/26540346/213279719-c0595c9d-b50c-413e-807e-62cb30ccd6b7.png)

This PR uses the spring dependency management plugin to enforce one consistent version of all jackson packages.


### Steps for Testing
Test that creating exercises with structured grading instructions is possible again.

### Review Progress
#### Code Review
- [x] Review 1
- [ ] Review 2
#### Manual Tests
- [x] Test 1
- [x] Test 2
